### PR TITLE
Fix for klog.V(X) log lines not printing when klog and glog are mixed.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/onsi/gomega v1.4.3
 	github.com/rexray/gocsi v0.4.1-0.20181205192803-207653674028
 	github.com/sirupsen/logrus v1.4.1
+	github.com/spf13/pflag v1.0.2
 	github.com/vmware/govmomi v0.20.0
 	golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
Same fix as in CCM: https://github.com/kubernetes/cloud-provider-vsphere/pull/211

Copied from CCM PR:
Addresses yet another issue when using klog and sub or vendored components using glog. This was affecting when klog.V(X) log entries would not appear. As in the example below, the ORG line would not print in the logs, but the NEW line would.

```
klog.V(2).Infof("ORG VM=%s IsActive=%t", uid, active)
klog.Infof("NEW VM=%s IsActive=%t", uid, active)
```

Verified fix on 1.114.1 and 1.13.7.

**Which issue this PR fixes**:
NA

**Special notes for your reviewer**:
Used openstack CCM as a basis for comparison.

**Release note**:
Does not affect user documentation or user interaction
