### PR TITLE
Remove node name dependency for vanilla in CSI controller

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -52,6 +52,7 @@ type NodeManagerInterface interface {
 	GetSharedDatastoresInK8SCluster(ctx context.Context) ([]*cnsvsphere.DatastoreInfo, error)
 	GetSharedDatastoresInTopology(ctx context.Context, topologyRequirement *csi.TopologyRequirement, zoneKey string, regionKey string) ([]*cnsvsphere.DatastoreInfo, map[string][]map[string]string, error)
 	GetNodeByName(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
+	GetNode(ctx context.Context, nodeUUID string, dc *cnsvsphere.Datacenter) (*cnsvsphere.VirtualMachine, error)
 	GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachine, error)
 }
 
@@ -648,7 +649,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 				return nil, status.Errorf(codes.Internal, msg)
 			}
 		}
-		node, err := c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+		node, err := c.nodeMgr.GetNode(ctx, req.NodeId, nil)
 		if err != nil {
 			msg := fmt.Sprintf("failed to find VirtualMachine for node:%q. Error: %v", req.NodeId, err)
 			log.Error(msg)
@@ -736,7 +737,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		}
 	}
 	// Block Volume
-	node, err := c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+	node, err := c.nodeMgr.GetNode(ctx, req.NodeId, nil)
 	if err != nil {
 		msg := fmt.Sprintf("failed to find VirtualMachine for node:%q. Error: %v", req.NodeId, err)
 		log.Error(msg)

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -217,6 +217,27 @@ func (f *FakeNodeManager) GetNodeByName(ctx context.Context, nodeName string) (*
 	return vm, nil
 }
 
+func (f *FakeNodeManager) GetNode(ctx context.Context, nodeUUID string, dc *cnsvsphere.Datacenter) (*cnsvsphere.VirtualMachine, error) {
+	var (
+		vm  *cnsvsphere.VirtualMachine
+		err error
+		t   *testing.T
+	)
+	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
+		vm, err = cnsvsphere.GetVirtualMachineByUUID(ctx, nodeUUID, false)
+		if err != nil {
+			t.Errorf("Couldn't find VM instance with nodeUUID %s, failed to discover with err: %v", nodeUUID, err)
+			return nil, err
+		}
+	} else {
+		obj := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+		vm = &cnsvsphere.VirtualMachine{
+			VirtualMachine: object.NewVirtualMachine(f.client, obj.Reference()),
+		}
+	}
+	return vm, nil
+}
+
 func (f *FakeNodeManager) GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachine, error) {
 	return nil, nil
 }

--- a/pkg/csi/service/vanilla/nodes.go
+++ b/pkg/csi/service/vanilla/nodes.go
@@ -113,6 +113,14 @@ func (nodes *Nodes) GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachi
 	return nodes.cnsNodeManager.GetAllNodes(ctx)
 }
 
+// GetNode returns VirtualMachine object for given nodeUUID.
+// This is called by ControllerPublishVolume and ControllerUnpublishVolume to perform attach and detach operations.
+// If Datacenter is passed, VirtualMachine will be searched within this datacenter given its UUID.
+// If not, it will be searched in all registered datacenters.
+func (nodes *Nodes) GetNode(ctx context.Context, nodeUUID string, dc *cnsvsphere.Datacenter) (*cnsvsphere.VirtualMachine, error) {
+	return nodes.cnsNodeManager.GetNode(ctx, nodeUUID, nil)
+}
+
 // GetSharedDatastoresInTopology returns shared accessible datastores for specified topologyRequirement along with the map of
 // datastore URL and array of accessibleTopology map for each datastore returned from this function.
 // Here in this function, argument topologyRequirement can be passed in following form


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR changes NodeGetInfo method in Node service to return node uuid instead of node name, for vanilla flavor.
The returned node Id is then being used in ControllerPublishVolume & ControllerUnpublishVolume requests. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
This avoids an extra look up to fetch node UUID from its name in ControllerPublishVolume & ControllerUnpublishVolume invocations.
Please note - we continue returning node name in GC as that is being used to fetch VM using VMOperator.

**Testing**:
After making the change, the CSINode object now has UUID in Spec.Drivers.NodeID field. Earlier it used to be node name.

```
root@k8s-master-464:~# kubectl describe csinode k8s-master-464
Name:         k8s-master-464
.
.
.
Spec:
  Drivers:
    Name:           csi.vsphere.vmware.com
    Node ID:        421b083f-b700-1e6b-77ad-9e5ab7c936fd
    Topology Keys:  <nil>
Events:             <none>
```

Also, the same NodeID is now being passed in ControllerPublishVolume requests.
```
2020-09-29T19:58:14.117Z	INFO	vanilla/controller.go:585	ControllerPublishVolume: called with args {VolumeId:80eeb7c3-4030-4d9e-8c54-2c3e7c1a7edd NodeId:421b8467-c1b3-1265-5ee2-45a1ad46ad89 VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[storage.kubernetes.io/csiProvisionerIdentity:1601408694424-8081-csi.vsphere.vmware.com type:vSphere CNS Block Volume] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "5975a9ef-1ae6-4af9-a9f1-8f8330981203"}
2020-09-29T19:58:16.051Z	INFO	volume/manager.go:289	AttachVolume: volumeID: "80eeb7c3-4030-4d9e-8c54-2c3e7c1a7edd", vm: "VirtualMachine:vm-49 [VirtualCenterHost: 10.184.91.192, UUID: 421b8467-c1b3-1265-5ee2-45a1ad46ad89, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.91.192]]", opId: "68e94fcf"	{"TraceId": "5975a9ef-1ae6-4af9-a9f1-8f8330981203"}
2020-09-29T19:58:16.055Z	INFO	volume/manager.go:322	AttachVolume: Volume attached successfully. volumeID: "80eeb7c3-4030-4d9e-8c54-2c3e7c1a7edd", opId: "68e94fcf", vm: "VirtualMachine:vm-49 [VirtualCenterHost: 10.184.91.192, UUID: 421b8467-c1b3-1265-5ee2-45a1ad46ad89, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.91.192]]", diskUUID: "6000C29d-bbdb-a13d-b359-c9b11f70889f"	{"TraceId": "5975a9ef-1ae6-4af9-a9f1-8f8330981203"}
2020-09-29T19:58:16.062Z	DEBUG	common/vsphereutil.go:353	Successfully attached disk 80eeb7c3-4030-4d9e-8c54-2c3e7c1a7edd to VM VirtualMachine:vm-49 [VirtualCenterHost: 10.184.91.192, UUID: 421b8467-c1b3-1265-5ee2-45a1ad46ad89, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.91.192]]. Disk UUID is 6000C29d-bbdb-a13d-b359-c9b11f70889f	{"TraceId": "5975a9ef-1ae6-4af9-a9f1-8f8330981203"}
```

