### PR TITLE
Update pod metadata in full sync only when pod status is running

### DIFF
--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -536,7 +536,7 @@ func buildPVCMapPodMap(ctx context.Context, pvList []*v1.PersistentVolume, metad
 			pvToPVCMap[pv.Name] = pvc
 			log.Debugf("FullSync: pvc %s/%s is backed by pv %s", pvc.Namespace, pvc.Name, pv.Name)
 			for _, pod := range pods {
-				if pod.Spec.Volumes != nil {
+				if pod.Status.Phase == v1.PodRunning && pod.Spec.Volumes != nil {
 					for _, volume := range pod.Spec.Volumes {
 						pvClaim := volume.VolumeSource.PersistentVolumeClaim
 						if pvClaim != nil && pvClaim.ClaimName == pvc.Name && pod.Namespace == pvc.Namespace {
@@ -548,7 +548,6 @@ func buildPVCMapPodMap(ctx context.Context, pvList []*v1.PersistentVolume, metad
 					}
 				}
 			}
-
 		}
 	}
 	return pvToPVCMap, pvcToPodMap, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is needed to fix the issue where, full sync updates pod name for Container Volumes on CNS UI even when pod is not in Running state. With this fix, the pod name will be updated only when Pod is in Running state, similar to how it is handled in the Syncer informers

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #347 

**Special notes for your reviewer**:
**Before:**
<pre>
kubectl describe pod 
Name:         example-vanilla-block-pod
Namespace:    default
...
Volumes:
  test-volume:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  example-vanilla-block-pvc
...
Status:       Pending

Events:
  Type     Reason                  Age                    From                     Message
  ----     ------                  ----                   ----                     -------
  Normal   Scheduled               5m59s                  default-scheduler        Successfully assigned default/example-vanilla-block-pod to k8s-node1
  Warning  FailedMount             99s                    kubelet, k8s-node1       Unable to attach or mount volumes: unmounted volumes=[test-volume], unattached volumes=[test-volume default-token-25dxl]: timed out waiting for the condition
</pre>
Even when Pod is in Pending, the pod name can be seen on CNS UI:
<img width="1103" alt="CNSUI-1" src="https://user-images.githubusercontent.com/14131348/92060135-e04fab80-ed47-11ea-98a4-b33220329975.png">


**After fix:**

<img width="1103" alt="CNSUI-2" src="https://user-images.githubusercontent.com/14131348/92060186-f8bfc600-ed47-11ea-88a5-c04d58049a58.png">

e2e logs: https://gist.github.com/chethanv28/950c2853acadc7e2b1b8379882057846

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update pod metadata in Full Sync only when Pod is in Running state
```
