### PR TITLE
[cherry-pick-to-release-2.0] - fix vsphere backward compatibility issue

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -584,6 +584,7 @@ func (m *defaultManager) QueryVolume(ctx context.Context, queryFilter cnstypes.C
 		log.Errorf("CNS QueryVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 		return nil, err
 	}
+	res = updateQueryResult(ctx, m, res)
 	return res, err
 }
 
@@ -606,5 +607,6 @@ func (m *defaultManager) QueryAllVolume(ctx context.Context, queryFilter cnstype
 		log.Errorf("CNS QueryAllVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 		return nil, err
 	}
+	res = updateQueryResult(ctx, m, res)
 	return res, err
 }

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"errors"
 
+	"github.com/vmware/govmomi/cns"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 
 	vimtypes "github.com/vmware/govmomi/vim25/types"
@@ -61,4 +64,25 @@ func IsDiskAttached(ctx context.Context, vm *cnsvsphere.VirtualMachine, volumeID
 	}
 	log.Debugf("Volume %s is not attached to VM: %+v", volumeID, vm)
 	return "", nil
+}
+
+// updateQueryResult helps update CnsQueryResult to populate volume.Metadata.EntityMetadata.ClusterID
+// with value from volume.Metadata.ContainerCluster.ClusterId
+// This is required to make driver code compatible to vSphere 67 release
+func updateQueryResult(ctx context.Context, m *defaultManager, res *cnstypes.CnsQueryResult) *cnstypes.CnsQueryResult {
+	if m.virtualCenter.Client.Version == cns.ReleaseVSAN67u3 {
+		log := logger.GetLogger(ctx)
+		for volumeIndex, volume := range res.Volumes {
+			for metadataIndex, metadata := range volume.Metadata.EntityMetadata {
+				if cnsK8sMetaEntityMetadata, ok := metadata.(*cnstypes.CnsKubernetesEntityMetadata); ok {
+					cnsK8sMetaEntityMetadata.ClusterID = volume.Metadata.ContainerCluster.ClusterId
+					volume.Metadata.EntityMetadata[metadataIndex] = cnsK8sMetaEntityMetadata
+				} else {
+					log.Debugf("metadata: %v is not of type CnsKubernetesEntityMetadata", metadata)
+				}
+			}
+			res.Volumes[volumeIndex] = volume
+		}
+	}
+	return res
 }

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -731,10 +731,7 @@ func isVsan67u3Release(ctx context.Context, c *controller) (bool, error) {
 		return false, err
 	}
 	log.Debugf("vCenter version is :%q", vc.Client.Version)
-	if vc.Client.Version == cns.ReleaseVSAN67u3 {
-		return true, nil
-	}
-	return false, nil
+	return vc.Client.Version == cns.ReleaseVSAN67u3, nil
 }
 
 func (c *controller) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is cherry-picking changes made in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/409 to release-2.0 branch for v2.0.1 patch release.

**Which issue this PR fixes**: 
fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/408


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix vsphere backward compatibility issue
```
