### PR TITLE
fix returning error after logging them

### DIFF
--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -527,7 +527,7 @@ func (s *service) NodeGetVolumeStats(
 
 	available, ok := (*(volMetrics.Available)).AsInt64()
 	if !ok {
-		log.Errorf("failed to fetch available bytes")
+		log.Warn("failed to fetch available bytes")
 	}
 	capacity, ok := (*(volMetrics.Capacity)).AsInt64()
 	if !ok {
@@ -536,22 +536,20 @@ func (s *service) NodeGetVolumeStats(
 	}
 	used, ok := (*(volMetrics.Used)).AsInt64()
 	if !ok {
-		log.Errorf("failed to fetch used bytes")
+		log.Warn("failed to fetch used bytes")
 	}
 	inodes, ok := (*(volMetrics.Inodes)).AsInt64()
 	if !ok {
-		log.Errorf("failed to fetch available inodes")
-		return nil, status.Error(codes.Unknown, "failed to fetch available inodes")
-
+		log.Errorf("failed to fetch total number of inodes")
+		return nil, status.Error(codes.Unknown, "failed to fetch total number of inodes")
 	}
 	inodesFree, ok := (*(volMetrics.InodesFree)).AsInt64()
 	if !ok {
-		log.Errorf("failed to fetch free inodes")
+		log.Warn("failed to fetch free inodes")
 	}
-
 	inodesUsed, ok := (*(volMetrics.InodesUsed)).AsInt64()
 	if !ok {
-		log.Errorf("failed to fetch used inodes")
+		log.Warn("failed to fetch used inodes")
 	}
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: []*csi.VolumeUsage{

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -120,12 +120,14 @@ func (c *controller) Init(config *config.Config) error {
 	// Check if file service is enabled on datastore present in targetvSANFileShareDatastoreURLs.
 	dsToFileServiceEnabledMap, err := common.IsFileServiceEnabled(ctx, c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs, c.manager)
 	if err != nil {
-		log.Errorf("File service enablement validation failed for datastore specified in TargetvSANFileShareDatastoreURLs. err=%v", err)
+		msg := fmt.Sprintf("file service enablement check failed for datastore specified in TargetvSANFileShareDatastoreURLs. err=%v", err)
+		log.Errorf(msg)
+		return errors.New(msg)
 	}
 	for _, targetFSDatastore := range c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs {
 		isFSEnabled := dsToFileServiceEnabledMap[targetFSDatastore]
 		if !isFSEnabled {
-			msg := fmt.Sprintf("File service is not enabled on datastore %s specified in TargetvSANFileShareDatastoreURLs", targetFSDatastore)
+			msg := fmt.Sprintf("file service is not enabled on datastore %s specified in TargetvSANFileShareDatastoreURLs", targetFSDatastore)
 			log.Errorf(msg)
 			return errors.New(msg)
 		}
@@ -165,9 +167,9 @@ func (c *controller) Init(config *config.Config) error {
 				}
 			case err, ok := <-watcher.Errors:
 				if !ok {
+					log.Errorf("fsnotify error: %+v", err)
 					return
 				}
-				log.Errorf("fsnotify error: %+v", err)
 			}
 			log.Debugf("fsnotify event processed")
 		}

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -115,9 +115,9 @@ func (c *controller) Init(config *config.Config) error {
 				}
 			case err, ok := <-watcher.Errors:
 				if !ok {
+					log.Errorf("fsnotify error: %+v", err)
 					return
 				}
-				log.Errorf("fsnotify error: %+v", err)
 			}
 			log.Debugf("fsnotify event processed")
 		}
@@ -140,10 +140,12 @@ func (c *controller) ReloadConfiguration() {
 	cfg, err := common.GetConfig(ctx)
 	if err != nil {
 		log.Errorf("failed to read config. Error: %+v", err)
+		return
 	}
 	newVCConfig, err := cnsvsphere.GetVirtualCenterConfig(cfg)
 	if err != nil {
 		log.Errorf("failed to get VirtualCenterConfig. err=%v", err)
+		return
 	}
 	if newVCConfig != nil {
 		var vcenter *cnsvsphere.VirtualCenter
@@ -154,11 +156,13 @@ func (c *controller) ReloadConfiguration() {
 			err = c.manager.VcenterManager.UnregisterAllVirtualCenters(ctx)
 			if err != nil {
 				log.Errorf("failed to unregister vcenter with virtualCenterManager.")
+				return
 			}
 			log.Debugf("Registering virtual center: %q with virtualCenterManager", newVCConfig.Host)
 			vcenter, err = c.manager.VcenterManager.RegisterVirtualCenter(ctx, newVCConfig)
 			if err != nil {
 				log.Errorf("failed to register VC with virtualCenterManager. err=%v", err)
+				return
 			}
 			c.manager.VcenterManager = cnsvsphere.GetVirtualCenterManager(ctx)
 		} else {

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -141,9 +141,9 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				}
 			case err, ok := <-watcher.Errors:
 				if !ok {
+					log.Errorf("fsnotify error: %+v", err)
 					return
 				}
-				log.Errorf("fsnotify error: %+v", err)
 			}
 			log.Debugf("fsnotify event processed")
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is returning error after logging them.
Error returned from `common.IsFileServiceEnabled` was not handled, and could cause Panic.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix returning error after logging them
```
