### PR TITLE
correct unix domain socket path for CSI driver

### DIFF
--- a/manifests/v1.0.2/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v1.0.2/deploy/vsphere-csi-node-ds.yaml
@@ -22,7 +22,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com-reg.sock"]
+                command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com-reg.sock /csi/csi.sock"]
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -31,7 +31,7 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com/csi.sock
+              value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
           securityContext:
             privileged: true
           volumeMounts:
@@ -92,10 +92,7 @@ spec:
         - name: liveness-probe
           image: quay.io/k8scsi/livenessprobe:v1.1.0
           args:
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
+          - --csi-address=/csi/csi.sock
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
@@ -107,10 +104,10 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
-            type: DirectoryOrCreate
+            type: Directory
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com
+            path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
@@ -119,3 +116,8 @@ spec:
         - name: device-dir
           hostPath:
             path: /dev
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists

--- a/manifests/v2.0.0/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.0.0/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -24,7 +24,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com-reg.sock"]
+              command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com-reg.sock /csi/csi.sock"]
         args:
         - "--v=5"
         - "--csi-address=$(ADDRESS)"
@@ -33,7 +33,7 @@ spec:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
-          value: /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com/csi.sock
+          value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
         securityContext:
           privileged: true
         volumeMounts:
@@ -96,10 +96,7 @@ spec:
       - name: liveness-probe
         image: quay.io/k8scsi/livenessprobe:v1.1.0
         args:
-        - "--csi-address=$(ADDRESS)"
-        env:
-        - name: ADDRESS
-          value: /csi/csi.sock
+        - --csi-address=/csi/csi.sock
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi
@@ -111,10 +108,10 @@ spec:
       - name: registration-dir
         hostPath:
           path: /var/lib/kubelet/plugins_registry
-          type: DirectoryOrCreate
+          type: Directory
       - name: plugin-dir
         hostPath:
-          path: /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com
+          path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/
           type: DirectoryOrCreate
       - name: pods-mount-dir
         hostPath:

--- a/manifests/v2.0.0/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.0.0/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -24,7 +24,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com-reg.sock"]
+              command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com-reg.sock /csi/csi.sock"]
         args:
         - "--v=5"
         - "--csi-address=$(ADDRESS)"
@@ -33,7 +33,7 @@ spec:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
-          value: /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com/csi.sock
+          value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
         securityContext:
           privileged: true
         volumeMounts:
@@ -96,10 +96,7 @@ spec:
       - name: liveness-probe
         image: quay.io/k8scsi/livenessprobe:v1.1.0
         args:
-        - "--csi-address=$(ADDRESS)"
-        env:
-        - name: ADDRESS
-          value: /csi/csi.sock
+        - --csi-address=/csi/csi.sock
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi
@@ -111,10 +108,10 @@ spec:
       - name: registration-dir
         hostPath:
           path: /var/lib/kubelet/plugins_registry
-          type: DirectoryOrCreate
+          type: Directory
       - name: plugin-dir
         hostPath:
-          path: /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com
+          path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/
           type: DirectoryOrCreate
       - name: pods-mount-dir
         hostPath:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR helps fix RegisterPlugin error observed on the kubelet.

This is because we used the incorrect path `/var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com/csi.sock` as  `DRIVER_REG_SOCK_PATH` in the deployment yaml.

As per node-driver-registrar usage documentation - https://github.com/kubernetes-csi/node-driver-registrar/blob/master/README.md#usage  and example - https://github.com/kubernetes-csi/node-driver-registrar/blob/master/README.md#example driver should create socket at `/var/lib/kubelet/plugins/<drivername.example.com>/csi.sock` other than the Kubelet plugin registry.



**Which issue this PR fixes** 
Fixes #220

**Special notes for your reviewer**:
Deployed driver using this updated YAML. kubelet is no longer emitting these errors.

**Before this change**

> May 14 19:50:28 k8-master-713 kubelet[5195]: I0514 19:50:28.977579 5195 clientconn.go:577] ClientConn switching balancer to "pick_first"
May 14 19:50:28 k8-master-713 kubelet[5195]: E0514 19:50:28.985525 5195 goroutinemap.go:150] Operation for "/var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com/csi.sock" failed. No retries permitted until 2020-05-14 19:52:30.985489804 -0700 PDT m=+7665.381717856 (durationBeforeRetry 2m2s). Error: "RegisterPlugin error -- failed to get plugin info using RPC GetInfo at socket /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com/csi.sock, err: rpc error: code = Unimplemented desc = unknown service pluginregistration.Registration"

**After this change**

> May 15 15:13:37 k8s-node1 kubelet[766]: I0515 15:13:37.691920     766 clientconn.go:933] ClientConn switching balancer to "pick_first"
May 15 15:13:37 k8s-node1 kubelet[766]: I0515 15:13:37.697292     766 csi_plugin.go:97] kubernetes.io/csi: Trying to validate a new CSI Driver with name: csi.vsphere.vmware.com endpoint: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock versions: 1.0.0
May 15 15:13:37 k8s-node1 kubelet[766]: I0515 15:13:37.697365     766 csi_plugin.go:110] kubernetes.io/csi: Register new plugin with name: csi.vsphere.vmware.com at endpoint: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
May 15 15:13:37 k8s-node1 kubelet[766]: I0515 15:13:37.697620     766 clientconn.go:106] parsed scheme: ""
May 15 15:13:37 k8s-node1 kubelet[766]: I0515 15:13:37.697634     766 clientconn.go:106] scheme "" not registered, fallback to default scheme
May 15 15:13:37 k8s-node1 kubelet[766]: I0515 15:13:37.697772     766 passthrough.go:48] ccResolverWrapper: sending update to cc: {[{/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock  <nil> 0 <nil>}] <nil> <nil>}
May 15 15:13:37 k8s-node1 kubelet[766]: I0515 15:13:37.697791     766 clientconn.go:933] ClientConn switching balancer to "pick_first"
May 15 15:13:37 k8s-node1 kubelet[766]: I0515 15:13:37.697904     766 clientconn.go:882] blockingPicker: the picked transport is not ready, loop back to repick
May 15 15:13:37 k8s-node1 kubelet[766]: E0515 15:13:37.738039     766 nodeinfomanager.go:568] Invalid attach limit value 0 cannot be added to CSINode object for "csi.vsphere.vmware.com"



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
correct unix domain socket path for CSI driver
```
