### PR TITLE
Inject version to CSI binary for docker image

### DIFF
--- a/cluster/images/csi/Dockerfile
+++ b/cluster/images/csi/Dockerfile
@@ -7,6 +7,9 @@ ARG GOLANG_IMAGE=golang:1.12.6
 # This build arg allows the specification of a custom Photon image.
 ARG PHOTON_IMAGE=photon:2.0
 
+# This build arg is the version to embed in the CSI binary
+ARG VERSION=unknown
+
 ################################################################################
 ##                              BUILD STAGE                                   ##
 ################################################################################
@@ -18,7 +21,7 @@ COPY go.mod go.sum ./
 COPY pkg/    pkg/
 COPY cmd/    cmd/
 ENV CGO_ENABLED=0
-RUN go build -a -ldflags='-w -s -extldflags="static"' -o vsphere-csi ./cmd/vsphere-csi
+RUN go build -a -ldflags='-w -s -extldflags=static -X main.version=${VERSION}' -o vsphere-csi ./cmd/vsphere-csi
 
 ################################################################################
 ##                               MAIN STAGE                                   ##

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -101,6 +101,7 @@ function build_images() {
   docker build \
     -f cluster/images/csi/Dockerfile \
     -t "${CSI_IMAGE_NAME}":"${VERSION}" \
+    --build-arg "VERSION=${VERSION}" \
     .
   if [ "${LATEST}" ]; then
     echo "tagging image ${CSI_IMAGE_NAME}:${VERSION} as latest"


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When updating how the docker image was created, specifying the version
during the binary build was mistakenly left out.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I noticed that I had missed doing this when I was adding the same tooling for CPI.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

/assign @dvonthenen 