### PR TITLE
Remove Pending Status Check in PodDelete

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -429,10 +429,6 @@ func podDeleted(obj interface{}, metadataSyncer *MetadataSyncInformer) {
 		return
 	}
 
-	if pod.Status.Phase == v1.PodPending {
-		return
-	}
-
 	klog.V(3).Infof("PodDeleted: Pod %s calling updatePodMetadata", pod.Name)
 	// Update pod metadata
 	if errorList := updatePodMetadata(pod, metadataSyncer, true); len(errorList) > 0 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR removes the pod status check in the podDelete. Previously, when the pod status is pending, the metadata syncer will do nothing, just return. While the correct logic should be whatever the status of pod is, the metadata syncer should call delete.

**Special notes for your reviewer**:
All e2e tests have been verified locally.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
removing pending status check for the pod Delete
```
