### PR TITLE
Honor GOPROXY for docker-in-docker builds.

### DIFF
--- a/cluster/images/csi/Dockerfile
+++ b/cluster/images/csi/Dockerfile
@@ -7,20 +7,25 @@ ARG GOLANG_IMAGE=golang:1.12.6
 # This build arg allows the specification of a custom Photon image.
 ARG PHOTON_IMAGE=photon:2.0
 
-# This build arg is the version to embed in the CSI binary
-ARG VERSION=unknown
-
 ################################################################################
 ##                              BUILD STAGE                                   ##
 ################################################################################
 # Build the manager as a statically compiled binary so it has no dependencies
 # libc, muscl, etc.
 FROM ${GOLANG_IMAGE} as builder
+
+# This build arg is the version to embed in the CSI binary
+ARG VERSION=unknown
+
+# This build arg controls the GOPROXY setting
+ARG GOPROXY
+
 WORKDIR /build
 COPY go.mod go.sum ./
 COPY pkg/    pkg/
 COPY cmd/    cmd/
 ENV CGO_ENABLED=0
+ENV GOPROXY ${GOPROXY:-}
 RUN go build -a -ldflags='-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.version=${VERSION}' -o vsphere-csi ./cmd/vsphere-csi
 
 ################################################################################

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -39,8 +39,8 @@ LATEST=
 CSI_IMAGE_NAME=
 VERSION=$(git describe --dirty --always 2>/dev/null)
 GCR_KEY_FILE="${GCR_KEY_FILE:-}"
-
-BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE-}"
+GOPROXY="${GOPROXY:-}"
+BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 
 # If BUILD_RELEASE_TYPE is not set then check to see if this is a PR
 # or release build. This may still be overridden below with the "-t" flag.
@@ -56,6 +56,11 @@ USAGE="
 usage: ${0} [FLAGS]
   Builds and optionally pushes new images for vSphere CSI driver
 
+  Honored environment variables:
+  GCR_KEY_FILE
+  GOPROXY
+  BUILD_RELEASE_TYPE
+
 FLAGS
   -h    show this help and exit
   -k    path to GCR key file. Used to login to registry if specified
@@ -63,7 +68,7 @@ FLAGS
   -l    tag the images as \"latest\" in addition to their version
         when used with -p, both tags will be pushed
   -p    push the images to the public container registry
-  -t    the build/release type (defaults to ${BUILD_RELEASE_TYPE})
+  -t    the build/release type (defaults to: ${BUILD_RELEASE_TYPE})
         one of [ci,pr,release]
 "
 
@@ -98,10 +103,12 @@ function build_images() {
   esac
 
   echo "building ${CSI_IMAGE_NAME}:${VERSION}"
+  echo "GOPROXY=${GOPROXY}"
   docker build \
     -f cluster/images/csi/Dockerfile \
     -t "${CSI_IMAGE_NAME}":"${VERSION}" \
     --build-arg "VERSION=${VERSION}" \
+    --build-arg "GOPROXY=${GOPROXY}" \
     .
   if [ "${LATEST}" ]; then
     echo "tagging image ${CSI_IMAGE_NAME}:${VERSION} as latest"


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Prow recently started setting GOPROXY for all its jobs by default. This
speeds up builds, but does not appy when using docker-in-docker. For our
jobs that build things in Docker, we need to supply GOPROXY ourselves.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This is a first attempt at this. Need to see the test output to see if it's working. If it is, builds should be considerably faster.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
