### PR TITLE
validating admission webhook for storageclass

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -22,23 +22,31 @@ import (
 	"fmt"
 	"os"
 
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
-
 	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 
-	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/k8scloudoperator"
+
+	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/cnsoperator/manager"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/k8scloudoperator"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/storagepool"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/types"
 )
 
+// OperationModeWebHookServer starts container for webhook server
+const operationModeWebHookServer = "WEBHOOK_SERVER"
+
+// OperationModeWebHookServer starts container for metadata sync
+const operationModeMetaDataSync = "METADATA_SYNC"
+
 var (
 	enableLeaderElection = flag.Bool("leader-election", false, "Enable leader election.")
 	printVersion         = flag.Bool("version", false, "Print syncer version and exit")
+	operationMode        = flag.String("operation-mode", operationModeMetaDataSync, "specify operation mode METADATA_SYNC or WEBHOOK_SERVER")
 )
 
 // main for vsphere syncer
@@ -48,56 +56,62 @@ func main() {
 		fmt.Printf("%s\n", syncer.Version)
 		return
 	}
-	log := logger.GetLoggerWithNoContext()
-	log.Infof("Version : %s", syncer.Version)
-	// run will be executed if this instance is elected as the leader
-	// or if leader election is not enabled
-	var run func(ctx context.Context)
-	var err error
-
 	logType := logger.LogLevel(os.Getenv(logger.EnvLoggerLevel))
 	logger.SetLoggerLevel(logType)
 	ctx, log := logger.GetNewContextWithLogger()
+	log.Infof("Version : %s", syncer.Version)
 
 	clusterFlavor := cnstypes.CnsClusterFlavor(os.Getenv(csitypes.EnvClusterFlavor))
 	if clusterFlavor == "" {
 		clusterFlavor = cnstypes.CnsClusterFlavorVanilla
 	}
-	configInfo, err := types.InitConfigInfo(ctx)
-	if err != nil {
-		log.Errorf("failed to initialize the configInfo. Err: %+v", err)
-		os.Exit(1)
-	}
 
-	// Initialize K8sCloudOperator for every instance of vsphere-syncer in the Supervisor
-	// Cluster, independent of whether leader election is enabled.
-	// K8sCloudOperator should run on every node where csi controller can run.
-	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
-		go func() {
-			if err := k8scloudoperator.InitK8sCloudOperatorService(ctx); err != nil {
-				log.Errorf("Error initializing K8s Cloud Operator gRPC sever. Error: %+v", err)
-				os.Exit(1)
-			}
-		}()
-	}
-
-	// Initialize syncer components that are dependant on the outcome of leader election, if enabled.
-	run = initSyncerComponents(ctx, clusterFlavor, configInfo)
-
-	if !*enableLeaderElection {
-		run(context.TODO())
-	} else {
-		k8sClient, err := k8s.NewClient(ctx)
+	if *operationMode == operationModeWebHookServer {
+		log.Infof("Starting container with operation mode: %v", operationModeWebHookServer)
+		if webHookStartError := admissionhandler.StartWebhookServer(ctx); webHookStartError != nil {
+			log.Fatalf("failed to start webhook server. err: %v", webHookStartError)
+		}
+	} else if *operationMode == operationModeMetaDataSync {
+		log.Infof("Starting container with operation mode: %v", operationModeMetaDataSync)
+		var err error
+		configInfo, err := types.InitConfigInfo(ctx)
 		if err != nil {
-			log.Errorf("Creating Kubernetes client failed. Err: %v", err)
+			log.Errorf("failed to initialize the configInfo. Err: %+v", err)
 			os.Exit(1)
 		}
-		lockName := "vsphere-syncer"
-		le := leaderelection.NewLeaderElection(k8sClient, lockName, run)
+		// run will be executed if this instance is elected as the leader
+		// or if leader election is not enabled
+		var run func(ctx context.Context)
 
-		if err := le.Run(); err != nil {
-			log.Fatalf("Error initializing leader election: %v", err)
+		// Initialize K8sCloudOperator for every instance of vsphere-syncer in the Supervisor
+		// Cluster, independent of whether leader election is enabled.
+		// K8sCloudOperator should run on every node where csi controller can run.
+		if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+			go func() {
+				if err := k8scloudoperator.InitK8sCloudOperatorService(ctx); err != nil {
+					log.Fatalf("Error initializing K8s Cloud Operator gRPC sever. Error: %+v", err)
+				}
+			}()
 		}
+		// Initialize syncer components that are dependant on the outcome of leader election, if enabled.
+		run = initSyncerComponents(ctx, clusterFlavor, configInfo)
+
+		if !*enableLeaderElection {
+			run(context.TODO())
+		} else {
+			k8sClient, err := k8s.NewClient(ctx)
+			if err != nil {
+				log.Fatalf("Creating Kubernetes client failed. Err: %v", err)
+			}
+			lockName := "vsphere-syncer"
+			le := leaderelection.NewLeaderElection(k8sClient, lockName, run)
+
+			if err := le.Run(); err != nil {
+				log.Fatalf("Error initializing leader election: %v", err)
+			}
+		}
+	} else {
+		log.Fatalf("unsupported operation mode: %v", *operationMode)
 	}
 }
 

--- a/manifests/latest/vsphere-7.0u1/vanilla/deploy/create-validation-webhook.sh
+++ b/manifests/latest/vsphere-7.0u1/vanilla/deploy/create-validation-webhook.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright 2020 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  cat <<EOF
+Usage: Patch validatingwebhook.yaml with CA_BUNDLE retrieved from Kubernetes API server
+and create ValidatingWebhookConfiguration and vsphere-webhook-svc service using patched yaml file
+
+usage: ${0} [OPTIONS]
+The following flags are required.
+       --namespace        Namespace where webhook service and secret reside.
+EOF
+  exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+        --namespace)
+            namespace="$2"
+            shift
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+[ -z "${namespace}" ] && namespace=kube-system
+
+CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')
+
+# clean-up previously created service and validatingwebhookconfiguration. Ignore errors if not present.
+
+kubectl delete service vsphere-webhook-svc --namespace "${namespace}" 2>/dev/null || true
+kubectl delete validatingwebhookconfiguration.admissionregistration.k8s.io validation.csi.vsphere.vmware.com --namespace "${namespace}" 2>/dev/null || true
+kubectl delete serviceaccount vsphere-csi-webhook --namespace "${namespace}" 2>/dev/null || true
+kubectl delete clusterrole.rbac.authorization.k8s.io vsphere-csi-webhook-role 2>/dev/null || true
+kubectl delete clusterrolebinding.rbac.authorization.k8s.io vsphere-csi-webhook-role-binding --namespace "${namespace}" 2>/dev/null || true
+kubectl delete deployment vsphere-csi-webhook --namespace "${namespace}" || true
+
+# patch validatingwebhook.yaml with CA_BUNDLE and create service and validatingwebhookconfiguration
+sed "s/caBundle: .*$/caBundle: ${CA_BUNDLE}/g" validatingwebhook.yaml | kubectl apply -f -

--- a/manifests/latest/vsphere-7.0u1/vanilla/deploy/generate-signed-webhook-certs.sh
+++ b/manifests/latest/vsphere-7.0u1/vanilla/deploy/generate-signed-webhook-certs.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Copyright 2020 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# File originally from https://github.com/istio/istio/blob/release-0.7/install/kubernetes/webhook-create-signed-cert.sh
+set -e
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    cat <<EOF
+Usage: Generate certificate suitable for use with an webhook service.
+
+This script uses k8s' CertificateSigningRequest API to a generate a
+certificate signed by k8s CA suitable for use with sidecar-injector webhook
+services. This requires permissions to create and approve CSR. See
+https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster for
+detailed explanation and additional instructions.
+
+usage: ${0} [OPTIONS]
+The following flags are required.
+       --namespace        Namespace where webhook service and secret reside.
+EOF
+    exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+        --namespace)
+            namespace="$2"
+            shift
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+[ -z "${namespace}" ] && namespace=kube-system
+
+service=vsphere-webhook-svc
+secret=vsphere-webhook-certs
+
+
+if [ ! -x "$(command -v openssl)" ]; then
+    echo "openssl not found"
+    exit 1
+fi
+
+if [ ! -x "$(command -v kubectl)" ]; then
+    echo "kubectl not found"
+    exit 1
+fi
+
+csrName=${service}.${namespace}
+tmpdir=$(mktemp -d)
+echo "creating certs in tmpdir ${tmpdir} "
+
+cat <<EOF >> "${tmpdir}"/csr.conf
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ${service}
+DNS.2 = ${service}.${namespace}
+DNS.3 = ${service}.${namespace}.svc
+EOF
+
+openssl genrsa -out "${tmpdir}"/server-key.pem 2048
+openssl req -new -key "${tmpdir}"/server-key.pem -subj "/O=C=US/ST=CA/L=Palo Alto/O=VMware/OU=CNS" -out "${tmpdir}"/server.csr -config "${tmpdir}"/csr.conf
+
+
+# clean-up any previously created CSR for our service. Ignore errors if not present.
+kubectl delete csr ${csrName} 2>/dev/null || true
+
+# create  server cert/key CSR and  send to k8s API
+cat <<EOF | kubectl create -f -
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: ${csrName}
+spec:
+  groups:
+  - system:authenticated
+  request: $(base64 "${tmpdir}"/server.csr | tr -d '\n')
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+EOF
+
+# verify CSR has been created
+while true; do
+    if kubectl get csr "${csrName}"; then
+        break
+    fi
+    echo "waiting for CertificateSigningRequest: ${csrName} to be available"
+    sleep 1
+done
+
+# approve and fetch the signed certificate
+kubectl certificate approve ${csrName}
+# verify certificate has been signed
+for _ in $(seq 10); do
+    serverCert=$(kubectl get csr ${csrName} -o jsonpath='{.status.certificate}')
+    if [[ ${serverCert} != '' ]]; then
+        break
+    fi
+    echo "waiting for certificate request to complete"
+    sleep 1
+done
+if [[ ${serverCert} == '' ]]; then
+    echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 10 attempts." >&2
+    exit 1
+fi
+echo "${serverCert}" | openssl base64 -d -A -out "${tmpdir}"/server-cert.pem
+
+cat <<eof >"${tmpdir}"/webhook.config
+[WebHookConfig]
+port = "8443"
+cert-file = "/etc/webhook/cert.pem"
+key-file = "/etc/webhook/key.pem"
+
+# FeatureStatesConfig holds the details about feature states configmap.
+# Default feature states configmap name is set to "csi-feature-states"  and namespace is set to "kube-system"
+# Provide the configmap name and namespace details only when feature states configmap is not in the default namespace
+[FeatureStatesConfig]
+name = "csi-feature-states"
+namespace = "${namespace}"
+eof
+
+
+# create the secret with CA cert and server cert/key
+kubectl create secret generic "${secret}" \
+        --from-file=key.pem="${tmpdir}"/server-key.pem \
+        --from-file=cert.pem="${tmpdir}"/server-cert.pem \
+        --from-file=webhook.config="${tmpdir}"/webhook.config \
+        --dry-run=client -o yaml |
+    kubectl -n "${namespace}" apply -f -

--- a/manifests/latest/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
+++ b/manifests/latest/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
@@ -1,0 +1,112 @@
+# Requires k8s 1.19+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-webhook-svc
+  namespace: kube-system
+  labels:
+    app: vsphere-csi-webhook
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    app: vsphere-csi-webhook
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.csi.vsphere.vmware.com
+webhooks:
+  - name: validation.csi.vsphere.vmware.com
+    clientConfig:
+      service:
+        name: vsphere-webhook-svc
+        namespace: kube-system
+        path: "/validate"
+      caBundle: ${CA_BUNDLE}
+    rules:
+      - apiGroups:   ["storage.k8s.io"]
+        apiVersions: ["v1", "v1beta1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["storageclasses"]
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-webhook
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-webhook-role
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-webhook-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-webhook
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-webhook-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-webhook
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vsphere-csi-webhook
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-webhook
+        role: vsphere-csi-webhook
+    spec:
+      serviceAccountName: vsphere-csi-webhook
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - operator: "Exists"
+          effect: NoSchedule
+        - operator: "Exists"
+          effect: NoExecute
+      dnsPolicy: "Default"
+      containers:
+        - name: vsphere-webhook
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:<syncer-image-tag-with-webhook-support>
+          args:
+            - "--operation-mode=WEBHOOK_SERVER"
+          imagePullPolicy: "Always"
+          env:
+            - name: WEBHOOK_CONFIG_PATH
+              value: "/etc/webhook/webhook.config"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+          volumeMounts:
+            - mountPath: /etc/webhook
+              name: webhook-certs
+              readOnly: true
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        - name: webhook-certs
+          secret:
+            secretName: vsphere-webhook-certs

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -36,9 +36,6 @@ import (
 )
 
 const (
-	// DefaultK8sServiceAccount is the default name of the Kubernetes
-	// service account for csi controller.
-	DefaultK8sServiceAccount string = "vsphere-csi-controller"
 	// DefaultVCenterPort is the default port used to access vCenter.
 	DefaultVCenterPort string = "443"
 	// DefaultGCPort is the default port used to access Supervisor Cluster.
@@ -53,8 +50,6 @@ const (
 	EnvGCConfig = "GC_CONFIG"
 	// DefaultpvCSIProviderPath is the default path of pvCSI provider config
 	DefaultpvCSIProviderPath = "/etc/cloud/pvcsi-provider"
-	// DefaultFeatureStateValue is the default value for Feature state switches
-	DefaultFeatureStateValue = false
 	// DefaultFSSConfigMapName is the default name Feature states config map
 	DefaultFSSConfigMapName = "csi-feature-states"
 	// DefaultFSSConfigMapNamespaceVanillaK8s is the default value for Feature state config map namespace
@@ -128,7 +123,7 @@ func getEnvKeyValue(match string, partial bool) (string, string, error) {
 // takes precedence.
 func FromEnv(ctx context.Context, cfg *Config) error {
 	if cfg == nil {
-		return fmt.Errorf("Config object cannot be nil")
+		return fmt.Errorf("config object cannot be nil")
 	}
 	log := logger.GetLogger(ctx)
 	//Init
@@ -307,11 +302,11 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 	if cfg.FeatureStatesConfig.Name == "" && cfg.FeatureStatesConfig.Namespace == "" {
 		cfg.FeatureStatesConfig.Name = DefaultFSSConfigMapName
 		if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-			// If featurte states config info is not provided in vsphere conf, use defaults for vanilla k8s cluster
+			// If feature states config info is not provided in vsphere conf, use defaults for vanilla k8s cluster
 			log.Infof("No feature states config information is provided in the Config. Using default config map name: %s and namespace: %s", DefaultFSSConfigMapName, DefaultFSSConfigMapNamespaceVanillaK8s)
 			cfg.FeatureStatesConfig.Namespace = DefaultFSSConfigMapNamespaceVanillaK8s
 		} else if clusterFlavor == cnstypes.CnsClusterFlavorWorkload || clusterFlavor == cnstypes.CnsClusterFlavorGuest {
-			// Featurte states config info is not provided in vsphere conf in project pacific, use defaults for supervisor and tkg clusters
+			// Feature states config info is not provided in vsphere conf in project pacific, use defaults for supervisor and tkg clusters
 			cfg.FeatureStatesConfig.Namespace = DefaultCSINamespace
 		}
 	}
@@ -384,7 +379,7 @@ func GetDefaultNetPermission() *NetPermissionConfig {
 // takes precedence.
 func FromEnvToGC(ctx context.Context, cfg *Config) error {
 	if cfg == nil {
-		return fmt.Errorf("Config object cannot be nil")
+		return fmt.Errorf("config object cannot be nil")
 	}
 	if v := os.Getenv("WCP_ENDPOINT"); v != "" {
 		cfg.GC.Endpoint = v
@@ -410,7 +405,7 @@ func FromEnvToGC(ctx context.Context, cfg *Config) error {
 // Environment variables are also checked
 func ReadGCConfig(ctx context.Context, config io.Reader) (*Config, error) {
 	if config == nil {
-		return nil, fmt.Errorf("Guest Cluster config file is not present")
+		return nil, fmt.Errorf("guest cluster config file is not present")
 	}
 	cfg := &Config{}
 	if err := gcfg.FatalOnly(gcfg.ReadInto(cfg, config)); err != nil {
@@ -481,6 +476,7 @@ func GetSupervisorNamespace(ctx context.Context) (string, error) {
 
 // GetClusterFlavor returns the cluster flavor based on the env variable set in the driver deployment file
 func GetClusterFlavor(ctx context.Context) (cnstypes.CnsClusterFlavor, error) {
+	log := logger.GetLogger(ctx)
 	// CLUSTER_FLAVOR is defined only in Supervisor and Guest cluster deployments.
 	// If it is empty, it is implied that cluster flavor is Vanilla K8S
 	clusterFlavor := cnstypes.CnsClusterFlavor(os.Getenv("CLUSTER_FLAVOR"))
@@ -489,5 +485,7 @@ func GetClusterFlavor(ctx context.Context) (cnstypes.CnsClusterFlavor, error) {
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorGuest || clusterFlavor == cnstypes.CnsClusterFlavorWorkload || clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		return clusterFlavor, nil
 	}
-	return "", fmt.Errorf("Unrecognized value set for CLUSTER_FLAVOR")
+	errMsg := "unrecognized value set for CLUSTER_FLAVOR"
+	log.Error(errMsg)
+	return "", fmt.Errorf(errMsg)
 }

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissionhandler
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/fsnotify/fsnotify"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+)
+
+type (
+	parameterSet map[string]struct{}
+)
+
+// Has checks if specified paramName present in the paramSet
+func (paramSet parameterSet) Has(paramName string) bool {
+	_, ok := paramSet[paramName]
+	return ok
+}
+
+var (
+	server *http.Server
+	cfg    *config
+	k8s    commonco.COCommonInterface
+)
+
+// watchConfigChange watches on the webhook configuration directory for changes like cert, key etc.
+// this is required for certificate rotation
+func watchConfigChange() {
+	ctx, log := logger.GetNewContextWithLogger()
+	cfg, err := getWebHookConfig(ctx)
+	if err != nil {
+		log.Fatalf("failed to get webhook config. err: %v", err)
+	}
+	log.Debugf("Webhook config: %v", cfg)
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatalf("failed to create fsnotify watcher. err=%v", err)
+	}
+	go func() {
+		for {
+			var restartWebHookError error
+			log.Debugf("Waiting for event on fsnotify watcher")
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				log.Debugf("fsnotify event: %q", event.String())
+				if event.Op&fsnotify.Remove == fsnotify.Remove {
+					log.Infof("Restarting webhook server with new config")
+					errChan := make(chan error)
+					go func() {
+						err := restartWebhookServer(ctx)
+						if err != nil {
+							errChan <- err
+							return
+						}
+					}()
+					restartWebHookError = <-errChan
+					if restartWebHookError != nil {
+						log.Errorf("failed to restart webhook server. err: %v", err)
+					}
+				}
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					log.Errorf("fsnotify error: %+v", err)
+					return
+				}
+			}
+			log.Debugf("fsnotify event processed")
+		}
+	}()
+	webHookConfigPath := os.Getenv(envWebHookConfigPath)
+	if webHookConfigPath == "" {
+		webHookConfigPath = defaultWebHookConfigPath
+	}
+	err = watcher.Add(webHookConfigPath)
+	if err != nil {
+		log.Fatalf("failed to watch on path: %q. err=%v", webHookConfigPath, err)
+	}
+}
+
+// StartWebhookServer starts the webhook server
+func StartWebhookServer(ctx context.Context) error {
+	var stopCh = make(chan bool)
+	log := logger.GetLogger(ctx)
+	var err error
+	if cfg == nil {
+		cfg, err = getWebHookConfig(ctx)
+		if err != nil {
+			log.Errorf("failed to get webhook config. err: %v", err)
+			return err
+		}
+		log.Debugf("webhook config: %v", cfg)
+	}
+	if k8s == nil {
+		k8s, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, cfg.FeatureStatesConfig)
+		if err != nil {
+			log.Errorf("failed to get k8s interface. err: %v", err)
+			return err
+		}
+	}
+	if k8s.IsFSSEnabled(ctx, common.CSIMigration) {
+		certs, err := tls.LoadX509KeyPair(cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile)
+		if err != nil {
+			log.Errorf("failed to load key pair. certFile: %q, keyFile: %q err: %v", cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile, err)
+			return err
+		}
+		if cfg.WebHookConfig.Port == "" {
+			cfg.WebHookConfig.Port = defaultWebhookServerPort
+		}
+		server = &http.Server{
+			Addr:      fmt.Sprintf(":%v", cfg.WebHookConfig.Port),
+			TLSConfig: &tls.Config{Certificates: []tls.Certificate{certs}},
+		}
+		// define http server and server handler
+		mux := http.NewServeMux()
+		mux.HandleFunc("/validate", validationHandler)
+		server.Handler = mux
+
+		// start webhook server
+		log.Debugf("Starting webhook server on port: %v", cfg.WebHookConfig.Port)
+		go func() {
+			if err = server.ListenAndServeTLS(cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile); err != nil {
+				if err == http.ErrServerClosed {
+					log.Info("Webhook server stopped")
+				} else {
+					log.Fatalf("failed to listen and serve webhook server. err: %v", err)
+				}
+			}
+		}()
+		log.Info("Webhook server started")
+		watchConfigChange()
+		<-stopCh
+		return nil
+	}
+	return errors.New("can't start webhook. no features are enabled which requires webhook")
+}
+
+// restartWebhookServer stops the webhook server and start webhook using updated config
+func restartWebhookServer(ctx context.Context) error {
+	log := logger.GetLogger(ctx)
+	cfg, err := getWebHookConfig(ctx)
+	if err != nil {
+		log.Errorf("failed to get webhook config. err: %v", err)
+	}
+	log.Debugf("Webhook config: %v", cfg)
+	log.Info("Shutting down webhook server gracefully...")
+	err = server.Shutdown(context.Background())
+	if err != nil {
+		log.Errorf("failed to get shutdown webhook server. err: %v", err)
+		return err
+	}
+	log.Info("Restarting webhook server...")
+	return StartWebhookServer(ctx)
+}
+
+// validationHandler is the handler for webhook http multiplexer to help validate resources
+// depending on the URL validation of AdmissionReview will be redirected to appropriate validation function
+func validationHandler(w http.ResponseWriter, r *http.Request) {
+	var body []byte
+	ctx, log := logger.GetNewContextWithLogger()
+	if r.Body != nil {
+		if data, err := ioutil.ReadAll(r.Body); err == nil {
+			body = data
+		}
+	}
+	if len(body) == 0 {
+		log.Error("received empty request body")
+		http.Error(w, "received empty request body", http.StatusBadRequest)
+		return
+	}
+	log.Debugf("Received request")
+	// verify the content type is accurate
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		log.Errorf("content-Type=%s, expect application/json", contentType)
+		http.Error(w, "invalid Content-Type, expect `application/json`", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	var admissionResponse *admissionv1.AdmissionResponse
+	ar := admissionv1.AdmissionReview{}
+	codecs := serializer.NewCodecFactory(runtime.NewScheme())
+	deserializer := codecs.UniversalDeserializer()
+	if _, _, err := deserializer.Decode(body, nil, &ar); err != nil {
+		log.Errorf("Can't decode body: %v", err)
+		admissionResponse = &admissionv1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: err.Error(),
+			},
+		}
+	} else {
+		if r.URL.Path == "/validate" {
+			log.Debugf("request URL path is /validate")
+			log.Debugf("admissionReview: %+v", ar)
+			switch ar.Request.Kind.Kind {
+			case "StorageClass":
+				admissionResponse = validateStorageClass(ctx, &ar)
+			default:
+				log.Infof("Skipping validation for resource type: %q", ar.Request.Kind.Kind)
+				admissionResponse = &admissionv1.AdmissionResponse{
+					Allowed: true,
+				}
+			}
+			log.Debugf("admissionResponse: %+v", admissionResponse)
+		}
+	}
+	admissionReview := admissionv1.AdmissionReview{}
+	admissionReview.APIVersion = "admission.k8s.io/v1"
+	admissionReview.Kind = "AdmissionReview"
+	if admissionResponse != nil {
+		admissionReview.Response = admissionResponse
+		if ar.Request != nil {
+			admissionReview.Response.UID = ar.Request.UID
+		}
+	}
+	resp, err := json.Marshal(admissionReview)
+	if err != nil {
+		log.Errorf("Can't encode response: %v", err)
+		http.Error(w, fmt.Sprintf("could not encode response: %v", err), http.StatusInternalServerError)
+	}
+	log.Debugf("Ready to write response")
+	if _, err := w.Write(resp); err != nil {
+		log.Errorf("Can't write response: %v", err)
+		http.Error(w, fmt.Sprintf("could not write response: %v", err), http.StatusInternalServerError)
+	}
+}

--- a/pkg/syncer/admissionhandler/config.go
+++ b/pkg/syncer/admissionhandler/config.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissionhandler
+
+import (
+	"context"
+	"os"
+
+	"gopkg.in/gcfg.v1"
+
+	commonconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+)
+
+const (
+	envWebHookConfigPath     = "WEBHOOK_CONFIG_PATH"
+	defaultWebHookConfigPath = "/etc/webhook/webhook.config"
+	defaultWebhookServerPort = "8443"
+)
+
+// config holds webhook configuration and FeatureStatesConfig
+type config struct {
+	// WebHookConfig contains the detail about webhook - certfile, keyfile, port etc.
+	WebHookConfig webHookConfig
+	// FeatureStatesConfig is the details about feature states configmap
+	FeatureStatesConfig commonconfig.FeatureStatesConfigInfo
+}
+
+// webHookConfig holds webhook configuration using which webhook http server will be created
+type webHookConfig struct {
+	// CertFile is the location of the certificate in the container
+	CertFile string `gcfg:"cert-file"`
+	// KeyFile is the location of the private-key in the container
+	KeyFile string `gcfg:"key-file"`
+	// Port is the webhook port on which http server should be started
+	Port string `gcfg:"port"`
+}
+
+// getWebHookConfig returns webhook config
+func getWebHookConfig(ctx context.Context) (*config, error) {
+	log := logger.GetLogger(ctx)
+	webHookConfigPath := os.Getenv(envWebHookConfigPath)
+	if webHookConfigPath == "" {
+		webHookConfigPath = defaultWebHookConfigPath
+	}
+	file, err := os.Open(webHookConfigPath)
+	if err != nil {
+		log.Errorf("failed to open %q. Err: %v", webHookConfigPath, err)
+		return nil, err
+	}
+	cfg := &config{}
+	if err := gcfg.FatalOnly(gcfg.ReadInto(cfg, file)); err != nil {
+		log.Errorf("error while reading webhook config from file: %q: err: %+v", webHookConfigPath, err)
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/pkg/syncer/admissionhandler/validatestorageclass.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissionhandler
+
+import (
+	"context"
+	"encoding/json"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	stroagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+)
+
+var (
+	unSupportedParameters = parameterSet{
+		common.CSIMigrationParams:                   struct{}{},
+		common.DiskFormatMigrationParam:             struct{}{},
+		common.HostFailuresToTolerateMigrationParam: struct{}{},
+		common.ForceProvisioningMigrationParam:      struct{}{},
+		common.CacheReservationMigrationParam:       struct{}{},
+		common.DiskstripesMigrationParam:            struct{}{},
+		common.ObjectspacereservationMigrationParam: struct{}{},
+		common.IopslimitMigrationParam:              struct{}{},
+	}
+)
+
+const (
+	volumeExpansionErrorMessage = "AllowVolumeExpansion can not be set to true on the in-tree vSphere StorageClass"
+	migrationParamErrorMessage  = "Invalid StorageClass Parameters. Migration specific parameters should not be used in the StorageClass"
+)
+
+// validateStorageClass helps validate AdmissionReview requests for StroageClass
+func validateStorageClass(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	if k8s != nil && !k8s.IsFSSEnabled(ctx, common.CSIMigration) {
+		// if CSI migration is disabled and webhook is running
+		// skip validation for StorageClass
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+	log := logger.GetLogger(ctx)
+	req := ar.Request
+	var result *metav1.Status
+	allowed := true
+
+	switch req.Kind.Kind {
+	case "StorageClass":
+		sc := stroagev1.StorageClass{}
+		log.Debugf("JSON req.Object.Raw: %v", string(req.Object.Raw))
+		if err := json.Unmarshal(req.Object.Raw, &sc); err != nil {
+			log.Error("error deserializing storage class")
+			return &admissionv1.AdmissionResponse{
+				Result: &metav1.Status{
+					Message: err.Error(),
+				},
+			}
+		}
+		log.Infof("Validating StorageClass: %q", sc.Name)
+		// AllowVolumeExpansion check for kubernetes.io/vsphere-volume provisioner
+		if sc.Provisioner == "kubernetes.io/vsphere-volume" {
+			if sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion {
+				allowed = false
+				result = &metav1.Status{
+					Reason: volumeExpansionErrorMessage,
+				}
+			}
+		} else if sc.Provisioner == "csi.vsphere.vmware.com" {
+			// Migration parameters check for csi.vsphere.vmware.com provisioner
+			for param := range sc.Parameters {
+				if unSupportedParameters.Has(param) {
+					allowed = false
+					result = &metav1.Status{
+						Reason: migrationParamErrorMessage,
+					}
+					break
+				}
+			}
+		}
+		if allowed {
+			log.Infof("Validation of StorageClass: %q Passed", sc.Name)
+		} else {
+			log.Errorf("validation of StorageClass: %q Failed", sc.Name)
+		}
+	default:
+		allowed = false
+		log.Errorf("Can't validate resource kind: %q using validateStorageClass function", req.Kind.Kind)
+	}
+	// return AdmissionResponse result
+	return &admissionv1.AdmissionResponse{
+		Allowed: allowed,
+		Result:  result,
+	}
+}

--- a/pkg/syncer/admissionhandler/validatestorageclass_test.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissionhandler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var admissionReview = v1.AdmissionReview{
+	Request: &v1.AdmissionRequest{
+		Kind: metav1.GroupVersionKind{
+			Kind: "StorageClass",
+		},
+	},
+}
+
+// TestValidateStorageClassForAllowVolumeExpansion is the unit test for validating admissionReview request containing
+// StorageClass with allowVolumeExpansion set to true
+func TestValidateStorageClassForAllowVolumeExpansion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	admissionReview.Request.Object = runtime.RawExtension{
+		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": {\n    \"name\": \"sc\",\n    \"uid\": \"e5d6b37e-db23-4c1d-9aed-e38cdd0f9ec6\",\n    \"creationTimestamp\": \"2020-08-27T20:19:00Z\"\n  },\n  \"provisioner\": \"kubernetes.io/vsphere-volume\",\n  \"parameters\": {\n    \"hostFailuresToTolerate\": \"2\"\n  },\n  \"reclaimPolicy\": \"Delete\",\n  \"allowVolumeExpansion\": true,\n  \"volumeBindingMode\": \"Immediate\"\n}"),
+	}
+	admissionResponse := validateStorageClass(ctx, &admissionReview)
+	if !strings.Contains(string(admissionResponse.Result.Reason), volumeExpansionErrorMessage) || admissionResponse.Allowed {
+		t.Fatalf("TestValidateStorageClassForAllowVolumeExpansion failed. admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
+	}
+	t.Log("TestValidateStorageClassForAllowVolumeExpansion Passed")
+}
+
+// TestValidateStorageClassForMigrationParameter is the unit test for validating admissionReview request containing
+// StorageClass with migration related parameters
+func TestValidateStorageClassForMigrationParameter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	admissionReview.Request.Object = runtime.RawExtension{
+		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": {\n    \"name\": \"sc\",\n    \"uid\": \"a9ed134e-aab1-4624-8de4-b9d961cad861\",\n    \"creationTimestamp\": \"2020-08-27T20:57:00Z\"\n  },\n  \"provisioner\": \"csi.vsphere.vmware.com\",\n  \"parameters\": {\n    \"hostfailurestotolerate-migrationparam\": \"2\"\n  },\n  \"reclaimPolicy\": \"Delete\",\n  \"volumeBindingMode\": \"Immediate\"\n}"),
+	}
+	admissionResponse := validateStorageClass(ctx, &admissionReview)
+	if !strings.Contains(string(admissionResponse.Result.Reason), migrationParamErrorMessage) || admissionResponse.Allowed {
+		t.Fatalf("TestValidateStorageClassForMigrationParameter failed. admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
+	}
+	t.Log("TestValidateStorageClassForMigrationParameter Passed")
+}
+
+// TestValidateStorageClassForValidStorageClass is the unit test for validating admissionReview request containing
+// a valid StorageClass
+func TestValidateStorageClassForValidStorageClass(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	admissionReview.Request.Object = runtime.RawExtension{
+		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": {\n    \"name\": \"sc\",\n    \"uid\": \"a896f427-929a-4fc5-be95-078d99d57774\",\n    \"creationTimestamp\": \"2020-08-27T20:20:28Z\"\n  },\n  \"provisioner\": \"kubernetes.io/vsphere-volume\",\n  \"parameters\": {\n    \"hostFailuresToTolerate\": \"2\"\n  },\n  \"reclaimPolicy\": \"Delete\",\n  \"volumeBindingMode\": \"Immediate\"\n}"),
+	}
+	admissionResponse := validateStorageClass(ctx, &admissionReview)
+	if admissionResponse.Result != nil || !admissionResponse.Allowed {
+		t.Fatalf("TestValidateStorageClassForValidStorageClass failed. admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
+	}
+	t.Log("TestValidateStorageClassForValidStorageClass Passed")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We need this PR to meet following requirements

1. In the translation library for vSphere CSI Migration, we have added migration specific parameters to help send VCP parameters to CSI Driver. We are documenting that, new storage class should not be created using these migration specific parameters. We want to prevent a user from creating a storage class with these migration specific parameters. Refer: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/312#discussion_r468377097

2. vSphere Cloud Provider was not supporting volume expansion, but vSphere CSI Driver does. We want to prevent the user to expand the capability of in-tree volume. For now, we are returning an un-implemented response when the migrated volume is observed in the Controller expand volume call. Upstream reviewers suggested writing an admission controller to prevent a user from adding "allowVolumeExpansion: true" in-tree VCP storage class. 
Refer: https://github.com/kubernetes/kubernetes/issues/93727#issuecomment-669710189


This PR is adding 
- script for generating k8s singed certificates and certificate secret volume
- script for creating validation webhook service - `vsphere-webhook-svc` , `ValidatingWebhookConfiguration`, webhook deployment, and service account, roles and role binding for webhook deployment pod.
- adding operation modes to syncer container - `WEBHOOK_SERVER` and `METADATA_SYNC`. modes can be configured via a command-line flag - `operation-mode`
-  admission webhook handler for storage class validations.
-  added support for webhook server certificate rotation.
- unit tests for admission review validations.

 

**Which issue this PR fixes**
fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/317

**Special notes for your reviewer**:
Executed full sync and metadata syncer tests to ensure we are not breaking existing functionality. 

```
export GINKGO_FOCUS="full-sync-test|label-updates\sfor\sfile\svolumes"
```

Test Logs: 
[e2e-full-sync-pr-337.log](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/5258514/e2e-full-sync-pr-337.log)


```
Ran 8 of 106 Specs in 2948.793 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 98 Skipped
PASS

Ginkgo ran 1 suite in 49m24.468512616s
Test Suite Passed
```
**Unit Tests**

```
=== RUN   TestValidateStorageClassForAllowVolumeExpansion
{"level":"info","time":"2020-09-12T00:49:30.288605-07:00","caller":"admissionhandler/validatestorageclass.go:53","msg":"Validating StorageClass: \"sc\""}
{"level":"info","time":"2020-09-12T00:49:30.289978-07:00","caller":"admissionhandler/validatestorageclass.go:78","msg":"Validation of StorageClass: \"sc\" Failed"}
--- PASS: TestValidateStorageClassForAllowVolumeExpansion (0.01s)
    validatestorageclass_test.go:49: TestValidateStorageClassForAllowVolumeExpansion Passed
=== RUN   TestValidateStorageClassForMigrationParameter
{"level":"info","time":"2020-09-12T00:49:30.292081-07:00","caller":"admissionhandler/validatestorageclass.go:53","msg":"Validating StorageClass: \"sc\""}
{"level":"info","time":"2020-09-12T00:49:30.292117-07:00","caller":"admissionhandler/validatestorageclass.go:78","msg":"Validation of StorageClass: \"sc\" Failed"}
--- PASS: TestValidateStorageClassForMigrationParameter (0.00s)
    validatestorageclass_test.go:64: TestValidateStorageClassForMigrationParameter Passed
=== RUN   TestValidateStorageClassForValidStorageClass
{"level":"info","time":"2020-09-12T00:49:30.293419-07:00","caller":"admissionhandler/validatestorageclass.go:53","msg":"Validating StorageClass: \"sc\""}
{"level":"info","time":"2020-09-12T00:49:30.293443-07:00","caller":"admissionhandler/validatestorageclass.go:76","msg":"Validation of StorageClass: \"sc\" Passed"}
--- PASS: TestValidateStorageClassForValidStorageClass (0.00s)
    validatestorageclass_test.go:79: TestValidateStorageClassForValidStorageClass Passed
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler	1.161s
```

**Deployment**

vSphere CSI webhook Pod runs in seperate deployment.

```
% kubectl get deployment vsphere-csi-webhook --namespace=kube-system
NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
vsphere-csi-webhook   1/1     1            1           5m21s
```

```
 ./generate-signed-webhook-certs.sh 
creating certs in tmpdir /var/folders/vy/_6dvxx7j5db9sq9n38qjymwr002gzv/T/tmp.mclIK6Jn 
Generating RSA private key, 2048 bit long modulus
..............................+++
..................................................................................................+++
e is 65537 (0x10001)
certificatesigningrequest.certificates.k8s.io "vsphere-webhook-svc.kube-system" deleted
Warning: certificates.k8s.io/v1beta1 CertificateSigningRequest is deprecated in v1.19+, unavailable in v1.22+; use certificates.k8s.io/v1 CertificateSigningRequest
certificatesigningrequest.certificates.k8s.io/vsphere-webhook-svc.kube-system created
NAME                              AGE   SIGNERNAME                     REQUESTOR          CONDITION
vsphere-webhook-svc.kube-system   0s    kubernetes.io/legacy-unknown   kubernetes-admin   Pending
certificatesigningrequest.certificates.k8s.io/vsphere-webhook-svc.kube-system approved
secret/vsphere-webhook-certs configured
```


```
./create-validation-webhook.sh
service "vsphere-webhook-svc" deleted
validatingwebhookconfiguration.admissionregistration.k8s.io "validation.csi.vsphere.vmware.com" deleted
serviceaccount "vsphere-csi-webhook" deleted
clusterrole.rbac.authorization.k8s.io "vsphere-csi-webhook-role" deleted
clusterrolebinding.rbac.authorization.k8s.io "vsphere-csi-webhook-role-binding" deleted
deployment.apps "vsphere-csi-webhook" deleted
service/vsphere-webhook-svc created
validatingwebhookconfiguration.admissionregistration.k8s.io/validation.csi.vsphere.vmware.com created
serviceaccount/vsphere-csi-webhook created
clusterrole.rbac.authorization.k8s.io/vsphere-csi-webhook-role created
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-webhook-role-binding created
deployment.apps/vsphere-csi-webhook created
```



After Executing the above two scripts webhook configuration, webhook secret and webhook service and webhook deployment will be created.

webhook secret looks like as below

<img width="791" alt="Screen Shot 2020-09-17 at 11 41 55 PM" src="https://user-images.githubusercontent.com/22985595/93565029-881bca80-f93f-11ea-93f3-790b0d2ccf52.png">


`vsphere-webhook-svc` service binds to `vsphere-csi-webhook` pod.

```
% kubectl describe service vsphere-webhook-svc --namespace=kube-system
Name:              vsphere-webhook-svc
Namespace:         kube-system
Labels:            app=vsphere-csi-webhook
Annotations:       <none>
Selector:          app=vsphere-csi-webhook
Type:              ClusterIP
IP:                10.108.246.80
Port:              <unset>  443/TCP
TargetPort:        8443/TCP
Endpoints:         10.244.0.71:8443
Session Affinity:  None
Events:            <none>
```



**Testing Done**

Performed Certificate Rotation After the webhook server was up and running.

```
{"level":"info","time":"2020-09-18T06:38:57.130878949Z","caller":"admissionhandler/admissionhandler.go:80","msg":"Restarting webhook server with new config","TraceId":"60ac49c3-f6b1-4593-9d0a-d92371c7c06f"}
{"level":"info","time":"2020-09-18T06:38:57.134094286Z","caller":"admissionhandler/admissionhandler.go:178","msg":"shutting down webhook server gracefully...","TraceId":"60ac49c3-f6b1-4593-9d0a-d92371c7c06f"}
{"level":"info","time":"2020-09-18T06:38:57.135490729Z","caller":"admissionhandler/admissionhandler.go:184","msg":"restarting webhook server...","TraceId":"60ac49c3-f6b1-4593-9d0a-d92371c7c06f"}
{"level":"info","time":"2020-09-18T06:38:57.136872035Z","caller":"admissionhandler/admissionhandler.go:156","msg":"webhook server stopped","TraceId":"70f1f735-eff2-45b8-bd44-69c71348d4c1"}
{"level":"info","time":"2020-09-18T06:38:57.137622506Z","caller":"admissionhandler/admissionhandler.go:162","msg":"webhook server started","TraceId":"60ac49c3-f6b1-4593-9d0a-d92371c7c06f"}
```

User trying to create a new CSI storageclass with migration specific parameters.

```
# kubectl create -f sc.yaml 
Error from server (Invalid StorageClass Parameters. Migration specific parameters should not be used in the storage class): error when creating "sc.yaml": admission webhook "scvalidation.csi.vsphere.vmware.com" denied the request: Invalid StorageClass Parameters. Migration specific parameters should not be used in the storage class
```

User trying to create a new CSI storageclass with migration specific parameters.

```
# kubectl create -f sc.yaml
Error from server (AllowVolumeExpansion can not be set to true on the in-tree vSphere storage class): error when creating "sc-volume-expansion.yaml": admission webhook "scvalidation.csi.vsphere.vmware.com" denied the request: AllowVolumeExpansion can not be set to true on the in-tree vSphere storage class
```

User trying to edit a VCP storageclass with allowVolumeExpansion: true

```
# kubectl edit sc vcpsc
Edit cancelled, no changes made.
```

User trying to patch a VCP storageclass with allowVolumeExpansion: true

```
# kubectl apply  -f sc-volume-expansion.yaml 
Error from server (AllowVolumeExpansion can not be set to true on the in-tree vSphere storage class): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"allowVolumeExpansion\":true,\"apiVersion\":\"storage.k8s.io/v1\",\"kind\":\"StorageClass\",\"metadata\":{\"annotations\":{},\"name\":\"vcpsc\"},\"parameters\":{\"hostFailuresToTolerate\":\"2\"},\"provisioner\":\"kubernetes.io/vsphere-volume\"}\n"}}}
to:
Resource: "storage.k8s.io/v1, Resource=storageclasses", GroupVersionKind: "storage.k8s.io/v1, Kind=StorageClass"
Name: "vcpsc", Namespace: ""
for: "sc-volume-expansion.yaml": admission webhook "scvalidation.csi.vsphere.vmware.com" denied the request: AllowVolumeExpansion can not be set to true on the in-tree vSphere storage class
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
validating admission webhook for storageclass
```

cc: @chethanv28 @SandeepPissay @xing-yang 