### PR TITLE
OCP 4.x support

### DIFF
--- a/manifests/v2.0.0/vsphere-7.0/3rd-Party-Clusters/Openshift/OCP4x/README.md
+++ b/manifests/v2.0.0/vsphere-7.0/3rd-Party-Clusters/Openshift/OCP4x/README.md
@@ -1,0 +1,43 @@
+# Container Storage Interface (CSI) driver for vSphere 7.x and OpenShift Container Platform
+This repository provides scripts for deploying the vSphere CSI provider on an OCP environment. The driver in these files is 2.0 
+
+# Installation
+
+Please read the prerequisites from the documentation below. 
+
+To create the vCenter roles you can use this script;
+
+    https://github.com/saintdle/PowerCLI/blob/master/Create_CSI_Driver_vCenter_Roles.ps1 
+
+Edit csi-vsphere-for-OCP.conf with your environment details.
+Create a Kubernetes secret that will contain configuration details to connect to vSphere.
+
+    Command: oc create secret generic vsphere-config-secret --from-file=csi-vsphere-for-OCP.conf --namespace=kube-system
+
+Create the necessary RBAC roles, service account and elevated privileges.
+
+    Command: oc create --from-file=vsphere-csi-controller-rbac-for-OCP.yaml
+
+Install the vSphere CSI driver which is made up of a CSI Controller and CSI Node daemonset.
+
+    Command: oc create --from-file=vsphere-csi-controller-deployment-for-OCP.yaml
+    Command: oc create --from-file=vsphere-csi-node-ds-for-OCP.yaml
+
+# Documentation
+
+Official documentation for vSphere CSI Driver is available here:
+
+    https://vsphere-csi-driver.sigs.k8s.io
+
+# vSphere CSI Driver Images
+
+v2.0.0
+
+    gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0
+    gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.0.0
+
+# Source Manifests
+The YAMLs in this repository are based on the manifests from the following locations;
+
+    https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/v2.0.0/vsphere-7.0/vanilla
+    https://github.com/dav1x/ocp-vsphere-csi

--- a/manifests/v2.0.0/vsphere-7.0/3rd-Party-Clusters/Openshift/OCP4x/csi-vsphere-for-OCP.conf
+++ b/manifests/v2.0.0/vsphere-7.0/3rd-Party-Clusters/Openshift/OCP4x/csi-vsphere-for-OCP.conf
@@ -1,0 +1,19 @@
+[Global]
+
+# run the following on your OCP cluster to get the ID 
+# oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{"\n"}'
+
+cluster-id = "OCP_CLUSTER_ID"
+
+
+[VirtualCenter "VC_FQDN"]
+
+insecure-flag = "true"
+
+user = "USER"
+
+password = "PASSWORD"
+
+port = "443"
+
+datacenters = "VC_DATACENTER"

--- a/manifests/v2.0.0/vsphere-7.0/3rd-Party-Clusters/Openshift/OCP4x/vsphere-csi-controller-deployment-for-OCP.yaml
+++ b/manifests/v2.0.0/vsphere-7.0/3rd-Party-Clusters/Openshift/OCP4x/vsphere-csi-controller-deployment-for-OCP.yaml
@@ -1,0 +1,217 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: '2'
+    kubectl.kubernetes.io/last-applied-configuration: >
+      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"name":"vsphere-csi-controller","namespace":"kube-system"},"spec":{"replicas":1,"securityContext":{"privileged":true},"selector":{"matchLabels":{"app":"vsphere-csi-controller"}},"strategy":{"rollingUpdate":{"maxSurge":0,"maxUnavailable":1},"type":"RollingUpdate"},"template":{"metadata":{"labels":{"app":"vsphere-csi-controller","role":"vsphere-csi"}},"spec":{"containers":[{"args":["--v=4","--timeout=300s","--csi-address=$(ADDRESS)","--leader-election"],"env":[{"name":"ADDRESS","value":"/csi/csi.sock"}],"image":"quay.io/k8scsi/csi-attacher:v2.0.0","name":"csi-attacher","volumeMounts":[{"mountPath":"/csi","name":"socket-dir"}]},{"args":["--v=4","--csiTimeout=300s","--csi-address=$(ADDRESS)","--leader-election"],"env":[{"name":"ADDRESS","value":"/csi/csi.sock"}],"image":"quay.io/k8scsi/csi-resizer:v0.3.0","name":"csi-resizer","volumeMounts":[{"mountPath":"/csi","name":"socket-dir"}]},{"env":[{"name":"CSI_ENDPOINT","value":"unix:///var/lib/csi/sockets/pluginproxy/csi.sock"},{"name":"X_CSI_MODE","value":"controller"},{"name":"VSPHERE_CSI_CONFIG","value":"/etc/cloud/csi-vsphere.conf"},{"name":"LOGGER_LEVEL","value":"DEVELOPMENT"}],"image":"gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0","imagePullPolicy":"Always","lifecycle":{"preStop":{"exec":{"command":["/bin/sh","-c","rm
+      -rf
+      /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]}}},"livenessProbe":{"failureThreshold":3,"httpGet":{"path":"/healthz","port":"healthz"},"initialDelaySeconds":10,"periodSeconds":5,"timeoutSeconds":3},"name":"vsphere-csi-controller","ports":[{"containerPort":9808,"name":"healthz","protocol":"TCP"}],"volumeMounts":[{"mountPath":"/etc/cloud","name":"vsphere-config-volume","readOnly":true},{"mountPath":"/var/lib/csi/sockets/pluginproxy/","name":"socket-dir"}]},{"args":["--csi-address=$(ADDRESS)"],"env":[{"name":"ADDRESS","value":"/var/lib/csi/sockets/pluginproxy/csi.sock"}],"image":"quay.io/k8scsi/livenessprobe:v1.1.0","name":"liveness-probe","volumeMounts":[{"mountPath":"/var/lib/csi/sockets/pluginproxy/","name":"socket-dir"}]},{"args":["--leader-election"],"env":[{"name":"FULL_SYNC_INTERVAL_MINUTES","value":"30"},{"name":"VSPHERE_CSI_CONFIG","value":"/etc/cloud/csi-vsphere.conf"},{"name":"LOGGER_LEVEL","value":"DEVELOPMENT"}],"image":"gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.0.0","imagePullPolicy":"Always","name":"vsphere-syncer","volumeMounts":[{"mountPath":"/etc/cloud","name":"vsphere-config-volume","readOnly":true}]},{"args":["--v=4","--timeout=300s","--csi-address=$(ADDRESS)","--feature-gates=Topology=true","--strict-topology","--enable-leader-election","--leader-election-type=leases"],"env":[{"name":"ADDRESS","value":"/csi/csi.sock"}],"image":"quay.io/k8scsi/csi-provisioner:v1.4.0","name":"csi-provisioner","volumeMounts":[{"mountPath":"/csi","name":"socket-dir"}]}],"dnsPolicy":"Default","nodeSelector":{"node-role.kubernetes.io/master":""},"serviceAccountName":"vsphere-csi-controller","tolerations":[{"effect":"NoSchedule","operator":"Exists"},{"effect":"NoExecute","operator":"Exists"}],"volumes":[{"name":"vsphere-config-volume","secret":{"secretName":"vsphere-config-secret"}},{"hostPath":{"path":"/var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com","type":"DirectoryOrCreate"},"name":"socket-dir"}]}}}}
+  selfLink: /apis/apps/v1/namespaces/kube-system/deployments/vsphere-csi-controller
+  resourceVersion: '496165'
+  name: vsphere-csi-controller
+  uid: 69320e20-ff28-4ed6-914b-bf910e3364dd
+  creationTimestamp: '2020-05-31T17:41:47Z'
+  generation: 6
+  namespace: kube-system
+  labels:
+    app: vsphere-csi-controller
+    role: vsphere-csi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vsphere-csi-controller
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: vsphere-csi-controller
+        role: vsphere-csi
+    spec:
+      dnsPolicy: "Default"
+      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ''
+      restartPolicy: Always
+      serviceAccountName: vsphere-csi-controller
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      securityContext: {}
+      containers:
+        - resources: {}
+          terminationMessagePath: /dev/termination-log
+          name: csi-attacher
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          terminationMessagePolicy: File
+          image: 'quay.io/k8scsi/csi-attacher:v2.0.0'
+          args:
+            - '--v=4'
+            - '--timeout=300s'
+            - '--csi-address=$(ADDRESS)'
+            - '--leader-election'
+        - resources: {}
+          terminationMessagePath: /dev/termination-log
+          name: csi-resizer
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          terminationMessagePolicy: File
+          image: 'quay.io/k8scsi/csi-resizer:v0.3.0'
+          args:
+            - '--v=4'
+            - '--csiTimeout=300s'
+            - '--csi-address=$(ADDRESS)'
+            - '--leader-election'
+        - resources: {}
+          terminationMessagePath: /dev/termination-log
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - '-c'
+                  - >-
+                    rm -rf
+                    /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
+          name: vsphere-csi-controller
+          securityContext:
+            privileged: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          env:
+            - name: CSI_ENDPOINT
+              value: 'unix:///var/lib/csi/sockets/pluginproxy/csi.sock'
+            - name: X_CSI_MODE
+              value: controller
+            - name: VSPHERE_CSI_CONFIG
+              value: /etc/cloud/csi-vsphere.conf
+            - name: LOGGER_LEVEL
+              value: DEVELOPMENT
+          securityContext:
+            privileged: true
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: vsphere-config-volume
+              readOnly: true
+              mountPath: /etc/cloud
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          terminationMessagePolicy: File
+          image: 'gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0'
+        - resources: {}
+          terminationMessagePath: /dev/termination-log
+          name: liveness-probe
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          terminationMessagePolicy: File
+          image: 'quay.io/k8scsi/livenessprobe:v1.1.0'
+          args:
+            - '--csi-address=$(ADDRESS)'
+        - resources: {}
+          terminationMessagePath: /dev/termination-log
+          name: vsphere-syncer
+          env:
+            - name: FULL_SYNC_INTERVAL_MINUTES
+              value: '30'
+            - name: VSPHERE_CSI_CONFIG
+              value: /etc/cloud/csi-vsphere.conf
+            - name: LOGGER_LEVEL
+              value: PRODUCTION
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: vsphere-config-volume
+              readOnly: true
+              mountPath: /etc/cloud
+          terminationMessagePolicy: File
+          image: 'gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.0.0'
+          args:
+            - '--leader-election'
+        - resources: {}
+          terminationMessagePath: /dev/termination-log
+          name: csi-provisioner
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          terminationMessagePolicy: File
+          image: 'quay.io/k8scsi/csi-provisioner:v1.4.0'
+          args:
+            - '--v=4'
+            - '--timeout=300s'
+            - '--csi-address=$(ADDRESS)'
+            - '--feature-gates=Topology=true'
+            - '--strict-topology'
+            - '--enable-leader-election'
+            - '--leader-election-type=leases'
+      serviceAccount: vsphere-csi-controller
+      volumes:
+        - name: vsphere-config-volume
+          secret:
+            secretName: vsphere-config-secret
+            defaultMode: 420
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
+            type: DirectoryOrCreate
+      dnsPolicy: Default
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+        - operator: Exists
+          effect: NoExecute
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+status:
+  observedGeneration: 6
+  replicas: 1
+  updatedReplicas: 1
+  unavailableReplicas: 1
+  conditions:
+    - type: Available
+      status: 'True'
+      lastUpdateTime: '2020-05-31T17:41:47Z'
+      lastTransitionTime: '2020-05-31T17:41:47Z'
+      reason: MinimumReplicasAvailable
+      message: Deployment has minimum availability.
+    - type: Progressing
+      status: 'True'
+      lastUpdateTime: '2020-05-31T18:20:04Z'
+      lastTransitionTime: '2020-05-31T17:41:47Z'
+      reason: ReplicaSetUpdated
+      message: ReplicaSet "vsphere-csi-controller-5b4b7bb79d" is progressing.

--- a/manifests/v2.0.0/vsphere-7.0/3rd-Party-Clusters/Openshift/OCP4x/vsphere-csi-controller-rbac-for-OCP.yaml
+++ b/manifests/v2.0.0/vsphere-7.0/3rd-Party-Clusters/Openshift/OCP4x/vsphere-csi-controller-rbac-for-OCP.yaml
@@ -1,0 +1,88 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "create", "delete", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups:
+    - security.openshift.io 
+    resourceNames:
+    - privileged 
+    resources:
+    - securitycontextconstraints 
+    verbs: 
+    - use
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: vsphere-csi-scc
+allowPrivilegedContainer: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:kube-system:vsphere-csi-controller
+---

--- a/manifests/v2.0.0/vsphere-7.0/3rd-Party-Clusters/Openshift/OCP4x/vsphere-csi-node-ds-for-OCP.yaml
+++ b/manifests/v2.0.0/vsphere-7.0/3rd-Party-Clusters/Openshift/OCP4x/vsphere-csi-node-ds-for-OCP.yaml
@@ -1,0 +1,129 @@
+# Minimum Kubernetes version - 1.16
+# For prior releases make sure to add required --feature-gates flags
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: vsphere-csi-node
+  updateStrategy:
+    type: "RollingUpdate"
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-node
+        role: vsphere-csi
+    spec:
+      dnsPolicy: "Default"
+      hostNetwork: true
+      containers:
+      - name: node-driver-registrar
+        image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com-reg.sock /csi/csi.sock"]
+        args:
+        - "--v=5"
+        - "--csi-address=$(ADDRESS)"
+        - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: DRIVER_REG_SOCK_PATH
+          value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+        - name: registration-dir
+          mountPath: /registration
+      - name: vsphere-csi-node
+        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0
+        imagePullPolicy: "Always"
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        - name: X_CSI_MODE
+          value: "node"
+        - name: X_CSI_SPEC_REQ_VALIDATION
+          value: "false"
+        # needed only for topology aware setups
+        #- name: VSPHERE_CSI_CONFIG
+        #  value: "/etc/cloud/csi-vsphere.conf" # here csi-vsphere.conf is the name of the file used for creating secret using "--from-file" flag
+        - name: X_CSI_DEBUG
+          value: "true"
+        - name: LOGGER_LEVEL
+          value: "PRODUCTION" # Options: PRODUCTION, DEVELOPMENT
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        # needed only for topology aware setups
+        #- name: vsphere-config-volume
+        #  mountPath: /etc/cloud
+        #  readOnly: true
+        - name: plugin-dir
+          mountPath: /csi
+        - name: pods-mount-dir
+          mountPath: /var/lib/kubelet
+          # needed so that any mounts setup inside this container are
+          # propagated back to the host machine.
+          mountPropagation: "Bidirectional"
+        - name: device-dir
+          mountPath: /dev
+        ports:
+          - name: healthz
+            containerPort: 9807
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          timeoutSeconds: 3
+          periodSeconds: 5
+          failureThreshold: 3
+      - name: liveness-probe
+        image: quay.io/k8scsi/livenessprobe:v1.1.0
+        args:
+        - --csi-address=/csi/csi.sock
+        - --health-port=9807
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+      volumes:
+      # needed only for topology aware setups
+      #- name: vsphere-config-volume
+      #  secret:
+      #    secretName: vsphere-config-secret
+      - name: registration-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry
+          type: Directory
+      - name: plugin-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/
+          type: DirectoryOrCreate
+      - name: pods-mount-dir
+        hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+      - name: device-dir
+        hostPath:
+          path: /dev
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request is to add documentation and YAML for configuring the CSI Driver with OCP 4.x 
which needs specific configuration for SCC in OCP, and changes to options such as health check ports to come online, as well as additional roles for looking at leases resource (otherwise you see an error in the logs constantly). 

I worked on this with @dav1x at Red Hat to verify the configuration. 

Confirmed with @mylesagray and @RobbieJVMW that adding this to the CSI repo is within the essence of opensource, and if you look at Red Hat's statement this is link, https://access.redhat.com/solutions/4867261, then I believe it is absolutely right for us to host these YAMLs and configurations/instructions. 

"The integration of OpenShift with CSI driver is possible. But the responsibility for support/testing pertains to the vendor (VMWare)."

As this is linked directly to the version 2.0 CSI driver, these instructions would not be shown for a newer driver version added, such as 2.1, therefore not confusing users on support. It would be expected that the YAMLs and configuration is checked for a new driver version and OCP version, and new instructions added for the OCP as 3rd party cluster as needed against the new driver. 

This is needed, because of the configurations in the YAML such as Security Context Constraints, which are only applicable for OpenShift Container Platform. 


