### PR TITLE
Update vSphere CPI dependency to v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/akutz/gofsutil v0.1.2
+	github.com/akutz/gosync v0.1.0 // indirect
 	github.com/akutz/memconn v0.1.0
 	github.com/container-storage-interface/spec v1.0.0
 	github.com/google/btree v1.0.0 // indirect
@@ -14,6 +15,8 @@ require (
 	github.com/onsi/gomega v1.4.3
 	github.com/rexray/gocsi v0.4.1-0.20181205192803-207653674028
 	github.com/sirupsen/logrus v1.4.1
+	github.com/thecodeteam/gofsutil v0.1.2 // indirect
+	github.com/thecodeteam/gosync v0.1.0 // indirect
 	github.com/vmware/govmomi v0.20.0
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
@@ -22,7 +25,8 @@ require (
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	google.golang.org/grpc v1.19.0
-	k8s.io/cloud-provider-vsphere v0.1.2-0.20190402145035-39e2b5e81d7e
+	k8s.io/cloud-provider-vsphere v0.2.1
 	k8s.io/klog v0.2.0
 	k8s.io/kubernetes v1.11.2
+	k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ k8s.io/apiserver v0.0.0-20180628044425-01459b68eb5f h1:eCb6E7epnzes186KGtXgA3PE2
 k8s.io/apiserver v0.0.0-20180628044425-01459b68eb5f/go.mod h1:6bqaTSOSJavUIXUtfaR9Os9JtTCm8ZqH2SUl2S60C4w=
 k8s.io/client-go v8.0.0+incompatible h1:tTI4hRmb1DRMl4fG6Vclfdi6nTM82oIrTT7HfitmxC4=
 k8s.io/client-go v8.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
-k8s.io/cloud-provider-vsphere v0.1.2-0.20190402145035-39e2b5e81d7e h1:mb1OpiTZTSahRKnhFFVwISXbbESr3VJFnG8CXmtQvfY=
-k8s.io/cloud-provider-vsphere v0.1.2-0.20190402145035-39e2b5e81d7e/go.mod h1:H0DXrMTFWrD4JruuGY/3HO0HFf3caYStPl/5FNtcSvM=
+k8s.io/cloud-provider-vsphere v0.2.1 h1:5BFHbfPAlLLYG0W+qFP63vsDM1dmcQZloFXQGX19oKc=
+k8s.io/cloud-provider-vsphere v0.2.1/go.mod h1:NFJuq0wgbjt3jErnuYKg8bDHa9eI5hPzMg798WGS41w=
 k8s.io/klog v0.2.0 h1:0ElL0OHzF3N+OhoJTL0uca20SxtYt4X4+bzHeqrB83c=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c h1:3KSCztE7gPitlZmWbNwue/2U0YruD65DqX3INopDAQM=


### PR DESCRIPTION


**What this PR does / why we need it**:
The latest vSphere Cloud Provider has efficiency improvements related to
zone support that the CSI plugin can benefit from.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
The `go.mod` changes are from running `go mod tidy`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
