### PR TITLE
Update manifests to implement liveness probe

### DIFF
--- a/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml
+++ b/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml
@@ -60,6 +60,18 @@ spec:
               readOnly: true
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
         - name: liveness-probe
           image: quay.io/k8scsi/livenessprobe:v1.1.0
           args:

--- a/manifests/1.14/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/1.14/deploy/vsphere-csi-node-ds.yaml
@@ -71,6 +71,18 @@ spec:
               mountPropagation: "Bidirectional"
             - name: device-dir
               mountPath: /dev
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
         - name: liveness-probe
           image: quay.io/k8scsi/livenessprobe:v1.1.0
           args:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CSI spec requires all driver to implement a liveness probe for the controllers. We had a liveness probe running but did not open a port on the controller to respond to the Probe requests. 
This change adds that to the controller/node manifest files.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
