### PR TITLE
fixed make test-e2e

### DIFF
--- a/hack/run-e2e-test.sh
+++ b/hack/run-e2e-test.sh
@@ -20,11 +20,14 @@ set -o pipefail
 
 # Fetching ginkgo for running the test
 export GO111MODULE=on
-if ! go mod vendor && go get -u github.com/onsi/ginkgo/ginkgo
+if ! (go mod vendor && go get -u github.com/onsi/ginkgo/ginkgo)
 then
     echo "go mod vendor or go get ginkgo error"
     exit 1
 fi
+
+# Add GOPATH/BIN to PATH
+PATH=$PATH:$(go env GOPATH)/bin
 
 # Exporting KUBECONFIG path if not set
 if [ -z "${KUBECONFIG-}" ]; then


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- This PR is fixing failure check when `go mod vendor` or `go get -u github.com/onsi/ginkgo/ginkgo`.

- Without this fix, `make test-e2e` was not downloading ginkgo CLI.

- Also added GOPATH/bin to env PATH.
 

**Special notes for your reviewer**:

**Before**

```
% make test-e2e
hack/run-e2e-test.sh
hack/run-e2e-test.sh: line 49: ginkgo: command not found
make: *** [test-e2e] Error 127
```

**After**

```
% make test-e2e
hack/run-e2e-test.sh
go: finding golang.org/x/sys latest
go: finding gopkg.in/tomb.v1 latest
Apr 14 11:50:29.074: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
W0414 11:50:29.074376   82464 test_context.go:409] Unable to find in-cluster config, using default host : http://127.0.0.1:8080
Running Suite: CNS CSI Driver End-to-End Tests
==============================================
Random Seed: 1586890222 - Will randomize all specs
Will run 36 of 76 specs
.
.
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
fixed make test-e2e
```
