### PR TITLE
Only check if vSAN file service is enabled when vSAN datastores are defined

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -117,19 +117,22 @@ func (c *controller) Init(config *config.Config) error {
 		log.Errorf("failed to get vcenter. err=%v", err)
 		return err
 	}
-	// Check if file service is enabled on datastore present in targetvSANFileShareDatastoreURLs.
-	dsToFileServiceEnabledMap, err := common.IsFileServiceEnabled(ctx, c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs, c.manager)
-	if err != nil {
-		msg := fmt.Sprintf("file service enablement check failed for datastore specified in TargetvSANFileShareDatastoreURLs. err=%v", err)
-		log.Errorf(msg)
-		return errors.New(msg)
-	}
-	for _, targetFSDatastore := range c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs {
-		isFSEnabled := dsToFileServiceEnabledMap[targetFSDatastore]
-		if !isFSEnabled {
-			msg := fmt.Sprintf("file service is not enabled on datastore %s specified in TargetvSANFileShareDatastoreURLs", targetFSDatastore)
+
+	if len(c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs) > 0 {
+		// Check if file service is enabled on datastore present in targetvSANFileShareDatastoreURLs.
+		dsToFileServiceEnabledMap, err := common.IsFileServiceEnabled(ctx, c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs, c.manager)
+		if err != nil {
+			msg := fmt.Sprintf("file service enablement check failed for datastore specified in TargetvSANFileShareDatastoreURLs. err=%v", err)
 			log.Errorf(msg)
 			return errors.New(msg)
+		}
+		for _, targetFSDatastore := range c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs {
+			isFSEnabled := dsToFileServiceEnabledMap[targetFSDatastore]
+			if !isFSEnabled {
+				msg := fmt.Sprintf("file service is not enabled on datastore %s specified in TargetvSANFileShareDatastoreURLs", targetFSDatastore)
+				log.Errorf(msg)
+				return errors.New(msg)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses an issue with startup of the CSI controller, when vSAN file service is not running and targetvSANFileShareDatastore

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #193 

**Special notes for your reviewer**:
First of all. Thanks for reviewing.
This is my first contribution to this project, and I am new to the vsphere csi drivers :partying_face: . 
I have tested this PR in our multi site vsphere on-prem clusters, and I am now able to bind pvcs.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Only check if vSAN file service is enabled when datastores are specified in TargetvSANFileShareDatastoreURLs
```
