### PR TITLE
Fix for Topology test cases

### DIFF
--- a/tests/e2e/partial_topology_values.go
+++ b/tests/e2e/partial_topology_values.go
@@ -44,7 +44,6 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		pvZone            string
 		pvRegion          string
 		allowedTopologies []v1.TopologySelectorLabelRequirement
-		nodeList          *v1.NodeList
 		pvclaim           *v1.PersistentVolumeClaim
 		storageclass      *storagev1.StorageClass
 		err               error
@@ -54,10 +53,10 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		namespace = f.Namespace.Name
 		bootstrap()
 		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
-		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		// Preparing allowedTopologies using topologies with shared and non shared datastores
 		regionZoneValue = GetAndExpectStringEnvVar(envRegionZoneWithSharedDS)
 	})
@@ -114,6 +113,11 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
 
 		ginkgo.By("Verify Pod is scheduled on a node belonging to same topology as the PV it is attached to")
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
 		err = verifyPodLocation(pod, nodeList, "", pvRegion)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -183,6 +187,11 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
 
 		ginkgo.By("Verify Pod is scheduled on a node belonging to same topology as the PV it is attached to")
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
 		err = verifyPodLocation(pod, nodeList, pvZone, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/tests/e2e/provision_with_multiple_zones.go
+++ b/tests/e2e/provision_with_multiple_zones.go
@@ -42,7 +42,6 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		zoneValues           []string
 		regionValues         []string
 		allowedTopologies    []v1.TopologySelectorLabelRequirement
-		nodeList             *v1.NodeList
 		pvclaim              *v1.PersistentVolumeClaim
 		pv                   *v1.PersistentVolume
 		storageclass         *storagev1.StorageClass
@@ -54,11 +53,10 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		namespace = f.Namespace.Name
 		bootstrap()
 		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
-		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
-
 		// Preparing allowedTopologies using topologies with shared and non shared datastores
 		topologyWithSharedDS = GetAndExpectStringEnvVar(envRegionZoneWithSharedDS)
 		topologyWithNoSharedDS := GetAndExpectStringEnvVar(envRegionZoneWithNoSharedDS)
@@ -104,8 +102,6 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		defer func() {
 			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvclaim.Name, *metav1.NewDeleteOptions(0))
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 		ginkgo.By("Expect claim to pass provisioning volume")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
@@ -131,6 +127,11 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
 
 		ginkgo.By("Verify Pod is scheduled on a node belonging to same topology as the shared datastore")
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
 		err = verifyPodLocation(pod, nodeList, pvZone, pvRegion)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -148,9 +149,5 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
 		pv = nil
 
-		ginkgo.By("Deleting the Storage Class")
-		err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		storageclass = nil
 	})
 })

--- a/tests/e2e/statefulset_with_topology.go
+++ b/tests/e2e/statefulset_with_topology.go
@@ -41,7 +41,6 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		pvZone            string
 		pvRegion          string
 		allowedTopologies []v1.TopologySelectorLabelRequirement
-		nodeList          *v1.NodeList
 		pod               *v1.Pod
 	)
 	ginkgo.BeforeEach(func() {
@@ -49,10 +48,10 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		namespace = f.Namespace.Name
 		bootstrap()
 		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
-		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		// Preparing allowedTopologies using topologies with shared datastores
 		regionZoneValue := GetAndExpectStringEnvVar(envRegionZoneWithSharedDS)
 		regionValues, zoneValues, allowedTopologies = topologyParameterForStorageClass(regionZoneValue)
@@ -111,7 +110,14 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 				ssPodsAfterDelete := fss.GetPodList(client, statefulset)
 				pod = &ssPodsAfterDelete.Items[0]
 				ginkgo.By("Verify Pod is scheduled in on a node belonging to same topology as the PV it is attached to")
+				nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+				framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+				if !(len(nodeList.Items) > 0) {
+					framework.Failf("Unable to find ready and schedulable Node")
+				}
 				err = verifyPodLocation(pod, nodeList, pvZone, pvRegion)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			}
 		}
 

--- a/tests/e2e/topology_aware_node_poweroff.go
+++ b/tests/e2e/topology_aware_node_poweroff.go
@@ -51,10 +51,10 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		namespace = f.Namespace.Name
 		bootstrap()
 		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
-		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 	})
 
 	/*
@@ -159,6 +159,11 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
 
 		ginkgo.By("Verify Pod is scheduled on another node belonging to same topology as the PV it is attached to")
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
 		err = verifyPodLocation(&pod, nodeList, pvZone, pvRegion)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/tests/e2e/volume_provisioning_with_topology.go
+++ b/tests/e2e/volume_provisioning_with_topology.go
@@ -46,7 +46,6 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 		pvZone            string
 		pvRegion          string
 		allowedTopologies []v1.TopologySelectorLabelRequirement
-		nodeList          *v1.NodeList
 		pod               *v1.Pod
 		pvclaim           *v1.PersistentVolumeClaim
 		storageclass      *storagev1.StorageClass
@@ -57,10 +56,10 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 		namespace = f.Namespace.Name
 		bootstrap()
 		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
-		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		regionZoneValue := GetAndExpectStringEnvVar(envRegionZoneWithSharedDS)
 		regionValues, zoneValues, allowedTopologies = topologyParameterForStorageClass(regionZoneValue)
 
@@ -118,6 +117,11 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
 
 		ginkgo.By("Verify Pod is scheduled on a node belonging to same topology as the PV it is attached to")
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
 		err = verifyPodLocation(pod, nodeList, pvZone, pvRegion)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**Fix for Topology test cases**

What this PR does / why we need it:
Refactored CSI Topology test cases

Test results: https://gist.github.com/kavyashree-r/f3a504bd5baba5a67e3dfca3235c1f82

```
kramachandr-a01:vsphere-csi-driver kramachandra$ make golangci-lint
hack/check-golangci-lint.sh
INFO [config_reader] Config search paths: [./ /Users/kramachandra/github/vsphere-csi-driver /Users/kramachandra/github /Users/kramachandra /Users /] 
INFO [lintersdb] Active 10 linters: [deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (types_sizes|compiled_files|deps|exports_file|files|imports|name) took 3.089209179s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 38.279346ms 
INFO [linters context/goanalysis] analyzers took 3.588057323s with top 10 stages: buildir: 324.639091ms, ineffassign: 87.65988ms, S1038: 84.600407ms, SA1012: 72.815521ms, S1039: 69.485655ms, printf: 68.887989ms, lostcancel: 67.035436ms, S1001: 65.575724ms, S1003: 65.55119ms, SA4022: 65.496874ms 
INFO [linters context/goanalysis] analyzers took 823.465878ms with top 10 stages: buildir: 669.858906ms, U1000: 153.606972ms 
INFO [runner] Issues before processing: 54, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_files: 54/54, autogenerated_exclude: 10/54, identifier_marker: 10/10, exclude: 0/10, cgo: 54/54, filename_unadjuster: 54/54, path_prettifier: 54/54, skip_dirs: 54/54 
INFO [runner] processing took 2.283654ms with stages: path_prettifier: 1.281524ms, exclude: 377.194µs, autogenerated_exclude: 322.925µs, identifier_marker: 178.628µs, skip_dirs: 105.546µs, cgo: 8.353µs, filename_unadjuster: 5.173µs, nolint: 1.053µs, max_same_issues: 962ns, skip_files: 369ns, diff: 353ns, uniq_by_line: 316ns, max_from_linter: 316ns, path_shortener: 271ns, source_code: 246ns, exclude-rules: 246ns, max_per_file_from_linter: 179ns 
INFO [runner] linters took 2.656876309s with stages: goanalysis_metalinter: 1.526637895s, unused: 1.127860637s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 60 samples, avg is 191.6MB, max is 407.2MB 
INFO Execution took 5.804359515s                  
kramachandr-a01:vsphere-csi-driver kramachandra$ 

```
