### PR TITLE
Add a staticcheck verify script and fix errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,18 +219,26 @@ cover: test
 ################################################################################
 ##                                 LINTING                                    ##
 ################################################################################
-.PHONY: fmt vet lint
+.PHONY: check fmt lint mdlint shellcheck vet
+check: fmt lint mdlint shellcheck staticcheck vet
+
 fmt:
 	hack/check-format.sh
-
-vet:
-	hack/check-vet.sh
 
 lint:
 	hack/check-lint.sh
 
-.PHONY: check
-check: fmt vet lint
+mdlint:
+	hack/check-mdlint.sh
+
+shellcheck:
+	hack/check-shell.sh
+
+staticcheck:
+	hack/check-staticcheck.sh
+
+vet:
+	hack/check-vet.sh
 
 ################################################################################
 ##                                 BUILD IMAGES                               ##

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	golang.org/x/tools v0.0.0-20190827205025-b29f5f60c37a // indirect
 	google.golang.org/grpc v1.19.0
 	gopkg.in/gcfg.v1 v1.2.3
+	honnef.co/go/tools v0.0.1-2019.2.2 // indirect
 	k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d
 	k8s.io/client-go v8.0.0+incompatible
 	k8s.io/cloud-provider-vsphere v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 bitbucket.org/ww/goautoneg v0.0.0-20120707110453-75cd24fc2f2c/go.mod h1:1vhO7Mn/FZMgOgDVGLy5X1mE6rq1HbkBdkF/yj8zkcg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/NYTimes/gziphandler v1.0.1/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -60,6 +61,7 @@ github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
+github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v0.0.0-20170306145142-6a5e28554805/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
@@ -87,6 +89,7 @@ github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -125,6 +128,7 @@ github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R
 github.com/rexray/gocsi v0.4.1-0.20181205192803-207653674028 h1:p4doTC3oVqECi6zAMj8lyzACz3l3RDw3yLjl8PjQa2c=
 github.com/rexray/gocsi v0.4.1-0.20181205192803-207653674028/go.mod h1:Ch1UhJqwcHZh8nqd003s/Brs0mzHm1T9vbDjFWl+mUE=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -161,6 +165,7 @@ go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 h1:7KByu05hhLed2MO29w7p1XfZvZ13m8mub3shuVftRs0=
@@ -169,6 +174,7 @@ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 h1:x/bBzNauLQAlE3fLku/xy92Y
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422 h1:QzoH/1pFpZguR8NrRHLcO6jKqfv2zpuSqZLgdm7ZmjI=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -208,6 +214,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b h1:qMK98NmNCRVDIYFycQ5yVRkvgDUFfdP8Ip4KqmDEB7g=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190827152308-062dbaebb618 h1:WtF22n/HcPWMhvZm4KWiQ0FcC1m8kk5ILpXYtY+qN7s=
 golang.org/x/tools v0.0.0-20190827152308-062dbaebb618/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190827205025-b29f5f60c37a h1:0JEq5ZQ3TgsRlFmz4BcD+E6U6cOk4pOImCQSyIG59ZM=
@@ -221,6 +228,7 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3 h1:m8OOJ4ccYHnx2f4gQwpno8nAX5OGOh7RLaaz0pj3Ogs=
@@ -239,6 +247,8 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.1-2019.2.2 h1:TEgegKbBqByGUb1Coo1pc2qIdf2xw6v0mYyLSYtyopE=
+honnef.co/go/tools v0.0.1-2019.2.2/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 k8s.io/api v0.0.0-20180628040859-072894a440bd h1:HzgYeLDS1jLxw8DGr68KJh9cdQ5iZJizG0HZWstIhfQ=
 k8s.io/api v0.0.0-20180628040859-072894a440bd/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apiextensions-apiserver v0.0.0-20180822171001-b12c11a9bd71 h1:3RyNt0n316gIniUn9maY3W0soge8YzBB1DPV0eQHTVU=

--- a/hack/check-format.sh
+++ b/hack/check-format.sh
@@ -41,7 +41,7 @@ goformat_exit_code=0; test -z "$(head -n 1 "${out}")" || goformat_exit_code=1
 rm -f "${out}" && touch "${out}"
 
 # Run goimports on all the sources.
-go get -u golang.org/x/tools/cmd/goimports
+go get golang.org/x/tools/cmd/goimports
 cmd=$(go list -f \{\{\.Target\}\} golang.org/x/tools/cmd/goimports)
 flags="-e -w"
 [ -z "${PROW_JOB_ID-}" ] || flags="-d ${flags}"

--- a/hack/check-staticcheck.sh
+++ b/hack/check-staticcheck.sh
@@ -22,8 +22,8 @@ set -o pipefail
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-go get golang.org/x/lint/golint
+go get honnef.co/go/tools/cmd/staticcheck
 
-CMD=$(go list -f \{\{\.Target\}\} golang.org/x/lint/golint)
+CHECKS="all,-ST1*"
 
-"${CMD}" -set_exit_status ./pkg/... ./cmd/...
+staticcheck -checks "${CHECKS}" ./...

--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -189,7 +189,6 @@ func (m *nodeManager) GetAllNodes() ([]*vsphere.VirtualMachine, error) {
 			}
 			if k8snodeUUID == "" {
 				klog.Errorf("Node: %q with empty providerId found in the cluster. aborting get all nodes", nodeName)
-				err = ErrEmptyProviderID
 				return true
 			}
 			m.nodeNameToUUID.Store(nodeName, k8snodeUUID)

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -131,10 +131,7 @@ func CompareKubernetesMetadata(pvMetaData *cnstypes.CnsKubernetesEntityMetadata,
 		return false
 	}
 	labelsMatch := reflect.DeepEqual(GetLabelsMapFromKeyValue(pvMetaData.Labels), GetLabelsMapFromKeyValue(cnsMetaData.Labels))
-	if !labelsMatch {
-		return false
-	}
-	return true
+	return labelsMatch
 }
 
 // Signer decodes the certificate and private key and returns SAML token needed for authentication

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -233,7 +233,6 @@ func validateConfig(cfg *Config) error {
 		}
 		insecure := vcConfig.InsecureFlag
 		if !insecure {
-			insecure = cfg.Global.InsecureFlag
 			vcConfig.InsecureFlag = cfg.Global.InsecureFlag
 		}
 	}

--- a/pkg/csi/service/fcd/controller.go
+++ b/pkg/csi/service/fcd/controller.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -45,10 +44,6 @@ import (
 type controller struct {
 	cfg     *vcfg.Config
 	connMgr *cm.ConnectionManager
-}
-
-func noResyncPeriodFunc() time.Duration {
-	return 0
 }
 
 // New creates a FCD controller
@@ -338,7 +333,7 @@ func (c *controller) ControllerPublishVolume(
 
 	log.Infof("AttachDisk(%s) succeeded with: VolID=%s UUID=%s", filePath, req.VolumeId, diskUUID)
 
-	publishInfo := make(map[string]string, 0)
+	publishInfo := make(map[string]string)
 	publishInfo[AttributeFirstClassDiskType] = FirstClassDiskTypeString
 	publishInfo[AttributeFirstClassDiskVcenter] = discoveryInfo.VcServer
 	publishInfo[AttributeFirstClassDiskDatacenter] = discoveryInfo.DataCenter.Name()

--- a/pkg/csi/service/fcd/controller_test.go
+++ b/pkg/csi/service/fcd/controller_test.go
@@ -148,7 +148,7 @@ func TestCompleteControllerFlow(t *testing.T) {
 	}
 
 	//create
-	params := make(map[string]string, 0)
+	params := make(map[string]string)
 	params[AttributeFirstClassDiskParentType] = string(vclib.TypeDatastore)
 	params[AttributeFirstClassDiskParentName] = myds.Name
 
@@ -253,7 +253,7 @@ func TestListBoundaries(t *testing.T) {
 	}
 
 	//create
-	params := make(map[string]string, 0)
+	params := make(map[string]string)
 	params[AttributeFirstClassDiskParentType] = string(vclib.TypeDatastore)
 	params[AttributeFirstClassDiskParentName] = myds.Name
 
@@ -393,7 +393,7 @@ func TestListOrder(t *testing.T) {
 	}
 
 	//create
-	params := make(map[string]string, 0)
+	params := make(map[string]string)
 	params[AttributeFirstClassDiskParentType] = string(vclib.TypeDatastore)
 	params[AttributeFirstClassDiskParentName] = myds.Name
 
@@ -618,7 +618,7 @@ func TestZoneSupport(t *testing.T) {
 	 */
 
 	//create
-	params := make(map[string]string, 0)
+	params := make(map[string]string)
 	params[AttributeFirstClassDiskParentType] = string(vclib.TypeDatastore)
 	params[AttributeFirstClassDiskParentName] = datastoreName
 
@@ -635,7 +635,7 @@ func TestZoneSupport(t *testing.T) {
 
 	// Target the eastern zone
 	topology := &csi.Topology{
-		Segments: make(map[string]string, 0),
+		Segments: make(map[string]string),
 	}
 	topology.Segments[LabelZoneRegion] = "k8s-region-US"
 	topology.Segments[LabelZoneFailureDomain] = "k8s-zone-US-east"

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -718,17 +717,6 @@ func getDevMounts(
 		}
 	}
 	return devMnts, nil
-}
-
-func getSystemUUID() (string, error) {
-	idb, err := ioutil.ReadFile(path.Join(dmiDir, "id", "product_uuid"))
-	if err != nil {
-		return "", err
-	}
-
-	id := strings.TrimSpace(string(idb))
-
-	return convertUUID(id), nil
 }
 
 func getDiskID(volID string, pubCtx map[string]string) (string, error) {

--- a/pkg/csi/testing/plugin_startup_test.go
+++ b/pkg/csi/testing/plugin_startup_test.go
@@ -19,7 +19,6 @@ package test
 import (
 	"context"
 	"net"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -152,7 +151,7 @@ func getPipedClient(ctx context.Context, sp gocsi.StoragePluginProvider) (*grpc.
 
 	clientOpts := []grpc.DialOption{
 		grpc.WithInsecure(),
-		grpc.WithDialer(func(string, time.Duration) (net.Conn, error) {
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 			return memconn.Dial("memu", "csi-vsphere-test")
 		}),
 	}


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
I figured since k/k now has support for running staticcheck, we should do it on our projects.

This patch adds a hack/verify-staticcheck.sh script, adds a Makefile
target for "make staticcheck", and fixes the errors found.

A couple of the other check scripts (format, lint) or modified to no
longer use `GO111MODULE=off` when they "go get" the needed tools. That
was there before to avoid having `go.mod` change when running the
scripts, but instead this patch just allows in the needed changes to
go.mod and the correct version should be installed every time. no need
to fight the tool. The `go get` commands are still needed in the
scripts, however, even if a `go mod download` has been done, because the
download won't install the tool, but `go get` will.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
The initial errors found were:

```
pkg/csi/service/fcd/controller.go:50:6: func noResyncPeriodFunc is unused (U1000)
pkg/csi/service/fcd/controller.go:341:41: should use make(map[string]string) instead (S1019)
pkg/csi/service/fcd/controller_test.go:151:36: should use make(map[string]string) instead (S1019)
pkg/csi/service/fcd/controller_test.go:256:36: should use make(map[string]string) instead (S1019)
pkg/csi/service/fcd/controller_test.go:396:36: should use make(map[string]string) instead (S1019)
pkg/csi/service/fcd/controller_test.go:621:36: should use make(map[string]string) instead (S1019)
pkg/csi/service/fcd/controller_test.go:638:37: should use make(map[string]string) instead (S1019)
pkg/csi/service/node.go:723:6: func getSystemUUID is unused (U1000)
pkg/csi/testing/plugin_startup_test.go:155:3: grpc.WithDialer is deprecated: use WithContextDialer instead  (SA1019)
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @dvonthenen 
