### PR TITLE
Added new metadata to PVC

### DIFF
--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -297,17 +297,15 @@ func (k8sCloudOperator *k8sCloudOperator) PlacePersistenceVolumeClaim(ctx contex
 	if err != nil {
 		return out, err
 	}
+
 	spTypes, present := sc.Annotations[spTypeAnnotationKey]
 	if !present || !strings.Contains(spTypes, vsanDirectType) {
 		log.Debug("storage class is not of type vsan direct, aborting placement")
 		return out, nil
 	}
-	// Validate accessibility requirements
-	if req.AccessibilityRequirements == nil {
-		return out, fmt.Errorf("invalid accessibility requirements input provided")
-	}
-	log.Infof("Get info of topology from input %s", req.AccessibilityRequirements)
+
 	log.Debugf("Enter placementEngine %s", req)
+	
 	err = PlacePVConStoragePool(ctx, k8sCloudOperator.k8sClient, req.AccessibilityRequirements, pvc)
 	if err != nil {
 		log.Errorf("Failed to place this PVC on sp with error %s", err)

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -44,6 +44,10 @@ const (
 
 	// key for HealthStatus annotation on PVC
 	annVolumeHealth = "volumehealth.storage.kubernetes.io/health"
+
+	//key for expressing timestamp for volume health annotation
+	annVolumeHealthTS = "volumehealth.storage.kubernetes.io/health-timestamp"
+
 	// default interval for csi volume health
 	defaultVolumeHealthIntervalInMin = 5
 

--- a/pkg/syncer/volume_health.go
+++ b/pkg/syncer/volume_health.go
@@ -19,6 +19,7 @@ package syncer
 import (
 	"context"
 	"fmt"
+	"time"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
@@ -93,6 +94,8 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 					log.Debugf("csiGetVolumeHealthStatus: update volume health annotation for pvc %s/%s from old value %s to new value %s",
 						pvc.Namespace, pvc.Name, val, volHealthStatus)
 					metav1.SetMetaDataAnnotation(&pvc.ObjectMeta, annVolumeHealth, volHealthStatus)
+					metav1.SetMetaDataAnnotation(&pvc.ObjectMeta, annVolumeHealthTS, time.Now().String())
+					log.Infof("set annotation for health to %s at time %s", volHealthStatus, time.Now().String()) 
 					_, err := k8sclient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(ctx, pvc, metav1.UpdateOptions{})
 					if err != nil {
 						if apierrors.IsConflict(err) {
@@ -105,6 +108,8 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 									"get from API server from old value %s to new value %s",
 									newPvc.Namespace, newPvc.Name, val, volHealthStatus)
 								metav1.SetMetaDataAnnotation(&newPvc.ObjectMeta, annVolumeHealth, volHealthStatus)
+								metav1.SetMetaDataAnnotation(&newPvc.ObjectMeta, annVolumeHealthTS, time.Now().String())
+								log.Infof("set annotation for health to %s at time %s", volHealthStatus, time.Now().String()) 
 								_, err := k8sclient.CoreV1().PersistentVolumeClaims(newPvc.Namespace).Update(ctx, newPvc, metav1.UpdateOptions{})
 								if err != nil {
 									log.Errorf("csiGetVolumeHealthStatus: Failed to update pvc %s/%s with err:%+v",


### PR DESCRIPTION

What this PR does / why we need it:
This pull request adds two new pieces of information to PVCs. 
(1) For host local PVCs if the placement engine is not able to find an appropriate storage pool, now the storage pool annotation contains the error. This helps partner operators understand why the provisioning is failing.
(2) Health annotation now comes with another annotation expressing when health was last updated. 

Testing Done:
Created PVCs on full datastore and saw the storage pool annotation show 
`Annotations:   failure-domain.beta.vmware.com/storagepool: FAILED_PLACEMENT-NotEnoughResources`

PVC created properly also now show the health TS annotation
`              
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Tue Sep 22 16:56:28 UTC 2020
`
