### PR TITLE
upgrade sidecar containers

### DIFF
--- a/manifests/latest/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/latest/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v3.0.0-rc2
+          image: quay.io/k8scsi/csi-attacher:v3.0.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -38,10 +38,10 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v1.0.0-rc2
+          image: quay.io/k8scsi/csi-resizer:v1.0.0
           args:
             - "--v=4"
-            - "--csiTimeout=300s"
+            - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
           env:
@@ -55,7 +55,7 @@ spec:
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: X_CSI_MODE
               value: "controller"
             - name: VSPHERE_CSI_CONFIG
@@ -66,7 +66,7 @@ spec:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
           ports:
             - name: healthz
@@ -81,15 +81,13 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.0.0
+          image: quay.io/k8scsi/livenessprobe:v2.1.0
           args:
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - "--v=4"
+            - "--csi-address=/csi/csi.sock"
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
-              name: socket-dir
+            - name: socket-dir
+              mountPath: /csi
         - name: vsphere-syncer
           image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.1
           args:
@@ -107,7 +105,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v2.0.0-rc3
+          image: quay.io/k8scsi/csi-provisioner:v2.0.0
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/latest/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/latest/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -20,15 +20,12 @@ spec:
       dnsPolicy: "Default"
       containers:
       - name: node-driver-registrar
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com-reg.sock /csi/csi.sock"]
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.0.1
         args:
         - "--v=5"
         - "--csi-address=$(ADDRESS)"
         - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+        - "--health-port=9809"
         env:
         - name: ADDRESS
           value: /csi/csi.sock
@@ -41,6 +38,15 @@ spec:
           mountPath: /csi
         - name: registration-dir
           mountPath: /registration
+        ports:
+        - containerPort: 9809
+          name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
       - name: vsphere-csi-node
         image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.1
         imagePullPolicy: "Always"
@@ -82,21 +88,19 @@ spec:
         - name: device-dir
           mountPath: /dev
         ports:
-          - name: healthz
-            containerPort: 9808
-            protocol: TCP
+          - containerPort: 9808
+            name: healthz
         livenessProbe:
           httpGet:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
-          timeoutSeconds: 3
-          periodSeconds: 5
-          failureThreshold: 3
+          timeoutSeconds: 5
       - name: liveness-probe
-        image: quay.io/k8scsi/livenessprobe:v2.0.0
+        image: quay.io/k8scsi/livenessprobe:v2.1.0
         args:
-        - --csi-address=/csi/csi.sock
+          - "--v=4"
+          - "--csi-address=/csi/csi.sock"
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi
@@ -111,7 +115,7 @@ spec:
           type: Directory
       - name: plugin-dir
         hostPath:
-          path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/
+          path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com
           type: DirectoryOrCreate
       - name: pods-mount-dir
         hostPath:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is upgrading CSI driver sidecar container images.

**Special notes for your reviewer**:
Testing is done.

- Verified logs emitted during the initialization of each sidecar container, no issue observed.
- Performed Volume life cycle operations creating/deleting SC, PVC, PV, and POD. no issue observed.
- Executed e2e test cases

test log - [e2e-tests.log](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/5221687/e2e-tests.log)

```
Summarizing 1 Failure:

[Fail] [csi-block-vanilla] [csi-supervisor] statefulset [It] Statefulset testing with parallel podManagementPolicy 
/Users/divyenp/go/pkg/mod/k8s.io/kubernetes@v1.18.5/test/e2e/framework/statefulset/rest.go:68

Ran 33 of 106 Specs in 5449.237 seconds
FAIL! -- 32 Passed | 1 Failed | 0 Pending | 73 Skipped
--- FAIL: TestE2E (5449.25s)
FAIL

Ginkgo ran 1 suite in 1h30m56.721727687s
Test Suite Failed
```


Note: Failure in the above result is not related to this code change.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
upgrade sidecar containers
```
