### PR TITLE
fixed golangci-lint issues and added golangci-lint check in the make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ test-e2e:
 ##                                 LINTING                                    ##
 ################################################################################
 .PHONY: check fmt lint mdlint shellcheck vet
-check: fmt lint mdlint shellcheck staticcheck vet
+check: fmt lint mdlint shellcheck staticcheck vet golangci-lint
 
 fmt:
 	hack/check-format.sh
@@ -361,7 +361,7 @@ mdlint:
 	hack/check-mdlint.sh
 
 golangci-lint:
-	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.27.0 golangci-lint run -v --timeout=300s
+	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.29.0 golangci-lint run -v --timeout=300s
 
 shellcheck:
 	hack/check-shell.sh

--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -130,14 +130,22 @@ func GetVolumeMigrationService(ctx context.Context, volumeManager *cnsvolume.Man
 				AddFunc: func(obj interface{}) {
 					log.Debugf("received add event for VolumeMigration CR!")
 					var volumeMigrationObject migrationv1alpha1.CnsVSphereVolumeMigration
-					runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object, &volumeMigrationObject)
+					err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object, &volumeMigrationObject)
+					if err != nil {
+						log.Errorf("failed to cast object to volumeMigrationObject. err: %v", err)
+						return
+					}
 					volumeMigrationInstance.volumePathToVolumeID.Store(volumeMigrationObject.Spec.VolumePath, volumeMigrationObject.Spec.VolumeID)
 					log.Debugf("successfully added volumePath: %q, volumeID: %q mapping in the cache", volumeMigrationObject.Spec.VolumePath, volumeMigrationObject.Spec.VolumeID)
 				},
 				DeleteFunc: func(obj interface{}) {
 					log.Debugf("received delete event for VolumeMigration CR!")
 					var volumeMigrationObject migrationv1alpha1.CnsVSphereVolumeMigration
-					runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object, &volumeMigrationObject)
+					err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object, &volumeMigrationObject)
+					if err != nil {
+						log.Errorf("failed to cast object to volumeMigrationObject. err: %v", err)
+						return
+					}
 					volumeMigrationInstance.volumePathToVolumeID.Delete(volumeMigrationObject.Spec.VolumePath)
 					log.Debugf("successfully deleted volumePath: %q, volumeID: %q mapping from cache", volumeMigrationObject.Spec.VolumePath, volumeMigrationObject.Spec.VolumeID)
 				},

--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -469,7 +469,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		log.Infof(" Profile ID :%s", profileID)
 		scParameters := make(map[string]string)
 		scParameters["storagePolicyID"] = profileID
-		client.StorageV1().StorageClasses().Delete(storagePolicyName, nil)
+		err = client.StorageV1().StorageClasses().Delete(storagePolicyName, nil)
 		storageclass, err := createStorageClass(client, scParameters, nil, "", "", false, storagePolicyName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		storageclass, err = client.StorageV1().StorageClasses().Get(storagePolicyName, metav1.GetOptions{})
@@ -522,7 +522,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Deleting the pod")
-		framework.DeletePodWithWait(f, client, pod)
+		err = framework.DeletePodWithWait(f, client, pod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s", pv.Spec.CSI.VolumeHandle, vmUUID))
 		ctx, cancel = context.WithCancel(context.Background())
@@ -588,7 +589,10 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		log.Infof(" Profile ID :%s", profileID)
 		scParameters := make(map[string]string)
 		scParameters["storagePolicyID"] = profileID
-		client.StorageV1().StorageClasses().Delete(storagePolicyName, nil)
+		err = client.StorageV1().StorageClasses().Delete(storagePolicyName, nil)
+		if err != nil {
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		}
 		storageclass, err := createStorageClass(client, scParameters, nil, "", "", false, storagePolicyName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		storageclass, err = client.StorageV1().StorageClasses().Get(storagePolicyName, metav1.GetOptions{})
@@ -644,7 +648,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Deleting the pod")
-		framework.DeletePodWithWait(f, client, pod)
+		framework.ExpectNoError(framework.DeletePodWithWait(f, client, pod), "Failed to delete pod ", pod.Name)
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s", pv.Spec.CSI.VolumeHandle, vmUUID))
 		ctx, cancel = context.WithCancel(context.Background())
@@ -712,7 +716,10 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		log.Infof(" Profile ID :%s", profileID)
 		scParameters := make(map[string]string)
 		scParameters["storagePolicyID"] = profileID
-		client.StorageV1().StorageClasses().Delete(storagePolicyName, nil)
+		err = client.StorageV1().StorageClasses().Delete(storagePolicyName, nil)
+		if err != nil {
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		}
 		storageclass, err := createStorageClass(client, scParameters, nil, "", "", false, storagePolicyName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		storageclass, err = client.StorageV1().StorageClasses().Get(storagePolicyName, metav1.GetOptions{})
@@ -773,7 +780,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Deleting the pod")
-		framework.DeletePodWithWait(f, client, pod)
+		framework.ExpectNoError(framework.DeletePodWithWait(f, client, pod), "Failed to delete pod ", pod.Name)
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s", pv.Spec.CSI.VolumeHandle, vmUUID))
 		ctx, cancel = context.WithCancel(context.Background())

--- a/tests/e2e/data_persistence.go
+++ b/tests/e2e/data_persistence.go
@@ -303,7 +303,10 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		log.Infof(" Profile ID :%s", profileID)
 		scParameters := make(map[string]string)
 		scParameters["storagePolicyID"] = profileID
-		client.StorageV1().StorageClasses().Delete(storagePolicyName, nil)
+		err = client.StorageV1().StorageClasses().Delete(storagePolicyName, nil)
+		if err != nil {
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		}
 		storageclass, err := createStorageClass(client, scParameters, nil, "", "", false, storagePolicyName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		storageclass, err = client.StorageV1().StorageClasses().Get(storagePolicyName, metav1.GetOptions{})
@@ -362,7 +365,7 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		createAndVerifyFilesOnVolume(namespace, pod.Name, []string{newEmptyFileName}, volumeFiles)
 
 		ginkgo.By("Deleting the pod")
-		framework.DeletePodWithWait(f, client, pod)
+		framework.ExpectNoError(framework.DeletePodWithWait(f, client, pod), "Failed to delete pod ", pod.Name)
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s", pv.Spec.CSI.VolumeHandle, vmUUID))
 		ctx, cancel = context.WithCancel(context.Background())
@@ -393,7 +396,7 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		createAndVerifyFilesOnVolume(namespace, pod.Name, []string{newEmptyFileName}, volumeFiles)
 
 		ginkgo.By("Deleting the pod")
-		framework.DeletePodWithWait(f, client, pod)
+		framework.ExpectNoError(framework.DeletePodWithWait(f, client, pod), "Failed to delete pod ", pod.Name)
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s", pv.Spec.CSI.VolumeHandle, vmUUID))
 		ctx, cancel = context.WithCancel(context.Background())

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -65,7 +65,6 @@ const (
 	vsphereSystemNamespace                     = "vmware-system-csi"
 	vsphereTKGSystemNamespace                  = "vmware-system-tkg"
 	vsphereControllerManager                   = "vmware-system-tkg-controller-manager"
-	podContainerCreatingState                  = "ContainerCreating"
 	vsanhealthServiceName                      = "vsan-health"
 	spsServiceName                             = "sps"
 	wcpServiceName                             = "wcp"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- fixed golangci-lint issues and added golangci-lint check in the make check.
- upgrade golangci-lint image to golangci-lint:v1.29.0


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

After this PR

```
% make golangci-lint
docker run --rm -v /Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver:/app -w /app golangci/golangci-lint:v1.29.0 golangci-lint run -v --timeout=300s
level=info msg="[config_reader] Config search paths: [./ /app /]"
level=info msg="[lintersdb] Active 10 linters: [deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck]"
level=info msg="[loader] Go packages loading at mode 575 (types_sizes|deps|exports_file|files|name|compiled_files|imports) took 2m14.2876599s"
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 243.159ms"
level=info msg="[linters context/goanalysis] analyzers took 3m0.496561s with top 10 stages: buildir: 2m35.95742s, inspect: 4.3900786s, fact_deprecated: 3.083888s, printf: 2.6829733s, ctrlflow: 2.4497439s, ineffassign: 2.2654182s, fact_purity: 2.2168778s, isgenerated: 1.775069s, deadcode: 316.7237ms, errcheck: 310.6337ms"
level=info msg="[linters context/goanalysis] analyzers took 11.1644895s with top 10 stages: buildir: 10.2648378s, U1000: 899.6517ms"
level=info msg="[runner] Issues before processing: 54, after processing: 0"
level=info msg="[runner] Processors filtering stat (out/in): cgo: 54/54, skip_dirs: 54/54, autogenerated_exclude: 10/54, identifier_marker: 10/10, exclude: 0/10, skip_files: 54/54, filename_unadjuster: 54/54, path_prettifier: 54/54"
level=info msg="[runner] processing took 64.7715ms with stages: path_prettifier: 31.1332ms, autogenerated_exclude: 30.1566ms, skip_dirs: 2.5879ms, exclude: 391.9µs, identifier_marker: 214.4µs, path_prefixer: 51.2µs, cgo: 31.2µs, max_same_issues: 16.9µs, nolint: 16.5µs, uniq_by_line: 15.8µs, path_shortener: 15.8µs, sort_results: 15.8µs, max_from_linter: 15.8µs, exclude-rules: 15.7µs, skip_files: 15.7µs, diff: 15.6µs, severity-rules: 15.5µs, source_code: 15.4µs, max_per_file_from_linter: 15.4µs, filename_unadjuster: 15.2µs"
level=info msg="[runner] linters took 32.098392s with stages: goanalysis_metalinter: 28.9977194s, unused: 3.0348983s"
level=info msg="File cache stats: 0 entries of total size 0B"
level=info msg="Memory: 1625 samples, avg is 246.2MB, max is 1424.8MB"
level=info msg="Execution took 2m46.6520717s"
```

Before this PR

```
% make golangci-lint
docker run --rm -v /Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver:/app -w /app golangci/golangci-lint:v1.27.0 golangci-lint run -v --timeout=300s
level=info msg="[config_reader] Config search paths: [./ /app /]"
level=info msg="[lintersdb] Active 10 linters: [deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck]"
level=info msg="[loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|files|imports|name|types_sizes) took 2m5.7197373s"
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 266.5057ms"
level=info msg="[linters context/goanalysis] analyzers took 3m38.5012993s with top 10 stages: buildir: 3m8.6758622s, inspect: 5.0842815s, fact_deprecated: 3.3884303s, ctrlflow: 3.2623502s, printf: 2.9029356s, ineffassign: 2.6700578s, fact_purity: 2.5128294s, isgenerated: 2.2554453s, S1038: 359.9001ms, S1012: 221.3521ms"
level=info msg="[linters context/goanalysis] analyzers took 16.5022296s with top 10 stages: buildir: 15.5942151s, U1000: 908.0145ms"
level=info msg="[runner/max_same_issues] 2/5 issues with text \"Error return value of `framework.DeletePodWithWait` is not checked\" were hidden, use --max-same-issues"
level=info msg="[runner/max_same_issues] 1/4 issues with text \"Error return value of `(k8s.io/client-go/kubernetes/typed/storage/v1.StorageClassInterface).Delete` is not checked\" were hidden, use --max-same-issues"
level=info msg="[runner] Issues before processing: 67, after processing: 9"
level=info msg="[runner] Processors filtering stat (out/in): uniq_by_line: 12/13, diff: 12/12, max_from_linter: 9/9, cgo: 67/67, skip_dirs: 67/67, exclude: 13/23, exclude-rules: 13/13, nolint: 13/13, path_shortener: 9/9, skip_files: 67/67, path_prettifier: 67/67, autogenerated_exclude: 23/67, max_per_file_from_linter: 12/12, max_same_issues: 9/12, source_code: 9/9, filename_unadjuster: 67/67, identifier_marker: 23/23"
level=info msg="[runner] processing took 160.1144ms with stages: path_prettifier: 63.4276ms, autogenerated_exclude: 50.8388ms, nolint: 24.8658ms, source_code: 14.3061ms, skip_dirs: 4.236ms, exclude: 1.3609ms, identifier_marker: 697.4µs, max_same_issues: 149.3µs, exclude-rules: 40.6µs, filename_unadjuster: 33.5µs, cgo: 28.8µs, uniq_by_line: 25.3µs, max_from_linter: 24.2µs, path_shortener: 23.7µs, max_per_file_from_linter: 19.7µs, skip_files: 18.4µs, diff: 18.3µs"
level=info msg="[runner] linters took 39.6630289s with stages: goanalysis_metalinter: 35.262697s, unused: 4.2391304s"
tests/e2e/e2e_common.go:68:2: `podContainerCreatingState` is unused (deadcode)
        podContainerCreatingState                  = "ContainerCreating"
        ^
pkg/apis/migration/migration.go:133:59: Error return value of `runtime.DefaultUnstructuredConverter.FromUnstructured` is not checked (errcheck)
                                        runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object, &volumeMigrationObject)
                                                                                             ^
pkg/apis/migration/migration.go:140:59: Error return value of `runtime.DefaultUnstructuredConverter.FromUnstructured` is not checked (errcheck)
                                        runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object, &volumeMigrationObject)
                                                                                             ^
tests/e2e/csi_static_provisioning_basic.go:472:45: Error return value of `(k8s.io/client-go/kubernetes/typed/storage/v1.StorageClassInterface).Delete` is not checked (errcheck)
                client.StorageV1().StorageClasses().Delete(storagePolicyName, nil)
                                                          ^
tests/e2e/csi_static_provisioning_basic.go:525:30: Error return value of `framework.DeletePodWithWait` is not checked (errcheck)
                framework.DeletePodWithWait(f, client, pod)
                                           ^
tests/e2e/csi_static_provisioning_basic.go:591:45: Error return value of `(k8s.io/client-go/kubernetes/typed/storage/v1.StorageClassInterface).Delete` is not checked (errcheck)
                client.StorageV1().StorageClasses().Delete(storagePolicyName, nil)
                                                          ^
tests/e2e/csi_static_provisioning_basic.go:647:30: Error return value of `framework.DeletePodWithWait` is not checked (errcheck)
                framework.DeletePodWithWait(f, client, pod)
                                           ^
tests/e2e/csi_static_provisioning_basic.go:715:45: Error return value of `(k8s.io/client-go/kubernetes/typed/storage/v1.StorageClassInterface).Delete` is not checked (errcheck)
                client.StorageV1().StorageClasses().Delete(storagePolicyName, nil)
                                                          ^
tests/e2e/csi_static_provisioning_basic.go:776:30: Error return value of `framework.DeletePodWithWait` is not checked (errcheck)
                framework.DeletePodWithWait(f, client, pod)
                                           ^
level=info msg="File cache stats: 3 entries of total size 57.1KiB"
level=info msg="Memory: 1582 samples, avg is 267.3MB, max is 1357.6MB"
level=info msg="Execution took 2m45.7458063s"
make: *** [golangci-lint] Error 1

```



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fixed golangci-lint issues and added golangci-lint check in the make check
```
