### PR TITLE
Fixed vcclient NotAuthenticated issue

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -272,6 +272,15 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		if len(scParams.Datastore) != 0 {
 			log.Infof("Converting datastore name: %q to Datastore URL", scParams.Datastore)
 			vcList := c.manager.VcenterManager.GetAllVirtualCenters()
+			if len(vcList) == 0 {
+				return nil, status.Errorf(codes.Internal, "Failed to get vCenter List")
+			}
+			err := vcList[0].Connect(ctx)
+			if err != nil {
+				msg := fmt.Sprintf("failed to connect to vCenter: %q. err: %+v", vcList[0].Config.Host, err)
+				log.Error(msg)
+				return nil, status.Errorf(codes.Internal, msg)
+			}
 			dcList, err := vcList[0].GetDatacenters(ctx)
 			if err != nil {
 				msg := fmt.Sprintf("failed to get datacenter list. err: %+v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making sure vCenter client retrieved from `c.manager.VcenterManager.GetAllVirtualCenters()` is authenticated and connected by calling Connect(ctx) method.


Fixes the following issue.

> {"level":"info","time":"2020-07-03T14:22:09.193386311Z","caller":"vanilla/controller.go:273","msg":"Converting datastore name: \"vsanDatastore\" to Datastore URL","TraceId":"79e16d11-fbfa-4c4c-b672-3cc039104637"}
2020-07-03T14:22:09.234518312Z {"level":"error","time":"2020-07-03T14:22:09.2324083Z","caller":"vsphere/virtualcenter.go:284","msg":"failed to fetch datacenter given dcPath k8s-dc with err: NotAuthenticated","TraceId":"79e16d11-fbfa-4c4c-b672-3cc039104637","


**Special notes for your reviewer**:
Observed while running VCP e2e test on the setup kept idle overnight. This change is required for vSphere CSI Migration.

@xing-yang @chethanv28 @SandeepPissay Can you help review this PR?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed vCenter Client NotAuthenticated issue
```
