### PR TITLE
Fix errors reported by gocritic

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -65,13 +65,13 @@ func main() {
 	if clusterFlavor == "" {
 		clusterFlavor = cnstypes.CnsClusterFlavorVanilla
 	}
-
-	if *operationMode == operationModeWebHookServer {
+	switch *operationMode {
+	case operationModeWebHookServer:
 		log.Infof("Starting container with operation mode: %v", operationModeWebHookServer)
 		if webHookStartError := admissionhandler.StartWebhookServer(ctx); webHookStartError != nil {
 			log.Fatalf("failed to start webhook server. err: %v", webHookStartError)
 		}
-	} else if *operationMode == operationModeMetaDataSync {
+	case operationModeMetaDataSync:
 		log.Infof("Starting container with operation mode: %v", operationModeMetaDataSync)
 		var err error
 		configInfo, err := types.InitConfigInfo(ctx)
@@ -110,7 +110,7 @@ func main() {
 				log.Fatalf("Error initializing leader election: %v", err)
 			}
 		}
-	} else {
+	default:
 		log.Fatalf("unsupported operation mode: %v", *operationMode)
 	}
 }

--- a/hack/check-golangci-lint.sh
+++ b/hack/check-golangci-lint.sh
@@ -54,5 +54,5 @@ shift $((OPTIND-1))
 if [ ! "${DO_DOCKER-}" ]; then
   golangci-lint run -v --timeout=1200s
 else
-  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v1.29.0 golangci-lint run -v --timeout=1200s
+  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v1.31.0 golangci-lint run -v --timeout=1200s --enable gocritic
 fi

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -352,15 +352,16 @@ func (m *defaultManager) DetachVolume(ctx context.Context, vm *cnsvsphere.Virtua
 			// Detach failed with NotFound error, check if the volume is already detached
 			log.Infof("VolumeID: %q, not found. Checking whether the volume is already detached", volumeID)
 			diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
-			if err != nil {
+			switch {
+			case err != nil:
 				log.Errorf("DetachVolume: CNS Detach has failed with err: %q. Unable to check if volume: %q is already detached from vm: %+v",
 					err, volumeID, vm)
 				return err
-			} else if diskUUID == "" {
+			case diskUUID == "":
 				log.Infof("DetachVolume: volumeID: %q not found on vm: %+v. Assuming volume is already detached",
 					volumeID, vm)
 				return nil
-			} else {
+			default:
 				msg := fmt.Sprintf("failed to detach cns volume:%q from node vm: %+v. err: %v", volumeID, vm, err)
 				log.Error(msg)
 				return errors.New(msg)
@@ -393,15 +394,16 @@ func (m *defaultManager) DetachVolume(ctx context.Context, vm *cnsvsphere.Virtua
 	if volumeOperationRes.Fault != nil {
 		// Volume is already attached to VM
 		diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
-		if err != nil {
+		switch {
+		case err != nil:
 			log.Errorf("DetachVolume: CNS Detach has failed with fault: %q. Unable to check if volume: %q is already detached from vm: %+v",
 				spew.Sdump(volumeOperationRes.Fault), volumeID, vm)
 			return err
-		} else if diskUUID == "" {
+		case diskUUID == "":
 			log.Infof("DetachVolume: volumeID: %q not found on vm: %+v. Assuming volume is already detached",
 				volumeID, vm)
 			return nil
-		} else {
+		default:
 			msg := fmt.Sprintf("failed to detach cns volume:%q from node vm: %+v. fault: %q, opId: %q", volumeID, vm, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 			log.Error(msg)
 			return errors.New(msg)
@@ -609,7 +611,7 @@ func (m *defaultManager) QueryVolume(ctx context.Context, queryFilter cnstypes.C
 		log.Errorf("ConnectCns failed with err: %+v", err)
 		return nil, err
 	}
-	//Call the CNS QueryVolume
+	// Call the CNS QueryVolume
 	res, err := m.virtualCenter.CnsClient.QueryVolume(ctx, queryFilter)
 	if err != nil {
 		log.Errorf("CNS QueryVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
@@ -631,7 +633,7 @@ func (m *defaultManager) QueryAllVolume(ctx context.Context, queryFilter cnstype
 		log.Errorf("ConnectCns failed with err: %+v", err)
 		return nil, err
 	}
-	//Call the CNS QueryAllVolume
+	// Call the CNS QueryAllVolume
 	res, err := m.virtualCenter.CnsClient.QueryAllVolume(ctx, queryFilter, querySelection)
 	if err != nil {
 		log.Errorf("CNS QueryAllVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
@@ -653,7 +655,7 @@ func (m *defaultManager) QueryVolumeInfo(ctx context.Context, volumeIDList []cns
 		log.Errorf("ConnectCns failed with err: %+v", err)
 		return nil, err
 	}
-	//Call the CNS QueryVolumeInfo
+	// Call the CNS QueryVolumeInfo
 	queryVolumeInfoTask, err := m.virtualCenter.CnsClient.QueryVolumeInfo(ctx, volumeIDList)
 	if err != nil {
 		log.Errorf("CNS QueryAllVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -126,12 +126,12 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("config object cannot be nil")
 	}
 	log := logger.GetLogger(ctx)
-	//Init
+	// Init
 	if cfg.VirtualCenter == nil {
 		cfg.VirtualCenter = make(map[string]*VirtualCenterConfig)
 	}
 
-	//Globals
+	// Globals
 	if v := os.Getenv("VSPHERE_VCENTER"); v != "" {
 		cfg.Global.VCenterIP = v
 	}
@@ -161,7 +161,7 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 	if v := os.Getenv("VSPHERE_LABEL_ZONE"); v != "" {
 		cfg.Labels.Zone = v
 	}
-	//Build VirtualCenter from ENVs
+	// Build VirtualCenter from ENVs
 	for _, e := range os.Environ() {
 		pair := strings.Split(e, "=")
 
@@ -233,7 +233,7 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 
 func validateConfig(ctx context.Context, cfg *Config) error {
 	log := logger.GetLogger(ctx)
-	//Fix default global values
+	// Fix default global values
 	if cfg.Global.VCenterPort == "" {
 		cfg.Global.VCenterPort = DefaultVCenterPort
 	}
@@ -340,7 +340,7 @@ func GetCnsconfig(ctx context.Context, cfgPath string) (*Config, error) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("GetCnsconfig called with cfgPath: %s", cfgPath)
 	var cfg *Config
-	//Read in the vsphere.conf if it exists
+	// Read in the vsphere.conf if it exists
 	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
 		log.Infof("Could not stat %s, reading config params from env", cfgPath)
 		// config from Env var only

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -21,7 +21,7 @@ import vsanfstypes "github.com/vmware/govmomi/vsan/vsanfs/types"
 // Config is used to read and store information from the cloud configuration file
 type Config struct {
 	Global struct {
-		//vCenter IP address or FQDN
+		// vCenter IP address or FQDN
 		VCenterIP string
 		// Kubernetes Cluster ID
 		ClusterID string `gcfg:"cluster-id"`

--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -58,7 +58,7 @@ func ValidateCreateVolumeRequest(ctx context.Context, req *csi.CreateVolumeReque
 // Function returns error if validation fails otherwise returns nil.
 func ValidateDeleteVolumeRequest(ctx context.Context, req *csi.DeleteVolumeRequest) error {
 	log := logger.GetLogger(ctx)
-	//check for required parameters
+	// check for required parameters
 	if len(req.VolumeId) == 0 {
 		msg := "Volume ID is a required parameter."
 		log.Error(msg)
@@ -72,7 +72,7 @@ func ValidateDeleteVolumeRequest(ctx context.Context, req *csi.DeleteVolumeReque
 // Function returns error if validation fails otherwise returns nil.
 func ValidateControllerPublishVolumeRequest(ctx context.Context, req *csi.ControllerPublishVolumeRequest) error {
 	log := logger.GetLogger(ctx)
-	//check for required parameters
+	// check for required parameters
 	if len(req.VolumeId) == 0 {
 		msg := "Volume ID is a required parameter."
 		log.Error(msg)
@@ -98,7 +98,7 @@ func ValidateControllerPublishVolumeRequest(ctx context.Context, req *csi.Contro
 // Function returns error if validation fails otherwise returns nil.
 func ValidateControllerUnpublishVolumeRequest(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) error {
 	log := logger.GetLogger(ctx)
-	//check for required parameters
+	// check for required parameters
 	if len(req.VolumeId) == 0 {
 		msg := "Volume ID is a required parameter."
 		log.Error(msg)
@@ -147,15 +147,16 @@ func CheckAPI(version string) error {
 func ValidateControllerExpandVolumeRequest(ctx context.Context, req *csi.ControllerExpandVolumeRequest) error {
 	log := logger.GetLogger(ctx)
 	// check for required parameters
-	if len(req.GetVolumeId()) == 0 {
+	switch {
+	case len(req.GetVolumeId()) == 0:
 		msg := "volume id is a required parameter"
 		log.Error(msg)
 		return status.Error(codes.InvalidArgument, msg)
-	} else if req.GetCapacityRange() == nil {
+	case req.GetCapacityRange() == nil:
 		msg := "capacity range is a required parameter"
 		log.Error(msg)
 		return status.Error(codes.InvalidArgument, msg)
-	} else if req.GetCapacityRange().GetRequiredBytes() < 0 || req.GetCapacityRange().GetLimitBytes() < 0 {
+	case req.GetCapacityRange().GetRequiredBytes() < 0 || req.GetCapacityRange().GetLimitBytes() < 0:
 		msg := "capacity ranges values cannot be negative"
 		log.Error(msg)
 		return status.Error(codes.InvalidArgument, msg)

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -46,7 +46,7 @@ func GetContainerOrchestratorInterface(ctx context.Context, orchestratorType int
 		}
 		return k8sorchestratorInstance, nil
 	default:
-		//if type is invalid, return an error
+		// if type is invalid, return an error
 		return nil, errors.New("Invalid orchestrator Type")
 	}
 }

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -81,7 +81,7 @@ const (
 	// NfsFsType represents nfs mount type
 	NfsFsType = "nfs"
 
-	//ProviderPrefix is the prefix used for the ProviderID set on the node
+	// ProviderPrefix is the prefix used for the ProviderID set on the node
 	// Example: vsphere://4201794a-f26b-8914-d95a-edeb7ecc4a8f
 	ProviderPrefix = "vsphere://"
 

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -560,7 +560,7 @@ func (s *service) NodeGetVolumeStats(
 	}, nil
 }
 
-//getMetrics helps get volume metrics using k8s fsInfo strategy
+// getMetrics helps get volume metrics using k8s fsInfo strategy
 func getMetrics(path string) (*k8svol.Metrics, error) {
 	if path == "" {
 		return nil, fmt.Errorf("no path given")
@@ -676,7 +676,7 @@ func (s *service) NodeGetInfo(
 				}
 			}
 		}()
-		//Connect to vCenter
+		// Connect to vCenter
 		err = vcenter.Connect(ctx)
 		if err != nil {
 			log.Errorf("failed to connect to vcenter host: %s. err=%v", vcenter.Config.Host, err)
@@ -734,11 +734,12 @@ func (s *service) NodeExpandVolume(
 	log.Infof("NodeExpandVolume: called with args %+v", *req)
 
 	volumeID := req.GetVolumeId()
-	if len(volumeID) == 0 {
+	switch {
+	case len(volumeID) == 0:
 		return nil, status.Error(codes.InvalidArgument, "volume id must be provided")
-	} else if req.GetCapacityRange() == nil {
+	case req.GetCapacityRange() == nil:
 		return nil, status.Error(codes.InvalidArgument, "capacity range must be provided")
-	} else if req.GetCapacityRange().GetRequiredBytes() < 0 || req.GetCapacityRange().GetLimitBytes() < 0 {
+	case req.GetCapacityRange().GetRequiredBytes() < 0 || req.GetCapacityRange().GetLimitBytes() < 0:
 		return nil, status.Error(codes.InvalidArgument, "capacity ranges values cannot be negative")
 	}
 
@@ -865,7 +866,7 @@ func publishMountVol(
 					rwo = "ro"
 				}
 				if !contains(m.Opts, rwo) {
-					//TODO make sure that all the mount options match
+					// TODO: make sure that all the mount options match
 					return nil, status.Error(codes.AlreadyExists,
 						"volume previously published with different options")
 				}
@@ -932,7 +933,8 @@ func publishBlockVol(
 	log.Debugf("publishBlockVol: device %+v, device mounts %q", *dev, devMnts)
 
 	// check if device is already mounted
-	if len(devMnts) == 0 {
+	switch len(devMnts) {
+	case 0:
 		// do the bind mount
 		mntFlags := make([]string, 0)
 		log.Debugf("PublishBlockVolume: Attempting to bind mount %q to %q with mount flags %v",
@@ -943,14 +945,14 @@ func publishBlockVol(
 			return nil, status.Error(codes.Internal, msg)
 		}
 		log.Debugf("PublishBlockVolume: Bind mount successful to path %q", params.target)
-	} else if len(devMnts) == 1 {
+	case 1:
 		// already mounted, make sure it's what we want
 		if devMnts[0].Path != params.target {
 			return nil, status.Error(codes.Internal,
 				"device already in use and mounted elsewhere")
 		}
 		log.Debugf("Volume already published to target. Parameters: [%+v]", params)
-	} else {
+	default:
 		return nil, status.Error(codes.AlreadyExists,
 			"block volume already mounted in more than one place")
 	}
@@ -998,7 +1000,7 @@ func publishFileVol(
 				rwo = "ro"
 			}
 			if !contains(m.Opts, rwo) {
-				//TODO make sure that all the mount options match
+				// TODO: make sure that all the mount options match
 				return nil, status.Error(codes.AlreadyExists,
 					"volume previously published with different options")
 			}
@@ -1259,8 +1261,8 @@ func getSystemUUID(ctx context.Context) (string, error) {
 }
 
 // convertUUID helps convert UUID to vSphere format
-//input uuid:    6B8C2042-0DD1-D037-156F-435F999D94C1
-//returned uuid: 42208c6b-d10d-37d0-156f-435f999d94c1
+// input uuid:    6B8C2042-0DD1-D037-156F-435F999D94C1
+// returned uuid: 42208c6b-d10d-37d0-156f-435f999d94c1
 func convertUUID(uuid string) (string, error) {
 	if len(uuid) != 36 {
 		return "", errors.New("uuid length should be 36")

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -86,7 +86,6 @@ func configFromSim() (*config.Config, func()) {
 func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.Config, func()) {
 	cfg := &config.Config{}
 	model := simulator.VPX()
-	defer model.Remove()
 
 	err := model.Create()
 	if err != nil {
@@ -117,6 +116,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer model.Remove()
 
 	cfg.VirtualCenter = make(map[string]*config.VirtualCenterConfig)
 	cfg.VirtualCenter[s.URL.Hostname()] = &config.VirtualCenterConfig{
@@ -629,7 +629,7 @@ func TestCompleteControllerFlow(t *testing.T) {
 	diskUUID := respControllerPublishVolume.PublishContext[common.AttributeFirstClassDiskUUID]
 	t.Log(fmt.Sprintf("ControllerPublishVolume succeed, diskUUID %s is returned", diskUUID))
 
-	//Detach
+	// Detach
 	reqControllerUnpublishVolume := &csi.ControllerUnpublishVolumeRequest{
 		VolumeId: volID,
 		NodeId:   NodeID,

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -230,13 +230,14 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	// Support case insensitive parameters
 	for paramName := range req.Parameters {
 		param := strings.ToLower(paramName)
-		if param == common.AttributeStoragePolicyID {
+		switch param {
+		case common.AttributeStoragePolicyID:
 			storagePolicyID = req.Parameters[paramName]
-		} else if param == common.AttributeAffineToHost {
+		case common.AttributeAffineToHost:
 			affineToHost = req.Parameters[common.AttributeAffineToHost]
 			// XXX: We don't set the accessibleNodes here as we expect the partners to specify the node selector in pod
 			// spec while creating it. This mode of placement will be deprecated soon as we progress towards storagePool
-		} else if param == common.AttributeStoragePool {
+		case common.AttributeStoragePool:
 			storagePool = req.Parameters[paramName]
 			if !isValidAccessibilityRequirement(topologyRequirement) {
 				return nil, status.Errorf(codes.InvalidArgument, "invalid accessibility requirements")
@@ -253,7 +254,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			}
 			accessibleNodes = append(accessibleNodes, overlappingNodes...)
 			log.Infof("Storage pool Accessible nodes for volume topology: %+v", accessibleNodes)
-		} else if param == common.AttributeHostLocal {
+		case common.AttributeHostLocal:
 			hostLocalMode = true
 			if !isValidAccessibilityRequirement(topologyRequirement) {
 				return nil, status.Errorf(codes.InvalidArgument, "invalid accessibility requirements")
@@ -275,7 +276,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			return nil, status.Errorf(codes.Internal, msg)
 		}
 		log.Infof("Will select datastore %s as per the provided storage pool %s", selectedDatastoreURL, storagePool)
-		//Ignore affineToHost if received, as storagePool takes precedence for placement decision
+		// Ignore affineToHost if received, as storagePool takes precedence for placement decision
 		affineToHost = ""
 	} else if hostLocalMode && hostLocalNodeName != "" {
 		// Query API server to get ESX Host Moid from the hostLocalNodeName

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -73,7 +73,6 @@ func configFromSim() (*config.Config, func()) {
 func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.Config, func()) {
 	cfg := &config.Config{}
 	model := simulator.VPX()
-	defer model.Remove()
 
 	err := model.Create()
 	if err != nil {
@@ -104,6 +103,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer model.Remove()
 
 	cfg.VirtualCenter = make(map[string]*config.VirtualCenterConfig)
 	cfg.VirtualCenter[s.URL.Hostname()] = &config.VirtualCenterConfig{

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -393,12 +393,10 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 					if volume.Attached && volume.DiskUuid != "" && volume.Error == "" {
 						diskUUID = volume.DiskUuid
 						log.Infof("observed disk UUID %q is set for the volume %q on virtualmachine %q", volume.DiskUuid, volume.Name, vm.Name)
-					} else {
-						if volume.Error != "" {
-							msg := fmt.Sprintf("observed Error: %q is set on the volume %q on virtualmachine %q", volume.Error, volume.Name, vm.Name)
-							log.Error(msg)
-							return nil, status.Errorf(codes.Internal, msg)
-						}
+					} else if volume.Error != "" {
+						msg := fmt.Sprintf("observed Error: %q is set on the volume %q on virtualmachine %q", volume.Error, volume.Name, vm.Name)
+						log.Error(msg)
+						return nil, status.Errorf(codes.Internal, msg)
 					}
 					break
 				}
@@ -410,7 +408,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 		log.Debugf("disk UUID %v is set for the volume: %q ", diskUUID, req.VolumeId)
 	}
 
-	//return PublishContext with diskUUID of the volume attached to node.
+	// return PublishContext with diskUUID of the volume attached to node.
 	publishInfo := make(map[string]string)
 	publishInfo[common.AttributeDiskType] = common.DiskTypeBlockVolume
 	publishInfo[common.AttributeFirstClassDiskUUID] = common.FormatDiskUUID(diskUUID)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -324,12 +324,13 @@ func createCustomResourceDefinition(ctx context.Context, crd *apiextensionsv1bet
 		return err
 	}
 	_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
-	if err == nil {
+	switch {
+	case err == nil:
 		log.Infof("%q CRD created successfully", crd.Name)
-	} else if apierrors.IsAlreadyExists(err) {
+	case apierrors.IsAlreadyExists(err):
 		log.Infof("%q CRD already exists", crd.Name)
 		return nil
-	} else {
+	default:
 		log.Errorf("failed to create %q CRD with err: %+v", crd.Name, err)
 		return err
 	}

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -220,21 +220,19 @@ func validationHandler(w http.ResponseWriter, r *http.Request) {
 				Message: err.Error(),
 			},
 		}
-	} else {
-		if r.URL.Path == "/validate" {
-			log.Debugf("request URL path is /validate")
-			log.Debugf("admissionReview: %+v", ar)
-			switch ar.Request.Kind.Kind {
-			case "StorageClass":
-				admissionResponse = validateStorageClass(ctx, &ar)
-			default:
-				log.Infof("Skipping validation for resource type: %q", ar.Request.Kind.Kind)
-				admissionResponse = &admissionv1.AdmissionResponse{
-					Allowed: true,
-				}
+	} else if r.URL.Path == "/validate" {
+		log.Debugf("request URL path is /validate")
+		log.Debugf("admissionReview: %+v", ar)
+		switch ar.Request.Kind.Kind {
+		case "StorageClass":
+			admissionResponse = validateStorageClass(ctx, &ar)
+		default:
+			log.Infof("Skipping validation for resource type: %q", ar.Request.Kind.Kind)
+			admissionResponse = &admissionv1.AdmissionResponse{
+				Allowed: true,
 			}
-			log.Debugf("admissionResponse: %+v", admissionResponse)
 		}
+		log.Debugf("admissionResponse: %+v", admissionResponse)
 	}
 	admissionReview := admissionv1.AdmissionReview{}
 	admissionReview.APIVersion = "admission.k8s.io/v1"

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -458,7 +458,7 @@ func recordEvent(ctx context.Context, r *ReconcileCnsRegisterVolume, instance *c
 	case v1.EventTypeWarning:
 		// Double backOff duration
 		backOffDurationMapMutex.Lock()
-		backOffDuration[instance.Name] = backOffDuration[instance.Name] * 2
+		backOffDuration[instance.Name] *= 2
 		r.recorder.Event(instance, v1.EventTypeWarning, "CnsRegisterVolumeFailed", msg)
 		backOffDurationMapMutex.Unlock()
 	case v1.EventTypeNormal:

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -223,12 +223,13 @@ func getMaxWorkerThreadsToReconcileCnsRegisterVolume(ctx context.Context) int {
 	workerThreads := defaultMaxWorkerThreadsForRegisterVolume
 	if v := os.Getenv("WORKER_THREADS_REGISTER_VOLUME"); v != "" {
 		if value, err := strconv.Atoi(v); err == nil {
-			if value <= 0 {
+			switch {
+			case value <= 0:
 				log.Warnf("Maximum number of worker threads to run set in env variable WORKER_THREADS_REGISTER_VOLUME %s is less than 1, will use the default value %d", v, defaultMaxWorkerThreadsForRegisterVolume)
-			} else if value > defaultMaxWorkerThreadsForRegisterVolume {
+			case value > defaultMaxWorkerThreadsForRegisterVolume:
 				log.Warnf("Maximum number of worker threads to run set in env variable WORKER_THREADS_REGISTER_VOLUME %s is greater than %d, will use the default value %d",
 					v, defaultMaxWorkerThreadsForRegisterVolume, defaultMaxWorkerThreadsForRegisterVolume)
-			} else {
+			default:
 				workerThreads = value
 				log.Debugf("Maximum number of worker threads to run to reconcile CnsRegisterVolume instances is set to %d", workerThreads)
 			}

--- a/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
@@ -467,7 +467,7 @@ func recordEvent(ctx context.Context, r *ReconcileCnsVolumeMetadata, instance *c
 	case v1.EventTypeWarning:
 		// Double backOff duration
 		backOffDurationMapMutex.Lock()
-		backOffDuration[instance.Name] = backOffDuration[instance.Name] * 2
+		backOffDuration[instance.Name] *= 2
 		backOffDurationMapMutex.Unlock()
 		r.recorder.Event(instance, v1.EventTypeWarning, "UpdateFailed", msg)
 		log.Error(msg)
@@ -490,12 +490,13 @@ func getMaxWorkerThreadsToReconcileCnsVolumeMetadata(ctx context.Context) int {
 	workerThreads := defaultMaxWorkerThreadsToProcessCnsVolumeMetadata
 	if v := os.Getenv("WORKER_THREADS_VOLUME_METADATA"); v != "" {
 		if value, err := strconv.Atoi(v); err == nil {
-			if value <= 0 {
+			switch {
+			case value <= 0:
 				log.Warnf("Maximum number of worker threads to run set in env variable WORKER_THREADS_VOLUME_METADATA %s is less than 1, will use the default value %d", v, defaultMaxWorkerThreadsToProcessCnsVolumeMetadata)
-			} else if value > defaultMaxWorkerThreadsToProcessCnsVolumeMetadata {
+			case value > defaultMaxWorkerThreadsToProcessCnsVolumeMetadata:
 				log.Warnf("Maximum number of worker threads to run set in env variable WORKER_THREADS_VOLUME_METADATA %s is greater than %d, will use the default value %d",
 					v, defaultMaxWorkerThreadsToProcessCnsVolumeMetadata, defaultMaxWorkerThreadsToProcessCnsVolumeMetadata)
-			} else {
+			default:
 				workerThreads = value
 				log.Debugf("Maximum number of worker threads to run is set to %d", workerThreads)
 			}

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -199,8 +199,8 @@ func watcher(ctx context.Context, cnsOperator *cnsOperator) error {
 	return err
 }
 
-//reloadConfiguration reloads configuration from the secret, and cnsOperator
-//with the latest configInfo
+// reloadConfiguration reloads configuration from the secret, and cnsOperator
+// with the latest configInfo
 func reloadConfiguration(ctx context.Context, cnsOperator *cnsOperator) error {
 	log := logger.GetLogger(ctx)
 	cfg, err := common.GetConfig(ctx)

--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -263,12 +263,12 @@ func (k8sCloudOperator *k8sCloudOperator) GetHostAnnotation(ctx context.Context,
 	return response, nil
 }
 
-//response of PlacePersistenceVolumeClaim RPC call include only success tag
-//pvc does not have a storage pool annotation and does not need a storage pool annotation — that is case 1
-//pvc already has a annotation  - case 2
-//pvc needs a storage pool annotation and we cant find one - case 3
-//pvc needs an annotation and we can find one - case 4
-//everything other than case 3 is success
+// response of PlacePersistenceVolumeClaim RPC call include only success tag
+// pvc does not have a storage pool annotation and does not need a storage pool annotation — that is case 1
+// pvc already has a annotation  - case 2
+// pvc needs a storage pool annotation and we cant find one - case 3
+// pvc needs an annotation and we can find one - case 4
+// everything other than case 3 is success
 func (k8sCloudOperator *k8sCloudOperator) PlacePersistenceVolumeClaim(ctx context.Context,
 	req *PVCPlacementRequest) (*PVCPlacementResponse, error) {
 

--- a/pkg/syncer/k8scloudoperator/placement.go
+++ b/pkg/syncer/k8scloudoperator/placement.go
@@ -49,7 +49,7 @@ const (
 	spPolicyAntiPreferred = "placement.beta.vmware.com/storagepool_antiAffinityPreferred"
 	// AntiAffinityRequired placement policy for storagepool
 	spPolicyAntiRequired = "placement.beta.vmware.com/storagepool_antiAffinityRequired"
-	//resource name to get storage class
+	// resource name to get storage class
 	resourceName = "storagepools"
 	// storagePool type name for vsan-direct
 	vsanDirect = "vsanD"
@@ -102,8 +102,8 @@ func isSPInList(name string, spList []StoragePoolInfo) bool {
 func PlacePVConStoragePool(ctx context.Context, client kubernetes.Interface, tops *csi.TopologyRequirement, curPVC *v1.PersistentVolumeClaim) error {
 	log := logger.GetLogger(ctx)
 
-	//XXX Return if this is not a vsan direct placement
-	//XXX Need an identifier on the sc
+	// XXX Return if this is not a vsan direct placement
+	// XXX Need an identifier on the sc
 
 	// Get all StoragePool list
 	sps, err := getStoragePoolList(ctx)
@@ -112,7 +112,7 @@ func PlacePVConStoragePool(ctx context.Context, client kubernetes.Interface, top
 		return err
 	}
 
-	if len(sps.Items) <= 0 { //there is no available storage pools
+	if len(sps.Items) == 0 { // there is no available storage pools
 		return fmt.Errorf("fail to find any storage pool")
 	}
 
@@ -132,7 +132,7 @@ func PlacePVConStoragePool(ctx context.Context, client kubernetes.Interface, top
 		return err
 	}
 
-	if len(spList) <= 0 {
+	if len(spList) == 0 {
 		log.Infof("Did not find any matching storage pools for %s", curPVC.Name)
 		return fmt.Errorf("Fail to find a storage pool passing all criteria")
 	}
@@ -151,7 +151,7 @@ func PlacePVConStoragePool(ctx context.Context, client kubernetes.Interface, top
 		return err
 	}
 
-	if len(spList) <= 0 {
+	if len(spList) == 0 {
 		log.Infof("Did not find any matching storage pools for %s", curPVC.Name)
 		return fmt.Errorf("Fail to find a storage pool passing all criteria")
 	}
@@ -215,7 +215,7 @@ func preFilterSPList(ctx context.Context, sps *unstructured.UnstructuredList, st
 			continue
 		}
 
-		//sc compatible filter
+		// sc compatible filter
 		scs, found, err := unstructured.NestedStringSlice(sp.Object, "status", "compatibleStorageClasses")
 		if !found || err != nil {
 			nonVsanDirect++
@@ -251,7 +251,7 @@ func preFilterSPList(ctx context.Context, sps *unstructured.UnstructuredList, st
 			continue
 		}
 
-		if spSize > volSizeBytes+bufferDiskSize { //filter by capacity
+		if spSize > volSizeBytes+bufferDiskSize { // filter by capacity
 			spList = append(spList, StoragePoolInfo{
 				Name:           spName,
 				FreeCapInBytes: spSize,
@@ -291,7 +291,7 @@ func isStoragePoolAccessibleByNodes(ctx context.Context, sp unstructured.Unstruc
 		return false
 	}
 
-	for _, host := range hostNames { //filter by node candidate list
+	for _, host := range hostNames { // filter by node candidate list
 		for _, node := range nodes {
 			if node == host {
 				return true

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -72,11 +72,12 @@ func getFullSyncIntervalInMin(ctx context.Context) int {
 	fullSyncIntervalInMin := defaultFullSyncIntervalInMin
 	if v := os.Getenv("FULL_SYNC_INTERVAL_MINUTES"); v != "" {
 		if value, err := strconv.Atoi(v); err == nil {
-			if value <= 0 {
+			switch {
+			case value <= 0:
 				log.Warnf("FullSync: fullSync interval set in env variable FULL_SYNC_INTERVAL_MINUTES %s is equal or less than 0, will use the default interval", v)
-			} else if value > defaultFullSyncIntervalInMin {
+			case value > defaultFullSyncIntervalInMin:
 				log.Warnf("FullSync: fullSync interval set in env variable FULL_SYNC_INTERVAL_MINUTES %s is larger than max value can be set, will use the default interval", v)
-			} else {
+			default:
 				fullSyncIntervalInMin = value
 				log.Infof("FullSync: fullSync interval is set to %d minutes", fullSyncIntervalInMin)
 			}
@@ -891,7 +892,8 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 			log.Errorf("PVUpdated: QueryVolume failed. error: %+v", err)
 			return
 		}
-		if len(queryResult.Volumes) == 0 {
+		switch {
+		case len(queryResult.Volumes) == 0:
 			log.Infof("PVUpdated: Verified volume: %q is not marked as container volume in CNS. Calling CreateVolume with BackingID to mark volume as Container Volume.", oldPv.Spec.CSI.VolumeHandle)
 			// Call CreateVolume for Static Volume Provisioning
 			createSpec := &cnstypes.CnsVolumeCreateSpec{
@@ -925,10 +927,10 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 			}
 			// Volume is successfully created so returning from here.
 			return
-		} else if queryResult.Volumes[0].VolumeId.Id == oldPv.Spec.CSI.VolumeHandle {
+		case queryResult.Volumes[0].VolumeId.Id == oldPv.Spec.CSI.VolumeHandle:
 			log.Infof("PVUpdated: Verified volume: %q is already marked as container volume in CNS.", oldPv.Spec.CSI.VolumeHandle)
 			// Volume is already present in the CNS, so continue with the UpdateVolumeMetadata
-		} else {
+		default:
 			log.Infof("PVUpdated: Queried volume: %q is other than requested volume: %q.", oldPv.Spec.CSI.VolumeHandle, queryResult.Volumes[0].VolumeId.Id)
 			// unknown Volume is returned from the CNS, so returning from here.
 			return

--- a/pkg/syncer/pvcsi_fullsync.go
+++ b/pkg/syncer/pvcsi_fullsync.go
@@ -97,15 +97,13 @@ func pvcsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) {
 			if err := metadataSyncer.cnsOperatorClient.Create(ctx, &guestObject); err != nil {
 				log.Warnf("FullSync: Failed to create CnsVolumeMetadata %v. Err: %v", guestObject.Name, err)
 			}
-		} else {
+		} else if guestObject.Spec.EntityType != cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePOD &&
+			!compareCnsVolumeMetadatas(&guestObject.Spec, &supervisorObject.Spec) {
 			// Compare objects between the guest cluster and supervisor cluster.
 			// Update the supervisor cluster API server if an object is stale.
-			if guestObject.Spec.EntityType != cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePOD &&
-				!compareCnsVolumeMetadatas(&guestObject.Spec, &supervisorObject.Spec) {
-				log.Infof("FullSync: Updating CnsVolumeMetadata %v on the supervisor cluster", guestObject.Name)
-				if err := metadataSyncer.cnsOperatorClient.Update(ctx, supervisorObject); err != nil {
-					log.Warnf("FullSync: Failed to update CnsVolumeMetadata %v. Err: %v", supervisorObject.Name, err)
-				}
+			log.Infof("FullSync: Updating CnsVolumeMetadata %v on the supervisor cluster", guestObject.Name)
+			if err := metadataSyncer.cnsOperatorClient.Update(ctx, supervisorObject); err != nil {
+				log.Warnf("FullSync: Failed to update CnsVolumeMetadata %v. Err: %v", supervisorObject.Name, err)
 			}
 		}
 	}

--- a/pkg/syncer/storagepool/crd.go
+++ b/pkg/syncer/storagepool/crd.go
@@ -55,12 +55,13 @@ func createCustomResourceDefinition(ctx context.Context, clientSet apiextensions
 		},
 	}
 	_, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
-	if err == nil {
+	switch {
+	case err == nil:
 		log.Infof("%q CRD created successfully", crdName)
-	} else if apierrors.IsAlreadyExists(err) {
+	case apierrors.IsAlreadyExists(err):
 		log.Infof("%q CRD already exists", crdName)
 		return nil
-	} else {
+	default:
 		log.Errorf("Failed to create %q CRD with err: %+v", crdName, err)
 		return err
 	}

--- a/pkg/syncer/storagepool/intended_state.go
+++ b/pkg/syncer/storagepool/intended_state.go
@@ -165,8 +165,8 @@ func newIntendedVsanSNAState(ctx context.Context, ds *cnsvsphere.DatastoreInfo,
 		dsMoid:        fmt.Sprintf("%s-%s", vsan.dsMoid, node),
 		dsType:        fmt.Sprintf("%s-sna", vsan.dsType),
 		spName:        fmt.Sprintf("%s-%s", vsan.spName, node),
-		capacity:      vsan.capacity,  //XXX Get these values in a later change
-		freeSpace:     vsan.freeSpace, //XXX Get these values in a later change
+		capacity:      vsan.capacity,  // XXX Get these values in a later change
+		freeSpace:     vsan.freeSpace, // XXX Get these values in a later change
 		url:           vsan.url,
 		accessible:    true,  // If this node is in accessible node list of the vsan-ds, then sp is accessible
 		datastoreInMM: false, // If this node is inMM - the storagepool will not exist at all

--- a/pkg/syncer/storagepool/listener.go
+++ b/pkg/syncer/storagepool/listener.go
@@ -125,13 +125,11 @@ func initListener(ctx context.Context, scWatchCntlr *StorageClassWatch, spContro
 						if err != nil {
 							log.Errorf("Error updating StoragePool for datastore %v. Err: %v", ds, err)
 						}
-					} else {
+					} else if !reconcileAllScheduled {
 						// Handle changes in "hosts in cluster", "hosts inMaintenanceMode state" and "Datastores mounted on hosts" by
 						// scheduling a reconcile of all StoragePool instances afresh. Schedule only once for a batch of updates
-						if !reconcileAllScheduled {
-							scheduleReconcileAllStoragePools(ctx, reconcileAllFreq, reconcileAllIterations, scWatchCntlr, spController)
-							reconcileAllScheduled = true
-						}
+						scheduleReconcileAllStoragePools(ctx, reconcileAllFreq, reconcileAllIterations, scWatchCntlr, spController)
+						reconcileAllScheduled = true
 					}
 				}
 				log.Debugf("Done processing %d property collector update(s)", len(updates))

--- a/pkg/syncer/storagepool/util.go
+++ b/pkg/syncer/storagepool/util.go
@@ -139,10 +139,7 @@ func getHostInMaintenanceMode(ctx context.Context, host *object.HostSystem) (boo
 
 // makeStoragePoolName returns the given datastore name dsName with any non-alphanumeric chars replaced with '-'
 func makeStoragePoolName(dsName string) string {
-	reg, err := regexp.Compile(`[^\\.a-zA-Z0-9]+`)
-	if err != nil {
-		return dsName
-	}
+	reg := regexp.MustCompile(`[^\\.a-zA-Z0-9]+`)
 	spName := "storagepool-" + reg.ReplaceAllString(dsName, "-")
 	// spName should be in lower case and should not end with "-"
 	spName = strings.TrimSuffix(strings.ToLower(spName), "-")

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -98,7 +98,6 @@ func configFromSim() (*cnsconfig.Config, func()) {
 func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*cnsconfig.Config, func()) {
 	cfg := &cnsconfig.Config{}
 	model := simulator.VPX()
-	defer model.Remove()
 
 	err := model.Create()
 	if err != nil {
@@ -127,6 +126,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*cnsconf
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer model.Remove()
 
 	cfg.VirtualCenter = make(map[string]*cnsconfig.VirtualCenterConfig)
 	cfg.VirtualCenter[s.URL.Hostname()] = &cnsconfig.VirtualCenterConfig{
@@ -732,7 +732,7 @@ func runTestFullSyncWorkflows(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//update pvc with new label
+	// update pvc with new label
 	newPVCLabel := make(map[string]string)
 	newPVCLabel[testPVCLabelName] = newTestPVCLabelValue
 	pvc.Labels = newPVCLabel

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -114,7 +114,7 @@ func IsValidVolume(ctx context.Context, volume v1.Volume, pod *v1.Pod, metadataS
 		log.Debugf("Pod %s does not have a valid vSphereVolume. Ignoring the pod update", pod.Name)
 		return false, nil, nil
 	}
-	//Verify if pv is vsphere volume and migration flag is disabled
+	// Verify if pv is vsphere volume and migration flag is disabled
 	if !metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
 		log.Warnf("%s feature switch is disabled. Cannot update vSphere volume metadata %s for the pod %s", common.CSIMigration, pv.Name, pod.Name)
 		return false, nil, nil

--- a/pkg/syncer/volume_health.go
+++ b/pkg/syncer/volume_health.go
@@ -33,7 +33,7 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 	log := logger.GetLogger(ctx)
 	log.Infof("csiGetVolumeHealthStatus: start")
 
-	//Call CNS QueryAll to get container volumes by cluster ID
+	// Call CNS QueryAll to get container volumes by cluster ID
 	queryFilter := cnstypes.CnsQueryFilter{
 		ContainerClusterIds: []string{
 			metadataSyncer.configInfo.Cfg.Global.ClusterID,

--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -688,7 +688,7 @@ func verifyResizeCompletedInSupervisor(pvcName string) bool {
 	pvcRequestedSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
 	pvcCapacitySize := pvc.Status.Capacity[v1.ResourceStorage]
 
-	//If pvc's capacity size is greater than or equal to pvc's request size then done
+	// If pvc's capacity size is greater than or equal to pvc's request size then done
 	if pvcCapacitySize.Cmp(pvcRequestedSize) < 0 {
 		return false
 	}
@@ -767,8 +767,7 @@ func checkPvcHasGivenStatusCondition(client clientset.Interface, namespace strin
 
 // convertGiStrToMibInt64 returns integer numbers of Mb equivalent to string of the form \d+Gi
 func convertGiStrToMibInt64(size resource.Quantity) int64 {
-	r, err := regexp.Compile("[0-9]+")
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	r := regexp.MustCompile("[0-9]+")
 	sizeInt, err := strconv.Atoi(r.FindString(size.String()))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	return int64(sizeInt * 1024)

--- a/tests/e2e/volume_health_test.go
+++ b/tests/e2e/volume_health_test.go
@@ -135,7 +135,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// verifying svc pvc health status
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -324,7 +324,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// verifying svc pvc health status
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -429,7 +429,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// verifying svc pvc health status
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -460,7 +460,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// verifying svc pvc health status
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -601,7 +601,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// verifying svc pvc health status
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -817,8 +817,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 		// Get the list of Volumes attached to Pods before scale dow
 		for _, sspod := range ssPodsBeforeScaleDown.Items {
-			// _, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
-			// gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			for _, volumespec := range sspod.Spec.Volumes {
 				if volumespec.PersistentVolumeClaim != nil {
 					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
@@ -1149,7 +1147,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
 		pv := pvs[0]
 		volumeID := pv.Spec.CSI.VolumeHandle
-		//svPVCName refers to PVC Name in the supervisor cluster
+		// svPVCName refers to PVC Name in the supervisor cluster
 		svPVCName := volumeID
 		volumeID = getVolumeIDFromSupervisorCluster(svPVCName)
 		gomega.Expect(volumeID).NotTo(gomega.BeEmpty())
@@ -1301,7 +1299,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvclaim.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// verifying svc pvc health status
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -1320,7 +1318,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvclaim.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// verifying svc pvc health status
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -482,12 +482,12 @@ func verifyVolPropertiesFromCnsQueryResults(e2eVSphere vSphere, volHandle string
 		queryResult.Volumes[0].VolumeType, queryResult.Volumes[0].HealthStatus,
 		queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).AccessPoints))
 
-	//Verifying disk size specified in PVC is honored
+	// Verifying disk size specified in PVC is honored
 	ginkgo.By("Verifying disk size specified in PVC is honored")
 	gomega.Expect(queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb == diskSizeInMb).
 		To(gomega.BeTrue(), "wrong disk size provisioned")
 
-	//Verifying volume type specified in PVC is honored
+	// Verifying volume type specified in PVC is honored
 	ginkgo.By("Verifying volume type specified in PVC is honored")
 	gomega.Expect(queryResult.Volumes[0].VolumeType == testVolumeType).To(gomega.BeTrue(), "volume type is not FILE")
 

--- a/tests/e2e/vsphere_file_volume_basic_mount.go
+++ b/tests/e2e/vsphere_file_volume_basic_mount.go
@@ -180,7 +180,7 @@ func invokeTestForCreateFileVolumeAndMount(f *framework.Framework, client client
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
 
-	//clean up for pvc
+	// clean up for pvc
 	defer func() {
 		err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -191,12 +191,12 @@ func invokeTestForCreateFileVolumeAndMount(f *framework.Framework, client client
 	// Verify variuos properties Capacity, VolumeType, datastore and datacenter of volume using CNS Query API
 	verifyVolPropertiesFromCnsQueryResults(e2eVSphere, volHandle)
 
-	//Create Pod1 with pvc created above
+	// Create Pod1 with pvc created above
 	ginkgo.By("Create Pod1 with pvc created above")
 	pod1, err := fpod.CreatePod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//cleanup for Pod1
+	// cleanup for Pod1
 	defer func() {
 		if !isDeletePodAfterFileCreation {
 			ginkgo.By(fmt.Sprintf("Deleting the pod : %s in namespace %s", pod1.Name, namespace))
@@ -209,17 +209,17 @@ func invokeTestForCreateFileVolumeAndMount(f *framework.Framework, client client
 		}
 	}()
 
-	//Create file1.txt on Pod1
+	// Create file1.txt on Pod1
 	ginkgo.By("Create file1.txt on Pod1")
 	err = framework.CreateEmptyFileOnPod(namespace, pod1.Name, filePath1)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//Write data on file1.txt on Pod1
+	// Write data on file1.txt on Pod1
 	data := "This file file1 is written by Pod1"
 	ginkgo.By("Write on file1.txt from Pod1")
 	writeDataOnFileFromPod(namespace, pod1.Name, filePath1, data)
 
-	//Delete Pod if needed
+	// Delete Pod if needed
 	if isDeletePodAfterFileCreation {
 		ginkgo.By(fmt.Sprintf("Deleting the pod : %s in namespace %s", pod1.Name, namespace))
 		err = fpod.DeletePodWithWait(client, pod1)
@@ -244,7 +244,7 @@ func invokeTestForCreateFileVolumeAndMount(f *framework.Framework, client client
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
-	//Create Pod2 using the same pvc
+	// Create Pod2 using the same pvc
 	ginkgo.By("Create Pod2 with pvc created above")
 	userid := int64(1000)
 	var pod2 *v1.Pod
@@ -255,7 +255,7 @@ func invokeTestForCreateFileVolumeAndMount(f *framework.Framework, client client
 	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//cleanup for Pod2
+	// cleanup for Pod2
 	defer func() {
 		ginkgo.By(fmt.Sprintf("Deleting the pod : %s in namespace %s", pod2.Name, namespace))
 		err = fpod.DeletePodWithWait(client, pod2)
@@ -266,27 +266,27 @@ func invokeTestForCreateFileVolumeAndMount(f *framework.Framework, client client
 		gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, pod2.Spec.NodeName))
 	}()
 
-	//Read file1.txt created from Pod1
+	// Read file1.txt created from Pod1
 	ginkgo.By("Read file1.txt from Pod2 created by Pod1")
 	output := readFileFromPod(namespace, pod2.Name, filePath1)
 	ginkgo.By(fmt.Sprintf("File contents from file1.txt are: %s", output))
-	data = data + "\n"
+	data += "\n"
 	gomega.Expect(output == data).To(gomega.BeTrue(), "Pod2 is able to read file1 written by Pod1")
 
-	//Create a file file2.txt from Pod2
+	// Create a file file2.txt from Pod2
 	err = framework.CreateEmptyFileOnPod(namespace, pod2.Name, filePath2)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//Write to the file
+	// Write to the file
 	ginkgo.By("Write on file2.txt from Pod2")
 	data = "This file file2 is written by Pod2"
 	writeDataOnFileFromPod(namespace, pod2.Name, filePath2, data)
 
 	if !isDeletePodAfterFileCreation {
-		//Read file2.txt created from Pod1
+		// Read file2.txt created from Pod1
 		ginkgo.By("Read file2.txt from Pod1 created by Pod2")
 		output = readFileFromPod(namespace, pod1.Name, filePath2)
-		data = data + "\n"
+		data += "\n"
 		ginkgo.By(fmt.Sprintf("File content of file2.txt are: %s", output))
 		gomega.Expect(output == data).To(gomega.BeTrue(), "Pod1 is able to read file2 written by Pod2")
 	}

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -927,7 +927,7 @@ func invokeTestForUnsupportedFileVolumeExpansion(f *framework.Framework, client 
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
 	ginkgo.By("Waiting for all claims to be in bound state")
-	//persistentvolumes
+	// persistentvolumes
 	_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1026,7 +1026,7 @@ func waitForFSResize(pvc *v1.PersistentVolumeClaim, c clientset.Interface) (*v1.
 		pvcSize := updatedPVC.Spec.Resources.Requests[v1.ResourceStorage]
 		pvcStatusSize := updatedPVC.Status.Capacity[v1.ResourceStorage]
 
-		//If pvc's status field size is greater than or equal to pvc's size then done
+		// If pvc's status field size is greater than or equal to pvc's size then done
 		if pvcStatusSize.Cmp(pvcSize) >= 0 {
 			return true, nil
 		}
@@ -1042,7 +1042,7 @@ func getFSSizeMb(f *framework.Framework, pod *v1.Pod) (int64, error) {
 		return -1, fmt.Errorf("unable to find mount path via `df -T`: %v", err)
 	}
 	arrMountOut := strings.Fields(string(output))
-	if len(arrMountOut) <= 0 {
+	if len(arrMountOut) == 0 {
 		return -1, fmt.Errorf("error when parsing output of `df -T`. output: %s", string(output))
 	}
 	var devicePath, strSize string

--- a/tests/e2e/vsphere_volume_mount.go
+++ b/tests/e2e/vsphere_volume_mount.go
@@ -145,39 +145,39 @@ func createFileVolumeAndMount(f *framework.Framework, client clientset.Interface
 	ginkgo.By("Verify if VolumeID is created on the datastore from list of datacenters provided in vsphere.conf")
 	gomega.Expect(isDatastoreBelongsToDatacenterSpecifiedInConfig(queryResult.Volumes[0].DatastoreUrl)).To(gomega.BeTrue(), "Volume is not provisioned on the datastore specified on config file")
 
-	//Create Pod1 with pvc created above
+	// Create Pod1 with pvc created above
 	ginkgo.By("Create Pod1 with pvc created above")
 	pod1, err := fpod.CreatePod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//cleanup for Pod1
+	// cleanup for Pod1
 	defer func() {
 		ginkgo.By(fmt.Sprintf("Deleting the pod : %s in namespace %s", pod1.Name, namespace))
 		err = fpod.DeletePodWithWait(client, pod1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}()
 
-	//Create file1.txt on Pod1
+	// Create file1.txt on Pod1
 	filePath := mntPath + "file1.txt"
 	ginkgo.By("Create file1.txt on Pod1")
 	err = framework.CreateEmptyFileOnPod(namespace, pod1.Name, filePath)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//Write data on file1.txt on Pod1
+	// Write data on file1.txt on Pod1
 	data := filePath
 	ginkgo.By("Writing the file file1.txt from Pod1")
 
 	_, err = framework.RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), pod1.Name, "--", "/bin/sh", "-c", fmt.Sprintf(" echo %s >  %s ", data, filePath))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//Read file1.txt created from Pod1
+	// Read file1.txt created from Pod1
 	ginkgo.By("Read file1.txt from Pod1 created by Pod1")
 	output, err := framework.RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), pod1.Name, "--", "/bin/sh", "-c", fmt.Sprintf("less %s", filePath))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	ginkgo.By(fmt.Sprintf("File contents from file1.txt are: %s", output))
 	gomega.Expect(output == data+"\n").To(gomega.BeTrue(), "Pod1 is able to read file1 written by Pod1")
 
-	//cleanup for Pod1
+	// cleanup for Pod1
 	ginkgo.By(fmt.Sprintf("Deleting the pod : %s in namespace %s", pod1.Name, namespace))
 	err = fpod.DeletePodWithWait(client, pod1)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -188,37 +188,37 @@ func createFileVolumeAndMount(f *framework.Framework, client clientset.Interface
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, nodeName))
 
-	//Create Pod2 using the same pvc
+	// Create Pod2 using the same pvc
 	ginkgo.By("Create Pod2 with pvc created above")
 	pod2, err := fpod.CreatePod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//cleanup for Pod2
+	// cleanup for Pod2
 	defer func() {
 		ginkgo.By(fmt.Sprintf("Deleting the pod : %s in namespace %s", pod2.Name, namespace))
 		err = fpod.DeletePodWithWait(client, pod2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}()
 
-	//Read file1.txt created from Pod2
+	// Read file1.txt created from Pod2
 	ginkgo.By("Read file1.txt from Pod2 created by Pod1")
 	output, err = framework.RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), pod2.Name, "--", "/bin/sh", "-c", fmt.Sprintf("less %s", filePath))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	ginkgo.By(fmt.Sprintf("File contents from file1.txt are: %s", output))
 	gomega.Expect(output == data+"\n").To(gomega.BeTrue(), "Pod2 is able to read file1 written by Pod1")
 
-	//Create a file file2.txt from Pod2
+	// Create a file file2.txt from Pod2
 	filePath = mntPath + "file2.txt"
 	err = framework.CreateEmptyFileOnPod(namespace, pod2.Name, filePath)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	ginkgo.By("Write on file2.txt from Pod2")
-	//Writing to the file
+	// Writing to the file
 	data = filePath
 	_, err = framework.RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), pod2.Name, "--", "/bin/sh", "-c", fmt.Sprintf("echo %s >   %s", data, filePath))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//Read file2.txt created from Pod2
+	// Read file2.txt created from Pod2
 	ginkgo.By("Read file2.txt from Pod2 created by Pod2")
 	output, err = framework.RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), pod2.Name, "--", "/bin/sh", "-c", fmt.Sprintf("less %s", filePath))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing linter errors caught by gocritic run as part of golangci-lint
For example:
<pre>
$ golangci-lint run --disable-all --enable gocritic
pkg/csi/service/vanilla/controller_test.go:93:3: exitAfterDefer: log.Fatal clutters `defer model.Remove()` (gocritic)
                log.Fatal(err)
                ^
pkg/csi/service/wcp/controller_test.go:80:3: exitAfterDefer: log.Fatal clutters `defer model.Remove()` (gocritic)
                log.Fatal(err)
                ^
pkg/csi/service/node.go:679:3: commentFormatting: put a space between `//` and comment text (gocritic)
                //Connect to vCenter
                ^
pkg/csi/service/node.go:869:6: commentFormatting: put a space between `//` and comment text (gocritic)
....
...
...
</pre>

Also, this PR is enabling gocritic as part of golangci-lint

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
After fixing:
<pre>
$ golangci-lint run --disable-all --enable gocritic
$ no results found
</pre>

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix linter errors caught by gocritic
```
