### PR TITLE
add order-only pre-req for make deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ dist: dist-csi-tgz dist-csi-zip
 ################################################################################
 # The deploy target is for use by Prow.
 .PHONY: deploy
-deploy:
+deploy: | $(DOCKER_SOCK)
 	$(MAKE) check
 	$(MAKE) build-bins
 	$(MAKE) unit-test


### PR DESCRIPTION
it's being skipped when recursing

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The post-submit job on Prow that builds and publishes images to gcr.io has not been working. @yastij found this fix for CCM and submitted the fix here: https://github.com/kubernetes/cloud-provider-vsphere/pull/195. This repo needs the same.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
