### PR TITLE
vSphere CSI driver is not supported on Windows based vCenter Server

### DIFF
--- a/docs/book/compatiblity_matrix.md
+++ b/docs/book/compatiblity_matrix.md
@@ -10,3 +10,5 @@ The following table describes compatibility of the vSphere CSI driver releases w
 Refer to [upgrade support matrix](upgrade_support_matrix.md) to learn about upgrade support.
 
 Refer to [feature matrix](supported_features_matrix.md) to learn about features added to the vSphere CSI 2.0 driver.
+
+Note: vSphere CSI driver is not supported on Windows based vCenter.

--- a/docs/book/supported_features_matrix.md
+++ b/docs/book/supported_features_matrix.md
@@ -18,6 +18,7 @@
 | VolumeHealth                                  | No                  | No              | Yes (_Block Volume_)                 | Yes (_Block Volume_)               |
 _Notes_:
 
+* vSphere CSI driver is not supported on Windows based vCenter.
 * Native K8s is any distribution that uses vanilla upstream Kubernetes binaries and pods (e.g. VMware TKG, TKGI, etc)
 * If the CSI version `2.0` driver is installed on K8s running on vSphere 6.7U3, the older CSI `1.0` driver features continue to work but the new CSI `2.0` features are not supported.
 * If the CSI version `1.0.2` is installed on K8s running on vSphere 7.0, the CSI `1.0` driver features continue to work. CSI version `1.0.1` is not compatible with vSphere 7.

--- a/docs/book/upgrade_support_matrix.md
+++ b/docs/book/upgrade_support_matrix.md
@@ -14,4 +14,7 @@ With vSphere CSI driver v2.0.0, deployment is changed from StatefulSet to Deploy
 
 To upgrade driver from v1.0.1/v1.0.2 to v2.0.0, driver needs to be removed and re-deployed using [new YAMLs](https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/vsphere-7.0/vanilla).
 
-Note: vSphere CSI driver v2.0.0 requires new set of roles and privileges on vSphere 7.0, please refer updated [roles and privileges requirement](driver-deployment/prerequisites.md).
+Note:
+
+- vSphere CSI driver v2.0.0 requires new set of roles and privileges on vSphere 7.0, please refer updated [roles and privileges requirement](driver-deployment/prerequisites.md).
+- vSphere CSI driver is not supported on Windows based vCenter.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR clarifies that vSphere CSI driver is not supported on the Windows-based vCenter server.

**Which issue this PR fixes**

fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/306

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
vSphere CSI driver is not supported on the Windows-based vCenter Server
```
