### PR TITLE
Update pod metadata for inline migrated volumes

### DIFF
--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -84,7 +84,7 @@ func getInlineMigratedVolumesInfo(ctx context.Context, metadataSyncer *metadataS
 					log.Warnf("FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", volume.VsphereVolume.VolumePath, err)
 					continue
 				}
-				inlineVolumes[volume.VsphereVolume.VolumePath] = volumeHandle
+				inlineVolumes[volumeHandle] = volume.VsphereVolume.VolumePath
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding support for updating pod metadata for inline migrated volumes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #253 

**Special notes for your reviewer**:
**Testing:**
Create a deployment with inline vSphere volume
<pre>
kubectl create -f inline.yaml 
deployment.apps/sample-inline-deployment created
root@k8s-master:~# kubectl get cnsvspherevolumemigrations.cns.vmware.com -A
NAME                                   AGE
75f9079e-22cc-4988-bfda-fe523a101ed8   69s
</pre>
Observed that the volume was registered successfully
<pre>
vSphere CNS driver registering volume "[vsanDatastore] d0f8635f-47b6-43a0-ead5-02003bdc230b/vm-1.vmdk" with create spec
</pre>

Observed that update metadata with pod information was invoked:
<pre>
2020-09-18T03:12:38.180Z	DEBUG	syncer/metadatasyncer.go:1097	Calling UpdateVolumeMetadata for volume 75f9079e-22cc-4988-bfda-fe523a101ed8 with updateSpec: (*types.CnsVolumeMetadataUpdateSpec)(0xc000a78380)({
 DynamicData: (types.DynamicData) {
 },
 VolumeId: (types.CnsVolumeId) {
  DynamicData: (types.DynamicData) {
  },
  Id: (string) (len=36) "75f9079e-22cc-4988-bfda-fe523a101ed8"
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=15) "demo-cluster-id",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=1 cap=1) {
   (*types.CnsKubernetesEntityMetadata)(0xc000a78280)({
    CnsEntityMetadata: (types.CnsEntityMetadata) {
     DynamicData: (types.DynamicData) {
     },
     EntityName: (string) (len=41) "sample-inline-deployment-7cdf578458-vvnb6",
     Labels: ([]types.KeyValue) <nil>,
     Delete: (bool) true,
     ClusterID: (string) (len=15) "demo-cluster-id"
    },
    EntityType: (string) (len=3) "POD",
    Namespace: (string) (len=7) "default",
    ReferredEntity: ([]types.CnsKubernetesEntityReference) <nil>
   })
  },
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=15) "demo-cluster-id",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA"
   }
  }
 }
})
</pre>

CNS UI:
<img width="1000" alt="Screen Shot 2020-09-17 at 8 11 41 PM" src="https://user-images.githubusercontent.com/14131348/93551664-4ed56180-f923-11ea-9bae-b3272fb559ae.png">


Unit tests: 
https://gist.github.com/chethanv28/c2c70b9543c764bbe37054b4cbeecaf0

e2e Tests:
In-progress

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update pod metadata for inline migrated volumes
```
