### PR TITLE
Use correct format for logging

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -664,7 +664,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	}
 	// Check for the race condition where DeleteVolume is called before ControllerUnpublishVolume
 	if deletedVolumes.Contains(req.VolumeId) {
-		log.Info("Skipping ControllerUnpublish for deleted volume ", req.VolumeId)
+		log.Infof("Skipping ControllerUnpublish for deleted volume %q", req.VolumeId)
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 	if !strings.Contains(req.VolumeId, ".vmdk") {
@@ -684,7 +684,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			return nil, status.Error(codes.Internal, msg)
 		}
 		if queryResult.Volumes[0].VolumeType == common.FileVolumeType {
-			log.Info("Skipping ControllerUnpublish for file volume ", req.VolumeId)
+			log.Infof("Skipping ControllerUnpublish for file volume %q", req.VolumeId)
 			return &csi.ControllerUnpublishVolumeResponse{}, nil
 		}
 	} else {

--- a/pkg/syncer/storagepool/intended_state.go
+++ b/pkg/syncer/storagepool/intended_state.go
@@ -144,7 +144,7 @@ func newIntendedVsanSNAState(ctx context.Context, ds *cnsvsphere.DatastoreInfo,
 	nodes := make([]string, 0)
 	nodes = append(nodes, node)
 
-	log.Infof("creating vsan sna sp", node)
+	log.Infof("creating vsan sna sp %q", node)
 	compatSC := make([]string, 0)
 	for _, scName := range vsan.compatSC {
 		if scWatchCntlr.isHostLocal(scName) {

--- a/pkg/syncer/storagepool/storageclasswatch.go
+++ b/pkg/syncer/storagepool/storageclasswatch.go
@@ -121,7 +121,7 @@ func (w *StorageClassWatch) watchStorageClass(ctx context.Context) {
 	for !done {
 		select {
 		case <-ctx.Done():
-			log.Info("watchStorageClass shutdown", "ctxErr", ctx.Err())
+			log.Infof("watchStorageClass shutdown. ctxErr: %+v", ctx.Err())
 			done = true
 		case e, ok := <-w.scWatch.ResultChan():
 			if !ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing the formatting issue related to logs in storagepool/intended_state.go

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #330 

**Special notes for your reviewer**:
Verified that the logs are printed with correct formatting
</pre>
{"level":"info","time":"2020-08-20T20:29:18.084571098Z","caller":"storagepool/intended_state.go:147","msg":"creating vsan sna sp sc2-10-186-56-9.eng.vmware.com","TraceId":"cfb872fa-e9fa-4891-a31c-90b8d13191b4"}
{"level":"info","time":"2020-08-20T20:29:18.140020088Z","caller":"storagepool/intended_state.go:147","msg":"creating vsan sna sp sc2-10-186-52-45.eng.vmware.com","TraceId":"cfb872fa-e9fa-4891-a31c-90b8d13191b4"}
</pre>

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Format logs in storagepoo/intended_state.go
```
