### PR TITLE
Remove akutz from reviewers in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- akutz
 - divyenpatel
 - dougm
 - SandeepPissay


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This patch removes akutz from the list of reviewers in the OWNERS file.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
NA

**Special notes for your reviewer**:
NA

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
