### PR TITLE
CSI migration - Full sync modifications

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -464,7 +464,7 @@ func pvcUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer
 			// Verify if there is an annotation update
 			if !reflect.DeepEqual(newPvc.GetAnnotations(), oldPvc.GetAnnotations()) {
 				// Verify if the annotation update is related to migration. If not, return
-				if !HasMigratedToAnnotation(ctx, oldPvc.GetAnnotations(), newPvc.GetAnnotations()) {
+				if !HasMigratedToAnnotationUpdate(ctx, oldPvc.GetAnnotations(), newPvc.GetAnnotations()) {
 					log.Debug("PVCUpdated: Migrated-to annotation not found for %s in namespace %s. Ignoring other annotation updates", newPvc.Name, newPvc.Namespace)
 					return
 				}
@@ -575,7 +575,7 @@ func pvUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer)
 			// Verify if there is an annotation update
 			if !reflect.DeepEqual(newPv.GetAnnotations(), oldPv.GetAnnotations()) {
 				// Verify if the annotation update is related to migration. If not, return
-				if !HasMigratedToAnnotation(ctx, oldPv.GetAnnotations(), newPv.GetAnnotations()) {
+				if !HasMigratedToAnnotationUpdate(ctx, oldPv.GetAnnotations(), newPv.GetAnnotations()) {
 					log.Debug("PVUpdated: Migrated-to annotation not found for %s. Ignoring other annotation updates", newPv.Name)
 					return
 				}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding full sync related changes to support in-tree vSphere volume Migration to CSI.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #244 

**Special notes for your reviewer**:
* This PR is dependent on another open PR which is out for review: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/235 
* This PR can be reviewed after the above PR is merged
* Verified that the label updates for migrated volumes and volumes created using in-tree storage class are pushed on to the CNS UI
* Verified that the full sync determines the desired state and pushes metadata on to CNS UI for non-CSI volumes
* https://github.com/chethanv28/CSI-migration-syncer-logs/blob/master/Full_Sync.md

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Full sync changes for CSI migration
```
