### PR TITLE
vSphere 7.0U2 feature - Online resize support for block volumes

### DIFF
--- a/example/vanilla-k8s-block-driver/example-sc.yaml
+++ b/example/vanilla-k8s-block-driver/example-sc.yaml
@@ -3,9 +3,10 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: example-vanilla-block-sc
   annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"  # Optional
 provisioner: csi.vsphere.vmware.com
+allowVolumeExpansion: true  # Optional: only applicable to vSphere 7.0U1 and above
 parameters:
-  datastoreurl: "ds:///vmfs/volumes/vsan:52cdfa80721ff516-ea1e993113acfc77/" #Optional Parameter
-  storagepolicyname: "vSAN Default Storage Policy"  #Optional Parameter
-  csi.storage.k8s.io/fstype: "ext4" #Optional Parameter
+  datastoreurl: "ds:///vmfs/volumes/vsan:52cdfa80721ff516-ea1e993113acfc77/"  # Optional Parameter
+  storagepolicyname: "vSAN Default Storage Policy"  # Optional Parameter
+  csi.storage.k8s.io/fstype: "ext4"  # Optional Parameter

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -9,6 +9,12 @@ metadata:
   name: vsphere-csi-controller
   namespace: {{ .PVCSINamespace }}
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-node
+  namespace: {{ .PVCSINamespace }}
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -49,14 +55,20 @@ metadata:
   name: vsphere-csi-node-role
   namespace: {{ .PVCSINamespace }}
 rules:
-  - apiGroups:
-    - "policy"
-    resources:
-    - podsecuritypolicies
-    verbs:
-    - use
-    resourceNames:
-    - vmware-system-privileged
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames: ["vmware-system-privileged"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-role
+  namespace: {{ .PVCSINamespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -78,11 +90,25 @@ metadata:
   namespace: {{ .PVCSINamespace }}
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-node
     namespace: {{ .PVCSINamespace }}
 roleRef:
   kind: Role
   name: vsphere-csi-node-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-binding
+  namespace: {{ .PVCSINamespace }}
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: {{ .PVCSINamespace }}
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-node-cluster-role
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Deployment
@@ -219,6 +245,7 @@ spec:
           args:
             - "--v=4"
             - "--timeout=300s"
+            - "--handle-volume-inuse-error=false"  # Set this to true if used in vSphere 7.0U1
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
             - "--kube-api-qps=100"
@@ -230,16 +257,16 @@ spec:
             - mountPath: /csi
               name: socket-dir
       volumes:
-      - name: pvcsi-provider-volume
-        secret:
-          secretName: pvcsi-provider-creds
-      - name: pvcsi-config-volume
-        configMap:
-          name: pvcsi-config
-      - name: socket-dir
-        hostPath:
-          path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-          type: DirectoryOrCreate
+        - name: pvcsi-provider-volume
+          secret:
+           secretName: pvcsi-provider-creds
+        - name: pvcsi-config-volume
+          configMap:
+            name: pvcsi-config
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
+            type: DirectoryOrCreate
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
@@ -266,6 +293,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      serviceAccountName: vsphere-csi-node
       containers:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>
@@ -308,6 +336,10 @@ spec:
           value: "GUEST_CLUSTER"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           privileged: true
           capabilities:
@@ -321,6 +353,13 @@ spec:
           mountPropagation: "Bidirectional"
         - name: device-dir
           mountPath: /dev
+        - name: blocks-dir
+          mountPath: /sys/block
+        - name: sys-devices-dir
+          mountPath: /sys/devices
+        - name: pvcsi-config-volume
+          mountPath: /etc/cloud/pvcsi-config
+          readOnly: true
       - name: liveness-probe
         image: vmware.io/csi-livenessprobe/csi-livenessprobe:<image_tag>
         args:
@@ -345,6 +384,17 @@ spec:
       - name: device-dir
         hostPath:
           path: /dev
+      - name: blocks-dir
+        hostPath:
+          path: /sys/block
+          type: Directory
+      - name: sys-devices-dir
+        hostPath:
+          path: /sys/devices
+          type: Directory
+      - name: pvcsi-config-volume
+        configMap:
+          name: pvcsi-config
       tolerations:
         - effect: NoExecute
           operator: Exists
@@ -362,8 +412,21 @@ data:
     [FeatureStatesConfig]
     name = "csi-feature-states"
     namespace = "{{ .PVCSINamespace }}"
+    [InternalFeatureStatesConfig]
+    name = "internal-feature-states.csi.vsphere.vmware.com"
+    namespace = "{{ .PVCSINamespace }}"
 kind: ConfigMap
 metadata:
   name: pvcsi-config
+  namespace: {{ .PVCSINamespace }}
+---
+apiVersion: v1
+data:
+  "volume-extend": "true"
+  "volume-health": "true"
+  "online-volume-extend": "false"
+kind: ConfigMap
+metadata:
+  name: internal-feature-states.csi.vsphere.vmware.com
   namespace: {{ .PVCSINamespace }}
 ---

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -9,6 +9,12 @@ metadata:
   name: vsphere-csi-controller
   namespace: {{ .PVCSINamespace }}
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-node
+  namespace: {{ .PVCSINamespace }}
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -49,14 +55,20 @@ metadata:
   name: vsphere-csi-node-role
   namespace: {{ .PVCSINamespace }}
 rules:
-  - apiGroups:
-    - "policy"
-    resources:
-    - podsecuritypolicies
-    verbs:
-    - use
-    resourceNames:
-    - vmware-system-privileged
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames: ["vmware-system-privileged"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-role
+  namespace: {{ .PVCSINamespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -78,11 +90,25 @@ metadata:
   namespace: {{ .PVCSINamespace }}
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-node
     namespace: {{ .PVCSINamespace }}
 roleRef:
   kind: Role
   name: vsphere-csi-node-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-binding
+  namespace: {{ .PVCSINamespace }}
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: {{ .PVCSINamespace }}
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-node-cluster-role
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Deployment
@@ -219,6 +245,7 @@ spec:
           args:
             - "--v=4"
             - "--timeout=300s"
+            - "--handle-volume-inuse-error=false"  # Set this to true if used in vSphere 7.0U1
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
             - "--kube-api-qps=100"
@@ -266,6 +293,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      serviceAccountName: vsphere-csi-node
       containers:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>
@@ -308,6 +336,10 @@ spec:
           value: "GUEST_CLUSTER"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           privileged: true
           capabilities:
@@ -321,6 +353,13 @@ spec:
           mountPropagation: "Bidirectional"
         - name: device-dir
           mountPath: /dev
+        - name: blocks-dir
+          mountPath: /sys/block
+        - name: sys-devices-dir
+          mountPath: /sys/devices
+        - name: pvcsi-config-volume
+          mountPath: /etc/cloud/pvcsi-config
+          readOnly: true
       - name: liveness-probe
         image: vmware.io/csi-livenessprobe/csi-livenessprobe:<image_tag>
         args:
@@ -345,6 +384,17 @@ spec:
       - name: device-dir
         hostPath:
           path: /dev
+      - name: blocks-dir
+        hostPath:
+          path: /sys/block
+          type: Directory
+      - name: sys-devices-dir
+        hostPath:
+          path: /sys/devices
+          type: Directory
+      - name: pvcsi-config-volume
+        configMap:
+          name: pvcsi-config
       tolerations:
         - effect: NoExecute
           operator: Exists
@@ -362,8 +412,21 @@ data:
     [FeatureStatesConfig]
     name = "csi-feature-states"
     namespace = "{{ .PVCSINamespace }}"
+    [InternalFeatureStatesConfig]
+    name = "internal-feature-states.csi.vsphere.vmware.com"
+    namespace = "{{ .PVCSINamespace }}"
 kind: ConfigMap
 metadata:
   name: pvcsi-config
+  namespace: {{ .PVCSINamespace }}
+---
+apiVersion: v1
+data:
+  "volume-extend": "true"
+  "volume-health": "true"
+  "online-volume-extend": "false"
+kind: ConfigMap
+metadata:
+  name: internal-feature-states.csi.vsphere.vmware.com
   namespace: {{ .PVCSINamespace }}
 ---

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -9,6 +9,12 @@ metadata:
   name: vsphere-csi-controller
   namespace: {{ .PVCSINamespace }}
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-node
+  namespace: {{ .PVCSINamespace }}
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -49,14 +55,20 @@ metadata:
   name: vsphere-csi-node-role
   namespace: {{ .PVCSINamespace }}
 rules:
-  - apiGroups:
-    - "policy"
-    resources:
-    - podsecuritypolicies
-    verbs:
-    - use
-    resourceNames:
-    - vmware-system-privileged
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames: ["vmware-system-privileged"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-role
+  namespace: {{ .PVCSINamespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -78,11 +90,25 @@ metadata:
   namespace: {{ .PVCSINamespace }}
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-node
     namespace: {{ .PVCSINamespace }}
 roleRef:
   kind: Role
   name: vsphere-csi-node-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-binding
+  namespace: {{ .PVCSINamespace }}
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: {{ .PVCSINamespace }}
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-node-cluster-role
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Deployment
@@ -219,6 +245,7 @@ spec:
           args:
             - "--v=4"
             - "--timeout=300s"
+            - "--handle-volume-inuse-error=false"  # Set this to true if used in vSphere 7.0U1
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
             - "--kube-api-qps=100"
@@ -266,6 +293,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      serviceAccountName: vsphere-csi-node
       containers:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>
@@ -308,6 +336,10 @@ spec:
           value: "GUEST_CLUSTER"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           privileged: true
           capabilities:
@@ -321,6 +353,13 @@ spec:
           mountPropagation: "Bidirectional"
         - name: device-dir
           mountPath: /dev
+        - name: blocks-dir
+          mountPath: /sys/block
+        - name: sys-devices-dir
+          mountPath: /sys/devices
+        - name: pvcsi-config-volume
+          mountPath: /etc/cloud/pvcsi-config
+          readOnly: true
       - name: liveness-probe
         image: vmware.io/csi-livenessprobe/csi-livenessprobe:<image_tag>
         args:
@@ -345,6 +384,17 @@ spec:
       - name: device-dir
         hostPath:
           path: /dev
+      - name: blocks-dir
+        hostPath:
+          path: /sys/block
+          type: Directory
+      - name: sys-devices-dir
+        hostPath:
+          path: /sys/devices
+          type: Directory
+      - name: pvcsi-config-volume
+        configMap:
+          name: pvcsi-config
       tolerations:
         - effect: NoExecute
           operator: Exists
@@ -362,8 +412,21 @@ data:
     [FeatureStatesConfig]
     name = "csi-feature-states"
     namespace = "{{ .PVCSINamespace }}"
+    [InternalFeatureStatesConfig]
+    name = "internal-feature-states.csi.vsphere.vmware.com"
+    namespace = "{{ .PVCSINamespace }}"
 kind: ConfigMap
 metadata:
   name: pvcsi-config
+  namespace: {{ .PVCSINamespace }}
+---
+apiVersion: v1
+data:
+  "volume-extend": "true"
+  "volume-health": "true"
+  "online-volume-extend": "false"
+kind: ConfigMap
+metadata:
+  name: internal-feature-states.csi.vsphere.vmware.com
   namespace: {{ .PVCSINamespace }}
 ---

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
@@ -78,6 +78,7 @@ spec:
           args:
             - --v=4
             - --timeout=300s
+            - --handle-volume-inuse-error=false  # Set this to true if used in vSphere 7.0U1
             - --csi-address=$(ADDRESS)
             - --leader-election
           env:
@@ -178,6 +179,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -42,6 +42,7 @@ spec:
           args:
             - "--v=4"
             - "--timeout=300s"
+            - "--handle-volume-inuse-error=false"  # Set this to true if used in vSphere 7.0U1
             - "--csi-address=$(ADDRESS)"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
@@ -143,6 +144,7 @@ apiVersion: v1
 data:
   "csi-migration": "false"
   "csi-auth-check": "false"
+  "online-volume-extend": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -17,6 +17,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      serviceAccountName: vsphere-csi-node
       dnsPolicy: "Default"
       containers:
       - name: node-driver-registrar
@@ -68,6 +69,10 @@ spec:
           value: "true"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           privileged: true
           capabilities:
@@ -87,6 +92,12 @@ spec:
           mountPropagation: "Bidirectional"
         - name: device-dir
           mountPath: /dev
+        - name: blocks-dir
+          mountPath: /sys/block
+        - name: sys-devices-dir
+          mountPath: /sys/devices
+        - name: vsphere-config-volume
+          mountPath: /etc/cloud
         ports:
           - containerPort: 9808
             name: healthz
@@ -124,6 +135,17 @@ spec:
       - name: device-dir
         hostPath:
           path: /dev
+      - name: blocks-dir
+        hostPath:
+          path: /sys/block
+          type: Directory
+      - name: sys-devices-dir
+        hostPath:
+          path: /sys/devices
+          type: Directory
+      - name: vsphere-config-volume
+        secret:
+          secretName: vsphere-config-secret
       tolerations:
         - effect: NoExecute
           operator: Exists

--- a/manifests/dev/vsphere-7.0u2/vanilla/rbac/vsphere-csi-node-rbac.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/rbac/vsphere-csi-node-rbac.yaml
@@ -1,0 +1,29 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-node
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-role
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-binding
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-node-cluster-role
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -18,7 +18,7 @@ package commonco
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
 
@@ -48,6 +48,6 @@ func GetContainerOrchestratorInterface(ctx context.Context, orchestratorType int
 		return k8sOrchestratorInstance, nil
 	default:
 		// If type is invalid, return an error
-		return nil, errors.New("invalid orchestrator type")
+		return nil, fmt.Errorf("invalid orchestrator type")
 	}
 }

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -189,6 +189,8 @@ func initFSS(ctx context.Context, k8sClient clientset.Interface, controllerClust
 
 	// Set up kubernetes resource listeners for k8s orchestrator
 	k8sOrchestratorInstance.informerManager = k8s.NewInformer(k8sClient)
+	// TODO: Restrict the Configmap listener to the CSI namespace.
+	// Refer to https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/464
 	k8sOrchestratorInstance.informerManager.AddConfigMapListener(
 		// Add
 		func(obj interface{}) {

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -198,6 +198,8 @@ const (
 	VolumeHealth = "volume-health"
 	// VolumeExtend is feature flag name for volume expansion
 	VolumeExtend = "volume-extend"
+	// OnlineVolumeExtend guards the feature for online volume expansion
+	OnlineVolumeExtend = "online-volume-extend"
 	// CSIMigration is feature flag for migrating in-tree vSphere volumes to CSI
 	CSIMigration = "csi-migration"
 	// CSIAuthCheck is feature flag for auth check

--- a/pkg/csi/service/identity.go
+++ b/pkg/csi/service/identity.go
@@ -66,13 +66,6 @@ func (s *service) GetPluginCapabilities(
 					},
 				},
 			},
-			{
-				Type: &csi.PluginCapability_VolumeExpansion_{
-					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
-						Type: csi.PluginCapability_VolumeExpansion_OFFLINE,
-					},
-				},
-			},
 		},
 	}
 	return rep, nil

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -50,6 +50,7 @@ import (
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
 
@@ -58,6 +59,8 @@ const (
 	blockPrefix = "wwn-0x"
 	dmiDir      = "/sys/class/dmi"
 )
+
+var containerOrchestratorUtility commonco.COCommonInterface
 
 type nodeStageParams struct {
 	// volID is the identifier for the underlying volume
@@ -742,8 +745,8 @@ func (s *service) NodeExpandVolume(
 		return nil, status.Error(codes.InvalidArgument, "capacity ranges values cannot be negative")
 	}
 
-	volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
-	volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
+	reqVolSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
+	reqVolSizeMB := int64(common.RoundUpSize(reqVolSizeBytes, common.MbInBytes))
 
 	// TODO(xyang): In CSI spec 1.2, NodeExpandVolume will be
 	// passing in a staging_target_path which is more precise
@@ -774,6 +777,26 @@ func (s *service) NodeExpandVolume(
 		Interface: realMounter,
 		Exec:      realExec,
 	}
+
+	if containerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend) {
+		// Fetch the current block size
+		currentBlockSizeBytes, err := getBlockSizeBytes(mounter, dev.RealDev)
+		if err != nil {
+			return nil, status.Error(codes.Internal, fmt.Sprintf("error when getting size of block volume at path %s: %v", dev.RealDev, err))
+		}
+		// Check if a rescan is required
+		if currentBlockSizeBytes < reqVolSizeBytes {
+			// If a device is expanded while it is attached to a VM, we need to rescan
+			// the device on the guest OS in order to see the modified size on the Guest OS
+			// Refer to https://kb.vmware.com/s/article/1006371
+			err = rescanDevice(ctx, dev)
+			if err != nil {
+				return nil, status.Error(codes.Internal, err.Error())
+			}
+		}
+	}
+
+	// Resize file system
 	resizer := resizefs.NewResizeFs(mounter)
 	_, err = resizer.Resize(dev.RealDev, volumePath)
 	if err != nil {
@@ -782,20 +805,20 @@ func (s *service) NodeExpandVolume(
 	log.Debugf("NodeExpandVolume: Resized filesystem with devicePath %s volumePath %s", dev.RealDev, volumePath)
 
 	// Check the block size
-	gotBlockSizeBytes, err := getBlockSizeBytes(mounter, dev.RealDev)
+	currentBlockSizeBytes, err := getBlockSizeBytes(mounter, dev.RealDev)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("error when getting size of block volume at path %s: %v", dev.RealDev, err))
 	}
 	// NOTE(xyang): Make sure new size is greater than or equal to the
 	// requested size. It is possible for volume size to be rounded up
 	// and therefore bigger than the requested size.
-	if gotBlockSizeBytes < volSizeBytes {
-		return nil, status.Errorf(codes.Internal, "requested volume size was %d, but got volume with size %d", volSizeBytes, gotBlockSizeBytes)
+	if currentBlockSizeBytes < reqVolSizeBytes {
+		return nil, status.Errorf(codes.Internal, "requested volume size was %d, but got volume with size %d", reqVolSizeBytes, currentBlockSizeBytes)
 	}
 
-	log.Infof("NodeExpandVolume: expanded volume successfully. devicePath %s volumePath %s size %d", dev.RealDev, volumePath, int64(units.FileSize(volSizeMB*common.MbInBytes)))
+	log.Infof("NodeExpandVolume: expanded volume successfully. devicePath %s volumePath %s size %d", dev.RealDev, volumePath, int64(units.FileSize(reqVolSizeMB*common.MbInBytes)))
 	return &csi.NodeExpandVolumeResponse{
-		CapacityBytes: int64(units.FileSize(volSizeMB * common.MbInBytes)),
+		CapacityBytes: int64(units.FileSize(reqVolSizeMB * common.MbInBytes)),
 	}, nil
 }
 
@@ -1067,6 +1090,35 @@ func getDevice(path string) (*Device, error) {
 		FullPath: path,
 		RealDev:  d,
 	}, nil
+}
+
+func rescanDevice(ctx context.Context, dev *Device) error {
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx)
+
+	devRescanPath, err := getDeviceRescanPath(dev)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(devRescanPath, []byte{'1'}, 0666)
+	if err != nil {
+		msg := fmt.Sprintf("error rescanning block device %q. %v", dev.RealDev, err)
+		log.Error(msg)
+		return fmt.Errorf(msg)
+	}
+	return nil
+}
+
+func getDeviceRescanPath(dev *Device) (string, error) {
+	// A typical dev.RealDev path looks like `/dev/sda`. To rescan a block
+	// device we need to write into `/sys/block/$DEVICE/device/rescan`
+	// Refer to https://kb.vmware.com/s/article/1006371
+	parts := strings.Split(dev.RealDev, "/")
+	if len(parts) == 3 && strings.HasPrefix(parts[1], "dev") {
+		return filepath.EvalSymlinks(filepath.Join("/sys/block", parts[2], "device", "rescan"))
+	}
+	return "", fmt.Errorf("illegal path for device %q", dev.RealDev)
 }
 
 // The files parameter is optional for testing purposes

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -804,7 +804,8 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		log.Error(msg)
 		return nil, status.Errorf(codes.Unimplemented, msg)
 	}
-	err := validateVanillaControllerExpandVolumeRequest(ctx, req)
+	isOnlineExpansionEnabled := containerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend)
+	err := validateVanillaControllerExpandVolumeRequest(ctx, req, isOnlineExpansionEnabled)
 	if err != nil {
 		msg := fmt.Sprintf("validation for ExpandVolume Request: %+v has failed. Error: %v", *req, err)
 		log.Error(msg)

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -556,7 +556,8 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	}
 	log.Infof("ControllerExpandVolume: called with args %+v", *req)
 
-	err := validateWCPControllerExpandVolumeRequest(ctx, req, c.manager)
+	isOnlineExpansionEnabled := c.coCommonInterface.IsFSSEnabled(ctx, common.OnlineVolumeExtend)
+	err := validateWCPControllerExpandVolumeRequest(ctx, req, c.manager, isOnlineExpansionEnabled)
 	if err != nil {
 		log.Errorf("validation for ExpandVolume Request: %+v has failed. Error: %v", *req, err)
 		return nil, err

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -566,57 +566,83 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	volumeID := req.GetVolumeId()
 	volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 
-	vmList := &vmoperatortypes.VirtualMachineList{}
-	err = c.vmOperatorClient.List(ctx, vmList, client.InNamespace(c.supervisorNamespace))
-	if err != nil {
-		msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
-		log.Error(msg)
-		return nil, status.Error(codes.Internal, msg)
-	}
+	if !c.coCommonInterface.IsFSSEnabled(ctx, common.OnlineVolumeExtend) {
+		vmList := &vmoperatortypes.VirtualMachineList{}
+		err = c.vmOperatorClient.List(ctx, vmList, client.InNamespace(c.supervisorNamespace))
+		if err != nil {
+			msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
+			log.Error(msg)
+			return nil, status.Error(codes.Internal, msg)
+		}
 
-	for _, vmInstance := range vmList.Items {
-		for _, vmVolume := range vmInstance.Status.Volumes {
-			if vmVolume.Name == volumeID && vmVolume.Attached {
-				msg := fmt.Sprintf("failed to expand volume: %q. Volume is attached to pod. Only offline volume expansion is supported", volumeID)
-				log.Error(msg)
-				return nil, status.Error(codes.FailedPrecondition, msg)
+		for _, vmInstance := range vmList.Items {
+			for _, vmVolume := range vmInstance.Status.Volumes {
+				if vmVolume.Name == volumeID && vmVolume.Attached {
+					msg := fmt.Sprintf("failed to expand volume: %q. Volume is attached to pod. Only offline volume expansion is supported", volumeID)
+					log.Error(msg)
+					return nil, status.Error(codes.FailedPrecondition, msg)
+				}
 			}
 		}
 	}
 
 	// Retrieve Supervisor PVC
-	pvc, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(ctx, volumeID, metav1.GetOptions{})
+	svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(ctx, volumeID, metav1.GetOptions{})
 	if err != nil {
 		msg := fmt.Sprintf("failed to retrieve supervisor PVC %q in %q namespace. Error: %+v", volumeID, c.supervisorNamespace, err)
 		log.Error(msg)
 		return nil, status.Error(codes.Internal, msg)
 	}
 
-	newQty := resource.NewQuantity(volSizeBytes, resource.Format(resource.BinarySI))
-	curQty := pvc.Spec.Resources.Requests[corev1.ResourceName(corev1.ResourceStorage)]
-	if (&curQty).Cmp(*newQty) == -1 {
-		// Update requested storage in PVC spec
-		pvcClone := pvc.DeepCopy()
-		pvcClone.Spec.Resources.Requests[corev1.ResourceName(corev1.ResourceStorage)] = *newQty
-		// Make a call to SV ControllerExpandVolume
-		log.Debugf("Increasing the size of supervisor PVC %s in namespace %s to %s", volumeID, c.supervisorNamespace, newQty.String())
-		pvc, err = c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Update(ctx, pvcClone, metav1.UpdateOptions{})
+	waitForSvPvcCondition := true
+	gcPvcRequestSize := resource.NewQuantity(volSizeBytes, resource.Format(resource.BinarySI))
+	svPvcRequestSize := svPVC.Spec.Resources.Requests[corev1.ResourceName(corev1.ResourceStorage)]
+	// Check if GC PVC request size is greater than SV PVC request size
+	switch (gcPvcRequestSize).Cmp(svPvcRequestSize) {
+	case 1:
+		// Update requested storage in SV PVC spec
+		svPvcClone := svPVC.DeepCopy()
+		svPvcClone.Spec.Resources.Requests[corev1.ResourceName(corev1.ResourceStorage)] = *gcPvcRequestSize
+
+		// Make an update call to SV API server
+		log.Infof("Increasing the size of supervisor PVC %s in namespace %s to %s", volumeID, c.supervisorNamespace, gcPvcRequestSize.String())
+		svPVC, err = c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Update(ctx, svPvcClone, metav1.UpdateOptions{})
 		if err != nil {
 			msg := fmt.Sprintf("failed to update supervisor PVC %q in %q namespace. Error: %+v", volumeID, c.supervisorNamespace, err)
 			log.Error(msg)
 			return nil, status.Error(codes.Internal, msg)
 		}
-	} else {
-		log.Debugf("Skipping resize call for supervisor PVC %s in namespace %s", volumeID, c.supervisorNamespace)
+	case 0:
+		// GC PVC request size is equal to SV PVC request size
+		log.Infof("Skipping resize call for supervisor PVC %s in namespace %s as it is already at the requested size", volumeID, c.supervisorNamespace)
+
+		// SV PVC is already in FileSystemResizePending condition indicates that SV PV has already been expanded to required size
+		if checkPVCCondition(ctx, svPVC, corev1.PersistentVolumeClaimFileSystemResizePending) {
+			waitForSvPvcCondition = false
+		} else {
+			// SV PVC is not in FileSystemResizePending condition and GC PVC request size is equal to SV PVC capacity
+			// indicates that SV PVC is already at required size
+			if (gcPvcRequestSize).Cmp(svPVC.Status.Capacity[corev1.ResourceName(corev1.ResourceStorage)]) == 0 {
+				waitForSvPvcCondition = false
+			}
+		}
+	default:
+		// GC PVC request size is lesser than SV PVC request size
+		msg := fmt.Sprintf("the requested size of the Supervisor PVC %s in namespace %s is %s which is greater than the requested size of %s",
+			volumeID, c.supervisorNamespace, svPvcRequestSize.String(), gcPvcRequestSize.String())
+		log.Error(msg)
+		return nil, status.Error(codes.InvalidArgument, msg)
 	}
 
-	// Wait for Supervisor PVC to change status to FilesystemResizePending
-	err = checkForSupervisorPVCCondition(ctx, c.supervisorClient, pvc,
-		corev1.PersistentVolumeClaimFileSystemResizePending, time.Duration(getResizeTimeoutInMin(ctx))*time.Minute)
-	if err != nil {
-		msg := fmt.Sprintf("failed to expand volume %s in namespace %s of supervisor cluster. Error: %+v", volumeID, c.supervisorNamespace, err)
-		log.Error(msg)
-		return nil, status.Error(codes.Internal, msg)
+	if waitForSvPvcCondition {
+		// Wait for Supervisor PVC to change status to FilesystemResizePending
+		err = checkForSupervisorPVCCondition(ctx, c.supervisorClient, svPVC,
+			corev1.PersistentVolumeClaimFileSystemResizePending, time.Duration(getResizeTimeoutInMin(ctx))*time.Minute)
+		if err != nil {
+			msg := fmt.Sprintf("failed to expand volume %s in namespace %s of supervisor cluster. Error: %+v", volumeID, c.supervisorNamespace, err)
+			log.Error(msg)
+			return nil, status.Error(codes.Internal, msg)
+		}
 	}
 
 	nodeExpansionRequired := true

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -141,9 +141,9 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			SupervisorFeatureStatesConfigInfo: metadataSyncer.configInfo.Cfg.FeatureStatesConfig,
 		}
 	} else {
-		mssg := fmt.Sprintf("unrecognized cluster flavor %q", clusterFlavor)
-		log.Error(mssg)
-		return errors.New(mssg)
+		msg := fmt.Sprintf("unrecognized cluster flavor %q", clusterFlavor)
+		log.Error(msg)
+		return errors.New(msg)
 	}
 
 	metadataSyncer.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor, k8sInitParams)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Extends support for online volume expansion of block volumes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Tested online resize workflow in Vanilla, supervisor and TKG clusters. 
Example logs - 
ControllerExpandVolume:
```
{"level":"info","time":"2020-10-22T23:17:35.717270095Z","caller":"vanilla/controller.go:800","msg":"ControllerExpandVolume: called with args {VolumeId:7f88d740-aea5-4baf-b1bd-e0a19cf22bba CapacityRange:required_bytes:3221225472  Secrets:map[] VolumeCapability:mount:<> access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"0c8b2e6b-cd50-447d-88b7-711fb19a854a"}
{"level":"warn","time":"2020-10-22T23:17:35.759084879Z","caller":"vsphere/virtualcenter.go:239","msg":"Creating a new client session as the existing session isn't valid or not authenticated"}
{"level":"info","time":"2020-10-22T23:17:35.902603465Z","caller":"vsphere/virtualcenter.go:153","msg":"New session ID for 'VSPHERE.LOCAL\\Administrator' = 52bd66cf-412b-3667-3eeb-1259f415ce29"}
{"level":"info","time":"2020-10-22T23:17:36.961039198Z","caller":"common/vsphereutil.go:397","msg":"Requested size 3072 Mb is greater than current size for volumeID: \"7f88d740-aea5-4baf-b1bd-e0a19cf22bba\". Need volume expansion.","TraceId":"0c8b2e6b-cd50-447d-88b7-711fb19a854a"}
{"level":"info","time":"2020-10-22T23:17:36.967064821Z","caller":"volume/manager.go:571","msg":"Calling CnsClient.ExtendVolume: VolumeID [\"7f88d740-aea5-4baf-b1bd-e0a19cf22bba\"] Size [3072] cnsExtendSpecList [[]types.CnsVolumeExtendSpec{types.CnsVolumeExtendSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:\"7f88d740-aea5-4baf-b1bd-e0a19cf22bba\"}, CapacityInMb:3072}}]","TraceId":"0c8b2e6b-cd50-447d-88b7-711fb19a854a"}
{"level":"info","time":"2020-10-22T23:17:41.675416063Z","caller":"volume/manager.go:587","msg":"ExpandVolume: volumeID: \"7f88d740-aea5-4baf-b1bd-e0a19cf22bba\", opId: \"604e3ff3\"","TraceId":"0c8b2e6b-cd50-447d-88b7-711fb19a854a"}
{"level":"info","time":"2020-10-22T23:17:41.676015048Z","caller":"volume/manager.go:605","msg":"ExpandVolume: Volume expanded successfully. volumeID: \"7f88d740-aea5-4baf-b1bd-e0a19cf22bba\", opId: \"604e3ff3\"","TraceId":"0c8b2e6b-cd50-447d-88b7-711fb19a854a"}
{"level":"info","time":"2020-10-22T23:17:41.676376745Z","caller":"common/vsphereutil.go:403","msg":"Successfully expanded volume for volumeid \"7f88d740-aea5-4baf-b1bd-e0a19cf22bba\" to new size 3072 Mb.","TraceId":"0c8b2e6b-cd50-447d-88b7-711fb19a854a”}
```

NodeExpandVolume:
```
{"level":"info","time":"2020-10-22T23:18:20.75659615Z","caller":"service/node.go:737","msg":"NodeExpandVolume: called with args {VolumeId:7f88d740-aea5-4baf-b1bd-e0a19cf22bba VolumePath:/var/lib/kubelet/pods/196e6446-7c34-41b1-8d0d-e668491075f4/volumes/kubernetes.io~csi/pvc-bdd7d729-2d10-4ec1-b514-20cf071fc01f/mount CapacityRange:required_bytes:3221225472  StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-bdd7d729-2d10-4ec1-b514-20cf071fc01f/globalmount VolumeCapability:mount:<> access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"74ea82d1-bc6b-483a-9e67-a0eb829ec211"}
{"level":"info","time":"2020-10-22T23:18:21.28042251Z","caller":"service/node.go:819","msg":"NodeExpandVolume: expanded volume successfully. devicePath /dev/sdb volumePath /var/lib/kubelet/pods/196e6446-7c34-41b1-8d0d-e668491075f4/volumes/kubernetes.io~csi/pvc-bdd7d729-2d10-4ec1-b514-20cf071fc01f/mount size 3221225472","TraceId":"74ea82d1-bc6b-483a-9e67-a0eb829ec211"}
time="2020-10-22T23:18:21Z" level=debug msg="/csi.v1.Node/NodeExpandVolume: REP 0112: CapacityBytes=3221225472, XXX_NoUnkeyedLiteral={}, XXX_sizecache=0"
```

PVC Final output
```
root@k8s-master-52:~# kubectl describe pvc block-pvc
Name:          block-pvc
Namespace:     default
StorageClass:  block-sc
Status:        Bound
Volume:        pvc-bdd7d729-2d10-4ec1-b514-20cf071fc01f
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      3Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    block-pod
Events:
  Type     Reason                      Age                  From                                     Message
  ----     ------                      ----                 ----                                     -------
  Warning  ExternalExpanding           95s (x2 over 5h29m)  volume_expand                            Ignoring the PVC: didn't find a plugin capable of expanding the volume; waiting for an external controller to process this PVC.
  Normal   Resizing                    95s (x2 over 5h29m)  external-resizer csi.vsphere.vmware.com  External resizer is resizing volume pvc-bdd7d729-2d10-4ec1-b514-20cf071fc01f
  Normal   FileSystemResizeRequired    89s (x2 over 5h29m)  external-resizer csi.vsphere.vmware.com  Require file system resize of volume on node
  Normal   FileSystemResizeSuccessful  49s (x2 over 5h24m)  kubelet, k8s-node-0754                   MountVolume.NodeExpandVolume succeeded for volume "pvc-bdd7d729-2d10-4ec1-b514-20cf071fc01f"
```
Pod Final Output
```
root@k8s-master-52:~# kdsc pod block-pod
Name:         block-pod
Namespace:    default
Priority:     0
Node:         k8s-node-0754/10.186.104.59
Start Time:   Thu, 22 Oct 2020 10:48:02 -0700
Labels:       <none>
Annotations:  <none>
Status:       Running
IP:           10.244.3.10
IPs:
  IP:  10.244.3.10
Containers:
  test-container:
    Container ID:  docker://ae7697361a7d503c9e5f5aa4cb8f7ec0a6cf9435a76b47137d3e6d6aa8e26d4d
    Image:         gcr.io/google_containers/busybox:1.24
    Image ID:      docker-pullable://gcr.io/google_containers/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/sh
      -c
      echo 'hello' > /mnt/volume1/index.html  && chmod o+rX /mnt /mnt/volume1/index.html && while true ; do sleep 2 ; done
    State:          Running
      Started:      Thu, 22 Oct 2020 10:48:25 -0700
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /mnt/volume1 from test-volume (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-z4wj4 (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  test-volume:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  block-pvc
    ReadOnly:   false
  default-token-z4wj4:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-z4wj4
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                 node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason                      Age                  From                    Message
  ----    ------                      ----                 ----                    -------
  Normal  FileSystemResizeSuccessful  17m (x2 over 5h40m)  kubelet, k8s-node-0754  MountVolume.NodeExpandVolume succeeded for volume "pvc-bdd7d729-2d10-4ec1-b514-20cf071fc01f"
```

```
/ # df -h
Filesystem                Size      Used Available Use% Mounted on
overlay                  10.8G      5.8G      4.4G  57% /
tmpfs                    64.0M         0     64.0M   0% /dev
tmpfs                     1.9G         0      1.9G   0% /sys/fs/cgroup
/dev/sdb                  2.9G      3.0M      2.8G   0% /mnt/volume1
/dev/mapper/sc2--10--184--155--191--vg-root
                         10.8G      5.8G      4.4G  57% /dev/termination-log
/dev/mapper/sc2--10--184--155--191--vg-root
                         10.8G      5.8G      4.4G  57% /etc/resolv.conf
/dev/mapper/sc2--10--184--155--191--vg-root
                         10.8G      5.8G      4.4G  57% /etc/hostname
/dev/mapper/sc2--10--184--155--191--vg-root
                         10.8G      5.8G      4.4G  57% /etc/hosts
shm                      64.0M         0     64.0M   0% /dev/shm
tmpfs                     1.9G     12.0K      1.9G   0% /var/run/secrets/kubernetes.io/serviceaccount
tmpfs                     1.9G         0      1.9G   0% /proc/acpi
tmpfs                    64.0M         0     64.0M   0% /proc/kcore
tmpfs                    64.0M         0     64.0M   0% /proc/keys
tmpfs                    64.0M         0     64.0M   0% /proc/timer_list
tmpfs                    64.0M         0     64.0M   0% /proc/sched_debug
tmpfs                     1.9G         0      1.9G   0% /proc/scsi
tmpfs                     1.9G         0      1.9G   0% /sys/firmware
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Online resize support for block volumes
```
