### PR TITLE
Deploy controller-related components on master nodes only

### DIFF
--- a/manifests/1.13/vsphere-csi-controller-ss.yaml
+++ b/manifests/1.13/vsphere-csi-controller-ss.yaml
@@ -14,6 +14,14 @@ spec:
         role: vsphere-csi
     spec:
       serviceAccount: vsphere-csi-controller
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v1.0.1

--- a/manifests/1.14/deploy/vsphere-csi-attacher.yaml
+++ b/manifests/1.14/deploy/vsphere-csi-attacher.yaml
@@ -14,6 +14,14 @@ spec:
       labels:
         app: vsphere-csi-attacher
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml
+++ b/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml
@@ -16,6 +16,14 @@ spec:
         role: vsphere-csi
     spec:
       serviceAccount: vsphere-csi-controller
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - name: vsphere-csi-controller
           image: gcr.io/cloud-provider-vsphere/vsphere-csi:latest

--- a/manifests/1.14/deploy/vsphere-csi-provisioner.yaml
+++ b/manifests/1.14/deploy/vsphere-csi-provisioner.yaml
@@ -14,6 +14,14 @@ spec:
       labels:
         app: vsphere-csi-provisioner
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the YAML such that the controller, attacher and provisioner components are only deployed to master nodes. This mimics the CCM behavior because since these components control key/important functionality to create/delete and attach/detach volumes from pods, these components need to be placed on highly available infrastructure and not placed on typical worker nodes. This solves the problem of these components landing on worker nodes only to have that worker node shutdown and no longer being able to field detach requests.

**Which issue this PR fixes**:
Does not fix, but helps to address this issue: https://github.com/kubernetes/cloud-provider-vsphere/issues/185

**Special notes for your reviewer**:
NA

**Release note**:
NA