### PR TITLE
Ignore pvc deletion error in the e2e test

### DIFF
--- a/tests/e2e/fullsynctest.go
+++ b/tests/e2e/fullsynctest.go
@@ -384,8 +384,7 @@ var _ bool = ginkgo.Describe("[csi-block-e2e] full-sync-test", func() {
 		// cleanup
 		for _, pvc := range pvclaims {
 			ginkgo.By(fmt.Sprintf("Deleting pvc %s in namespace %s", pvc.Name, pvc.Namespace))
-			err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(pvc.Name, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			_ = client.CoreV1().PersistentVolumeClaims(namespace).Delete(pvc.Name, nil)
 		}
 
 		for _, pv := range pvs {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing one of the e2e test which tests multiple pvc deletion and updates. As part of these multiple operations it is safe to ignore the pvc deletion error in the cleanup step. Because, in the subsequent step we delete the pv and cleanup the namespaces. Hence the pvc will also be deleted.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Ignoring the err if any, returned by the DeletePVC() API

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix full sync e2e test : Verify Multiple PVCs are deleted/updated after full sync
```

**Results**:
<pre>
$ make test-e2e
hack/run-e2e-test.sh
go: finding github.com/onsi/ginkgo/ginkgo latest
Oct  8 16:39:12.587: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CNS CSI Driver End-to-End Tests
==============================================
Random Seed: 1570577943 - Will randomize all specs
Will run 1 of 42 specs

SSSSSSSS
------------------------------
[csi-block-e2e] full-sync-test 
  Verify Multiple PVCs are deleted/updated after full sync
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/fullsynctest.go:314
[BeforeEach] [csi-block-e2e] full-sync-test
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.14.2/test/e2e/framework/framework.go:149
STEP: Creating a kubernetes client
Oct  8 16:39:12.587: INFO: >>> kubeConfig: /Users/chethanv/.kube/config
STEP: Building a namespace api object, basename e2e-full-sync-test
Oct  8 16:39:12.684: INFO: Found PodSecurityPolicies; assuming PodSecurityPolicy is enabled.
Oct  8 16:39:12.704: INFO: Found ClusterRoles; assuming RBAC is enabled.
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-full-sync-test-286
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [csi-block-e2e] full-sync-test
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/fullsynctest.go:77
[It] Verify Multiple PVCs are deleted/updated after full sync
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/fullsynctest.go:314
STEP: Creating StorageClass With scParameters: map[] and allowedTopologies: [] and ReclaimPolicy: Retain
STEP: Creating PVC using the Storage Class sc-zh6gn with disk size  and labels: map[]
STEP: Waiting for claim pvc-bl5sx to be in bound phase
Oct  8 16:39:12.943: INFO: Waiting up to 5m0s for PersistentVolumeClaims [pvc-bl5sx] to have phase Bound
Oct  8 16:39:12.955: INFO: PersistentVolumeClaim pvc-bl5sx found but phase is Pending instead of Bound.
Oct  8 16:39:14.971: INFO: PersistentVolumeClaim pvc-bl5sx found but phase is Pending instead of Bound.
Oct  8 16:39:16.980: INFO: PersistentVolumeClaim pvc-bl5sx found but phase is Pending instead of Bound.
Oct  8 16:39:18.987: INFO: PersistentVolumeClaim pvc-bl5sx found but phase is Pending instead of Bound.
Oct  8 16:39:20.997: INFO: PersistentVolumeClaim pvc-bl5sx found but phase is Pending instead of Bound.
Oct  8 16:39:23.013: INFO: PersistentVolumeClaim pvc-bl5sx found but phase is Pending instead of Bound.
Oct  8 16:39:25.025: INFO: PersistentVolumeClaim pvc-bl5sx found but phase is Pending instead of Bound.
Oct  8 16:39:27.034: INFO: PersistentVolumeClaim pvc-bl5sx found but phase is Pending instead of Bound.
Oct  8 16:39:29.042: INFO: PersistentVolumeClaim pvc-bl5sx found but phase is Pending instead of Bound.
Oct  8 16:39:31.050: INFO: PersistentVolumeClaim pvc-bl5sx found and phase=Bound (18.106966372s)
STEP: Creating PVC using the Storage Class sc-zh6gn with disk size  and labels: map[]
STEP: Waiting for claim pvc-zck4r to be in bound phase
Oct  8 16:39:31.075: INFO: Waiting up to 5m0s for PersistentVolumeClaims [pvc-zck4r] to have phase Bound
Oct  8 16:39:31.091: INFO: PersistentVolumeClaim pvc-zck4r found but phase is Pending instead of Bound.
Oct  8 16:39:33.104: INFO: PersistentVolumeClaim pvc-zck4r found but phase is Pending instead of Bound.
Oct  8 16:39:35.117: INFO: PersistentVolumeClaim pvc-zck4r found but phase is Pending instead of Bound.
Oct  8 16:39:37.126: INFO: PersistentVolumeClaim pvc-zck4r found but phase is Pending instead of Bound.
Oct  8 16:39:39.145: INFO: PersistentVolumeClaim pvc-zck4r found but phase is Pending instead of Bound.
Oct  8 16:39:41.155: INFO: PersistentVolumeClaim pvc-zck4r found but phase is Pending instead of Bound.
Oct  8 16:39:43.171: INFO: PersistentVolumeClaim pvc-zck4r found and phase=Bound (12.095812195s)
STEP: Creating PVC using the Storage Class sc-zh6gn with disk size  and labels: map[]
STEP: Waiting for claim pvc-zp4nk to be in bound phase
Oct  8 16:39:43.210: INFO: Waiting up to 5m0s for PersistentVolumeClaims [pvc-zp4nk] to have phase Bound
Oct  8 16:39:43.225: INFO: PersistentVolumeClaim pvc-zp4nk found but phase is Pending instead of Bound.
Oct  8 16:39:45.243: INFO: PersistentVolumeClaim pvc-zp4nk found but phase is Pending instead of Bound.
Oct  8 16:39:47.262: INFO: PersistentVolumeClaim pvc-zp4nk found but phase is Pending instead of Bound.
Oct  8 16:39:49.280: INFO: PersistentVolumeClaim pvc-zp4nk found but phase is Pending instead of Bound.
Oct  8 16:39:51.295: INFO: PersistentVolumeClaim pvc-zp4nk found but phase is Pending instead of Bound.
Oct  8 16:39:53.307: INFO: PersistentVolumeClaim pvc-zp4nk found but phase is Pending instead of Bound.
Oct  8 16:39:55.318: INFO: PersistentVolumeClaim pvc-zp4nk found but phase is Pending instead of Bound.
Oct  8 16:39:57.337: INFO: PersistentVolumeClaim pvc-zp4nk found but phase is Pending instead of Bound.
Oct  8 16:39:59.351: INFO: PersistentVolumeClaim pvc-zp4nk found but phase is Pending instead of Bound.
Oct  8 16:40:01.360: INFO: PersistentVolumeClaim pvc-zp4nk found and phase=Bound (18.150493333s)
STEP: Creating PVC using the Storage Class sc-zh6gn with disk size  and labels: map[]
STEP: Waiting for claim pvc-ppxkd to be in bound phase
Oct  8 16:40:01.403: INFO: Waiting up to 5m0s for PersistentVolumeClaims [pvc-ppxkd] to have phase Bound
Oct  8 16:40:01.421: INFO: PersistentVolumeClaim pvc-ppxkd found but phase is Pending instead of Bound.
Oct  8 16:40:03.429: INFO: PersistentVolumeClaim pvc-ppxkd found but phase is Pending instead of Bound.
Oct  8 16:40:05.445: INFO: PersistentVolumeClaim pvc-ppxkd found but phase is Pending instead of Bound.
Oct  8 16:40:07.455: INFO: PersistentVolumeClaim pvc-ppxkd found but phase is Pending instead of Bound.
Oct  8 16:40:09.467: INFO: PersistentVolumeClaim pvc-ppxkd found but phase is Pending instead of Bound.
Oct  8 16:40:11.482: INFO: PersistentVolumeClaim pvc-ppxkd found but phase is Pending instead of Bound.
Oct  8 16:40:13.496: INFO: PersistentVolumeClaim pvc-ppxkd found but phase is Pending instead of Bound.
Oct  8 16:40:15.505: INFO: PersistentVolumeClaim pvc-ppxkd found and phase=Bound (14.101898103s)
STEP: Creating PVC using the Storage Class sc-zh6gn with disk size  and labels: map[]
STEP: Waiting for claim pvc-2wlrg to be in bound phase
Oct  8 16:40:15.532: INFO: Waiting up to 5m0s for PersistentVolumeClaims [pvc-2wlrg] to have phase Bound
Oct  8 16:40:15.551: INFO: PersistentVolumeClaim pvc-2wlrg found but phase is Pending instead of Bound.
Oct  8 16:40:17.570: INFO: PersistentVolumeClaim pvc-2wlrg found but phase is Pending instead of Bound.
Oct  8 16:40:19.601: INFO: PersistentVolumeClaim pvc-2wlrg found but phase is Pending instead of Bound.
Oct  8 16:40:21.612: INFO: PersistentVolumeClaim pvc-2wlrg found but phase is Pending instead of Bound.
Oct  8 16:40:23.631: INFO: PersistentVolumeClaim pvc-2wlrg found but phase is Pending instead of Bound.
Oct  8 16:40:25.647: INFO: PersistentVolumeClaim pvc-2wlrg found but phase is Pending instead of Bound.
Oct  8 16:40:27.663: INFO: PersistentVolumeClaim pvc-2wlrg found but phase is Pending instead of Bound.
Oct  8 16:40:29.672: INFO: PersistentVolumeClaim pvc-2wlrg found and phase=Bound (14.139898307s)
STEP: Stopping vsan-health on the vCenter host

Oct  8 16:40:29.686: INFO: Invoking command service-control --stop vsan-health on vCenter host 10.160.68.110:22
STEP: Sleeping for 15 seconds to allow vsan-health to completely shutdown
STEP: Deleting pvc pvc-bl5sx in namespace e2e-full-sync-test-286
STEP: Deleting pvc pvc-zck4r in namespace e2e-full-sync-test-286
STEP: Updating labels map[app:e2e-fullsync] for pvc pvc-zp4nk in namespace e2e-full-sync-test-286
STEP: Updating labels map[app:e2e-fullsync] for pv pvc-f26d50cf-ea24-11e9-881f-0050568dddbf
STEP: Starting vsan-health on the vCenter host

Oct  8 16:40:55.301: INFO: Invoking command service-control --start vsan-health on vCenter host 10.160.68.110:22
STEP: Sleeping for 15 seconds to allow vsan-health to come up again
STEP: Sleeping for 120 seconds to allow full sync finish
STEP: Waiting for pvc metadata to be deleted for pvc pvc-bl5sx in namespace e2e-full-sync-test-286
Oct  8 16:43:32.329: INFO: queryResult: (*types.CnsQueryResult)(0xc0009c2480)({
 DynamicData: (types.DynamicData) {
 },
 Volumes: ([]types.CnsVolume) (len=1 cap=4) {
  (types.CnsVolume) {
   DynamicData: (types.DynamicData) {
   },
   VolumeId: (types.CnsVolumeId) {
    DynamicData: (types.DynamicData) {
    },
    Id: (string) (len=36) "9d38cf40-2401-4d7f-8d92-06e199280447"
   },
   Name: (string) (len=40) "pvc-d58c8f85-ea24-11e9-881f-0050568dddbf",
   VolumeType: (string) (len=5) "BLOCK",
   DatastoreUrl: (string) (len=58) "ds:///vmfs/volumes/vsan:528721c1051556d4-7340e66a7e27768f/",
   Metadata: (types.CnsVolumeMetadata) {
    DynamicData: (types.DynamicData) {
    },
    ContainerCluster: (types.CnsContainerCluster) {
     DynamicData: (types.DynamicData) {
     },
     ClusterType: (string) (len=10) "KUBERNETES",
     ClusterId: (string) (len=15) "demo-cluster-id",
     VSphereUser: (string) (len=27) "VSPHERE.LOCAL\\Administrator"
    },
    EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=1 cap=4) {
     (*types.CnsKubernetesEntityMetadata)(0xc0001bca00)({
      CnsEntityMetadata: (types.CnsEntityMetadata) {
       DynamicData: (types.DynamicData) {
       },
       EntityName: (string) (len=40) "pvc-d58c8f85-ea24-11e9-881f-0050568dddbf",
       Labels: ([]types.KeyValue) <nil>,
       Delete: (bool) false
      },
      EntityType: (string) (len=17) "PERSISTENT_VOLUME",
      Namespace: (string) ""
     })
    }
   },
   BackingObjectDetails: (types.CnsBackingObjectDetails) {
    DynamicData: (types.DynamicData) {
    },
    CapacityInMb: (int64) 2048
   },
   ComplianceStatus: (string) (len=9) "compliant",
   DatastoreAccessibilityStatus: (string) (len=10) "accessible",
   StoragePolicyId: (string) (len=36) "aa6d5a82-1c88-45da-85d3-3d74b91a5bad"
  }
 },
 Cursor: (types.CnsCursor) {
  DynamicData: (types.DynamicData) {
  },
  Offset: (int64) 1,
  Limit: (int64) 100,
  TotalRecords: (int64) 1
 }
})

STEP: Waiting for pvc metadata to be deleted for pvc pvc-zck4r in namespace e2e-full-sync-test-286
Oct  8 16:43:34.519: INFO: queryResult: (*types.CnsQueryResult)(0xc0009c2900)({
 DynamicData: (types.DynamicData) {
 },
 Volumes: ([]types.CnsVolume) (len=1 cap=4) {
  (types.CnsVolume) {
   DynamicData: (types.DynamicData) {
   },
   VolumeId: (types.CnsVolumeId) {
    DynamicData: (types.DynamicData) {
    },
    Id: (string) (len=36) "8d3a4055-f040-4bf7-aa8e-d3df5bcdbd0b"
   },
   Name: (string) (len=40) "pvc-e05aedfc-ea24-11e9-881f-0050568dddbf",
   VolumeType: (string) (len=5) "BLOCK",
   DatastoreUrl: (string) (len=58) "ds:///vmfs/volumes/vsan:528721c1051556d4-7340e66a7e27768f/",
   Metadata: (types.CnsVolumeMetadata) {
    DynamicData: (types.DynamicData) {
    },
    ContainerCluster: (types.CnsContainerCluster) {
     DynamicData: (types.DynamicData) {
     },
     ClusterType: (string) (len=10) "KUBERNETES",
     ClusterId: (string) (len=15) "demo-cluster-id",
     VSphereUser: (string) (len=27) "VSPHERE.LOCAL\\Administrator"
    },
    EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=1 cap=4) {
     (*types.CnsKubernetesEntityMetadata)(0xc0001bcaf0)({
      CnsEntityMetadata: (types.CnsEntityMetadata) {
       DynamicData: (types.DynamicData) {
       },
       EntityName: (string) (len=40) "pvc-e05aedfc-ea24-11e9-881f-0050568dddbf",
       Labels: ([]types.KeyValue) <nil>,
       Delete: (bool) false
      },
      EntityType: (string) (len=17) "PERSISTENT_VOLUME",
      Namespace: (string) ""
     })
    }
   },
   BackingObjectDetails: (types.CnsBackingObjectDetails) {
    DynamicData: (types.DynamicData) {
    },
    CapacityInMb: (int64) 2048
   },
   ComplianceStatus: (string) (len=9) "compliant",
   DatastoreAccessibilityStatus: (string) (len=10) "accessible",
   StoragePolicyId: (string) (len=36) "aa6d5a82-1c88-45da-85d3-3d74b91a5bad"
  }
 },
 Cursor: (types.CnsCursor) {
  DynamicData: (types.DynamicData) {
  },
  Offset: (int64) 1,
  Limit: (int64) 100,
  TotalRecords: (int64) 1
 }
})

STEP: Waiting for labels map[app:e2e-fullsync] to be updated for pvc pvc-zp4nk in namespace e2e-full-sync-test-286
Oct  8 16:43:36.708: INFO: queryResult: (*types.CnsQueryResult)(0xc0006cade0)({
 DynamicData: (types.DynamicData) {
 },
 Volumes: ([]types.CnsVolume) (len=1 cap=4) {
  (types.CnsVolume) {
   DynamicData: (types.DynamicData) {
   },
   VolumeId: (types.CnsVolumeId) {
    DynamicData: (types.DynamicData) {
    },
    Id: (string) (len=36) "073fed52-1599-41c6-a842-d559198d8256"
   },
   Name: (string) (len=40) "pvc-e795aefb-ea24-11e9-881f-0050568dddbf",
   VolumeType: (string) (len=5) "BLOCK",
   DatastoreUrl: (string) (len=58) "ds:///vmfs/volumes/vsan:528721c1051556d4-7340e66a7e27768f/",
   Metadata: (types.CnsVolumeMetadata) {
    DynamicData: (types.DynamicData) {
    },
    ContainerCluster: (types.CnsContainerCluster) {
     DynamicData: (types.DynamicData) {
     },
     ClusterType: (string) (len=10) "KUBERNETES",
     ClusterId: (string) (len=15) "demo-cluster-id",
     VSphereUser: (string) (len=27) "VSPHERE.LOCAL\\Administrator"
    },
    EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=2 cap=4) {
     (*types.CnsKubernetesEntityMetadata)(0xc0006541e0)({
      CnsEntityMetadata: (types.CnsEntityMetadata) {
       DynamicData: (types.DynamicData) {
       },
       EntityName: (string) (len=9) "pvc-zp4nk",
       Labels: ([]types.KeyValue) (len=1 cap=4) {
        (types.KeyValue) {
         DynamicData: (types.DynamicData) {
         },
         Key: (string) (len=3) "app",
         Value: (string) (len=12) "e2e-fullsync"
        }
       },
       Delete: (bool) false
      },
      EntityType: (string) (len=23) "PERSISTENT_VOLUME_CLAIM",
      Namespace: (string) (len=22) "e2e-full-sync-test-286"
     }),
     (*types.CnsKubernetesEntityMetadata)(0xc000654230)({
      CnsEntityMetadata: (types.CnsEntityMetadata) {
       DynamicData: (types.DynamicData) {
       },
       EntityName: (string) (len=40) "pvc-e795aefb-ea24-11e9-881f-0050568dddbf",
       Labels: ([]types.KeyValue) <nil>,
       Delete: (bool) false
      },
      EntityType: (string) (len=17) "PERSISTENT_VOLUME",
      Namespace: (string) ""
     })
    }
   },
   BackingObjectDetails: (types.CnsBackingObjectDetails) {
    DynamicData: (types.DynamicData) {
    },
    CapacityInMb: (int64) 2048
   },
   ComplianceStatus: (string) (len=9) "compliant",
   DatastoreAccessibilityStatus: (string) (len=10) "accessible",
   StoragePolicyId: (string) (len=36) "aa6d5a82-1c88-45da-85d3-3d74b91a5bad"
  }
 },
 Cursor: (types.CnsCursor) {
  DynamicData: (types.DynamicData) {
  },
  Offset: (int64) 1,
  Limit: (int64) 100,
  TotalRecords: (int64) 1
 }
})

STEP: Waiting for labels map[app:e2e-fullsync] to be updated for pv pvc-f26d50cf-ea24-11e9-881f-0050568dddbf
Oct  8 16:43:38.892: INFO: queryResult: (*types.CnsQueryResult)(0xc0009c2cf0)({
 DynamicData: (types.DynamicData) {
 },
 Volumes: ([]types.CnsVolume) (len=1 cap=4) {
  (types.CnsVolume) {
   DynamicData: (types.DynamicData) {
   },
   VolumeId: (types.CnsVolumeId) {
    DynamicData: (types.DynamicData) {
    },
    Id: (string) (len=36) "7964aead-471e-44e2-b0cb-8eed102e0438"
   },
   Name: (string) (len=40) "pvc-f26d50cf-ea24-11e9-881f-0050568dddbf",
   VolumeType: (string) (len=5) "BLOCK",
   DatastoreUrl: (string) (len=58) "ds:///vmfs/volumes/vsan:528721c1051556d4-7340e66a7e27768f/",
   Metadata: (types.CnsVolumeMetadata) {
    DynamicData: (types.DynamicData) {
    },
    ContainerCluster: (types.CnsContainerCluster) {
     DynamicData: (types.DynamicData) {
     },
     ClusterType: (string) (len=10) "KUBERNETES",
     ClusterId: (string) (len=15) "demo-cluster-id",
     VSphereUser: (string) (len=27) "VSPHERE.LOCAL\\Administrator"
    },
    EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=2 cap=4) {
     (*types.CnsKubernetesEntityMetadata)(0xc0001bcbe0)({
      CnsEntityMetadata: (types.CnsEntityMetadata) {
       DynamicData: (types.DynamicData) {
       },
       EntityName: (string) (len=9) "pvc-ppxkd",
       Labels: ([]types.KeyValue) <nil>,
       Delete: (bool) false
      },
      EntityType: (string) (len=23) "PERSISTENT_VOLUME_CLAIM",
      Namespace: (string) (len=22) "e2e-full-sync-test-286"
     }),
     (*types.CnsKubernetesEntityMetadata)(0xc0001bcc30)({
      CnsEntityMetadata: (types.CnsEntityMetadata) {
       DynamicData: (types.DynamicData) {
       },
       EntityName: (string) (len=40) "pvc-f26d50cf-ea24-11e9-881f-0050568dddbf",
       Labels: ([]types.KeyValue) (len=1 cap=4) {
        (types.KeyValue) {
         DynamicData: (types.DynamicData) {
         },
         Key: (string) (len=3) "app",
         Value: (string) (len=12) "e2e-fullsync"
        }
       },
       Delete: (bool) false
      },
      EntityType: (string) (len=17) "PERSISTENT_VOLUME",
      Namespace: (string) ""
     })
    }
   },
   BackingObjectDetails: (types.CnsBackingObjectDetails) {
    DynamicData: (types.DynamicData) {
    },
    CapacityInMb: (int64) 2048
   },
   ComplianceStatus: (string) (len=9) "compliant",
   DatastoreAccessibilityStatus: (string) (len=10) "accessible",
   StoragePolicyId: (string) (len=36) "aa6d5a82-1c88-45da-85d3-3d74b91a5bad"
  }
 },
 Cursor: (types.CnsCursor) {
  DynamicData: (types.DynamicData) {
  },
  Offset: (int64) 1,
  Limit: (int64) 100,
  TotalRecords: (int64) 1
 }
})

STEP: Deleting pvc pvc-bl5sx in namespace e2e-full-sync-test-286
STEP: Deleting pvc pvc-zck4r in namespace e2e-full-sync-test-286
STEP: Deleting pvc pvc-zp4nk in namespace e2e-full-sync-test-286
STEP: Deleting pvc pvc-ppxkd in namespace e2e-full-sync-test-286
STEP: Deleting pvc pvc-2wlrg in namespace e2e-full-sync-test-286
STEP: Deleting the PV pvc-d58c8f85-ea24-11e9-881f-0050568dddbf
STEP: Deleting the PV pvc-e05aedfc-ea24-11e9-881f-0050568dddbf
STEP: Deleting the PV pvc-e795aefb-ea24-11e9-881f-0050568dddbf
STEP: Deleting the PV pvc-f26d50cf-ea24-11e9-881f-0050568dddbf
STEP: Deleting the PV pvc-fada1d67-ea24-11e9-881f-0050568dddbf
[AfterEach] [csi-block-e2e] full-sync-test
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.14.2/test/e2e/framework/framework.go:150
Oct  8 16:43:39.131: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-full-sync-test-286" for this suite.
Oct  8 16:43:45.185: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Oct  8 16:43:45.408: INFO: namespace e2e-full-sync-test-286 deletion completed in 6.249486739s

• [SLOW TEST:272.822 seconds]
[csi-block-e2e] full-sync-test
/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/fullsynctest.go:51
  Verify Multiple PVCs are deleted/updated after full sync
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/fullsynctest.go:314
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 42 Specs in 272.822 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 41 Skipped
PASS

Ginkgo ran 1 suite in 4m41.642388979s
Test Suite Passed
</pre>

