### PR TITLE
Make fss configmap configurable for Vanilla K8S

### DIFF
--- a/example/vanilla-k8s-block-driver/vsphere.conf
+++ b/example/vanilla-k8s-block-driver/vsphere.conf
@@ -7,3 +7,10 @@ user = "vcenter username"
 password = "vcenter password"
 port = "443"
 datacenters = "list of comma seperated datacenters where node VMs are present"
+
+# FeatureStatesConfig holds the details about feature states configmap.
+# Default feature states configmap name is set to "csi-feature-states"  and namespace is set to "kube-system" 
+# Provide the configmap name and namespace details only when feature states configmap is not in the default namespace
+[FeatureStatesConfig]
+name = "csi-feature-states"
+namespace = "kube-system"

--- a/manifests/latest/vsphere-7.0/supervisorcluster/k8s-1.15/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/latest/vsphere-7.0/supervisorcluster/k8s-1.15/deploy/vsphere-csi-controller-deployment.yaml
@@ -92,8 +92,6 @@ spec:
               value: "29000"
             - name: VSPHERE_CSI_CONFIG
               value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
-            - name: FEATURE_STATES
-              value: /etc/vmware/wcp/csi-feature-states/csi-feature-states.conf
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
@@ -104,9 +102,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
-              readOnly: true
-            - mountPath: /etc/vmware/wcp/csi-feature-states
-              name: csi-fss-config-volume
               readOnly: true
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -139,8 +134,6 @@ spec:
               value: "29000"
             - name: VSPHERE_CSI_CONFIG
               value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
-            - name: FEATURE_STATES
-              value: /etc/vmware/wcp/csi-feature-states/csi-feature-states.conf
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
           imagePullPolicy: "IfNotPresent"
@@ -148,16 +141,10 @@ spec:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /etc/vmware/wcp/csi-feature-states
-              name: csi-fss-config-volume
-              readOnly: true
       volumes:
         - name: vsphere-config-volume
           secret:
             secretName: vsphere-config-secret
-        - name: csi-fss-config-volume
-          configMap:
-            name: csi-feature-states
         - name: socket-dir
           hostPath:
             path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -63,6 +63,14 @@ type Config struct {
 		Zone   string `gcfg:"zone"`
 		Region string `gcfg:"region"`
 	}
+	// FeatureStatesConfig is the details about feature states configmap
+	FeatureStatesConfig FeatureStatesConfigInfo
+}
+
+// FeatureStatesConfigInfo is the details about feature states configmap
+type FeatureStatesConfigInfo struct {
+	Name      string `gcfg:"name"`
+	Namespace string `gcfg:"namespace"`
 }
 
 // NetPermissionConfig consists of information used to restrict the

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 
-	cnstypes "github.com/vmware/govmomi/cns/types"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
@@ -35,11 +35,11 @@ type COCommonInterface interface {
 
 // GetContainerOrchestratorInterface returns orchestrator object
 // for a given container orchestrator type
-func GetContainerOrchestratorInterface(ctx context.Context, orchestratorType int, clusterFlavour cnstypes.CnsClusterFlavor) (COCommonInterface, error) {
+func GetContainerOrchestratorInterface(ctx context.Context, orchestratorType int, featureStatesConfigInfo config.FeatureStatesConfigInfo) (COCommonInterface, error) {
 	log := logger.GetLogger(ctx)
 	switch orchestratorType {
 	case common.Kubernetes:
-		k8sorchestratorInstance, err := k8sorchestrator.Newk8sOrchestrator(ctx, clusterFlavour)
+		k8sorchestratorInstance, err := k8sorchestrator.Newk8sOrchestrator(ctx, featureStatesConfigInfo)
 		if err != nil {
 			log.Errorf("Creating k8sorchestratorInstance failed. Err: %v", err)
 			return nil, err

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -158,21 +158,6 @@ const (
 	// AnnMigratedTo annotation is added to a PVC and PV that is supposed to be
 	// provisioned/deleted by its corresponding CSI driver
 	AnnMigratedTo = "pv.kubernetes.io/migrated-to"
-
-	// IPs is Client IP address, IP range or IP subnet
-	IPs string = "ips"
-
-	// CSINamespaceVanillaK8S is the namespace of CSI driver in Vanilla K8S
-	CSINamespaceVanillaK8S = "kube-system"
-
-	// CSINamespaceWorkload is the namespace of CSI in Supervisor Cluster
-	CSINamespaceWorkload = "vmware-system-csi"
-
-	// CSINamespaceTkgCluster is the namespace of CSI in TKG Cluster
-	CSINamespaceTkgCluster = "vmware-system-csi"
-
-	// CSIFeatureStatesConfigMapName is the name of configmap to store FSS values
-	CSIFeatureStatesConfigMapName = "csi-feature-states"
 )
 
 // Supported container orchestrators

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -159,7 +159,7 @@ func (c *controller) Init(config *config.Config) error {
 	cfgPath := common.GetConfigPath(ctx)
 
 	// Initialize CO utility
-	containerOrchestratorUtility, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, cnstypes.CnsClusterFlavorVanilla)
+	containerOrchestratorUtility, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, config.FeatureStatesConfig)
 	if err != nil {
 		log.Errorf("Failed to create co agnostic interface. err=%v", err)
 		return err

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -107,7 +107,7 @@ func (c *controller) Init(config *cnsconfig.Config) error {
 		log.Errorf("failed to create fsnotify watcher. err=%v", err)
 		return err
 	}
-	c.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, cnstypes.CnsClusterFlavorWorkload)
+	c.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, config.FeatureStatesConfig)
 	if err != nil {
 		log.Errorf("Failed to create co agnostic interface. err=%v", err)
 		return err

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fsnotify/fsnotify"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
-	cnstypes "github.com/vmware/govmomi/cns/types"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -109,7 +108,7 @@ func (c *controller) Init(config *cnsconfig.Config) error {
 		log.Errorf("failed to create fsnotify watcher. err=%v", err)
 		return err
 	}
-	c.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, cnstypes.CnsClusterFlavorGuest)
+	c.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, config.FeatureStatesConfig)
 	if err != nil {
 		log.Errorf("Failed to create co agnostic interface. err=%v", err)
 		return err

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -122,14 +122,13 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		log.Errorf("Creating Kubernetes client failed. Err: %v", err)
 		return err
 	}
-	metadataSyncer.clusterFlavor = clusterFlavor
 	// Initialize the k8s orchestrator interface
-	metadataSyncer.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, metadataSyncer.clusterFlavor)
+	metadataSyncer.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, metadataSyncer.configInfo.Cfg.FeatureStatesConfig)
 	if err != nil {
 		log.Errorf("Failed to create co agnostic interface. err=%v", err)
 		return err
 	}
-
+	metadataSyncer.clusterFlavor = clusterFlavor
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		// Initialize client to supervisor cluster
 		// if metadata syncer is being initialized for guest clusters


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making feature states configmap name and namespace configurable based on user defined vsphere config

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #293 

**Special notes for your reviewer**:
Testing:
When FSS config info is not defined in vsphere conf:
<pre>
2020-07-31T08:26:55.498Z	INFO	config/config.go:304	No feature states config information is provided in the Config. Using default config map name: csi-feature-states and namespace: kube-system	{"TraceId": "12413eb9-4e40-4782-89ca-8d451ef79247"}
</pre> 

e2e test logs
--------------
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/297#issuecomment-668304678

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Make FSS configmap name and namespace configurable
```
