### PR TITLE
fixing k8s prow golangci-lint error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ mdlint:
 	hack/check-mdlint.sh
 
 golangci-lint:
-	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.29.0 golangci-lint run -v --timeout=300s
+	hack/check-golangci-lint.sh
 
 shellcheck:
 	hack/check-shell.sh

--- a/hack/check-golangci-lint.sh
+++ b/hack/check-golangci-lint.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+usage() {
+  cat <<EOF
+usage: ${0} [FLAGS]
+  Lints the project's go files.
+
+FLAGS
+  -d    use the docker image
+  -h    prints this help screen
+EOF
+}
+
+while getopts ':dh' opt; do
+  case "${opt}" in
+  d)
+    DO_DOCKER=1
+    ;;
+  h)
+    usage 1>&2; exit 1
+    ;;
+  \?)
+    { echo "invalid option: -${OPTARG}"; usage; } 1>&2; exit 1
+    ;;
+  :)
+    echo "option -${OPTARG} requires an argument" 1>&2; exit 1
+    ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ ! "${DO_DOCKER-}" ]; then
+  golangci-lint run -v --timeout=1200s
+else
+  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v1.29.0 golangci-lint run -v --timeout=1200s
+fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
k8s prow is failing - https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_vsphere-csi-driver/277/pull-vsphere-csi-driver-verify-golangci-lint/1286329344318246912/build-log.txt

```
.
.
docker run --rm -v /home/prow/go/src/sigs.k8s.io/vsphere-csi-driver:/app -w /app golangci/golangci-lint:v1.29.0 golangci-lint run -v --timeout=300s
make: docker: Command not found
make: *** [Makefile:364: golangci-lint] Error 127
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fixing k8s prow golangci-lint error
```
