### PR TITLE
Add/create csi-ci testing image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,9 @@
 # Go test binaries
 *.test
 
+# Test reports
+junit_check.xml
+
 # binaries
 /vsphere-csi
+/vsphere-csi.linux_amd64

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,6 @@ all: build
 PWD := $(abspath .)
 BASE_DIR := $(notdir $(PWD))
 
-# PROJECT_ROOT is used when host access is required when running
-# Docker-in-Docker (DinD).
-export PROJECT_ROOT ?= $(PWD)
-
 # BUILD_OUT is the root directory containing the build output.
 export BUILD_OUT ?= .build
 
@@ -221,7 +217,7 @@ endif
 TEST_FLAGS ?= -v
 .PHONY: unit build-unit-tests
 unit unit-test:
-	env -u VSPHERE_SERVER -u VSPHERE_PASSWORD -u VSPHERE_USER go test $(TEST_FLAGS) $(PKGS_WITH_TESTS)
+	go test $(TEST_FLAGS) $(PKGS_WITH_TESTS)
 build-unit-tests:
 	$(foreach pkg,$(PKGS_WITH_TESTS),go test $(TEST_FLAGS) -c $(pkg); )
 
@@ -297,6 +293,18 @@ push-$(IMAGE_CSI) upload-$(IMAGE_CSI): $(IMAGE_CSI_D) login-to-image-registry | 
 
 .PHONY: push-images upload-images
 push-images upload-images: upload-csi-image
+
+################################################################################
+##                                  CI IMAGE                                  ##
+################################################################################
+build-ci-image:
+	$(MAKE) -C hack/images/ci build
+
+push-ci-image:
+	$(MAKE) -C hack/images/ci push
+
+print-ci-image:
+	@$(MAKE) --no-print-directory -C hack/images/ci print
 
 ################################################################################
 ##                               PRINT VERISON                                ##

--- a/hack/images/ci/Dockerfile
+++ b/hack/images/ci/Dockerfile
@@ -1,0 +1,153 @@
+################################################################################
+##                               BUILD ARGS                                   ##
+################################################################################
+# The golang image is used to create the project's module and build caches
+# and is also the image on which this image is based.
+ARG GOLANG_IMAGE=golang:1.12
+
+################################################################################
+##                            GO MOD CACHE STAGE                              ##
+################################################################################
+# Create a Go module cache.
+FROM ${GOLANG_IMAGE} as mod-cache
+WORKDIR /build
+COPY go.mod go.sum ./
+COPY pkg ./pkg/
+COPY cmd ./cmd/
+ARG GOOS
+ARG GOARCH
+ENV GOOS=${GOOS:-linux} GOARCH=${GOARCH:-amd64}
+RUN go mod download && go mod verify
+
+################################################################################
+##                           GO BUILD CACHE STAGE                             ##
+################################################################################
+# Create a Go build cache. Please note the reason the Makefile is not used and
+# "go build" is invoked directly is to avoid having to rebuild this stage as a
+# result of the Makefile changing.
+FROM ${GOLANG_IMAGE} as build-cache
+WORKDIR /build
+COPY --from=mod-cache /go/pkg/mod /go/pkg/mod/
+COPY go.mod go.sum hack/make/ldflags.txt ./
+COPY pkg ./pkg/
+COPY cmd ./cmd/
+ARG GOOS
+ARG GOARCH
+ENV CGO_ENABLED=0 GOOS=${GOOS:-linux} GOARCH=${GOARCH:-amd64}
+RUN LDFLAGS=$(cat ldflags.txt) && \
+    go build -ldflags "${LDFLAGS}" ./cmd/vsphere-csi
+
+################################################################################
+##                               LINT STAGE                                   ##
+################################################################################
+FROM ${GOLANG_IMAGE} as lint
+RUN go get -u golang.org/x/lint/golint
+
+################################################################################
+##                               MAIN STAGE                                   ##
+################################################################################
+FROM ${GOLANG_IMAGE}
+LABEL "maintainer" "Travis Rhoden <trhoden@vmware.com>"
+
+################################################################################
+##                             PACKAGE UPDATES                                ##
+################################################################################
+# Install the dependencies. The list is a union of the dependencies required
+# by the following images:
+#   * https://github.com/kubernetes/test-infra/blob/master/images/bootstrap/Dockerfile
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      git \
+      jq \
+      mercurial \
+      python3 \
+      unzip \
+      zip && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
+    curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 - && \
+    pip3 install setuptools wheel --upgrade
+
+# Download the Google Cloud SDK
+RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-245.0.0-linux-x86_64.tar.gz | \
+    tar xzC / && \
+    /google-cloud-sdk/bin/gcloud components update
+
+################################################################################
+##                             DOCKER-IN-DOCKER                               ##
+################################################################################
+# Again, copied from test-infra's bootstrap image:
+# https://github.com/kubernetes/test-infra/blob/master/images/bootstrap/Dockerfile
+
+# Install Docker deps, some of these are already installed in the image but
+# that's fine since they won't re-install and we can reuse the code below
+# for another image someday.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      apt-transport-https \
+      ca-certificates \
+      curl \
+      gnupg2 \
+      software-properties-common \
+      lsb-release && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
+# Add the Docker apt-repository
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "${ID}")/gpg | apt-key add - && \
+    add-apt-repository \
+      "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "${ID}") \
+      $(lsb_release -cs) stable"
+
+# Install Docker
+# TODO(bentheelder): the `sed` is a bit of a hack, look into alternatives.
+# Why this exists: `docker service start` on debian runs a `cgroupfs_mount` method,
+# We're already inside docker though so we can be sure these are already mounted.
+# Trying to remount these makes for a very noisy error block in the beginning of
+# the pod logs, so we just comment out the call to it... :shrug:
+# TODO(benthelder): update docker version. This is pinned because of
+# https://github.com/kubernetes/test-infra/issues/6187
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce=18.06.* && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
+    sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
+
+# Move Docker's storage location
+RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' | \
+    tee --append /etc/default/docker
+
+# NOTE this should be mounted and persisted as a volume ideally (!)
+# We will make a fallback one now just in case
+RUN mkdir /docker-graph
+
+# Setting this environment variable is an easy way for processes running
+# in the container to know DinD is enabled.
+ENV DOCKER_IN_DOCKER_ENABLED=true
+
+################################################################################
+##                       CONFIGURE GOOGLE CLOUD SDK                           ##
+################################################################################
+# Update the PATH to include the Google Cloud SDK and disable its prompts and
+# update the gcloud components.
+ENV PATH="/google-cloud-sdk/bin:${PATH}" CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+################################################################################
+##                             INSTALL LINT                                   ##
+################################################################################
+COPY --from=lint /go/bin/golint /usr/local/bin/
+
+################################################################################
+##                         PRIME GO MOD & BUILD CACHES                        ##
+################################################################################
+COPY --from=mod-cache   /go/pkg/mod           /go/pkg/mod/
+COPY --from=build-cache /root/.cache/go-build /root/.cache/go-build/
+RUN  mkdir -p /home/prow/go/pkg && ln -s /go/pkg/mod /home/prow/go/pkg/mod
+
+################################################################################
+##                           ADD LOCAL SOURCES                                ##
+################################################################################
+# Copy the sources into the project's traditional Gopath location in the
+# image. It's possible to bind mount up-to-date sources over the ones in
+# the image when the latter is run as a container.
+WORKDIR /go/src/sigs.k8s.io/vsphere-csi-driver/
+COPY . ./

--- a/hack/images/ci/Makefile
+++ b/hack/images/ci/Makefile
@@ -1,0 +1,43 @@
+all: build
+
+include ../../../hack/make/login-to-image-registry.mk
+
+VERSION ?= $(shell git describe --exact-match 2>/dev/null || git describe --match=$$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
+IMAGE := $(REGISTRY)/csi-ci
+IMAGE_D := $(VERSION).d
+
+build: $(IMAGE_D)
+$(IMAGE_D): Dockerfile
+	docker build -t $(IMAGE):$(VERSION) -f $< ../../..
+	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest
+	@touch $@
+
+.PHONY: rebuild
+rebuild: MAKEFLAGS += --always-make
+rebuild:
+	$(MAKE) build
+
+.PHONY: push
+push: $(IMAGE_D) login-to-image-registry
+	docker push $(IMAGE):$(VERSION)
+	docker push $(IMAGE):latest
+
+.PHONY: ls-images
+ls-images:
+	docker images --filter=reference=$(IMAGE):*
+
+.PHONY: clean
+DOCKER_RMI_FLAGS := --no-prune
+clean:
+	rm -f $(IMAGE_D)
+	docker rmi $(DOCKER_RMI_FLAGS) $(IMAGE):$(VERSION) $(IMAGE):latest 2>/dev/null || true
+
+.PHONY: clobber
+clobber: DOCKER_RMI_FLAGS :=
+clobber: clean
+	rm -f *.d
+	docker rmi $$(docker images -qf reference=$(IMAGE):*) 2>/dev/null || true
+
+.PHONY: print
+print:
+	@echo $(IMAGE):$(VERSION)

--- a/hack/images/ci/README.md
+++ b/hack/images/ci/README.md
@@ -1,0 +1,111 @@
+# Continuous integration
+
+The image `gcr.io/cloud-provider-vsphere/csi-ci` is used by Prow jobs to build, test, and deploy the CSI provider.
+
+## The CI workflow
+
+Prow jobs are configured to perform the following steps:
+
+| Job type | Linters | Build binaries | Unit test | Build images | Integration test | Deploy images | Conformance test |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Presubmit | ✓ | ✓ | ✓ | ✓ | | | |
+| Postsubmit | ✓ | ✓ | ✓ | ✓ | | ✓ | |
+
+## Up-to-date sources
+
+When running on Prow the jobs map the current sources into the CI container. That may be simulated locally by running the examples from a directory containing the desired sources and providing the `docker run` command with the following flags:
+
+* `-v "$(pwd)":/go/src/sigs.k8s.io/vsphere-csi-driver`
+
+## Docker-in-Docker
+
+Several of the jobs require Docker-in-Docker. To mimic that locally there are two options:
+
+1. [Provide the host's Docker to the container](#provide-the-hosts-docker-to-the-container)
+2. [Run the Docker server inside the container](#run-the-docker-server-inside-the-container)
+
+### Provide the host's Docker to the container
+
+While Prow jobs [run the Docker server inside the container](#run-the-docker-server-inside-the-container), this option provides a low-cost (memory, disk) solution for testing locally. This option is enabled by running the examples from a directory containing the desired sources and providing the `docker run` command with the following flags:
+
+* `-v /var/run/docker.sock:/var/run/docker.sock`
+* `-v "$(pwd)":/go/src/sigs.k8s.io/vsphere-csi-driver`
+
+Please note that this option is only available when using a local copy of the sources. This is because all of the paths known to Docker will be of the local host system, not from the container.
+
+### Run the Docker server inside the container
+This is option that Prow jobs utilize and is also the method illustrated by the examples below. Please keep in mind that using this option locally requires a large amount of memory and disk space available to Docker:
+
+| Type | Minimum Requirement |
+|------|---------------------|
+| Memory | 8GiB |
+| Disk | 200GiB |
+
+For Windows and macOS systems this means adjusting the size of the Docker VM disk and the amount of memory the Docker VM is allowed to use.
+
+Resources notwithstanding, running the Docker server inside the container also requires providing the `docker run` command with the following flags:
+
+* `--privileged`
+
+## Check the sources
+
+To check the sources run the following command:
+
+```shell
+$ docker run -it --rm \
+  -e "ARTIFACTS=/out" -v "$(pwd)":/out \
+  -v "$(pwd)":/go/src/sigs.k8s.io/vsphere-csi-driver \
+  gcr.io/cloud-provider-vsphere/csi-ci \
+  make check
+```
+
+The above command will create the following files in the working directory:
+
+* `junit_check.xml`
+
+## Build the CSI binary
+
+The CI image is built with Go module and build caches from a recent build of the project's `master` branch. Therefore the CI image can be used to build the CSI binary in a matter of seconds:
+
+```shell
+$ docker run -it --rm \
+  -e "BIN_OUT=/out" -v "$(pwd)":/out \
+  -v "$(pwd)":/go/src/sigs.k8s.io/vsphere-csi-driver \
+  gcr.io/cloud-provider-vsphere/csi-ci \
+  make build
+```
+
+The above command will create the following files in the working directory:
+
+* `vsphere-csi.linux_amd64`
+
+## Execute the unit tests
+
+```shell
+$ docker run -it --rm \
+  -v "$(pwd)":/go/src/sigs.k8s.io/vsphere-csi-driver \
+  gcr.io/cloud-provider-vsphere/csi-ci \
+  make unit-test
+```
+
+## Build the CSI image
+
+Building the CSI image inside another image requires Docker-in-Docker (DinD):
+
+```shell
+$ docker run -it --rm --privileged \
+  -v "$(pwd)":/go/src/sigs.k8s.io/vsphere-csi-driver \
+  gcr.io/cloud-provider-vsphere/csi-ci \
+  make build-images
+```
+
+## Deploy the CSI image
+Pushing the images requires bind mounting a GCR key file into the container and setting the environment variable `GCR_KEY_FILE` to inform the deployment process the location of the key file:
+
+```shell
+$ docker run -it --rm --privileged \
+  -v "$(pwd)":/go/src/sigs.k8s.io/vsphere-csi-driver \
+  -e "GCR_KEY_FILE=/keyfile.json" -v "$(pwd)/keyfile.json":/keyfile.json \
+  gcr.io/cloud-provider-vsphere/csi-ci \
+  make push-images
+```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Inspired by the testing ci image found in the vsphere CCM,
this patch adds a CSI specific CI image used for building and testing.
This image can then be used by Prow and local devs for fast builds.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Once this is in, we can update the Prow jobs to point to `gcr.io/cloud-provider-vsphere/csi-ci` image instead of the `ci` image. This image is almost identical to the previous one, but will diverge over time as the go mod caches for the two projects diverge. Also, this image removes KIND and sk8 at the moment so they are unused. That reduces image size by ~500M.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
