### PR TITLE
static fileshare volume provisioning without fstype

### DIFF
--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -404,7 +404,7 @@ func getVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, pvToCnsE
 		switch operationType {
 		case "createVolume":
 			var volumeType string
-			if pv.Spec.CSI.FSType == common.NfsV4FsType || pv.Spec.CSI.FSType == common.NfsFsType {
+			if IsMultiAttachAllowed(pv) {
 				volumeType = common.FileVolumeType
 			} else {
 				volumeType = common.BlockVolumeType

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -849,7 +849,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 	if oldPv.Status.Phase == v1.VolumePending && newPv.Status.Phase == v1.VolumeAvailable && newPv.Spec.StorageClassName == "" {
 		// Static PV is Created
 		var volumeType string
-		if oldPv.Spec.CSI.FSType == common.NfsV4FsType || oldPv.Spec.CSI.FSType == common.NfsFsType {
+		if IsMultiAttachAllowed(oldPv) {
 			volumeType = common.FileVolumeType
 		} else {
 			volumeType = common.BlockVolumeType
@@ -939,7 +939,8 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 	volumeOperationsLock.Lock()
 	defer volumeOperationsLock.Unlock()
 
-	if pv.Spec.CSI.FSType == common.NfsV4FsType || pv.Spec.CSI.FSType == common.NfsFsType {
+	if IsMultiAttachAllowed(pv) {
+		// if PV is file share volume
 		log.Debugf("PVDeleted: vSphere CSI Driver is calling UpdateVolumeMetadata to delete volume metadata references for PV: %q", pv.Name)
 		var metadataList []cnstypes.BaseCnsEntityMetadata
 		pvMetadata := cnsvsphere.GetCnsKubernetesEntityMetaData(pv.Name, nil, true, string(cnstypes.CnsKubernetesEntityTypePV), "", metadataSyncer.configInfo.Cfg.Global.ClusterID, nil)

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -242,3 +242,20 @@ func GetSCNameFromPVC(pvc *v1.PersistentVolumeClaim) (string, error) {
 	}
 	return *scName, nil
 }
+
+// IsMultiAttachAllowed helps check accessModes on the PV and return true if volume can be attached to
+// multiple nodes.
+func IsMultiAttachAllowed(pv *v1.PersistentVolume) bool {
+	if pv == nil {
+		return false
+	}
+	if len(pv.Spec.AccessModes) == 0 {
+		return false
+	}
+	for _, accessMode := range pv.Spec.AccessModes {
+		if accessMode == v1.ReadWriteMany || accessMode == v1.ReadOnlyMany {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing Static file share Volume provisioning when `fstype` is not specified in the PV spec.
`fstype` is an optional parameter for dynamic file share volume provisioning https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/example/vanilla-k8s-file-driver/example-sc.yaml#L10
so it should be optional for static file share volume provisioning.


**Which issue this PR fixes**
fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/344

**Special notes for your reviewer**:
Verified change using PV YAML

```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: static-file-share-pv-name
  annotations:
    pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
  labels:
    "static-pv-label-key": "static-pv-label-value"      # This label is used as selector to bind with volume claim.
                                                        # This can be any unique key-value to identify PV.
spec:
  capacity:
    storage: 5Gi
  accessModes:
    - ReadWriteMany
  persistentVolumeReclaimPolicy: Delete
  csi:
    driver: "csi.vsphere.vmware.com"
    volumeAttributes:
      type: "vSphere CNS File Volume"
    "volumeHandle": "file:5c57a66e-26d7-42c9-9aa8-366a32660e29" # vsan file share volume id, note prefix: file is required in the volumeHandle
```

Also Created PVC to bind with this PV and Created Pods to verify end to end workflow.

```
 % kubectl get pv 
NAME                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                STORAGECLASS   REASON   AGE
static-file-share-pv-name   5Gi        RWX            Delete           Bound    default/static-file-share-pvc-name                           148m

% kubectl describe pv
Name:            static-file-share-pv-name
Labels:          static-pv-label-key=static-pv-label-value
Annotations:     pv.kubernetes.io/bound-by-controller: yes
                 pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:      [kubernetes.io/pv-protection external-attacher/csi-vsphere-vmware-com]
StorageClass:    
Status:          Bound
Claim:           default/static-file-share-pvc-name
Reclaim Policy:  Delete
Access Modes:    RWX
VolumeMode:      Filesystem
Capacity:        5Gi
Node Affinity:   <none>
Message:         
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            
    VolumeHandle:      file:5c57a66e-26d7-42c9-9aa8-366a32660e29
    ReadOnly:          false
    VolumeAttributes:      type=vSphere CNS File Volume
Events:                <none>

% kubectl get pvc
NAME                         STATUS   VOLUME                      CAPACITY   ACCESS MODES   STORAGECLASS   AGE
static-file-share-pvc-name   Bound    static-file-share-pv-name   5Gi        RWX                           148m

% kubectl get pods
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-file-pod1   1/1     Running   0          107m
example-vanilla-file-pod2   1/1     Running   0          107m
example-vanilla-file-pod3   1/1     Running   0          107m


```

**Syncer Logs:** 
[vsphere-syncer-static.log](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/5165102/vsphere-syncer-static.log)


**E2E Test logs**
Executed full sync and syncer test cases
using `GINKGO_FOCUS="full-sync-test|label-updates\sfor\sfile\svolumes"`

Test logs - https://gist.github.com/divyenpatel/c84b7924f8109873b4e998e32637924b#file-pr-345-e2e-test-logs

Summary

```
Ran 8 of 106 Specs in 2997.490 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 98 Skipped
PASS

Ginkgo ran 1 suite in 50m15.66584085s
Test Suite Passed
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
static fileshare volume provisioning without fstype
```

cc: @shalini-b 