### PR TITLE
Fix docker login before pushing images

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -34,7 +34,6 @@ readonly CSI_IMAGE_PR=${BASE_IMAGE_REPO}/csi/pr/driver
 # CI images
 readonly CSI_IMAGE_CI=${BASE_IMAGE_REPO}/csi/ci/driver
 
-AUTH=
 PUSH=
 LATEST=
 CSI_IMAGE_NAME=
@@ -109,18 +108,10 @@ function build_images() {
   fi
 }
 
-function logout() {
-  if [ "${AUTH}" ]; then
-    gcloud auth revoke
-  fi
-}
-
 function login() {
   # If GCR_KEY_FILE is set, use that service account to login
   if [ "${GCR_KEY_FILE}" ]; then
-    trap logout EXIT
-    gcloud auth activate-service-account --key-file "${GCR_KEY_FILE}" || fatal "unable to login"
-    AUTH=1
+    docker login -u _json_key --password-stdin https://gcr.io <"${GCR_KEY_FILE}" || fatal "unable to login"
   fi
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The previous script was just using `gcloud auth` to login, but that's only needed if we are using `gsutil` to push binaries, which we are not doing for CSI. So instead we just need the `docker login` command.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

/assign @dvonthenen 