### PR TITLE
Check provisioner annotation for pvc/pv provisioned using in tree storage class

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -158,6 +158,20 @@ const (
 	// AnnMigratedTo annotation is added to a PVC and PV that is supposed to be
 	// provisioned/deleted by its corresponding CSI driver
 	AnnMigratedTo = "pv.kubernetes.io/migrated-to"
+
+	// AnnStorageProvisioner annotation is added to a PVC that is supposed to be dynamically
+	// provisioned. Its value is name of volume plugin that is supposed to provision
+	// a volume for this PVC.
+	AnnStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
+
+	// AnnDynamicallyProvisioned annotation is added to a PV that has been dynamically provisioned by
+	// Kubernetes. Its value is name of volume plugin that created the volume.
+	// It serves both user (to show where a PV comes from) and Kubernetes (to
+	// recognize dynamically provisioned PVs in its decisions).
+	AnnDynamicallyProvisioned = "pv.kubernetes.io/provisioned-by"
+
+	// InTreePluginName is the name of vsphere cloud provider in kubernetes
+	InTreePluginName = "kubernetes.io/vsphere-volume"
 )
 
 // Supported container orchestrators

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -497,7 +497,7 @@ func getVolumesToBeDeleted(ctx context.Context, cnsVolumeList []cnstypes.CnsVolu
 				if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
 					// If migration is ON, verify if the volume is present in inlineVolumeMap
 					if _, existsInInlineVolumeMap := inlineVolumeMap[vol.VolumeId.Id]; !existsInInlineVolumeMap {
-						log.Infof("FullSync: Inline migrated volume with id %s added to cnsDeletionMap", vol.VolumeId.Id)
+						log.Infof("FullSync: Volume with id %q added to cnsDeletionMap", vol.VolumeId.Id)
 						cnsDeletionMap[vol.VolumeId.Id] = true
 					} else {
 						log.Debugf("FullSync: Inline migrated volume with id %s is in use. Skipping for deletion", vol.VolumeId.Id)

--- a/pkg/syncer/util_test.go
+++ b/pkg/syncer/util_test.go
@@ -1,0 +1,84 @@
+package syncer
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	validMigratedPVCMetadata   metav1.ObjectMeta
+	validMigratedPVMetadata    metav1.ObjectMeta
+	validLegacyPVCMetadata     metav1.ObjectMeta
+	validLegacyPVMetadata      metav1.ObjectMeta
+	invalidMigratedPVCMetadata metav1.ObjectMeta
+	invalidMigratedPVMetadata  metav1.ObjectMeta
+)
+
+func init() {
+	validMigratedPVCMetadata = metav1.ObjectMeta{
+		Name: "migrated-vcppvc",
+		Annotations: map[string]string{
+			"pv.kubernetes.io/migrated-to":                  "csi.vsphere.vmware.com",
+			"volume.beta.kubernetes.io/storage-provisioner": "kubernetes.io/vsphere-volume",
+		},
+	}
+	validLegacyPVCMetadata = metav1.ObjectMeta{
+		Name: "vcppvcProvisionedByCSI",
+		Annotations: map[string]string{
+			"volume.beta.kubernetes.io/storage-provisioner": "csi.vsphere.vmware.com",
+		},
+	}
+	validMigratedPVMetadata = metav1.ObjectMeta{
+		Name: "migrated-vcppv",
+		Annotations: map[string]string{
+			"pv.kubernetes.io/migrated-to":    "csi.vsphere.vmware.com",
+			"pv.kubernetes.io/provisioned-by": "kubernetes.io/vsphere-volume",
+		},
+	}
+	validLegacyPVMetadata = metav1.ObjectMeta{
+		Name: "vcppvProvisionedByCSI",
+		Annotations: map[string]string{
+			"pv.kubernetes.io/provisioned-by": "csi.vsphere.vmware.com",
+		},
+	}
+	invalidMigratedPVCMetadata = metav1.ObjectMeta{
+		Name: "migrated-invalid-vcppvc",
+		Annotations: map[string]string{
+			"pv.kubernetes.io/migrated-to":                  "unknown.csi.driver",
+			"volume.beta.kubernetes.io/storage-provisioner": "kubernetes.io/vsphere-volume",
+		},
+	}
+	invalidMigratedPVCMetadata = metav1.ObjectMeta{
+		Name: "migrated-invalid-vcppv",
+		Annotations: map[string]string{
+			"pv.kubernetes.io/migrated-to":    "unknown.csi.driver",
+			"pv.kubernetes.io/provisioned-by": "kubernetes.io/vsphere-volume",
+		},
+	}
+
+}
+func TestValidMigratedAndLegacyVolume(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if !isValidvSphereVolumeClaim(ctx, validMigratedPVCMetadata) {
+		t.Errorf("Expected: isValidvSphereVolumeClaim to return True\n Actual: isValidvSphereVolumeClaim returned False")
+	}
+	if !isValidvSphereVolumeClaim(ctx, validLegacyPVCMetadata) {
+		t.Errorf("Expected: isValidvSphereVolumeClaim to return True\n Actual: isValidvSphereVolumeClaim returned False")
+	}
+	if isValidvSphereVolumeClaim(ctx, invalidMigratedPVCMetadata) {
+		t.Errorf("Expected: isValidvSphereVolumeClaim to return False\n Actual: isValidvSphereVolumeClaim returned True")
+	}
+	if !isValidvSphereVolume(ctx, validMigratedPVMetadata) {
+		t.Errorf("Expected: isValidvSphereVolume to return True\n Actual: isValidvSphereVolume returned False")
+	}
+	if !isValidvSphereVolume(ctx, validLegacyPVMetadata) {
+		t.Errorf("Expected: isValidvSphereVolume to return True\n Actual: isValidvSphereVolume returned False")
+	}
+	if isValidvSphereVolume(ctx, invalidMigratedPVMetadata) {
+		t.Errorf("Expected: isValidvSphereVolume to return Fale\n Actual: isValidvSphereVolume returned True")
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is needed to update volume metadata for PVC/PV provisioned by CSI driver using in-tree storage class

**Special notes for your reviewer**:
Testing:
<pre>
Name:          vcppvc
Namespace:     default
StorageClass:  vcpsc
Status:        Bound
Volume:        pvc-23e9446c-e344-44f0-a12c-6279562c7e91
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               pv.kubernetes.io/migrated-to: csi.vsphere.vmware.com <<<<<<<<=========== Migrated Volume
               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/vsphere-volume.  
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
Events:        <none>

kubectl describe pv
Name:            pvc-23e9446c-e344-44f0-a12c-6279562c7e91
Labels:          <none>
Annotations:     kubernetes.io/createdby: vsphere-volume-dynamic-provisioner
                 pv.kubernetes.io/bound-by-controller: yes
                 pv.kubernetes.io/migrated-to: csi.vsphere.vmware.com.  <<<<<<<<=========== Migrated Volume
                 pv.kubernetes.io/provisioned-by: kubernetes.io/vsphere-volume
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    vcpsc
Status:          Bound
Claim:           default/vcppvc
Reclaim Policy:  Delete
Access Modes:    RWO
VolumeMode:      Filesystem
Capacity:        1Mi
Node Affinity:   <none>
Message:         
Source:
    Type:               vSphereVolume (a Persistent Disk resource in vSphere)
    VolumePath:         [vsanDatastore] 4eef2a5f-1806-21ce-9423-02003bdc230b/kubernetes-dynamic-pvc-23e9446c-e344-44f0-a12c-6279562c7e91.vmdk
    FSType:             ext4
    StoragePolicyName:  vSAN Default Storage Policy
Events:                 <none>



root@k8s-master:~# kubectl describe pvc
Name:          vcppvc-1
Namespace:     default
StorageClass:  vcpsc
Status:        Bound
Volume:        pvc-4a1a0bb3-f0f4-4efb-a5c6-128efac1546e
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com <<<<<==== Volume created by CSI driver
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
Events:


kubectl describe pv
Name:            pvc-4a1a0bb3-f0f4-4efb-a5c6-128efac1546e
Labels:          <none>
Annotations:     pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com.  <<<<<====== Volume created by CSI driver
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    vcpsc
Status:          Bound
Claim:           default/vcppvc-1
Reclaim Policy:  Delete
Access Modes:    RWO
VolumeMode:      Filesystem
Capacity:        1Mi
Node Affinity:   <none>
Message:         
Source:
    Type:               vSphereVolume (a Persistent Disk resource in vSphere).   
    VolumePath:         [vsanDatastore] d65a2b5f-4b2c-a59d-f5a4-02003bdc230b/637dba1fc9c1446c8f7865d3612cd787.vmdk
    FSType:             
    StoragePolicyName:  
Events:                 <none>

</pre>
<img width="1106" alt="CNS UI " src="https://user-images.githubusercontent.com/14131348/89666733-c1b4dc80-d88f-11ea-920f-cd3f5499e3a2.png">

<img width="1103" alt="CNS UI-2" src="https://user-images.githubusercontent.com/14131348/89675085-2e36d800-d89e-11ea-9dcf-1e102d3840ea.png">

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Metadata updates for volumes provisioned by CSI driver using in-tree storage class
```
