### PR TITLE
Address performance issues in existing volume health reconciler design

### DIFF
--- a/pkg/syncer/volume_health_reconciler.go
+++ b/pkg/syncer/volume_health_reconciler.go
@@ -19,26 +19,80 @@ package syncer
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
-
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
 
 // VolumeHealthReconciler is the interface for volume health reconciler
 type VolumeHealthReconciler interface {
 	// Run starts the reconciler.
 	Run(ctx context.Context, workers int)
+}
+
+// Map of volume handles to the list of PV's that point to this volume handle.
+// Keys are strings representing volume handles.
+// Values are list of strings representing PV names that reference this volume.
+type volumeHandleToPVs struct {
+	*sync.RWMutex
+	items map[string][]string
+}
+
+// Adds a pv to the list of pv's referenced by a volumeHandle.
+// Creates an entry in the map if it doesn't exist
+func (m *volumeHandleToPVs) add(volumeHandle, pvName string) {
+	_, log := logger.GetNewContextWithLogger()
+	m.Lock()
+	defer m.Unlock()
+	pvList := m.items[volumeHandle]
+	log.Debugf("Add PV %s to list %+v for volume %s", pvName, pvList, volumeHandle)
+	pvList = append(pvList, pvName)
+	m.items[volumeHandle] = pvList
+}
+
+// Removes a pv from the list of pv's referencing a volumeHandle.
+// Deletes the entry if list of pv's is empty.
+func (m *volumeHandleToPVs) remove(volumeHandle, pvToRemove string) {
+	_, log := logger.GetNewContextWithLogger()
+	m.Lock()
+	defer m.Unlock()
+	if pvList, ok := m.items[volumeHandle]; ok {
+		for index, pvName := range pvList {
+			if pvName == pvToRemove {
+				log.Debugf("Remove PV %s from list %+v for volume %s", pvToRemove, pvList, volumeHandle)
+				pvList = append(pvList[:index], pvList[index+1:]...)
+			}
+		}
+		if len(pvList) == 0 {
+			log.Debugf("Delete volume %s from volumeHandleToPVs mapping", volumeHandle)
+			delete(m.items, volumeHandle)
+		} else {
+			log.Debugf("Set new list for volume %s to %+v", volumeHandle, pvList)
+			m.items[volumeHandle] = pvList
+		}
+	}
+}
+
+// Returns the list of pv's referencing a volumeHandle.
+// Returns an empty list if this entry doesn't exist.
+func (m *volumeHandleToPVs) get(volumeHandle string) []string {
+	_, log := logger.GetNewContextWithLogger()
+	m.RLock()
+	defer m.RUnlock()
+	log.Debugf("PV list for volume %s: %+v", volumeHandle, m.items[volumeHandle])
+	return m.items[volumeHandle]
 }
 
 type volumeHealthReconciler struct {
@@ -59,6 +113,9 @@ type volumeHealthReconciler struct {
 	svcPVCSynced cache.InformerSynced
 	// Supervisor Cluster namespace
 	supervisorNamespace string
+
+	// Volume handle to PV list mapping
+	volumeHandleToPVs *volumeHandleToPVs
 }
 
 // NewVolumeHealthReconciler returns a VolumeHealthReconciler.
@@ -71,7 +128,7 @@ func NewVolumeHealthReconciler(
 	tkgInformerFactory informers.SharedInformerFactory,
 	svcInformerFactory informers.SharedInformerFactory,
 	svcPVCRateLimiter workqueue.RateLimiter,
-	supervisorNamespace string) VolumeHealthReconciler {
+	supervisorNamespace string, stopCh <-chan struct{}) (VolumeHealthReconciler, error) {
 	svcPVCInformer := svcInformerFactory.Core().V1().PersistentVolumeClaims()
 	tkgPVInformer := tkgInformerFactory.Core().V1().PersistentVolumes()
 
@@ -91,6 +148,10 @@ func NewVolumeHealthReconciler(
 		svcPVCSynced:        svcPVCInformer.Informer().HasSynced,
 		svcClaimQueue:       svcClaimQueue,
 		supervisorNamespace: supervisorNamespace,
+		volumeHandleToPVs: &volumeHandleToPVs{
+			RWMutex: &sync.RWMutex{},
+			items:   make(map[string][]string),
+		},
 	}
 
 	svcPVCInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
@@ -98,7 +159,78 @@ func NewVolumeHealthReconciler(
 		UpdateFunc: rc.svcUpdatePVC,
 	}, resyncPeriod)
 
-	return rc
+	tkgPVInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+		AddFunc:    nil,
+		UpdateFunc: rc.tkgUpdatePV,
+		DeleteFunc: rc.tkgDeletePV,
+	}, resyncPeriod)
+
+	ctx, log := logger.GetNewContextWithLogger()
+
+	// Start TKG Informers
+	tkgInformerFactory.Start(stopCh)
+	if !cache.WaitForCacheSync(stopCh, rc.tkgPVSynced) {
+		return nil, fmt.Errorf("cannot sync tkg pv cache")
+	}
+
+	// Initialize volumeHandleToPVs map with existing PV's
+	// Since this mapping is lost across pvCSI restarts, it needs to be
+	// initialized with existing values to prevent missing an SVC-PVC
+	// event due to absence of an entry in the map.
+	// This is done after TKG informers cache is synced to avoid missing a PV that
+	// enters the Bound state after volumeHandleToPVs is initialized
+	pvs, err := rc.tkgKubeClient.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("failed to list TKG PV's with error: %+v", err)
+		return nil, err
+	}
+	for _, pv := range pvs.Items {
+		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == csitypes.Name && pv.Status.Phase == v1.VolumeBound {
+			// Add to volumeHandleToPVs
+			rc.volumeHandleToPVs.add(pv.Spec.CSI.VolumeHandle, pv.Name)
+		}
+	}
+
+	// Start SVC Informers. This is done after volumeHandleToPV mapping is
+	// initialized to prevent incorrectly skipping a PV due to absence in
+	// the map.
+	svcInformerFactory.Start(stopCh)
+	if !cache.WaitForCacheSync(stopCh, rc.svcPVCSynced) {
+		return nil, fmt.Errorf("cannot sync supervisor pvc cache")
+	}
+	return rc, nil
+}
+
+func (rc *volumeHealthReconciler) tkgUpdatePV(oldObj, newObj interface{}) {
+	_, log := logger.GetNewContextWithLogger()
+	oldPv, ok := oldObj.(*v1.PersistentVolume)
+	if !ok {
+		return
+	}
+	newPv, ok := newObj.(*v1.PersistentVolume)
+	if !ok {
+		return
+	}
+	if newPv.Spec.CSI != nil && newPv.Spec.CSI.Driver == csitypes.Name && oldPv.Status.Phase != v1.VolumeBound && newPv.Status.Phase == v1.VolumeBound {
+		// Add to volumeHandleToPVs
+		rc.volumeHandleToPVs.add(newPv.Spec.CSI.VolumeHandle, newPv.Name)
+
+		// Add SVC PVC to work queue to add volume health annotation to statically provisioned volumes
+		objKey := rc.supervisorNamespace + "/" + newPv.Spec.CSI.VolumeHandle
+		log.Infof("Add %s to claim queue", objKey)
+		rc.svcClaimQueue.Add(objKey)
+	}
+}
+
+func (rc *volumeHealthReconciler) tkgDeletePV(obj interface{}) {
+	pv, ok := obj.(*v1.PersistentVolume)
+	if !ok {
+		return
+	}
+	if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == csitypes.Name {
+		// Remove from volumeHandleToPVs
+		rc.volumeHandleToPVs.remove(pv.Spec.CSI.VolumeHandle, pv.Name)
+	}
 }
 
 func (rc *volumeHealthReconciler) svcAddPVC(obj interface{}) {
@@ -152,11 +284,6 @@ func (rc *volumeHealthReconciler) Run(
 
 	stopCh := ctx.Done()
 
-	if !cache.WaitForCacheSync(stopCh, rc.tkgPVSynced, rc.svcPVCSynced) {
-		log.Errorf("Cannot sync supervisor and/or TKG pv/pvc caches")
-		return
-	}
-
 	for i := 0; i < workers; i++ {
 		go wait.Until(rc.syncPVCs, 0, stopCh)
 	}
@@ -209,55 +336,54 @@ func (rc *volumeHealthReconciler) syncPVC(key string) error {
 	log.Infof("syncPVC: Found Supervisor Cluster PVC: %s/%s", svcPVC.Namespace, svcPVC.Name)
 
 	// The input PVC is a Supervisor Cluster PVC
-	// Find Tanzu Kubernetes Grid PV
-	// Find Tanzu Kubernetes Grid PVC accordingly and update it
-	tkgPV, err := rc.findTKGPVforSupervisorPVC(ctx, svcPVC)
+	// Find list of Tanzu Kubernetes Grid PV's referencing this PVC
+	// Find corresponding Tanzu Kubernetes Grid PVCs and update them
+	tkgPVList, err := rc.findTKGPVforSupervisorPVC(ctx, svcPVC)
 	if err != nil {
 		return err
 	}
-	if tkgPV == nil {
-		log.Debugf("Tanzu Kubernetes Grid PV not found for Supervisor PVC %s/%s", svcPVC.Namespace, svcPVC.Name)
-		return fmt.Errorf("tanzu Kubernetes Grid PV not found for Supervisor PVC %s/%s", svcPVC.Namespace, svcPVC.Name)
+	if tkgPVList == nil {
+		// If no PV is found, the SV PVC may not be referenced within this TKG. Do not requeue this request.
+		log.Debugf("Tanzu Kubernetes Grid PV not found for Supervisor PVC %s/%s. Igonoring ...", svcPVC.Namespace, svcPVC.Name)
+		return nil
 	}
 
-	log.Debugf("Found Tanzu Kubernetes Grid PV %s", tkgPV.Name)
+	log.Debugf("Found Tanzu Kubernetes Grid PV's: %v", tkgPVList)
 
-	// Update Tanzu Kubernetes Grid PVC volume health annotation
-	err = rc.updateTKGPVC(ctx, svcPVC, tkgPV)
-	if err != nil {
-		log.Errorf("Update Tanzu Kubernetes Grid PVC for PV %s failed: %v", tkgPV.Name, err)
-		return err
+	for _, tkgPV := range tkgPVList {
+		// Update Tanzu Kubernetes Grid PVC volume health annotation
+		err = rc.updateTKGPVC(ctx, svcPVC, tkgPV)
+		if err != nil {
+			log.Errorf("updating Tanzu Kubernetes Grid PVC for PV %s failed: %v", tkgPV.Name, err)
+			return err
+		}
+		log.Infof("Updated Tanzu Kubernetes Grid PVC for PV %s", tkgPV.Name)
 	}
 
-	log.Infof("Updated Tanzu Kubernetes Grid PVC for PV %s", tkgPV.Name)
 	return nil
 }
 
-// find PV in TKG that matches PVC in supervisor cluster
-// Returns PV in TKG
-func (rc *volumeHealthReconciler) findTKGPVforSupervisorPVC(ctx context.Context, svcPVC *v1.PersistentVolumeClaim) (*v1.PersistentVolume, error) {
+// find list of PV's in TKG that matches PVC in supervisor cluster
+// Returns list of pointers to PV's in TKG
+func (rc *volumeHealthReconciler) findTKGPVforSupervisorPVC(ctx context.Context, svcPVC *v1.PersistentVolumeClaim) ([]*v1.PersistentVolume, error) {
 	log := logger.GetLogger(ctx)
-	// For each PV in Tanzu Kubernetes Grid, find corresponding PVC name in the Supervisor Cluster (svcPVCName := tkgPV.Spec.CSI.VolumeHandle)
-	// Compare retrieved SC PVC Name with PVC name in Supervisor Cluster triggered by the Add/Update event and find a match.
+	// For the SV PVC for which this event was triggered, find the TKG PV's that reference this PVC.
+	var tkgPVList []*v1.PersistentVolume
 	log.Debugf("findTKGPVforSupervisorPVC enter: Supervisor Cluster PVC %s/%s", svcPVC.Namespace, svcPVC.Name)
-	tkgPVs, err := rc.tkgPVLister.List(labels.Everything())
-	if err != nil {
-		log.Errorf("No persistent volumes found in Tanzu Kubernetes Grid")
-		return nil, err
+
+	pvNames := rc.volumeHandleToPVs.get(svcPVC.Name)
+	if len(pvNames) == 0 {
+		return nil, nil
 	}
-	for _, tkgPV := range tkgPVs {
-		log.Debugf("findTKGPVforSupervisorPVC: Supervisor Cluster PVC name: %s, Tanzu Kubernetes Grid PV CSI VolumeHandle: %s", svcPVC.Name, tkgPV.Spec.CSI.VolumeHandle)
-		if svcPVC.Name == tkgPV.Spec.CSI.VolumeHandle {
-			log.Infof("Found Tanzu Kubernetes Grid PV %s for Supervisor Cluster PVC %s/%s", tkgPV.Name, svcPVC.Namespace, svcPVC.Name)
-			return tkgPV, nil
+	for _, name := range pvNames {
+		tkgPV, err := rc.tkgPVLister.Get(name)
+		if err != nil {
+			log.Errorf("failed to get TKG PV %s with error: %+v", name, err)
+			return nil, err
 		}
+		tkgPVList = append(tkgPVList, tkgPV)
 	}
-
-	log.Debugf("findTKGPVforSupervisorPVC: Tanzu Kubernetes Grid PV not found for Supervisor Cluster PVC %s/%s", svcPVC.Namespace, svcPVC.Name)
-
-	// Tanzu Kubernetes Grid PV not found. Return error so it will be
-	// added back to the queue for retries
-	return nil, fmt.Errorf("tanzu Kubernetes Grid PV not found for Supervisor PVC %s/%s", svcPVC.Namespace, svcPVC.Name)
+	return tkgPVList, nil
 }
 
 // update PVC in TKG based on PVC in supervisor cluster


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses performance concerns in the existing volume health reconciler design in the following way:
- `findTKGPVforSupervisorPVC` - Use a in-memory mapping of volume handle to PV's to avoid `List`ing all PV's during each reconcile loop to determine which PV refers to a volume handle. The map is maintained using informers to provide easy lookup. This map is used to find all PVs referencing a volume for every SV-PVC event, rather than querying the API server.
NOTE: This change also extends the mapping of {volumeHandle -> PV} to be a one-to-many mapping, ie, many PV's can refer to the same volume handle. 

- Add volume health annotation for statically provisioned PVC's without continuously queueing SV PVC's that are not claimed in a TKG cluster. 

This PR also removes the singleton `VolumeHealthReconciler` and retries attempts to initialize it in case of a failure. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #388 and #414

**Testing**:

E2E Tests:
3 tests that failed are test errors and have relevant bugs that are being fixed by FVT team. All Volume health tests are passing

```
22:56:59  Summarizing 3 Failures:
22:56:59  [Fail] Basic Static Provisioning [It] [csi-guest] Static provisioning workflow in guest cluster 
22:56:59  [Fail] [csi-guest] Volume Expansion Test [It] Verify offline expansion triggers FS resize 
22:56:59  [Fail] Basic Static Provisioning [It] [csi-guest] Static provisioning workflow II in guest cluster 
22:56:59  Ran 14 of 106 Specs in 2961.071 seconds
22:56:59  FAIL! -- 11 Passed | 3 Failed | 0 Pending | 92 Skipped
22:56:59  --- FAIL: TestE2E (2961.10s)
```

Manual Tests:

1. Dynamically created TKG PVC:
- Health status visible 
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl describe pvc
Name:          example-vanilla-block-pvc
Namespace:     default
...
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
...
```
- Relevant syncer logs
```
2020-10-06T17:47:39.838Z        DEBUG   syncer/volume_health_reconciler.go:62   Add PV pvc-a10e6377-4d72-426e-9855-f5ed5d181d5a to list [] for volume 30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-a10e6377-4d72-426e-9855-f5ed5d181d5a {"TraceId": "580d032e-6530-4a57-be97-22cfb9aa8b11"}
...
2020-10-06T17:49:55.456Z        INFO    syncer/volume_health_reconciler.go:213  addPVC: add test-gc-e2e-demo-ns/30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974 to claim queue        {"TraceId": "480d9747-f19d-49ed-937e-0a768eb02418"}
2020-10-06T17:49:55.456Z        DEBUG   syncer/volume_health_reconciler.go:310  syncPVC: Started PVC processing test-gc-e2e-demo-ns/30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974   {"TraceId": "5752e75d-63a5-453c-b1cc-c8cb2c0ec9e4"}
2020-10-06T17:49:55.456Z        INFO    syncer/volume_health_reconciler.go:327  syncPVC: Found Supervisor Cluster PVC: test-gc-e2e-demo-ns/30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974    {"TraceId": "5752e75d-63a5-453c-b1cc-c8cb2c0ec9e4"}
2020-10-06T17:49:55.456Z        DEBUG   syncer/volume_health_reconciler.go:363  findTKGPVforSupervisorPVC enter: Supervisor Cluster PVC test-gc-e2e-demo-ns/30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974   {"TraceId": "5752e75d-63a5-453c-b1cc-c8cb2c0ec9e4"}
2020-10-06T17:49:55.458Z        DEBUG   syncer/volume_health_reconciler.go:389  updateTKGPVC enter: Supervisor Cluster PVC test-gc-e2e-demo-ns/30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974, Tanzu Kubernetes Grid PV pvc-3957cd6b-c125-42fd-89e2-39505a20c974     {"TraceId": "5752e75d-63a5-453c-b1cc-c8cb2c0ec9e4"}
```

2. Statically provisioned volume 
- Health status visible 
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl describe pvc
Name:          static-pvc-name
Namespace:     default
...
               volumehealth.storage.kubernetes.io/health: accessible
...
```
- Relevant syncer logs
```
2020-10-06T17:59:59.745Z        DEBUG   syncer/volume_health_reconciler.go:62   Add PV static-pv-name to list [pvc-3957cd6b-c125-42fd-89e2-39505a20c974] for volume 30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974   {"TraceId": "18a49819-27fb-4996-beba-93379da45acd"}
...
2020-10-06T17:59:59.802Z        INFO    syncer/volume_health_reconciler.go:351  Updated Tanzu Kubernetes Grid PVC for PV pvc-3957cd6b-c125-42fd-89e2-39505a20c974       {"TraceId": "8548d6c0-3919-4875-b740-7468755e2a90"}
2020-10-06T17:59:59.803Z        DEBUG   syncer/volume_health_reconciler.go:389  updateTKGPVC enter: Supervisor Cluster PVC test-gc-e2e-demo-ns/30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974, Tanzu Kubernetes Grid PV static-pv-name       {"TraceId": "8548d6c0-3919-4875-b740-7468755e2a90"}
2020-10-06T17:59:59.859Z        INFO    syncer/volume_health_reconciler.go:401  updateTKGPVC: Detected volume health annotation change. Need to update Tanzu Kubernetes Grid PVC default/static-pvc-name. Existing TKG PVC annotation: . New annotation: accessible     {"TraceId": "8548d6c0-3919-4875-b740-7468755e2a90"}
...
2020-10-06T18:00:01.112Z        INFO    syncer/volume_health_reconciler.go:409  updateTKGPVC: Updated Tanzu Kubernetes Grid PVC default/static-pvc-name {"TraceId": "9c1941a8-991d-4dd4-b24c-2b3b6121661d"}
```

3. Toggle volume health; status change visible on all TKG PVC's 
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl describe pvc
Name:          example-vanilla-block-pvc
Namespace:     default
...
               volumehealth.storage.kubernetes.io/health: inaccessible
...
Name:          static-pvc-name
Namespace:     default
...
               volumehealth.storage.kubernetes.io/health: inaccessible
...
```

4. Volume not used in TKG is not requeued
- Relevant syncer logs
```
2020-10-06T17:47:39.750Z        INFO    syncer/volume_health_reconciler.go:213  addPVC: add test-gc-e2e-demo-ns/supervisor-pvc to claim queue        {"TraceId": "2bc9a117-5dc9-48e2-a9b1-ae0aa1a3a95a"}
2020-10-06T17:47:39.839Z        DEBUG   syncer/volume_health_reconciler.go:310  syncPVC: Started PVC processing test-gc-e2e-demo-ns/supervisor-pvc   {"TraceId": "f2c0adb2-fbc5-449c-99c3-6af83aeb2de6"}
2020-10-06T17:47:39.839Z        INFO    syncer/volume_health_reconciler.go:327  syncPVC: Found Supervisor Cluster PVC: test-gc-e2e-demo-ns/supervisor-pvc    {"TraceId": "f2c0adb2-fbc5-449c-99c3-6af83aeb2de6"}
2020-10-06T17:47:39.839Z        DEBUG   syncer/volume_health_reconciler.go:363  findTKGPVforSupervisorPVC enter: Supervisor Cluster PVC test-gc-e2e-demo-ns/supervisor-pvc   {"TraceId": "f2c0adb2-fbc5-449c-99c3-6af83aeb2de6"}
2020-10-06T17:47:39.840Z        DEBUG   syncer/volume_health_reconciler.go:338  Tanzu Kubernetes Grid PV not found for Supervisor PVC test-gc-e2e-demo-ns/supervisor-pvc. Igonoring ...      {"TraceId": "f2c0adb2-fbc5-449c-99c3-6af83aeb2de6"}
```

5. Volume handle to PV map creation across pvCSI restarts
- Bring down pvCSI replica count to 0
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl edit deployment -n vmware-system-csi
deployment.apps/vsphere-csi-controller edite
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl get pod -n vmware-system-csi
NAME                     READY   STATUS    RESTARTS   AGE
vsphere-csi-node-bj4rh   3/3     Running   0          2d16h
vsphere-csi-node-cl5x7   3/3     Running   0          2d16h
```
- Change PVC volume health annotation in SV cluster to inaccesssible
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl edit pvc -n test-gc-e2e-demo-ns 30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974
persistentvolumeclaim/30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974 edited
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl describe pvc -n test-gc-e2e-demo-ns 30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974
Name:          30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974
Namespace:     test-gc-e2e-demo-ns
StorageClass:  gc-storage-profile
Status:        Bound
Volume:        pvc-da5d5c21-ff2c-4922-be11-07bac198f0a5
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: inaccessible
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
Events:        <none>
```
- Verify volume health in TKG is still `accessible`
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl describe pvc
Name:          example-vanilla-block-pvc
Namespace:     default
...
               volumehealth.storage.kubernetes.io/health: accessible
...
Name:          static-pvc-name
Namespace:     default
...
               volumehealth.storage.kubernetes.io/health: accessible
...
```
- Bring up pvCSI replica count to 1
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl edit deployment -n vmware-system-csi
deployment.apps/vsphere-csi-controller edited
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl get pod -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-84c856b555-hn28j   6/6     Running   0          13s
vsphere-csi-node-bj4rh                    3/3     Running   0          2d16h
vsphere-csi-node-cl5x7                    3/3     Running   0          2d16h
```
- Verify volume handle to PV mapping is created and TKG PVC's health status changes to inaccessible
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl describe pvc
Name:          example-vanilla-block-pvc
Namespace:     default
...
               volumehealth.storage.kubernetes.io/health: inaccessible
...
Name:          static-pvc-name
Namespace:     default
...
               volumehealth.storage.kubernetes.io/health: inaccessible
...
```
- Syncer logs
```
2020-10-06T19:05:06.833Z        DEBUG   syncer/volume_health_reconciler.go:62   Add PV pvc-3957cd6b-c125-42fd-89e2-39505a20c974 to list [] for volume 30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974 {"TraceId": "94d106cb-6f33-48c5-9198-cff0fad864ce"}
2020-10-06T19:05:06.833Z        DEBUG   syncer/volume_health_reconciler.go:62   Add PV static-pv-name to list [pvc-3957cd6b-c125-42fd-89e2-39505a20c974] for volume 30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-3957cd6b-c125-42fd-89e2-39505a20c974   {"TraceId": "06e0f686-68b0-4d7d-a885-a7996aa8768d"}
...
2020-10-06T19:05:06.890Z        INFO    syncer/volume_health_reconciler.go:401  updateTKGPVC: Detected volume health annotation change. Need to update Tanzu Kubernetes Grid PVC default/example-vanilla-block-pvc. Existing TKG PVC annotation: accessible. New annotation: inaccessible       {"TraceId": "e0379e72-a2e9-4653-a5fe-fd527566efc2"}
...
2020-10-06T19:05:06.959Z        INFO    syncer/volume_health_reconciler.go:401  updateTKGPVC: Detected volume health annotation change. Need to update Tanzu Kubernetes Grid PVC default/static-pvc-name. Existing TKG PVC annotation: accessible. New annotation: inaccessible {"TraceId": "e0379e72-a2e9-4653-a5fe-fd527566efc2"}

```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Improve performance of existing volume health reconciler.
```
