### PR TITLE
E2E tests for vsphere CSI driver

### DIFF
--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = ginkgo.Describe("[csi-block-e2e] Basic Static Provisioning", func() {
+	f := framework.NewDefaultFramework("e2e-csistaticprovision")
+
+	var (
+		client              clientset.Interface
+		namespace           string
+		fcdID               string
+		pv                  *v1.PersistentVolume
+		pvc                 *v1.PersistentVolumeClaim
+		defaultDatacenter   *object.Datacenter
+		defaultDatastore    *object.Datastore
+		deleteFCDRequired   bool
+		pandoraSyncWaitTime int
+		err                 error
+		datastoreURL        string
+	)
+
+	ginkgo.BeforeEach(func() {
+		bootstrap()
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		if os.Getenv(envPandoraSyncWaitTime) != "" {
+			pandoraSyncWaitTime, err = strconv.Atoi(os.Getenv(envPandoraSyncWaitTime))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		} else {
+			pandoraSyncWaitTime = defaultPandoraSyncWaitTime
+		}
+		deleteFCDRequired = false
+		var datacenters []string
+		datastoreURL = GetAndExpectStringEnvVar(envSharedDatastoreURL)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		finder := find.NewFinder(e2eVSphere.Client.Client, false)
+		cfg, err := getConfig()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		dcList := strings.Split(cfg.Global.Datacenters, ",")
+		for _, dc := range dcList {
+			dcName := strings.TrimSpace(dc)
+			if dcName != "" {
+				datacenters = append(datacenters, dcName)
+			}
+		}
+
+		for _, dc := range datacenters {
+			defaultDatacenter, err = finder.Datacenter(ctx, dc)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			finder.SetDatacenter(defaultDatacenter)
+			defaultDatastore, err = getDatastoreByURL(ctx, datastoreURL, defaultDatacenter)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	})
+
+	ginkgo.AfterEach(func() {
+		ginkgo.By("Performing test cleanup")
+		if deleteFCDRequired {
+			ginkgo.By(fmt.Sprintf("Deleting FCD: %s", fcdID))
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			err := e2eVSphere.deleteFCD(ctx, fcdID, defaultDatastore.Reference())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		if pvc != nil {
+			framework.ExpectNoError(framework.DeletePersistentVolumeClaim(client, pvc.Name, namespace), "Failed to delete PVC ", pvc.Name)
+		}
+
+		if pv != nil {
+			framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
+			framework.ExpectNoError(e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle))
+		}
+	})
+
+	/*
+		This test verifies the static provisioning workflow.
+
+		Test Steps:
+		1. Create FCD and wait for fcd to allow syncing with pandora.
+		2. Create PV Spec with volumeID set to FCDID created in Step-1, and PersistentVolumeReclaimPolicy is set to Delete.
+		3. Create PVC with the storage request set to PV's storage capacity.
+		4. Wait for PV and PVC to bound.
+		5. Create a POD.
+		6. Verify volume is attached to the node and volume is accessible in the pod.
+		7. Verify container volume metadata is present in CNS cache.
+		8. Delete POD.
+		9. Verify volume is detached from the node.
+		10. Delete PVC.
+		11. Verify PV is deleted automatically.
+	*/
+	ginkgo.It("Verify basic static provisioning workflow", func() {
+		var err error
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ginkgo.By("Creating FCD Disk")
+		fcdID, err := e2eVSphere.createFCD(ctx, "BasicStaticFCD", diskSizeInMb, defaultDatastore.Reference())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		deleteFCDRequired = true
+
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow newly created FCD:%s to sync with pandora", pandoraSyncWaitTime, fcdID))
+		time.Sleep(time.Duration(pandoraSyncWaitTime) * time.Second)
+
+		// Creating label for PV.
+		// PVC will use this label as Selector to find PV
+		staticPVLabels := make(map[string]string)
+		staticPVLabels["fcd-id"] = fcdID
+
+		ginkgo.By("Creating the PV")
+		pv = getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimDelete, staticPVLabels)
+		pv, err = client.CoreV1().PersistentVolumes().Create(pv)
+		if err != nil {
+			return
+		}
+		err = e2eVSphere.waitForCNSVolumeToBeCreated(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Creating the PVC")
+		pvc = getPersistentVolumeClaimSpec(namespace, staticPVLabels, pv.Name)
+		pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(pvc)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Wait for PV and PVC to Bind
+		framework.ExpectNoError(framework.WaitOnPVandPVC(client, namespace, pv, pvc))
+
+		// Set deleteFCDRequired to false.
+		// After PV, PVC is in the bind state, Deleting PVC should delete container volume.
+		// So no need to delete FCD directly using vSphere API call.
+		deleteFCDRequired = false
+
+		ginkgo.By("Verifying CNS entry is present in cache")
+		_, err = e2eVSphere.queryCNSVolumeWithResult(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Creating the Pod")
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaims = append(pvclaims, pvc)
+		pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Verify the volume attached to the node: %s", pod.Spec.NodeName))
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), fmt.Sprintf("Volume is not attached"))
+
+		ginkgo.By("Verify the volume is accessible and available to the pod by creating an empty file")
+		filepath := filepath.Join("/mnt/volume1", "/emptyFile.txt")
+		_, err = framework.LookForStringInPodExec(namespace, pod.Name, []string{"/bin/touch", filepath}, "", time.Minute)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify container volume metadata is present in CNS cache")
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolume with VolumeID: %s", pv.Spec.CSI.VolumeHandle))
+		_, err = e2eVSphere.queryCNSVolumeWithResult(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify container volume metadata is matching the one in CNS cache")
+		err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle, pvc.Name, pv.ObjectMeta.Name, pod.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Deleting the Pod")
+		framework.ExpectNoError(framework.DeletePodWithWait(f, client, pod), "Failed to delete pod ", pod.Name)
+
+		ginkgo.By(fmt.Sprintf("Verify volume is detached from the node: %s", pod.Spec.NodeName))
+		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume is not detached from the node"))
+
+		ginkgo.By("Deleting the PV Claim")
+		framework.ExpectNoError(framework.DeletePersistentVolumeClaim(client, pvc.Name, namespace), "Failed to delete PVC ", pvc.Name)
+		pvc = nil
+
+		ginkgo.By("Verify PV should be deleted automatically")
+		framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
+		pv = nil
+	})
+
+})

--- a/tests/e2e/provision_with_multiple_zones.go
+++ b/tests/e2e/provision_with_multiple_zones.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = ginkgo.Describe("[csi-block-e2e-zone] Topology-Aware-Provisioning-With-Multiple-Zones", func() {
+	f := framework.NewDefaultFramework("e2e-vsphere-topology-aware-provisioning")
+	var (
+		client               clientset.Interface
+		namespace            string
+		zoneValues           []string
+		regionValues         []string
+		allowedTopologies    []v1.TopologySelectorLabelRequirement
+		nodeList             *v1.NodeList
+		pvclaim              *v1.PersistentVolumeClaim
+		pv                   *v1.PersistentVolume
+		storageclass         *storagev1.StorageClass
+		topologyWithSharedDS string
+		err                  error
+	)
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		bootstrap()
+		nodeList = framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		// Preparing allowedTopologies using topologies with shared and non shared datastores
+		topologyWithSharedDS = GetAndExpectStringEnvVar(envRegionZoneWithSharedDS)
+		topologyWithNoSharedDS := GetAndExpectStringEnvVar(envRegionZoneWithNoSharedDS)
+		topologyValues := topologyWithSharedDS + "," + topologyWithNoSharedDS
+		regionValues, zoneValues, allowedTopologies = topologyParameterForStorageClass(topologyValues)
+	})
+
+	ginkgo.AfterEach(func() {
+		ginkgo.By("Performing test cleanup")
+		if pvclaim != nil {
+			framework.ExpectNoError(framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace), "Failed to delete PVC ", pvclaim.Name)
+		}
+
+		if pv != nil {
+			framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
+			framework.ExpectNoError(e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle))
+			err = client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+		}
+	})
+
+	/*
+		Provisioning with multiple zones and regions specified in the Storage Class.
+		Volume will be provisioned on first zone/region with shared datastore across nodes.
+
+		Steps
+		1. Create a Storage Class with multiple valid regions and zones specified in “AllowedTopologies”
+		2. Create a PVC using above SC
+		3. Wait for PVC to be in bound phase
+		4. Verify PV is created in zone and region that has shared accessible datastores acorss all nodes in this zone/region
+		5. Create a Pod attached to the above PV
+		6. Verify Pod is scheduled on node located within the specified zone and region
+		7. Delete Pod and wait for disk to be detached
+		8. Delete PVC
+		9. Delete Storage Class
+	*/
+	ginkgo.It("Verify provisioning with multiple zones and with only one zone associated with shared datastore", func() {
+		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, nil, "", allowedTopologies, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+		defer client.CoreV1().PersistentVolumeClaims(namespace).Delete(pvclaim.Name, nil)
+
+		ginkgo.By("Expect claim to pass provisioning volume")
+		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
+
+		ginkgo.By("Verify if volume is provisioned in specified zone and region")
+		pv = getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)
+		pvRegion, pvZone, err := verifyVolumeTopology(pv, zoneValues, regionValues)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify if volume is provisioned in zone and region containing shared datastore")
+		gomega.Expect(strings.Contains(topologyWithSharedDS, pvRegion)).To(gomega.BeTrue(), fmt.Sprintf("Topology with shared datatore %q does not contain region in which volume is provisioned: %q", topologyWithSharedDS, pvRegion))
+		gomega.Expect(strings.Contains(topologyWithSharedDS, pvZone)).To(gomega.BeTrue(), fmt.Sprintf("Topology with shared datatore %q does not contain zone in which volume is provisioned: %q", topologyWithSharedDS, pvZone))
+
+		ginkgo.By("Creating a pod")
+		pod, err := framework.CreatePod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify volume is attached to the node")
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), fmt.Sprintf("Volume is not attached to the node"))
+
+		ginkgo.By("Verify Pod is scheduled on a node belonging to same topology as the shared datastore")
+		err = verifyPodLocation(pod, nodeList, pvZone, pvRegion)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Performing cleanup")
+		ginkgo.By("Deleting the pod and wait for disk to detach")
+		err = framework.DeletePodWithWait(f, client, pod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Deleting the PVC")
+		err = framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pvclaim = nil
+
+		ginkgo.By("Verify if PV is deleted")
+		framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
+		pv = nil
+
+		ginkgo.By("Deleting the Storage Class")
+		err = client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		storageclass = nil
+	})
+})

--- a/tests/e2e/statefulset_with_topology.go
+++ b/tests/e2e/statefulset_with_topology.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = ginkgo.Describe("[csi-block-e2e-zone] Topology-Aware-Provisioning-With-Statefulset", func() {
+	f := framework.NewDefaultFramework("e2e-vsphere-topology-aware-provisioning")
+	var (
+		client            clientset.Interface
+		namespace         string
+		zoneValues        []string
+		regionValues      []string
+		pvZone            string
+		pvRegion          string
+		allowedTopologies []v1.TopologySelectorLabelRequirement
+		nodeList          *v1.NodeList
+		pod               *v1.Pod
+	)
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		bootstrap()
+		nodeList = framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+		// Preparing allowedTopologies using topologies with shared datastores
+		regionZoneValue := GetAndExpectStringEnvVar(envRegionZoneWithSharedDS)
+		regionValues, zoneValues, allowedTopologies = topologyParameterForStorageClass(regionZoneValue)
+	})
+
+	/*
+		Test to verify stateful set with one replica is scheduled on a node within the topology after killing it.
+		Stateful set should be scheduled on Node located within the selected zone/region.
+
+		Steps
+		1. Create a Storage Class with spec containing valid region and zone in “AllowedTopologies”.
+		2. Create Statefulset using the above SC
+		3. Verify PV is present in specified Topology
+		4. Verify Pod is scheduled on node within the specified zone and region
+		5. Kill Pod
+		6. Verify Pod is rescheduled to a node within the same zone and region
+		7. Delete Statefulset
+		8. Delete PVC
+		9. Delete SC
+	*/
+	ginkgo.It("Verify if stateful set is scheduled on a node within the topology after deleting the pod", func() {
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(storageclassname, nil, allowedTopologies, "", "")
+		sc, err := client.StorageV1().StorageClasses().Create(scSpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(sc.Name, nil)
+
+		ginkgo.By("Creating statefulset with single replica")
+		statefulsetTester := framework.NewStatefulSetTester(client)
+		statefulset := createStatefulSetWithOneReplica(client, manifestPath, namespace)
+		statefulsetTester.WaitForStatusReadyReplicas(statefulset, 1)
+		gomega.Expect(statefulsetTester.CheckMount(statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+
+		ssPodsBeforeDelete := statefulsetTester.GetPodList(statefulset)
+		gomega.Expect(ssPodsBeforeDelete.Items).NotTo(gomega.BeEmpty(), fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeDelete.Items) == 1).To(gomega.BeTrue(), "Number of Pods in the statefulset should be 1")
+
+		ginkgo.By("Deleting the pod")
+		pod = &ssPodsBeforeDelete.Items[0]
+		statefulsetTester.DeleteStatefulPodAtIndex(0, statefulset)
+
+		// Wait for 30 seconds, after deleting the pod. By the end of this wait, the pod would be created again on any of the nodes
+		time.Sleep(time.Duration(sleepTimeOut) * time.Second)
+
+		for _, volumespec := range pod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+				pvRegion, pvZone, err = verifyVolumeTopology(pv, zoneValues, regionValues)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				ssPodsAfterDelete := statefulsetTester.GetPodList(statefulset)
+				pod = &ssPodsAfterDelete.Items[0]
+				ginkgo.By("Verify Pod is scheduled in on a node belonging to same topology as the PV it is attached to")
+				err = verifyPodLocation(pod, nodeList, pvZone, pvRegion)
+			}
+		}
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+		framework.DeleteAllStatefulSets(client, namespace)
+	})
+
+})

--- a/tests/e2e/vsphere_shared_datastore.go
+++ b/tests/e2e/vsphere_shared_datastore.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+/*
+	Test to verify provisioning is dependant on type of datastore (shared/non-shared), when no storage policy is offered
+
+	Steps
+	1. Create StorageClass with shared/non-shared datastore.
+	2. Create PVC which uses the StorageClass created in step 1.
+	3. Expect:
+		3a. Volume provisioning to fail if non-shared datastore
+		3b. Volume provisioning to pass if shared datastore
+
+	This test reads env
+	1. SHARED_VSPHERE_DATASTORE_URL (set to shared datastore URL)
+	2. NONSHARED_VSPHERE_DATASTORE_URL (set to non-shared datastor URL)
+*/
+
+var _ = ginkgo.Describe("[csi-block-e2e] Datastore Based Volume Provisioning With No Storage Policy", func() {
+	f := framework.NewDefaultFramework("e2e-vsphere-volume-provisioning-no-storage-policy")
+	var (
+		client                clientset.Interface
+		namespace             string
+		scParameters          map[string]string
+		sharedDatastoreURL    string
+		nonSharedDatastoreURL string
+	)
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		scParameters = make(map[string]string)
+		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+	})
+
+	// Shared datastore should be provisioned successfully
+	ginkgo.It("Verify dynamic provisioning of PV passes with user specified shared datastore and no storage policy specified in the storage class", func() {
+		ginkgo.By("Invoking Test for user specified Shared Datastore in Storage class for volume provisioning")
+		sharedDatastoreURL = GetAndExpectStringEnvVar(envSharedDatastoreURL)
+		scParameters[scParamDatastoreURL] = sharedDatastoreURL
+		storageclass, pvclaim, err := createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+		defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+
+		ginkgo.By("Expect claim to pass provisioning volume as shared datastore")
+		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume on shared datastore with err: %v", err))
+	})
+
+	// Setting non-shared datastore in the storage class should fail dynamic volume provisioning
+	ginkgo.It("Verify dynamic provisioning of PV fails with user specified non-shared datastore and no storage policy specified in the storage class", func() {
+		ginkgo.By("Invoking Test for user specified non-shared Datastore in storage class for volume provisioning")
+		nonSharedDatastoreURL = GetAndExpectStringEnvVar(envNonSharedStorageClassDatastoreURL)
+		scParameters[scParamDatastoreURL] = nonSharedDatastoreURL
+		storageclass, pvclaim, err := createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+		defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+
+		ginkgo.By("Expect claim to fail provisioning volume on non shared datastore")
+		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute/2)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		// eventList contains the events related to pvc
+		eventList, _ := client.CoreV1().Events(pvclaim.Namespace).List(metav1.ListOptions{})
+		actualErrMsg := eventList.Items[len(eventList.Items)-1].Message
+		fmt.Println(fmt.Sprintf("Actual failure message: %+q", actualErrMsg))
+		expectedErrMsg := "failed to provision volume with StorageClass \"" + storageclass.Name + "\""
+		fmt.Println(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
+		gomega.Expect(strings.Contains(actualErrMsg, expectedErrMsg)).To(gomega.BeTrue(), fmt.Sprintf("actualErrMsg: %q does not contain expectedErrMsg: %q", actualErrMsg, expectedErrMsg))
+
+	})
+})

--- a/tests/e2e/vsphere_volume_disksize.go
+++ b/tests/e2e/vsphere_volume_disksize.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+/*
+	Test to verify disk size specified in PVC is being honored during volume creation.
+
+	Steps
+	1. Create StorageClass.
+	2. Create PVC with valid disk size.
+	3. Expect PVC to pass
+	4. Verify disk size specified is being honored
+*/
+
+var _ = ginkgo.Describe("[csi-block-e2e] Volume Disk Size ", func() {
+	f := framework.NewDefaultFramework("volume-disksize")
+	var (
+		client       clientset.Interface
+		namespace    string
+		scParameters map[string]string
+		datastoreURL string
+		pvclaims     []*v1.PersistentVolumeClaim
+	)
+	ginkgo.BeforeEach(func() {
+		bootstrap()
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		scParameters = make(map[string]string)
+		datastoreURL = GetAndExpectStringEnvVar(envSharedDatastoreURL)
+		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+	})
+
+	// Test for valid disk size of 2Gi
+	ginkgo.It("Verify dynamic provisioning of pv using storageclass with a valid disk size passes", func() {
+		ginkgo.By("Invoking Test for valid disk size")
+		scParameters[scParamDatastoreURL] = datastoreURL
+		storageclass, pvclaim, err := createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+		defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+
+		ginkgo.By("Expect claim to provision volume successfully")
+		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume"))
+
+		pvclaims = append(pvclaims, pvclaim)
+
+		persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", persistentvolumes[0].Spec.CSI.VolumeHandle))
+		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(persistentvolumes[0].Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if len(queryResult.Volumes) == 0 {
+			err = fmt.Errorf("Error: QueryCNSVolumeWithResult returned no volume")
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Verifying disk size specified in PVC in honored")
+		if queryResult.Volumes[0].BackingObjectDetails.CapacityInMb != diskSizeInMb {
+			err = fmt.Errorf("Wrong disk size provisioned ")
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})

--- a/tests/e2e/vsphere_volume_fstype.go
+++ b/tests/e2e/vsphere_volume_fstype.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+/*
+
+Test to verify fstype specified in storage-class is being honored after volume creation.
+
+Steps
+1. Create StorageClass with fstype set to valid type (default case included).
+2. Create PVC which uses the StorageClass created in step 1.
+3. Wait for PV to be provisioned.
+4. Wait for PVC's status to become Bound.
+5. Create pod using PVC on specific node.
+6. Wait for Disk to be attached to the node.
+7. Execute command in the pod to get fstype.
+8. Delete pod and Wait for Volume Disk to be detached from the Node.
+9. Delete PVC, PV and Storage Class.
+
+Test to verify if an invalid fstype specified in storage class fails pod creation.
+
+ Steps
+ 1. Create StorageClass with inavlid.
+ 2. Create PVC which uses the StorageClass created in step 1.
+ 3. Wait for PV to be provisioned.
+ 4. Wait for PVC's status to become Bound.
+ 5. Create pod using PVC.
+ 6. Verify if the pod creation fails.
+ 7. Verify if the MountVolume.MountDevice fails because it is unable to find the file system executable file on the node.
+*/
+
+var _ = ginkgo.Describe("[csi-block-e2e] Volume Filesystem Type Test", func() {
+	f := framework.NewDefaultFramework("volume-fstype")
+	var (
+		client    clientset.Interface
+		namespace string
+	)
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		bootstrap()
+		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+	})
+
+	ginkgo.It("CSI - verify fstype - ext3 formatted volume", func() {
+		invokeTestForFstype(f, client, namespace, ext3FSType, ext3FSType)
+	})
+
+	ginkgo.It("CSI - verify fstype - default value should be ext4", func() {
+		invokeTestForFstype(f, client, namespace, "", ext4FSType)
+	})
+
+	ginkgo.It("CSI - verify invalid fstype", func() {
+		invokeTestForInvalidFstype(f, client, namespace, invalidFSType)
+	})
+})
+
+func invokeTestForFstype(f *framework.Framework, client clientset.Interface, namespace string, fstype string, expectedContent string) {
+	ginkgo.By(fmt.Sprintf("Invoking Test for fstype: %s", fstype))
+	scParameters := make(map[string]string)
+	scParameters["fstype"] = fstype
+
+	// Create Storage class and PVC
+	ginkgo.By("Creating Storage Class With Fstype")
+	storageclass, pvclaim, err := createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+
+	// Waiting for PVC to be bound
+	var pvclaims []*v1.PersistentVolumeClaim
+	pvclaims = append(pvclaims, pvclaim)
+	ginkgo.By("Waiting for all claims to be in bound state")
+	persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Create a POD to use this PVC, and verify volume has been attached
+	ginkgo.By("Creating pod to attach PV to the node")
+	pod, err := framework.CreatePod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By("Verify volume is attached to the node")
+	pv := persistentvolumes[0]
+	isDiskAttached, err := e2eVSphere.isVolumeAttachedToNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(isDiskAttached).To(gomega.BeTrue(), fmt.Sprintf("Volume is not attached to the node"))
+
+	ginkgo.By("Verify the volume is accessible and filesystem type is as expected")
+	_, err = framework.LookForStringInPodExec(namespace, pod.Name, []string{"/bin/cat", "/mnt/volume1/fstype"}, expectedContent, time.Minute)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Delete POD and PVC
+	ginkgo.By("Deleting the pod")
+	framework.DeletePodWithWait(f, client, pod)
+
+	ginkgo.By("Verify volume is detached from the node")
+	isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+
+	err = framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func invokeTestForInvalidFstype(f *framework.Framework, client clientset.Interface, namespace string, fstype string) {
+	scParameters := make(map[string]string)
+	scParameters["fstype"] = fstype
+
+	// Create Storage class and PVC
+	ginkgo.By("Creating Storage Class With Invalid Fstype")
+	storageclass, pvclaim, err := createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+
+	// Waiting for PVC to be bound
+	var pvclaims []*v1.PersistentVolumeClaim
+	pvclaims = append(pvclaims, pvclaim)
+	ginkgo.By("Waiting for all claims to be in bound state")
+	persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Create a POD to use this PVC, and verify volume has been attached
+	ginkgo.By("Creating pod to attach PV to the node")
+	pod, err := framework.CreatePod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
+	gomega.Expect(err).To(gomega.HaveOccurred())
+
+	eventList, err := client.CoreV1().Events(namespace).List(metav1.ListOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(eventList.Items).NotTo(gomega.BeEmpty())
+	pv := persistentvolumes[0]
+	errorMsg := `MountVolume.MountDevice failed for volume "` + pv.Name
+	isFailureFound := false
+	for _, item := range eventList.Items {
+		ginkgo.By(fmt.Sprintf("Print errorMessage %q \n", item.Message))
+		if strings.Contains(item.Message, errorMsg) {
+			isFailureFound = true
+		}
+	}
+	gomega.Expect(isFailureFound).To(gomega.BeTrue(), "Unable to verify MountVolume.MountDevice failure")
+
+	// pod.Spec.NodeName may not be set yet when pod just created
+	// refetch pod to get pod.Spec.NodeName
+	podNodeName := pod.Spec.NodeName
+	ginkgo.By(fmt.Sprintf("podNodeName: %v podName: %v", podNodeName, pod.Name))
+	pod, err = client.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	podNodeName = pod.Spec.NodeName
+	ginkgo.By(fmt.Sprintf("Refetch the POD: podNodeName: %v podName: %v", podNodeName, pod.Name))
+
+	// Delete POD and PVC
+	ginkgo.By("Deleting the pod")
+	framework.DeletePodWithWait(f, client, pod)
+
+	ginkgo.By("Verify volume is detached from the node")
+	isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, podNodeName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, podNodeName))
+
+	err = framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is to add e2e test cases to verify volume provisioning during various scenarios including vsphere features as listed below:
Static Provisioning Basic tests
Dynamic/Static Provisioning with multiple zones
Dynamic/Static Provisioning with vSphere shared datastores
Dynamic/Static Provisioning with different vSphere volume disk sizes
Dynamic/Static Provisioning with different vSphere file system types
Stateful sets Scheduling with topology

We need this PR to support e2e test execution for any changes in the future.

**Special notes for your reviewer**:
This PR has dependencies on https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/57, will be merged after that is merged.

Run tests using $make test-e2e
End to end tests can be run by following the README file in /tests/e2e folder
Developers will need zones enabled in the VC testbed to run zone tests

**Test Results**
```
[csi-block-e2e-zone] Topology-Aware-Provisioning-With-Statefulset 
  Verify if stateful set is scheduled on a node within the topology after deleting the pod
STEP: Creating a kubernetes client
Sep 13 10:04:07.327: INFO: >>> kubeConfig: /Users/chethanv/.kube/config
STEP: Building a namespace api object, basename e2e-vsphere-topology-aware-provisioning
Sep 13 10:04:07.446: INFO: Found PodSecurityPolicies; assuming PodSecurityPolicy is enabled.
Sep 13 10:04:07.482: INFO: Found ClusterRoles; assuming RBAC is enabled.
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-vsphere-topology-aware-provisioning-2642
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [csi-block-e2e-zone] Topology-Aware-Provisioning-With-Statefulset
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/statefulset_with_topology.go:44
[It] Verify if stateful set is scheduled on a node within the topology after deleting the pod
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/statefulset_with_topology.go:72
STEP: Creating StorageClass for Statefulset
STEP: Creating statefulset with single replica
Sep 13 10:04:07.750: INFO: Waiting for statefulset status.replicas updated to 1
Sep 13 10:04:07.761: INFO: Waiting for stateful set status.readyReplicas to become 1, currently 0
Sep 13 10:04:17.770: INFO: Waiting for stateful set status.readyReplicas to become 1, currently 0
Sep 13 10:04:27.784: INFO: Waiting for stateful set status.readyReplicas to become 1, currently 0
Sep 13 10:04:37.776: INFO: Waiting for stateful set status.readyReplicas to become 1, currently 0
Sep 13 10:04:47.786: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-vsphere-topology-aware-provisioning-2642 web-0 -- /bin/sh -x -c ls -idlh /usr/share/nginx/html'
Sep 13 10:04:48.917: INFO: stderr: "+ ls -idlh /usr/share/nginx/html\n"
Sep 13 10:04:48.917: INFO: stdout: "2 drwxr-xr-x 3 root root 4.0K Sep 13 17:04 /usr/share/nginx/html\n"
Sep 13 10:04:48.917: INFO: stdout of ls -idlh /usr/share/nginx/html on web-0: 2 drwxr-xr-x 3 root root 4.0K Sep 13 17:04 /usr/share/nginx/html
Sep 13 10:04:48.927: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-vsphere-topology-aware-provisioning-2642 web-0 -- /bin/sh -x -c find /usr/share/nginx/html'
Sep 13 10:04:49.241: INFO: stderr: "+ find /usr/share/nginx/html\n"
Sep 13 10:04:49.241: INFO: stdout: "/usr/share/nginx/html\n/usr/share/nginx/html/lost+found\n"
Sep 13 10:04:49.241: INFO: stdout of find /usr/share/nginx/html on web-0: /usr/share/nginx/html
/usr/share/nginx/html/lost+found
Sep 13 10:04:49.249: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-vsphere-topology-aware-provisioning-2642 web-0 -- /bin/sh -x -c touch /usr/share/nginx/html/1568394287778129000'
Sep 13 10:04:49.568: INFO: stderr: "+ touch /usr/share/nginx/html/1568394287778129000\n"
Sep 13 10:04:49.568: INFO: stdout: ""
Sep 13 10:04:49.568: INFO: stdout of touch /usr/share/nginx/html/1568394287778129000 on web-0: 
STEP: Deleting the pod
Sep 13 10:05:19.646: INFO: PV pvc-7f924d02-d648-11e9-8dd4-005056aaafa5 is located in zone: k8s-zone-1 and region: k8s-region-1
STEP: Verify Pod is scheduled in on a node belonging to same topology as the PV it is attached to
Sep 13 10:05:19.656: INFO: Deleting all statefulset in namespace: e2e-vsphere-topology-aware-provisioning-2642
Sep 13 10:05:19.667: INFO: Scaling statefulset web to 0
Sep 13 10:05:29.708: INFO: Waiting for statefulset status.replicas updated to 0
Sep 13 10:05:29.715: INFO: Deleting statefulset web
Sep 13 10:05:29.738: INFO: Deleting pvc: www-web-0 with volume pvc-7f924d02-d648-11e9-8dd4-005056aaafa5
Sep 13 10:05:29.764: INFO: Still waiting for pvs of statefulset to disappear:
pvc-7f924d02-d648-11e9-8dd4-005056aaafa5: {Phase:Bound Message: Reason:}
[AfterEach] [csi-block-e2e-zone] Topology-Aware-Provisioning-With-Statefulset
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.14.2/test/e2e/framework/framework.go:150
Sep 13 10:05:39.789: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-vsphere-topology-aware-provisioning-2642" for this suite.
Sep 13 10:05:45.835: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Sep 13 10:05:46.119: INFO: namespace e2e-vsphere-topology-aware-provisioning-2642 deletion completed in 6.316132053s
• [SLOW TEST:98.792 seconds]
[csi-block-e2e-zone] Topology-Aware-Provisioning-With-Statefulset
/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/statefulset_with_topology.go:31
  Verify if stateful set is scheduled on a node within the topology after deleting the pod
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/statefulset_with_topology.go:72
------------------------------
SSSSSS
Ran 1 of 42 Specs in 98.792 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 41 Skipped
PASS
Ginkgo ran 1 suite in 1m46.656725239s
Test Suite Passed
```
```
[csi-block-e2e] Datastore Based Volume Provisioning With No Storage Policy 
  Verify dynamic provisioning of PV fails with user specified non-shared datastore and no storage policy specified in the storage class
STEP: Creating a kubernetes client
Sep 13 10:14:08.109: INFO: >>> kubeConfig: /Users/chethanv/.kube/config
STEP: Building a namespace api object, basename e2e-vsphere-volume-provisioning-no-storage-policy
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-vsphere-volume-provisioning-no-storage-policy-7935
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [csi-block-e2e] Datastore Based Volume Provisioning With No Storage Policy
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:56
[It] Verify dynamic provisioning of PV fails with user specified non-shared datastore and no storage policy specified in the storage class
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:82
STEP: Invoking Test for user specified non-shared Datastore in storage class for volume provisioning
STEP: Creating StorageClass With scParameters: map[DatastoreURL:ds:///vmfs/volumes/5d6469b2-c46976cd-3247-02008017c10e/] and allowedTopologies: []
STEP: Creating StorageClass With scParameters: map[DatastoreURL:ds:///vmfs/volumes/5d6469b2-c46976cd-3247-02008017c10e/] and allowedTopologies: [] and ReclaimPolicy: 
STEP: Creating PVC using the Storage Class sc-fgzsh with disk size  and labels: map[]
STEP: Expect claim to fail provisioning volume on non shared datastore
Sep 13 10:14:08.331: INFO: Waiting up to 30s for PersistentVolumeClaims [pvc-qjtzn] to have phase Bound
Sep 13 10:14:08.342: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:10.358: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:12.368: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:14.388: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:16.399: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:18.409: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:20.424: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:22.434: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:24.450: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:26.466: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:28.474: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:30.491: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:32.506: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:34.522: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Sep 13 10:14:36.533: INFO: PersistentVolumeClaim pvc-qjtzn found but phase is Pending instead of Bound.
Actual failure message: "failed to provision volume with StorageClass \"sc-fgzsh\": rpc error: code = InvalidArgument desc = DatastoreURL: ds:///vmfs/volumes/5d6469b2-c46976cd-3247-02008017c10e/ specified in the storage class is not accessible in the topology:[+requisite:<segments:<key:\"failure-domain.beta.kubernetes.io/region\" value:\"k8s-region-1\" > segments:<key:\"failure-domain.beta.kubernetes.io/zone\" value:\"k8s-zone-1\" > > requisite:<segments:<key:\"failure-domain.beta.kubernetes.io/region\" value:\"k8s-region-2\" > segments:<key:\"failure-domain.beta.kubernetes.io/zone\" value:\"k8s-zone-2\" > > requisite:<segments:<key:\"failure-domain.beta.kubernetes.io/region\" value:\"k8s-region-3\" > segments:<key:\"failure-domain.beta.kubernetes.io/zone\" value:\"k8s-zone-3\" > > preferred:<segments:<key:\"failure-domain.beta.kubernetes.io/region\" value:\"k8s-region-3\" > segments:<key:\"failure-domain.beta.kubernetes.io/zone\" value:\"k8s-zone-3\" > > preferred:<segments:<key:\"failure-domain.beta.kubernetes.io/region\" value:\"k8s-region-1\" > segments:<key:\"failure-domain.beta.kubernetes.io/zone\" value:\"k8s-zone-1\" > > preferred:<segments:<key:\"failure-domain.beta.kubernetes.io/region\" value:\"k8s-region-2\" > segments:<key:\"failure-domain.beta.kubernetes.io/zone\" value:\"k8s-zone-2\" > > ]"
Expected failure message: "failed to provision volume with StorageClass \"sc-fgzsh\""
Sep 13 10:14:38.553: INFO: Deleting PersistentVolumeClaim "pvc-qjtzn"
[AfterEach] [csi-block-e2e] Datastore Based Volume Provisioning With No Storage Policy
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.14.2/test/e2e/framework/framework.go:150
Sep 13 10:14:38.589: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-vsphere-volume-provisioning-no-storage-policy-7935" for this suite.
Sep 13 10:14:44.648: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Sep 13 10:14:45.040: INFO: namespace e2e-vsphere-volume-provisioning-no-storage-policy-7935 deletion completed in 6.436523409s
• [SLOW TEST:36.931 seconds]
[csi-block-e2e] Datastore Based Volume Provisioning With No Storage Policy
/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:47
  Verify dynamic provisioning of PV fails with user specified non-shared datastore and no storage policy specified in the storage class
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:82
------------------------------
SSSS
Ran 1 of 42 Specs in 98.792 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 41 Skipped
PASS
Ginkgo ran 1 suite in 1m51.654263146s
Test Suite Passed
```
```
[csi-block-e2e] Volume Filesystem Type Test 
  CSI - verify fstype - default value should be ext4
STEP: Creating a kubernetes client
Sep 13 10:38:00.210: INFO: >>> kubeConfig: /Users/chethanv/.kube/config
STEP: Building a namespace api object, basename volume-fstype
Sep 13 10:38:00.312: INFO: Found PodSecurityPolicies; assuming PodSecurityPolicy is enabled.
Sep 13 10:38:00.340: INFO: Found ClusterRoles; assuming RBAC is enabled.
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in volume-fstype-253
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [csi-block-e2e] Volume Filesystem Type Test
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_volume_fstype.go:65
[It] CSI - verify fstype - default value should be ext4
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_volume_fstype.go:79
STEP: Invoking Test for fstype: 
STEP: Creating Storage Class With Fstype
STEP: Creating StorageClass With scParameters: map[fstype:] and allowedTopologies: []
STEP: Creating StorageClass With scParameters: map[fstype:] and allowedTopologies: [] and ReclaimPolicy: 
STEP: Creating PVC using the Storage Class sc-lssss with disk size  and labels: map[]
STEP: Waiting for all claims to be in bound state
Sep 13 10:38:00.597: INFO: Waiting up to 5m0s for PersistentVolumeClaims [pvc-rssxs] to have phase Bound
Sep 13 10:38:00.610: INFO: PersistentVolumeClaim pvc-rssxs found but phase is Pending instead of Bound.
Sep 13 10:38:02.627: INFO: PersistentVolumeClaim pvc-rssxs found but phase is Pending instead of Bound.
Sep 13 10:38:04.665: INFO: PersistentVolumeClaim pvc-rssxs found but phase is Pending instead of Bound.
Sep 13 10:38:06.679: INFO: PersistentVolumeClaim pvc-rssxs found but phase is Pending instead of Bound.
Sep 13 10:38:08.689: INFO: PersistentVolumeClaim pvc-rssxs found but phase is Pending instead of Bound.
Sep 13 10:38:10.707: INFO: PersistentVolumeClaim pvc-rssxs found but phase is Pending instead of Bound.
Sep 13 10:38:12.722: INFO: PersistentVolumeClaim pvc-rssxs found but phase is Pending instead of Bound.
Sep 13 10:38:14.737: INFO: PersistentVolumeClaim pvc-rssxs found and phase=Bound (14.139600224s)
STEP: Creating pod to attach PV to the node
STEP: Verify volume is attached to the node
Sep 13 10:38:26.863: INFO: VM uuid is: 422a57b6-0f35-d14d-64d1-a97603fb2b9b for node: k8s-node4
[AfterEach] [csi-block-e2e] Volume Filesystem Type Test
STEP: Verify the volume is accessible and filesystem type is as expected
STEP: Deleting the pod
STEP: Verify volume is detached from the node
STEP: Destroying namespace "volume-fstype-253" for this suite.
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 42 Specs in 98.792 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 41 Skipped
PASS
Ginkgo ran 1 suite in 1m51.654263146s
Test Suite Passed
```


**Release note**:
```
E2E tests for vsphere CSI Driver 
```
