### PR TITLE
Fix full sync test : Bring down the controller and verify volume creation is picked up after FULL SYNC

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -57,7 +57,7 @@ const (
 	invalidFSType                              = "ext10"
 	execCommand                                = "/bin/df -T /mnt/volume1 | /bin/awk 'FNR == 2 {print $2}' > /mnt/volume1/fstype && while true ; do sleep 2 ; done"
 	kubeSystemNamespace                        = "kube-system"
-	syncerStatefulsetName                      = "vsphere-csi-metadata-syncer"
+	vSphereCSIControllerPodNamePrefix          = "vsphere-csi-controller"
 )
 
 // GetAndExpectStringEnvVar parses a string from env variable

--- a/tests/e2e/fullsynctest.go
+++ b/tests/e2e/fullsynctest.go
@@ -69,7 +69,7 @@ var _ bool = ginkgo.Describe("[csi-block-e2e] full-sync-test", func() {
 		fcdName                  = "BasicStaticFCD"
 		stopVsanHealthOperation  = "stop"
 		startVsanHealthOperation = "start"
-		vcenterPort              = "22"
+		sshdPort                 = "22"
 		numberOfPVC              = 5
 	)
 
@@ -140,7 +140,7 @@ var _ bool = ginkgo.Describe("[csi-block-e2e] full-sync-test", func() {
 		time.Sleep(time.Duration(pandoraSyncWaitTime) * time.Second)
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + vcenterPort
+		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(stopVsanHealthOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -187,7 +187,7 @@ var _ bool = ginkgo.Describe("[csi-block-e2e] full-sync-test", func() {
 		pv := pvs[0]
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + vcenterPort
+		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(stopVsanHealthOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -267,7 +267,7 @@ var _ bool = ginkgo.Describe("[csi-block-e2e] full-sync-test", func() {
 		}
 		gomega.Expect(datastore).NotTo(gomega.BeNil())
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + vcenterPort
+		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(stopVsanHealthOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -328,7 +328,7 @@ var _ bool = ginkgo.Describe("[csi-block-e2e] full-sync-test", func() {
 		}
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + vcenterPort
+		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(stopVsanHealthOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -439,7 +439,7 @@ var _ bool = ginkgo.Describe("[csi-block-e2e] full-sync-test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + vcenterPort
+		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(stopVsanHealthOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -524,7 +524,7 @@ var _ bool = ginkgo.Describe("[csi-block-e2e] full-sync-test", func() {
 		framework.ExpectNoError(framework.WaitOnPVandPVC(client, namespace, pv, pvc))
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + vcenterPort
+		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(stopVsanHealthOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -553,7 +553,7 @@ var _ bool = ginkgo.Describe("[csi-block-e2e] full-sync-test", func() {
 
 	})
 
-	ginkgo.It("Bring down syncer pod and verify PV metadata is created in CNS", func() {
+	ginkgo.It("Scale down csi driver statefulset and verify PV metadata is created in CNS", func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -584,13 +584,9 @@ var _ bool = ginkgo.Describe("[csi-block-e2e] full-sync-test", func() {
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow newly created FCD:%s to sync with pandora", pandoraSyncWaitTime, fcdID))
 		time.Sleep(time.Duration(pandoraSyncWaitTime) * time.Second)
 
-		statefulsetTester := framework.NewStatefulSetTester(client)
-		statefulset := statefulsetTester.GetStatefulSet(kubeSystemNamespace, syncerStatefulsetName)
-		replicas := *(statefulset.Spec.Replicas)
-		ginkgo.By(fmt.Sprintf("Kill syncer statefulset by scaling down statefulsets to number of Replica: %v", replicas-1))
-		_, scaleDownErr := statefulsetTester.Scale(statefulset, replicas-1)
-		gomega.Expect(scaleDownErr).NotTo(gomega.HaveOccurred())
-		statefulsetTester.WaitForStatusReadyReplicas(statefulset, replicas-1)
+		ginkgo.By("Scaling down the csi driver to zero replica")
+		statefulSet := updateStatefulSetReplica(client, 0, vSphereCSIControllerPodNamePrefix, kubeSystemNamespace)
+		ginkgo.By(fmt.Sprintf("Successfully scaled down the csi driver statefulset:%s to zero replicas", statefulSet.Name))
 
 		ginkgo.By(fmt.Sprintf("Creating the PV with the fcdID %s", fcdID))
 		staticPVLabels := make(map[string]string)
@@ -599,11 +595,9 @@ var _ bool = ginkgo.Describe("[csi-block-e2e] full-sync-test", func() {
 		pv, err = client.CoreV1().PersistentVolumes().Create(pv)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Recreate syncer statefulset by scaling up statefulsets to number of Replica: %v", replicas))
-		_, scaleUpErr := statefulsetTester.Scale(statefulset, replicas)
-		gomega.Expect(scaleUpErr).NotTo(gomega.HaveOccurred())
-		statefulsetTester.WaitForStatusReplicas(statefulset, replicas)
-		statefulsetTester.WaitForStatusReadyReplicas(statefulset, replicas)
+		ginkgo.By("Scaling up the csi driver to one replica")
+		statefulSet = updateStatefulSetReplica(client, 1, vSphereCSIControllerPodNamePrefix, kubeSystemNamespace)
+		ginkgo.By(fmt.Sprintf("Successfully scaled up the csi driver statefulset:%s to one replica", statefulSet.Name))
 
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow full sync finish", fullSyncWaitTime))
 		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -215,6 +216,18 @@ func createStatefulSetWithOneReplica(client clientset.Interface, manifestPath st
 	*statefulSet.Spec.Replicas = 1
 	_, err = client.AppsV1().StatefulSets(namespace).Create(statefulSet)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	return statefulSet
+}
+
+// updateStatefulSetReplica helps to update the replica for a statefulset
+func updateStatefulSetReplica(client clientset.Interface, count int32, name string, namespace string) *appsv1.StatefulSet {
+	statefulSet, err := client.AppsV1().StatefulSets(namespace).Get(name, metav1.GetOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	*statefulSet.Spec.Replicas = count
+	_, err = client.AppsV1().StatefulSets(namespace).Update(statefulSet)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	ginkgo.By("Waiting for update operation on statefulset to take effect")
+	time.Sleep(1 * time.Minute)
 	return statefulSet
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing one of the e2e test for full sync functionality where, the syncer container is brought down and then verify whether Volume operations succeeds on the CNS side after syncer comes back up.  We need this PR to run all e2e tests successfully

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Set GINKGO FOCUS to "Bring down syncer pod and verify PV metadata is created in CNS"
export GINKGO_FOCUS="Bring down syncer pod and verify PV metadata is created in CNS"

Run tests using $make test-e2e

**Test results**:
```
$ make test-e2e
hack/run-e2e-test.sh
go: finding github.com/onsi/ginkgo/ginkgo latest
Oct  3 09:50:49.973: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CNS CSI Driver End-to-End Tests
==============================================
Random Seed: 1570121440 - Will randomize all specs
Will run 1 of 42 specs

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[csi-block-e2e] full-sync-test 
  Scale down csi driver statefulset and verify PV metadata is created in CNS
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/fullsynctest.go:556
[BeforeEach] [csi-block-e2e] full-sync-test
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.14.2/test/e2e/framework/framework.go:149
STEP: Creating a kubernetes client
Oct  3 09:50:49.974: INFO: >>> kubeConfig: /Users/chethanv/.kube/config
STEP: Building a namespace api object, basename e2e-full-sync-test
Oct  3 09:50:50.061: INFO: Found PodSecurityPolicies; assuming PodSecurityPolicy is enabled.
Oct  3 09:50:50.088: INFO: Found ClusterRoles; assuming RBAC is enabled.
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-full-sync-test-9711
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [csi-block-e2e] full-sync-test
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/fullsynctest.go:76
[It] Scale down csi driver statefulset and verify PV metadata is created in CNS
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/fullsynctest.go:556
STEP: Creating FCD Disk
STEP: Sleeping for 90 seconds to allow newly created FCD:0c57fc31-3d25-4d98-a4a1-bc65e56283ed to sync with pandora
STEP: Scaling down the csi driver to zero replica
STEP: Waiting for update operation on statefulset to take effect
STEP: Successfully scaled down the csi driver statefulset:vsphere-csi-controller to zero replicas
STEP: Creating the PV with the fcdID 0c57fc31-3d25-4d98-a4a1-bc65e56283ed
STEP: Scaling up the csi driver to one replica
STEP: Waiting for update operation on statefulset to take effect
STEP: Successfully scaled up the csi driver statefulset:vsphere-csi-controller to one replica
STEP: Sleeping for 120 seconds to allow full sync finish
STEP: Waiting for volume 0c57fc31-3d25-4d98-a4a1-bc65e56283ed to be created
Oct  3 09:56:25.661: INFO: volume "0c57fc31-3d25-4d98-a4a1-bc65e56283ed" has successfully created
STEP: Deleting the PV vspherepv-t496w
STEP: Deleting FCD: 0c57fc31-3d25-4d98-a4a1-bc65e56283ed
[AfterEach] [csi-block-e2e] full-sync-test
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.14.2/test/e2e/framework/framework.go:150
Oct  3 09:56:26.403: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-full-sync-test-9711" for this suite.
Oct  3 09:56:32.451: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Oct  3 09:56:32.750: INFO: namespace e2e-full-sync-test-9711 deletion completed in 6.332418268s

• [SLOW TEST:342.778 seconds]
[csi-block-e2e] full-sync-test
/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/fullsynctest.go:51
  Scale down csi driver statefulset and verify PV metadata is created in CNS
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/fullsynctest.go:556
------------------------------
SSSSSSSS
Ran 1 of 42 Specs in 342.779 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 41 Skipped
PASS

Ginkgo ran 1 suite in 5m52.039216441s
Test Suite Passed
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix e2e test for full sync
```
