### PR TITLE
Set feature state once before full sync operations

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -60,6 +60,9 @@ func main() {
 	ctx, log := logger.GetNewContextWithLogger()
 
 	clusterFlavor := cnstypes.CnsClusterFlavor(os.Getenv(csitypes.EnvClusterFlavor))
+	if clusterFlavor == "" {
+		clusterFlavor = cnstypes.CnsClusterFlavorVanilla
+	}
 	configInfo, err := types.InitConfigInfo(ctx)
 	if err != nil {
 		log.Errorf("failed to initialize the configInfo. Err: %+v", err)

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -36,7 +36,11 @@ import (
 func csiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) {
 	log := logger.GetLogger(ctx)
 	log.Infof("FullSync: start")
-
+	var migrationFeatureStateForFullSync bool
+	// Fetch CSI migration feature state once, before performing full sync operations
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
+		migrationFeatureStateForFullSync = metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration)
+	}
 	// Get K8s PVs in State "Bound", "Available" or "Released"
 	k8sPVs, err := getPVsInBoundAvailableOrReleased(ctx, metadataSyncer)
 	if err != nil {
@@ -52,7 +56,7 @@ func csiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) {
 	for _, pv := range k8sPVs {
 		var volumeHandle string
 		var err error
-		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
+		if migrationFeatureStateForFullSync && pv.Spec.VsphereVolume != nil {
 			// For vSphere volumes, the migration service will register volumes in CNS.
 			migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
 			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
@@ -88,7 +92,7 @@ func csiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) {
 		return
 	}
 	// get map of "pv to EntityMetadata" in CNS and "pv to EntityMetadata" in kubernetes
-	pvToCnsEntityMetadataMap, pvToK8sEntityMetadataMap, err := getEntityMetadata(ctx, k8sPVs, queryAllResult.Volumes, pvToPVCMap, pvcToPodMap, metadataSyncer)
+	pvToCnsEntityMetadataMap, pvToK8sEntityMetadataMap, err := getEntityMetadata(ctx, k8sPVs, queryAllResult.Volumes, pvToPVCMap, pvcToPodMap, metadataSyncer, migrationFeatureStateForFullSync)
 	if err != nil {
 		log.Errorf("FullSync: getEntityMetadata failed with err %+v", err)
 		return
@@ -96,8 +100,8 @@ func csiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) {
 	log.Debugf("FullSync: pvToCnsEntityMetadataMap %+v \n pvToK8sEntityMetadataMap: %+v \n", spew.Sdump(pvToCnsEntityMetadataMap), spew.Sdump(pvToK8sEntityMetadataMap))
 	// Get specs for create and update volume calls
 	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor)
-	createSpecArray, updateSpecArray := getVolumeSpecs(ctx, k8sPVs, pvToCnsEntityMetadataMap, pvToK8sEntityMetadataMap, containerCluster)
-	volToBeDeleted, err := getVolumesToBeDeleted(ctx, queryAllResult.Volumes, k8sPVMap, metadataSyncer)
+	createSpecArray, updateSpecArray := getVolumeSpecs(ctx, k8sPVs, pvToCnsEntityMetadataMap, pvToK8sEntityMetadataMap, containerCluster, migrationFeatureStateForFullSync)
+	volToBeDeleted, err := getVolumesToBeDeleted(ctx, queryAllResult.Volumes, k8sPVMap, metadataSyncer, migrationFeatureStateForFullSync)
 	if err != nil {
 		log.Errorf("FullSync: failed to get list of volumes to be deleted with err %+v", err)
 		return
@@ -105,9 +109,9 @@ func csiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) {
 	wg := sync.WaitGroup{}
 	wg.Add(3)
 	// Perform operations
-	go fullSyncCreateVolumes(ctx, createSpecArray, metadataSyncer, &wg)
+	go fullSyncCreateVolumes(ctx, createSpecArray, metadataSyncer, &wg, migrationFeatureStateForFullSync)
 	go fullSyncUpdateVolumes(ctx, updateSpecArray, metadataSyncer, &wg)
-	go fullSyncDeleteVolumes(ctx, volToBeDeleted, metadataSyncer, &wg)
+	go fullSyncDeleteVolumes(ctx, volToBeDeleted, metadataSyncer, &wg, migrationFeatureStateForFullSync)
 	wg.Wait()
 
 	cleanupCnsMaps(k8sPVMap)
@@ -119,7 +123,7 @@ func csiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) {
 // fullSyncCreateVolumes create volumes with given array of createSpec
 // Before creating a volume, all current K8s volumes are retrieved
 // If the volume is successfully created, it is removed from cnsCreationMap
-func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVolumeCreateSpec, metadataSyncer *metadataSyncInformer, wg *sync.WaitGroup) {
+func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVolumeCreateSpec, metadataSyncer *metadataSyncInformer, wg *sync.WaitGroup, migrationFeatureStateForFullSync bool) {
 	log := logger.GetLogger(ctx)
 	defer wg.Done()
 	currentK8sPVMap := make(map[string]bool)
@@ -135,7 +139,7 @@ func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVo
 	for _, pv := range currentK8sPV {
 		var volumeHandle string
 		var err error
-		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
+		if migrationFeatureStateForFullSync && pv.Spec.VsphereVolume != nil {
 			migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
 			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
@@ -174,7 +178,7 @@ func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVo
 // fullSyncDeleteVolumes delete volumes with given array of volumeId
 // Before deleting a volume, all current K8s volumes are retrieved
 // If the volume is successfully deleted, it is removed from cnsDeletionMap
-func fullSyncDeleteVolumes(ctx context.Context, volumeIDDeleteArray []cnstypes.CnsVolumeId, metadataSyncer *metadataSyncInformer, wg *sync.WaitGroup) {
+func fullSyncDeleteVolumes(ctx context.Context, volumeIDDeleteArray []cnstypes.CnsVolumeId, metadataSyncer *metadataSyncInformer, wg *sync.WaitGroup, migrationFeatureStateForFullSync bool) {
 	defer wg.Done()
 	log := logger.GetLogger(ctx)
 	deleteDisk := false
@@ -191,7 +195,7 @@ func fullSyncDeleteVolumes(ctx context.Context, volumeIDDeleteArray []cnstypes.C
 	for _, pv := range currentK8sPV {
 		var volumeHandle string
 		var err error
-		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
+		if migrationFeatureStateForFullSync && pv.Spec.VsphereVolume != nil {
 			migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
 			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
@@ -240,8 +244,10 @@ func fullSyncDeleteVolumes(ctx context.Context, volumeIDDeleteArray []cnstypes.C
 					log.Warnf("FullSync: fullSyncDeleteVolumes: Failed to delete volume %s with error %+v", volume.VolumeId.Id, err)
 					continue
 				}
-				if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
+				if migrationFeatureStateForFullSync {
 					err := volumeMigrationService.DeleteVolumeInfo(ctx, volume.VolumeId.Id)
+					// For non-migrated volumes DeleteVolumeInfo will not return error and
+					// So, the volume id will be deleted from cnsDeletionMap
 					if err != nil {
 						log.Warnf("FullSync: fullSyncDeleteVolumes: Failed to delete volume mapping CR for %s with error %+v", volume.VolumeId.Id, err)
 						continue
@@ -296,7 +302,7 @@ func buildCnsMetadataList(ctx context.Context, pv *v1.PersistentVolume, pvToPVCM
 
 // getEntityMetadata builds and return map of pv to EntityMetadata in CNS (pvToCnsEntityMetadataMap) and
 // map of pv to EntityMetadata in kubernetes (pvToK8sEntityMetadataMap)
-func getEntityMetadata(ctx context.Context, pvList []*v1.PersistentVolume, cnsVolumeList []cnstypes.CnsVolume, pvToPVCMap pvcMap, pvcToPodMap podMap, metadataSyncer *metadataSyncInformer) (map[string][]cnstypes.BaseCnsEntityMetadata, map[string][]cnstypes.BaseCnsEntityMetadata, error) {
+func getEntityMetadata(ctx context.Context, pvList []*v1.PersistentVolume, cnsVolumeList []cnstypes.CnsVolume, pvToPVCMap pvcMap, pvcToPodMap podMap, metadataSyncer *metadataSyncInformer, migrationFeatureStateForFullSync bool) (map[string][]cnstypes.BaseCnsEntityMetadata, map[string][]cnstypes.BaseCnsEntityMetadata, error) {
 	log := logger.GetLogger(ctx)
 	pvToCnsEntityMetadataMap := make(map[string][]cnstypes.BaseCnsEntityMetadata)
 	pvToK8sEntityMetadataMap := make(map[string][]cnstypes.BaseCnsEntityMetadata)
@@ -311,7 +317,7 @@ func getEntityMetadata(ctx context.Context, pvList []*v1.PersistentVolume, cnsVo
 		k8sMetadata := buildCnsMetadataList(ctx, pv, pvToPVCMap, pvcToPodMap, metadataSyncer.configInfo.Cfg.Global.ClusterID)
 		var volumeHandle string
 		var err error
-		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
+		if migrationFeatureStateForFullSync && pv.Spec.VsphereVolume != nil {
 			migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
 			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
@@ -357,7 +363,7 @@ func getEntityMetadata(ctx context.Context, pvList []*v1.PersistentVolume, cnsVo
 
 // getVolumeSpecs return list of CnsVolumeCreateSpec for volumes which needs to be created in CNS and a list of
 // CnsVolumeMetadataUpdateSpec for volumes which needs to be updated in CNS.
-func getVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, pvToCnsEntityMetadataMap map[string][]cnstypes.BaseCnsEntityMetadata, pvToK8sEntityMetadataMap map[string][]cnstypes.BaseCnsEntityMetadata, containerCluster cnstypes.CnsContainerCluster) ([]cnstypes.CnsVolumeCreateSpec, []cnstypes.CnsVolumeMetadataUpdateSpec) {
+func getVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, pvToCnsEntityMetadataMap map[string][]cnstypes.BaseCnsEntityMetadata, pvToK8sEntityMetadataMap map[string][]cnstypes.BaseCnsEntityMetadata, containerCluster cnstypes.CnsContainerCluster, migrationFeatureStateForFullSync bool) ([]cnstypes.CnsVolumeCreateSpec, []cnstypes.CnsVolumeMetadataUpdateSpec) {
 	log := logger.GetLogger(ctx)
 	var createSpecArray []cnstypes.CnsVolumeCreateSpec
 	var updateSpecArray []cnstypes.CnsVolumeMetadataUpdateSpec
@@ -366,7 +372,7 @@ func getVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, pvToCnsE
 		var operationType string
 		var volumeHandle string
 		var err error
-		if common.CSIMigrationFeatureEnabled && pv.Spec.VsphereVolume != nil {
+		if migrationFeatureStateForFullSync && pv.Spec.VsphereVolume != nil {
 			migrationVolumeSpec := migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath, StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
 			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
@@ -473,13 +479,13 @@ func getVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, pvToCnsE
 
 // getVolumesToBeDeleted return list of volumeIds that need to be deleted
 // A volumeId is added to this list only if it was present in cnsDeletionMap across two cycles of full sync
-func getVolumesToBeDeleted(ctx context.Context, cnsVolumeList []cnstypes.CnsVolume, k8sPVMap map[string]string, metadataSyncer *metadataSyncInformer) ([]cnstypes.CnsVolumeId, error) {
+func getVolumesToBeDeleted(ctx context.Context, cnsVolumeList []cnstypes.CnsVolume, k8sPVMap map[string]string, metadataSyncer *metadataSyncInformer, migrationFeatureStateForFullSync bool) ([]cnstypes.CnsVolumeId, error) {
 	log := logger.GetLogger(ctx)
 	var volToBeDeleted []cnstypes.CnsVolumeId
 	// inlineVolumeMap holds the volume path information for migrated volumes which are used by Pods
 	inlineVolumeMap := make(map[string]string)
 	var err error
-	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
+	if migrationFeatureStateForFullSync {
 		inlineVolumeMap, err = getInlineMigratedVolumesInfo(ctx, metadataSyncer)
 		if err != nil {
 			log.Errorf("FullSync: Failed to get inline migrated volumes. Err: %v", err)
@@ -494,7 +500,7 @@ func getVolumesToBeDeleted(ctx context.Context, cnsVolumeList []cnstypes.CnsVolu
 				volToBeDeleted = append(volToBeDeleted, vol.VolumeId)
 			} else {
 				// Add to cnsDeletionMap
-				if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
+				if migrationFeatureStateForFullSync {
 					// If migration is ON, verify if the volume is present in inlineVolumeMap
 					if _, existsInInlineVolumeMap := inlineVolumeMap[vol.VolumeId.Id]; !existsInInlineVolumeMap {
 						log.Infof("FullSync: Volume with id %q added to cnsDeletionMap", vol.VolumeId.Id)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is improving the way full sync operations are invoked during CSI migration. Full sync is currently performing numerous operations in one cycle, and this PR is making sure the operations are run based on CSI migration feature state before the start of full sync cycle. Each operation in full sync need not fetch the feature state every time. This could lead to full sync volume maps to go for a toss
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #294 

**Special notes for your reviewer**:
<pre>
Create VCP volumes
Deployed CSI driver with migration disabled and full sync set to 1 minute
Enable migration on kubelet and controller-manager
Restart kubelet
Enable migration on CSI driver
Wait for 1 full sync cyle
Verified volumes were migrated with metadata updated on CNS UI

2020-09-02T17:56:36.085Z	DEBUG	syncer/fullsync.go:125	FullSync: cnsCreationMap at end of cycle: map[]	{"TraceId": "c05c510b-c366-4c74-ac6b-a5dde4e17fbc"}
2020-09-02T17:56:36.085Z	INFO	syncer/fullsync.go:126	FullSync: end	{"TraceId": "c05c510b-c366-4c74-ac6b-a5dde4e17fbc"}
2020-09-02T17:56:36.439Z	INFO	syncer/metadatasyncer.go:263	fullSync is triggered	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:36.440Z	INFO	syncer/fullsync.go:44	FullSync: start	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:36.440Z	INFO	syncer/fullsync.go:47	IsFSSEnabled true	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:36.440Z	DEBUG	syncer/util.go:30	FullSync: Getting all PVs in Bound, Available or Released state	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:36.441Z	DEBUG	syncer/util.go:221	pv.kubernetes.io/migrated-to annotation found with value "csi.vsphere.vmware.com" for PV: "pvc-3fbbc429-c405-409f-a000-e97205091ef9"	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:36.441Z	DEBUG	syncer/util.go:39	FullSync: pv pvc-3fbbc429-c405-409f-a000-e97205091ef9 is in state Bound	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:36.442Z	DEBUG	syncer/util.go:221	pv.kubernetes.io/migrated-to annotation found with value "csi.vsphere.vmware.com" for PV: "pvc-7586799e-b9b7-4630-a06e-4c8d9a815518"	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:36.442Z	DEBUG	syncer/util.go:39	FullSync: pv pvc-7586799e-b9b7-4630-a06e-4c8d9a815518 is in state Bound	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:36.454Z	DEBUG	migration/migration.go:180	VolumeID: "16a72b26-bb3d-45c4-a626-9953f3d770ae" found from the cache for VolumePath: "[vsanDatastore] 4eef2a5f-1806-21ce-9423-02003bdc230b/kubernetes-dynamic-pvc-3fbbc429-c405-409f-a000-e97205091ef9.vmdk"	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:36.455Z	DEBUG	migration/migration.go:180	VolumeID: "7131b35b-c7cb-499b-94f8-b627b0fee492" found from the cache for VolumePath: "[vsanDatastore] 4eef2a5f-1806-21ce-9423-02003bdc230b/kubernetes-dynamic-pvc-7586799e-b9b7-4630-a06e-4c8d9a815518.vmdk"	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:36.455Z	DEBUG	syncer/fullsync.go:547	FullSync: pvc default/vcppvc is backed by pv pvc-3fbbc429-c405-409f-a000-e97205091ef9	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:36.456Z	DEBUG	syncer/fullsync.go:547	FullSync: pvc default/vcppvc-1 is backed by pv pvc-7586799e-b9b7-4630-a06e-4c8d9a815518	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:36.460Z	DEBUG	syncer/fullsync.go:85	FullSync: pvToPVCMap map[pvc-3fbbc429-c405-409f-a000-e97205091ef9:&PersistentVolumeClaim{ObjectMeta:{vcppvc  default /api/v1/namespaces/default/persistentvolumeclaims/vcppvc 3fbbc429-c405-409f-a000-e97205091ef9 7172151 0 2020-09-02 17:46:37 +0000 UTC <nil> <nil> map[] map[pv.kubernetes.io/bind-completed:yes pv.kubernetes.io/bound-by-controller:yes pv.kubernetes.io/migrated-to:csi.vsphere.vmware.com volume.beta.kubernetes.io/storage-
....
....
	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:38.804Z	INFO	syncer/fullsync.go:411	FullSync: update is not required for volume: "7131b35b-c7cb-499b-94f8-b627b0fee492"	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:38.804Z	DEBUG	syncer/fullsync.go:503	FullSync: Volume with id eafca33b-412d-4a41-a662-5952cf6d95a3 added to delete list as it was present in cnsDeletionMap across two fullsync cycles	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:38.804Z	DEBUG	syncer/util.go:30	FullSync: Getting all PVs in Bound, Available or Released state	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:38.804Z	DEBUG	syncer/util.go:221	pv.kubernetes.io/migrated-to annotation found with value "csi.vsphere.vmware.com" for PV: "pvc-3fbbc429-c405-409f-a000-e97205091ef9"	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:38.804Z	DEBUG	syncer/util.go:39	FullSync: pv pvc-3fbbc429-c405-409f-a000-e97205091ef9 is in state Bound	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:38.804Z	DEBUG	syncer/util.go:221	pv.kubernetes.io/migrated-to annotation found with value "csi.vsphere.vmware.com" for PV: "pvc-7586799e-b9b7-4630-a06e-4c8d9a815518"	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:38.804Z	DEBUG	syncer/util.go:39	FullSync: pv pvc-7586799e-b9b7-4630-a06e-4c8d9a815518 is in state Bound	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:38.804Z	DEBUG	migration/migration.go:180	VolumeID: "16a72b26-bb3d-45c4-a626-9953f3d770ae" found from the cache for VolumePath: "[vsanDatastore] 4eef2a5f-1806-21ce-9423-02003bdc230b/kubernetes-dynamic-pvc-3fbbc429-c405-409f-a000-e97205091ef9.vmdk"	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:38.804Z	DEBUG	migration/migration.go:180	VolumeID: "7131b35b-c7cb-499b-94f8-b627b0fee492" found from the cache for VolumePath: "[vsanDatastore] 4eef2a5f-1806-21ce-9423-02003bdc230b/kubernetes-dynamic-pvc-7586799e-b9b7-4630-a06e-4c8d9a815518.vmdk"	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}
2020-09-02T17:56:38.804Z	DEBUG	syncer/util.go:142	Query volumes with offset: 0 and limit: 500	{"TraceId": "06329dfd-39f2-46b7-95af-570de27e04d3"}

<img width="1121" alt="CNS UI" src="https://user-images.githubusercontent.com/14131348/92020996-e6289b00-ed0d-11ea-9725-41364c34e6d2.png">

</pre>
e2e logs: https://gist.github.com/chethanv28/d49f74a46c2bb270c6a55442e3b420a9
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Set feature state flag once before running full sync operations
```
