### PR TITLE
Fix CreateVolume validation to raise error for invalid parameters

### DIFF
--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -35,9 +35,7 @@ func validateVanillaCreateVolumeRequest(ctx context.Context, req *csi.CreateVolu
 	params := req.GetParameters()
 	for paramName := range params {
 		paramName = strings.ToLower(paramName)
-		if paramName != common.AttributeDatastoreURL && paramName != common.AttributeStoragePolicyName && paramName != common.AttributeFsType &&
-			!strings.HasPrefix(paramName, common.AllowRoot) && !strings.HasPrefix(paramName, common.Permission) &&
-			!strings.HasPrefix(paramName, common.IPs) {
+		if paramName != common.AttributeDatastoreURL && paramName != common.AttributeStoragePolicyName && paramName != common.AttributeFsType {
 			msg := fmt.Sprintf("Volume parameter %s is not a valid Vanilla CSI parameter.", paramName)
 			return status.Error(codes.InvalidArgument, msg)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: CreateVolume validation supports input of certain parameters which are not supported. Instead, they have been shifted to the vsphere CSI config file. This MR fixes the issue and raises an error for such parameters.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix CreateVolume validation to raise error for certain invalid parameters
```
