### PR TITLE
fix: use the same images for both vSphere product

### DIFF
--- a/manifests/v2.0.0/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.0.0/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0
           lifecycle:
             preStop:
               exec:
@@ -89,7 +89,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.0.0-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.0.0
           args:
             - "--leader-election"
           imagePullPolicy: "Always"

--- a/manifests/v2.0.0/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.0.0/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -42,7 +42,7 @@ spec:
         - name: registration-dir
           mountPath: /registration
       - name: vsphere-csi-node
-        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0-rc.1
+        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME


### PR DESCRIPTION
**What this PR does / why we need it**:
Set the same image as already done for `vsphere-7.0` (removes `.rc-1`)

**Which issue this PR fixes**:
fixes #211 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Upgrade images for vSphere 67u3 to v2.0.0
```
