### PR TITLE
Mitigate CVE-2019-11255

### DIFF
--- a/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml
+++ b/manifests/1.14/deploy/vsphere-csi-controller-ss.yaml
@@ -97,7 +97,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.2.1
+          image: quay.io/k8scsi/csi-provisioner:v1.2.2
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Mitigate CVE-2019-11255 by bumping external-provisioner image version to v1.2.2.

**Release note**:
```release-note
Mitigate CVE-2019-11255 by bumping external-provisioner image version to v1.2.2. CVE announcement: https://groups.google.com/forum/#!topic/kubernetes-security-announce/aXiYN0q4uIw
```
