### PR TITLE
remove mounting vsphere-config-secret in vsphere-csi-node daemonset

### DIFF
--- a/manifests/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -55,8 +55,9 @@ spec:
           value: "node"
         - name: X_CSI_SPEC_REQ_VALIDATION
           value: "false"
-        - name: VSPHERE_CSI_CONFIG
-          value: "/etc/cloud/csi-vsphere.conf" # here csi-vsphere.conf is the name of the file used for creating secret using "--from-file" flag
+        # needed only for topology aware setups
+        #- name: VSPHERE_CSI_CONFIG
+        #  value: "/etc/cloud/csi-vsphere.conf" # here csi-vsphere.conf is the name of the file used for creating secret using "--from-file" flag
         - name: X_CSI_DEBUG
           value: "true"
         - name: LOGGER_LEVEL
@@ -67,9 +68,10 @@ spec:
             add: ["SYS_ADMIN"]
           allowPrivilegeEscalation: true
         volumeMounts:
-        - name: vsphere-config-volume
-          mountPath: /etc/cloud
-          readOnly: true
+        # needed only for topology aware setups
+        #- name: vsphere-config-volume
+        #  mountPath: /etc/cloud
+        #  readOnly: true
         - name: plugin-dir
           mountPath: /csi
         - name: pods-mount-dir
@@ -102,9 +104,10 @@ spec:
         - name: plugin-dir
           mountPath: /csi
       volumes:
-      - name: vsphere-config-volume
-        secret:
-          secretName: vsphere-config-secret
+      # needed only for topology aware setups
+      #- name: vsphere-config-volume
+      #  secret:
+      #    secretName: vsphere-config-secret
       - name: registration-dir
         hostPath:
           path: /var/lib/kubelet/plugins_registry

--- a/manifests/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -55,8 +55,9 @@ spec:
           value: "node"
         - name: X_CSI_SPEC_REQ_VALIDATION
           value: "false"
-        - name: VSPHERE_CSI_CONFIG
-          value: "/etc/cloud/csi-vsphere.conf" # here csi-vsphere.conf is the name of the file used for creating secret using "--from-file" flag
+        # needed only for topology aware setups
+        #- name: VSPHERE_CSI_CONFIG
+        #  value: "/etc/cloud/csi-vsphere.conf" # here csi-vsphere.conf is the name of the file used for creating secret using "--from-file" flag
         - name: X_CSI_DEBUG
           value: "true"
         - name: LOGGER_LEVEL
@@ -67,9 +68,10 @@ spec:
             add: ["SYS_ADMIN"]
           allowPrivilegeEscalation: true
         volumeMounts:
-        - name: vsphere-config-volume
-          mountPath: /etc/cloud
-          readOnly: true
+        # needed only for topology aware setups
+        #- name: vsphere-config-volume
+        #  mountPath: /etc/cloud
+        #  readOnly: true
         - name: plugin-dir
           mountPath: /csi
         - name: pods-mount-dir
@@ -102,9 +104,10 @@ spec:
         - name: plugin-dir
           mountPath: /csi
       volumes:
-      - name: vsphere-config-volume
-        secret:
-          secretName: vsphere-config-secret
+      # needed only for topology aware setups
+      #- name: vsphere-config-volume
+      #  secret:
+      #    secretName: vsphere-config-secret
       - name: registration-dir
         hostPath:
           path: /var/lib/kubelet/plugins_registry

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -315,10 +315,11 @@ func GetCnsconfig(ctx context.Context, cfgPath string) (*Config, error) {
 	var cfg *Config
 	//Read in the vsphere.conf if it exists
 	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
+		log.Infof("Could not stat %s, reading config params from env", cfgPath)
 		// config from Env var only
 		cfg = &Config{}
-		if err := FromEnv(ctx, cfg); err != nil {
-			log.Errorf("Error reading vsphere.conf\n")
+		if fromEnvErr := FromEnv(ctx, cfg); fromEnvErr != nil {
+			log.Errorf("Failed to get config params from env. Err: %v", fromEnvErr)
 			return cfg, err
 		}
 	} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is removing mounting of vsphere-config-secret in vsphere-csi-node daemonset pods.

`vsphere-config-secret` is only required on node daemonset when topology feature is to be used.
This is required in the topology aware setup so that node can determine its topology by connecting to vCenter, to publish `AccessibleTopology` in the `NodeGetInfoResponse`.

Why we need this change now?
this change was already present in `v1.0.2`, but while merging development repository, this change was missed in this PR - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/151

@RaunakShah added this fix in `v1.0.2` - https://github.com/kubernetes-sigs/vsphere-csi-driver/commit/136e3ec78653f2d3a9446456e455ebba0d1f7845

**Special notes for your reviewer**:

Verified correctness in the yaml change with deploying driver using this updated yaml and latest image.

```
% kubectl create -f .
deployment.apps/vsphere-csi-controller created
csidriver.storage.k8s.io/csi.vsphere.vmware.com created
daemonset.apps/vsphere-csi-node created
```

Also verified basic provisioning workflow.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
removed mounting vsphere-config-secret requirement in vsphere-csi-node daemonset
```
