### PR TITLE
Modify syncer util function to fetch only PV information for migrated volumes

### DIFF
--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -27,23 +27,7 @@ func getPVsInBoundAvailableOrReleased(ctx context.Context, metadataSyncer *metad
 	}
 	for _, pv := range allPVs {
 		if (pv.Spec.CSI != nil && pv.Spec.CSI.Driver == csitypes.Name) || (metadataSyncer.configInfo.Cfg.FeatureStates.CSIMigration && pv.Spec.VsphereVolume != nil) {
-			var volumeHandle string
-			var err error
-			if metadataSyncer.configInfo.Cfg.FeatureStates.CSIMigration && pv.Spec.VsphereVolume != nil {
-				if _, annMigratedToFound := pv.Annotations[common.AnnMigratedTo]; annMigratedToFound {
-					volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
-					if err != nil {
-						log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %q pv %q with error %+v", pv.Spec.VsphereVolume.VolumePath, pv.Name, err)
-						return nil, err
-					}
-				} else {
-					log.Infof("%v annotation not found for vSphere volume %q", common.AnnMigratedTo, pv.Name)
-					continue
-				}
-			} else {
-				volumeHandle = pv.Spec.CSI.VolumeHandle
-			}
-			log.Debugf("FullSync: pv %v is in state %v", volumeHandle, pv.Status.Phase)
+			log.Debugf("FullSync: pv %v is in state %v", pv.Name, pv.Status.Phase)
 			if pv.Status.Phase == v1.VolumeBound || pv.Status.Phase == v1.VolumeAvailable || pv.Status.Phase == v1.VolumeReleased {
 				pvsInDesiredState = append(pvsInDesiredState, pv)
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is modifying full sync util function to only fetch list of PVs. Previously the util function was registering volumes when migration is ON

**Special notes for your reviewer**:
* Verified that the label updates for migrated volumes and volumes created using in-tree storage class are pushed on to the CNS UI
* Verified that the full sync determines the desired state and pushes metadata on to CNS UI for non-CSI volumes
* https://github.com/chethanv28/CSI-migration-syncer-logs/blob/master/Full_Sync.md
* Full Sync analysis for 500 volumes: https://github.com/chethanv28/CSI-migration-syncer-logs/blob/master/FullSync_Analysis.md

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Full sync util function modifications
```
