### PR TITLE
Removing upper bound check on VC version during csi controller init

### DIFF
--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -107,7 +107,7 @@ func ValidateControllerUnpublishVolumeRequest(req *csi.ControllerUnpublishVolume
 // CheckAPI checks if specified version is 6.7.3 or higher
 func CheckAPI(version string) error {
 	items := strings.Split(version, ".")
-	if len(items) < 2 || len(items) > 3 {
+	if len(items) < 2 {
 		return fmt.Errorf("Invalid API Version format")
 	}
 	major, err := strconv.Atoi(items[0])
@@ -124,7 +124,7 @@ func CheckAPI(version string) error {
 	}
 
 	if major == MinSupportedVCenterMajor && minor == MinSupportedVCenterMinor {
-		if len(items) == 3 {
+		if len(items) >= 3 {
 			patch, err := strconv.Atoi(items[2])
 			if err != nil || patch < MinSupportedVCenterPatch {
 				return fmt.Errorf("Invalid patch version value")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing the issue where controller fails to initialize with error="Invalid API Version format" for newer/upcoming VC versions . The CheckAPI(version string) validates whether the VC version contains 3 or lesser number of digits in the versioning i.e, Major.Minor.Patch. However the VC versioning can change with different releases and have more/fewer digits.

**Special notes for your reviewer**:
Removed upper bound check and modified version checking to verify vc versions >= 6.7.3

**Release note**:

```
Fix version check in Controller Init
```
**Logs with custom message to show the validation**
<pre>
I0923 06:06:42.826740       1 config.go:284] GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
I0923 06:06:42.826978       1 config.go:228] Initializing vc server 10.160.91.20
I0923 06:06:42.827026       1 controller.go:68] Initializing CNS controller
I0923 06:06:42.827038       1 virtualcentermanager.go:61] Initializing defaultVirtualCenterManager...
I0923 06:06:42.827042       1 virtualcentermanager.go:63] Successfully initialized defaultVirtualCenterManager
I0923 06:06:42.827061       1 virtualcentermanager.go:105] Successfully registered VC "10.160.91.20"
I0923 06:06:42.827095       1 manager.go:59] Initializing volume.defaultManager...
I0923 06:06:42.827099       1 manager.go:63] volume.defaultManager initialized
I0923 06:06:42.968590       1 virtualcenter.go:131] New session ID for 'VSPHERE.LOCAL\Administrator' = 52ccf997-523c-9ef6-1658-5d2fbeb5a1f0
</pre>
