### PR TITLE
allow thin volume provisioning with vcp sc post migration

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -240,7 +240,9 @@ func ParseStorageClassParams(ctx context.Context, params map[string]string, csiM
 				param = strings.ToLower(param)
 				if param == DatastoreMigrationParam {
 					scParams.Datastore = value
-				} else if param == DiskFormatMigrationParam || param == HostFailuresToTolerateMigrationParam ||
+				} else if param == DiskFormatMigrationParam && value == "thin" {
+					continue
+				} else if param == HostFailuresToTolerateMigrationParam ||
 					param == ForceProvisioningMigrationParam || param == CacheReservationMigrationParam ||
 					param == DiskstripesMigrationParam || param == ObjectspacereservationMigrationParam ||
 					param == IopslimitMigrationParam {

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -324,6 +324,37 @@ func TestParseStorageClassParamsWithMigrationEnabledNagative(t *testing.T) {
 	t.Logf("expected err received. err: %v", err)
 }
 
+func TestParseStorageClassParamsWithDiskFormatMigrationEnableNegative(t *testing.T) {
+	csiMigrationFeatureState := true
+	params := map[string]string{
+		CSIMigrationParams:       "true",
+		DiskFormatMigrationParam: "thick",
+	}
+	scParam, err := ParseStorageClassParams(ctx, params, csiMigrationFeatureState)
+	if err == nil {
+		t.Errorf("error expected but not received. scParam received from ParseStorageClassParams: %v", scParam)
+	}
+	t.Logf("expected err received. err: %v", err)
+}
+
+func TestParseStorageClassParamsWithDiskFormatMigrationEnablePositive(t *testing.T) {
+	csiMigrationFeatureState := true
+	params := map[string]string{
+		CSIMigrationParams:       "true",
+		DiskFormatMigrationParam: "thin",
+	}
+	expectedScParams := &StorageClassParams{
+		CSIMigration: "true",
+	}
+	scParam, err := ParseStorageClassParams(ctx, params, csiMigrationFeatureState)
+	if err != nil {
+		t.Errorf("failed to parse params: %+v, err: %+v", params, err)
+	}
+	if !isStorageClassParamsEqual(expectedScParams, scParam) {
+		t.Errorf("Expected: %+v\n Actual: %+v", expectedScParams, scParam)
+	}
+}
+
 func TestParseStorageClassParamsWithMigrationEnabledPositive(t *testing.T) {
 	csiMigrationFeatureState := true
 	params := map[string]string{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
allow thin volume provisioning with vcp sc post-migration using `disk-format` sc parameter.

**Which issue this PR fixes** 
fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/378

**Special notes for your reviewer**:

unit tests

```
=== RUN   TestParseStorageClassParamsWithDiskFormatMigrationEnableNegative
--- PASS: TestParseStorageClassParamsWithDiskFormatMigrationEnableNegative (0.00s)
    util_test.go:336: expected err received. err: invalid parameter. key:diskformat-migrationparam, value:thick
=== RUN   TestParseStorageClassParamsWithDiskFormatMigrationEnablePositive
--- PASS: TestParseStorageClassParamsWithDiskFormatMigrationEnablePositive (0.00s)
```

e2e test result

```
18:39:13  Summarizing 2 Failures:
18:39:13  
18:39:13  [Fail] [csi-block-vanilla] full-sync-test [It] Scale down driver deployment to zero replica and verify PV metadata is created in CNS 
18:39:13  /home/worker/workspace/github-csi-block-vanilla/Results/81/vsphere-csi-driver/tests/e2e/fullsync_test_for_block_volume.go:689
18:39:13  
18:39:13  [Fail] [csi-block-vanilla] [csi-supervisor] statefulset [AfterEach] Statefulset testing with parallel podManagementPolicy 
18:39:13  /home/worker/workspace/github-csi-block-vanilla/Results/81/go/pkg/mod/k8s.io/kubernetes@v1.18.5/test/e2e/framework/statefulset/rest.go:140
18:39:13  
18:39:13  Ran 33 of 106 Specs in 7106.473 seconds
18:39:13  FAIL! -- 31 Passed | 2 Failed | 0 Pending | 73 Skipped
18:39:13  --- FAIL: TestE2E (7106.49s)
18:39:13  FAIL
```

Failures are not related to this change - See the failure summary here. 
[failure-summary-379.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/5272952/failure-summary-379.txt)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
allow thin volume provisioning with vcp sc post-migration
```


cc: @chethanv28  @sashrith 
