### PR TITLE
Update arguments for external resizer v1.0.0 in pvcsi manifests

### DIFF
--- a/manifests/latest/vsphere-7.0u1/guestcluster/1.16/pvcsi.yaml
+++ b/manifests/latest/vsphere-7.0u1/guestcluster/1.16/pvcsi.yaml
@@ -218,9 +218,11 @@ spec:
           image: vmware.io/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:<image_tag>
           args:
             - "--v=4"
-            - "--csiTimeout=300s"
+            - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/latest/vsphere-7.0u1/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/latest/vsphere-7.0u1/guestcluster/1.17/pvcsi.yaml
@@ -219,9 +219,11 @@ spec:
           image: vmware.io/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:<image_tag>
           args:
             - "--v=4"
-            - "--csiTimeout=300s"
+            - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR updates the arguments provided to external resizer in pvCSI. The updates are:
- `csiTimeout` was changed to `timeout`. 
- qps and burst are configurable.

See changelog for v1.0.0 for more details - https://github.com/kubernetes-csi/external-resizer/blob/release-1.0/CHANGELOG-1.0.md

NOTE that this is only updated in 7.0u1 manifests as 7.0 is already shipped with external-resizer v0.5.0
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update arguments for external resizer v1.0.0 in pvCSI manifests
```
