### PR TITLE
print version in the log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ GOARCH ?= amd64
 
 LDFLAGS := $(shell cat hack/make/ldflags.txt)
 LDFLAGS_CSI := $(LDFLAGS) -X "$(MOD_NAME)/pkg/csi/service.Version=$(VERSION)"
-LDFLAGS_SYNCER := $(LDFLAGS)
+LDFLAGS_SYNCER := $(LDFLAGS) -X "$(MOD_NAME)/pkg/syncer.Version=$(VERSION)"
 
 # The CSI binary.
 CSI_BIN_NAME := vsphere-csi

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
@@ -36,11 +37,18 @@ import (
 
 var (
 	enableLeaderElection = flag.Bool("leader-election", false, "Enable leader election.")
+	printVersion         = flag.Bool("version", false, "Print syncer version and exit")
 )
 
 // main for vsphere syncer
 func main() {
 	flag.Parse()
+	if *printVersion {
+		fmt.Printf("%s\n", syncer.Version)
+		return
+	}
+	log := logger.GetLoggerWithNoContext()
+	log.Infof("Version : %s", syncer.Version)
 	// run will be executed if this instance is elected as the leader
 	// or if leader election is not enabled
 	var run func(ctx context.Context)

--- a/cmd/vsphere-csi/main.go
+++ b/cmd/vsphere-csi/main.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/provider"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
 
@@ -37,6 +38,8 @@ func main() {
 		fmt.Printf("%s\n", service.Version)
 		return
 	}
+	log := logger.GetLoggerWithNoContext()
+	log.Infof("Version : %s", service.Version)
 
 	gocsi.Run(
 		context.Background(),

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -24,6 +24,9 @@ ARG BASE_IMAGE=photon:3.0
 ################################################################################
 FROM ${GOLANG_IMAGE} as builder
 
+# This build arg is the version to embed in the CSI binary
+ARG VERSION=unknown
+
 ARG GOPROXY
 
 WORKDIR /build
@@ -38,7 +41,7 @@ ENV CGO_ENABLED=0
 
 ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
 
-RUN go build -o vsphere-syncer ./cmd/syncer
+RUN go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/pkg/syncer.Version=${VERSION}" -o vsphere-syncer ./cmd/syncer
 
 ################################################################################
 ##                               MAIN STAGE                                   ##

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -28,6 +28,9 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/types"
 )
 
+// Version of the syncer. This should be set via ldflags.
+var Version string
+
 const (
 	// default interval for csi full sync, used unless overridden by user in csi-controller YAML
 	defaultFullSyncIntervalInMin = 30


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
print version in the log


**Special notes for your reviewer**:

Logs

vsphere-csi-controller

> 2020-07-07T23:02:58.484391330Z {"level":"info","time":"2020-07-07T23:02:58.483845924Z","caller":"vsphere-csi/main.go:42","msg":"Version : v2.0.0-rc.1-56-gcd7a460d-dirty"}

vsphere-syncer

>2020-07-07T23:03:05.239781755Z {"level":"info","time":"2020-07-07T23:03:05.231607277Z","caller":"syncer/main.go:51","msg":"Version : v2.0.0-rc.1-56-gcd7a460d-dirty"}

vsphere-csi-node

> 2020-07-07T23:03:07.898903344Z {"level":"info","time":"2020-07-07T23:03:07.898535568Z","caller":"vsphere-csi/main.go:42","msg":"Version : v2.0.0-rc.1-56-gcd7a460d-dirty"}


CLI version flags

```
root@k8s-master:~#  exec kubectl exec -i -t -n kube-system vsphere-csi-controller-5c4c56dbf8-sjsnf -c vsphere-csi-controller "--" sh -c "clear; (bash || ash || sh)"
'xterm': unknown terminal type.
root [ / ]# ./bin/vsphere-csi -version
v2.0.0-rc.1-56-gcd7a460d-dirty


root@k8s-master:~# exec kubectl exec -i -t -n kube-system vsphere-csi-controller-5c4c56dbf8-sjsnf -c vsphere-syncer "--" sh -c "clear; (bash || ash || sh)"
sh: clear: command not found
root [ / ]# ./bin/vsphere-syncer -version
v2.0.0-rc.1-56-gcd7a460d-dirty
root [ / ]# 

```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
print version in the log
```
