### PR TITLE
Make building of ci/base images similar

### DIFF
--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -1,9 +1,23 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ################################################################################
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.12
+ARG GOLANG_IMAGE=golang:1.12.6
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##

--- a/images/ci/Makefile
+++ b/images/ci/Makefile
@@ -1,41 +1,42 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 all: build
 
 include ../../hack/make/login-to-image-registry.mk
 
 VERSION ?= $(shell git describe --always --dirty)
 IMAGE := $(REGISTRY)/csi-ci
-IMAGE_D := $(VERSION).d
 
-build: $(IMAGE_D)
-$(IMAGE_D): Dockerfile
-	docker build -t $(IMAGE):$(VERSION) -f $< ../../..
+.PHONY: build
+build:
+	docker build -t $(IMAGE):$(VERSION) -f Dockerfile ../..
 	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest
-	@touch $@
-
-.PHONY: rebuild
-rebuild: MAKEFLAGS += --always-make
-rebuild:
-	$(MAKE) build
 
 .PHONY: push
-push: $(IMAGE_D) login-to-image-registry
+push: login-to-image-registry
 	docker push $(IMAGE):$(VERSION)
 	docker push $(IMAGE):latest
-
-.PHONY: ls-images
-ls-images:
-	docker images --filter=reference=$(IMAGE):*
 
 .PHONY: clean
 DOCKER_RMI_FLAGS := --no-prune
 clean:
-	rm -f $(IMAGE_D)
 	docker rmi $(DOCKER_RMI_FLAGS) $(IMAGE):$(VERSION) $(IMAGE):latest 2>/dev/null || true
 
 .PHONY: clobber
 clobber: DOCKER_RMI_FLAGS :=
 clobber: clean
-	rm -f *.d
 	docker rmi $$(docker images -qf reference=$(IMAGE):*) 2>/dev/null || true
 
 .PHONY: print

--- a/images/driver-base/Dockerfile
+++ b/images/driver-base/Dockerfile
@@ -1,4 +1,3 @@
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/images/driver-base/Makefile
+++ b/images/driver-base/Makefile
@@ -14,8 +14,10 @@
 
 all: build
 
+include ../../hack/make/login-to-image-registry.mk
+
 VERSION ?= $(shell git describe --always --dirty)
-IMAGE_NAME ?= gcr.io/cloud-provider-vsphere/extra/csi-driver-base
+IMAGE_NAME ?= $(REGISTRY)/extra/csi-driver-base
 IMAGE_TAG ?= $(IMAGE_NAME):$(VERSION)
 
 build:
@@ -23,7 +25,21 @@ build:
 	docker tag $(IMAGE_TAG) $(IMAGE_NAME):latest
 .PHONY: build
 
-push:
+push: login-to-image-registry
 	docker push $(IMAGE_TAG)
 	docker push $(IMAGE_NAME):latest
 .PHONY: push
+
+.PHONY: clean
+DOCKER_RMI_FLAGS := --no-prune
+clean:
+	docker rmi $(DOCKER_RMI_FLAGS) $(IMAGE_TAG) $(IMAGE_NAME):latest 2>/dev/null || true
+
+.PHONY: clobber
+clobber: DOCKER_RMI_FLAGS :=
+clobber: clean
+	docker rmi $$(docker images -qf reference=$(IMAGE_NAME):*) 2>/dev/null || true
+
+.PHONY: print
+print:
+	@echo $(IMAGE_TAG)

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ################################################################################
 ##                               BUILD ARGS                                   ##
 ################################################################################


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The Makefiles for the CI and base images were wildly different. This
patch has them take a common approach. The .d marker files for the ci
image are gone -- they aren't really necessary, and I'd rather rely on
the Docker cache anyways.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
/assign @dvonthenen 

I need to evaluate if the "CI" image is being used properly. We haven't updated it in a while, and anywhere it is being used isn't getting the benefit from it anymore since the mod and build caches are so out of date. But I at least wanted to clean things up to put the repo in a good state.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
