### PR TITLE
refactor vanilla controller operations workflows

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -521,25 +521,19 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		return nil, err
 	}
 	var volumePath string
-
-	// in-tree volume support
 	if strings.Contains(req.VolumeId, ".vmdk") {
-		volumePath = req.VolumeId
-	}
-	if containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
-		// Migration feature switch is enabled
-		if volumePath != "" {
-			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, migration.VolumeSpec{VolumePath: volumePath})
-			if err != nil {
-				msg := fmt.Sprintf("failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
-				log.Error(msg)
-				return nil, status.Errorf(codes.Internal, msg)
-			}
+		// in-tree volume support
+		if !containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
+			// Migration feature switch is disabled
+			msg := fmt.Sprintf("volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", req.VolumeId)
+			log.Error(msg)
+			return nil, status.Errorf(codes.Internal, msg)
 		}
-	} else {
-		// Migration feature switch is disabled
-		if volumePath != "" {
-			msg := fmt.Sprintf("volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", volumePath)
+		// Migration feature switch is enabled
+		volumePath = req.VolumeId
+		req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, migration.VolumeSpec{VolumePath: req.VolumeId})
+		if err != nil {
+			msg := fmt.Sprintf("failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
 			log.Error(msg)
 			return nil, status.Errorf(codes.Internal, msg)
 		}
@@ -550,7 +544,9 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		log.Error(msg)
 		return nil, status.Errorf(codes.Internal, msg)
 	}
-	if containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) && volumePath != "" {
+	// Migration feature switch is enabled and volumePath is set
+	if volumePath != "" {
+		// Delete VolumePath to VolumeID mapping
 		err = volumeMigrationService.DeleteVolumeInfo(ctx, req.VolumeId)
 		if err != nil {
 			msg := fmt.Sprintf("failed to delete volumeInfo CR for volume: %q. Error: %+v", req.VolumeId, err)
@@ -577,14 +573,6 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 		log.Error(msg)
 		return nil, status.Errorf(codes.Internal, msg)
 	}
-	node, err := c.nodeMgr.GetNodeByName(ctx, req.NodeId)
-	if err != nil {
-		msg := fmt.Sprintf("failed to find VirtualMachine for node:%q. Error: %v", req.NodeId, err)
-		log.Error(msg)
-		return nil, status.Errorf(codes.Internal, msg)
-	}
-
-	log.Debugf("Found VirtualMachine for node:%q.", req.NodeId)
 	publishInfo := make(map[string]string)
 	// Check whether its a block or file volume
 	if common.IsFileVolumeRequest(ctx, []*csi.VolumeCapability{req.GetVolumeCapability()}) {
@@ -622,30 +610,31 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 		}
 	} else {
 		// Block Volume
-		// in-tree volume support
-		var volumePath string
 		if strings.Contains(req.VolumeId, ".vmdk") {
-			volumePath = req.VolumeId
-		}
-		if containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
-			// Migration feature switch is enabled
-			if volumePath != "" {
-				storagePolicyName := req.VolumeContext[common.AttributeStoragePolicyName]
-				req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, migration.VolumeSpec{VolumePath: volumePath, StoragePolicyName: storagePolicyName})
-				if err != nil {
-					msg := fmt.Sprintf("failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
-					log.Error(msg)
-					return nil, status.Errorf(codes.Internal, msg)
-				}
+			// in-tree volume support
+			if !containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
+				// Migration feature switch is disabled
+				msg := fmt.Sprintf("volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", req.VolumeId)
+				log.Error(msg)
+				return nil, status.Errorf(codes.Internal, msg)
 			}
-		} else {
-			// Migration feature switch is disabled
-			if volumePath != "" {
-				msg := fmt.Sprintf("volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", volumePath)
+			// Migration feature switch is enabled
+			storagePolicyName := req.VolumeContext[common.AttributeStoragePolicyName]
+			volumePath := req.VolumeId
+			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, migration.VolumeSpec{VolumePath: volumePath, StoragePolicyName: storagePolicyName})
+			if err != nil {
+				msg := fmt.Sprintf("failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
 				log.Error(msg)
 				return nil, status.Errorf(codes.Internal, msg)
 			}
 		}
+		node, err := c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+		if err != nil {
+			msg := fmt.Sprintf("failed to find VirtualMachine for node:%q. Error: %v", req.NodeId, err)
+			log.Error(msg)
+			return nil, status.Errorf(codes.Internal, msg)
+		}
+		log.Debugf("Found VirtualMachine for node:%q.", req.NodeId)
 		diskUUID, err := common.AttachVolumeUtil(ctx, c.manager, node, req.VolumeId)
 		if err != nil {
 			msg := fmt.Sprintf("failed to attach disk: %+q with node: %q err %+v", req.VolumeId, req.NodeId, err)
@@ -655,10 +644,9 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 		publishInfo[common.AttributeDiskType] = common.DiskTypeBlockVolume
 		publishInfo[common.AttributeFirstClassDiskUUID] = common.FormatDiskUUID(diskUUID)
 	}
-	resp := &csi.ControllerPublishVolumeResponse{
+	return &csi.ControllerPublishVolumeResponse{
 		PublishContext: publishInfo,
-	}
-	return resp, nil
+	}, nil
 }
 
 // ControllerUnpublishVolume detaches a volume from the Node VM.
@@ -679,39 +667,8 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		log.Info("Skipping ControllerUnpublish for deleted volume ", req.VolumeId)
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
-
-	// in-tree volume support
-	var volumePath string
-	if strings.Contains(req.VolumeId, ".vmdk") {
-		volumePath = req.VolumeId
-	}
-	if containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
-		// Migration feature switch is enabled
-		if volumePath != "" {
-			// ControllerUnpublishVolume will never be the first call back for vmdk registration with CNS.
-			// Here in the migration.VolumeSpec, we do not supply SPBM Policy name.
-			// Node drain is the pre-requisite for volume migration, so volume will be registered with SPBM policy
-			// during ControllerPublish if metadata-syncer fails to register volume using associated SPBM Policy.
-			// for ControllerUnpublishVolume we anticipate volume is already registered with CNS, and volumeMigrationService
-			// should return volumeID for requested VolumePath
-			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, migration.VolumeSpec{VolumePath: volumePath})
-			if err != nil {
-				msg := fmt.Sprintf("failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
-				log.Error(msg)
-				return nil, status.Errorf(codes.Internal, msg)
-			}
-		}
-	} else {
-		// Migration feature switch is disabled
-		if volumePath != "" {
-			msg := fmt.Sprintf("volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", volumePath)
-			log.Error(msg)
-			return nil, status.Errorf(codes.Internal, msg)
-		}
-	}
-	// check if volume is block or file, skip detach for file volume
-	var isFileVolume bool
-	if volumePath == "" {
+	if !strings.Contains(req.VolumeId, ".vmdk") {
+		// check if volume is block or file, skip detach for file volume
 		queryFilter := cnstypes.CnsQueryFilter{
 			VolumeIds: []cnstypes.CnsVolumeId{{Id: req.VolumeId}},
 		}
@@ -727,24 +684,44 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			return nil, status.Error(codes.Internal, msg)
 		}
 		if queryResult.Volumes[0].VolumeType == common.FileVolumeType {
-			isFileVolume = true
-		}
-	}
-	if !isFileVolume {
-		node, err := c.nodeMgr.GetNodeByName(ctx, req.NodeId)
-		if err != nil {
-			msg := fmt.Sprintf("failed to find VirtualMachine for node:%q. Error: %v", req.NodeId, err)
-			log.Error(msg)
-			return nil, status.Error(codes.Internal, msg)
-		}
-		err = common.DetachVolumeUtil(ctx, c.manager, node, req.VolumeId)
-		if err != nil {
-			msg := fmt.Sprintf("failed to detach disk: %+q from node: %q err %+v", req.VolumeId, req.NodeId, err)
-			log.Error(msg)
-			return nil, status.Error(codes.Internal, msg)
+			log.Info("Skipping ControllerUnpublish for file volume ", req.VolumeId)
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
 		}
 	} else {
-		log.Info("Skipping ControllerUnpublish for file volume ", req.VolumeId)
+		// in-tree volume support
+		if !containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
+			// Migration feature switch is disabled
+			msg := fmt.Sprintf("volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", req.VolumeId)
+			log.Error(msg)
+			return nil, status.Errorf(codes.Internal, msg)
+		}
+		// Migration feature switch is enabled
+		// ControllerUnpublishVolume will never be the first call back for vmdk registration with CNS.
+		// Here in the migration.VolumeSpec, we do not supply SPBM Policy name.
+		// Node drain is the pre-requisite for volume migration, so volume will be registered with SPBM policy
+		// during ControllerPublish if metadata-syncer fails to register volume using associated SPBM Policy.
+		// for ControllerUnpublishVolume we anticipate volume is already registered with CNS, and volumeMigrationService
+		// should return volumeID for requested VolumePath
+		volumePath := req.VolumeId
+		req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, migration.VolumeSpec{VolumePath: volumePath})
+		if err != nil {
+			msg := fmt.Sprintf("failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
+			log.Error(msg)
+			return nil, status.Errorf(codes.Internal, msg)
+		}
+	}
+	// Block Volume
+	node, err := c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+	if err != nil {
+		msg := fmt.Sprintf("failed to find VirtualMachine for node:%q. Error: %v", req.NodeId, err)
+		log.Error(msg)
+		return nil, status.Error(codes.Internal, msg)
+	}
+	err = common.DetachVolumeUtil(ctx, c.manager, node, req.VolumeId)
+	if err != nil {
+		msg := fmt.Sprintf("failed to detach disk: %+q from node: %q err %+v", req.VolumeId, req.NodeId, err)
+		log.Error(msg)
+		return nil, status.Error(codes.Internal, msg)
 	}
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Refactored vanilla controller workflows to remove duplicate checks for migrated volume path.
- Moved node VM retrieval right before volume attach/detach to save the calls for file volume.
- Made sure migration FSS switch is retrieved only once, in the Delete Volume call. It was retrieved twice at multiple code blocks. This helps ensure the whole workflow is executed considering the one feature switch state.


**Special notes for your reviewer**:
Executed existing e2e test cases to verify regression is not introduced by this change. 

Test Log: https://gist.github.com/divyenpatel/e676fedfb8c486903a37d70d3dddcc97

```
Ran 33 of 106 Specs in 5850.126 seconds
SUCCESS! -- 33 Passed | 0 Failed | 0 Pending | 73 Skipped
PASS

Ginkgo ran 1 suite in 1h38m14.165731743s
Test Suite Passed
```

I have also verified code is not breaking the migration feature with manual testing.
- Verified volume provisioning and pod creation/deletion and volume deletion work fine using in-tree provisioner when the migration feature is enabled.
- Verified creating pod, deleting pod using the migrated volume created before migration feature is enabled. no regression observed. Also verified deleting this volume after the migration is enabled.


Also verified creating file-share volume, creating pod using file share volumes, deleting pod, deleting PVC.
Used example posted here - https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/example/vanilla-k8s-file-driver



**Release note**:

```release-note
refactor vanilla controller operations workflows
```

@chethanv28 @SandeepPissay please help review this PR.
