### PR TITLE
disable volume expansion for migrated volumes

### DIFF
--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -523,6 +523,24 @@ func TestExtendVolume(t *testing.T) {
 	}
 }
 
+// TestMigratedExtendVolume helps test ControllerExpandVolume with VolumeId having migrated volume
+func TestMigratedExtendVolume(t *testing.T) {
+	ct := getControllerTest(t)
+	reqExpand := &csi.ControllerExpandVolumeRequest{
+		VolumeId: "[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1024,
+		},
+	}
+	t.Log(fmt.Sprintf("ControllerExpandVolume will be called with req +%v", *reqExpand))
+	_, err := ct.controller.ControllerExpandVolume(ctx, reqExpand)
+	if err != nil {
+		t.Logf("Expected error received. migrated volume with VMDK path can not be expanded")
+	} else {
+		t.Fatal("Expected error not received when ControllerExpandVolume is called with volume having vmdk path")
+	}
+}
+
 func TestCompleteControllerFlow(t *testing.T) {
 	ct := getControllerTest(t)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is disabling volume expansion for migrated volumes.

**Which issue this PR fixes**
fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/300

**Special notes for your reviewer**:

Testing done

**Unit Test**

```
=== RUN   TestMigratedExtendVolume
{"level":"info","time":"2020-08-07T12:45:21.721805-07:00","caller":"vanilla/controller.go:758","msg":"ControllerExpandVolume: called with args {VolumeId:[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk CapacityRange:required_bytes:1024  Secrets:map[] VolumeCapability:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"7b8be6d6-1fd1-462b-84f2-8a053cb525bc"}
{"level":"error","time":"2020-08-07T12:45:21.721817-07:00","caller":"vanilla/controller.go:762","msg":"Cannot expand migrated vSphere volume. :\"[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk\"","TraceId":"7b8be6d6-1fd1-462b-84f2-8a053cb525bc","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.(*controller).ControllerExpandVolume\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/vanilla/controller.go:762\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.TestMigratedExtendVolume\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:535\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestMigratedExtendVolume (0.00s)
    controller_test.go:534: ControllerExpandVolume will be called with req +{[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk required_bytes:1024  map[] <nil> {} [] 0}
    controller_test.go:537: Expected error received. migrated volume with VMDK path can not be expanded
```

**E2E Test Manual**

1. upgraded csi-translation-lib in the external resizer to include vSphere translation library and build it locally.
2. Deployed CSI driver using this locally build resizer.
3. verified volume expansion is not permitted for migrated volume.

```
# kubectl describe pvc
Name:          vcppvc
Namespace:     default
StorageClass:  vcpsc
Status:        Bound
Volume:        pvc-aadea07e-9e59-40a9-b9a8-62b9e5c0de68
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               pv.kubernetes.io/migrated-to: csi.vsphere.vmware.com
               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/vsphere-volume
               volume.kubernetes.io/storage-resizer: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      2Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
Conditions:
  Type       Status  LastProbeTime                     LastTransitionTime                Reason  Message
  ----       ------  -----------------                 ------------------                ------  -------
  Resizing   True    Mon, 01 Jan 0001 00:00:00 +0000   Tue, 04 Aug 2020 12:58:45 -0700           
Events:
  Type     Reason                 Age              From                                     Message
  ----     ------                 ----             ----                                     -------
  Normal   ProvisioningSucceeded  2m59s            persistentvolume-controller              Successfully provisioned volume pvc-aadea07e-9e59-40a9-b9a8-62b9e5c0de68 using kubernetes.io/vsphere-volume
  Normal   ExternalExpanding      5s               volume_expand                            CSI migration enabled for kubernetes.io/vsphere-volume; waiting for external resizer to expand the pvc
  Normal   Resizing               2s (x3 over 5s)  external-resizer csi.vsphere.vmware.com  External resizer is resizing volume pvc-aadea07e-9e59-40a9-b9a8-62b9e5c0de68
  Warning  VolumeResizeFailed     2s (x3 over 5s)  external-resizer csi.vsphere.vmware.com  resize volume pvc-aadea07e-9e59-40a9-b9a8-62b9e5c0de68 failed: rpc error: code = Unimplemented desc = Cannot expand in-tree volume. :"[vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-aadea07e-9e59-40a9-b9a8-62b9e5c0de68.vmdk"
```

Controller Logs

> 2020-08-04T20:00:49.800518381Z 2020-08-04T20:00:49.797Z	INFO	vanilla/controller.go:758	ControllerExpandVolume: called with args {VolumeId:[vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-aadea07e-9e59-40a9-b9a8-62b9e5c0de68.vmdk CapacityRange:required_bytes:3221225472  Secrets:map[] VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "2e294a6d-1636-4b5c-8258-415eb824a308"}

> 2020-08-04T20:00:49.800576742Z 2020-08-04T20:00:49.797Z	DEBUG	k8sorchestrator/k8sorchestrator.go:162	Feature: csi-migration state is set to true	{"TraceId": "2e294a6d-1636-4b5c-8258-415eb824a308"}

>2020-08-04T20:00:49.800652495Z 2020-08-04T20:00:49.797Z	ERROR	vanilla/controller.go:768	Cannot expand in-tree volume. :"[vsanDatastore] 56631b5f-627a-7a01-5b88-02009d31bab6/kubernetes-dynamic-pvc-aadea07e-9e59-40a9-b9a8-62b9e5c0de68.vmdk"	{"TraceId": "2e294a6d-1636-4b5c-8258-415eb824a308"}



**Release note**:

```release-note
disable volume expansion for migrated volumes
```


@xing-yang @SandeepPissay @chethanv28 Can you reviwe this PR?