### PR TITLE
upgrade base driver image

### DIFF
--- a/images/driver-base/Dockerfile
+++ b/images/driver-base/Dockerfile
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM photon:2.0
-LABEL "maintainer" "Travis Rhoden <trhoden@vmware.com"
+FROM photon:3.0
+LABEL "maintainers"="Divyen Patel <divyenp@vmware.com>, Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>, Xing Yang <yangxi@vmware.com>"
 
 RUN tdnf -y remove toybox
-
+RUN tdnf -y upgrade
 RUN tdnf -y install \
   util-linux \
   e2fsprogs \
   xfsprogs \
-  btrfs-progs
+  btrfs-progs \
+  nfs-utils
 
 RUN tdnf clean all


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Upgrade base driver image to use `photon:3.0` as base.
* Adding `nfs-utils`.


**Special notes for your reviewer**:
* `nfs-utils` is required to allow mounting nfs volumes created using vsan file service. In the next PR we will be adding support for RWM - file share volumes.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
upgrade base driver image to photon:3.0 and adding nfs-utils
```
