### PR TITLE
check migrated-to annotation before pushing vSphere volume's metadata to vCenter

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -431,7 +431,7 @@ func pvcUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer
 	if newPvc == nil || !ok {
 		return
 	}
-
+	log.Debugf("PVCUpdated: PVC Updated from %+v to %+v", oldPvc, newPvc)
 	if newPvc.Status.Phase != v1.ClaimBound {
 		log.Debugf("PVCUpdated: New PVC not in Bound phase")
 		return
@@ -458,26 +458,29 @@ func pvcUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer
 		}
 		log.Debugf("PVCUpdated: Found Persistent Volume %s from API server", newPvc.Spec.VolumeName)
 	}
+	migrationEnabled := metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration)
 	// Verify if csi migration is ON and check if there is any label update or migrated-to annotation was received for the PVC
-	if pv.Spec.VsphereVolume != nil {
-		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
-			if oldPvc.Status.Phase == v1.ClaimBound &&
-				reflect.DeepEqual(newPvc.GetAnnotations(), oldPvc.GetAnnotations()) &&
-				reflect.DeepEqual(newPvc.Labels, oldPvc.Labels) {
-				log.Debug("PVCUpdated: PVC labels and annotations have not changed for %s in namespace %s", newPvc.Name, newPvc.Namespace)
-				return
-			}
-			// Verify if there is an annotation update
-			if !reflect.DeepEqual(newPvc.GetAnnotations(), oldPvc.GetAnnotations()) {
-				// Verify if the annotation update is related to migration. If not, return
-				if !HasMigratedToAnnotationUpdate(ctx, oldPvc.GetAnnotations(), newPvc.GetAnnotations()) {
-					log.Debug("PVCUpdated: Migrated-to annotation not found for %s in namespace %s. Ignoring other annotation updates", newPvc.Name, newPvc.Namespace)
+	if migrationEnabled && pv.Spec.VsphereVolume != nil {
+		if !migratedToAnnotationExists(ctx, newPvc.Annotations) {
+			log.Debugf("PVCUpdated: migration annotation is not present on the PVC %q in namespace %q. Skipping update", newPvc.Name, newPvc.Namespace)
+			return
+		}
+		if oldPvc.Status.Phase == v1.ClaimBound &&
+			reflect.DeepEqual(newPvc.GetAnnotations(), oldPvc.GetAnnotations()) &&
+			reflect.DeepEqual(newPvc.Labels, oldPvc.Labels) {
+			log.Debugf("PVCUpdated: PVC labels and annotations have not changed for %s in namespace %s", newPvc.Name, newPvc.Namespace)
+			return
+		}
+		// Verify if there is an annotation update
+		if !reflect.DeepEqual(newPvc.GetAnnotations(), oldPvc.GetAnnotations()) {
+			// Verify if the annotation update is related to migration. If not, return
+			if !HasMigratedToAnnotationUpdate(ctx, oldPvc.GetAnnotations(), newPvc.GetAnnotations()) {
+				log.Debugf("PVCUpdated: Migrated-to annotation is not added for %s in namespace %s. Ignoring other annotation updates", newPvc.Name, newPvc.Namespace)
+				// Check if there are no label update, then return
+				if !reflect.DeepEqual(newPvc.Labels, oldPvc.Labels) {
 					return
 				}
 			}
-		} else { // Migration flag is set to false
-			log.Warnf("PVCUpdated: volume-migration feature switch is disabled. Cannot update vSphere volume claim %s", newPvc.Name)
-			return
 		}
 	} else {
 		// Verify if pv is vsphere csi volume
@@ -522,19 +525,19 @@ func pvcDeleted(obj interface{}, metadataSyncer *metadataSyncInformer) {
 		log.Errorf("PVCDeleted: Error getting Persistent Volume for pvc %s in namespace %s with err: %v", pvc.Name, pvc.Namespace, err)
 		return
 	}
-
-	// Verify if pv is a vsphere csi volume
-	if (pv.Spec.CSI == nil || pv.Spec.CSI.Driver != csitypes.Name) && (metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume == nil) {
-		log.Debugf("PVCDeleted: Not a vSphere CSI Volume or migrated vSphere Volume")
-		return
+	migrationEnabled := metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration)
+	if migrationEnabled && pv.Spec.VsphereVolume != nil {
+		if !migratedToAnnotationExists(ctx, pvc.Annotations) {
+			log.Debugf("PVCDeleted: migration annotation is not present on the PVC %q in namespace %q. Skipping deletion of PVC metadata.", pvc.Name, pvc.Namespace)
+			return
+		}
+	} else {
+		// Verify if pv is vSphere csi volume
+		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != csitypes.Name {
+			log.Debugf("PVCDeleted: Not a vSphere CSI Volume")
+			return
+		}
 	}
-
-	// Verify if pv is a vsphere volume and migration flag is set to false
-	if pv.Spec.VsphereVolume != nil && !metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
-		log.Warnf("PVCDeleted: volume-migration feature switch is disabled. Cannot delete vSphere volume metadata for %s", pvc.Name)
-		return
-	}
-
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		// Invoke volume deleted method for pvCSI
 		pvcsiVolumeDeleted(ctx, string(pvc.GetUID()), metadataSyncer)
@@ -569,31 +572,33 @@ func pvUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer)
 		log.Debugf("PVUpdated: PV %s metadata is not updated since updated PV is in phase %s", newPv.Name, newPv.Status.Phase)
 		return
 	}
-	// Verify if csi migration is ON and check if there is any label update or migrated-to annotation was received for the PV
-	if newPv.Spec.VsphereVolume != nil {
-		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
-			if (oldPv.Status.Phase == v1.VolumeAvailable || oldPv.Status.Phase == v1.VolumeBound) &&
-				reflect.DeepEqual(newPv.GetAnnotations(), oldPv.GetAnnotations()) &&
-				reflect.DeepEqual(newPv.Labels, oldPv.Labels) {
-				log.Debug("PVUpdated: PV labels and annotations have not changed")
-				return
-			}
-			// Verify if there is an annotation update
-			if !reflect.DeepEqual(newPv.GetAnnotations(), oldPv.GetAnnotations()) {
-				// Verify if the annotation update is related to migration. If not, return
-				if !HasMigratedToAnnotationUpdate(ctx, oldPv.GetAnnotations(), newPv.GetAnnotations()) {
-					log.Debug("PVUpdated: Migrated-to annotation not found for %s. Ignoring other annotation updates", newPv.Name)
+	migrationEnabled := metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration)
+	if migrationEnabled && newPv.Spec.VsphereVolume != nil {
+		if !migratedToAnnotationExists(ctx, newPv.Annotations) {
+			log.Debugf("PVUpdated: migration annotation is not present on the PV %q. Skipping update of PV metadata.", newPv.Name)
+			return
+		}
+		if (oldPv.Status.Phase == v1.VolumeAvailable || oldPv.Status.Phase == v1.VolumeBound) &&
+			reflect.DeepEqual(newPv.GetAnnotations(), oldPv.GetAnnotations()) &&
+			reflect.DeepEqual(newPv.Labels, oldPv.Labels) {
+			log.Debug("PVUpdated: PV labels and annotations have not changed")
+			return
+		}
+		// Verify if migration annotation is getting removed.
+		if !reflect.DeepEqual(newPv.GetAnnotations(), oldPv.GetAnnotations()) {
+			// Verify if the annotation update is related to migration. If not, return
+			if !HasMigratedToAnnotationUpdate(ctx, oldPv.GetAnnotations(), newPv.GetAnnotations()) {
+				log.Debugf("PVUpdated: Migrated-to annotation is not added for %q. Ignoring other annotation updates", newPv.Name)
+				// Check if there are no label update, then return
+				if !reflect.DeepEqual(newPv.Labels, oldPv.Labels) {
 					return
 				}
 			}
-		} else { // Migration flag is set to to false
-			log.Warnf("PVUpdated: volume-migration feature switch is disabled. Cannot update vSphere volume %s", newPv.Name)
-			return
 		}
 	} else {
-		// Verify if pv is a vsphere csi volume
-		if oldPv.Spec.CSI == nil || newPv.Spec.CSI == nil || newPv.Spec.CSI.Driver != csitypes.Name {
-			log.Debugf("PVUpdated: PV is not a Vsphere CSI Volume: %+v", newPv)
+		// Verify if pv is a vSphere csi volume
+		if newPv.Spec.CSI == nil || newPv.Spec.CSI.Driver != csitypes.Name {
+			log.Debugf("PVUpdated: PV is not a vSphere CSI Volume: %+v", newPv)
 			return
 		}
 		// Return if labels are unchanged
@@ -602,7 +607,6 @@ func pvUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer)
 			return
 		}
 	}
-
 	if oldPv.Status.Phase == v1.VolumeBound && newPv.Status.Phase == v1.VolumeReleased && oldPv.Spec.PersistentVolumeReclaimPolicy == v1.PersistentVolumeReclaimDelete {
 		log.Debugf("PVUpdated: Volume will be deleted by controller")
 		return
@@ -631,20 +635,21 @@ func pvDeleted(obj interface{}, metadataSyncer *metadataSyncInformer) {
 		log.Warnf("PVDeleted: unrecognized object %+v", obj)
 		return
 	}
-	log.Debugf("PVDeleted: Deleting PV: %+v", pv)
+	log.Debugf("PVDeleted: PV: %+v", pv)
 
-	// Verify if pv is a vsphere csi volume
-	if (pv.Spec.CSI == nil || pv.Spec.CSI.Driver != csitypes.Name) && (metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume == nil) {
-		log.Debugf("PVDeleted: Not a vSphere CSI Volume or migrated vSphere Volume: %+v", pv)
-		return
+	migrationEnabled := metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration)
+	if migrationEnabled && pv.Spec.VsphereVolume != nil {
+		if !migratedToAnnotationExists(ctx, pv.Annotations) {
+			log.Debugf("PVDeleted: migration annotation is not present on the PV %q. Skipping deletion of PV metadata.", pv.Name)
+			return
+		}
+	} else {
+		// Verify if pv is a vSphere csi volume
+		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != csitypes.Name {
+			log.Debugf("PVDeleted: Not a vSphere CSI Volume. PV: %+v", pv)
+			return
+		}
 	}
-
-	// Verify if pv is a vsphere volume and migration flag is set to false
-	if pv.Spec.VsphereVolume != nil && !metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
-		log.Warnf("PVDeleted: volume-migration feature switch is disabled. Cannot delete vSphere volume metadata for %s", pv.Name)
-		return
-	}
-
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		// Invoke volume deleted method for pvCSI
 		pvcsiVolumeDeleted(ctx, string(pv.GetUID()), metadataSyncer)


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making sure to check `pv.kubernetes.io/migrated-to: csi.vsphere.vmware.com` annotation present on PVC/PV before pushing its metadata to CNS.

**Which issue this PR fixes**
fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/295

**Special notes for your reviewer**:
Testing Done.

Verified metadata syncer logs, PVC update is getting skipped for vSphere Volume
> 2020-07-31T00:50:42.638547679Z 2020-07-31T00:50:42.630Z	INFO	syncer/metadatasyncer.go:465	migration annotation is not present on the PVC. Skipping update	{"TraceId": "07de587e-9e5f-43ba-83f6-fc7076f61463"}

Verified metadata syncer logs, PV update is getting skipped for vSphere Volume
> 2020-07-31T00:50:42.763714507Z 2020-07-31T00:50:42.761Z	INFO	syncer/metadatasyncer.go:575	migration annotation is not present on the PV. Skipping update	{"TraceId": "85c7d9a4-768b-4f79-bfe0-62f0759eb02d"}


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
check migrated-to annotation before pushing vSphere volume's metadata to vCenter
```

@chethanv28 Can you review this PR?
