### PR TITLE
Removing hostNetwork: true setting from CSI controller and node pods

### DIFF
--- a/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml
+++ b/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml
@@ -24,7 +24,7 @@ spec:
         - operator: "Exists"
           key: node-role.kubernetes.io/master
           effect: NoSchedule
-      hostNetwork: true
+      dnsPolicy: "Default"
       containers:
         - name: csi-attacher
           image: quay.io/k8scsi/csi-attacher:v1.1.1

--- a/manifests/1.14/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/1.14/deploy/vsphere-csi-node-ds.yaml
@@ -15,7 +15,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
-      hostNetwork: true
+      dnsPolicy: "Default"
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
@@ -43,6 +43,10 @@ spec:
           image: vmware/vsphere-block-csi-driver:v1.0.0
           imagePullPolicy: "Always"
           env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: X_CSI_MODE

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -353,17 +353,16 @@ func (s *service) NodeGetInfo(
 	ctx context.Context,
 	req *csi.NodeGetInfoRequest) (
 	*csi.NodeGetInfoResponse, error) {
-	nodeID, err := os.Hostname()
-	if err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"Unable to retrieve Node ID, err: %s", err)
+	nodeID := os.Getenv("NODE_NAME")
+	if nodeID == "" {
+		return nil, status.Error(codes.Internal, "ENV NODE_NAME is not set")
 	}
 	var cfg *cnsconfig.Config
 	cfgPath = csictx.Getenv(ctx, cnsconfig.EnvCloudConfig)
 	if cfgPath == "" {
 		cfgPath = cnsconfig.DefaultCloudConfigPath
 	}
-	cfg, err = cnsconfig.GetCnsconfig(cfgPath)
+	cfg, err := cnsconfig.GetCnsconfig(cfgPath)
 	if err != nil {
 		klog.Errorf("Failed to read cnsconfig. Error: %v", err)
 		return nil, status.Errorf(codes.Internal, err.Error())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is removing `hostNetwork : true` setting from CSI controller and node DaemonSet pods.

With this change we are also setting `dnsPolicy: "Default"` for pod spec which allows pod to inherits the name resolution configuration from the node that the pods run on. Without this, when vCenter Host is specified by FQDN, pod cannot establish connection to vCenter, and results into this error - `err: Post https://sc2-rdops-vm09-dhcp-60-181.eng.vmware.com:443/sdk: dial tcp: i/o timeout`


This change is required to fix concern mentioned at https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/68#issuecomment-536668095 

With this change, we will be able to merge liveness probe change made in this PR - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/68

We have verified liveness probe works fine on both node DeamonSet pod and controller pod when both pods are deployed on the same node. 


**Which issue this PR fixes**
fixes #70 

**Special notes for your reviewer**:

With the image built from this change, @RaunakShah has also verified `csinodes` is correctly populating `Node ID:` with actual node names and volume is successfully getting attached to the node.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Removing hostNetwork setting from CSI controller and node pods
```
