### PR TITLE
updating deployment yamls with v1.0.1 images

### DIFF
--- a/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml
+++ b/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml
@@ -39,7 +39,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: vmware/vsphere-block-csi-driver:v1.0.0
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.1
           lifecycle:
             preStop:
               exec:
@@ -83,7 +83,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: vsphere-syncer
-          image: vmware/volume-metadata-syncer:v1.0.0
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.1
           args:
             - "--v=2"
           imagePullPolicy: "Always"

--- a/manifests/1.14/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/1.14/deploy/vsphere-csi-node-ds.yaml
@@ -40,7 +40,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: vsphere-csi-node
-          image: vmware/vsphere-block-csi-driver:v1.0.0
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.1
           imagePullPolicy: "Always"
           env:
             - name: NODE_NAME


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is updating vSphere CSI driver deployment YAML files with images for release [v1.0.1]( https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v1.0.1)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
updating deployment yamls with v1.0.1 images
```
