### PR TITLE
Added VMDK test cases for static provisioning on SVC

### DIFF
--- a/tests/e2e/data_persistence.go
+++ b/tests/e2e/data_persistence.go
@@ -330,7 +330,7 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		createResourceQuota(client, namespace, rqLimit, storagePolicyName)
 
 		ginkgo.By("Import above created FCD ")
-		cnsRegisterVolume := getCNSRegisterVolumeSpec(ctx, namespace, fcdID, pvcName, v1.ReadWriteOnce)
+		cnsRegisterVolume := getCNSRegisterVolumeSpec(ctx, namespace, fcdID, "", pvcName, v1.ReadWriteOnce)
 		err = createCNSRegisterVolume(ctx, restConfig, cnsRegisterVolume)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		framework.ExpectNoError(waitForCNSRegisterVolumeToGetCreated(ctx, restConfig, namespace, cnsRegisterVolume, poll, pollTimeout))

--- a/tests/e2e/docs/supervisor_cluster_setup.md
+++ b/tests/e2e/docs/supervisor_cluster_setup.md
@@ -85,6 +85,8 @@ datacenters should be comma separated if deployed on multi-datacenters
     export SHARED_VSPHERE_DATASTORE_URL="<shared-vsphere-datastore-url>"
     # Set the NONSHARED_VSPHERE_DATASTORE_URL to the url fetched from the Vcenter as mentioned in the steps above
     export NONSHARED_VSPHERE_DATASTORE_URL="<non-shared-vsphere-datastore-url>"
+    # Set this variable to run static provisioning VMDK test cases.
+    export DISK_URL_PATH="https://<VC_IP>/folder/<vmName>/<vmName_1.vmdk>?dcPath=<DatacenterPath>&dsName=<dataStoreName>"
 
 ### To run full sync test, need do extra following steps
 

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -114,6 +114,9 @@ const (
 	waitTimeForCNSNodeVMAttachmentReconciler   = 30 * time.Second
 	wcpServiceName                             = "wcp"
 	zoneKey                                    = "failure-domain.beta.kubernetes.io/zone"
+	envVmdkDiskURL                             = "DISK_URL_PATH"
+	vsanDefaultStorageClassInSVC               = "vsan-default-storage-policy"
+	vsanDefaultStoragePolicyName               = "vSAN Default Storage Policy"
 )
 
 // The following variables are required to know cluster type to run common e2e tests

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1315,7 +1315,7 @@ func writeConfigToSecretString(cfg e2eTestConfig) (string, error) {
 }
 
 // Function to create CnsRegisterVolume spec, with given FCD ID and PVC name
-func getCNSRegisterVolumeSpec(ctx context.Context, namespace string, fcdID string, persistentVolumeClaimName string, accessMode v1.PersistentVolumeAccessMode) *cnsregistervolumev1alpha1.CnsRegisterVolume {
+func getCNSRegisterVolumeSpec(ctx context.Context, namespace string, fcdID string, vmdkPath string, persistentVolumeClaimName string, accessMode v1.PersistentVolumeAccessMode) *cnsregistervolumev1alpha1.CnsRegisterVolume {
 	var (
 		cnsRegisterVolume *cnsregistervolumev1alpha1.CnsRegisterVolume
 	)
@@ -1328,12 +1328,19 @@ func getCNSRegisterVolumeSpec(ctx context.Context, namespace string, fcdID strin
 			Namespace:    namespace,
 		},
 		Spec: cnsregistervolumev1alpha1.CnsRegisterVolumeSpec{
-			PvcName:  persistentVolumeClaimName,
-			VolumeID: fcdID,
+			PvcName: persistentVolumeClaimName,
 			AccessMode: v1.PersistentVolumeAccessMode(
 				accessMode,
 			),
 		},
+	}
+
+	if vmdkPath != "" {
+		cnsRegisterVolume.Spec.DiskURLPath = vmdkPath
+	}
+
+	if fcdID != "" {
+		cnsRegisterVolume.Spec.VolumeID = fcdID
 	}
 	return cnsRegisterVolume
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->


**Added VMDK test cases for static provisioning on SVC**

VMDK Test logs : https://gist.github.com/kavyashree-r/3476e65d7fa681cc9cda764099c23359
```
kramachandr-a01:vsphere-csi-driver kramachandra$ make golangci-lint
hack/check-golangci-lint.sh
INFO [config_reader] Config search paths: [./ /Users/kramachandra/github/vmdk/vsphere-csi-driver /Users/kramachandra/github/vmdk /Users/kramachandra/github /Users/kramachandra /Users /] 
INFO [lintersdb] Active 10 linters: [deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|exports_file|imports|name|compiled_files|files|types_sizes) took 5.50237167s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 27.762583ms 
INFO [linters context/goanalysis] analyzers took 1m51.54017693s with top 10 stages: buildir: 1m41.459373151s, inspect: 1.683409355s, ctrlflow: 1.642936882s, fact_deprecated: 1.467798352s, printf: 1.446665304s, fact_purity: 1.010455398s, ineffassign: 248.294325ms, S1038: 190.313806ms, S1019: 107.789151ms, S1012: 106.90959ms 
INFO [linters context/goanalysis] analyzers took 8.564497963s with top 10 stages: buildir: 7.97114053s, U1000: 593.357433ms 
INFO [runner] Issues before processing: 54, after processing: 0 
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 54/54, skip_files: 54/54, autogenerated_exclude: 10/54, identifier_marker: 10/10, cgo: 54/54, path_prettifier: 54/54, skip_dirs: 54/54, exclude: 0/10 
INFO [runner] processing took 2.726241ms with stages: exclude: 938.183µs, identifier_marker: 516.316µs, autogenerated_exclude: 491.408µs, path_prettifier: 385.11µs, filename_unadjuster: 274.845µs, skip_dirs: 102.565µs, cgo: 13.406µs, max_same_issues: 1.085µs, nolint: 977ns, uniq_by_line: 370ns, diff: 366ns, exclude-rules: 363ns, max_from_linter: 291ns, skip_files: 290ns, source_code: 254ns, path_shortener: 238ns, max_per_file_from_linter: 174ns 
INFO [runner] linters took 16.925375292s with stages: goanalysis_metalinter: 14.48065001s, unused: 2.441377545s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 211 samples, avg is 873.0MB, max is 1356.7MB 
INFO Execution took 22.480241771s                 
```