### PR TITLE
move codenrhoden to emeritus in OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,9 +8,11 @@ reviewers:
 - xing-yang
 
 approvers:
-- codenrhoden
 - divyenpatel
 - dvonthenen
 - frapposelli
 - SandeepPissay
 - xing-yang
+
+emeritus_approvers:
+- codenrhoden


### PR DESCRIPTION
**What this PR does / why we need it**:
As I am no longer all that active in this project, and am not well versed with CNS, I feel like I should be moved to `emeritus` status. There are still pieces of the codebase where I may have useful knowledge, so please feel free to ping me as needed. :)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#emeritus

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

/assign @xing-yang @dvonthenen 