### PR TITLE
Invoke node Update only for providerID changes

### DIFF
--- a/pkg/csi/service/cns/nodes.go
+++ b/pkg/csi/service/cns/nodes.go
@@ -58,7 +58,20 @@ func (nodes *Nodes) nodeAdd(obj interface{}) {
 }
 
 func (nodes *Nodes) nodeUpdate(oldObj interface{}, newObj interface{}) {
-	nodes.nodeRegister(newObj)
+	newNode, ok := newObj.(*v1.Node)
+	if !ok {
+		klog.Warningf("nodeUpdate: unrecognized object newObj %[1]T%+[1]v", newObj)
+		return
+	}
+	oldNode, ok := oldObj.(*v1.Node)
+	if !ok {
+		klog.Warningf("nodeUpdate: unrecognized object oldObj %[1]T%+[1]v", oldObj)
+		return
+	}
+	if oldNode.Spec.ProviderID != newNode.Spec.ProviderID {
+		klog.V(2).Infof("nodeUpdate: Observed ProviderID change from %q to %q for the node: %q", oldNode.Spec.ProviderID, newNode.Spec.ProviderID, newNode.Name)
+		nodes.nodeRegister(newObj)
+	}
 }
 
 func (nodes *Nodes) nodeRegister(obj interface{}) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is addressing the issue mentioned here: https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/131
We need to make sure nodeRegister is called only when we observe change in the ProviderID.

**Which issue this PR fixes**  
Fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/131

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Invoke NodeRegister only when Provider Id change is observed.
```
