### PR TITLE
Allow root CA to be configured

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -100,6 +100,9 @@ func GetVirtualCenterConfig(cfg *config.Config) (*VirtualCenterConfig, error) {
 	for idx := range vcConfig.DatacenterPaths {
 		vcConfig.DatacenterPaths[idx] = strings.TrimSpace(vcConfig.DatacenterPaths[idx])
 	}
+	if len(cfg.Global.CAFile) > 0 && !cfg.Global.InsecureFlag {
+		vcConfig.CAFile = cfg.Global.CAFile
+	}
 	return vcConfig, nil
 }
 

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -80,8 +80,13 @@ type VirtualCenterConfig struct {
 	Username string
 	// Password represents the virtual center password in clear text.
 	Password string
-	// Insecure tells if an insecure connection is allowed.
+	// Specifies whether to verify the server's certificate chain. Set to true to
+	// skip verification.
 	Insecure bool
+	// Specifies the path to a CA certificate in PEM format. This has no effect if
+	// Insecure is enabled. Optional; if not configured, the system's CA
+	// certificates will be used.
+	CAFile string
 	// RoundTripperCount is the SOAP round tripper count. (retries = RoundTripperCount - 1)
 	RoundTripperCount int
 	// DatacenterPaths represents paths of datacenters on the virtual center.
@@ -111,6 +116,12 @@ func (vc *VirtualCenter) newClient(ctx context.Context) (*govmomi.Client, error)
 	}
 
 	soapClient := soap.NewClient(url, vc.Config.Insecure)
+	if len(vc.Config.CAFile) > 0 && !vc.Config.Insecure {
+		if err := soapClient.SetRootCAs(vc.Config.CAFile); err != nil {
+			klog.Errorf("Failed to load CA file: %v", err)
+			return nil, err
+		}
+	}
 	vimClient, err := vim25.NewClient(ctx, soapClient)
 	if err != nil {
 		klog.Errorf("Failed to create new client with err: %v", err)

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -29,8 +29,13 @@ type Config struct {
 		Password string `gcfg:"password"`
 		// vCenter port.
 		VCenterPort string `gcfg:"port"`
-		// True if vCenter uses self-signed cert.
+		// Specifies whether to verify the server's certificate chain. Set to true to
+		// skip verification.
 		InsecureFlag bool `gcfg:"insecure-flag"`
+		// Specifies the path to a CA certificate in PEM format. This has no effect if
+		// InsecureFlag is enabled. Optional; if not configured, the system's CA
+		// certificates will be used.
+		CAFile string `gcfg:"ca-file"`
 		// Datacenter in which Node VMs are located.
 		Datacenters string `gcfg:"datacenters"`
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Some vSphere installations sign certificates with private CAs that need
to be trusted for TLS connections. In order for the TLS handshake to
succeed, the CSI driver needs one of,
- explicitly configured CA certs in the SOAP client, or
- custom CA installed in the driver's container (e.g. /etc/ssl/certs/)

I implemented the first option because it is more explicit and
straightforward, even if it requires a little extra code.

To make this work, I added the `ca-file` setting that is present in the
[legacy VCP config format][1]. When connecting to a vCenter, this config
field is used in the SOAP client.

[1]: https://github.com/kubernetes/legacy-cloud-providers/blob/9a3abe860347621b5976ce5ce9d7e7213c2d123d/vsphere/vsphere.go#L146-L148


Sample config file
```ini
[Global]
datacenters = "my-dc"
insecure-flag = false
ca-file = "/etc/vsphere/certificate/ca.crt"
user = "user@vsphere.local"
password = "my-password"
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
