### PR TITLE
use correct env INCLUSTER_CLIENT_BURST

### DIFF
--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -64,7 +64,7 @@ spec:
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
               value: "100"
-            - name: INCLUSTER_CLIENT_QPS
+            - name: INCLUSTER_CLIENT_BURST
               value: "100"
           volumeMounts:
             - mountPath: /etc/cloud
@@ -106,7 +106,7 @@ spec:
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
               value: "100"
-            - name: INCLUSTER_CLIENT_QPS
+            - name: INCLUSTER_CLIENT_BURST
               value: "100"
           volumeMounts:
             - mountPath: /etc/cloud

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -66,7 +66,7 @@ spec:
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
               value: "100"
-            - name: INCLUSTER_CLIENT_QPS
+            - name: INCLUSTER_CLIENT_BURST
               value: "100"
           volumeMounts:
             - mountPath: /etc/cloud
@@ -108,7 +108,7 @@ spec:
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
               value: "100"
-            - name: INCLUSTER_CLIENT_QPS
+            - name: INCLUSTER_CLIENT_BURST
               value: "100"
           volumeMounts:
             - mountPath: /etc/cloud


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

`INCLUSTER_CLIENT_QPS` used incorrectly instead of `INCLUSTER_CLIENT_BURST`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
use correct env INCLUSTER_CLIENT_BURST
```
