### PR TITLE
Handling PVC updates during csi migration

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -154,4 +154,8 @@ const (
 
 	// IopslimitMigrationParam is raw vSAN Policy Parameter
 	IopslimitMigrationParam = "iopslimit-migrationparam"
+
+	// AnnMigratedTo annotation is added to a PVC and PV that is supposed to be
+	// provisioned/deleted by its corresponding CSI driver
+	AnnMigratedTo = "pv.kubernetes.io/migrated-to"
 )

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -191,7 +191,7 @@ func (c *controller) Init(config *config.Config) error {
 	deletedVolumes = timedmap.New(1 * time.Minute)
 	if config.FeatureStates.CSIMigration {
 		common.CSIMigrationFeatureEnabled = true
-		log.Infof("CSI Migration Feature is Enabled. Loading Volume Migration Service")
+		log.Info("CSI Migration Feature is Enabled. Loading Volume Migration Service")
 		volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &c.manager.VolumeManager, config)
 		if err != nil {
 			log.Errorf("failed to get migration service. Err: %v", err)

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -10,6 +10,7 @@ import (
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	volumes "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
@@ -132,4 +133,18 @@ func getPVCKey(ctx context.Context, obj interface{}) (string, error) {
 	}
 	log.Infof("getPVCKey: PVC key %s", objKey)
 	return objKey, nil
+}
+
+// HasMigratedToAnnotation returns true if the migrated-to annotation is found in the newer object
+func HasMigratedToAnnotation(ctx context.Context, prevAnnotations map[string]string, newAnnotations map[string]string) bool {
+	log := logger.GetLogger(ctx)
+	// Checking if the migrated-to annotation is found in the new PV
+	if _, annMigratedToFound := newAnnotations[common.AnnMigratedTo]; annMigratedToFound {
+		if _, annMigratedToFound = prevAnnotations[common.AnnMigratedTo]; !annMigratedToFound {
+			log.Debugf("Received %v annotation update", common.AnnMigratedTo)
+			return true
+		}
+	}
+	log.Debug("%v annotation not found", common.AnnMigratedTo)
+	return false
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding PVC update related changes to support in-tree vSphere volume Migration to CSI.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #243

**Special notes for your reviewer**:
* Verified that the PVC and PV names for migrated volumes and for volumes created using in-tree storage class are pushed on to the CNS UI
* Testing done: https://github.com/chethanv28/CSI-migration-syncer-logs/blob/master/Update_PVC.md

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Support PVC updates for migrated volumes and CSI volumes created with in-Tree storage class
```
