### PR TITLE
updating v2.0.0-rc.1 images in the deployment YAMLs

### DIFF
--- a/manifests/v2.0.0/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.0.0/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: vmware/vsphere-csi:<vsphere_csi_ver>
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0-rc.1
           lifecycle:
             preStop:
               exec:
@@ -89,7 +89,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: vsphere-syncer
-          image: vmware/syncer:<syncer_ver>
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.0.0-rc.1
           args:
             - "--leader-election"
           imagePullPolicy: "Always"

--- a/manifests/v2.0.0/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.0.0/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -42,7 +42,7 @@ spec:
         - name: registration-dir
           mountPath: /registration
       - name: vsphere-csi-node
-        image: vmware/vsphere-csi:<vsphere_csi_ver>
+        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0-rc.1
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME

--- a/manifests/v2.0.0/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.0.0/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: vmware/vsphere-csi:<vsphere_csi_ver>
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0-rc.1
           lifecycle:
             preStop:
               exec:
@@ -102,7 +102,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: vsphere-syncer
-          image: vmware/syncer:<syncer_ver>
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.0.0-rc.1
           args:
             - "--leader-election"
           imagePullPolicy: "Always"

--- a/manifests/v2.0.0/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.0.0/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -42,7 +42,7 @@ spec:
         - name: registration-dir
           mountPath: /registration
       - name: vsphere-csi-node
-        image: vmware/vsphere-csi:<vsphere_csi_ver>
+        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0-rc.1
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

`rc.1` for `v.2.0.0` is cut off from commit - 30e03355369cfcf606b8c8cb40abdbd80342bc75 from release-2.0 branch.

Tag - https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/v2.0.0-rc.1

This PR is updating deployment manifests with `v2.0.0-rc.1` images.

- gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0-rc.1
- gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0-rc.1


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
updating v2.0.0-rc.1 images in the deployment YAMLs
```
