### PR TITLE
correcting cluster flavor name in the limit doc

### DIFF
--- a/docs/book/limits.md
+++ b/docs/book/limits.md
@@ -1,10 +1,10 @@
 # vSphere CSI Driver - Limits
 
-| Limits                                              | vanilla block                     | vanilla File                         | WCP supervisor | WCP Guest    |
-|-----------------------------------------------------|-----------------------------------|--------------------------------------|----------------|--------------|
-| Scale                                               | 10000 volumes for vsan, nfs, vmfs | 32 File shares (5 clients per share) | 7000 volumes   | 7000 volumes |
-|                                                     | 840 volumes for vVOL              |                                      |                |              |
-| Number of PVCs per VMwith 4 controllers             | Max 59                            | N/A                                  | Max 29         | Max 59       |
-| Multiple instances of CSI pods in Multi-master mode | replica = 1                       | replica = 1                          | replica = 1    | replica = 1  |
+| Limits                                              | vanilla block                     | vanilla File                         | Pacific supervisor cluster | Tanzu Kubernetes Grid |
+|-----------------------------------------------------|-----------------------------------|--------------------------------------|----------------------------|-----------------------|
+| Scale                                               | 10000 volumes for vsan, nfs, vmfs | 32 File shares (5 clients per share) | 7000 volumes               | 7000 volumes          |
+|                                                     | 840 volumes for vVOL              |                                      |                            |                       |
+| Number of PVCs per VMwith 4 controllers             | Max 59                            | N/A                                  | Max 29                     | Max 59                |
+| Multiple instances of CSI pods in Multi-master mode | replica = 1                       | replica = 1                          | replica = 1                | replica = 1           |
 
 Note: Only a single vCenter is supported by vSphere CSI Driver. To use vSphere CSI driver, make sure node VMs do not spread across multiple vCenter servers.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Addressing comment - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/192#discussion_r414842130 from @SandeepPissay 

Preview Link : https://deploy-preview-197--kubernetes-sigs-vsphere-csi-driver.netlify.app/limits.html

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
correcting cluster flavor name in the limit doc
```
