### PR TITLE
adding QPS and BURST param for k8s client in volume migration service and other k8s clients in the system

### DIFF
--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -62,6 +62,10 @@ spec:
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
@@ -100,6 +104,10 @@ spec:
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -64,6 +64,10 @@ spec:
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
@@ -102,6 +106,10 @@ spec:
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -85,7 +85,7 @@ func (c *controller) Init(config *cnsconfig.Config) error {
 		return err
 	}
 	c.tanzukubernetesClusterUID = config.GC.TanzuKubernetesClusterUID
-	restClientConfig := k8s.GetRestClientConfig(ctx, config.GC.Endpoint, config.GC.Port)
+	restClientConfig := k8s.GetRestClientConfigForSupervisor(ctx, config.GC.Endpoint, config.GC.Port)
 	c.supervisorClient, err = k8s.NewSupervisorClient(ctx, restClientConfig)
 	if err != nil {
 		log.Errorf("failed to create supervisorClient. Error: %+v", err)
@@ -162,7 +162,7 @@ func (c *controller) ReloadConfiguration() {
 		return
 	}
 	if cfg != nil {
-		restClientConfig := k8s.GetRestClientConfig(ctx, cfg.GC.Endpoint, cfg.GC.Port)
+		restClientConfig := k8s.GetRestClientConfigForSupervisor(ctx, cfg.GC.Endpoint, cfg.GC.Port)
 		c.supervisorClient, err = k8s.NewSupervisorClient(ctx, restClientConfig)
 		if err != nil {
 			log.Errorf("failed to create supervisorClient. Error: %+v", err)

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -68,7 +68,7 @@ func configFromEnvOrSim(ctx context.Context) (clientset.Interface, error) {
 		return configFromSim()
 	}
 	isUnitTest = false
-	restClientConfig := k8s.GetRestClientConfig(ctx, cfg.GC.Endpoint, cfg.GC.Port)
+	restClientConfig := k8s.GetRestClientConfigForSupervisor(ctx, cfg.GC.Endpoint, cfg.GC.Port)
 	supervisorClient, err := k8s.NewSupervisorClient(ctx, restClientConfig)
 	if err != nil {
 		return nil, err

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -133,7 +133,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		// Initialize client to supervisor cluster
 		// if metadata syncer is being initialized for guest clusters
-		restClientConfig := k8s.GetRestClientConfig(ctx, metadataSyncer.configInfo.Cfg.GC.Endpoint, metadataSyncer.configInfo.Cfg.GC.Port)
+		restClientConfig := k8s.GetRestClientConfigForSupervisor(ctx, metadataSyncer.configInfo.Cfg.GC.Endpoint, metadataSyncer.configInfo.Cfg.GC.Port)
 		metadataSyncer.cnsOperatorClient, err = k8s.NewClientForGroup(ctx, restClientConfig, cnsoperatorv1alpha1.GroupName)
 		if err != nil {
 			log.Errorf("Creating Cns Operator client failed. Err: %v", err)
@@ -341,7 +341,7 @@ func ReloadConfiguration(ctx context.Context, metadataSyncer *metadataSyncInform
 	}
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		var err error
-		restClientConfig := k8s.GetRestClientConfig(ctx, cfg.GC.Endpoint, metadataSyncer.configInfo.Cfg.GC.Port)
+		restClientConfig := k8s.GetRestClientConfigForSupervisor(ctx, cfg.GC.Endpoint, metadataSyncer.configInfo.Cfg.GC.Port)
 		metadataSyncer.cnsOperatorClient, err = k8s.NewClientForGroup(ctx, restClientConfig, cnsoperatorv1alpha1.GroupName)
 		if err != nil {
 			log.Errorf("failed to create cns operator client. Err: %v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

It takes ~2s for the CNS server to create the CNS volume, but it takes roughly 11s to call GetVolumePath() and another 11s to call saveVolumeInfo(). This is quite long and our performance team thinks the main delay is k8s client throttle. They want to increase the QPS for the k8sclient used by the CSI migration, we should be able to reduce the latency for these two calls a lot with that.

This PR is adding QPS and BURST param for k8s client in volume migration service and other k8s clients in the system via env variable in the Pod spec.

Setting Qps to 100 and Burst to 100, to begin with, and keeping these parameters configurable via env variable.


**Special notes for your reviewer**:
Set QPS and Burst to 120 and verified k8s client in the volume migration service is taking supplied qps and burst.
Checked controller and syncer logs. k8s client is getting created with supplied qps and burst.

> 2020-09-25T15:02:55.943688876Z 2020-09-25T15:02:55.943Z	INFO	migration/migration.go:107	Initializing volume migration service...	{"TraceId": "b477c2cd-ebcc-4dcf-b01c-bb84fad49d58"}
2020-09-25T15:02:55.943692605Z 2020-09-25T15:02:55.943Z	INFO	kubernetes/kubernetes.go:83	k8s client using in-cluster config	{"TraceId": "b477c2cd-ebcc-4dcf-b01c-bb84fad49d58"}
2020-09-25T15:02:55.944154920Z 2020-09-25T15:02:55.943Z	INFO	kubernetes/kubernetes.go:268	Setting client QPS to 120.000000 and Burst to 120.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
adding INCLUSTER_CLIENT_QPS and INCLUSTER_CLIENT_BURST param to vanilla
```
cc: @chethanv28 