### PR TITLE
Add --version flag and fix Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ GOOS ?= linux
 GOARCH ?= amd64
 
 LDFLAGS := $(shell cat hack/make/ldflags.txt)
-LDFLAGS_CSI := $(LDFLAGS) -X "$(MOD_NAME)/pkg/csi/service.version=$(VERSION)"
+LDFLAGS_CSI := $(LDFLAGS) -X "$(MOD_NAME)/pkg/csi/service.Version=$(VERSION)"
 LDFLAGS_SYNCER := $(LDFLAGS)
 
 # The CSI binary.

--- a/cmd/vsphere-csi/main.go
+++ b/cmd/vsphere-csi/main.go
@@ -19,16 +19,25 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 
 	"github.com/rexray/gocsi"
 
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/provider"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
+
+var printVersion = flag.Bool("version", false, "Print driver version and exit")
 
 // main is ignored when this package is built as a go plug-in.
 func main() {
 	flag.Parse()
+	if *printVersion {
+		fmt.Printf("%s\n", service.Version)
+		return
+	}
+
 	gocsi.Run(
 		context.Background(),
 		csitypes.Name,

--- a/docs/book/development.md
+++ b/docs/book/development.md
@@ -22,7 +22,7 @@
 
   ``` sh
   make build
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.version=v0.2.1-359-g167910f-dirty"' -o /Users/lipingx/go/src/vsphere-csi-driver/.build/bin/vsphere-csi.linux_amd64 cmd/vsphere-csi/main.go
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.Version=v0.2.1-359-g167910f-dirty"' -o /Users/lipingx/go/src/vsphere-csi-driver/.build/bin/vsphere-csi.linux_amd64 cmd/vsphere-csi/main.go
   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s' -o /Users/lipingx/go/src/vsphere-csi-driver/.build/bin/syncer.linux_amd64 cmd/syncer/main.go
   ```
 
@@ -81,7 +81,7 @@ vSphere CSI driver includes two images:
   Step 11/16 : ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
   ---> Using cache
   ---> 941f37953062
-  Step 12/16 : RUN go build -a -ldflags='-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.version=${VERSION}' -o vsphere-csi ./cmd/vsphere-csi
+  Step 12/16 : RUN go build -a -ldflags='-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.Version=${VERSION}' -o vsphere-csi ./cmd/vsphere-csi
   ---> Using cache
   ---> 48fa690544af
   Step 13/16 : FROM ${BASE_IMAGE}

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -40,7 +40,7 @@ COPY pkg/    pkg/
 COPY cmd/    cmd/
 ENV CGO_ENABLED=0
 ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
-RUN go build -a -ldflags='-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.version=${VERSION}' -o vsphere-csi ./cmd/vsphere-csi
+RUN go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.Version=${VERSION}" -o vsphere-csi ./cmd/vsphere-csi
 
 ################################################################################
 ##                               MAIN STAGE                                   ##

--- a/pkg/csi/service/identity.go
+++ b/pkg/csi/service/identity.go
@@ -23,8 +23,8 @@ import (
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
 
-// set via ldflags
-var version string
+// Version of the driver. This should be set via ldflags.
+var Version string
 
 func (s *service) Probe(
 	ctx context.Context,
@@ -41,7 +41,7 @@ func (s *service) GetPluginInfo(
 
 	return &csi.GetPluginInfoResponse{
 		Name:          csitypes.Name,
-		VendorVersion: version,
+		VendorVersion: Version,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This adds a --version flag as a quick way to output the binary version. It also fixes the Dockerfile so that builds will embed the intended version instead of a literal `${VERSION}`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add --version flag to driver
```
