### PR TITLE
Modifying the FSS configmap name in vanilla to internal

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -25,14 +25,13 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/k8scloudoperator"
-
-	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/cnsoperator/manager"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/k8scloudoperator"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/storagepool"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/types"
 )
@@ -61,9 +60,9 @@ func main() {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Infof("Version : %s", syncer.Version)
 
-	clusterFlavor := cnstypes.CnsClusterFlavor(os.Getenv(csitypes.EnvClusterFlavor))
-	if clusterFlavor == "" {
-		clusterFlavor = cnstypes.CnsClusterFlavorVanilla
+	clusterFlavor, err := config.GetClusterFlavor(ctx)
+	if err != nil {
+		log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
 	}
 
 	if *operationMode == operationModeWebHookServer {

--- a/docs/book/features/vsphere_csi_migration.md
+++ b/docs/book/features/vsphere_csi_migration.md
@@ -87,7 +87,7 @@ To try out vSphere CSI migration in beta for vSphere plugin, perform the followi
              "csi-migration": "true"
            kind: ConfigMap
            metadata:
-             name: csi-feature-states
+             name: internal-feature-states.csi.vsphere.vmware.com
              namespace: kube-system
 
 4. Install admission webhook.

--- a/example/vanilla-k8s-block-driver/vsphere.conf
+++ b/example/vanilla-k8s-block-driver/vsphere.conf
@@ -8,9 +8,9 @@ password = "vcenter password"
 port = "443"
 datacenters = "list of comma separated datacenter paths where node VMs are present"
 
-# FeatureStatesConfig holds the details about feature states configmap.
-# Default feature states configmap name is set to "csi-feature-states"  and namespace is set to "kube-system" 
+# InternalFeatureStatesConfig holds the details about internal feature states configmap.
+# Default feature states configmap name is set to "internal-feature-states.csi.vsphere.vmware.com"  and namespace is set to "kube-system"
 # Provide the configmap name and namespace details only when feature states configmap is not in the default namespace
-[FeatureStatesConfig]
-name = "csi-feature-states"
+[InternalFeatureStatesConfig]
+name = "internal-feature-states.csi.vsphere.vmware.com"
 namespace = "kube-system"

--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -125,7 +125,7 @@ data:
   "csi-auth-check": "false"
 kind: ConfigMap
 metadata:
-  name: csi-feature-states
+  name: internal-feature-states.csi.vsphere.vmware.com
   namespace: kube-system
 ---
 apiVersion: storage.k8s.io/v1beta1

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -138,7 +138,7 @@ data:
   "csi-auth-check": "false"
 kind: ConfigMap
 metadata:
-  name: csi-feature-states
+  name: internal-feature-states.csi.vsphere.vmware.com
   namespace: kube-system
 ---
 apiVersion: storage.k8s.io/v1beta1

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/generate-signed-webhook-certs.sh
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/generate-signed-webhook-certs.sh
@@ -137,11 +137,11 @@ port = "8443"
 cert-file = "/etc/webhook/cert.pem"
 key-file = "/etc/webhook/key.pem"
 
-# FeatureStatesConfig holds the details about feature states configmap.
-# Default feature states configmap name is set to "csi-feature-states"  and namespace is set to "kube-system"
+# InternalFeatureStatesConfig holds the details about internal feature states configmap.
+# Default feature states configmap name is set to "internal-feature-states.csi.vsphere.vmware.com"  and namespace is set to "kube-system"
 # Provide the configmap name and namespace details only when feature states configmap is not in the default namespace
-[FeatureStatesConfig]
-name = "csi-feature-states"
+[InternalFeatureStatesConfig]
+name = "internal-feature-states.csi.vsphere.vmware.com"
 namespace = "${namespace}"
 eof
 

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -141,7 +141,7 @@ data:
   "csi-auth-check": "false"
 kind: ConfigMap
 metadata:
-  name: csi-feature-states
+  name: internal-feature-states.csi.vsphere.vmware.com
   namespace: kube-system
 ---
 apiVersion: storage.k8s.io/v1 # For k8s 1.17 or lower use storage.k8s.io/v1beta1

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/generate-signed-webhook-certs.sh
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/generate-signed-webhook-certs.sh
@@ -137,11 +137,11 @@ port = "8443"
 cert-file = "/etc/webhook/cert.pem"
 key-file = "/etc/webhook/key.pem"
 
-# FeatureStatesConfig holds the details about feature states configmap.
-# Default feature states configmap name is set to "csi-feature-states"  and namespace is set to "kube-system"
+# InternalFeatureStatesConfig holds the details about internal feature states configmap.
+# Default feature states configmap name is set to "internal-feature-states.csi.vsphere.vmware.com"  and namespace is set to "kube-system"
 # Provide the configmap name and namespace details only when feature states configmap is not in the default namespace
-[FeatureStatesConfig]
-name = "csi-feature-states"
+[InternalFeatureStatesConfig]
+name = "internal-feature-states.csi.vsphere.vmware.com"
 namespace = "${namespace}"
 eof
 

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -145,7 +145,7 @@ data:
   "csi-auth-check": "false"
 kind: ConfigMap
 metadata:
-  name: csi-feature-states
+  name: internal-feature-states.csi.vsphere.vmware.com
   namespace: kube-system
 ---
 apiVersion: storage.k8s.io/v1 # For k8s 1.17 use storage.k8s.io/v1beta1

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -65,8 +65,12 @@ type Config struct {
 		Zone   string `gcfg:"zone"`
 		Region string `gcfg:"region"`
 	}
-	// FeatureStatesConfig is the details about feature states configmap
+	// FeatureStatesConfig contains feature states configmap info specific to supervisor cluster
 	FeatureStatesConfig FeatureStatesConfigInfo
+
+	// InternalFeatureStatesConfig contains feature states configmap info specific to pvCSI and vanilla drivers
+	// NOTE: Do not edit this. Only to be used for dev and testing purposes.
+	InternalFeatureStatesConfig FeatureStatesConfigInfo
 }
 
 // FeatureStatesConfigInfo is the details about feature states configmap

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -20,7 +20,8 @@ import (
 	"context"
 	"errors"
 
-	"sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
@@ -35,18 +36,18 @@ type COCommonInterface interface {
 
 // GetContainerOrchestratorInterface returns orchestrator object
 // for a given container orchestrator type
-func GetContainerOrchestratorInterface(ctx context.Context, orchestratorType int, featureStatesConfigInfo config.FeatureStatesConfigInfo) (COCommonInterface, error) {
+func GetContainerOrchestratorInterface(ctx context.Context, orchestratorType int, clusterFlavor cnstypes.CnsClusterFlavor, params interface{}) (COCommonInterface, error) {
 	log := logger.GetLogger(ctx)
 	switch orchestratorType {
 	case common.Kubernetes:
-		k8sorchestratorInstance, err := k8sorchestrator.Newk8sOrchestrator(ctx, featureStatesConfigInfo)
+		k8sOrchestratorInstance, err := k8sorchestrator.Newk8sOrchestrator(ctx, clusterFlavor, params)
 		if err != nil {
-			log.Errorf("Creating k8sorchestratorInstance failed. Err: %v", err)
+			log.Errorf("creating k8sOrchestratorInstance failed. Err: %v", err)
 			return nil, err
 		}
-		return k8sorchestratorInstance, nil
+		return k8sOrchestratorInstance, nil
 	default:
-		//if type is invalid, return an error
-		return nil, errors.New("Invalid orchestrator Type")
+		// If type is invalid, return an error
+		return nil, errors.New("invalid orchestrator type")
 	}
 }

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -18,70 +18,194 @@ package k8sorchestrator
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
+	"sync/atomic"
 
+	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
 	"sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
 )
 
 var (
-	k8sOrchestratorInstance         *K8sOrchestrator
-	onceFork8sOrchestratorInstance  sync.Once
-	featureStatesConfigMapName      string
-	featureStatesConfigMapNamespace string
+	k8sOrchestratorInstance            *K8sOrchestrator
+	k8sOrchestratorInstanceInitialized uint32
 )
+
+// FSSConfigMapInfo contains details about the FSS configmap(s) present in all flavors
+type FSSConfigMapInfo struct {
+	featureStates      map[string]string
+	configMapName      string
+	configMapNamespace string
+}
 
 // K8sOrchestrator defines set of properties specific to K8s
 type K8sOrchestrator struct {
-	featureStates   map[string]string
+	supervisorFSS   FSSConfigMapInfo
+	internalFSS     FSSConfigMapInfo
 	informerManager *k8s.InformerManager
+	clusterFlavor   cnstypes.CnsClusterFlavor
 }
 
+// K8sGuestInitParams lists the set of parameters required to run the init for K8sOrchestrator in Guest cluster
+type K8sGuestInitParams struct {
+	InternalFeatureStatesConfigInfo   config.FeatureStatesConfigInfo
+	SupervisorFeatureStatesConfigInfo config.FeatureStatesConfigInfo
+}
+
+// K8sSupervisorInitParams lists the set of parameters required to run the init for K8sOrchestrator in Supervisor cluster
+type K8sSupervisorInitParams struct {
+	SupervisorFeatureStatesConfigInfo config.FeatureStatesConfigInfo
+}
+
+// K8sVanillaInitParams lists the set of parameters required to run the init for K8sOrchestrator in Vanilla cluster
+type K8sVanillaInitParams struct {
+	InternalFeatureStatesConfigInfo config.FeatureStatesConfigInfo
+}
+
+var mutex = &sync.RWMutex{}
+
 // Newk8sOrchestrator instantiates K8sOrchestrator object and returns this object
-func Newk8sOrchestrator(ctx context.Context, featureStatesConfigMapInfo config.FeatureStatesConfigInfo) (*K8sOrchestrator, error) {
-	var coInstanceErr error
-	onceFork8sOrchestratorInstance.Do(func() {
-		log := logger.GetLogger(ctx)
-		log.Info("Initializing k8sOrchestratorInstance")
-		k8sOrchestratorInstance = &K8sOrchestrator{}
-		k8sOrchestratorInstance.featureStates = make(map[string]string)
-		k8sClient, coInstanceErr := k8s.NewClient(ctx)
-		if coInstanceErr != nil {
-			log.Errorf("Creating Kubernetes client failed. Err: %v", coInstanceErr)
-			return
+// NOTE: As Newk8sOrchestrator is created in the init of the driver and syncer components,
+// raise an error only if it is of utmost importance
+func Newk8sOrchestrator(ctx context.Context, controllerClusterFlavor cnstypes.CnsClusterFlavor, params interface{}) (*K8sOrchestrator, error) {
+	var (
+		coInstanceErr error
+		k8sClient     clientset.Interface
+	)
+	if atomic.LoadUint32(&k8sOrchestratorInstanceInitialized) == 0 {
+		mutex.Lock()
+		defer mutex.Unlock()
+		if k8sOrchestratorInstanceInitialized == 0 {
+			log := logger.GetLogger(ctx)
+			log.Info("Initializing k8sOrchestratorInstance")
+
+			// Create a K8s client
+			k8sClient, coInstanceErr = k8s.NewClient(ctx)
+			if coInstanceErr != nil {
+				log.Errorf("Creating Kubernetes client failed. Err: %v", coInstanceErr)
+				return nil, coInstanceErr
+			}
+
+			k8sOrchestratorInstance = &K8sOrchestrator{}
+			k8sOrchestratorInstance.clusterFlavor = controllerClusterFlavor
+			coInstanceErr = initFSS(ctx, k8sClient, controllerClusterFlavor, params)
+			if coInstanceErr != nil {
+				log.Errorf("Failed to initialize the orchestrator. Error: %v", coInstanceErr)
+				return nil, coInstanceErr
+			}
+
+			atomic.StoreUint32(&k8sOrchestratorInstanceInitialized, 1)
+			log.Info("k8sOrchestratorInstance initialized")
 		}
-		featureStatesConfigMapName = featureStatesConfigMapInfo.Name
-		featureStatesConfigMapNamespace = featureStatesConfigMapInfo.Namespace
-		fssConfigMap, err := k8sClient.CoreV1().ConfigMaps(featureStatesConfigMapNamespace).Get(ctx, featureStatesConfigMapName, metav1.GetOptions{})
-		if err != nil {
-			log.Errorf("failed to fetch configmap %s from namespace %s. Setting the feature states to default values: %v. Error: %v", featureStatesConfigMapName, featureStatesConfigMapNamespace, k8sOrchestratorInstance.featureStates, err)
-		} else {
-			updateFSSValues(ctx, fssConfigMap, k8sOrchestratorInstance)
+	}
+	return k8sOrchestratorInstance, nil
+}
+
+// initFSS performs all the operations required to initialize the Feature states map and keep a watch on it
+func initFSS(ctx context.Context, k8sClient clientset.Interface, controllerClusterFlavor cnstypes.CnsClusterFlavor, params interface{}) error {
+	log := logger.GetLogger(ctx)
+	var (
+		fssConfigMap *v1.ConfigMap
+		err          error
+	)
+
+	// Store configmap info in global variables to access later
+	if controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		k8sOrchestratorInstance.supervisorFSS.featureStates = make(map[string]string)
+		// Validate init params
+		svInitParams, ok := params.(K8sSupervisorInitParams)
+		if !ok {
+			return fmt.Errorf("expected orchestrator params of type K8sSupervisorInitParams, got %T instead", params)
 		}
-		// Set up kubernetes resource listeners for metadata syncer
-		k8sOrchestratorInstance.informerManager = k8s.NewInformer(k8sClient)
-		k8sOrchestratorInstance.informerManager.AddConfigMapListener(
-			func(obj interface{}) {
-				configMapAdded(obj, k8sOrchestratorInstance)
-			}, // Add
-			func(oldObj interface{}, newObj interface{}) { // Update
-				configMapUpdated(oldObj, newObj, k8sOrchestratorInstance)
-			},
-			func(obj interface{}) {
-				configMapDeleted(obj, k8sOrchestratorInstance)
-			}) // Delete
-		log.Info("k8sOrchestratorInstance initialized")
-		k8sOrchestratorInstance.informerManager.Listen()
-	})
-	return k8sOrchestratorInstance, coInstanceErr
+		k8sOrchestratorInstance.supervisorFSS.configMapName = svInitParams.SupervisorFeatureStatesConfigInfo.Name
+		k8sOrchestratorInstance.supervisorFSS.configMapNamespace = svInitParams.SupervisorFeatureStatesConfigInfo.Namespace
+	}
+	if controllerClusterFlavor == cnstypes.CnsClusterFlavorVanilla {
+		k8sOrchestratorInstance.internalFSS.featureStates = make(map[string]string)
+		// Validate init params
+		vanillaInitParams, ok := params.(K8sVanillaInitParams)
+		if !ok {
+			return fmt.Errorf("expected orchestrator params of type K8sVanillaInitParams, got %T instead", params)
+		}
+		k8sOrchestratorInstance.internalFSS.configMapName = vanillaInitParams.InternalFeatureStatesConfigInfo.Name
+		k8sOrchestratorInstance.internalFSS.configMapNamespace = vanillaInitParams.InternalFeatureStatesConfigInfo.Namespace
+	}
+	if controllerClusterFlavor == cnstypes.CnsClusterFlavorGuest {
+		k8sOrchestratorInstance.supervisorFSS.featureStates = make(map[string]string)
+		k8sOrchestratorInstance.internalFSS.featureStates = make(map[string]string)
+		// Validate init params
+		guestInitParams, ok := params.(K8sGuestInitParams)
+		if !ok {
+			return fmt.Errorf("expected orchestrator params of type K8sGuestInitParams, got %T instead", params)
+		}
+		k8sOrchestratorInstance.internalFSS.configMapName = guestInitParams.InternalFeatureStatesConfigInfo.Name
+		k8sOrchestratorInstance.internalFSS.configMapNamespace = guestInitParams.InternalFeatureStatesConfigInfo.Namespace
+		k8sOrchestratorInstance.supervisorFSS.configMapName = guestInitParams.SupervisorFeatureStatesConfigInfo.Name
+		k8sOrchestratorInstance.supervisorFSS.configMapNamespace = guestInitParams.SupervisorFeatureStatesConfigInfo.Namespace
+	}
+
+	// Initialize supervisor FSS map values
+	if controllerClusterFlavor == cnstypes.CnsClusterFlavorGuest || controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		if k8sOrchestratorInstance.supervisorFSS.configMapName != "" && k8sOrchestratorInstance.supervisorFSS.configMapNamespace != "" {
+			// Retrieve configmap
+			fssConfigMap, err = k8sClient.CoreV1().ConfigMaps(k8sOrchestratorInstance.supervisorFSS.configMapNamespace).Get(
+				ctx, k8sOrchestratorInstance.supervisorFSS.configMapName, metav1.GetOptions{})
+			if err != nil {
+				log.Errorf("failed to fetch configmap %s from namespace %s. Setting the supervisor feature states to default values: %v. Error: %v",
+					k8sOrchestratorInstance.supervisorFSS.configMapName, k8sOrchestratorInstance.supervisorFSS.configMapNamespace,
+					k8sOrchestratorInstance.supervisorFSS, err)
+			} else {
+				// Update values
+				k8sOrchestratorInstance.supervisorFSS.featureStates = fssConfigMap.Data
+				log.Infof("New supervisor feature states values stored successfully: %v", k8sOrchestratorInstance.supervisorFSS.featureStates)
+			}
+		}
+	}
+
+	// Initialize internal FSS map values
+	if controllerClusterFlavor == cnstypes.CnsClusterFlavorGuest || controllerClusterFlavor == cnstypes.CnsClusterFlavorVanilla {
+		if k8sOrchestratorInstance.internalFSS.configMapName != "" && k8sOrchestratorInstance.internalFSS.configMapNamespace != "" {
+			// Retrieve configmap
+			fssConfigMap, err = k8sClient.CoreV1().ConfigMaps(k8sOrchestratorInstance.internalFSS.configMapNamespace).Get(
+				ctx, k8sOrchestratorInstance.internalFSS.configMapName, metav1.GetOptions{})
+			if err != nil {
+				log.Errorf("failed to fetch configmap %s from namespace %s. Setting the internal feature states to default values: %v. Error: %v",
+					k8sOrchestratorInstance.internalFSS.configMapName, k8sOrchestratorInstance.internalFSS.configMapNamespace,
+					k8sOrchestratorInstance.internalFSS.featureStates, err)
+			} else {
+				// Update values
+				k8sOrchestratorInstance.internalFSS.featureStates = fssConfigMap.Data
+				log.Infof("New internal feature states values stored successfully: %v", k8sOrchestratorInstance.internalFSS.featureStates)
+			}
+		}
+	}
+
+	// Set up kubernetes resource listeners for k8s orchestrator
+	k8sOrchestratorInstance.informerManager = k8s.NewInformer(k8sClient)
+	k8sOrchestratorInstance.informerManager.AddConfigMapListener(
+		// Add
+		func(obj interface{}) {
+			configMapAdded(obj)
+		}, // Update
+		func(oldObj interface{}, newObj interface{}) {
+			configMapUpdated(oldObj, newObj)
+		}, // Delete
+		func(obj interface{}) {
+			configMapDeleted(obj)
+		})
+	k8sOrchestratorInstance.informerManager.Listen()
+	return nil
 }
 
 // configMapAdded adds feature state switch values from configmap that has been created on K8s cluster
-func configMapAdded(obj interface{}, c *K8sOrchestrator) {
+func configMapAdded(obj interface{}) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = logger.NewContextWithLogger(ctx)
@@ -92,13 +216,19 @@ func configMapAdded(obj interface{}, c *K8sOrchestrator) {
 		log.Warnf("configMapAdded: unrecognized object %+v", obj)
 		return
 	}
-	if fssConfigMap.Name == featureStatesConfigMapName && fssConfigMap.Namespace == featureStatesConfigMapNamespace {
-		updateFSSValues(ctx, fssConfigMap, c)
+	if fssConfigMap.Name == k8sOrchestratorInstance.supervisorFSS.configMapName &&
+		fssConfigMap.Namespace == k8sOrchestratorInstance.supervisorFSS.configMapNamespace {
+		k8sOrchestratorInstance.supervisorFSS.featureStates = fssConfigMap.Data
+		log.Infof("New feature states values from %q stored successfully: %v", fssConfigMap.Name, k8sOrchestratorInstance.supervisorFSS.featureStates)
+	} else if fssConfigMap.Name == k8sOrchestratorInstance.internalFSS.configMapName &&
+		fssConfigMap.Namespace == k8sOrchestratorInstance.internalFSS.configMapNamespace {
+		k8sOrchestratorInstance.internalFSS.featureStates = fssConfigMap.Data
+		log.Infof("New feature states values from %q stored successfully: %v", fssConfigMap.Name, k8sOrchestratorInstance.internalFSS.featureStates)
 	}
 }
 
 // configMapUpdated updates feature state switch values from configmap that has been created on K8s cluster
-func configMapUpdated(oldObj, newObj interface{}, c *K8sOrchestrator) {
+func configMapUpdated(oldObj, newObj interface{}) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = logger.NewContextWithLogger(ctx)
@@ -108,13 +238,17 @@ func configMapUpdated(oldObj, newObj interface{}, c *K8sOrchestrator) {
 		log.Warnf("configMapUpdated: unrecognized new object %+v", newObj)
 		return
 	}
-	if fssConfigMap.Name == featureStatesConfigMapName && fssConfigMap.Namespace == featureStatesConfigMapNamespace {
-		updateFSSValues(ctx, fssConfigMap, c)
+	if fssConfigMap.Name == k8sOrchestratorInstance.supervisorFSS.configMapName && fssConfigMap.Namespace == k8sOrchestratorInstance.supervisorFSS.configMapNamespace {
+		k8sOrchestratorInstance.supervisorFSS.featureStates = fssConfigMap.Data
+		log.Infof("New feature states values from %q stored successfully: %v", fssConfigMap.Name, k8sOrchestratorInstance.supervisorFSS.featureStates)
+	} else if fssConfigMap.Name == k8sOrchestratorInstance.internalFSS.configMapName && fssConfigMap.Namespace == k8sOrchestratorInstance.internalFSS.configMapNamespace {
+		k8sOrchestratorInstance.internalFSS.featureStates = fssConfigMap.Data
+		log.Infof("New feature states values from %q stored successfully: %v", fssConfigMap.Name, k8sOrchestratorInstance.internalFSS.featureStates)
 	}
 }
 
 // configMapDeleted clears the feature state switch values from the feature states map
-func configMapDeleted(obj interface{}, c *K8sOrchestrator) {
+func configMapDeleted(obj interface{}) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = logger.NewContextWithLogger(ctx)
@@ -124,34 +258,92 @@ func configMapDeleted(obj interface{}, c *K8sOrchestrator) {
 		log.Warnf("configMapDeleted: unrecognized object %+v", obj)
 		return
 	}
-	if fssConfigMap.Name == featureStatesConfigMapName && fssConfigMap.Namespace == featureStatesConfigMapNamespace {
-		for featureName := range c.featureStates {
-			c.featureStates[featureName] = strconv.FormatBool(false)
+	// Supervisor FSS configmap
+	if fssConfigMap.Name == k8sOrchestratorInstance.supervisorFSS.configMapName && fssConfigMap.Namespace == k8sOrchestratorInstance.supervisorFSS.configMapNamespace {
+		for featureName := range k8sOrchestratorInstance.supervisorFSS.featureStates {
+			k8sOrchestratorInstance.supervisorFSS.featureStates[featureName] = strconv.FormatBool(false)
 		}
-		log.Infof("configMapDeleted: %v deleted. Setting feature state values to false %v", fssConfigMap.Name, c.featureStates)
+		log.Infof("configMapDeleted: %v deleted. Setting supervisor feature state values to false %v", fssConfigMap.Name,
+			k8sOrchestratorInstance.supervisorFSS.featureStates)
+	}
+	// Internal FSS configmap
+	if fssConfigMap.Name == k8sOrchestratorInstance.internalFSS.configMapName && fssConfigMap.Namespace == k8sOrchestratorInstance.internalFSS.configMapNamespace {
+		for featureName := range k8sOrchestratorInstance.internalFSS.featureStates {
+			k8sOrchestratorInstance.internalFSS.featureStates[featureName] = strconv.FormatBool(false)
+		}
+		log.Infof("configMapDeleted: %v deleted. Setting internal feature state values to false %v", fssConfigMap.Name,
+			k8sOrchestratorInstance.internalFSS.featureStates)
 	}
 }
 
-// updateFSSValues updates feature state switch values in the k8sorchestrator
-func updateFSSValues(ctx context.Context, fssConfigMap *v1.ConfigMap, c *K8sOrchestrator) {
-	log := logger.GetLogger(ctx)
-	c.featureStates = fssConfigMap.Data
-	log.Infof("New feature states values stored successfully: %v", c.featureStates)
-}
-
-// IsFSSEnabled checks if feature state switch is enabled for the given feature indicated by featureName
+// IsFSSEnabled utilises the cluster flavor to check their corresponding FSS maps and returns
+// if the feature state switch is enabled for the given feature indicated by featureName
 func (c *K8sOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) bool {
 	log := logger.GetLogger(ctx)
-	var featureState bool
-	var err error
-	if flag, ok := c.featureStates[featureName]; ok {
-		featureState, err = strconv.ParseBool(flag)
-		if err != nil {
-			log.Errorf("Error while converting %v feature state value: %v to boolean. Setting the feature state to false", featureName, featureState)
+	var (
+		internalFeatureState   bool
+		supervisorFeatureState bool
+		err                    error
+	)
+	if c.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
+		// Check internal FSS map
+		if flag, ok := c.internalFSS.featureStates[featureName]; ok {
+			internalFeatureState, err = strconv.ParseBool(flag)
+			if err != nil {
+				log.Errorf("Error while converting %v feature state value: %v to boolean. Setting the feature state to false", featureName, internalFeatureState)
+				return false
+			}
+			return internalFeatureState
+		}
+		log.Debugf("Could not find the %s feature state in ConfigMap %s. Setting the feature state to false", featureName, c.internalFSS.configMapName)
+		return false
+	} else if c.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		// Check SV FSS map
+		if flag, ok := c.supervisorFSS.featureStates[featureName]; ok {
+			supervisorFeatureState, err = strconv.ParseBool(flag)
+			if err != nil {
+				log.Errorf("Error while converting %v feature state value: %v to boolean. Setting the feature state to false", featureName, supervisorFeatureState)
+				return false
+			}
+			return supervisorFeatureState
+		}
+		log.Debugf("Could not find the %s feature state in ConfigMap %s. Setting the feature state to false", featureName, c.supervisorFSS.configMapName)
+		return false
+	} else if c.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
+		// Check internal FSS map
+		if flag, ok := c.internalFSS.featureStates[featureName]; ok {
+			internalFeatureState, err := strconv.ParseBool(flag)
+			if err != nil {
+				log.Errorf("Error while converting %v feature state value: %v to boolean. Setting the feature state to false", featureName, internalFeatureState)
+				return false
+			}
+			if !internalFeatureState {
+				// If FSS set to false, return
+				log.Infof("%s feature state set to false in %s ConfigMap", featureName, c.internalFSS.configMapName)
+				return internalFeatureState
+			}
+		} else {
+			log.Debugf("Could not find the %s feature state in ConfigMap %s. Setting the feature state to false", featureName, c.internalFSS.configMapName)
 			return false
 		}
-		return featureState
+		// Check SV FSS map
+		if flag, ok := c.supervisorFSS.featureStates[featureName]; ok {
+			supervisorFeatureState, err := strconv.ParseBool(flag)
+			if err != nil {
+				log.Errorf("Error while converting %v feature state value: %v to boolean. Setting the feature state to false", featureName, supervisorFeatureState)
+				return false
+			}
+			if !supervisorFeatureState {
+				// If FSS set to false, return
+				log.Infof("%s feature state set to false in %s ConfigMap", featureName, c.supervisorFSS.configMapName)
+				return supervisorFeatureState
+			}
+		} else {
+			log.Debugf("Could not find the %s feature state in ConfigMap %s. Setting the feature state to false", featureName, c.supervisorFSS.configMapName)
+			return false
+		}
+		return true
 	}
-	log.Debugf("Could not find the feature state for : %v. Setting the feature state to %v", featureName, featureState)
+	log.Debugf("cluster flavor %q not recognised. Defaulting to false", c.clusterFlavor)
 	return false
 }

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sorchestrator
+
+import (
+	"context"
+	"testing"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+)
+
+var (
+	ctx    context.Context
+	cancel context.CancelFunc
+)
+
+func init() {
+	// Create context
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+}
+
+// TestIsFSSEnabledInGcWithSync tests IsFSSEnabled in GC flavor with two FSS in sync scenarios:
+// Scenario 1: FSS is enabled both in SV and GC
+// Scenario 2: FSS is disabled both in SV and GC
+func TestIsFSSEnabledInGcWithSync(t *testing.T) {
+	svFSS := map[string]string{
+		"volume-extend": "true",
+		"volume-health": "false",
+	}
+	svFSSConfigMapInfo := FSSConfigMapInfo{
+		configMapName:      cnsconfig.DefaultSupervisorFSSConfigMapName,
+		configMapNamespace: cnsconfig.DefaultCSINamespace,
+		featureStates:      svFSS,
+	}
+	internalFSS := map[string]string{
+		"volume-extend": "true",
+		"volume-health": "false",
+	}
+	internalFSSConfigMapInfo := FSSConfigMapInfo{
+		configMapName:      cnsconfig.DefaultInternalFSSConfigMapName,
+		configMapNamespace: cnsconfig.DefaultCSINamespace,
+		featureStates:      internalFSS,
+	}
+	k8sOrchestrator := K8sOrchestrator{
+		supervisorFSS: svFSSConfigMapInfo,
+		clusterFlavor: cnstypes.CnsClusterFlavorGuest,
+		internalFSS:   internalFSSConfigMapInfo,
+	}
+	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "volume-extend")
+	if !isEnabled {
+		t.Errorf("volume-extend feature state is disabled!")
+	}
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "volume-health")
+	if isEnabled {
+		t.Errorf("volume-health feature state is enabled!")
+	}
+}
+
+// TestIsFSSEnabledInGcWithoutSync tests IsFSSEnabled in GC flavor with two FSS non-sync scenarios:
+// Scenario 1: FSS is enabled in SV but disabled in GC
+// Scenario 2: FSS is disabled in SV but enabled in GC
+func TestIsFSSEnabledInGcWithoutSync(t *testing.T) {
+	svFSS := map[string]string{
+		"volume-extend": "true",
+		"volume-health": "false",
+	}
+	svFSSConfigMapInfo := FSSConfigMapInfo{
+		configMapName:      cnsconfig.DefaultSupervisorFSSConfigMapName,
+		configMapNamespace: cnsconfig.DefaultCSINamespace,
+		featureStates:      svFSS,
+	}
+	internalFSS := map[string]string{
+		"volume-extend": "false",
+		"volume-health": "true",
+	}
+	internalFSSConfigMapInfo := FSSConfigMapInfo{
+		configMapName:      cnsconfig.DefaultInternalFSSConfigMapName,
+		configMapNamespace: cnsconfig.DefaultCSINamespace,
+		featureStates:      internalFSS,
+	}
+	k8sOrchestrator := K8sOrchestrator{
+		supervisorFSS: svFSSConfigMapInfo,
+		clusterFlavor: cnstypes.CnsClusterFlavorGuest,
+		internalFSS:   internalFSSConfigMapInfo,
+	}
+	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "volume-extend")
+	if isEnabled {
+		t.Errorf("volume-extend feature state is enabled!")
+	}
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "volume-health")
+	if isEnabled {
+		t.Errorf("volume-health feature state is enabled!")
+	}
+}
+
+// TestIsFSSEnabledInGcWrongValues tests IsFSSEnabled in GC flavor in two scenarios:
+// Scenario 1: Wrong value given to feature state
+// Scenario 2: Missing feature state
+func TestIsFSSEnabledInGcWrongValues(t *testing.T) {
+	svFSS := map[string]string{
+		"volume-extend": "true",
+		"volume-health": "true",
+	}
+	svFSSConfigMapInfo := FSSConfigMapInfo{
+		configMapName:      cnsconfig.DefaultSupervisorFSSConfigMapName,
+		configMapNamespace: cnsconfig.DefaultCSINamespace,
+		featureStates:      svFSS,
+	}
+	internalFSS := map[string]string{
+		"volume-extend": "enabled",
+	}
+	internalFSSConfigMapInfo := FSSConfigMapInfo{
+		configMapName:      cnsconfig.DefaultInternalFSSConfigMapName,
+		configMapNamespace: cnsconfig.DefaultCSINamespace,
+		featureStates:      internalFSS,
+	}
+	k8sOrchestrator := K8sOrchestrator{
+		supervisorFSS: svFSSConfigMapInfo,
+		clusterFlavor: cnstypes.CnsClusterFlavorGuest,
+		internalFSS:   internalFSSConfigMapInfo,
+	}
+	// Wrong value given
+	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "volume-extend")
+	if isEnabled {
+		t.Errorf("volume-extend feature state is enabled even when it was assigned a wrong value!")
+	}
+	// Feature state missing
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "volume-health")
+	if isEnabled {
+		t.Errorf("Non existing feature state volume-health is enabled!")
+	}
+}
+
+// TestIsFSSEnabledInSV tests IsFSSEnabled in Supervisor flavor - all scenarios
+func TestIsFSSEnabledInSV(t *testing.T) {
+	svFSS := map[string]string{
+		"volume-extend": "true",
+		"volume-health": "false",
+		"csi-migration": "enabled",
+	}
+	svFSSConfigMapInfo := FSSConfigMapInfo{
+		configMapName:      cnsconfig.DefaultSupervisorFSSConfigMapName,
+		configMapNamespace: cnsconfig.DefaultCSINamespace,
+		featureStates:      svFSS,
+	}
+	k8sOrchestrator := K8sOrchestrator{
+		supervisorFSS: svFSSConfigMapInfo,
+		clusterFlavor: cnstypes.CnsClusterFlavorWorkload,
+	}
+	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "volume-extend")
+	if !isEnabled {
+		t.Errorf("volume-extend feature state is disabled!")
+	}
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "volume-health")
+	if isEnabled {
+		t.Errorf("volume-health feature state is enabled!")
+	}
+	// Wrong value given
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "csi-migration")
+	if isEnabled {
+		t.Errorf("csi-migration feature state is enabled even when it was assigned a wrong value!")
+	}
+	// Feature state missing
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "online-volume-extend")
+	if isEnabled {
+		t.Errorf("Non existing feature state online-volume-extend is enabled!")
+	}
+}
+
+// TestIsFSSEnabledInVanilla tests IsFSSEnabled in vanilla flavor - all scenarios
+func TestIsFSSEnabledInVanilla(t *testing.T) {
+	internalFSS := map[string]string{
+		"csi-migration": "true",
+		"volume-extend": "false",
+		"volume-health": "disabled",
+	}
+	internalFSSConfigMapInfo := FSSConfigMapInfo{
+		configMapName:      cnsconfig.DefaultInternalFSSConfigMapName,
+		configMapNamespace: cnsconfig.DefaultCSINamespaceVanillaK8s,
+		featureStates:      internalFSS,
+	}
+	k8sOrchestrator := K8sOrchestrator{
+		clusterFlavor: cnstypes.CnsClusterFlavorVanilla,
+		internalFSS:   internalFSSConfigMapInfo,
+	}
+	// Should be enabled
+	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "csi-migration")
+	if !isEnabled {
+		t.Errorf("csi-migration feature state is disabled!")
+	}
+	// Should be disabled
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "volume-extend")
+	if isEnabled {
+		t.Errorf("volume-extend feature state is enabled!")
+	}
+	// Wrong value given
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "volume-health")
+	if isEnabled {
+		t.Errorf("volume-health feature state is enabled even when it was assigned a wrong value!")
+	}
+	// Feature state missing
+	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "online-volume-extend")
+	if isEnabled {
+		t.Errorf("Non existing feature state online-volume-extend is enabled!")
+	}
+}
+
+// TestIsFSSEnabledWithWrongClusterFlavor tests IsFSSEnabled when cluster flavor is not supported
+func TestIsFSSEnabledWithWrongClusterFlavor(t *testing.T) {
+	k8sOrchestrator := K8sOrchestrator{
+		clusterFlavor: "Vanila",
+	}
+	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "volume-extend")
+	if isEnabled {
+		t.Errorf("volume-extend feature state enabled even when cluster flavor is wrong")
+	}
+}

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -25,24 +25,23 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vmware/govmomi/cns"
-
-	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/fsnotify/fsnotify"
+	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/units"
 	"github.com/zekroTJA/timedmap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
 
@@ -96,7 +95,7 @@ func New() csitypes.CnsController {
 }
 
 // Init is initializing controller struct
-func (c *controller) Init(config *config.Config) error {
+func (c *controller) Init(config *cnsconfig.Config) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = logger.NewContextWithLogger(ctx)
@@ -162,10 +161,16 @@ func (c *controller) Init(config *config.Config) error {
 	go cnsvolume.ClearTaskInfoObjects()
 	cfgPath := common.GetConfigPath(ctx)
 
-	// Initialize CO utility
-	containerOrchestratorUtility, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, config.FeatureStatesConfig)
+	// Initialize CO common utility
+	clusterFlavor, err := cnsconfig.GetClusterFlavor(ctx)
 	if err != nil {
-		log.Errorf("Failed to create co agnostic interface. err=%v", err)
+		log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
+		return err
+	}
+	containerOrchestratorUtility, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor,
+		k8sorchestrator.K8sVanillaInitParams{InternalFeatureStatesConfigInfo: config.InternalFeatureStatesConfig})
+	if err != nil {
+		log.Errorf("Failed to create CO agnostic interface. Error: %v", err)
 		return err
 	}
 	if containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIAuthCheck) {
@@ -178,6 +183,7 @@ func (c *controller) Init(config *config.Config) error {
 		c.authMgr = authMgr
 		go common.ComputeDatastoreIgnoreMap(authMgr.(*common.AuthManager))
 	}
+
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Errorf("failed to create fsnotify watcher. err=%v", err)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -154,18 +154,18 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 	case vmoperatorv1alpha1.GroupName:
 		err = vmoperatorv1alpha1.AddToScheme(scheme)
 		if err != nil {
-			log.Error("failed to add to scheme with err: %+v", err)
+			log.Errorf("failed to add to scheme with err: %+v", err)
 			return nil, err
 		}
 	case cnsoperatorv1alpha1.GroupName:
 		err = cnsoperatorv1alpha1.AddToScheme(scheme)
 		if err != nil {
-			log.Error("failed to add to scheme with err: %+v", err)
+			log.Errorf("failed to add to scheme with err: %+v", err)
 			return nil, err
 		}
 		err = migrationv1alpha1.AddToScheme(scheme)
 		if err != nil {
-			log.Error("failed to add to scheme with err: %+v", err)
+			log.Errorf("failed to add to scheme with err: %+v", err)
 			return nil, err
 		}
 	}
@@ -173,7 +173,7 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 		Scheme: scheme,
 	})
 	if err != nil {
-		log.Error("failed to create client for group %s with err: %+v", groupName, err)
+		log.Errorf("failed to create client for group %s with err: %+v", groupName, err)
 	}
 	return client, err
 
@@ -197,7 +197,7 @@ func NewVirtualMachineWatcher(ctx context.Context, config *restclient.Config, na
 
 	client, err := apiutils.RESTClientForGVK(gvk, config, serializer.NewCodecFactory(scheme))
 	if err != nil {
-		log.Error("failed to create RESTClient with err: %+v", err)
+		log.Errorf("failed to create RESTClient with err: %+v", err)
 		return nil, err
 	}
 	return cache.NewListWatchFromClient(client, virtualMachineKind, namespace, fields.Everything()), nil

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -32,8 +32,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
@@ -124,7 +126,13 @@ func StartWebhookServer(ctx context.Context) error {
 		log.Debugf("webhook config: %v", cfg)
 	}
 	if k8s == nil {
-		k8s, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, cfg.FeatureStatesConfig)
+		clusterFlavor, err := cnsconfig.GetClusterFlavor(ctx)
+		if err != nil {
+			log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
+			return err
+		}
+		k8s, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor,
+			k8sorchestrator.K8sVanillaInitParams{InternalFeatureStatesConfigInfo: cfg.InternalFeatureStatesConfig})
 		if err != nil {
 			log.Errorf("failed to get k8s interface. err: %v", err)
 			return err

--- a/pkg/syncer/admissionhandler/config.go
+++ b/pkg/syncer/admissionhandler/config.go
@@ -36,8 +36,8 @@ const (
 type config struct {
 	// WebHookConfig contains the detail about webhook - certfile, keyfile, port etc.
 	WebHookConfig webHookConfig
-	// FeatureStatesConfig is the details about feature states configmap
-	FeatureStatesConfig commonconfig.FeatureStatesConfigInfo
+	// InternalFeatureStatesConfig is the details about feature states configmap
+	InternalFeatureStatesConfig commonconfig.FeatureStatesConfigInfo
 }
 
 // webHookConfig holds webhook configuration using which webhook http server will be created


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: We will be introducing a new internal feature state switch configmap named `internal-feature-states.csi.vsphere.vmware.com` in TKGS in the next release. This PR changes the name of the current FSS configmap `csi-feature-states` used in vanilla to `internal-feature-states.csi.vsphere.vmware.com` so as to maintain uniformity between Vanilla and TKGS flavors.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Testing done on all 3 flavors. Checked the logs in controller and syncer containers.
Logs from Vanilla:
**Init**
Controller:
```
2020-10-08T20:23:38.910Z	INFO	k8sorchestrator/k8sorchestrator.go:67	Initializing k8sOrchestratorInstance	{"TraceId": "00187473-ca72-459f-9445-1aa89b6929ca"}
2020-10-08T20:23:38.910Z	INFO	kubernetes/kubernetes.go:83	k8s client using in-cluster config	{"TraceId": "00187473-ca72-459f-9445-1aa89b6929ca"}
2020-10-08T20:23:38.910Z	INFO	kubernetes/kubernetes.go:267	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "00187473-ca72-459f-9445-1aa89b6929ca"}
2020-10-08T20:23:38.933Z	INFO	k8sorchestrator/k8sorchestrator.go:133	New internal feature states values stored successfully: map[csi-migration:true]	{"TraceId": "00187473-ca72-459f-9445-1aa89b6929ca"}
2020-10-08T20:23:38.933Z	INFO	k8sorchestrator/k8sorchestrator.go:84	k8sOrchestratorInstance initialized	{"TraceId": "00187473-ca72-459f-9445-1aa89b6929ca"}
2020-10-08T20:23:38.933Z	INFO	vanilla/controller.go:213	CSI Migration Feature is Enabled. Loading Volume Migration Service	{"TraceId": "00187473-ca72-459f-9445-1aa89b6929ca"}
2020-10-08T20:23:38.934Z	INFO	migration/migration.go:107	Initializing volume migration service...	{"TraceId": "00187473-ca72-459f-9445-1aa89b6929ca"}
2020-10-08T20:23:38.959Z	INFO	k8sorchestrator/k8sorchestrator.go:171	New feature states values stored successfully: map[csi-migration:true]	{"TraceId": "4d2e6876-0ef3-43cb-83fa-38ce29037ed1"}
```
Syncer:
```
2020-10-08T20:24:21.665Z	INFO	k8sorchestrator/k8sorchestrator.go:67	Initializing k8sOrchestratorInstance
2020-10-08T20:24:21.665Z	INFO	kubernetes/kubernetes.go:83	k8s client using in-cluster config
2020-10-08T20:24:21.666Z	INFO	kubernetes/kubernetes.go:267	Setting client QPS to 100.000000 and Burst to 100.
2020-10-08T20:24:21.680Z	INFO	k8sorchestrator/k8sorchestrator.go:133	New internal feature states values stored successfully: map[csi-migration:true]
2020-10-08T20:24:21.682Z	INFO	k8sorchestrator/k8sorchestrator.go:84	k8sOrchestratorInstance initialized
2020-10-08T20:24:21.693Z	INFO	k8sorchestrator/k8sorchestrator.go:171	New feature states values stored successfully: map[csi-migration:true]	{"TraceId": "8d2931f2-31ea-49bc-a0fe-e0024a465dfb"}
2020-10-08T20:24:21.940Z	INFO	migration/migration.go:107	Initializing volume migration service...	{"TraceId": "72c63b6d-d2ed-43ab-9e6b-8a16d64f55b3"}
```

**Configmap value update**
Controller:
```
2020-10-08T20:32:15.584Z	INFO	k8sorchestrator/k8sorchestrator.go:191	New feature states values stored successfully: map[csi-migration:false]	{"TraceId": "a918e717-d394-487c-bc09-345f78caa66f"}
```
Syncer:
```
2020-10-08T20:32:15.574Z	INFO	k8sorchestrator/k8sorchestrator.go:191	New feature states values stored successfully: map[csi-migration:false]	{"TraceId": "a5132c86-96ca-45b3-b1f6-5429f11fa862"}
```

**Configmap delete**
Controller:
```
2020-10-08T20:32:15.584Z	INFO	k8sorchestrator/k8sorchestrator.go:191	New feature states values stored successfully: map[csi-migration:false]	{"TraceId": "a918e717-d394-487c-bc09-345f78caa66f"}
2020-10-08T20:41:28.823Z	INFO	k8sorchestrator/k8sorchestrator.go:219	configMapDeleted: internal-feature-states.csi.vsphere.vmware.com deleted. Setting internal feature state values to false map[csi-migration:false]	{"TraceId": "9031e9dc-2273-4301-93b3-c1f9353d465a"}
```
Syncer:
```
2020-10-08T20:41:28.829Z	INFO	k8sorchestrator/k8sorchestrator.go:219	configMapDeleted: internal-feature-states.csi.vsphere.vmware.com deleted. Setting internal feature state values to false map[csi-migration:false]	{"TraceId": "a4a28c7c-8db3-4fae-b917-40d297fe0f1e"}
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Change the FSS configmap name in Vanilla
```
