### PR TITLE
Set Storage Policy ID while registering migrated in-tree vSphere volume

### DIFF
--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -47,12 +47,19 @@ import (
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
 )
 
+// VolumeSpec contains VolumePath and StoragePolicyID
+// using which Volume can be looked up using VolumeMigrationService
+type VolumeSpec struct {
+	VolumePath        string
+	StoragePolicyName string
+}
+
 // VolumeMigrationService exposes interfaces to support VCP to CSI migration.
 // It will maintain internal state to map volume path to volume ID and reverse mapping.
 type VolumeMigrationService interface {
-	// GetVolumeID returns VolumeID for given VolumePath
+	// GetVolumeID returns VolumeID for given VolumeSpec
 	// Returns an error if not able to retrieve VolumeID.
-	GetVolumeID(ctx context.Context, volumePath string) (string, error)
+	GetVolumeID(ctx context.Context, volumeSpec VolumeSpec) (string, error)
 
 	// GetVolumePath returns VolumePath for given VolumeID
 	// Returns an error if not able to retrieve VolumePath.
@@ -164,26 +171,26 @@ func GetVolumeMigrationService(ctx context.Context, volumeManager *cnsvolume.Man
 	return volumeMigrationInstance, nil
 }
 
-// GetVolumeID returns VolumeID for given VolumePath
+// GetVolumeID returns VolumeID for given VolumeSpec
 // Returns an error if not able to retrieve VolumeID.
-func (volumeMigration *volumeMigration) GetVolumeID(ctx context.Context, volumePath string) (string, error) {
+func (volumeMigration *volumeMigration) GetVolumeID(ctx context.Context, volumeSpec VolumeSpec) (string, error) {
 	log := logger.GetLogger(ctx)
-	info, found := volumeMigration.volumePathToVolumeID.Load(volumePath)
+	info, found := volumeMigration.volumePathToVolumeID.Load(volumeSpec.VolumePath)
 	if found {
-		log.Infof("VolumeID: %q found from the cache for VolumePath: %q", info.(string), volumePath)
+		log.Debugf("VolumeID: %q found from the cache for VolumePath: %q", info.(string), volumeSpec.VolumePath)
 		return info.(string), nil
 	}
-	log.Infof("Could not retrieve VolumeID from cache for Volume Path: %q. volume may not be registered. Registering Volume with CNS", volumePath)
-	volumeID, err := volumeMigration.registerVolume(ctx, volumePath)
+	log.Infof("Could not retrieve VolumeID from cache for Volume Path: %q. volume may not be registered. Registering Volume with CNS", volumeSpec.VolumePath)
+	volumeID, err := volumeMigration.registerVolume(ctx, volumeSpec)
 	if err != nil {
-		log.Errorf("failed to register volume for VolumePath: %q, with err: %v", volumePath, err)
+		log.Errorf("failed to register volume for volumeSpec: %v, with err: %v", volumeSpec, err)
 		return "", err
 	}
-	log.Infof("successfully registered volume: %q with CNS. VolumeID: %q", volumePath, volumeID)
+	log.Infof("Successfully registered volumeSpec: %v with CNS. VolumeID: %v", volumeSpec, volumeID)
 	cnsvSphereVolumeMigration := migrationv1alpha1.CnsVSphereVolumeMigration{
 		ObjectMeta: metav1.ObjectMeta{Name: volumeID},
 		Spec: migrationv1alpha1.CnsVSphereVolumeMigrationSpec{
-			VolumePath: volumePath,
+			VolumePath: volumeSpec.VolumePath,
 			VolumeID:   volumeID,
 		},
 	}
@@ -193,7 +200,6 @@ func (volumeMigration *volumeMigration) GetVolumeID(ctx context.Context, volumeP
 		log.Errorf("failed to save cnsvSphereVolumeMigration CR:%v, err: %v", err)
 		return "", err
 	}
-	log.Infof("successfully saved cnsvSphereVolumeMigration CR: %v", cnsvSphereVolumeMigration)
 	return volumeID, nil
 }
 
@@ -236,7 +242,7 @@ func (volumeMigration *volumeMigration) GetVolumePath(ctx context.Context, volum
 	log.Debugf("QueryVolumeInfo successfully returned volumeInfo %v for volumeIDList %v:", spew.Sdump(queryVolumeInfoResult), volumeIds)
 	cnsBlockVolumeInfo := interface{}(queryVolumeInfoResult.VolumeInfo).(*cnstypes.CnsBlockVolumeInfo)
 	fileBackingInfo := interface{}(cnsBlockVolumeInfo.VStorageObject.Config.Backing).(*vim25types.BaseConfigInfoDiskFileBackingInfo)
-	log.Infof("successfully retrieved volume path: %q for VolumeID: %q", fileBackingInfo.FilePath, volumeID)
+	log.Infof("Successfully retrieved volume path: %q for VolumeID: %q", fileBackingInfo.FilePath, volumeID)
 	cnsvSphereVolumeMigration := migrationv1alpha1.CnsVSphereVolumeMigration{
 		ObjectMeta: metav1.ObjectMeta{Name: volumeID},
 		Spec: migrationv1alpha1.CnsVSphereVolumeMigrationSpec{
@@ -250,7 +256,6 @@ func (volumeMigration *volumeMigration) GetVolumePath(ctx context.Context, volum
 		log.Errorf("failed to save cnsvSphereVolumeMigration CR:%v, err: %v", err)
 		return "", err
 	}
-	log.Infof("successfully saved cnsvSphereVolumeMigration CR: %v", cnsvSphereVolumeMigration)
 	return fileBackingInfo.FilePath, nil
 }
 
@@ -268,7 +273,7 @@ func (volumeMigration *volumeMigration) saveVolumeInfo(ctx context.Context, cnsV
 		log.Info("CR already exists")
 		return nil
 	}
-	log.Infof("successfully created CR for cnsVSphereVolumeMigration: %+v", cnsVSphereVolumeMigration)
+	log.Infof("Successfully created CR for cnsVSphereVolumeMigration: %+v", cnsVSphereVolumeMigration)
 	return nil
 }
 
@@ -292,9 +297,9 @@ func (volumeMigration *volumeMigration) DeleteVolumeInfo(ctx context.Context, vo
 	return nil
 }
 
-// registerVolume takes VolumePath and helps register Volume with CNS
+// registerVolume takes VolumeSpec and helps register Volume with CNS
 // Returns VolumeID for successful registration, otherwise return error
-func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volumePath string) (string, error) {
+func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volumeSpec VolumeSpec) (string, error) {
 	log := logger.GetLogger(ctx)
 	uuid, err := uuid.NewUUID()
 	if err != nil {
@@ -302,13 +307,13 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volu
 		return "", err
 	}
 	re := regexp.MustCompile(`\[([^\[\]]*)\]`)
-	if !re.MatchString(volumePath) {
-		msg := fmt.Sprintf("failed to extract datastore name from in-tree volume path: %q", volumePath)
+	if !re.MatchString(volumeSpec.VolumePath) {
+		msg := fmt.Sprintf("failed to extract datastore name from in-tree volume path: %q", volumeSpec.VolumePath)
 		log.Errorf(msg)
 		return "", errors.New(msg)
 	}
-	datastoreName := re.FindAllString(volumePath, -1)[0]
-	vmdkPath := strings.TrimSpace(strings.Trim(volumePath, datastoreName))
+	datastoreName := re.FindAllString(volumeSpec.VolumePath, -1)[0]
+	vmdkPath := strings.TrimSpace(strings.Trim(volumeSpec.VolumePath, datastoreName))
 	datastoreName = strings.Trim(strings.Trim(datastoreName, "["), "]")
 
 	var datacenters string
@@ -325,22 +330,16 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volu
 		host = key
 		break
 	}
+	// Get vCenter
+	vCenter, err := vsphere.GetVirtualCenterManager(ctx).GetVirtualCenter(ctx, host)
+	if err != nil {
+		log.Errorf("failed to get vCenter. err: %v", err)
+		return "", err
+	}
 	datacenterPaths := make([]string, 0)
 	if datacenters != "" {
 		datacenterPaths = strings.Split(datacenters, ",")
 	} else {
-		// Get vCenter
-		vCenter, err := vsphere.GetVirtualCenterManager(ctx).GetVirtualCenter(ctx, host)
-		if err != nil {
-			log.Errorf("failed to get vCenter. err: %v", err)
-			return "", err
-		}
-		// Connect to vCenter
-		err = vCenter.Connect(ctx)
-		if err != nil {
-			log.Errorf("failed to connect to vCenter. err: %v", err)
-			return "", err
-		}
 		// Get all datacenters from vCenter
 		dcs, err := vCenter.GetDatacenters(ctx)
 		if err != nil {
@@ -353,39 +352,53 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volu
 		log.Debugf("retrieved all datacenters %v from vCenter", datacenterPaths)
 	}
 	var volumeID *cnstypes.CnsVolumeId
+	var storagePolicyID string
+	if volumeSpec.StoragePolicyName != "" {
+		log.Debugf("Obtaining storage policy ID for storage policy name: %q", volumeSpec.StoragePolicyName)
+		storagePolicyID, err = vCenter.GetStoragePolicyIDByName(ctx, volumeSpec.StoragePolicyName)
+		if err != nil {
+			msg := fmt.Sprintf("Error occurred while getting stroage policy ID from storage policy name: %q, err: %+v", volumeSpec.StoragePolicyName, err)
+			log.Error(msg)
+			return "", errors.New(msg)
+		}
+		log.Debugf("Obtained storage policy ID: %q for storage policy name: %q", storagePolicyID, volumeSpec.StoragePolicyName)
+	}
+	var containerClusterArray []cnstypes.CnsContainerCluster
+	containerCluster := vsphere.GetContainerCluster(volumeMigration.cnsConfig.Global.ClusterID, user, cnstypes.CnsClusterFlavorVanilla)
+	containerClusterArray = append(containerClusterArray, containerCluster)
+	createSpec := &cnstypes.CnsVolumeCreateSpec{
+		Name:       uuid.String(),
+		VolumeType: common.BlockVolumeType,
+		Metadata: cnstypes.CnsVolumeMetadata{
+			ContainerCluster:      containerCluster,
+			ContainerClusterArray: containerClusterArray,
+		},
+	}
+	if storagePolicyID != "" {
+		profileSpec := &vim25types.VirtualMachineDefinedProfileSpec{
+			ProfileId: storagePolicyID,
+		}
+		createSpec.Profile = append(createSpec.Profile, profileSpec)
+	}
 	for _, datacenter := range datacenterPaths {
 		// Format:
 		// https://<vc_ip>/folder/<vm_vmdk_path>?dcPath=<datacenter-path>&dsName=<datastoreName>
 		backingDiskURLPath := "https://" + host + "/folder/" +
 			vmdkPath + "?dcPath=" + url.PathEscape(datacenter) + "&dsName=" + url.PathEscape(datastoreName)
-
-		log.Infof("Registering volume: %q using backingDiskURLPath :%q", volumePath, backingDiskURLPath)
-		var containerClusterArray []cnstypes.CnsContainerCluster
-		containerCluster := vsphere.GetContainerCluster(volumeMigration.cnsConfig.Global.ClusterID, user, cnstypes.CnsClusterFlavorVanilla)
-		containerClusterArray = append(containerClusterArray, containerCluster)
-		createSpec := &cnstypes.CnsVolumeCreateSpec{
-			Name:       uuid.String(),
-			VolumeType: common.BlockVolumeType,
-			Metadata: cnstypes.CnsVolumeMetadata{
-				ContainerCluster:      containerCluster,
-				ContainerClusterArray: containerClusterArray,
-			},
-			BackingObjectDetails: &cnstypes.CnsBlockBackingDetails{
-				BackingDiskUrlPath: backingDiskURLPath,
-			},
-		}
-		log.Debugf("vSphere CNS driver registering volume %q with create spec %+v", volumePath, spew.Sdump(createSpec))
+		createSpec.BackingObjectDetails = &cnstypes.CnsBlockBackingDetails{BackingDiskUrlPath: backingDiskURLPath}
+		log.Infof("Registering volume: %q using backingDiskURLPath :%q", volumeSpec.VolumePath, backingDiskURLPath)
+		log.Debugf("vSphere CNS driver registering volume %q with create spec %+v", volumeSpec.VolumePath, spew.Sdump(createSpec))
 		volumeID, err = (*volumeMigration.volumeManager).CreateVolume(ctx, createSpec)
 		if err != nil {
-			log.Warnf("failed to register volume %q with error %+v", volumePath, err)
+			log.Warnf("failed to register volume %q with createSpec: %v. error: %+v", volumeSpec.VolumePath, createSpec, err)
 		} else {
 			break
 		}
 	}
 	if volumeID != nil {
-		log.Infof("successfully registered volume %q as container volume with ID: %q", volumePath, volumeID.Id)
+		log.Infof("Successfully registered volume %q as container volume with ID: %q", volumeSpec.VolumePath, volumeID.Id)
 	} else {
-		msg := fmt.Sprintf("registration failed for volumePath: %q", volumePath)
+		msg := fmt.Sprintf("registration failed for volumeSpec: %v", volumeSpec)
 		log.Error(msg)
 		return "", errors.New(msg)
 	}

--- a/pkg/common/cns-lib/vsphere/datacenter.go
+++ b/pkg/common/cns-lib/vsphere/datacenter.go
@@ -126,13 +126,6 @@ func asyncGetAllDatacenters(ctx context.Context, dcsChan chan<- *Datacenter, err
 			return
 		default:
 		}
-
-		if err := vc.Connect(ctx); err != nil {
-			log.Errorf("Failed connecting to VC %q with err: %v", vc.Config.Host, err)
-			errChan <- err
-			return
-		}
-
 		dcs, err := vc.GetDatacenters(ctx)
 		if err != nil {
 			log.Errorf("failed to fetch datacenters for vc %v with err: %v", vc.Config.Host, err)

--- a/pkg/common/cns-lib/vsphere/pbm.go
+++ b/pkg/common/cns-lib/vsphere/pbm.go
@@ -82,6 +82,11 @@ func (vc *VirtualCenter) DisconnectPbm(ctx context.Context) error {
 // GetStoragePolicyIDByName gets storage policy ID by name.
 func (vc *VirtualCenter) GetStoragePolicyIDByName(ctx context.Context, storagePolicyName string) (string, error) {
 	log := logger.GetLogger(ctx)
+	err := vc.ConnectPbm(ctx)
+	if err != nil {
+		log.Errorf("Error occurred while connecting to PBM, err: %+v", err)
+		return "", err
+	}
 	storagePolicyID, err := vc.PbmClient.ProfileIDByName(ctx, storagePolicyName)
 	if err != nil {
 		log.Errorf("failed to get StoragePolicyID from StoragePolicyName %s with err: %v", storagePolicyName, err)

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -306,6 +306,11 @@ func (vc *VirtualCenter) getDatacenters(ctx context.Context, dcPaths []string) (
 // is configured in VirtualCenterConfig during registration, only the listed
 // Datacenters are returned.
 func (vc *VirtualCenter) GetDatacenters(ctx context.Context) ([]*Datacenter, error) {
+	log := logger.GetLogger(ctx)
+	if err := vc.Connect(ctx); err != nil {
+		log.Errorf("failed to connect to vCenter. err: %v", err)
+		return nil, err
+	}
 	if len(vc.Config.DatacenterPaths) != 0 {
 		return vc.getDatacenters(ctx, vc.Config.DatacenterPaths)
 	}
@@ -330,6 +335,10 @@ func (vc *VirtualCenter) Disconnect(ctx context.Context) error {
 // GetHostsByCluster return hosts inside the cluster using cluster moref.
 func (vc *VirtualCenter) GetHostsByCluster(ctx context.Context, clusterMorefValue string) ([]*HostSystem, error) {
 	log := logger.GetLogger(ctx)
+	if err := vc.Connect(ctx); err != nil {
+		log.Errorf("failed to connect to vCenter. err: %v", err)
+		return nil, err
+	}
 	clusterMoref := types.ManagedObjectReference{
 		Type:  "ClusterComputeResource",
 		Value: clusterMorefValue,
@@ -353,6 +362,10 @@ func (vc *VirtualCenter) GetHostsByCluster(ctx context.Context, clusterMorefValu
 // GetVsanDatastores returns all the vsan datastore exists in the vc inventory
 func (vc *VirtualCenter) GetVsanDatastores(ctx context.Context) ([]mo.Datastore, error) {
 	log := logger.GetLogger(ctx)
+	if err := vc.Connect(ctx); err != nil {
+		log.Errorf("failed to connect to vCenter. err: %v", err)
+		return nil, err
+	}
 	datacenters, err := vc.GetDatacenters(ctx)
 	if err != nil {
 		log.Errorf("failed to find datacenters from VC: %+v, Error: %+v", vc.Config.Host, err)
@@ -395,6 +408,10 @@ func (vc *VirtualCenter) GetVsanDatastores(ctx context.Context) ([]mo.Datastore,
 // GetDatastoresByCluster return datastores inside the cluster using cluster moref.
 func (vc *VirtualCenter) GetDatastoresByCluster(ctx context.Context, clusterMorefValue string) ([]*DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
+	if err := vc.Connect(ctx); err != nil {
+		log.Errorf("failed to connect to vCenter. err: %v", err)
+		return nil, err
+	}
 	clusterMoref := types.ManagedObjectReference{
 		Type:  "ClusterComputeResource",
 		Value: clusterMorefValue,

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 
+	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 )
@@ -41,9 +42,9 @@ type mockVolumeMigration struct {
 
 // MockVolumeMigrationService is a mocked VolumeMigrationService needed for CSI migration feature
 type MockVolumeMigrationService interface {
-	// GetVolumeID returns VolumeID for given VolumePath
+	// GetVolumeID returns VolumeID for given migration volumeSpec
 	// Returns an error if not able to retrieve VolumeID.
-	GetVolumeID(ctx context.Context, volumePath string) (string, error)
+	GetVolumeID(ctx context.Context, volumeSpec migration.VolumeSpec) (string, error)
 
 	// GetVolumePath returns VolumePath for given VolumeID
 	// Returns an error if not able to retrieve VolumePath.

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"sync"
 
+	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
@@ -80,8 +81,8 @@ func GetFakeVolumeMigrationService(ctx context.Context, volumeManager *cnsvolume
 }
 
 // GetVolumeID mocks the method with returns Volume Id for a given Volume Path
-func (dummyInstance *mockVolumeMigration) GetVolumeID(ctx context.Context, volumePath string) (string, error) {
-	return mapVolumePathToID["dummy-vms-CR"]["VolumeID"], nil
+func (dummyInstance *mockVolumeMigration) GetVolumeID(ctx context.Context, volumeSpec migration.VolumeSpec) (string, error) {
+	return mapVolumePathToID["dummy-vms-CR"][volumeSpec.VolumePath], nil
 }
 
 // GetVolumePath mocks the method with returns Volume Path for a given Volume ID

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -44,11 +44,6 @@ func CreateBlockVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluste
 	}
 	if spec.ScParams.StoragePolicyName != "" {
 		// Get Storage Policy ID from Storage Policy Name
-		err = vc.ConnectPbm(ctx)
-		if err != nil {
-			log.Errorf("Error occurred while connecting to PBM, err: %+v", err)
-			return "", err
-		}
 		spec.StoragePolicyID, err = vc.GetStoragePolicyIDByName(ctx, spec.ScParams.StoragePolicyName)
 		if err != nil {
 			log.Errorf("Error occurred while getting Profile Id from Profile Name: %s, err: %+v", spec.ScParams.StoragePolicyName, err)
@@ -193,11 +188,6 @@ func CreateFileVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 	}
 	if spec.ScParams.StoragePolicyName != "" {
 		// Get Storage Policy ID from Storage Policy Name
-		err = vc.ConnectPbm(ctx)
-		if err != nil {
-			log.Errorf("Error occurred while connecting to PBM, err: %+v", err)
-			return "", err
-		}
 		spec.StoragePolicyID, err = vc.GetStoragePolicyIDByName(ctx, spec.ScParams.StoragePolicyName)
 		if err != nil {
 			log.Errorf("Error occurred while getting Profile Id from Profile Name: %q, err: %+v", spec.ScParams.StoragePolicyName, err)

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
@@ -53,9 +54,10 @@ func csiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) {
 		var err error
 		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
 			// For vSphere volumes, the migration service will register volumes in CNS.
-			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
+			migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
+			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
-				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", pv.Spec.VsphereVolume.VolumePath, err)
+				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v with error %+v", migrationVolumeSpec, err)
 				return
 			}
 		} else {
@@ -134,9 +136,10 @@ func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVo
 		var volumeHandle string
 		var err error
 		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
-			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
+			migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
+			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
-				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", pv.Spec.VsphereVolume.VolumePath, err)
+				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v with error %+v", migrationVolumeSpec, err)
 				return
 			}
 		} else {
@@ -189,9 +192,10 @@ func fullSyncDeleteVolumes(ctx context.Context, volumeIDDeleteArray []cnstypes.C
 		var volumeHandle string
 		var err error
 		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
-			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
+			migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
+			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
-				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", pv.Spec.VsphereVolume.VolumePath, err)
+				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v with error %+v", migrationVolumeSpec, err)
 				return
 			}
 		} else {
@@ -308,9 +312,10 @@ func getEntityMetadata(ctx context.Context, pvList []*v1.PersistentVolume, cnsVo
 		var volumeHandle string
 		var err error
 		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
-			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
+			migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
+			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
-				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", pv.Spec.VsphereVolume.VolumePath, err)
+				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v with error %+v", migrationVolumeSpec, err)
 				return nil, nil, err
 			}
 		} else {
@@ -362,9 +367,10 @@ func getVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, pvToCnsE
 		var volumeHandle string
 		var err error
 		if common.CSIMigrationFeatureEnabled && pv.Spec.VsphereVolume != nil {
-			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
+			migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
+			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
-				log.Warnf("FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", pv.Spec.VsphereVolume.VolumePath, err)
+				log.Warnf("FullSync: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v with error %+v", migrationVolumeSpec, err)
 				continue
 			}
 		} else {

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -721,9 +721,10 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim, pv *v1.Pe
 	var volumeHandle string
 	var err error
 	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
-		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
+		migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
+		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 		if err != nil {
-			log.Errorf("PVC Updated: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", pv.Spec.VsphereVolume.VolumePath, err)
+			log.Errorf("PVC Updated: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v with error %+v", migrationVolumeSpec, err)
 			return
 		}
 	} else {
@@ -801,9 +802,10 @@ func csiPVCDeleted(ctx context.Context, pvc *v1.PersistentVolumeClaim, pv *v1.Pe
 	var volumeHandle string
 	var err error
 	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
-		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
+		migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
+		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 		if err != nil {
-			log.Errorf("PVC Deleted: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", pv.Spec.VsphereVolume.VolumePath, err)
+			log.Errorf("PVC Deleted: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v with error %+v", migrationVolumeSpec, err)
 			return
 		}
 	} else {
@@ -837,7 +839,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 	var err error
 	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor)
 	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && newPv.Spec.VsphereVolume != nil {
-		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, newPv.Spec.VsphereVolume.VolumePath)
+		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migration.VolumeSpec{VolumePath: newPv.Spec.VsphereVolume.VolumePath, StoragePolicyName: newPv.Spec.VsphereVolume.StoragePolicyName})
 		if err != nil {
 			log.Errorf("PVUpdated: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", newPv.Spec.VsphereVolume.VolumePath, err)
 			return
@@ -986,9 +988,10 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 		var err error
 		var volumeHandle string
 		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
-			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
+			migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
+			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
-				log.Errorf("PVDeleted: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", pv.Spec.VsphereVolume.VolumePath, err)
+				log.Errorf("PVDeleted: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v with error %+v", migrationVolumeSpec, err)
 				return
 			}
 		} else {
@@ -1032,9 +1035,10 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 				var volumeHandle string
 				var err error
 				if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
-					volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, pv.Spec.VsphereVolume.VolumePath)
+					migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
+					volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 					if err != nil {
-						log.Errorf("Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", pv.Spec.VsphereVolume.VolumePath, err)
+						log.Errorf("Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v with error %+v", migrationVolumeSpec, err)
 						return
 					}
 				} else {

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
 	volumes "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
@@ -71,7 +72,7 @@ func getInlineMigratedVolumesInfo(ctx context.Context, metadataSyncer *metadataS
 		for _, volume := range pod.Spec.Volumes {
 			// Check if migration is ON and volumes if of type vSphereVolume
 			if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && volume.VsphereVolume != nil {
-				volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, volume.VsphereVolume.VolumePath)
+				volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migration.VolumeSpec{VolumePath: volume.VsphereVolume.VolumePath, StoragePolicyName: volume.VsphereVolume.StoragePolicyName})
 				if err != nil {
 					log.Warnf("FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", volume.VsphereVolume.VolumePath, err)
 					continue


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is supplying SPBM Policy of in-tree vSphere Volume while registering volume with CNS.


**Which issue this PR fixes**
fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/255

**Special notes for your reviewer**:

Verified that PV Created using Storage Policy `vSAN Default Storage Policy` and migrated to vSphere CSI Driver and showing up on the CNS UI with SPBM Policy associated.

```
# kubectl describe pv 
Name:            pvc-b1792c12-35f1-4cfd-946c-7ef84643cdd4
Labels:          <none>
Annotations:     kubernetes.io/createdby: vsphere-volume-dynamic-provisioner
                 pv.kubernetes.io/bound-by-controller: yes
                 pv.kubernetes.io/migrated-to: csi.vsphere.vmware.com
                 pv.kubernetes.io/provisioned-by: kubernetes.io/vsphere-volume
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    vcpsc
Status:          Bound
Claim:           default/vcppvc
Reclaim Policy:  Delete
Access Modes:    RWO
VolumeMode:      Filesystem
Capacity:        2Gi
Node Affinity:   <none>
Message:         
Source:
    Type:               vSphereVolume (a Persistent Disk resource in vSphere)
    VolumePath:         [vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-b1792c12-35f1-4cfd-946c-7ef84643cdd4.vmdk
    FSType:             ext4
    StoragePolicyName:  vSAN Default Storage Policy
Events:                 <none>
```

<img width="1298" alt="Screen Shot 2020-07-27 at 12 23 47 PM" src="https://user-images.githubusercontent.com/22985595/88583616-52282d00-d005-11ea-8eae-20a9d4aa29f5.png">



**Testing done with on latest commit**

1. Created PV using storage class having StoragePolicyName set to `my-custom-vsan-policy`

```
# kubectl describe pv
Name:            pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7
Labels:          <none>
Annotations:     kubernetes.io/createdby: vsphere-volume-dynamic-provisioner
                 pv.kubernetes.io/bound-by-controller: yes
                 pv.kubernetes.io/provisioned-by: kubernetes.io/vsphere-volume
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    vcpsc
Status:          Bound
Claim:           default/vcppvc
Reclaim Policy:  Delete
Access Modes:    RWO
VolumeMode:      Filesystem
Capacity:        2Gi
Node Affinity:   <none>
Message:         
Source:
    Type:               vSphereVolume (a Persistent Disk resource in vSphere)
    VolumePath:         [vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7.vmdk
    FSType:             ext4
    StoragePolicyName:  my-custom-vsan-policy
Events:                 <none>
```

2. Renamed SPBM Policy to my-custom-vsan-policy-1 on vCenter. Enabled Migration and Installed CSI Driver. Verified volume registration is failing with Profile not found.

> 2020-07-30T18:06:32.392762259Z 2020-07-30T18:06:32.392Z	ERROR	migration/migration.go:369	Error occurred while getting stroage policy ID from storage policy name: "my-custom-vsan-policy", err: no pbm profile found with name: "my-custom-vsan-policy"	{"TraceId": "31b1c874-d132-4093-b5c3-c8abde6ec8c3"}

> 2020-07-30T18:06:32.393344986Z 2020-07-30T18:06:32.392Z	ERROR	migration/migration.go:186	failed to register volume for volumeSpec: {[vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7.vmdk my-custom-vsan-policy}, with err: Error occurred while getting stroage policy ID from storage policy name: "my-custom-vsan-policy", err: no pbm profile found with name: "my-custom-vsan-policy"	{"TraceId": "31b1c874-d132-4093-b5c3-c8abde6ec8c3"}



3. Renamed SPBM Policy back to to `my-custom-vsan-policy` on vCenter.

4. Performed Operation on volume and Verified volume registration happened successfully and metadata is updated in CNS.

```
kubectl label pv pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7 testkey=testval
persistentvolume/pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7 labeled
```


Logs

```
2020-07-30T18:08:35.318511445Z 2020-07-30T18:08:35.318Z	INFO	migration/migration.go:183	Could not retrieve VolumeID from cache for Volume Path: "[vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7.vmdk". volume may not be registered. Registering Volume with CNS	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
2020-07-30T18:08:35.366211058Z 2020-07-30T18:08:35.365Z	DEBUG	migration/migration.go:365	Obtaining storage policy ID for storage policy name: "my-custom-vsan-policy"	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
2020-07-30T18:08:35.429188686Z 2020-07-30T18:08:35.428Z	INFO	migration/migration.go:372	Obtained storage policy ID: "7ee29319-56cb-4b56-bef3-36bfd01d2f62" for storage policy name: "my-custom-vsan-policy"	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
2020-07-30T18:08:35.429224951Z 2020-07-30T18:08:35.428Z	INFO	migration/migration.go:380	Registering volume: "[vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7.vmdk" using backingDiskURLPath :"https://10.186.32.129/folder/56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7.vmdk?dcPath=VSAN-DC&dsName=vsanDatastore"	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
2020-07-30T18:08:35.436661290Z 2020-07-30T18:08:35.436Z	DEBUG	migration/migration.go:401	vSphere CNS driver registering volume "[vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7.vmdk" with create spec (*types.CnsVolumeCreateSpec)(0xc000257180)({
2020-07-30T18:08:35.436700425Z  DynamicData: (types.DynamicData) {
2020-07-30T18:08:35.436706054Z  },
2020-07-30T18:08:35.436710315Z  Name: (string) (len=36) "af67ba73-d28f-11ea-afea-76f74793fadd",
2020-07-30T18:08:35.436715185Z  VolumeType: (string) (len=5) "BLOCK",
2020-07-30T18:08:35.436718202Z  Datastores: ([]types.ManagedObjectReference) <nil>,
2020-07-30T18:08:35.436721184Z  Metadata: (types.CnsVolumeMetadata) {
2020-07-30T18:08:35.436723845Z   DynamicData: (types.DynamicData) {
2020-07-30T18:08:35.436726440Z   },
2020-07-30T18:08:35.436728981Z   ContainerCluster: (types.CnsContainerCluster) {
2020-07-30T18:08:35.436731766Z    DynamicData: (types.DynamicData) {
2020-07-30T18:08:35.436734386Z    },
2020-07-30T18:08:35.436737046Z    ClusterType: (string) (len=10) "KUBERNETES",
2020-07-30T18:08:35.436739817Z    ClusterId: (string) (len=15) "demo-cluster-id",
2020-07-30T18:08:35.436742655Z    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
2020-07-30T18:08:35.436745453Z    ClusterFlavor: (string) (len=7) "VANILLA"
2020-07-30T18:08:35.436748061Z   },
2020-07-30T18:08:35.436750462Z   EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
2020-07-30T18:08:35.436753377Z   ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
2020-07-30T18:08:35.436756042Z    (types.CnsContainerCluster) {
2020-07-30T18:08:35.436758790Z     DynamicData: (types.DynamicData) {
2020-07-30T18:08:35.436761517Z     },
2020-07-30T18:08:35.436764133Z     ClusterType: (string) (len=10) "KUBERNETES",
2020-07-30T18:08:35.436782608Z     ClusterId: (string) (len=15) "demo-cluster-id",
2020-07-30T18:08:35.436785487Z     VSphereUser: (string) (len=27) "Administrator@vsphere.local",
2020-07-30T18:08:35.436788106Z     ClusterFlavor: (string) (len=7) "VANILLA"
2020-07-30T18:08:35.436790746Z    }
2020-07-30T18:08:35.436793143Z   }
2020-07-30T18:08:35.436795972Z  },
2020-07-30T18:08:35.436798559Z  BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc0005931a0)({
2020-07-30T18:08:35.436801320Z   CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
2020-07-30T18:08:35.436804092Z    DynamicData: (types.DynamicData) {
2020-07-30T18:08:35.436806667Z    },
2020-07-30T18:08:35.436809136Z    CapacityInMb: (int64) 0
2020-07-30T18:08:35.436811637Z   },
2020-07-30T18:08:35.436813963Z   BackingDiskId: (string) "",
2020-07-30T18:08:35.436816791Z   BackingDiskUrlPath: (string) (len=166) "https://10.186.32.129/folder/56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7.vmdk?dcPath=VSAN-DC&dsName=vsanDatastore"
2020-07-30T18:08:35.436820177Z  }),
2020-07-30T18:08:35.436822745Z  Profile: ([]types.BaseVirtualMachineProfileSpec) (len=1 cap=1) {
2020-07-30T18:08:35.436825531Z   (*types.VirtualMachineDefinedProfileSpec)(0xc000804fc0)({
2020-07-30T18:08:35.436828127Z    VirtualMachineProfileSpec: (types.VirtualMachineProfileSpec) {
2020-07-30T18:08:35.436830701Z     DynamicData: (types.DynamicData) {
2020-07-30T18:08:35.436833189Z     }
2020-07-30T18:08:35.436835608Z    },
2020-07-30T18:08:35.436838977Z    ProfileId: (string) (len=36) "7ee29319-56cb-4b56-bef3-36bfd01d2f62",
2020-07-30T18:08:35.436841968Z    ReplicationSpec: (*types.ReplicationSpec)(<nil>),
2020-07-30T18:08:35.436844780Z    ProfileData: (*types.VirtualMachineProfileRawData)(<nil>),
2020-07-30T18:08:35.436847658Z    ProfileParams: ([]types.KeyValue) <nil>
2020-07-30T18:08:35.436850296Z   })
2020-07-30T18:08:35.436852686Z  },
2020-07-30T18:08:35.436855059Z  CreateSpec: (types.BaseCnsBaseCreateSpec) <nil>
2020-07-30T18:08:35.436857702Z })
2020-07-30T18:08:35.436860359Z 	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
2020-07-30T18:08:35.448081801Z 2020-07-30T18:08:35.447Z	DEBUG	volume/manager.go:167	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
2020-07-30T18:08:40.755911435Z 2020-07-30T18:08:40.745Z	INFO	volume/manager.go:201	CreateVolume: VolumeName: "af67ba73-d28f-11ea-afea-76f74793fadd", opId: "b4860e92"	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
2020-07-30T18:08:40.756430556Z 2020-07-30T18:08:40.754Z	DEBUG	volume/manager.go:244	Deleted task for af67ba73-d28f-11ea-afea-76f74793fadd from volumeTaskMap for statically provisioned volume	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
2020-07-30T18:08:40.756557864Z 2020-07-30T18:08:40.754Z	INFO	volume/manager.go:249	CreateVolume: Volume created successfully. VolumeName: "af67ba73-d28f-11ea-afea-76f74793fadd", opId: "b4860e92", volumeID: "6dbf2996-e344-436b-92a1-7ace86bf56f6"	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
2020-07-30T18:08:40.756565044Z 2020-07-30T18:08:40.755Z	INFO	migration/migration.go:410	successfully registered volume "[vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7.vmdk" as container volume with ID: "6dbf2996-e344-436b-92a1-7ace86bf56f6"	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
2020-07-30T18:08:40.756574658Z 2020-07-30T18:08:40.755Z	INFO	migration/migration.go:189	successfully registered volumeSpec: {[vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7.vmdk my-custom-vsan-policy} with CNS. VolumeID: 6dbf2996-e344-436b-92a1-7ace86bf56f6	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
2020-07-30T18:08:40.757387713Z 2020-07-30T18:08:40.757Z	DEBUG	migration/migration.go:197	Saving cnsvSphereVolumeMigration CR: {{ } {6dbf2996-e344-436b-92a1-7ace86bf56f6      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] []  []} {[vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7.vmdk 6dbf2996-e344-436b-92a1-7ace86bf56f6}}	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
2020-07-30T18:08:40.758106192Z 2020-07-30T18:08:40.757Z	INFO	migration/migration.go:268	creating CR for cnsVSphereVolumeMigration: &{TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:6dbf2996-e344-436b-92a1-7ace86bf56f6 GenerateName: Namespace: SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[]} Spec:{VolumePath:[vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7.vmdk VolumeID:6dbf2996-e344-436b-92a1-7ace86bf56f6}}	{"TraceId": "f9ea8b17-fa7d-4207-b8b4-a51cae8e29e5"}
```


```
# kubectl get Cnsvspherevolumemigrations
NAME                                   AGE
6dbf2996-e344-436b-92a1-7ace86bf56f6   49s

# kubectl describe  Cnsvspherevolumemigrations
Name:         6dbf2996-e344-436b-92a1-7ace86bf56f6
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsVSphereVolumeMigration
Metadata:
  Creation Timestamp:  2020-07-30T18:08:40Z
  Generation:          1
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:volumeid:
        f:volumepath:
    Manager:         vsphere-syncer
    Operation:       Update
    Time:            2020-07-30T18:08:40Z
  Resource Version:  1495126
  Self Link:         /apis/cns.vmware.com/v1alpha1/cnsvspherevolumemigrations/6dbf2996-e344-436b-92a1-7ace86bf56f6
  UID:               28efc510-7a49-4293-9b3d-43e0c266658b
Spec:
  Volumeid:    6dbf2996-e344-436b-92a1-7ace86bf56f6
  Volumepath:  [vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-a0481a96-5d09-49f1-98cd-9f30bbf6d7d7.vmdk
Events:        <none>
```

**E2E Test Execution Logs and Result**

exected all block e2e tests.
Test log - https://gist.github.com/divyenpatel/bc07b5d2e31a9185c9a444e1302a528b

1 test failed out of 33 and failure is not related to this change.

```
Summarizing 1 Failure:

[Fail] [csi-block-vanilla] Relocate detached volume  [BeforeEach] Verify relocating detached volume works fine 
/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/tests/e2e/e2e_common.go:121

Ran 33 of 106 Specs in 6217.758 seconds
FAIL! -- 32 Passed | 1 Failed | 0 Pending | 73 Skipped
--- FAIL: TestE2E (6217.77s)
FAIL
```




**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Set Storage Policy ID while registering migrated in-tree vSphere volume
```

@chethanv28 Can you help review this PR?
