### PR TITLE
Add validation for CnsRegisterVolume to check if storage policy belongs to namespace

### DIFF
--- a/manifests/dev/vsphere-7.0/supervisorcluster/k8s-1.15/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/dev/vsphere-7.0/supervisorcluster/k8s-1.15/rbac/vsphere-csi-controller-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods"]
+    resources: ["nodes", "pods", "resourcequotas"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]

--- a/manifests/dev/vsphere-7.0u1/supervisorcluster/k8s-1.15/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/dev/vsphere-7.0u1/supervisorcluster/k8s-1.15/rbac/vsphere-csi-controller-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods"]
+    resources: ["nodes", "pods", "resourcequotas"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]

--- a/manifests/dev/vsphere-7.0u1/supervisorcluster/k8s-1.16/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/dev/vsphere-7.0u1/supervisorcluster/k8s-1.16/rbac/vsphere-csi-controller-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "persistentvolumeclaims", "pods"]
+    resources: ["nodes", "persistentvolumeclaims", "pods", "resourcequotas"]
     verbs: ["get", "list", "watch", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/rbac/vsphere-csi-controller-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps"]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/rbac/vsphere-csi-controller-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps"]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/rbac/vsphere-csi-controller-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps"]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]

--- a/manifests/v2.0.0/vsphere-7.0/supervisorcluster/k8s-1.15/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/v2.0.0/vsphere-7.0/supervisorcluster/k8s-1.15/rbac/vsphere-csi-controller-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "persistentvolumeclaims", "pods"]
+    resources: ["nodes", "persistentvolumeclaims", "pods", "resourcequotas"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -256,14 +256,14 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(request reconcile.Request) (recon
 	}
 
 	// Get K8S storageclass name mapping the storagepolicy id
-	storageClassName, err := getK8sStorageClassName(ctx, k8sclient, volume.StoragePolicyId)
+	storageClassName, err := getK8sStorageClassName(ctx, k8sclient, volume.StoragePolicyId, request.Namespace)
 	if err != nil {
-		msg := fmt.Sprintf("Failed to find K8S Storageclass mapping storagepolicyId: %s", volume.StoragePolicyId)
+		msg := fmt.Sprintf("Failed to find K8S Storageclass mapping storagepolicyId: %s and assigned to namespace: %s", volume.StoragePolicyId, request.Namespace)
 		log.Error(msg)
 		setInstanceError(ctx, r, instance, msg)
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
-	log.Infof("Volume with storagepolicyId: %s is mapping to K8S storage class: %s", volume.StoragePolicyId, storageClassName)
+	log.Infof("Volume with storagepolicyId: %s is mapping to K8S storage class: %s and assigned to namespace: %s", volume.StoragePolicyId, storageClassName, request.Namespace)
 
 	capacityInMb := volume.BackingObjectDetails.(cnstypes.BaseCnsBackingObjectDetails).GetCnsBackingObjectDetails().CapacityInMb
 	accessMode := instance.Spec.AccessMode

--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -1429,7 +1429,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		cnsRegisterVolume = getCNSRegistervolume(ctx, restConfig, cnsRegisterVolume)
 		actualErrorMsg := cnsRegisterVolume.Status.Error
 		log.Infof("Error message :%s", actualErrorMsg)
-		expectedErrorMsg := "Failed to create PVC: " + pvcName + " for volume with err: persistentvolumeclaims \"" + pvcName + "\" is forbidden"
+		expectedErrorMsg := fmt.Sprintf("Failed to find K8S Storageclass mapping storagepolicyId: %s and assigned to namespace: %s", profileID, autocreatednamespace)
 		if !strings.Contains(actualErrorMsg, expectedErrorMsg) {
 			log.Errorf("Expected error message : %s", expectedErrorMsg)
 			log.Errorf("Actual error message : %s", actualErrorMsg)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a validation during static provisioning in WCP - to additionally check if the k8s storage class that has the same storage policy as the existing CNS volume, is also assigned to the namespace in which we are creating CnsRegisterVolume instance.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #420 

**Special notes for your reviewer**:
After introducing this change, below are the logs for different scenarios:

*1. Policy is assigned to the namespace (Happy path)*
```
root@422af2a662a3d824811878caa829e6fc [ ~ ]# kubectl describe ns playground-ns
Name:         playground-ns
.
.
Resource Quotas
 Name:                                                                   playground-ns-storagequota
 Resource                                                                Used  Hard
 --------                                                                ---   ---
 abc.storageclass.storage.k8s.io/requests.storage                        1Gi   5Gi
 wcpglobal-storage-profile.storageclass.storage.k8s.io/requests.storage  0     5Gi

No LimitRange resource.
```
CnsRegisterVolume instance created with VolumeID whose storage policy ID matches with k8s storage class `abc`
```
root@422af2a662a3d824811878caa829e6fc [ ~ ]# kubectl apply -f manifests/cns-registervolume.yaml -n playground-ns
cnsregistervolume.cns.vmware.com/import-db created
```
CnsRegisterVolume Controller logs -
```
{"level":"info","time":"2020-10-09T18:08:29.074124646Z","caller":"cnsregistervolume/util.go:145","msg":"Found k8s storage class: abc with storagePolicyId: a528c9c5-5217-4dcd-9df9-3ed177e74f52 and the policy is assigned to namespace: playground-ns","TraceId":"9363d9fc-921d-426e-8de2-3dc61b9878e6"}
{"level":"info","time":"2020-10-09T18:08:29.074466625Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:266","msg":"Volume with storagepolicyId: a528c9c5-5217-4dcd-9df9-3ed177e74f52 is mapping to K8S storage class: abc","TraceId":"9363d9fc-921d-426e-8de2-3dc61b9878e6"}
{"level":"info","time":"2020-10-09T18:08:29.095517528Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:277","msg":"PV: static-pv-ba0296ea-57ba-4235-9cc0-b04e71b82c83 not found. Creating a new PV","TraceId":"9363d9fc-921d-426e-8de2-3dc61b9878e6"}
{"level":"info","time":"2020-10-09T18:08:29.151398874Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:294","msg":"PV: static-pv-ba0296ea-57ba-4235-9cc0-b04e71b82c83 is created successfully","TraceId":"9363d9fc-921d-426e-8de2-3dc61b9878e6"}
{"level":"info","time":"2020-10-09T18:08:29.156487092Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:309","msg":"Now creating pvc: static-pvc","TraceId":"9363d9fc-921d-426e-8de2-3dc61b9878e6"}
{"level":"info","time":"2020-10-09T18:08:29.246986934Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:350","msg":"PVC: static-pvc is created successfully","TraceId":"9363d9fc-921d-426e-8de2-3dc61b9878e6"}
```
```
root@422af2a662a3d824811878caa829e6fc [ ~ ]# kubectl get pvc -n playground-ns
NAME                        STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS   AGE
static-pvc                  Bound    static-pv-ba0296ea-57ba-4235-9cc0-b04e71b82c83   1Gi        RWO            abc            86s

root@422af2a662a3d824811878caa829e6fc [ ~ ]# kubectl get pv
NAME                                             CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                     STORAGECLASS       REASON   AGE
static-pv-ba0296ea-57ba-4235-9cc0-b04e71b82c83   1Gi        RWO            Delete           Bound    playground-ns/static-pvc                  abc                         118s
```



*2. Policy not assigned to the namespace, but present in k8s cluster*
```
root@422af2a662a3d824811878caa829e6fc [ ~ ]# kubectl describe ns playground-ns
Name:         playground-ns
.
.
Resource Quotas
 Name:                                                                   playground-ns-storagequota
 Resource                                                                Used  Hard
 --------                                                                ---   ---
 wcpglobal-storage-profile.storageclass.storage.k8s.io/requests.storage  0     5Gi

No LimitRange resource.
```
CnsRegisterVolume instance created with VolumeID whose storage policy ID matches with k8s storage class `abc`, but `abc` is not assigned to the namespace(as seen in resource quotas above)
```
root@422af2a662a3d824811878caa829e6fc [ ~ ]# kubectl apply -f manifests/cns-registervolume.yaml -n playground-ns
cnsregistervolume.cns.vmware.com/import-db created
```
CnsRegisterVolume Controller logs -
```
{"level":"error","time":"2020-10-09T19:11:42.763348476Z","caller":"cnsregistervolume/util.go:154","msg":"Failed to find matching K8s Storageclass. Either storagepolicyId: a528c9c5-5217-4dcd-9df9-3ed177e74f52 doesn't match any storage class, or the policy is not assigned to namespace: playground-ns","TraceId":"ede49fe6-0c13-441a-b030-1227e1f2414b"
.
.
{"level":"error","time":"2020-10-09T18:39:22.191854148Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:262","msg":"Failed to find K8S Storageclass mapping storagepolicyId: a528c9c5-5217-4dcd-9df9-3ed177e74f52 and assigned to namespace: playground-ns","TraceId":"6107c79c-053d-4aad-aa83-7abed3ea3a68"
```

E2E Tests:
Ran relevant tests after adding RBAC rules for resource quota. Out of 12 tests, 11 passed in the first run and 1 passed in the subsequent run after changing the error message on a test case.
Logs - https://gist.github.com/gohilankit/69fe61b1c0b77bbcd9c8490c0b8a36cf

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
This change requires the service account to read resourcequotas. Hence RBAC needs to be modified to add this rule for all WCP deployments
```
