### PR TITLE
Initialize CnsRegisterVolume CRD in CNS Operator init.

### DIFF
--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -110,7 +110,7 @@ func GetVolumeMigrationService(ctx context.Context, volumeManager *cnsvolume.Man
 			volumeManager:        volumeManager,
 			cnsConfig:            cnsConfig,
 		}
-		volumeMigrationServiceInitErr = k8s.CreateCustomResourceDefinition(ctx, CRDName, CRDSingular, CRDPlural,
+		volumeMigrationServiceInitErr = k8s.CreateCustomResourceDefinitionFromSpec(ctx, CRDName, CRDSingular, CRDPlural,
 			reflect.TypeOf(migrationv1alpha1.CnsVSphereVolumeMigration{}).Name(), migrationv1alpha1.SchemeGroupVersion.Group, migrationv1alpha1.SchemeGroupVersion.Version, apiextensionsv1beta1.ClusterScoped)
 		if volumeMigrationServiceInitErr != nil {
 			log.Errorf("failed to create volume migration CRD. Error: %v", volumeMigrationServiceInitErr)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
@@ -43,6 +45,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	apiutils "sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
@@ -55,8 +58,9 @@ import (
 )
 
 const (
-	timeout  = 60 * time.Second
-	pollTime = 5 * time.Second
+	timeout      = 60 * time.Second
+	pollTime     = 5 * time.Second
+	manifestPath = "/config"
 )
 
 // GetKubeConfig helps retrieve Kubernetes Config
@@ -264,23 +268,11 @@ func getClientThroughput(ctx context.Context, inClusterClient bool) (float32, in
 	return qps, burst
 }
 
-// CreateCustomResourceDefinition creates the CRD and add it into Kubernetes.
+// CreateCustomResourceDefinitionFromSpec creates the custom resource definition from given spec
 // If there is error, function will do the clean up
-func CreateCustomResourceDefinition(ctx context.Context, crdName string, crdSingular string, crdPlural string,
+func CreateCustomResourceDefinitionFromSpec(ctx context.Context, crdName string, crdSingular string, crdPlural string,
 	crdKind string, crdGroup string, crdVersion string, crdScope apiextensionsv1beta1.ResourceScope) error {
-	log := logger.GetLogger(ctx)
-	// Get a config to talk to the apiserver
-	cfg, err := GetKubeConfig(ctx)
-	if err != nil {
-		log.Errorf("failed to get Kubernetes config. Err: %+v", err)
-		return err
-	}
-	apiextensionsClientSet, err := apiextensionsclientset.NewForConfig(cfg)
-	if err != nil {
-		log.Errorf("failed to create Kubernetes client using config. Err: %+v", err)
-		return err
-	}
-	crd := &apiextensionsv1beta1.CustomResourceDefinition{
+	crdSpec := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crdName,
 		},
@@ -300,23 +292,63 @@ func CreateCustomResourceDefinition(ctx context.Context, crdName string, crdSing
 			},
 		},
 	}
-	_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
-	if err == nil {
-		log.Infof("%q CRD created successfully", crdName)
-	} else if apierrors.IsAlreadyExists(err) {
-		log.Infof("%q CRD already exists", crdName)
-		return nil
-	} else {
-		log.Errorf("failed to create %q CRD with err: %+v", crdName, err)
+	return createCustomResourceDefinition(ctx, crdSpec)
+}
+
+// CreateCustomResourceDefinitionFromManifest creates custom resource definition spec from
+// manifest file
+func CreateCustomResourceDefinitionFromManifest(ctx context.Context, fileName string) error {
+	log := logger.GetLogger(ctx)
+	manifestcrd, err := getCRDFromManifest(ctx, fileName)
+	if err != nil {
+		log.Errorf("Failed to read the CRD spec from manifest file: %s with err: %+v", fileName, err)
 		return err
 	}
 
-	// CRD takes some time to be established
-	// Creating an instance of non-established runs into errors. So, wait for CRD to be created
-	err = wait.Poll(pollTime, timeout, func() (bool, error) {
-		crd, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
+	return createCustomResourceDefinition(ctx, manifestcrd)
+
+}
+
+// createCustomResourceDefinition takes a custom resource definition spec and creates it on the API server
+func createCustomResourceDefinition(ctx context.Context, crd *apiextensionsv1beta1.CustomResourceDefinition) error {
+	log := logger.GetLogger(ctx)
+	// Get a config to talk to the apiserver
+	cfg, err := GetKubeConfig(ctx)
+	if err != nil {
+		log.Errorf("failed to get Kubernetes config. Err: %+v", err)
+		return err
+	}
+	apiextensionsClientSet, err := apiextensionsclientset.NewForConfig(cfg)
+	if err != nil {
+		log.Errorf("failed to create Kubernetes client using config. Err: %+v", err)
+		return err
+	}
+	_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
+	if err == nil {
+		log.Infof("%q CRD created successfully", crd.Name)
+	} else if apierrors.IsAlreadyExists(err) {
+		log.Infof("%q CRD already exists", crd.Name)
+		return nil
+	} else {
+		log.Errorf("failed to create %q CRD with err: %+v", crd.Name, err)
+		return err
+	}
+
+	err = waitForCustomResourceToBeEstablished(ctx, apiextensionsClientSet, crd.Name)
+	if err != nil {
+		log.Errorf("CRD %q created but failed to establish. Err: %+v", crd.Name, err)
+	}
+	return err
+}
+
+// waitForCustomResourceToBeEstablished waits until the CRD status is Established
+func waitForCustomResourceToBeEstablished(ctx context.Context,
+	clientSet apiextensionsclientset.Interface, crdName string) error {
+	log := logger.GetLogger(ctx)
+	err := wait.Poll(pollTime, timeout, func() (bool, error) {
+		crd, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
 		if err != nil {
-			log.Errorf("failed to get %q CRD with err: %+v", crdName, err)
+			log.Errorf("Failed to get %q CRD with err: %+v", crdName, err)
 			return false, err
 		}
 		for _, cond := range crd.Status.Conditions {
@@ -336,13 +368,41 @@ func CreateCustomResourceDefinition(ctx context.Context, crdName string, crdSing
 
 	// If there is an error, delete the object to keep it clean.
 	if err != nil {
-		log.Infof("Cleanup %q CRD because the CRD created was not successfully established. Error: %+v", crdName, err)
-		deleteErr := apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(ctx, crdName, metav1.DeleteOptions{})
+		log.Infof("Cleanup %q CRD because the CRD created was not successfully established. Err: %+v", crdName, err)
+		deleteErr := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(ctx, crdName, *metav1.NewDeleteOptions(0))
 		if deleteErr != nil {
-			log.Errorf("failed to delete %q CRD with error: %+v", crdName, deleteErr)
+			log.Errorf("Failed to delete %q CRD with err: %+v", crdName, deleteErr)
 		}
 	}
 	return err
+}
+
+// getCRDFromManifest reads a .json/yaml file and returns the CRD in it.
+func getCRDFromManifest(ctx context.Context, fileName string) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+	var crd apiextensionsv1beta1.CustomResourceDefinition
+	log := logger.GetLogger(ctx)
+
+	fullPath := filepath.Join(manifestPath, fileName)
+	data, err := ioutil.ReadFile(fullPath)
+	if os.IsNotExist(err) {
+		log.Errorf("Manifest file: %s doesn't exist. Error: %+v", fullPath, err)
+		return nil, err
+	} else if err != nil {
+		log.Errorf("Failed to read the manifest file: %s. Error: %+v", fullPath, err)
+		return nil, err
+	}
+
+	json, err := utilyaml.ToJSON(data)
+	if err != nil {
+		log.Errorf("Failed to convert the manifest file: %s content to JSON with error: %+v", fullPath, err)
+		return nil, err
+	}
+
+	if err := runtime.DecodeInto(legacyscheme.Codecs.UniversalDecoder(), json, &crd); err != nil {
+		log.Errorf("Failed to decode json content: %+v to crd with error: %+v", json, err)
+		return nil, err
+	}
+	return &crd, nil
 }
 
 // GetDynamicInformer returns informer for specified CRD group, version and name

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -384,14 +384,14 @@ func getCRDFromManifest(ctx context.Context, fileName string) (*apiextensionsv1b
 
 	fullPath := filepath.Join(manifestPath, fileName)
 	data, err := ioutil.ReadFile(fullPath)
-	if os.IsNotExist(err) {
-		log.Errorf("Manifest file: %s doesn't exist. Error: %+v", fullPath, err)
-		return nil, err
-	} else if err != nil {
-		log.Errorf("Failed to read the manifest file: %s. Error: %+v", fullPath, err)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Errorf("Manifest file: %s doesn't exist. Error: %+v", fullPath, err)
+		} else {
+			log.Errorf("Failed to read the manifest file: %s. Error: %+v", fullPath, err)
+		}
 		return nil, err
 	}
-
 	json, err := utilyaml.ToJSON(data)
 	if err != nil {
 		log.Errorf("Failed to convert the manifest file: %s content to JSON with error: %+v", fullPath, err)

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -76,7 +76,7 @@ func InitCnsOperator(configInfo *types.ConfigInfo) error {
 	// Create CnsNodeVmAttachment CRD
 	crdKindNodeVMAttachment := reflect.TypeOf(cnsnodevmattachmentv1alpha1.CnsNodeVmAttachment{}).Name()
 	crdNameNodeVMAttachment := apis.CnsNodeVMAttachmentPlural + "." + apis.SchemeGroupVersion.Group
-	err = k8s.CreateCustomResourceDefinition(ctx, crdNameNodeVMAttachment, apis.CnsNodeVMAttachmentSingular, apis.CnsNodeVMAttachmentPlural,
+	err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, crdNameNodeVMAttachment, apis.CnsNodeVMAttachmentSingular, apis.CnsNodeVMAttachmentPlural,
 		crdKindNodeVMAttachment, apis.SchemeGroupVersion.Group, apis.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
 	if err != nil {
 		log.Errorf("failed to create %q CRD. Err: %+v", crdNameNodeVMAttachment, err)
@@ -87,10 +87,17 @@ func InitCnsOperator(configInfo *types.ConfigInfo) error {
 	crdKindVolumeMetadata := reflect.TypeOf(cnsvolumemetadatav1alpha1.CnsVolumeMetadata{}).Name()
 	crdNameVolumeMetadata := apis.CnsVolumeMetadataPlural + "." + apis.SchemeGroupVersion.Group
 
-	err = k8s.CreateCustomResourceDefinition(ctx, crdNameVolumeMetadata, apis.CnsVolumeMetadataSingular, apis.CnsVolumeMetadataPlural,
+	err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, crdNameVolumeMetadata, apis.CnsVolumeMetadataSingular, apis.CnsVolumeMetadataPlural,
 		crdKindVolumeMetadata, apis.SchemeGroupVersion.Group, apis.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
 	if err != nil {
 		log.Errorf("failed to create %q CRD. Err: %+v", crdKindVolumeMetadata, err)
+		return err
+	}
+
+	// Create CnsRegisterVolume CRD from manifest
+	err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cnsregistervolume_crd.yaml")
+	if err != nil {
+		log.Errorf("Failed to create %q CRD. Err: %+v", apis.CnsRegisterVolumePlural, err)
 		return err
 	}
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Creates CnsRegisterVolume CRD during CNS Operator init. Also added back function to create CRD from manifest and some
refactoring. 

Syncer logs before this change:
```
{"level":"info","time":"2020-09-10T21:44:51.732518754Z","caller":"syncer/main.go:52","msg":"Version : v2.1.0-13de7f5"}
{"level":"info","time":"2020-09-10T21:44:51.742754331Z","caller":"logger/logger.go:37","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2020-09-10T21:44:51.776968734Z","caller":"config/config.go:286","msg":"No Net Permissions given in Config. Using default permissions.","TraceId":"0c03feae-4670-436b-8a5d-5f2845c1c605"}
...
{"level":"info","time":"2020-09-10T21:44:54.217749768Z","caller":"manager/init.go:140","msg":"Starting Cns Operator","TraceId":"42a72a45-1316-4de4-97b8-6a348f9d2271"}
{"level":"info","time":"2020-09-10T21:44:54.218169938Z","caller":"manager/init.go:131","msg":"Triggering CnsRegisterVolume cleanup routine","TraceId":"bc8c317e-e270-45d6-88cb-b4c655aab757"}
{"level":"info","time":"2020-09-10T21:44:54.218375069Z","caller":"manager/cleanupcnsregistervolumes.go:35","msg":"cleanUpCnsRegisterVolumeInstances: start","TraceId":"bc8c317e-e270-45d6-88cb-b4c655aab757"}
{"level":"error","time":"2020-09-10T21:44:57.187826591Z","caller":"manager/init.go:144","msg":"failed to start Cns operator. Err: no matches for kind \"CnsRegisterVolume\" in version \"cns.vmware.com/v1alpha1\"","TraceId":"bc8c317e-e270-45d6-88cb-b4c655aab757","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/cnsoperator/manager.InitCnsOperator\n\t/build/pkg/syncer/cnsoperator/manager/init.go:144\nmain.initSyncerComponents.func1.2\n\t/build/cmd/syncer/main.go:116"}
{"level":"error","time":"2020-09-10T21:44:57.188033978Z","caller":"syncer/main.go:117","msg":"Error initializing Cns Operator. Error: no matches for kind \"CnsRegisterVolume\" in version \"cns.vmware.com/v1alpha1\"","stacktrace":"main.initSyncerComponents.func1.2\n\t/build/cmd/syncer/main.go:117"}
```
Logs after this change:
```
"level":"info","time":"2020-09-10T23:55:59.484420669Z","caller":"syncer/main.go:52","msg":"Version : v2.1.0-rc.1-35-g2588b71-dirty"}
{"level":"info","time":"2020-09-10T23:55:59.485526224Z","caller":"logger/logger.go:37","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2020-09-10T23:55:59.4861573Z","caller":"config/config.go:286","msg":"No Net Permissions given in Config. Using default permissions.","TraceId":"b2249ade-4146-4942-863c-aac556af0fef"}
...
{"level":"info","time":"2020-09-10T23:55:59.83442113Z","caller":"kubernetes/kubernetes.go:328","msg":"\"cnsregistervolumes.cns.vmware.com\" CRD created successfully","TraceId":"4d08d649-8f09-4140-aaf7-13166a66af54"}
...
{"level":"info","time":"2020-09-10T23:56:06.594830472Z","caller":"manager/init.go:147","msg":"Starting Cns Operator","TraceId":"4d08d649-8f09-4140-aaf7-13166a66af54"}
{"level":"info","time":"2020-09-10T23:56:06.607563884Z","caller":"manager/init.go:138","msg":"Triggering CnsRegisterVolume cleanup routine","TraceId":"16ff229f-ee84-45ac-aa7f-f2182c3c52c9"}
{"level":"info","time":"2020-09-10T23:56:06.630796554Z","caller":"manager/cleanupcnsregistervolumes.go:35","msg":"cleanUpCnsRegisterVolumeInstances: start","TraceId":"16ff229f-ee84-45ac-aa7f-f2182c3c52c9"}
{"level":"info","time":"2020-09-10T23:56:08.164574211Z","caller":"manager/init.go:140","msg":"Completed CnsRegisterVolume cleanup","TraceId":"16ff229f-ee84-45ac-aa7f-f2182c3c52c9"}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #354

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Create CnsRegisterVolume CRD during CNS Operator init
```
