### PR TITLE
Address clean up of files on node crash

### DIFF
--- a/pkg/csi/service/fcd/controller.go
+++ b/pkg/csi/service/fcd/controller.go
@@ -336,7 +336,7 @@ func (c *controller) ControllerPublishVolume(
 		return nil, err
 	}
 
-	log.Infof("AttachDisk(%s) succeeded with UUID: %s", filePath, diskUUID)
+	log.Infof("AttachDisk(%s) succeeded with: VolID=%s UUID=%s", filePath, req.VolumeId, diskUUID)
 
 	publishInfo := make(map[string]string, 0)
 	publishInfo[AttributeFirstClassDiskType] = FirstClassDiskTypeString
@@ -396,6 +396,8 @@ func (c *controller) ControllerUnpublishVolume(
 		log.Errorf("DetachDisk(%s = %s) failed. Err: %v", fcd.Config.Name, filePath, err)
 		return nil, err
 	}
+
+	log.Infof("DetachDisk(%s) succeeded with: VolID=%s", filePath, req.VolumeId)
 
 	resp := &csi.ControllerUnpublishVolumeResponse{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
On a node/VM crash, the csi.sock file is left behind and does not clean up in the current model. This is mainly due to the postStop in the lifecycle not executing because the node is down. Needs to be done on both the controller and node modes.

**Which issue this PR fixes**:
Does not fix, but helps to address this issue:
https://github.com/kubernetes/cloud-provider-vsphere/issues/185
https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/15

**Special notes for your reviewer**:
Tested on 6.7u2

**Release note**:
NA