### PR TITLE
Fix staticcheck script for CI

### DIFF
--- a/hack/check-staticcheck.sh
+++ b/hack/check-staticcheck.sh
@@ -23,7 +23,8 @@ set -o pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 go get honnef.co/go/tools/cmd/staticcheck
+CMD=$(go list -f \{\{\.Target\}\} honnef.co/go/tools/cmd/staticcheck)
 
 CHECKS="all,-ST1*"
 
-staticcheck -checks "${CHECKS}" ./...
+"${CMD}" -checks "${CHECKS}" ./...


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
After installing the staticcheck binary, the binary location may not be
in PATH, so look up the exact location and call it explicitly. The other
hack/check-* scripts do this already, it was just overlooked.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes logs seen [here](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_vsphere-csi-driver/52/pull-vsphere-csi-driver-verify-staticcheck/1167264123734462466)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/assign @dvonthenen 