### PR TITLE
Added doc to clarify the max allowed characters for cluster-id

### DIFF
--- a/docs/book/driver-deployment/installation.md
+++ b/docs/book/driver-deployment/installation.md
@@ -66,7 +66,7 @@ datacenters = "<datacenter-name1>, <datacenter-name2>, ..."
 
 Where the entries have the following meaning:
 
-- `cluster-id` - represents the unique cluster identifier. Each kubernetes cluster should have it's own unique cluster-id set in the configuration file.
+- `cluster-id` - represents the unique cluster identifier. Each kubernetes cluster should have it's own unique cluster-id set in the configuration file. The cluster ID should not exceed 64 characters.
 
 - `VirtualCenter` - section defines vCenter IP address / FQDN.
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Added doc to clarify the max allowed characters for cluster-id property in vSphere configuration file.

**Which issue this PR fixes** : fixes #318

**Special notes for your reviewer**:
The doc change is simple. Verified that the md file is showing the added text correctly in IDE. I don't intend to run any tests as this is a doc only change.

**Release note**:

```release-note
Added doc to clarify the max allowed characters(64) for cluster-id property in vSphere configuration file.
```
