### PR TITLE
Remove device check in NodeGetVolumeStats

### DIFF
--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -511,15 +511,6 @@ func (s *service) NodeGetVolumeStats(
 		return nil, status.Errorf(codes.InvalidArgument, "received empty targetpath %q", targetPath)
 	}
 
-	dev, err := getDevFromMount(targetPath)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "unable to retrieve device from target %q", targetPath)
-	}
-	if dev == nil {
-		return nil, status.Errorf(codes.Internal, "could not find device mounted on targetpath %v", targetPath)
-	}
-	//TODO Check that the matching device is a vSphere volume, and that the volID matches the mount point
-
 	volMetrics, err := getMetrics(targetPath)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -1314,6 +1305,13 @@ func getDevFromMount(target string) (*Device, error) {
 	// Path:/var/lib/kubelet/pods/c46d6473-0810-11ea-94c1-005056825b1f/volumes/kubernetes.io~csi/pvc-9e3d1d08-080f-11ea-be93-005056825b1f/mount
 	// Source:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-9e3d1d08-080f-11ea-be93-005056825b1f/globalmount
 	// Type:ext4
+	// Opts:[rw relatime]
+
+	// example for File Volume
+	// Device:h10-186-38-214.vsanfs3.testdomain:/5231f3d8-f06b-b67c-8cd1-f3c126013ce4
+	// Path:/var/lib/kubelet/pods/ba41b064-bd0b-4a47-afff-8d262ec6308a/volumes/kubernetes.io~csi/pvc-a425f631-f93c-4cb6-9d61-03bd2dd81b44/mount
+	// Source:h10-186-38-214.vsanfs3.testdomain:/5231f3d8-f06b-b67c-8cd1-f3c126013ce4
+	// Type:nfs4
 	// Opts:[rw relatime]
 
 	for _, m := range mnts {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is removing the logic to check for devices mounted on the target path, which was earlier throwing an error if the device data could not be retrieved. For file volumes there's no underlying device, and for block volumes the volume stats can directly be computed from the mount path. Hence this check is not needed for both file as well as block volumes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #322

**Special notes for your reviewer**:

This doesn't change anything for the block volumes. 
The node volume stats are getting reported now for file volumes also.
```
 time="2020-09-03T16:56:37Z" level=debug msg="/csi.v1.Node/NodeGetVolumeStats: REQ 9739: VolumeId=file:8948c49b-1b59-4315-bc8e-e913f10d47eb, VolumePath=/var/lib/kubelet/pods/2aab79a6-0fb5-4823-9916-1a8572514c08/volumes/kubernetes.io~csi/pvc-9aa8ee32-9302-4ed2-9d93-26207de1d53d/mount, XXX_NoUnkeyedLiteral={}, XXX_sizecache=0"
 time="2020-09-03T16:56:37Z" level=debug msg="/csi.v1.Node/NodeGetVolumeStats: REP 9739: Usage=[available:4003672883200 total:4003777740800 unit:BYTES  available:2317000813 total:2317000818 used:5 unit:INODES ], XXX_NoUnkeyedLiteral={}, XXX_sizecache=0"
```

Also, the stats do get updated after creating files on the volume mount. Notice the `available` and `used` fields getting updated after some space is claimed at the mount point.
```
 time="2020-09-03T16:56:37Z" level=debug msg="/csi.v1.Node/NodeGetVolumeStats: REQ 9739: VolumeId=file:8948c49b-1b59-4315-bc8e-e913f10d47eb, VolumePath=/var/lib/kubelet/pods/2aab79a6-0fb5-4823-9916-1a8572514c08/volumes/kubernetes.io~csi/pvc-9aa8ee32-9302-4ed2-9d93-26207de1d53d/mount, XXX_NoUnkeyedLiteral={}, XXX_sizecache=0"
 time="2020-09-03T16:56:37Z" level=debug msg="/csi.v1.Node/NodeGetVolumeStats: REP 9739: Usage=[available:4003672883200 total:4003777740800 unit:BYTES  available:2317000813 total:2317000818 used:5 unit:INODES ], XXX_NoUnkeyedLiteral={}, XXX_sizecache=0"
``` 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
