### PR TITLE
Make corrections in log messages

### DIFF
--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -387,7 +387,7 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volu
 			vmdkPath + "?dcPath=" + url.PathEscape(datacenter) + "&dsName=" + url.PathEscape(datastoreName)
 		createSpec.BackingObjectDetails = &cnstypes.CnsBlockBackingDetails{BackingDiskUrlPath: backingDiskURLPath}
 		log.Infof("Registering volume: %q using backingDiskURLPath :%q", volumeSpec.VolumePath, backingDiskURLPath)
-		log.Debugf("vSphere CNS driver registering volume %q with create spec %+v", volumeSpec.VolumePath, spew.Sdump(createSpec))
+		log.Debugf("vSphere CSI driver registering volume %q with create spec %+v", volumeSpec.VolumePath, spew.Sdump(createSpec))
 		volumeID, err = (*volumeMigration.volumeManager).CreateVolume(ctx, createSpec)
 		if err != nil {
 			log.Warnf("failed to register volume %q with createSpec: %v. error: %+v", volumeSpec.VolumePath, createSpec, err)

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -326,7 +326,7 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 func ReadConfig(ctx context.Context, config io.Reader) (*Config, error) {
 	log := logger.GetLogger(ctx)
 	if config == nil {
-		return nil, fmt.Errorf("no vSphere cloud provider config file given")
+		return nil, fmt.Errorf("no vSphere CSI driver config file given")
 	}
 	cfg := &Config{}
 	if err := gcfg.FatalOnly(gcfg.ReadInto(cfg, config)); err != nil {

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -169,7 +169,7 @@ func CreateBlockVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluste
 		createSpec.Profile = append(createSpec.Profile, profileSpec)
 	}
 
-	log.Debugf("vSphere CNS driver creating volume %s with create spec %+v", spec.Name, spew.Sdump(createSpec))
+	log.Debugf("vSphere CSI driver creating volume %s with create spec %+v", spec.Name, spew.Sdump(createSpec))
 	volumeID, err := manager.VolumeManager.CreateVolume(ctx, createSpec)
 	if err != nil {
 		log.Errorf("failed to create disk %s with error %+v", spec.Name, err)
@@ -311,7 +311,7 @@ func CreateFileVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 		createSpec.Profile = append(createSpec.Profile, profileSpec)
 	}
 
-	log.Debugf("vSphere CNS driver creating volume %q with create spec %+v", spec.Name, spew.Sdump(createSpec))
+	log.Debugf("vSphere CSI driver creating volume %q with create spec %+v", spec.Name, spew.Sdump(createSpec))
 	volumeID, err := manager.VolumeManager.CreateVolume(ctx, createSpec)
 	if err != nil {
 		log.Errorf("failed to create file volume %q with error %+v", spec.Name, err)
@@ -344,7 +344,7 @@ func AttachVolumeUtil(ctx context.Context, manager *Manager,
 	vm *vsphere.VirtualMachine,
 	volumeID string) (string, error) {
 	log := logger.GetLogger(ctx)
-	log.Debugf("vSphere CNS driver is attaching volume: %q to vm: %q", volumeID, vm.String())
+	log.Debugf("vSphere CSI driver is attaching volume: %q to vm: %q", volumeID, vm.String())
 	diskUUID, err := manager.VolumeManager.AttachVolume(ctx, vm, volumeID)
 	if err != nil {
 		log.Errorf("failed to attach disk %q with VM: %q. err: %+v", volumeID, vm.String(), err)
@@ -359,7 +359,7 @@ func DetachVolumeUtil(ctx context.Context, manager *Manager,
 	vm *vsphere.VirtualMachine,
 	volumeID string) error {
 	log := logger.GetLogger(ctx)
-	log.Debugf("vSphere CNS driver is detaching volume: %s from node vm: %s", volumeID, vm.InventoryPath)
+	log.Debugf("vSphere CSI driver is detaching volume: %s from node vm: %s", volumeID, vm.InventoryPath)
 	err := manager.VolumeManager.DetachVolume(ctx, vm, volumeID)
 	if err != nil {
 		log.Errorf("failed to detach disk %s with err %+v", volumeID, err)
@@ -373,7 +373,7 @@ func DetachVolumeUtil(ctx context.Context, manager *Manager,
 func DeleteVolumeUtil(ctx context.Context, volManager cnsvolume.Manager, volumeID string, deleteDisk bool) error {
 	log := logger.GetLogger(ctx)
 	var err error
-	log.Debugf("vSphere Cloud Provider deleting volume: %s with deleteDisk flag: %t", volumeID, deleteDisk)
+	log.Debugf("vSphere CSI driver is deleting volume: %s with deleteDisk flag: %t", volumeID, deleteDisk)
 	err = volManager.DeleteVolume(ctx, volumeID, deleteDisk)
 	if err != nil {
 		log.Errorf("failed to delete disk %s, deleteDisk flag: %t with error %+v", volumeID, deleteDisk, err)
@@ -387,7 +387,7 @@ func DeleteVolumeUtil(ctx context.Context, volManager cnsvolume.Manager, volumeI
 func ExpandVolumeUtil(ctx context.Context, manager *Manager, volumeID string, capacityInMb int64) error {
 	var err error
 	log := logger.GetLogger(ctx)
-	log.Debugf("vSphere CNS driver expanding volume %q to new size %d Mb.", volumeID, capacityInMb)
+	log.Debugf("vSphere CSI driver expanding volume %q to new size %d Mb.", volumeID, capacityInMb)
 
 	expansionRequired, err := isExpansionRequired(ctx, volumeID, capacityInMb, manager)
 	if err != nil {

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -288,7 +288,7 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(request reconcile.Request) (rec
 			}
 		}
 
-		log.Debugf("vSphere CNS driver is attaching volume: %q to nodevm: %+v for CnsNodeVmAttachment request with name: %q on namespace: %q",
+		log.Debugf("vSphere CSI driver is attaching volume: %q to nodevm: %+v for CnsNodeVmAttachment request with name: %q on namespace: %q",
 			volumeID, nodeVM, request.Name, request.Namespace)
 		diskUUID, attachErr := volumes.GetManager(ctx, vcenter).AttachVolume(ctx, nodeVM, volumeID)
 
@@ -368,7 +368,7 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(request reconcile.Request) (rec
 			recordEvent(ctx, r, instance, v1.EventTypeWarning, msg)
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
-		log.Debugf("vSphere CNS driver is detaching volume: %q to nodevm: %+v for CnsNodeVmAttachment request with name: %q on namespace: %q",
+		log.Debugf("vSphere CSI driver is detaching volume: %q to nodevm: %+v for CnsNodeVmAttachment request with name: %q on namespace: %q",
 			cnsVolumeID, nodeVM, request.Name, request.Namespace)
 		detachErr := volumes.GetManager(ctx, vcenter).DetachVolume(ctx, nodeVM, cnsVolumeID)
 		if detachErr != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is just making minor corrections to log messages to avoid confusion while reading the logs.
It is better to use vSphere CNS driver in log messages instead of vSphere Cloud Provider, especially with volume migration support in-place the existing wordings in the logs are mis-leading.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
