### PR TITLE
Bump up govmomi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.3
-	github.com/vmware/govmomi v0.22.2-0.20200530130842-aa97c4d3353d
+	github.com/vmware/govmomi v0.23.1
 	github.com/zekroTJA/timedmap v1.1.2
 	go.uber.org/zap v1.15.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect

--- a/go.sum
+++ b/go.sum
@@ -649,10 +649,8 @@ github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmF
 github.com/vmware-tanzu/vm-operator-api v0.1.3 h1:4vxewu0jAN3fSoCBI6FhjmRGJ7ci0R2WNu/I6hacTYs=
 github.com/vmware-tanzu/vm-operator-api v0.1.3/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/vmware/govmomi v0.22.2-0.20200423211401-3decde69e9aa h1:niVlmp/yviM+iTSmNBpVPTIUFZGZ0uTEAMBSkoKRbjY=
-github.com/vmware/govmomi v0.22.2-0.20200423211401-3decde69e9aa/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
-github.com/vmware/govmomi v0.22.2-0.20200530130842-aa97c4d3353d h1:h1kyM4hGh9MGtnEfF1bxPKJF7+sDbSMlZim1wr1DkZU=
-github.com/vmware/govmomi v0.22.2-0.20200530130842-aa97c4d3353d/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
+github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/tests/e2e/connection.go
+++ b/tests/e2e/connection.go
@@ -78,6 +78,8 @@ func newClient(ctx context.Context, vs *vSphere) *govmomi.Client {
 	url.User = neturl.UserPassword(vs.Config.Global.User, vs.Config.Global.Password)
 	client, err := govmomi.NewClient(ctx, url, true)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = client.UseServiceVersion(vsanNamespace)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	client.RoundTripper = vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(roundTripperDefaultCount))
 	return client
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This is PR bumping up govmomi to v0.23.1


**Special notes for your reviewer**:
Verified the e2e test which creates few volumes and verifies data persistence
Verified the e2e test which uses datastoreURL in SC params
<pre>
$ make test-e2e
hack/run-e2e-test.sh
go: finding golang.org/x/sys latest
go: finding gopkg.in/tomb.v1 latest
Jul 23 16:02:02.180: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
W0723 16:02:02.180425   99343 test_context.go:414] Unable to find in-cluster config, using default host : http://127.0.0.1:8080
I0723 16:02:02.180529   99343 test_context.go:423] Tolerating taints "" when considering if nodes are ready
Running Suite: CNS CSI Driver End-to-End Tests
==============================================
Random Seed: 1595545308 - Will randomize all specs
Will run 1 of 106 specs

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
Data Persistence 
  [csi-block-vanilla] [csi-supervisor] [csi-guest] Should create and delete pod with the same volume source
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/data_persistence.go:106
[BeforeEach] Data Persistence
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.18.5/test/e2e/framework/framework.go:178
STEP: Creating a kubernetes client
Jul 23 16:02:02.193: INFO: >>> kubeConfig: /Users/chethanv/.kube/config
STEP: Building a namespace api object, basename e2e-data-persistence
Jul 23 16:02:02.465: INFO: Found PodSecurityPolicies; assuming PodSecurityPolicy is enabled.
Jul 23 16:02:02.523: INFO: Found ClusterRoles; assuming RBAC is enabled.
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-data-persistence-8081
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] Data Persistence
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/data_persistence.go:71
[It] [csi-block-vanilla] [csi-supervisor] [csi-guest] Should create and delete pod with the same volume source
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/data_persistence.go:106
STEP: Creating Storage Class and PVC
STEP: CNS_TEST: Running for vanilla k8s setup
STEP: Creating StorageClass [""] With scParameters: map[] and allowedTopologies: [] and ReclaimPolicy:  and allowVolumeExpansion: false
STEP: Creating PVC using the Storage Class sc-nk78w with disk size  and labels: map[] accessMode: 
STEP: Waiting for claim pvc-f898q to be in bound phase
Jul 23 16:02:03.097: INFO: Waiting up to 5m0s for PersistentVolumeClaims [pvc-f898q] to have phase Bound
Jul 23 16:02:03.125: INFO: PersistentVolumeClaim pvc-f898q found but phase is Pending instead of Bound.
Jul 23 16:02:05.149: INFO: PersistentVolumeClaim pvc-f898q found but phase is Pending instead of Bound.
Jul 23 16:02:07.171: INFO: PersistentVolumeClaim pvc-f898q found and phase=Bound (4.07369674s)
STEP: Creating pod
STEP: Verify volume: 104e00aa-3ca6-4640-8c55-d77a5d898ee0 is attached to the node: k8s-node-0873
STEP: VM UUID is: 4225e714-44d2-7f3e-3c8f-b296ceac19cb for node: k8s-node-0873
Jul 23 16:02:27.908: INFO: vmRef: VirtualMachine:vm-43 for the VM uuid: 4225e714-44d2-7f3e-3c8f-b296ceac19cb
Jul 23 16:02:27.949: INFO: Found FCDID "104e00aa-3ca6-4640-8c55-d77a5d898ee0" attached to VM "k8s-node-1595441097.25"
Jul 23 16:02:27.949: INFO: Found the disk "104e00aa-3ca6-4640-8c55-d77a5d898ee0" is attached to the VM with UUID: "4225e714-44d2-7f3e-3c8f-b296ceac19cb"
STEP: Creating an empty file on the volume mounted on: pvc-tester-8b47r
Jul 23 16:02:27.949: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-data-persistence-8081 pvc-tester-8b47r -- /bin/sh -c touch /mnt/volume1/e2e-data-persistence-8081_file_A.txt'
Jul 23 16:02:29.337: INFO: stderr: ""
Jul 23 16:02:29.338: INFO: stdout: ""
STEP: Verify files exist on volume mounted on: pvc-tester-8b47r
Jul 23 16:02:29.338: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-data-persistence-8081 pvc-tester-8b47r -- /bin/ls /mnt/volume1/e2e-data-persistence-8081_file_A.txt'
Jul 23 16:02:29.799: INFO: stderr: ""
Jul 23 16:02:29.799: INFO: stdout: "/mnt/volume1/e2e-data-persistence-8081_file_A.txt\n"
STEP: Deleting the pod
Jul 23 16:02:29.799: INFO: Deleting pod "pvc-tester-8b47r" in namespace "e2e-data-persistence-8081"
Jul 23 16:02:29.825: INFO: Wait up to 5m0s for pod "pvc-tester-8b47r" to be fully deleted
STEP: Verify volume is detached from the node
STEP: VM UUID is: 4225e714-44d2-7f3e-3c8f-b296ceac19cb for node: k8s-node-0873
Jul 23 16:02:36.028: INFO: vmRef: VirtualMachine:vm-43 for the VM uuid: 4225e714-44d2-7f3e-3c8f-b296ceac19cb
Jul 23 16:02:36.066: INFO: Found FCDID "104e00aa-3ca6-4640-8c55-d77a5d898ee0" attached to VM "k8s-node-1595441097.25"
Jul 23 16:02:36.066: INFO: Found the disk "104e00aa-3ca6-4640-8c55-d77a5d898ee0" is attached to the VM with UUID: "4225e714-44d2-7f3e-3c8f-b296ceac19cb"
Jul 23 16:02:36.066: INFO: Waiting for disk: "104e00aa-3ca6-4640-8c55-d77a5d898ee0" to be detached from the node :"k8s-node-0873"
STEP: VM UUID is: 4225e714-44d2-7f3e-3c8f-b296ceac19cb for node: k8s-node-0873
Jul 23 16:02:37.984: INFO: vmRef: VirtualMachine:vm-43 for the VM uuid: 4225e714-44d2-7f3e-3c8f-b296ceac19cb
Jul 23 16:02:38.024: INFO: failed to find FCDID "104e00aa-3ca6-4640-8c55-d77a5d898ee0" attached to VM "k8s-node-1595441097.25"
Jul 23 16:02:38.024: INFO: Disk: 104e00aa-3ca6-4640-8c55-d77a5d898ee0 successfully detached
STEP: Creating a new pod using the same volume
STEP: Verify volume: 104e00aa-3ca6-4640-8c55-d77a5d898ee0 is attached to the node: k8s-node-0873
STEP: VM UUID is: 4225e714-44d2-7f3e-3c8f-b296ceac19cb for node: k8s-node-0873
Jul 23 16:02:50.217: INFO: vmRef: VirtualMachine:vm-43 for the VM uuid: 4225e714-44d2-7f3e-3c8f-b296ceac19cb
Jul 23 16:02:50.251: INFO: Found FCDID "104e00aa-3ca6-4640-8c55-d77a5d898ee0" attached to VM "k8s-node-1595441097.25"
Jul 23 16:02:50.251: INFO: Found the disk "104e00aa-3ca6-4640-8c55-d77a5d898ee0" is attached to the VM with UUID: "4225e714-44d2-7f3e-3c8f-b296ceac19cb"
STEP: Creating a second empty file on the same volume mounted on: pvc-tester-pw7zt
Jul 23 16:02:50.251: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-data-persistence-8081 pvc-tester-pw7zt -- /bin/sh -c touch /mnt/volume1/e2e-data-persistence-8081_file_B.txt'
Jul 23 16:02:50.805: INFO: stderr: ""
Jul 23 16:02:50.806: INFO: stdout: ""
STEP: Verify files exist on volume mounted on: pvc-tester-pw7zt
Jul 23 16:02:50.806: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-data-persistence-8081 pvc-tester-pw7zt -- /bin/ls /mnt/volume1/e2e-data-persistence-8081_file_A.txt'
Jul 23 16:02:51.227: INFO: stderr: ""
Jul 23 16:02:51.227: INFO: stdout: "/mnt/volume1/e2e-data-persistence-8081_file_A.txt\n"
Jul 23 16:02:51.227: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/Users/chethanv/.kube/config exec --namespace=e2e-data-persistence-8081 pvc-tester-pw7zt -- /bin/ls /mnt/volume1/e2e-data-persistence-8081_file_B.txt'
Jul 23 16:02:51.661: INFO: stderr: ""
Jul 23 16:02:51.661: INFO: stdout: "/mnt/volume1/e2e-data-persistence-8081_file_B.txt\n"
STEP: Deleting the pod
Jul 23 16:02:51.661: INFO: Deleting pod "pvc-tester-pw7zt" in namespace "e2e-data-persistence-8081"
Jul 23 16:02:51.682: INFO: Wait up to 5m0s for pod "pvc-tester-pw7zt" to be fully deleted
STEP: Verify volume is detached from the node
STEP: VM UUID is: 4225e714-44d2-7f3e-3c8f-b296ceac19cb for node: k8s-node-0873
Jul 23 16:02:58.089: INFO: vmRef: VirtualMachine:vm-43 for the VM uuid: 4225e714-44d2-7f3e-3c8f-b296ceac19cb
Jul 23 16:02:58.147: INFO: failed to find FCDID "104e00aa-3ca6-4640-8c55-d77a5d898ee0" attached to VM "k8s-node-1595441097.25"
Jul 23 16:02:58.147: INFO: Disk: 104e00aa-3ca6-4640-8c55-d77a5d898ee0 successfully detached
Jul 23 16:02:58.147: INFO: Deleting PersistentVolumeClaim "pvc-f898q"
Jul 23 16:03:00.266: INFO: volume "104e00aa-3ca6-4640-8c55-d77a5d898ee0" has successfully deleted
[AfterEach] Data Persistence
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.18.5/test/e2e/framework/framework.go:179
Jul 23 16:03:00.288: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-data-persistence-8081" for this suite.

• [SLOW TEST:58.146 seconds]
Data Persistence
/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/data_persistence.go:59
  [csi-block-vanilla] [csi-supervisor] [csi-guest] Should create and delete pod with the same volume source
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/data_persistence.go:106
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 106 Specs in 58.147 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 105 Skipped
PASS

Ginkgo ran 1 suite in 1m11.801414812s
Test Suite Passed


$ export GINKGO_FOCUS="Verify dynamic provisioning of PV passes with user specified shared datastore and no storage policy specified in the storage class"
chethanv-a01:vsphere-csi-driver chethanv$ make test-e2e
hack/run-e2e-test.sh
go: finding golang.org/x/sys latest
go: finding gopkg.in/tomb.v1 latest
Jul 23 16:05:22.022: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
W0723 16:05:22.022719     666 test_context.go:414] Unable to find in-cluster config, using default host : http://127.0.0.1:8080
I0723 16:05:22.022862     666 test_context.go:423] Tolerating taints "" when considering if nodes are ready
Running Suite: CNS CSI Driver End-to-End Tests
==============================================
Random Seed: 1595545514 - Will randomize all specs
Will run 1 of 106 specs

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy 
  Verify dynamic provisioning of PV passes with user specified shared datastore and no storage policy specified in the storage class
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:70
[BeforeEach] [csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.18.5/test/e2e/framework/framework.go:178
STEP: Creating a kubernetes client
Jul 23 16:05:22.038: INFO: >>> kubeConfig: /Users/chethanv/.kube/config
STEP: Building a namespace api object, basename e2e-vsphere-volume-provisioning-no-storage-policy
Jul 23 16:05:22.216: INFO: Found PodSecurityPolicies; assuming PodSecurityPolicy is enabled.
Jul 23 16:05:22.269: INFO: Found ClusterRoles; assuming RBAC is enabled.
STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-vsphere-volume-provisioning-no-storage-policy-8081
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:58
[It] Verify dynamic provisioning of PV passes with user specified shared datastore and no storage policy specified in the storage class
  /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:70
STEP: Invoking Test for user specified Shared Datastore in Storage class for volume provisioning
STEP: Creating StorageClass [""] With scParameters: map[DatastoreURL:ds:///vmfs/volumes/vsan:52b75bd4019d50d7-139b1dc9d08d2cad/] and allowedTopologies: [] and ReclaimPolicy:  and allowVolumeExpansion: false
STEP: Creating PVC using the Storage Class sc-ns5gx with disk size  and labels: map[] accessMode: 
STEP: Expect claim to pass provisioning volume as shared datastore
Jul 23 16:05:22.493: INFO: Waiting up to 1m0s for PersistentVolumeClaims [pvc-brc76] to have phase Bound
Jul 23 16:05:22.525: INFO: PersistentVolumeClaim pvc-brc76 found but phase is Pending instead of Bound.
Jul 23 16:05:24.549: INFO: PersistentVolumeClaim pvc-brc76 found but phase is Pending instead of Bound.
Jul 23 16:05:26.572: INFO: PersistentVolumeClaim pvc-brc76 found and phase=Bound (4.079256304s)
Jul 23 16:05:26.593: INFO: Deleting PersistentVolumeClaim "pvc-brc76"
[AfterEach] [csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy
  /Users/chethanv/go/pkg/mod/k8s.io/kubernetes@v1.18.5/test/e2e/framework/framework.go:179
Jul 23 16:05:26.619: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-vsphere-volume-provisioning-no-storage-policy-8081" for this suite.
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 106 Specs in 4.654 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 105 Skipped
PASS

Ginkgo ran 1 suite in 12.162845036s
Test Suite Passed
</pre>
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump up govmomi
```
