### PR TITLE
Fixup CI image creation

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -43,7 +43,7 @@ CSI_IMAGE_NAME=
 SYNCER_IMAGE_NAME=
 VERSION=$(git describe --dirty --always 2>/dev/null)
 GCR_KEY_FILE="${GCR_KEY_FILE:-}"
-GOPROXY="${GOPROXY:-}"
+GOPROXY="${GOPROXY:-https://proxy.golang.org}"
 BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 
 # If BUILD_RELEASE_TYPE is not set then check to see if this is a PR

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -30,7 +30,9 @@ COPY pkg ./pkg/
 COPY cmd ./cmd/
 ARG GOOS
 ARG GOARCH
+ARG GOPROXY
 ENV GOOS=${GOOS:-linux} GOARCH=${GOARCH:-amd64}
+ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
 RUN go mod download && go mod verify
 
 ################################################################################
@@ -47,7 +49,9 @@ COPY pkg ./pkg/
 COPY cmd ./cmd/
 ARG GOOS
 ARG GOARCH
+ARG GOPROXY
 ENV CGO_ENABLED=0 GOOS=${GOOS:-linux} GOARCH=${GOARCH:-amd64}
+ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
 RUN LDFLAGS=$(cat ldflags.txt) && \
     go build -ldflags "${LDFLAGS}" ./cmd/vsphere-csi
 

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -54,12 +54,8 @@ ENV CGO_ENABLED=0 GOOS=${GOOS:-linux} GOARCH=${GOARCH:-amd64}
 ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
 RUN LDFLAGS=$(cat ldflags.txt) && \
     go build -ldflags "${LDFLAGS}" ./cmd/vsphere-csi
-
-################################################################################
-##                               LINT STAGE                                   ##
-################################################################################
-FROM ${GOLANG_IMAGE} as lint
-RUN go get -u golang.org/x/lint/golint
+RUN LDFLAGS=$(cat ldflags.txt) && \
+    go build -ldflags "${LDFLAGS}" ./cmd/syncer
 
 ################################################################################
 ##                               MAIN STAGE                                   ##
@@ -81,14 +77,14 @@ RUN apt-get update && \
       jq \
       mercurial \
       python3 \
+      python3-pip \
       unzip \
       zip && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
-    curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 - && \
     pip3 install setuptools wheel --upgrade
 
 # Download the Google Cloud SDK
-RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-245.0.0-linux-x86_64.tar.gz | \
+RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-265.0.0-linux-x86_64.tar.gz | \
     tar xzC / && \
     /google-cloud-sdk/bin/gcloud components update
 
@@ -148,11 +144,6 @@ ENV DOCKER_IN_DOCKER_ENABLED=true
 # Update the PATH to include the Google Cloud SDK and disable its prompts and
 # update the gcloud components.
 ENV PATH="/google-cloud-sdk/bin:${PATH}" CLOUDSDK_CORE_DISABLE_PROMPTS=1
-
-################################################################################
-##                             INSTALL LINT                                   ##
-################################################################################
-COPY --from=lint /go/bin/golint /usr/local/bin/
 
 ################################################################################
 ##                         PRIME GO MOD & BUILD CACHES                        ##

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -39,7 +39,7 @@ COPY go.mod go.sum ./
 COPY pkg/    pkg/
 COPY cmd/    cmd/
 ENV CGO_ENABLED=0
-ENV GOPROXY ${GOPROXY:-}
+ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
 RUN go build -a -ldflags='-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.version=${VERSION}' -o vsphere-csi ./cmd/vsphere-csi
 
 ################################################################################

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -36,7 +36,7 @@ COPY cmd/    cmd/
 
 ENV CGO_ENABLED=0
 
-ENV GOPROXY ${GOPROXY:-}
+ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
 
 RUN go build -o vsphere-syncer ./cmd/syncer
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR has a few commits in it to clean up the create of the "CI" image.

I found that when I build locally, using `hack/release.sh`, but that builds were failing unless I set `GOPROXY`. It was unable to get all the go mods. This only happens when running in a container. It's also not a problem on Prow because we honor the `GOPROXY` env var set on Prow, which is already set to `https://proxy.golang.org`. We might as well just default to that across the board (and that is the default in 1.13), and I found that it unblocked me *and* sped up builds.

I needed to add support for `GOPROXY` to the CI image Dockerfile.

I also found that when trying to build a newer version of the CI image, the build failed completely. I had to make a couple small tweaks to fix that.

**Special notes for your reviewer**:
I think I'd like to move away from the CI image eventually. It made sense many months ago, but is mostly negated by Prow's support for `GOPROXY`. It was created to speed up builds, and it does do that by quite a bit if starting from scratch, but since Prow is our primary target, and Prow is so close the GOPROXY (meaning, in GCE), mod downloads are pretty darn fast.

Also, there is a downside to the CI image when it gets stale. It caches compiled versions where it can (our own source code changes, but there might be some pieces that don't require a re-compile), and that's great in theory, except those cached versions are from whatever version of Go was used to compile at the time. Right now, the current CI version being used reports `1.12.4`. So even though we recently updated our images to use go `1.12.10`, there may be packages sill compiled with `1.12.4`. That's not good if there are security vulnerabilities there.

So this patch will update everything to the latest, but I'm going to take it on as a follow-up to remove the CI image from our process later on.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

/assign @dvonthenen 