### PR TITLE
Defer closing wait groups in full sync to cover all exit points

### DIFF
--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -120,6 +120,7 @@ func getPVsInBoundAvailableOrReleased(k8sclient clientset.Interface) ([]*v1.Pers
 // Before creating a volume, all current K8s volumes are retrieved
 // If the volume is successfully created, it is removed from cnsCreationMap
 func fullSyncCreateVolumes(createSpecArray []cnstypes.CnsVolumeCreateSpec, metadataSyncer *MetadataSyncInformer, k8sclient clientset.Interface, wg *sync.WaitGroup) {
+	defer wg.Done()
 	currentK8sPVMap := make(map[string]bool)
 	volumeOperationsLock.Lock()
 	defer volumeOperationsLock.Unlock()
@@ -148,14 +149,13 @@ func fullSyncCreateVolumes(createSpecArray []cnstypes.CnsVolumeCreateSpec, metad
 		}
 		delete(cnsCreationMap, (createSpec.BackingObjectDetails).(*cnstypes.CnsBlockBackingDetails).BackingDiskId)
 	}
-
-	wg.Done()
 }
 
 // fullSyncDeleteVolumes delete volumes with given array of volumeId
 // Before deleting a volume, all current K8s volumes are retrieved
 // If the volume is successfully deleted, it is removed from cnsDeletionMap
 func fullSyncDeleteVolumes(volumeIDDeleteArray []cnstypes.CnsVolumeId, metadataSyncer *MetadataSyncInformer, k8sclient clientset.Interface, wg *sync.WaitGroup) {
+	defer wg.Done()
 	deleteDisk := false
 	currentK8sPVMap := make(map[string]bool)
 	volumeOperationsLock.Lock()
@@ -182,18 +182,17 @@ func fullSyncDeleteVolumes(volumeIDDeleteArray []cnstypes.CnsVolumeId, metadataS
 		}
 		delete(cnsDeletionMap, volID.Id)
 	}
-	wg.Done()
 }
 
 // fullSyncUpdateVolumes update metadata for volumes with given array of createSpec
 func fullSyncUpdateVolumes(updateSpecArray []cnstypes.CnsVolumeMetadataUpdateSpec, metadataSyncer *MetadataSyncInformer, wg *sync.WaitGroup) {
+	defer wg.Done()
 	for _, updateSpec := range updateSpecArray {
 		klog.V(4).Infof("FullSync: Calling UpdateVolumeMetadata for volume %s with updateSpec: %+v", updateSpec.VolumeId.Id, spew.Sdump(updateSpec))
 		if err := volumes.GetManager(metadataSyncer.vcenter).UpdateVolumeMetadata(&updateSpec); err != nil {
 			klog.Warningf("FullSync:UpdateVolumeMetadata failed with err %v", err)
 		}
 	}
-	wg.Done()
 }
 
 // buildCnsUpdateMetadataList build metadata list for given PV


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR `defer`s closing on wait groups used in full sync. Full sync spawns new threads and creates a wait group. It blocks until the count of this wait group equals 0. 
There was a bug recently where one of the threads returned before closing its wait group. 
By using the power of golangs `defer`, we can cover all exit points.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Defer closing full sync wait groups 
```
