### PR TITLE
fail volume creation when unsupported VCP parameters are observed, instead of silently dropping them.

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -230,28 +230,28 @@ func ParseStorageClassParams(ctx context.Context, params map[string]string) (*St
 				log.Warnf("param 'fstype' is deprecated, please use 'csi.storage.k8s.io/fstype' instead")
 			} else if param == CSIMigrationParams {
 				scParams.CSIMigration = value
-				log.Infof("vSphere CSI Driver supports StoragePolicyName, Datastore and fsType parameters supplied from legacy in-tree provisioner. All other parameters supplied in csimigrationparams will be dropped.")
 			} else {
 				otherParams[param] = value
 			}
 		}
-
 		// check otherParams belongs to in-tree migrated Parameters
 		if scParams.CSIMigration == "true" {
 			for param, value := range otherParams {
 				param = strings.ToLower(param)
 				if param == DatastoreMigrationParam {
 					scParams.Datastore = value
-				} else if param != DiskFormatMigrationParam && param != HostFailuresToTolerateMigrationParam &&
-					param != ForceProvisioningMigrationParam && param != CacheReservationMigrationParam &&
-					param != DiskstripesMigrationParam && param != ObjectspacereservationMigrationParam &&
-					param != IopslimitMigrationParam {
-					return nil, fmt.Errorf("Invalid parameter key:%v, value:%v", param, value)
+				} else if param == DiskFormatMigrationParam || param == HostFailuresToTolerateMigrationParam ||
+					param == ForceProvisioningMigrationParam || param == CacheReservationMigrationParam ||
+					param == DiskstripesMigrationParam || param == ObjectspacereservationMigrationParam ||
+					param == IopslimitMigrationParam {
+					return nil, fmt.Errorf("vSphere CSI driver does not support creating volume using in-tree vSphere volume plugin parameter key:%v, value:%v", param, value)
+				} else {
+					return nil, fmt.Errorf("invalid parameter. key:%v, value:%v", param, value)
 				}
 			}
 		} else {
 			if len(otherParams) != 0 {
-				return nil, fmt.Errorf("Invalid parameters :%v", otherParams)
+				return nil, fmt.Errorf("invalid parameters :%v", otherParams)
 			}
 		}
 	}

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -303,7 +303,7 @@ func TestParseStorageClassParamsWithValidParams(t *testing.T) {
 	}
 }
 
-func TestParseStorageClassParamsWithMigrationEnabled(t *testing.T) {
+func TestParseStorageClassParamsWithMigrationEnabledNagative(t *testing.T) {
 	CSIMigrationFeatureEnabled = true
 	params := map[string]string{
 		CSIMigrationParams:                   "true",
@@ -316,17 +316,31 @@ func TestParseStorageClassParamsWithMigrationEnabled(t *testing.T) {
 		ObjectspacereservationMigrationParam: "50",
 		IopslimitMigrationParam:              "16",
 	}
-	expectedScParams := &StorageClassParams{
-		CSIMigration:      "true",
-		StoragePolicyName: "policy1",
-		Datastore:         "vSANDatastore",
+	scParam, err := ParseStorageClassParams(ctx, params)
+	if err == nil {
+		t.Errorf("error expected but not received. scParam received from ParseStorageClassParams: %v", scParam)
 	}
-	actualScParams, err := ParseStorageClassParams(ctx, params)
+	t.Logf("expected err received. err: %v", err)
+}
+
+func TestParseStorageClassParamsWithMigrationEnabledPositive(t *testing.T) {
+	CSIMigrationFeatureEnabled = true
+	params := map[string]string{
+		CSIMigrationParams:         "true",
+		DatastoreMigrationParam:    "vSANDatastore",
+		AttributeStoragePolicyName: "policy1",
+	}
+	expectedScParams := &StorageClassParams{
+		Datastore:         "vSANDatastore",
+		StoragePolicyName: "policy1",
+		CSIMigration:      "true",
+	}
+	scParam, err := ParseStorageClassParams(ctx, params)
 	if err != nil {
 		t.Errorf("failed to parse params: %+v", params)
 	}
-	if !isStorageClassParamsEqual(expectedScParams, actualScParams) {
-		t.Errorf("Expected: %+v\n Actual: %+v", expectedScParams, actualScParams)
+	if !isStorageClassParamsEqual(expectedScParams, scParam) {
+		t.Errorf("Expected: %+v\n Actual: %+v", expectedScParams, scParam)
 	}
 }
 
@@ -338,9 +352,9 @@ func TestParseStorageClassParamsWithMigrationDisabled(t *testing.T) {
 		AttributeStoragePolicyName:           "policy1",
 		HostFailuresToTolerateMigrationParam: "1",
 	}
-	actualScParams, err := ParseStorageClassParams(ctx, params)
+	scParam, err := ParseStorageClassParams(ctx, params)
 	if err == nil {
-		t.Errorf("error expected but not received. actualScParams: %v", actualScParams)
+		t.Errorf("error expected but not received. scParam received from ParseStorageClassParams: %v", scParam)
 	}
 	t.Logf("expected err received. err: %v", err)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is failing volume creation using unsupported VCP parameters, instead of silently dropping them.

We need to do this to comply with StorageClass SLA. Users should not be under the wrong impression that, SLA for the newly created volume is met.


**Special notes for your reviewer**:
Updated unit tests.

```
=== RUN   TestParseStorageClassParamsWithDeprecatedFSType
{"level":"warn","time":"2020-09-14T19:23:41.285971-07:00","caller":"common/util.go:216","msg":"param 'fstype' is deprecated, please use 'csi.storage.k8s.io/fstype' instead"}
--- PASS: TestParseStorageClassParamsWithDeprecatedFSType (0.00s)
=== RUN   TestParseStorageClassParamsWithValidParams
--- PASS: TestParseStorageClassParamsWithValidParams (0.00s)
=== RUN   TestParseStorageClassParamsWithMigrationEnabledNagative
--- PASS: TestParseStorageClassParamsWithMigrationEnabledNagative (0.00s)
    util_test.go:323: expected err received. err: vSphere CSI driver does not support creating volume using in-tree vSphere volume plugin parameter key:forceprovisioning-migrationparam, value:true
=== RUN   TestParseStorageClassParamsWithMigrationEnabledPositive
--- PASS: TestParseStorageClassParamsWithMigrationEnabledPositive (0.00s)
=== RUN   TestParseStorageClassParamsWithMigrationDisabled
--- PASS: TestParseStorageClassParamsWithMigrationDisabled (0.00s)
    util_test.go:359: expected err received. err: Invalid param: "csimigration" and value: "true"
PASS

```

**Executed e2e tests manually**

```
Summarizing 2 Failures:

Test Logs: 
[PR-358-e2e-test.log](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/5229219/PR-358-e2e-test.log)

[Fail] [csi-block-vanilla] label-updates [It] Verify PVC name is removed from PV entry on CNS after PVC is deleted when Reclaim Policy is set to retain. 
/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/tests/e2e/labelupdates.go:393

[Fail] [csi-block-vanilla] Storage Policy Based Volume Provisioning [It] Verify non-existing SPBM policy is not honored for dynamic volume provisioning using storageclass 
/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/tests/e2e/storagepolicy.go:259

Ran 33 of 106 Specs in 6362.419 seconds
FAIL! -- 31 Passed | 2 Failed | 0 Pending | 73 Skipped
```

Tests failed due to slow etcd server on my setup - ` Error: etcdserver: request timed out`

Re-executed both failed tests again, they passed. - [PR-358-re-execute-failed-tests.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/5229238/PR-358-re-execute-failed-tests.txt)



```
• [SLOW TEST:45.473 seconds]
[csi-block-vanilla] label-updates
/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/tests/e2e/labelupdates.go:59
  Verify PVC name is removed from PV entry on CNS after PVC is deleted when Reclaim Policy is set to retain.
  /Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/tests/e2e/labelupdates.go:347
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 106 Specs in 45.474 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 105 Skipped
PASS
```

```
• [SLOW TEST:31.973 seconds]
[csi-block-vanilla] Storage Policy Based Volume Provisioning
/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/tests/e2e/storagepolicy.go:51
  Verify non-existing SPBM policy is not honored for dynamic volume provisioning using storageclass
  /Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/tests/e2e/storagepolicy.go:122
------------------------------
SS
Ran 1 of 106 Specs in 31.974 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 105 Skipped
PASS

Ginkgo ran 1 suite in 41.756430709s
```
**Release note**:

```release-note
fail volume creation when unsupported VCP parameters are observed, instead of silently dropping them.
```


cc: @SandeepPissay @chethanv28 @xing-yang @sashrith 