### PR TITLE
CSI support for CNS telemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.3
-	github.com/vmware/govmomi v0.23.2-0.20200914215146-b553bfc00728
+	github.com/vmware/govmomi v0.23.2-0.20200915235406-49b4974659e1
 	github.com/zekroTJA/timedmap v1.1.2
 	go.uber.org/zap v1.15.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect

--- a/go.sum
+++ b/go.sum
@@ -642,11 +642,8 @@ github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJ
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware-tanzu/vm-operator-api v0.1.3 h1:4vxewu0jAN3fSoCBI6FhjmRGJ7ci0R2WNu/I6hacTYs=
 github.com/vmware-tanzu/vm-operator-api v0.1.3/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
-github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
-github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
-github.com/vmware/govmomi v0.23.2-0.20200914215146-b553bfc00728 h1:ZNyGvj9oVMJormlAZuO/1NuWEukPvIl/MyrG5vgjx7o=
-github.com/vmware/govmomi v0.23.2-0.20200914215146-b553bfc00728/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.23.2-0.20200915235406-49b4974659e1 h1:cOmmloKpYtLP8sHzFK9g841PXQzjIB6abTdz7uvrakI=
+github.com/vmware/govmomi v0.23.2-0.20200915235406-49b4974659e1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
+++ b/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
@@ -71,6 +71,11 @@ type CnsVolumeMetadataSpec struct {
 	// namespace is set for objects whose EntityType is PERSISTENT_VOLUME.
 	//+optional
 	Namespace string `json:"namespace,omitempty"`
+
+	// ClusterDistribution indicates the cluster distribution where the
+	// PVCSI driver is deployed
+	//+optional
+	ClusterDistribution string `json:"clusterdistribution,omitempty"`
 }
 
 // CnsVolumeMetadataStatus defines the observed state of CnsVolumeMetadata
@@ -141,13 +146,14 @@ func CreateCnsVolumeMetadataSpec(volumeHandle []string, gcConfig config.GCConfig
 			OwnerReferences: []metav1.OwnerReference{GetCnsVolumeMetadataOwnerReference(cnsoperatortypes.GCAPIVersion, cnsoperatortypes.GCKind, gcConfig.TanzuKubernetesClusterName, gcConfig.TanzuKubernetesClusterUID)},
 		},
 		Spec: CnsVolumeMetadataSpec{
-			VolumeNames:      volumeHandle,
-			GuestClusterID:   gcConfig.TanzuKubernetesClusterUID,
-			EntityType:       entityType,
-			EntityName:       name,
-			Labels:           labels,
-			Namespace:        namespace,
-			EntityReferences: reference,
+			VolumeNames:         volumeHandle,
+			GuestClusterID:      gcConfig.TanzuKubernetesClusterUID,
+			EntityType:          entityType,
+			EntityName:          name,
+			Labels:              labels,
+			Namespace:           namespace,
+			EntityReferences:    reference,
+			ClusterDistribution: gcConfig.ClusterDistribution,
 		},
 	}
 }

--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -364,7 +364,7 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volu
 		log.Debugf("Obtained storage policy ID: %q for storage policy name: %q", storagePolicyID, volumeSpec.StoragePolicyName)
 	}
 	var containerClusterArray []cnstypes.CnsContainerCluster
-	containerCluster := vsphere.GetContainerCluster(volumeMigration.cnsConfig.Global.ClusterID, user, cnstypes.CnsClusterFlavorVanilla)
+	containerCluster := vsphere.GetContainerCluster(volumeMigration.cnsConfig.Global.ClusterID, user, cnstypes.CnsClusterFlavorVanilla, volumeMigration.cnsConfig.Global.ClusterDistribution)
 	containerClusterArray = append(containerClusterArray, containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
 		Name:       uuid.String(),

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -81,12 +81,13 @@ func GetCnsKubernetesEntityMetaData(entityName string, labels map[string]string,
 }
 
 // GetContainerCluster creates ContainerCluster object from given parameters
-func GetContainerCluster(clusterid string, username string, clusterflavor cnstypes.CnsClusterFlavor) cnstypes.CnsContainerCluster {
+func GetContainerCluster(clusterid string, username string, clusterflavor cnstypes.CnsClusterFlavor, clusterdistribution string) cnstypes.CnsContainerCluster {
 	return cnstypes.CnsContainerCluster{
-		ClusterType:   string(cnstypes.CnsClusterTypeKubernetes),
-		ClusterId:     clusterid,
-		VSphereUser:   username,
-		ClusterFlavor: string(clusterflavor),
+		ClusterType:         string(cnstypes.CnsClusterTypeKubernetes),
+		ClusterId:           clusterid,
+		VSphereUser:         username,
+		ClusterFlavor:       string(clusterflavor),
+		ClusterDistribution: clusterdistribution,
 	}
 }
 

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -46,6 +46,8 @@ type Config struct {
 		// VCClientTimeout specifies a time limit in minutes for requests made by client
 		// If not set, default will be 5 minutes
 		VCClientTimeout int `gcfg:"vc-client-timeout"`
+		// Cluster Distribution Name
+		ClusterDistribution string `gcfg:"cluster-distribution"`
 	}
 
 	// Multiple sets of Net Permissions applied to all file shares
@@ -112,4 +114,6 @@ type GCConfig struct {
 	TanzuKubernetesClusterUID string `gcfg:"tanzukubernetescluster-uid"`
 	// Guest Cluster Name
 	TanzuKubernetesClusterName string `gcfg:"tanzukubernetescluster-name"`
+	// Cluster Distribution Name
+	ClusterDistribution string `gcfg:"cluster-distribution"`
 }

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -135,7 +135,7 @@ func CreateBlockVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluste
 		}
 	}
 	var containerClusterArray []cnstypes.CnsContainerCluster
-	containerCluster := vsphere.GetContainerCluster(manager.CnsConfig.Global.ClusterID, manager.CnsConfig.VirtualCenter[vc.Config.Host].User, clusterFlavor)
+	containerCluster := vsphere.GetContainerCluster(manager.CnsConfig.Global.ClusterID, manager.CnsConfig.VirtualCenter[vc.Config.Host].User, clusterFlavor, manager.CnsConfig.Global.ClusterDistribution)
 	containerClusterArray = append(containerClusterArray, containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
 		Name:       spec.Name,
@@ -282,7 +282,7 @@ func CreateFileVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 	}
 
 	var containerClusterArray []cnstypes.CnsContainerCluster
-	containerCluster := vsphere.GetContainerCluster(manager.CnsConfig.Global.ClusterID, manager.CnsConfig.VirtualCenter[vc.Config.Host].User, clusterFlavor)
+	containerCluster := vsphere.GetContainerCluster(manager.CnsConfig.Global.ClusterID, manager.CnsConfig.VirtualCenter[vc.Config.Host].User, clusterFlavor, manager.CnsConfig.Global.ClusterDistribution)
 	containerClusterArray = append(containerClusterArray, containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
 		Name:       spec.Name,

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -419,6 +419,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		log.Error(msg)
 		return nil, status.Errorf(codes.Internal, msg)
 	}
+
 	attributes := make(map[string]string)
 	attributes[common.AttributeDiskType] = common.DiskTypeBlockVolume
 	if csiMigrationFeatureState && scParams.CSIMigration == "true" {

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -318,6 +318,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		log.Error(msg)
 		return nil, status.Errorf(codes.Internal, msg)
 	}
+
 	attributes := make(map[string]string)
 	attributes[common.AttributeDiskType] = common.DiskTypeBlockVolume
 	resp := &csi.CreateVolumeResponse{

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -69,7 +69,7 @@ func constructCreateSpecForInstance(r *ReconcileCnsRegisterVolume, instance *cns
 	}
 	containerCluster := vsphere.GetContainerCluster(r.configInfo.Cfg.Global.ClusterID,
 		r.configInfo.Cfg.VirtualCenter[host].User,
-		cnstypes.CnsClusterFlavorWorkload)
+		cnstypes.CnsClusterFlavorWorkload, r.configInfo.Cfg.Global.ClusterDistribution)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
 		Name:       volumeName,
 		VolumeType: common.BlockVolumeType,

--- a/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
@@ -363,7 +363,7 @@ func (r *ReconcileCnsVolumeMetadata) updateCnsMetadata(ctx context.Context, inst
 		metadata := cnsvsphere.GetCnsKubernetesEntityMetaData(instance.Spec.EntityName, instance.Spec.Labels, deleteFlag, string(instance.Spec.EntityType), instance.Spec.Namespace, instance.Spec.GuestClusterID, []cnstypes.CnsKubernetesEntityReference{entityReferences[index]})
 		metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(metadata))
 
-		cluster := cnsvsphere.GetContainerCluster(instance.Spec.GuestClusterID, r.configInfo.Cfg.VirtualCenter[host].User, cnstypes.CnsClusterFlavorGuest)
+		cluster := cnsvsphere.GetContainerCluster(instance.Spec.GuestClusterID, r.configInfo.Cfg.VirtualCenter[host].User, cnstypes.CnsClusterFlavorGuest, instance.Spec.ClusterDistribution)
 		updateSpec := &cnstypes.CnsVolumeMetadataUpdateSpec{
 			VolumeId: cnstypes.CnsVolumeId{
 				Id: pv.Spec.CSI.VolumeHandle,

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -106,7 +106,7 @@ func csiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) {
 	}
 	log.Debugf("FullSync: pvToCnsEntityMetadataMap %+v \n pvToK8sEntityMetadataMap: %+v \n", spew.Sdump(pvToCnsEntityMetadataMap), spew.Sdump(pvToK8sEntityMetadataMap))
 	// Get specs for create and update volume calls
-	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor)
+	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor, metadataSyncer.configInfo.Cfg.Global.ClusterDistribution)
 	createSpecArray, updateSpecArray := fullSyncGetVolumeSpecs(ctx, k8sPVs, pvToCnsEntityMetadataMap, pvToK8sEntityMetadataMap, containerCluster, metadataSyncer, migrationFeatureStateForFullSync)
 	volToBeDeleted, err := getVolumesToBeDeleted(ctx, queryAllResult.Volumes, k8sPVMap, metadataSyncer, migrationFeatureStateForFullSync)
 	if err != nil {

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -781,7 +781,7 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim, pv *v1.Pe
 	pvcMetadata := cnsvsphere.GetCnsKubernetesEntityMetaData(pvc.Name, pvc.Labels, false, string(cnstypes.CnsKubernetesEntityTypePVC), pvc.Namespace, metadataSyncer.configInfo.Cfg.Global.ClusterID, []cnstypes.CnsKubernetesEntityReference{entityReference})
 
 	metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(pvcMetadata))
-	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor)
+	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor, metadataSyncer.configInfo.Cfg.Global.ClusterDistribution)
 
 	updateSpec := &cnstypes.CnsVolumeMetadataUpdateSpec{
 		VolumeId: cnstypes.CnsVolumeId{
@@ -831,7 +831,7 @@ func csiPVCDeleted(ctx context.Context, pvc *v1.PersistentVolumeClaim, pv *v1.Pe
 	} else {
 		volumeHandle = pv.Spec.CSI.VolumeHandle
 	}
-	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor)
+	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor, metadataSyncer.configInfo.Cfg.Global.ClusterDistribution)
 	updateSpec := &cnstypes.CnsVolumeMetadataUpdateSpec{
 		VolumeId: cnstypes.CnsVolumeId{
 			Id: volumeHandle,
@@ -857,7 +857,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 	metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(pvMetadata))
 	var volumeHandle string
 	var err error
-	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor)
+	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor, metadataSyncer.configInfo.Cfg.Global.ClusterDistribution)
 	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && newPv.Spec.VsphereVolume != nil {
 		// In case if feature state switch is enabled after syncer is deployed, we need to initialize the volumeMigrationService
 		if err = initVolumeMigrationService(ctx, metadataSyncer); err != nil {
@@ -972,7 +972,7 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 		pvMetadata := cnsvsphere.GetCnsKubernetesEntityMetaData(pv.Name, nil, true, string(cnstypes.CnsKubernetesEntityTypePV), "", metadataSyncer.configInfo.Cfg.Global.ClusterID, nil)
 		metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(pvMetadata))
 
-		containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor)
+		containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor, metadataSyncer.configInfo.Cfg.Global.ClusterDistribution)
 		updateSpec := &cnstypes.CnsVolumeMetadataUpdateSpec{
 			VolumeId: cnstypes.CnsVolumeId{
 				Id: pv.Spec.CSI.VolumeHandle,
@@ -1114,7 +1114,7 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 				continue
 			}
 		}
-		containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor)
+		containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor, metadataSyncer.configInfo.Cfg.Global.ClusterDistribution)
 		updateSpec := &cnstypes.CnsVolumeMetadataUpdateSpec{
 			VolumeId: cnstypes.CnsVolumeId{
 				Id: volumeHandle,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is to support CNS telemetry for cluster-distribution.  CSI helps to retrieve cluster distribution where customers have deployed CSI on vSphere. This is a critical requirement for CNS Analytics to know the adoption on different platforms. 

**Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #**

This fix is to enable CNS telemetry for cluster distribution.

**Special notes for your reviewer:**

The following tests are done in vanilla/SVC/TKG flavors. 
OLD image: without the telemetry changes
NEW image: including the CNS telemetry changes

**Vanilla Cluster**

Test steps:
1.  create PVC1 using the vsphere-csi-driver with new image and sphere-config with cluster-distribution:OpenShift 
2. Verify the cluster-distribution is set.

```
2020-09-25T22:44:16.062Z	INFO	volume/manager.go:249	CreateVolume: Volume created successfully. VolumeName: "pvc-ad4c80da-2167-49c0-b5d9-69183956069c", opId: "31b53647", volumeID: "afa3e18c-0b77-4f15-b757-8627766bec8a"	{"TraceId": "e1371576-6598-4846-acab-49c2dfe1f762"}
2020-09-25T22:44:16.282Z	INFO	vanilla/controller.go:396	QueryVolume for volumeID afa3e18c-0b77-4f15-b757-8627766bec8a is (*types.CnsQueryResult)(0xc0005ec8a0)({
 DynamicData: (types.DynamicData) {
 },
 Volumes: ([]types.CnsVolume) (len=1 cap=1) {
  (types.CnsVolume) {
   DynamicData: (types.DynamicData) {
   },
   VolumeId: (types.CnsVolumeId) {
    DynamicData: (types.DynamicData) {
    },
    Id: (string) (len=36) "afa3e18c-0b77-4f15-b757-8627766bec8a"
   },
   DatastoreUrl: (string) (len=58) "ds:///vmfs/volumes/vsan:524f0c83003d697c-b67ae4bec09d8333/",
   Name: (string) (len=40) "pvc-ad4c80da-2167-49c0-b5d9-69183956069c",
   VolumeType: (string) (len=5) "BLOCK",
   StoragePolicyId: (string) (len=36) "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
   Metadata: (types.CnsVolumeMetadata) {
    DynamicData: (types.DynamicData) {
    },
    ContainerCluster: (types.CnsContainerCluster) {
     DynamicData: (types.DynamicData) {
     },
     ClusterType: (string) (len=10) "KUBERNETES",
     ClusterId: (string) (len=12) "demo-cluster",
     VSphereUser: (string) (len=27) "Administrator@vsphere.local",
     ClusterFlavor: (string) (len=7) "VANILLA",
     ClusterDistribution: (string) (len=9) "OpenShift"
    },
    EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
    ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
     (types.CnsContainerCluster) {
      DynamicData: (types.DynamicData) {
      },
      ClusterType: (string) (len=10) "KUBERNETES",
      ClusterId: (string) (len=12) "demo-cluster",
      VSphereUser: (string) (len=27) "Administrator@vsphere.local",
      ClusterFlavor: (string) (len=7) "VANILLA",
      ClusterDistribution: (string) (len=9) "OpenShift"
     }
    }

```
Test steps:
1. create PVC1 using the vsphere-csi-driver with OLD image 
2. Verify there is no cluster-distribution field.
3. re-create the vsphere-config with cluster-distribution:OpenShift and re-deploy the vsphere-csi-driver using NEW image.
4. update the PVC1 with label key1=value1
5. Verify the cluster-distribution is set by the vsphere-syncer

```
2020-09-29T23:17:43.235Z	DEBUG	common/vsphereutil.go:177	vSphere CNS driver creating volume pvc-7e046550-8b61-4aae-a085-eed719b3cdec with create spec (*types.CnsVolumeCreateSpec)(0xc000662380)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-7e046550-8b61-4aae-a085-eed719b3cdec",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=1 cap=1) {
  (types.ManagedObjectReference) Datastore:datastore-36
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=16) "vSAN-FVT-Cluster",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA"
  },

2020-09-29T23:39:49.329Z	INFO	volume/manager.go:531	UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: "977e6704-98af-4be4-80fb-5139aacf649f", opId: "5e92982c"	{"TraceId": "621e6a5b-7be9-43ee-94a7-f0efc295766c"}
2020-09-29T23:39:49.440Z	INFO	syncer/metadatasyncer.go:795	QueryVolume for volumeID 977e6704-98af-4be4-80fb-5139aacf649f is (*types.CnsQueryResult)(0xc000a27d10)({
 DynamicData: (types.DynamicData) {
 },
 Volumes: ([]types.CnsVolume) (len=1 cap=1) {
  (types.CnsVolume) {
   DynamicData: (types.DynamicData) {
   },
   VolumeId: (types.CnsVolumeId) {
    DynamicData: (types.DynamicData) {
    },
    Id: (string) (len=36) "977e6704-98af-4be4-80fb-5139aacf649f"
   },
   DatastoreUrl: (string) (len=58) "ds:///vmfs/volumes/vsan:5255d429880604d5-7f4a18f3ce361c74/",
   Name: (string) (len=40) "pvc-7e046550-8b61-4aae-a085-eed719b3cdec",
   VolumeType: (string) (len=5) "BLOCK",
   StoragePolicyId: (string) (len=36) "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
   Metadata: (types.CnsVolumeMetadata) {
    DynamicData: (types.DynamicData) {
    },
    ContainerCluster: (types.CnsContainerCluster) {
     DynamicData: (types.DynamicData) {
     },
     ClusterType: (string) (len=10) "KUBERNETES",
     ClusterId: (string) (len=12) "demo-cluster",
     VSphereUser: (string) (len=27) "Administrator@vsphere.local",
     ClusterFlavor: (string) (len=7) "VANILLA",
     ClusterDistribution: (string) (len=9) "OpenShift"
    },

```
**Supervisor Cluster**

Test steps:
1.  create PVC1 using the vsphere-csi-driver with new image and sphere-config with cluster-distribution:Redhat 
2. Verify the cluster-distribution is set.

```
2020-09-30T00:14:06.392Z	INFO	volume/manager.go:249	CreateVolume: Volume created successfully. VolumeName: "pvc-d5d6f3fc-1d1f-4533-a4aa-6d8225a20959", opId: "658a6525", volumeID: "efc0d4f5-7003-466e-9e00-4b2bd9e13be5"	{"TraceId": "c41680f9-9c0e-42b8-bb09-11a63b8476a2"}
2020-09-30T00:14:09.936Z	INFO	wcp/controller.go:338	QueryVolume for volumeID efc0d4f5-7003-466e-9e00-4b2bd9e13be5 is (*types.CnsQueryResult)(0xc000626ed0)({
 DynamicData: (types.DynamicData) {
 },
 Volumes: ([]types.CnsVolume) (len=1 cap=1) {
  (types.CnsVolume) {
   DynamicData: (types.DynamicData) {
   },
   VolumeId: (types.CnsVolumeId) {
    DynamicData: (types.DynamicData) {
    },
    Id: (string) (len=36) "efc0d4f5-7003-466e-9e00-4b2bd9e13be5"
   },
   DatastoreUrl: (string) (len=58) "ds:///vmfs/volumes/vsan:52915f9f560cbf14-9718ce564b25e108/",
   Name: (string) (len=40) "pvc-d5d6f3fc-1d1f-4533-a4aa-6d8225a20959",
   VolumeType: (string) (len=5) "BLOCK",
   StoragePolicyId: (string) (len=36) "5900aef2-7b9c-44ed-98bf-8c2a08846dec",
   Metadata: (types.CnsVolumeMetadata) {
    DynamicData: (types.DynamicData) {
    },
    ContainerCluster: (types.CnsContainerCluster) {
     DynamicData: (types.DynamicData) {
     },
     ClusterType: (string) (len=10) "KUBERNETES",
     ClusterId: (string) (len=9) "domain-c9",
     VSphereUser: (string) (len=27) "Administrator@vsphere.local",
     ClusterFlavor: (string) (len=8) "WORKLOAD",
     ClusterDistribution: (string) (len=6) "Redhat"
    },


```
Test steps:
1. create PVC1 using the vsphere-csi-driver with OLD image 
2. Verify there is no cluster-distribution field.
3. re-create the vsphere-config with cluster-distribution:Redhat and re-deploy the vsphere-csi-driver using NEW image.
4. update the PVC1 with label key1=value1
5. Verify the cluster-distribution is set by the vsphere-syncer

```
2020-09-30T00:04:24.866Z	DEBUG	common/vsphereutil.go:177	vSphere CNS driver creating volume pvc-14cd5410-516c-4718-aa82-e204e00cc1c1 with create spec (*types.CnsVolumeCreateSpec)(0xc000206000)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-14cd5410-516c-4718-aa82-e204e00cc1c1",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=1 cap=1) {
  (types.ManagedObjectReference) Datastore:datastore-48
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=9) "domain-c9",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=8) "WORKLOAD"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=9) "domain-c9",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=8) "WORKLOAD"

2020-09-30T00:12:37.843Z	INFO	volume/manager.go:531	UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: "00870fd2-9d27-4039-a11c-34be195c3189", opId: "658a64df"	{"TraceId": "e79cd429-3bdc-48cc-8832-4c8a41597ff0"}
2020-09-30T00:12:40.752Z	INFO	syncer/metadatasyncer.go:795	QueryVolume for volumeID 00870fd2-9d27-4039-a11c-34be195c3189 is (*types.CnsQueryResult)(0xc000629e60)({
 DynamicData: (types.DynamicData) {
 },
 Volumes: ([]types.CnsVolume) (len=1 cap=1) {
  (types.CnsVolume) {
   DynamicData: (types.DynamicData) {
   },
   VolumeId: (types.CnsVolumeId) {
    DynamicData: (types.DynamicData) {
    },
    Id: (string) (len=36) "00870fd2-9d27-4039-a11c-34be195c3189"
   },
   DatastoreUrl: (string) (len=58) "ds:///vmfs/volumes/vsan:52915f9f560cbf14-9718ce564b25e108/",
   Name: (string) (len=40) "pvc-14cd5410-516c-4718-aa82-e204e00cc1c1",
   VolumeType: (string) (len=5) "BLOCK",
   StoragePolicyId: (string) (len=36) "5900aef2-7b9c-44ed-98bf-8c2a08846dec",
   Metadata: (types.CnsVolumeMetadata) {
    DynamicData: (types.DynamicData) {
    },
    ContainerCluster: (types.CnsContainerCluster) {
     DynamicData: (types.DynamicData) {
     },
     ClusterType: (string) (len=10) "KUBERNETES",
     ClusterId: (string) (len=9) "domain-c9",
     VSphereUser: (string) (len=27) "Administrator@vsphere.local",
     ClusterFlavor: (string) (len=8) "WORKLOAD",
     ClusterDistribution: (string) (len=6) "Redhat"
    },
    EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=2 cap=2) {
     (*types.CnsKubernetesEntityMetadata)(0xc000eb2f00)({
      CnsEntityMetadata: (types.CnsEntityMetadata) {
       DynamicData: (types.DynamicData) {
       },
       EntityName: (string) (len=15) "mysql-pvc-claim",
       Labels: ([]types.KeyValue) (len=1 cap=1) {
        (types.KeyValue) {
         DynamicData: (types.DynamicData) {
         },
         Key: (string) (len=4) "key1",
         Value: (string) (len=6) "value1"
        }
```
**TKG Cluster**

Compatibility Test1: 

TKG with OLD image based on the SVC with NEW image
1. created PVC in TKG
2. verify the PVC created successfully with new cnsvolumeMetadata CRD in SVC
```
Logs from TKG:
{"level":"info","time":"2020-09-30T00:42:28.79944052Z","caller":"wcpguest/controller_helper.go:210","msg":"PersistentVolumeClaim 318c9dd4-ed6d-49bf-8ce2-5ef336478d9e-c1741a32-b8e9-4ecd-8ee5-84475b5f2f9e in namespace test-gc-e2e-demo-ns is in state Bound","TraceId":"fb45dd8d-ea3d-472e-9b68-3e217b6dbda2"}

Logs for cnsvolumeMetadata reconciler from SVC:
2020-09-30T00:42:29.400Z        DEBUG   cnsvolumemetadata/cnsvolumemetadata_controller.go:306   ReconcileCnsVolumeMetadata: Calling updateCnsMetadata for instance "318c9dd4-ed6d-49bf-8ce2-5ef336478d9e-c1741a32-b8e9-4ecd-8ee5-84475b5f2f9e" with delete flag false   {"TraceId": "afc3f8dd-0dbc-4a83-96ab-4a470ed68840"}
2020-09-30T00:42:29.432Z        INFO    cnsvolumemetadata/cnsvolumemetadata_controller.go:377   ReconcileCnsVolumeMetadata: Calling UpdateVolumeMetadata for volume "318c9dd4-ed6d-49bf-8ce2-5ef336478d9e-c1741a32-b8e9-4ecd-8ee5-84475b5f2f9e" of instance "318c9dd4-ed6d-49bf-8ce2-5ef336478d9e-2261b0ef-2e6f-4950-8c36-ed38c8aedc61" with updateSpec: (*types.CnsVolumeMetadataUpdateSpec)(0xc000618fc0)({
 DynamicData: (types.DynamicData) {
 },
 VolumeId: (types.CnsVolumeId) {
  DynamicData: (types.DynamicData) {
  },
  Id: (string) (len=36) "270eaba9-cbea-490b-b3fe-ea236f938818"
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=36) "318c9dd4-ed6d-49bf-8ce2-5ef336478d9e",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=13) "GUEST_CLUSTER",
   ClusterDistribution: (string) ""
  },

```
Compatibility Test2: 
TKG with NEW image based on the SVC with OLD image
1. created PVC in TKG
2. verify the PVC created successfully with old cnsvolumeMetadata CRD(without cluster distribution) in SVC

```
Logs from TKG:
2020-10-12T20:04:44.485Z	INFO	wcpguest/controller_helper.go:210	PersistentVolumeClaim 214abae5-871d-4630-bad3-eb11e02fc590-b98cd579-d4b6-4b78-abe0-40585c9e741c in namespace test-gc-e2e-demo-ns is in state Bound	{"TraceId": "fd8466b9-e2f2-47fb-b6d2-415c10414fb7"}

Logs for cnsvolumeMetadata reconciler from SVC:
2020-10-12T20:04:44.736Z        DEBUG   cnsvolumemetadata/cnsvolumemetadata_controller.go:377   ReconcileCnsVolumeMetadata: Calling UpdateVolumeMetadata for volume "214abae5-871d-4630-bad3-eb11e02fc590-b98cd579-d4b6-4b78-abe0-40585c9e741c" of instance "214abae5-871d-4630-bad3-eb11e02fc590-52781eb3-6247-4f60-8af9-5c902c416ce0" with updateSpec: (*types.CnsVolumeMetadataUpdateSpec)(0xc000653f00)({
 DynamicData: (types.DynamicData) {
 },
 VolumeId: (types.CnsVolumeId) {
  DynamicData: (types.DynamicData) {
  },
  Id: (string) (len=36) "2a2f3d1e-20de-415c-8aa2-1a281c7a0153"
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=36) "214abae5-871d-4630-bad3-eb11e02fc590",
   VSphereUser: (string) (len=78) "workload_storage_management-48e1a16c-dba2-4b78-a7b8-46a0c08b7ccc@vsphere.local",
   ClusterFlavor: (string) (len=13) "GUEST_CLUSTER"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=1 cap=1) {
   (*types.CnsKubernetesEntityMetadata)(0xc000653e00)({
    CnsEntityMetadata: (types.CnsEntityMetadata) {
     DynamicData: (types.DynamicData) {
     },
     EntityName: (string) (len=40) "pvc-b98cd579-d4b6-4b78-abe0-40585c9e741c",
     Labels: ([]types.KeyValue) <nil>,
     Delete: (bool) false,
     ClusterID: (string) (len=36) "214abae5-871d-4630-bad3-eb11e02fc590"
    },
    EntityType: (string) (len=17) "PERSISTENT_VOLUME",
```
Compatibility Test3: 
TKG with NEW image based on the SVC with NEW image
1. created PVC in TKG 
2. verify the PVC created successfully with new cnsvolumeMetadata CRD in SVC and cluster distribution is set to TKGService

```
Logs from TKG:
2020-10-12T20:50:47.372Z	INFO	wcpguest/controller_helper.go:210	PersistentVolumeClaim 214abae5-871d-4630-bad3-eb11e02fc590-aff47d57-d122-48fc-bed7-c56ea9c55a77 in namespace test-gc-e2e-demo-ns is in state Bound	{"TraceId": "fd82af0a-3a87-4a0e-bb15-ad42fd576685"}

Logs for cnsvolumeMetadata reconciler from SVC:
2020-10-12T20:50:47.652Z        DEBUG   cnsvolumemetadata/cnsvolumemetadata_controller.go:377   ReconcileCnsVolumeMetadata: Calling UpdateVolumeMetadata for volume "214abae5-871d-4630-bad3-eb11e02fc590-aff47d57-d122-48fc-bed7-c56ea9c55a77" of instance "214abae5-871d-4630-bad3-eb11e02fc590-cc5ad725-8d30-4d9e-8b94-7dc57f974a36" with updateSpec: (*types.CnsVolumeMetadataUpdateSpec)(0xc000612e10)({
 DynamicData: (types.DynamicData) {
 },
 VolumeId: (types.CnsVolumeId) {
  DynamicData: (types.DynamicData) {
  },
  Id: (string) (len=36) "576dfa81-60c5-41a3-a704-067984b4c048"
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=36) "214abae5-871d-4630-bad3-eb11e02fc590",
   VSphereUser: (string) (len=78) "workload_storage_management-48e1a16c-dba2-4b78-a7b8-46a0c08b7ccc@vsphere.local",
   ClusterFlavor: (string) (len=13) "GUEST_CLUSTER",
   ClusterDistribution: (string) (len=10) "TKGService"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=1 cap=1) {
   (*types.CnsKubernetesEntityMetadata)(0xc000910600)({
    CnsEntityMetadata: (types.CnsEntityMetadata) {
     DynamicData: (types.DynamicData) {
     },
```

UPGRADE TEST1:

New TKG image, old SVC image
1. Create a PVC in TKG, verify no ClusterDistribution is set on CNS
2. Upgrade SV image, update the created PVC label, verify the ClusterDistribution set on CNS

```
Logs:
2020-10-12T22:43:11.946Z        DEBUG   cnsvolumemetadata/cnsvolumemetadata_controller.go:377   ReconcileCnsVolumeMetadata: Calling UpdateVolumeMetadata for volume "214abae5-871d-4630-bad3-eb11e02fc590-d2557286-dc1b-4830-89e6-b9ca6c876be3" of instance "214abae5-871d-4630-bad3-eb11e02fc590-93e79790-dbd5-423e-944e-5c08ff0de808" with updateSpec: (*types.CnsVolumeMetadataUpdateSpec)(0xc000cbc180)({
 DynamicData: (types.DynamicData) {
 },
VolumeId: (types.CnsVolumeId) {
  DynamicData: (types.DynamicData) {
  },
  Id: (string) (len=36) "946566c7-7139-40f2-93f8-9d2132184b96"
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=36) "214abae5-871d-4630-bad3-eb11e02fc590",
   VSphereUser: (string) (len=78) "workload_storage_management-48e1a16c-dba2-4b78-a7b8-46a0c08b7ccc@vsphere.local",
   ClusterFlavor: (string) (len=13) "GUEST_CLUSTER"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=1 cap=1) {
   (*types.CnsKubernetesEntityMetadata)(0xc000cbc100)({
    CnsEntityMetadata: (types.CnsEntityMetadata) {
     DynamicData: (types.DynamicData) {

After UPGRADE SVC and update the TKG PVC label:

2020-10-12T22:47:54.141Z        DEBUG   cnsvolumemetadata/cnsvolumemetadata_controller.go:377   ReconcileCnsVolumeMetadata: Calling UpdateVolumeMetadata for volume "214abae5-871d-4630-bad3-eb11e02fc590-d2557286-dc1b-4830-89e6-b9ca6c876be3" of instance "214abae5-871d-4630-bad3-eb11e02fc590-d2557286-dc1b-4830-89e6-b9ca6c876be3" with updateSpec: (*types.CnsVolumeMetadataUpdateSpec)(0xc000f2a6c0)({
 DynamicData: (types.DynamicData) {
 },
 VolumeId: (types.CnsVolumeId) {
  DynamicData: (types.DynamicData) {
  },
  Id: (string) (len=36) "946566c7-7139-40f2-93f8-9d2132184b96"
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=36) "214abae5-871d-4630-bad3-eb11e02fc590",
   VSphereUser: (string) (len=78) "workload_storage_management-48e1a16c-dba2-4b78-a7b8-46a0c08b7ccc@vsphere.local",
   ClusterFlavor: (string) (len=13) "GUEST_CLUSTER",
   ClusterDistribution: (string) (len=10) "TKGService"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=1 cap=1) {
   (*types.CnsKubernetesEntityMetadata)(0xc00128b300)({
    CnsEntityMetadata: (types.CnsEntityMetadata) {
     DynamicData: (types.DynamicData) {
     },
     EntityName: (string) (len=15) "mysql-pvc-claim",
     Labels: ([]types.KeyValue) (len=1 cap=1) {
      (types.KeyValue) {
       DynamicData: (types.DynamicData) {
       },
       Key: (string) (len=4) "key1",
       Value: (string) (len=6) "value1"
      }
     },

```
UPGRADE TEST2

New SVC image, old TKG image
1. Create a PVC in TKG, verify no ClusterDistribution is set on CNS
2. Upgrade TKG image and set ClusterDistribution in the configmap, update the created PVC label, verify the ClusterDistribution set on CNS
```
Logs:
2020-10-13T07:39:23.281Z        DEBUG   cnsvolumemetadata/cnsvolumemetadata_controller.go:377   ReconcileCnsVolumeMetadata: Calling UpdateVolumeMetadata for volume "214abae5-871d-4630-bad3-eb11e02fc590-f3d0a25c-d54d-491b-ace9-fb2c58fdbe93" of instance "214abae5-871d-4630-bad3-eb11e02fc590-f3d0a25c-d54d-491b-ace9-fb2c58fdbe93" with updateSpec: (*types.CnsVolumeMetadataUpdateSpec)(0xc0010bcea0)({
 DynamicData: (types.DynamicData) {
 },
 VolumeId: (types.CnsVolumeId) {
  DynamicData: (types.DynamicData) {
  },
  Id: (string) (len=36) "6f40bc8a-e1e6-4063-ab3c-849a4dd04956"
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=36) "214abae5-871d-4630-bad3-eb11e02fc590",
   VSphereUser: (string) (len=78) "workload_storage_management-48e1a16c-dba2-4b78-a7b8-46a0c08b7ccc@vsphere.local",
   ClusterFlavor: (string) (len=13) "GUEST_CLUSTER",
   ClusterDistribution: (string) ""
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=1 cap=1) {
   (*types.CnsKubernetesEntityMetadata)(0xc000952a00)({
    CnsEntityMetadata: (types.CnsEntityMetadata) {
     DynamicData: (types.DynamicData) {
     },
     EntityName: (string) (len=15) "mysql-pvc-claim",
     Labels: ([]types.KeyValue) <nil>,
     Delete: (bool) false,
     ClusterID: (string) (len=36) "214abae5-871d-4630-bad3-eb11e02fc590"
    },

AFTER UPGRADE TKG and update the TKG pvc label:

2020-10-13T07:47:31.294Z        DEBUG   cnsvolumemetadata/cnsvolumemetadata_controller.go:377   ReconcileCnsVolumeMetadata: Calling UpdateVolumeMetadata for volume "214abae5-871d-4630-bad3-eb11e02fc590-f3d0a25c-d54d-491b-ace9-fb2c58fdbe93" of instance "214abae5-871d-4630-bad3-eb11e02fc590-f3d0a25c-d54d-491b-ace9-fb2c58fdbe93" with updateSpec: (*types.CnsVolumeMetadataUpdateSpec)(0xc000f2be60)({
 DynamicData: (types.DynamicData) {
 },
 VolumeId: (types.CnsVolumeId) {
  DynamicData: (types.DynamicData) {
  },
  Id: (string) (len=36) "6f40bc8a-e1e6-4063-ab3c-849a4dd04956"
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=36) "214abae5-871d-4630-bad3-eb11e02fc590",
   VSphereUser: (string) (len=78) "workload_storage_management-48e1a16c-dba2-4b78-a7b8-46a0c08b7ccc@vsphere.local",
   ClusterFlavor: (string) (len=13) "GUEST_CLUSTER",
   ClusterDistribution: (string) (len=10) "TKGService"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=1 cap=1) {
   (*types.CnsKubernetesEntityMetadata)(0xc00128ad80)({
    CnsEntityMetadata: (types.CnsEntityMetadata) {
     DynamicData: (types.DynamicData) {
     },
     EntityName: (string) (len=15) "mysql-pvc-claim",
     Labels: ([]types.KeyValue) (len=1 cap=1) {
      (types.KeyValue) {
       DynamicData: (types.DynamicData) {
       },
       Key: (string) (len=4) "key1",
       Value: (string) (len=6) "value1"
      }
     },


