### PR TITLE
Fix PVUpdate pre check

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -298,7 +298,7 @@ func pvUpdated(oldObj, newObj interface{}, metadataSyncer *MetadataSyncInformer)
 		return
 	}
 	// Return if labels are unchanged
-	if oldPv.Status.Phase == v1.VolumeAvailable && reflect.DeepEqual(newPv.GetLabels(), oldPv.GetLabels()) {
+	if (oldPv.Status.Phase == v1.VolumeAvailable || oldPv.Status.Phase == v1.VolumeBound) && reflect.DeepEqual(newPv.GetLabels(), oldPv.GetLabels()) {
 		klog.V(3).Infof("PVUpdated: PV labels have not changed")
 		return
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixes the PVUpdate pre check. Eliminates redundant Update calls to CNS when the reclaimPolicy of a PV is changed. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/138

**Special notes for your reviewer**:
Testing: 
Manually verified that when a PV's reclaimPolicy is updated, a call is not propagated to CNS

```
root@4232dd4473647686ef47300ba28b91b3 [ ~ ]# kubectl edit pv pvc-00abb7af-8b03-444f-95f9-3319860e05ad 
persistentvolume/pvc-00abb7af-8b03-444f-95f9-3319860e05ad edited
```

Logs: No log for this operation

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix PVUpdate pre check 
```
