### PR TITLE
Use Common CO interface for Vanilla K8S to handle CSI migration feature switch

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -47,10 +47,6 @@ const (
 	DefaultGCConfigPath = "/etc/cloud/pvcsi-config/cns-csi.conf"
 	// EnvVSphereCSIConfig contains the path to the CSI vSphere Config
 	EnvVSphereCSIConfig = "VSPHERE_CSI_CONFIG"
-	// EnvFeatureStates contains the path to the CSI Feature States Config
-	EnvFeatureStates = "FEATURE_STATES"
-	// DefaultVanillaFeatureStateConfigPath is the default path of csi feature states config file in Vanilla Cluster
-	DefaultVanillaFeatureStateConfigPath = "/etc/cloud/csi-feature-states/csi-feature-states.conf"
 	// EnvGCConfig contains the path to the CSI GC Config
 	EnvGCConfig = "GC_CONFIG"
 	// DefaultpvCSIProviderPath is the default path of pvCSI provider config
@@ -349,39 +345,6 @@ func GetCnsconfig(ctx context.Context, cfgPath string) (*Config, error) {
 		}
 	}
 	return cfg, nil
-}
-
-// GetFeatureStatesConfig returns feature states config from specified file path
-func GetFeatureStatesConfig(ctx context.Context, featureStatesCfgPath string, cfg *Config) error {
-	log := logger.GetLogger(ctx)
-	log.Debugf("GetFeatureStatesConfig called with featureStatesCfgPath: %s", featureStatesCfgPath)
-	//Fetch feature state information in the csi-feature-states.conf if it exists
-	if _, err := os.Stat(featureStatesCfgPath); os.IsNotExist(err) {
-		log.Warnf("failed to stat csi-feature-states.conf. Setting the feature state values to false")
-		cfg.FeatureStates.CSIMigration = false
-		cfg.FeatureStates.VolumeExtend = false
-		cfg.FeatureStates.VolumeHealth = false
-		return nil
-	}
-	featureStatesConfig, err := os.Open(featureStatesCfgPath)
-	if err != nil {
-		log.Errorf("failed to open %s. Err: %v", featureStatesCfgPath, err)
-		return err
-	}
-	if err := gcfg.FatalOnly(gcfg.ReadInto(cfg, featureStatesConfig)); err != nil {
-		log.Errorf("error while reading config file: %+v", err)
-		return err
-	}
-	if !cfg.FeatureStates.CSIMigration {
-		log.Infof("CSI Migration feature is disabled.")
-	}
-	if !cfg.FeatureStates.VolumeExtend {
-		log.Infof("Volume resize feature is disabled.")
-	}
-	if !cfg.FeatureStates.VolumeHealth {
-		log.Infof("Volume health feature is disabled.")
-	}
-	return nil
 }
 
 // GetDefaultNetPermission returns the default file share net permission.

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -63,15 +63,6 @@ type Config struct {
 		Zone   string `gcfg:"zone"`
 		Region string `gcfg:"region"`
 	}
-	// Set of features with state flags
-	FeatureStates FeatureStateSwitches
-}
-
-// FeatureStateSwitches contains flags to enable/disable features
-type FeatureStateSwitches struct {
-	CSIMigration bool `gcfg:"csi-migration"`
-	VolumeExtend bool `gcfg:"volume-extend"`
-	VolumeHealth bool `gcfg:"volume-health"`
 }
 
 // NetPermissionConfig consists of information used to restrict the

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unittestcommon
+
+import (
+	"context"
+	"sync"
+
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+)
+
+// FakeK8SOrchestrator is used to mock common K8S Orchestrator instance to store FSS values
+type FakeK8SOrchestrator struct {
+	featureStates map[string]string
+}
+
+// volumeMigration holds mocked migrated volume information
+type mockVolumeMigration struct {
+	// volumePath to volumeId map
+	volumePathToVolumeID sync.Map
+	// volumeManager helps perform Volume Operations
+	volumeManager *cnsvolume.Manager
+	// cnsConfig helps retrieve vSphere CSI configuration for RegisterVolume Operation
+	cnsConfig *cnsconfig.Config
+}
+
+// MockVolumeMigrationService is a mocked VolumeMigrationService needed for CSI migration feature
+type MockVolumeMigrationService interface {
+	// GetVolumeID returns VolumeID for given VolumePath
+	// Returns an error if not able to retrieve VolumeID.
+	GetVolumeID(ctx context.Context, volumePath string) (string, error)
+
+	// GetVolumePath returns VolumePath for given VolumeID
+	// Returns an error if not able to retrieve VolumePath.
+	GetVolumePath(ctx context.Context, volumeID string) (string, error)
+
+	// DeleteVolumeInfo helps delete mapping of volumePath to VolumeID for specified volumeID
+	DeleteVolumeInfo(ctx context.Context, volumeID string) error
+}

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unittestcommon
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
+)
+
+var mapVolumePathToID map[string]map[string]string
+
+// GetFakeContainerOrchestratorInterface returns a dummy CO interface based on the CO type
+func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCommonInterface, error) {
+	if orchestratorType == common.Kubernetes {
+		fakeCO := &FakeK8SOrchestrator{
+			featureStates: map[string]string{
+				"volume-extend": "true",
+				"volume-health": "true",
+				"csi-migration": "true",
+			},
+		}
+		return fakeCO, nil
+	}
+	return nil, fmt.Errorf("Unrecognized CO type")
+
+}
+
+// IsFSSEnabled returns the FSS values for a given feature
+func (c *FakeK8SOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) bool {
+	var featureState bool
+	var err error
+	if flag, ok := c.featureStates[featureName]; ok {
+		featureState, err = strconv.ParseBool(flag)
+		if err != nil {
+			return false
+		}
+		return featureState
+	}
+	return false
+}
+
+// GetFakeVolumeMigrationService returns the mocked VolumeMigrationService
+func GetFakeVolumeMigrationService(ctx context.Context, volumeManager *cnsvolume.Manager, cnsConfig *cnsconfig.Config) (MockVolumeMigrationService, error) {
+	// fakeVolumeMigrationInstance is a mocked instance of volumeMigration
+	fakeVolumeMigrationInstance := &mockVolumeMigration{
+		volumePathToVolumeID: sync.Map{},
+		volumeManager:        volumeManager,
+		cnsConfig:            cnsConfig,
+	}
+	// Storing a dummy volume migration instance in the mapping
+	mapVolumePathToID = make(map[string]map[string]string)
+	mapVolumePathToID = map[string]map[string]string{
+		"dummy-vms-CR": {
+			"VolumePath": "[vsanDatastore] 9c01ed5e/kubernetes-dynamic-pvc-d8698e54.vmdk",
+			"VolumeID":   "191c6d51-ed59-4340-9841-638c09f642b7",
+		},
+	}
+	return fakeVolumeMigrationInstance, nil
+}
+
+// GetVolumeID mocks the method with returns Volume Id for a given Volume Path
+func (dummyInstance *mockVolumeMigration) GetVolumeID(ctx context.Context, volumePath string) (string, error) {
+	return mapVolumePathToID["dummy-vms-CR"]["VolumeID"], nil
+}
+
+// GetVolumePath mocks the method with returns Volume Path for a given Volume ID
+func (dummyInstance *mockVolumeMigration) GetVolumePath(ctx context.Context, volumeID string) (string, error) {
+	return mapVolumePathToID["dummy-vms-CR"]["VolumePath"], nil
+}
+
+// DeleteVolumeInfo mocks the method to delete mapping of volumePath to VolumeID for specified volumeID
+func (dummyInstance *mockVolumeMigration) DeleteVolumeInfo(ctx context.Context, volumeID string) error {
+	delete(mapVolumePathToID, "dummy-vms-CR")
+	return nil
+}

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"errors"
 
+	cnstypes "github.com/vmware/govmomi/cns/types"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
 // COCommonInterface provides functionality to define
@@ -33,10 +35,16 @@ type COCommonInterface interface {
 
 // GetContainerOrchestratorInterface returns orchestrator object
 // for a given container orchestrator type
-func GetContainerOrchestratorInterface(orchestratorType int) (COCommonInterface, error) {
+func GetContainerOrchestratorInterface(ctx context.Context, orchestratorType int, clusterFlavour cnstypes.CnsClusterFlavor) (COCommonInterface, error) {
+	log := logger.GetLogger(ctx)
 	switch orchestratorType {
 	case common.Kubernetes:
-		return k8sorchestrator.Newk8sOrchestrator(), nil
+		k8sorchestratorInstance, err := k8sorchestrator.Newk8sOrchestrator(ctx, clusterFlavour)
+		if err != nil {
+			log.Errorf("Creating k8sorchestratorInstance failed. Err: %v", err)
+			return nil, err
+		}
+		return k8sorchestratorInstance, nil
 	default:
 		//if type is invalid, return an error
 		return nil, errors.New("Invalid orchestrator Type")

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -162,8 +162,14 @@ const (
 	// IPs is Client IP address, IP range or IP subnet
 	IPs string = "ips"
 
-	// CSINamespace is the namespace of pvCSI in TKC Cluster
-	CSINamespace = "vmware-system-csi"
+	// CSINamespaceVanillaK8S is the namespace of CSI driver in Vanilla K8S
+	CSINamespaceVanillaK8S = "kube-system"
+
+	// CSINamespaceWorkload is the namespace of CSI in Supervisor Cluster
+	CSINamespaceWorkload = "vmware-system-csi"
+
+	// CSINamespaceTkgCluster is the namespace of CSI in TKG Cluster
+	CSINamespaceTkgCluster = "vmware-system-csi"
 
 	// CSIFeatureStatesConfigMapName is the name of configmap to store FSS values
 	CSIFeatureStatesConfigMapName = "csi-feature-states"
@@ -171,7 +177,7 @@ const (
 
 // Supported container orchestrators
 const (
-	Kubernetes = iota // Default container orchestor for TKC, Supervisor Cluster and Vanilla K8s
+	Kubernetes = iota // Default container orchestrator for TKC, Supervisor Cluster and Vanilla K8s
 )
 
 // Feature state flag names
@@ -180,4 +186,6 @@ const (
 	VolumeHealth = "volume-health"
 	// VolumeExtend is feature flag name for volume expansion
 	VolumeExtend = "volume-extend"
+	// CSIMigration is feature flag for migrating in-tree vSphere volumes to CSI
+	CSIMigration = "csi-migration"
 )

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -46,6 +46,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
 )
@@ -279,6 +280,10 @@ func getControllerTest(t *testing.T) *controllerTest {
 				sharedDatastoreURL: sharedDatastoreURL,
 				k8sClient:          k8sClient,
 			},
+		}
+		containerOrchestratorUtility, err = unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+		if err != nil {
+			t.Fatalf("Failed to create co agnostic interface. err=%v", err)
 		}
 		controllerTestInstance = &controllerTest{
 			controller: c,

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -107,7 +107,7 @@ func (c *controller) Init(config *cnsconfig.Config) error {
 		log.Errorf("failed to create fsnotify watcher. err=%v", err)
 		return err
 	}
-	c.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(common.Kubernetes)
+	c.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, cnstypes.CnsClusterFlavorWorkload)
 	if err != nil {
 		log.Errorf("Failed to create co agnostic interface. err=%v", err)
 		return err

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fsnotify/fsnotify"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	cnstypes "github.com/vmware/govmomi/cns/types"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -108,7 +109,7 @@ func (c *controller) Init(config *cnsconfig.Config) error {
 		log.Errorf("failed to create fsnotify watcher. err=%v", err)
 		return err
 	}
-	c.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(common.Kubernetes)
+	c.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, cnstypes.CnsClusterFlavorGuest)
 	if err != nil {
 		log.Errorf("Failed to create co agnostic interface. err=%v", err)
 		return err

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -260,7 +260,7 @@ func getClientThroughput(ctx context.Context, inClusterClient bool) (float32, in
 			burst = value
 		}
 	}
-	log.Infof("Setting Supervisor client QPS to %f and Burst to %d.", qps, burst)
+	log.Infof("Setting client QPS to %f and Burst to %d.", qps, burst)
 	return qps, burst
 }
 

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -51,7 +51,7 @@ func csiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) {
 	for _, pv := range k8sPVs {
 		var volumeHandle string
 		var err error
-		if metadataSyncer.configInfo.Cfg.FeatureStates.CSIMigration && pv.Spec.VsphereVolume != nil {
+		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
 			// For vSphere volumes, the migration service will register volumes in CNS.
 			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
 			if err != nil {
@@ -133,7 +133,7 @@ func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVo
 	for _, pv := range currentK8sPV {
 		var volumeHandle string
 		var err error
-		if metadataSyncer.configInfo.Cfg.FeatureStates.CSIMigration && pv.Spec.VsphereVolume != nil {
+		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
 			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
 			if err != nil {
 				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", pv.Spec.VsphereVolume.VolumePath, err)
@@ -188,7 +188,7 @@ func fullSyncDeleteVolumes(ctx context.Context, volumeIDDeleteArray []cnstypes.C
 	for _, pv := range currentK8sPV {
 		var volumeHandle string
 		var err error
-		if metadataSyncer.configInfo.Cfg.FeatureStates.CSIMigration && pv.Spec.VsphereVolume != nil {
+		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
 			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
 			if err != nil {
 				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", pv.Spec.VsphereVolume.VolumePath, err)
@@ -236,7 +236,7 @@ func fullSyncDeleteVolumes(ctx context.Context, volumeIDDeleteArray []cnstypes.C
 					log.Warnf("FullSync: fullSyncDeleteVolumes: Failed to delete volume %s with error %+v", volume.VolumeId.Id, err)
 					continue
 				}
-				if metadataSyncer.configInfo.Cfg.FeatureStates.CSIMigration {
+				if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
 					err := volumeMigrationService.DeleteVolumeInfo(ctx, volume.VolumeId.Id)
 					if err != nil {
 						log.Warnf("FullSync: fullSyncDeleteVolumes: Failed to delete volume mapping CR for %s with error %+v", volume.VolumeId.Id, err)
@@ -307,7 +307,7 @@ func getEntityMetadata(ctx context.Context, pvList []*v1.PersistentVolume, cnsVo
 		k8sMetadata := buildCnsMetadataList(ctx, pv, pvToPVCMap, pvcToPodMap, metadataSyncer.configInfo.Cfg.Global.ClusterID)
 		var volumeHandle string
 		var err error
-		if metadataSyncer.configInfo.Cfg.FeatureStates.CSIMigration && pv.Spec.VsphereVolume != nil {
+		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
 			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
 			if err != nil {
 				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", pv.Spec.VsphereVolume.VolumePath, err)
@@ -473,7 +473,7 @@ func getVolumesToBeDeleted(ctx context.Context, cnsVolumeList []cnstypes.CnsVolu
 	// inlineVolumeMap holds the volume path information for migrated volumes which are used by Pods
 	inlineVolumeMap := make(map[string]string)
 	var err error
-	if metadataSyncer.configInfo.Cfg.FeatureStates.CSIMigration {
+	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
 		inlineVolumeMap, err = getInlineMigratedVolumesInfo(ctx, metadataSyncer)
 		if err != nil {
 			log.Errorf("FullSync: Failed to get inline migrated volumes. Err: %v", err)
@@ -488,7 +488,7 @@ func getVolumesToBeDeleted(ctx context.Context, cnsVolumeList []cnstypes.CnsVolu
 				volToBeDeleted = append(volToBeDeleted, vol.VolumeId)
 			} else {
 				// Add to cnsDeletionMap
-				if metadataSyncer.configInfo.Cfg.FeatureStates.CSIMigration {
+				if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
 					// If migration is ON, verify if the volume is present in inlineVolumeMap
 					if _, existsInInlineVolumeMap := inlineVolumeMap[vol.VolumeId.Id]; !existsInInlineVolumeMap {
 						log.Infof("FullSync: Inline migrated volume with id %s added to cnsDeletionMap", vol.VolumeId.Id)

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -42,6 +42,8 @@ import (
 	volumes "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/unittestcommon"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/types"
@@ -209,6 +211,15 @@ func TestSyncerWorkflows(t *testing.T) {
 	metadataSyncer.pvcLister = metadataSyncer.k8sInformerManager.GetPVCLister()
 	metadataSyncer.podLister = metadataSyncer.k8sInformerManager.GetPodLister()
 	metadataSyncer.k8sInformerManager.Listen()
+
+	volumeMigrationService, err = unittestcommon.GetFakeVolumeMigrationService(ctx, &metadataSyncer.volumeManager, metadataSyncer.configInfo.Cfg)
+	if err != nil {
+		t.Fatalf("failed to get migration service. Err: %v", err)
+	}
+	metadataSyncer.coCommonInterface, err = unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatalf("Failed to create co agnostic interface. err=%v", err)
+	}
 
 	var sharedDatastore string
 	if v := os.Getenv("VSPHERE_DATASTORE_URL"); v != "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is need to have similarity in reading FSS for Vanilla K8S. FSS for CSI migration has to be fetched using the Common CO Interface, similar to other cluster flavors

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #278 

**Special notes for your reviewer**:
Ran few basic e2e Tests:

<pre>
$ export GINKGO_FOCUS="Should create and delete pod with the same volume source"
chethanv-a01:vsphere-csi-driver chethanv$ vi e2eTest.conf 
(reverse-i-search)`make ': make images
chethanv-a01:vsphere-csi-driver chethanv$ 
chethanv-a01:vsphere-csi-driver chethanv$ make test-e2e
hack/run-e2e-test.sh
go: finding gopkg.in/tomb.v1 latest
go: finding golang.org/x/sys latest
go: downloading golang.org/x/sys v0.0.0-20200724161237-0e2f3a69832c
go: extracting golang.org/x/sys v0.0.0-20200724161237-0e2f3a69832c
Jul 24 09:40:06.717: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
W0724 09:40:06.717300   27492 test_context.go:414] Unable to find in-cluster config, using default host : http://127.0.0.1:8080
I0724 09:40:06.717408   27492 test_context.go:423] Tolerating taints "" when considering if nodes are ready
Running Suite: CNS CSI Driver End-to-End Tests
==============================================
Random Seed: 1595608794 - Will randomize all specs
Will run 1 of 106 specs

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
Data Persistence 
  [csi-block-vanilla] [csi-supervisor] [csi-guest] Should create and delete pod with the same volume source
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/data_persistence.go:106
[BeforeEach] Data Persistence
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.18.5/test/e2e/framework/framework.go:178
STEP: Creating a kubernetes client
Jul 24 09:40:06.728: INFO: >>> kubeConfig: /Users/chethanv/.kube/config
STEP: Building a namespace api object, basename e2e-data-persistence
Jul 24 09:40:06.942: INFO: Found PodSecurityPolicies; assuming PodSecurityPolicy is enabled.
Jul 24 09:40:07.033: INFO: Found ClusterRoles; assuming RBAC is enabled.
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-data-persistence-8081
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] Data Persistence
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/data_persistence.go:71
[It] [csi-block-vanilla] [csi-supervisor] [csi-guest] Should create and delete pod with the same volume source
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/data_persistence.go:106
STEP: Creating Storage Class and PVC
STEP: CNS_TEST: Running for vanilla k8s setup
STEP: Creating StorageClass [""] With scParameters: map[] and allowedTopologies: [] and ReclaimPolicy:  and allowVolumeExpansion: false
STEP: Creating PVC using the Storage Class sc-j4wtf with disk size  and labels: map[] accessMode: 
STEP: Waiting for claim pvc-qh6w8 to be in bound phase
Jul 24 09:40:07.631: INFO: Waiting up to 5m0s for PersistentVolumeClaims [pvc-qh6w8] to have phase Bound
Jul 24 09:40:07.662: INFO: PersistentVolumeClaim pvc-qh6w8 found but phase is Pending instead of Bound.
Jul 24 09:40:09.681: INFO: PersistentVolumeClaim pvc-qh6w8 found but phase is Pending instead of Bound.
Jul 24 09:40:11.699: INFO: PersistentVolumeClaim pvc-qh6w8 found but phase is Pending instead of Bound.
Jul 24 09:40:13.731: INFO: PersistentVolumeClaim pvc-qh6w8 found but phase is Pending instead of Bound.
Jul 24 09:40:15.761: INFO: PersistentVolumeClaim pvc-qh6w8 found but phase is Pending instead of Bound.
Jul 24 09:40:17.795: INFO: PersistentVolumeClaim pvc-qh6w8 found and phase=Bound (10.164080284s)
STEP: Creating pod
STEP: Verify volume: 5d6bb67a-2e45-4c42-9bf0-277e4a219f2b is attached to the node: k8s-node-0873
STEP: VM UUID is: 4225e714-44d2-7f3e-3c8f-b296ceac19cb for node: k8s-node-0873
Jul 24 09:40:40.051: INFO: vmRef: VirtualMachine:vm-43 for the VM uuid: 4225e714-44d2-7f3e-3c8f-b296ceac19cb
Jul 24 09:40:40.097: INFO: Found FCDID "5d6bb67a-2e45-4c42-9bf0-277e4a219f2b" attached to VM "k8s-node-1595441097.25"
Jul 24 09:40:40.097: INFO: Found the disk "5d6bb67a-2e45-4c42-9bf0-277e4a219f2b" is attached to the VM with UUID: "4225e714-44d2-7f3e-3c8f-b296ceac19cb"
STEP: Creating an empty file on the volume mounted on: pvc-tester-5d8jt
Jul 24 09:40:40.097: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-data-persistence-8081 pvc-tester-5d8jt -- /bin/sh -c touch /mnt/volume1/e2e-data-persistence-8081_file_A.txt'
Jul 24 09:40:41.935: INFO: stderr: ""
Jul 24 09:40:41.935: INFO: stdout: ""
STEP: Verify files exist on volume mounted on: pvc-tester-5d8jt
Jul 24 09:40:41.935: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-data-persistence-8081 pvc-tester-5d8jt -- /bin/ls /mnt/volume1/e2e-data-persistence-8081_file_A.txt'
Jul 24 09:40:42.493: INFO: stderr: ""
Jul 24 09:40:42.493: INFO: stdout: "/mnt/volume1/e2e-data-persistence-8081_file_A.txt\n"
STEP: Deleting the pod
Jul 24 09:40:42.493: INFO: Deleting pod "pvc-tester-5d8jt" in namespace "e2e-data-persistence-8081"
Jul 24 09:40:42.524: INFO: Wait up to 5m0s for pod "pvc-tester-5d8jt" to be fully deleted
STEP: Verify volume is detached from the node
STEP: VM UUID is: 4225e714-44d2-7f3e-3c8f-b296ceac19cb for node: k8s-node-0873
Jul 24 09:40:50.689: INFO: vmRef: VirtualMachine:vm-43 for the VM uuid: 4225e714-44d2-7f3e-3c8f-b296ceac19cb
Jul 24 09:40:50.728: INFO: failed to find FCDID "5d6bb67a-2e45-4c42-9bf0-277e4a219f2b" attached to VM "k8s-node-1595441097.25"
Jul 24 09:40:50.728: INFO: Disk: 5d6bb67a-2e45-4c42-9bf0-277e4a219f2b successfully detached
STEP: Creating a new pod using the same volume
STEP: Verify volume: 5d6bb67a-2e45-4c42-9bf0-277e4a219f2b is attached to the node: k8s-node-0873
STEP: VM UUID is: 4225e714-44d2-7f3e-3c8f-b296ceac19cb for node: k8s-node-0873
Jul 24 09:41:02.944: INFO: vmRef: VirtualMachine:vm-43 for the VM uuid: 4225e714-44d2-7f3e-3c8f-b296ceac19cb
Jul 24 09:41:02.985: INFO: Found FCDID "5d6bb67a-2e45-4c42-9bf0-277e4a219f2b" attached to VM "k8s-node-1595441097.25"
Jul 24 09:41:02.985: INFO: Found the disk "5d6bb67a-2e45-4c42-9bf0-277e4a219f2b" is attached to the VM with UUID: "4225e714-44d2-7f3e-3c8f-b296ceac19cb"
STEP: Creating a second empty file on the same volume mounted on: pvc-tester-j68ks
Jul 24 09:41:02.986: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-data-persistence-8081 pvc-tester-j68ks -- /bin/sh -c touch /mnt/volume1/e2e-data-persistence-8081_file_B.txt'
Jul 24 09:41:03.565: INFO: stderr: ""
Jul 24 09:41:03.565: INFO: stdout: ""
STEP: Verify files exist on volume mounted on: pvc-tester-j68ks
Jul 24 09:41:03.565: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-data-persistence-8081 pvc-tester-j68ks -- /bin/ls /mnt/volume1/e2e-data-persistence-8081_file_A.txt'
Jul 24 09:41:04.022: INFO: stderr: ""
Jul 24 09:41:04.022: INFO: stdout: "/mnt/volume1/e2e-data-persistence-8081_file_A.txt\n"
Jul 24 09:41:04.022: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-data-persistence-8081 pvc-tester-j68ks -- /bin/ls /mnt/volume1/e2e-data-persistence-8081_file_B.txt'
Jul 24 09:41:04.513: INFO: stderr: ""
Jul 24 09:41:04.513: INFO: stdout: "/mnt/volume1/e2e-data-persistence-8081_file_B.txt\n"
STEP: Deleting the pod
Jul 24 09:41:04.513: INFO: Deleting pod "pvc-tester-j68ks" in namespace "e2e-data-persistence-8081"
Jul 24 09:41:04.534: INFO: Wait up to 5m0s for pod "pvc-tester-j68ks" to be fully deleted
STEP: Verify volume is detached from the node
STEP: VM UUID is: 4225e714-44d2-7f3e-3c8f-b296ceac19cb for node: k8s-node-0873
Jul 24 09:41:12.714: INFO: vmRef: VirtualMachine:vm-43 for the VM uuid: 4225e714-44d2-7f3e-3c8f-b296ceac19cb
Jul 24 09:41:12.758: INFO: failed to find FCDID "5d6bb67a-2e45-4c42-9bf0-277e4a219f2b" attached to VM "k8s-node-1595441097.25"
Jul 24 09:41:12.758: INFO: Disk: 5d6bb67a-2e45-4c42-9bf0-277e4a219f2b successfully detached
Jul 24 09:41:12.759: INFO: Deleting PersistentVolumeClaim "pvc-qh6w8"
Jul 24 09:41:14.875: INFO: volume "5d6bb67a-2e45-4c42-9bf0-277e4a219f2b" has successfully deleted
[AfterEach] Data Persistence
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.18.5/test/e2e/framework/framework.go:179
Jul 24 09:41:14.905: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-data-persistence-8081" for this suite.

• [SLOW TEST:68.279 seconds]
Data Persistence
/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/data_persistence.go:59
  [csi-block-vanilla] [csi-supervisor] [csi-guest] Should create and delete pod with the same volume source
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/data_persistence.go:106
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 106 Specs in 68.280 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 105 Skipped
PASS

Ginkgo ran 1 suite in 1m20.061694702s
Test Suite Passed
chethanv-a01:vsphere-csi-driver chethanv$ export GINKGO_FOCUS="Datastore Based Volume Provisioning With No Storage Policy"
chethanv-a01:vsphere-csi-driver chethanv$ make test-e2e
hack/run-e2e-test.sh
go: finding golang.org/x/sys latest
go: finding gopkg.in/tomb.v1 latest
Jul 24 09:41:39.303: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
W0724 09:41:39.303727   27625 test_context.go:414] Unable to find in-cluster config, using default host : http://127.0.0.1:8080
I0724 09:41:39.303829   27625 test_context.go:423] Tolerating taints "" when considering if nodes are ready
Running Suite: CNS CSI Driver End-to-End Tests
==============================================
Random Seed: 1595608890 - Will randomize all specs
Will run 2 of 106 specs

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy 
  Verify dynamic provisioning of PV fails with user specified non-shared datastore and no storage policy specified in the storage class
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:90
[BeforeEach] [csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.18.5/test/e2e/framework/framework.go:178
STEP: Creating a kubernetes client
Jul 24 09:41:39.316: INFO: >>> kubeConfig: /Users/chethanv/.kube/config
STEP: Building a namespace api object, basename e2e-vsphere-volume-provisioning-no-storage-policy
Jul 24 09:41:39.497: INFO: Found PodSecurityPolicies; assuming PodSecurityPolicy is enabled.
Jul 24 09:41:39.604: INFO: Found ClusterRoles; assuming RBAC is enabled.
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-vsphere-volume-provisioning-no-storage-policy-8081
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:58
[It] Verify dynamic provisioning of PV fails with user specified non-shared datastore and no storage policy specified in the storage class
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:90
STEP: Invoking Test for user specified non-shared Datastore in storage class for volume provisioning
STEP: Creating StorageClass [""] With scParameters: map[DatastoreURL:ds:///vmfs/volumes/5f187b13-38c69688-cef5-0200a8969aca/] and allowedTopologies: [] and ReclaimPolicy:  and allowVolumeExpansion: false
STEP: Creating PVC using the Storage Class sc-dbmw8 with disk size  and labels: map[] accessMode: 
STEP: Expect claim to fail provisioning volume on non shared datastore
Jul 24 09:41:39.861: INFO: Waiting up to 30s for PersistentVolumeClaims [pvc-b2krj] to have phase Bound
Jul 24 09:41:39.898: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:41:41.922: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:41:43.946: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:41:45.970: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:41:47.993: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:41:50.028: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:41:52.053: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:41:54.082: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:41:56.102: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:41:58.127: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:42:00.150: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:42:02.180: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:42:04.209: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:42:06.232: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:42:08.260: INFO: PersistentVolumeClaim pvc-b2krj found but phase is Pending instead of Bound.
Jul 24 09:42:10.261: INFO: Expected failure message: "failed to provision volume with StorageClass \"sc-dbmw8\""
STEP: EventList item: "waiting for a volume to be created, either by external provisioner \"csi.vsphere.vmware.com\" or manually created by system administrator" 

STEP: EventList item: "External provisioner is provisioning volume for claim \"e2e-vsphere-volume-provisioning-no-storage-policy-8081/pvc-b2krj\"" 

STEP: EventList item: "failed to provision volume with StorageClass \"sc-dbmw8\": rpc error: code = Internal desc = failed to create volume. Error: Datastore: ds:///vmfs/volumes/5f187b13-38c69688-cef5-0200a8969aca/ specified in the storage class is not accessible to all nodes." 

Jul 24 09:42:10.321: INFO: Deleting PersistentVolumeClaim "pvc-b2krj"
[AfterEach] [csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.18.5/test/e2e/framework/framework.go:179
Jul 24 09:42:10.371: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-vsphere-volume-provisioning-no-storage-policy-8081" for this suite.

• [SLOW TEST:31.132 seconds]
[csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy
/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:49
  Verify dynamic provisioning of PV fails with user specified non-shared datastore and no storage policy specified in the storage class
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:90
------------------------------
SSSSSSSS
------------------------------
[csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy 
  Verify dynamic provisioning of PV passes with user specified shared datastore and no storage policy specified in the storage class
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:70
[BeforeEach] [csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.18.5/test/e2e/framework/framework.go:178
STEP: Creating a kubernetes client
Jul 24 09:42:10.448: INFO: >>> kubeConfig: /Users/chethanv/.kube/config
STEP: Building a namespace api object, basename e2e-vsphere-volume-provisioning-no-storage-policy
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-vsphere-volume-provisioning-no-storage-policy-7887
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:58
[It] Verify dynamic provisioning of PV passes with user specified shared datastore and no storage policy specified in the storage class
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:70
STEP: Invoking Test for user specified Shared Datastore in Storage class for volume provisioning
STEP: Creating StorageClass [""] With scParameters: map[DatastoreURL:ds:///vmfs/volumes/vsan:52b75bd4019d50d7-139b1dc9d08d2cad/] and allowedTopologies: [] and ReclaimPolicy:  and allowVolumeExpansion: false
STEP: Creating PVC using the Storage Class sc-q7clg with disk size  and labels: map[] accessMode: 
STEP: Expect claim to pass provisioning volume as shared datastore
Jul 24 09:42:10.898: INFO: Waiting up to 1m0s for PersistentVolumeClaims [pvc-wnjjl] to have phase Bound
Jul 24 09:42:10.929: INFO: PersistentVolumeClaim pvc-wnjjl found but phase is Pending instead of Bound.
Jul 24 09:42:12.948: INFO: PersistentVolumeClaim pvc-wnjjl found but phase is Pending instead of Bound.
Jul 24 09:42:14.967: INFO: PersistentVolumeClaim pvc-wnjjl found and phase=Bound (4.068218512s)
Jul 24 09:42:15.010: INFO: Deleting PersistentVolumeClaim "pvc-wnjjl"
[AfterEach] [csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.18.5/test/e2e/framework/framework.go:179
Jul 24 09:42:15.038: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-vsphere-volume-provisioning-no-storage-policy-7887" for this suite.
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 2 of 106 Specs in 35.809 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 104 Skipped
PASS

Ginkgo ran 1 suite in 45.114290345s
Test Suite Passed

Changed configmap dynamically and verified logs:

{"level":"info","time":"2020-07-27T17:09:43.466574026Z","caller":"k8sorchestrator/k8sorchestrator.go:148","msg":"New feature states values stored successfully: map[csi-migration:true]","TraceId":"c63903be-8805-4676-a547-a0741b637b19"}

</pre>
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use common CO Interface in Vanilla K8S controller
```
