### PR TITLE
Add script for running shellcheck on scripts

### DIFF
--- a/hack/check-shell.sh
+++ b/hack/check-shell.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+usage() {
+  cat <<EOF
+usage: ${0} [FLAGS]
+  Lints the project's shell scripts.
+
+FLAGS
+  -d    use the docker image
+  -h    prints this help screen
+EOF
+}
+
+while getopts ':dh' opt; do
+  case "${opt}" in
+  d)
+    DO_DOCKER=1
+    ;;
+  h)
+    usage 1>&2; exit 1
+    ;;
+  \?)
+    { echo "invalid option: -${OPTARG}"; usage; } 1>&2; exit 1
+    ;;
+  :)
+    echo "option -${OPTARG} requires an argument" 1>&2; exit 1
+    ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ ! "${DO_DOCKER-}" ] && command -v shellcheck >/dev/null 2>&1; then
+  find . -path ./vendor -prune -o -name "*.*sh" -type f -print0 | xargs -0 shellcheck
+else
+  docker run --rm -t -v "$(pwd)":/build:ro gcr.io/cluster-api-provider-vsphere/extra/shellcheck
+fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
I'm porting over a bunch of the improvements made in the CAPV repo. Individual scripts for checking various parts of the project, that can be test by Prow only when certain file types change.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I've run this check against the repo already and nothing failed, so we won't get any new test failures when this is added to Prow.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
