### PR TITLE
Update ENV variable name in syncer to match with the deployment yaml file

### DIFF
--- a/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml
+++ b/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml
@@ -76,7 +76,7 @@ spec:
             - "--v=2"
           imagePullPolicy: "Always"
           env:
-            - name: X_CSI_FULL_SYNC_INTERVAL_MINUTES
+            - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
             - name: VSPHERE_CSI_CONFIG
               value: "/etc/cloud/csi-vsphere.conf"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -57,7 +57,7 @@ ssh root@vcip "chmod 700 .ssh; chmod 640 .ssh/authorized_keys"
 ```shell
 
 ### Setting full sync time var
-1. Add `X_CSI_FULL_SYNC_INTERVAL_MINUTES` in csi-driver-deploy.yaml for vsphere-csi-metadata-syncer
+1. Add `FULL_SYNC_INTERVAL_MINUTES` in csi-driver-deploy.yaml for vsphere-csi-metadata-syncer
 2. Setting time interval in the env
 
 ```shell


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR will fix the ENV variable name for FULL SYNC interval in syncer source files to match with the ENV specified in the deployment file
We need this change for users to customize the full sync interval and for this the ENV variables in the source code must match with the deployment yaml file
https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml

**Special notes for your reviewer**:
Deploy CSI driver and customize the value of the FULL SYNC to different values.
Currently the default value is set to 30minutes both in the source files and yaml file. But with this change, if users change the FULL SYNC to different value it will be reflected in the container at runtime as well

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix ENV variable to support customization of FULL SYNC interval
```

**Snapshot of the Deployment file**:

```
kind: StatefulSet
apiVersion: apps/v1
metadata:
  name: vsphere-csi-controller
  namespace: kube-system
...
...
...
        - name: vsphere-syncer
          image: <repository:image-name:tag>
          args:
            - "--v=2"
          imagePullPolicy: "Always"
          env:
            - name: FULL_SYNC_INTERVAL_MINUTES
              value: "30"
            - name: VSPHERE_CSI_CONFIG
              value: "/etc/cloud/csi-vsphere.conf"
          volumeMounts:
            - mountPath: /etc/cloud
              name: vsphere-config-volume
              readOnly: true

```
