### PR TITLE
TKGS: Initialize FSS config info when reading GC config

### DIFF
--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -359,6 +359,9 @@ data:
     port = "{{ .SupervisorMasterPort }}"
     tanzukubernetescluster-uid = "{{ .TanzuKubernetesClusterUID }}"
     tanzukubernetescluster-name = "{{ .TanzuKubernetesClusterName }}"
+    [FeatureStatesConfig]
+    name = "csi-feature-states"
+    namespace = "{{ .PVCSINamespace }}"
 kind: ConfigMap
 metadata:
   name: pvcsi-config

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -359,6 +359,9 @@ data:
     port = "{{ .SupervisorMasterPort }}"
     tanzukubernetescluster-uid = "{{ .TanzuKubernetesClusterUID }}"
     tanzukubernetescluster-name = "{{ .TanzuKubernetesClusterName }}"
+    [FeatureStatesConfig]
+    name = "csi-feature-states"
+    namespace = "{{ .PVCSINamespace }}"
 kind: ConfigMap
 metadata:
   name: pvcsi-config

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -359,6 +359,9 @@ data:
     port = "{{ .SupervisorMasterPort }}"
     tanzukubernetescluster-uid = "{{ .TanzuKubernetesClusterUID }}"
     tanzukubernetescluster-name = "{{ .TanzuKubernetesClusterName }}"
+    [FeatureStatesConfig]
+    name = "csi-feature-states"
+    namespace = "{{ .PVCSINamespace }}"
 kind: ConfigMap
 metadata:
   name: pvcsi-config

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -305,8 +305,8 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 			// If feature states config info is not provided in vsphere conf, use defaults for vanilla k8s cluster
 			log.Infof("No feature states config information is provided in the Config. Using default config map name: %s and namespace: %s", DefaultFSSConfigMapName, DefaultFSSConfigMapNamespaceVanillaK8s)
 			cfg.FeatureStatesConfig.Namespace = DefaultFSSConfigMapNamespaceVanillaK8s
-		} else if clusterFlavor == cnstypes.CnsClusterFlavorWorkload || clusterFlavor == cnstypes.CnsClusterFlavorGuest {
-			// Feature states config info is not provided in vsphere conf in project pacific, use defaults for supervisor and tkg clusters
+		} else if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+			// Feature states config info is not provided in vsphere conf in project pacific, use defaults for supervisor cluster
 			cfg.FeatureStatesConfig.Namespace = DefaultCSINamespace
 		}
 	}
@@ -391,9 +391,6 @@ func FromEnvToGC(ctx context.Context, cfg *Config) error {
 		cfg.GC.TanzuKubernetesClusterUID = v
 	}
 
-	if cfg.GC.Port == "" {
-		cfg.GC.Port = DefaultGCPort
-	}
 	err := validateGCConfig(ctx, cfg)
 	if err != nil {
 		return err
@@ -441,6 +438,18 @@ func GetGCconfig(ctx context.Context, cfgPath string) (*Config, error) {
 			log.Errorf("failed to parse config. Err: %v", err)
 			return cfg, err
 		}
+	}
+	// Set default GCPort if Port is still empty
+	if cfg.GC.Port == "" {
+		cfg.GC.Port = DefaultGCPort
+	}
+	// Set default fss configmap name if SV FSS configmap info is not available in GC Config
+	if cfg.FeatureStatesConfig.Name == "" {
+		cfg.FeatureStatesConfig.Name = DefaultFSSConfigMapName
+	}
+	// Set default csi namespace if SV FSS configmap info is not available in GC Config
+	if cfg.FeatureStatesConfig.Namespace == "" {
+		cfg.FeatureStatesConfig.Namespace = DefaultCSINamespace
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is addressing the issue where FSS configmap information is empty for TKG cluster. This was happening because validateConfig is only called for Supervisor and Vanilla clusters. For TKG cluster we have another method by name:`GetGCconfig` and we can utilize this method to initialize FSS configmap info.

**Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged)**: fixes #402 

**Special notes for your reviewer**:
Before:
<pre>
{"level":"error","time":"2020-08-20T23:26:30.111764005Z","caller":"k8sorchestrator/k8sorchestrator.go:61","msg":"failed to fetch configmap  from namespace . Setting the feature states to default values: map[]. Error: resource name may not be empty","TraceId":"9043c9fc-a2fb-47d0-9345-128ddbb8f218","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.Newk8sOrchestrator.func1\n\t/build/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:61\nsync.(*Once).doSlow\n\t/usr/local/go/src/sync/once.go:66\nsync.(*Once).Do\n\t/usr/local/go/src/sync/once.go:57\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.Newk8sOrchestrator\n\t/build/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:47\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco.GetContainerOrchestratorInterface\n\t/build/pkg/csi/service/common/commonco/coagnostic.go:42\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.(*controller).Init\n\t/build/pkg/csi/service/wcpguest/controller.go:111\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service.(*service).BeforeServe\n\t/build/pkg/csi/service/service.go:121\ngithub.com/rexray/gocsi.(*StoragePlugin).Serve.func1\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/gocsi.go:246\nsync.(*Once).doSlow\n\t/usr/local/go/src/sync/once.go:66\nsync.(*Once).Do\n\t/usr/local/go/src/sync/once.go:57\ngithub.com/rexray/gocsi.(*StoragePlugin).Serve\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/gocsi.go:211\ngithub.com/rexray/gocsi.Run\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/gocsi.go:130\nmain.main\n\t/build/cmd/vsphere-csi/main.go:44\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203"}
</pre>

After:
<pre>
{"level":"info","time":"2020-08-21T00:18:01.047745536Z","caller":"k8sorchestrator/k8sorchestrator.go:139","msg":"New feature states values stored successfully: map[volume-extend:true volume-health:true]","TraceId":"c0a1fba9-9813-48ca-b71d-1abb35ded1e2"}
</pre>

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix FSS configmap info retrieval for TKG cluster
```
