### PR TITLE
Update yaml and docs to use stringdata for secrets

### DIFF
--- a/docs/deploying_csi_vsphere_with_rbac.md
+++ b/docs/deploying_csi_vsphere_with_rbac.md
@@ -69,11 +69,11 @@ kind: Secret
 metadata:
   name: vcsi
   namespace: kube-system
-data:
-  1.2.3.4.username: "Replace with output from `echo -n YOUR_VCENTER_USERNAME | base64`"
-  1.2.3.4.password: "Replace with output from `echo -n YOUR_VCENTER_PASSWORD | base64`"
-  10.0.0.1.username: "Replace with output from `echo -n YOUR_VCENTER_USERNAME | base64`"
-  10.0.0.1.password: "Replace with output from `echo -n YOUR_VCENTER_PASSWORD | base64`"
+stringData:
+  1.2.3.4.username: "<YOUR_VCENTER_USERNAME>"
+  1.2.3.4.password: "<YOUR_VCENTER_PASSWORD>"
+  10.0.0.1.username: "<YOUR_VCENTER_USERNAME>"
+  10.0.0.1.password: "<YOUR_VCENTER_PASSWORD>"
 ```
 
 Create the secret by running the following command:

--- a/manifests/vcsi-secret.yaml
+++ b/manifests/vcsi-secret.yaml
@@ -3,6 +3,6 @@ kind: Secret
 metadata:
   name: vcsi
   namespace: kube-system
-data:
-  1.2.3.4.username: "Replace with output from `echo -n YOUR_VCENTER_USERNAME | base64`"
-  1.2.3.4.password: "Replace with output from `echo -n YOUR_VCENTER_PASSWORD | base64`"
+stringData:
+  1.2.3.4.username: "<YOUR_VCENTER_USERNAME>"
+  1.2.3.4.password: "<YOUR_VCENTER_PASSWORD>"


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the CCM and CSI share similarities with some basics like credentials, it makes sense to keep those procedures the same. This updates the yaml and docs to use stringdata in secrets as a preferred method.

This keeps CSI inline with these CCM PRs:
https://github.com/kubernetes/cloud-provider-vsphere/pull/184
https://github.com/kubernetes/cloud-provider-vsphere/pull/213

**Which issue this PR fixes**:
NA

**Special notes for your reviewer**:
The older method will still work, but we are documenting the preferred method for creating a secret

**Release note**:
NA