### PR TITLE
Remove vsphere credentials from csi node daemonset

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -262,10 +262,11 @@ func GetCnsconfig(cfgPath string) (*Config, error) {
 	var cfg *Config
 	//Read in the vsphere.conf if it exists
 	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
+		klog.V(2).Infof("Could not stat %s, reading config params from env", cfgPath)
 		// config from Env var only
 		cfg = &Config{}
-		if err := FromEnv(cfg); err != nil {
-			klog.Errorf("Error reading vsphere.conf\n")
+		if fromEnvErr := FromEnv(cfg); fromEnvErr != nil {
+			klog.Errorf("Failed to get config params from env. Err: %v", fromEnvErr)
 			return cfg, err
 		}
 	} else {

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -32,7 +32,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog"
-
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
@@ -364,6 +363,12 @@ func (s *service) NodeGetInfo(
 	}
 	cfg, err := cnsconfig.GetCnsconfig(cfgPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			klog.V(2).Infof("Config file not provided to node daemonset. Assuming non-topology aware cluster.")
+			return &csi.NodeGetInfoResponse{
+				NodeId: nodeID,
+			}, nil
+		}
 		klog.Errorf("Failed to read cnsconfig. Error: %v", err)
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
@@ -371,6 +376,7 @@ func (s *service) NodeGetInfo(
 	topology := &csi.Topology{}
 
 	if cfg.Labels.Zone != "" && cfg.Labels.Region != "" {
+		klog.V(2).Infof("Config file provided to node daemonset with zones and regions. Assuming topology aware cluster.")
 		vcenterconfig, err := cnsvsphere.GetVirtualCenterConfig(cfg)
 		if err != nil {
 			klog.Errorf("Failed to get VirtualCenterConfig from cns config. err=%v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Changing the default to remove `csi-vsphere.conf` as a mounted volume to node daemonset. This is only needed for topology aware clusters. 
Also addressing an issue where the node daemonset would fail if this volume was not mounted.  

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR addresses https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/95

**Special notes for your reviewer**:

**Testing**:
For non-topology aware setups:

Logs showing node daemonset can successfully register with kubelet
```
{"log":"I1205 20:21:52.304096       1 service.go:88] configured: csi.vsphere.vmware.com with map[mode:node]\n","stream":"stderr","time":"2019-12-05T20:21:52.307895822Z"}
{"log":"time=\"2019-12-05T20:21:52Z\" level=info msg=\"identity service registered\"\n","stream":"stderr","time":"2019-12-05T20:21:52.308266734Z"}
{"log":"time=\"2019-12-05T20:21:52Z\" level=info msg=\"node service registered\"\n","stream":"stderr","time":"2019-12-05T20:21:52.308275623Z"}
{"log":"time=\"2019-12-05T20:21:52Z\" level=info msg=serving endpoint=\"unix:///csi/csi.sock\"\n","stream":"stderr","time":"2019-12-05T20:21:52.308279094Z"}
{"log":"I1205 20:21:54.591428       1 config.go:261] GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf\n","stream":"stderr","time":"2019-12-05T20:21:54.591716655Z"}
{"log":"I1205 20:21:54.591838       1 config.go:265] Could not stat /etc/cloud/csi-vsphere.conf, reading config params from env\n","stream":"stderr","time":"2019-12-05T20:21:54.592128802Z"}
{"log":"E1205 20:21:54.592305       1 config.go:202] No Virtual Center hosts defined\n","stream":"stderr","time":"2019-12-05T20:21:54.592819448Z"}
{"log":"E1205 20:21:54.592936       1 config.go:269] Failed to get config params from env. Err: No Virtual Center hosts defined\n","stream":"stderr","time":"2019-12-05T20:21:54.594325039Z"}
{"log":"I1205 20:21:54.593568       1 node.go:367] Config file not provided to node daemonset. Assuming non-topology aware cluster\n","stream":"stderr","time":"2019-12-05T20:21:54.594349877Z"}
```

Create a PVC and POD

```
root@k8-master-642:~# kubectl get pvc
NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS               AGE
example-vanilla-block-pvc   Bound    pvc-924d23cd-163b-11ea-ad42-00505691fe6a   1Mi        RWO            example-vanilla-block-sc   42h
root@k8-master-642:~# kubectl get pod
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   1/1     Running   0          2m59s
```


For topology aware setups:

Logs showing node daemonset can successfully register with kubelet
```
{"log":"I1206 00:57:06.057890       1 service.go:88] configured: csi.vsphere.vmware.com with map[mode:node]\n","stream":"stderr","time":"2019-12-06T00:57:06.075632954Z"}
{"log":"time=\"2019-12-06T00:57:06Z\" level=info msg=\"identity service registered\"\n","stream":"stderr","time":"2019-12-06T00:57:06.075952709Z"}
{"log":"time=\"2019-12-06T00:57:06Z\" level=info msg=\"node service registered\"\n","stream":"stderr","time":"2019-12-06T00:57:06.075968483Z"}
{"log":"time=\"2019-12-06T00:57:06Z\" level=info msg=serving endpoint=\"unix:///csi/csi.sock\"\n","stream":"stderr","time":"2019-12-06T00:57:06.075972504Z"}
{"log":"I1206 00:57:08.113064       1 config.go:261] GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf\n","stream":"stderr","time":"2019-12-06T00:57:08.121567715Z"}
{"log":"I1206 00:57:08.114773       1 config.go:206] Initializing vc server 10.160.122.172\n","stream":"stderr","time":"2019-12-06T00:57:08.121621019Z"}
{"log":"I1206 00:57:08.114914       1 node.go:379] Config file provided with Zone and Region. Assuming topology aware cluster.\n","stream":"stderr","time":"2019-12-06T00:57:08.121628155Z”}
```

`csinodes` CRD contains zone and region keys
```
root@k8s-master:~# kubectl describe csinodes
Name:         k8s-node1
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  storage.k8s.io/v1beta1
Kind:         CSINode
Metadata:
  Creation Timestamp:  2019-12-06T00:57:09Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node1
    UID:             b2c6642d-a5a7-43f4-bcd6-9017cbb751cf
  Resource Version:  15588
  Self Link:         /apis/storage.k8s.io/v1beta1/csinodes/k8s-node1
  UID:               ef0a8c72-d613-4d1b-96d6-0fe8ce497daa
Spec:
  Drivers:
    Name:     csi.vsphere.vmware.com
    Node ID:  k8s-node1
    Topology Keys:
      failure-domain.beta.kubernetes.io/region
      failure-domain.beta.kubernetes.io/zone
Events:  <none>
```

Create PVC and Pod:

```
root@k8s-master:~# kubectl get pvc
NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS               AGE
example-vanilla-block-pvc   Bound    pvc-5d61d5ba-9fe6-409a-be32-c773c4c77089   5Gi        RWO            example-vanilla-block-sc   16s
root@k8s-master:~# kubectl get pod
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   1/1     Running   0          21s
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Changing the default to remove `csi-vsphere.conf` as a mounted volume to node daemonset. 
```
