### PR TITLE
Update GoCSI to v1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/prometheus/client_golang v1.1.0 // indirect
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/prometheus/procfs v0.0.4 // indirect
-	github.com/rexray/gocsi v1.0.0
+	github.com/rexray/gocsi v1.0.1
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/soheilhy/cmux v0.1.4 // indirect
 	github.com/spf13/cobra v0.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.0.4 h1:w8DjqFMJDjuVwdZBQoOozr4MVWOnwF7RcL/7uxBjY78=
 github.com/prometheus/procfs v0.0.4/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
-github.com/rexray/gocsi v1.0.0 h1:Ar60eLCskW3iiy1XLmtjikVeJVM/QvHQtVm/Fe17Hz4=
-github.com/rexray/gocsi v1.0.0/go.mod h1:Ch1UhJqwcHZh8nqd003s/Brs0mzHm1T9vbDjFWl+mUE=
+github.com/rexray/gocsi v1.0.1 h1:MHEFxnXfifR3rQmwWeNma3GbFqPoC7Rbns9IsKmuMgY=
+github.com/rexray/gocsi v1.0.1/go.mod h1:Ch1UhJqwcHZh8nqd003s/Brs0mzHm1T9vbDjFWl+mUE=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This update pulls in a newer version of GoCSI, which contains a fix for the SIGSEGV seen in #106.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
I'm not sure if this fixes #106 entirely or not. It will eliminate the SIGSEGV (and that may be all the issue is about, I'll let the maintainers decide that), but I know there is also a connection/timeout issue.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

/assign @xing-yang 