### PR TITLE
Add vsanD disk decommission controller in syncer container

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,13 +33,14 @@ require (
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.3
-	github.com/vmware/govmomi v0.23.2-0.20200915235406-49b4974659e1
+	github.com/vmware/govmomi v0.23.2-0.20201015235820-81318771d0e0
 	github.com/zekroTJA/timedmap v1.1.2
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
 	golang.org/x/tools v0.0.0-20201013053347-2db1cd791039 // indirect
 	google.golang.org/appengine v1.6.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -645,8 +645,11 @@ github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJ
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware-tanzu/vm-operator-api v0.1.3 h1:4vxewu0jAN3fSoCBI6FhjmRGJ7ci0R2WNu/I6hacTYs=
 github.com/vmware-tanzu/vm-operator-api v0.1.3/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
+github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.23.2-0.20200915235406-49b4974659e1 h1:cOmmloKpYtLP8sHzFK9g841PXQzjIB6abTdz7uvrakI=
 github.com/vmware/govmomi v0.23.2-0.20200915235406-49b4974659e1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.23.2-0.20201015235820-81318771d0e0 h1:vFYRzFxHXDERRZ3nLuLHEvTP1oZwu+tgSb8XHSki2tU=
+github.com/vmware/govmomi v0.23.2-0.20201015235820-81318771d0e0/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/rbac/vsphere-csi-controller-rbac.yaml
@@ -35,7 +35,7 @@ rules:
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["storagepools"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
+    verbs: ["get", "watch", "list", "delete", "update", "create", "patch"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "create", "update"]

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/rbac/vsphere-csi-controller-rbac.yaml
@@ -35,7 +35,7 @@ rules:
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["storagepools"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
+    verbs: ["get", "watch", "list", "delete", "update", "create", "patch"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "create", "update"]

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/rbac/vsphere-csi-controller-rbac.yaml
@@ -35,7 +35,7 @@ rules:
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["storagepools"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
+    verbs: ["get", "watch", "list", "delete", "update", "create", "patch"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "create", "update"]

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -317,7 +317,7 @@ func getVsanDirectDatastores(ctx context.Context, vc *VirtualCenter, clusterID s
 	// get all datastores in this cluster
 	datastoreInfos, err := vc.GetDatastoresByCluster(ctx, clusterID)
 	if err != nil {
-		log.Warnf("Not able to fetch datastores in cluster %s. Err: %v", clusterID, err)
+		log.Warnf("Not able to fetch datastores in cluster %q. Err: %v", clusterID, err)
 		return nil, err
 	}
 
@@ -333,4 +333,21 @@ func getVsanDirectDatastores(ctx context.Context, vc *VirtualCenter, clusterID s
 		}
 	}
 	return datastores, nil
+}
+
+// GetDatastoreInfoByURL returns info of a datastore found in given cluster whose URL matches the specified datastore URL
+func GetDatastoreInfoByURL(ctx context.Context, vc *VirtualCenter, clusterID, dsURL string) (*DatastoreInfo, error) {
+	log := logger.GetLogger(ctx)
+	// get all datastores in this cluster
+	datastoreInfos, err := vc.GetDatastoresByCluster(ctx, clusterID)
+	if err != nil {
+		log.Warnf("Not able to fetch datastores in cluster %q. Err: %v", clusterID, err)
+		return nil, err
+	}
+	for _, dsInfo := range datastoreInfos {
+		if dsInfo.Info.Url == dsURL {
+			return dsInfo, nil
+		}
+	}
+	return nil, fmt.Errorf("datastore corresponding to URL %v not found in cluster %v", dsURL, clusterID)
 }

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package common
 
+import "time"
+
 const (
 	// MbInBytes is the number of bytes in one mebibyte.
 	MbInBytes = int64(1024 * 1024)
@@ -188,8 +190,10 @@ const (
 	Kubernetes = iota // Default container orchestrator for TKC, Supervisor Cluster and Vanilla K8s
 )
 
-// Feature state flag names
+// Constants related to Feature state
 const (
+	// default interval to check if the feature is enabled or not
+	DefaultFeatureEnablementCheckInterval = 1 * time.Minute
 	// VolumeHealth is the feature flag name for volume health
 	VolumeHealth = "volume-health"
 	// VolumeExtend is feature flag name for volume expansion
@@ -198,4 +202,6 @@ const (
 	CSIMigration = "csi-migration"
 	// CSIAuthCheck is feature flag for auth check
 	CSIAuthCheck = "csi-auth-check"
+	// VSANDirectDiskDecommission is feature flag for vsanD disk decommission
+	VSANDirectDiskDecommission = "vsan-direct-disk-decommission"
 )

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -178,6 +178,33 @@ func getK8sCloudOperatorClientConnection(ctx context.Context) (*grpc.ClientConn,
 	return conn, nil
 }
 
+// GetsvMotionPlanFromK8sCloudOperatorService gets storage vMotion plan from K8sCloudOperator gRPC service
+func GetsvMotionPlanFromK8sCloudOperatorService(ctx context.Context, storagePoolName string, maintenanceMode string) (map[string]string, error) {
+	log := logger.GetLogger(ctx)
+	conn, err := getK8sCloudOperatorClientConnection(ctx)
+	if err != nil {
+		log.Errorf("Failed to establish the connection to k8s cloud operator service when getting svMotion plan for SP: %s. Error: %+v", storagePoolName, err)
+		return nil, err
+	}
+	defer conn.Close()
+	// Create a client stub for k8s cloud operator gRPC service
+	client := k8scloudoperator.NewK8SCloudOperatorClient(conn)
+
+	res, err := client.GetStorageVMotionPlan(ctx,
+		&k8scloudoperator.StorageVMotionRequest{
+			StoragePoolName: storagePoolName,
+			MaintenanceMode: maintenanceMode,
+		})
+	if err != nil {
+		msg := fmt.Sprintf("Failed to get storage vMotion plan from the k8s cloud operator service. Error: %+v", err)
+		log.Error(msg)
+		return nil, err
+	}
+
+	log.Infof("Got storage vMotion plan: %v from K8sCloudOperator gRPC service", res.SvMotionPlan)
+	return res.SvMotionPlan, nil
+}
+
 // getVMUUIDFromK8sCloudOperatorService gets the vmuuid from K8sCloudOperator gRPC service
 func getVMUUIDFromK8sCloudOperatorService(ctx context.Context, volumeID string, nodeName string) (string, error) {
 	log := logger.GetLogger(ctx)

--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -37,7 +37,6 @@ import (
 
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer"
 
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
@@ -288,7 +287,7 @@ func (k8sCloudOperator *k8sCloudOperator) PlacePersistenceVolumeClaim(ctx contex
 		return out, err
 	}
 
-	scName, err := syncer.GetSCNameFromPVC(pvc)
+	scName, err := GetSCNameFromPVC(pvc)
 	if err != nil {
 		log.Errorf("Fail to get Storage class name from PVC with +v", err)
 		return out, err

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -301,7 +301,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		}()
 	}
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
-		volumeHealthEnablementTicker := time.NewTicker(defaultFeatureEnablementCheckInterval)
+		volumeHealthEnablementTicker := time.NewTicker(common.DefaultFeatureEnablementCheckInterval)
 		defer volumeHealthEnablementTicker.Stop()
 		// Trigger volume health reconciler
 		go func() {
@@ -311,7 +311,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 					log.Debugf("VolumeHealth feature is disabled on the cluster")
 				} else {
 					if err := initVolumeHealthReconciler(ctx, k8sClient, metadataSyncer.supervisorClient); err != nil {
-						log.Warnf("Error while initializing volume health reconciler. Err:%+v. Retry will be triggered at %v", err, time.Now().Add(defaultFeatureEnablementCheckInterval))
+						log.Warnf("Error while initializing volume health reconciler. Err:%+v. Retry will be triggered at %v", err, time.Now().Add(common.DefaultFeatureEnablementCheckInterval))
 						continue
 					}
 					break
@@ -319,7 +319,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			}
 		}()
 
-		volumeResizeEnablementTicker := time.NewTicker(defaultFeatureEnablementCheckInterval)
+		volumeResizeEnablementTicker := time.NewTicker(common.DefaultFeatureEnablementCheckInterval)
 		defer volumeResizeEnablementTicker.Stop()
 		// Trigger resize reconciler
 		go func() {
@@ -329,7 +329,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 					log.Debugf("ExpandVolume feature is disabled on the cluster")
 				} else {
 					if err := initResizeReconciler(ctx, k8sClient, metadataSyncer.supervisorClient); err != nil {
-						log.Warnf("Error while initializing volume resize reconciler. Err:%+v. Retry will be triggered at %v", err, time.Now().Add(defaultFeatureEnablementCheckInterval))
+						log.Warnf("Error while initializing volume resize reconciler. Err:%+v. Retry will be triggered at %v", err, time.Now().Add(common.DefaultFeatureEnablementCheckInterval))
 						continue
 					}
 					break

--- a/pkg/syncer/storagepool/diskDecommissionController.go
+++ b/pkg/syncer/storagepool/diskDecommissionController.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepool
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/semaphore"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp"
+	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
+)
+
+const (
+	drainModeField        = "decommMode"
+	drainStatusField      = "status"
+	drainFailReasonField  = "reason"
+	drainSuccessStatus    = "done"
+	drainFailStatus       = "fail"
+	ensureAccessibilityMM = "ensureAccessibility"
+	fullDataEvacuationMM  = "evacuateAll"
+	targetSPAnnotationKey = spTypePrefix + "migrate-to-storagepool"
+)
+
+// DiskDecommController is responsible for watching and processing disk decommission request
+type DiskDecommController struct {
+	migrationCntlr   *migrationController
+	k8sDynamicClient dynamic.Interface
+	spResource       *schema.GroupVersionResource
+	pvResource       *schema.GroupVersionResource
+	pvcResource      *schema.GroupVersionResource
+	spWatch          watch.Interface
+	// stores the current disk decommission mode ("ensureAccessibility"/"evacuateAll"/none) of a SP to evaluate whether or not
+	// a new event is a request for disk decommissioning of a SP. Keys are SP name and values are disk decomm mode.
+	diskDecommMode map[string]string
+	// 1 weighted semaphore to make sure only one disk decomm request is being executed
+	execSemaphore *semaphore.Weighted
+}
+
+// DecommissionDisk is responsible for making progress on disk decommission request.
+// It does so by getting SvMotion plan from placement engine, persisting the migration plan through PVC objects and
+// and passing this info to migration controller which migrates the volume to other local host attached disk.
+func (w *DiskDecommController) DecommissionDisk(ctx context.Context, storagePoolName string, maintenanceMode string) {
+	log := logger.GetLogger(ctx)
+	// make sure only 1 DecommissionDisk func is executing for a StoragePool
+	_ = w.execSemaphore.Acquire(ctx, 1)
+	defer w.execSemaphore.Release(1)
+	migrationFailed := false
+	for {
+		if migrationFailed {
+			errorString := fmt.Sprintf("Fail to migrate all volumes from datastore %v", storagePoolName)
+			err := updateDrainStatus(ctx, storagePoolName, drainFailStatus, errorString)
+			if err != nil {
+				log.Errorf("Failed to update drain status to '%v'. Error: %v", drainFailStatus, err)
+			}
+			return
+		}
+		// get drain label of storagePool
+		_, found, _ := getDrainMode(ctx, storagePoolName)
+		if !found {
+			log.Infof("Disk decommission of StoragePool %v has been aborted/ terminated", storagePoolName)
+			return
+		}
+
+		svMotionPlan, err := wcp.GetsvMotionPlanFromK8sCloudOperatorService(ctx, storagePoolName, maintenanceMode)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to decommission disk. Error: %+v", err)
+			err := updateDrainStatus(ctx, storagePoolName, drainFailStatus, msg)
+			if err != nil {
+				log.Errorf("Failed to update drain status to %v. Error: %v", drainFailStatus, err)
+			}
+			return
+		}
+		if len(svMotionPlan) == 0 {
+			log.Infof("Successfully decommission disk %v", storagePoolName)
+			err := updateDrainStatus(ctx, storagePoolName, drainSuccessStatus, "")
+			if err != nil {
+				log.Errorf("Failed to update drain label of %v to %v. Error: %v", storagePoolName, drainSuccessStatus, err)
+			}
+			return
+		}
+
+		pvcToMigrate := make([]*unstructured.Unstructured, 0)
+		for pvName, targetSPName := range svMotionPlan {
+			pv, err := w.k8sDynamicClient.Resource(*w.pvResource).Get(ctx, pvName, metav1.GetOptions{})
+			if err != nil {
+				log.Errorf("Failed to get PV resource %v. Error: %v", pvName, err)
+				migrationFailed = true
+				break
+			}
+			pvcName, _, _ := unstructured.NestedString(pv.Object, "spec", "claimRef", "name")
+			namespace, found, err := unstructured.NestedString(pv.Object, "spec", "claimRef", "namespace")
+			if pvcName == "" || !found || err != nil {
+				log.Errorf("Failed to get PVC bounded to PV %v. Error: %v", pvName, err)
+				migrationFailed = true
+				break
+			}
+			pvc, err := addTargetSPAnnotationOnPVC(ctx, pvcName, namespace, targetSPName)
+			if err != nil {
+				log.Errorf("Failed to add target SP annotation to PVC %v. Error: %v", pvcName, err)
+				migrationFailed = true
+				break
+			}
+			pvcToMigrate = append(pvcToMigrate, pvc)
+		}
+
+		_, unsuccessfulMigrations := w.migrationCntlr.MigrateVolumes(ctx, pvcToMigrate, true)
+		if len(unsuccessfulMigrations) != 0 {
+			migrationFailed = true
+		}
+	}
+}
+
+func initDiskDecommController(ctx context.Context, migrationCntlr *migrationController) (*DiskDecommController, error) {
+	log := logger.GetLogger(ctx)
+	log.Infof("Starting disk decommission controller")
+	k8sDynamicClient, spResource, err := getSPClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	w := &DiskDecommController{}
+	w.k8sDynamicClient = k8sDynamicClient
+	w.migrationCntlr = migrationCntlr
+	w.spResource = spResource
+	w.pvResource = &schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}
+	w.pvcResource = &schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}
+	w.diskDecommMode = make(map[string]string)
+	w.execSemaphore = semaphore.NewWeighted(1)
+
+	// get all the pvc resource for which targetSPAnnotationKey annotations exists.
+	// This will give us list of all pending migrations.
+	pvcList, err := w.k8sDynamicClient.Resource(*w.pvcResource).Namespace(v1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return w, err
+	}
+
+	pvcToMigrate := make([]*unstructured.Unstructured, 0)
+	for _, pvc := range pvcList.Items {
+		targetSPName, _, _ := unstructured.NestedString(pvc.Object, "metadata", "annotations", targetSPAnnotationKey)
+		if targetSPName != "" {
+			pvcToMigrate = append(pvcToMigrate, &pvc)
+		}
+	}
+	w.migrationCntlr.MigrateVolumes(ctx, pvcToMigrate, false)
+
+	// start StoragePool watch to look for events putting SP under disk decommission
+	err = w.renewStoragePoolWatch(ctx)
+	if err != nil {
+		return w, err
+	}
+	go w.watchStoragePool(ctx)
+
+	// get all sp resource
+	spList, err := w.k8sDynamicClient.Resource(*w.spResource).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return w, err
+	}
+	// make progress on StoragePool which are under disk decommission
+	for _, sp := range spList.Items {
+		spName := sp.GetName()
+		if w.shouldEnterDiskDecommission(ctx, &sp) && spName != "" {
+			maintenanceMode := w.diskDecommMode[spName]
+			go w.DecommissionDisk(ctx, spName, maintenanceMode)
+		}
+	}
+	return w, nil
+}
+
+// As our watch can and will expire, we need a helper to renew it. Note that after we re-new it,
+// we will get a bunch of already processed events.
+func (w *DiskDecommController) renewStoragePoolWatch(ctx context.Context) error {
+	log := logger.GetLogger(ctx)
+	spClient, spResource, err := getSPClient(ctx)
+	if err != nil {
+		return err
+	}
+	// This means every 24h our watch may expire and require to be re-created.
+	// When that happens, we may need to do a full remediation, hence we change
+	// from 30m (default) to 24h.
+	timeout := int64(60 * 60 * 24) // 24h
+	w.spWatch, err = spClient.Resource(*spResource).Watch(ctx, metav1.ListOptions{
+		TimeoutSeconds: &timeout,
+	})
+	if err != nil {
+		log.Errorf("Failed to start StoragePool watch. Error: %v", err)
+		return err
+	}
+	w.k8sDynamicClient = spClient
+	return nil
+}
+
+// watchStoragePool looks for event putting a SP under disk decommission. It does so by storing the current drain label
+// value for each StoragePool. Once it gets an event which updates the drain label (established by comparing stored drain
+// label value with new one) of a SP to ensureAccessibilityMM/fullDataEvacuationMM it invokes the func to process disk decommossion
+// of that storage pool.
+func (w *DiskDecommController) watchStoragePool(ctx context.Context) {
+	log := logger.GetLogger(ctx)
+	done := false
+	for !done {
+		select {
+		case <-ctx.Done():
+			log.Info("StoragePool watch shutdown", "ctxErr", ctx.Err())
+			done = true
+		case e, ok := <-w.spWatch.ResultChan():
+			if !ok {
+				log.Info("StoragePool watch not ok")
+				err := w.renewStoragePoolWatch(ctx)
+				for err != nil {
+					err = w.renewStoragePoolWatch(ctx)
+				}
+				continue
+			}
+			sp, ok := e.Object.(*unstructured.Unstructured)
+			if !ok {
+				log.Warnf("Object in StoragePool watch event is not of type *unstructured.Unstructured, but of type %T", e.Object)
+				continue
+			}
+			spName := sp.GetName()
+			if ok := w.shouldEnterDiskDecommission(ctx, sp); ok {
+				maintenanceMode := w.diskDecommMode[spName]
+				log.Infof("Got enter disk decommission request for StoragePool %v with MM %v", spName, maintenanceMode)
+				go w.DecommissionDisk(ctx, spName, maintenanceMode)
+			}
+		}
+	}
+	log.Info("watchStoragePool ends")
+}
+
+func (w *DiskDecommController) shouldEnterDiskDecommission(ctx context.Context, sp *unstructured.Unstructured) bool {
+	log := logger.GetLogger(ctx)
+	spName := sp.GetName()
+	driver, found, _ := unstructured.NestedString(sp.Object, "spec", "driver")
+	if !found || driver != csitypes.Name || spName == "" {
+		log.Warnf("StoragePool watch event for %v does not correspond to %v driver.", spName, csitypes.Name)
+		return false
+	}
+	drainMode, found, err := unstructured.NestedString(sp.Object, "spec", "parameters", drainModeField)
+	if err != nil {
+		log.Warnf("Error reading the drain mode from StoragePool event of %v. Error: %v", spName, err)
+		return false
+	}
+	defer func() {
+		if !found {
+			delete(w.diskDecommMode, spName)
+		} else {
+			w.diskDecommMode[spName] = drainMode
+		}
+	}()
+	if (drainMode == fullDataEvacuationMM || drainMode == ensureAccessibilityMM) && drainMode != w.diskDecommMode[spName] {
+		// check if status field is already populated
+		drainStatus, _, _ := unstructured.NestedString(sp.Object, "status", "diskDecomm", drainStatusField)
+		if drainStatus != drainFailStatus && drainStatus != drainSuccessStatus {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/syncer/storagepool/migrationController.go
+++ b/pkg/syncer/storagepool/migrationController.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/vim25/soap"
+	vim25types "github.com/vmware/govmomi/vim25/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/k8scloudoperator"
+)
+
+// migrationController is responsible for processing CNS volume relocation to another StoragePool
+type migrationController struct {
+	vc        *cnsvsphere.VirtualCenter
+	clusterID string
+}
+
+func initMigrationController(vc *cnsvsphere.VirtualCenter, clusterID string) *migrationController {
+	migrationCntlr := migrationController{
+		vc:        vc,
+		clusterID: clusterID,
+	}
+	return &migrationCntlr
+}
+
+func (m *migrationController) relocateCNSVolume(ctx context.Context, volumeID string, targetSPName string) error {
+	log := logger.GetLogger(ctx)
+	k8sDynamicClient, spResource, err := getSPClient(ctx)
+	if err != nil {
+		return err
+	}
+	sp, err := k8sDynamicClient.Resource(*spResource).Get(ctx, targetSPName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get StoragePool object with name %v", targetSPName)
+	}
+
+	datastoreURL, found, err := unstructured.NestedString(sp.Object, "spec", "parameters", "datastoreUrl")
+	if !found || err != nil {
+		return fmt.Errorf("failed to find datastoreUrl in StoragePool %s", targetSPName)
+	}
+	dsInfo, err := vsphere.GetDatastoreInfoByURL(ctx, m.vc, m.clusterID, datastoreURL)
+	if err != nil {
+		return fmt.Errorf("failed to get datastore corressponding to URL %v", datastoreURL)
+	}
+
+	volManager := volume.GetManager(ctx, m.vc)
+	relocateSpec := cnstypes.NewCnsBlockVolumeRelocateSpec(volumeID, dsInfo.Reference())
+
+	task, err := volManager.RelocateVolume(ctx, relocateSpec)
+	log.Infof("Return from CNS Relocate API, task: %v, Error: %v", task, err)
+	if err != nil {
+		// handle case when target DS is same as source DS, i.e. volume has already relocated.
+		if soap.IsSoapFault(err) {
+			soapFault := soap.ToSoapFault(err)
+			log.Debugf("type of fault: %v. SoapFault Info: %v", reflect.TypeOf(soapFault.VimFault()), soapFault)
+			_, isAlreadyExistErr := soapFault.VimFault().(vim25types.AlreadyExists)
+			if isAlreadyExistErr {
+				// volume already exists in the target SP, hence return success.
+				return nil
+			}
+		}
+		return err
+	}
+	taskInfo, err := task.WaitForResult(ctx)
+	if err != nil {
+		return err
+	}
+	results := taskInfo.Result.(cnstypes.CnsVolumeOperationBatchResult)
+	for _, result := range results.VolumeResults {
+		fault := result.GetCnsVolumeOperationResult().Fault
+		if fault != nil {
+			log.Errorf("Fault: %+v encountered while relocating volume %v", fault, volumeID)
+			return fmt.Errorf(fault.LocalizedMessage)
+		}
+	}
+	return nil
+}
+
+func (m *migrationController) migrateVolume(ctx context.Context, pvc *unstructured.Unstructured) (done bool, err error) {
+	log := logger.GetLogger(ctx)
+	pvcName := pvc.GetName()
+	pvcNamespace := pvc.GetNamespace()
+
+	defer func() {
+		_, err := removeTargetSPAnnotationOnPVC(ctx, pvcName, pvcNamespace)
+		if err != nil {
+			log.Errorf("Failed to remove target SP annotation from PVC %v. Error: %v", pvcName, err)
+		}
+	}()
+
+	pvResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}
+	k8sDynamicClient, spResource, err := getSPClient(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	pvName, found, err := unstructured.NestedString(pvc.Object, "spec", "volumeName")
+	if !found || err != nil {
+		return false, fmt.Errorf("could not get PV name bounded to PVC %v. PV info present in pvc resource: %v. Error: %v", pvcName, found, err)
+	}
+	pv, err := k8sDynamicClient.Resource(pvResource).Get(ctx, pvName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Failed to get PV resource with name %v. Err: %v", pvName, err)
+		return false, err
+	}
+
+	volumeID, found, err := unstructured.NestedString(pv.Object, "spec", "csi", "volumeHandle")
+	if !found || err != nil {
+		return false, fmt.Errorf("failed to get volumeID corresponding to pv %v. VolumeID info present in spec: %v. Error: %v", pvName, found, err)
+	}
+	targetSPName, found, err := unstructured.NestedString(pvc.Object, "metadata", "annotations", targetSPAnnotationKey)
+	if !found || err != nil {
+		return false, fmt.Errorf("failed to get target StoragePool of PVC %v. target SP name present in annotations: %v. Error: %v", pvcName, found, err)
+	}
+	targetSP, err := k8sDynamicClient.Resource(*spResource).Get(ctx, targetSPName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Failed to get target StoragePool resource %v. Err: %v", targetSPName, err)
+		return false, err
+	}
+	log.Debugf("Migrating volume %v to SP %v", volumeID, targetSP.GetName())
+
+	err = m.relocateCNSVolume(ctx, volumeID, targetSPName)
+	if err != nil {
+		log.Errorf("Could not migrate PVC %v to StoragePool %v. Error: %v", pvcName, targetSPName, err)
+		return false, err
+	}
+
+	log.Infof("Successfully migrated pvc %v to StoragePool %v", pvcName, targetSPName)
+	// change storagePool annotations in the PVC.
+	_ = updateSourceSPAnnotationOnPVC(ctx, pvcName, pvcNamespace, targetSPName)
+	return true, nil
+}
+
+// MigrateVolumes given a list of PVC migrates the corresponding volume for each PVC to the target SP specified by
+// targetSPAnnotationKey (cns.vmware.com/migrate-to-storagepool) annotation. If the annotation is not present on the PVC
+// the corresponding migration fails. The function returns a tuple consisting of list of PVCs for which migration succeeded
+// and a list of PVCs for which migration failed. The migration is performed sequentially one by one by calling CNS Relocate API.
+// If abortOnFirstFailure is true then after encountering first migration failure it aborts remaining PVC migrations and adds them
+// to unsuccessfulMigrations list.
+// On successful migration k8scloudoperator.StoragePoolAnnotationKey annotation is updated on PVC to reflect new StoragePool
+// targetSPAnnotationKey annotation is removed from PVC for both successful and unsuccessful migrations.
+func (m *migrationController) MigrateVolumes(ctx context.Context, pvcList []*unstructured.Unstructured, abortOnFirstFailure bool) (successfulMigrations []*unstructured.Unstructured, unsuccessfulMigrations []*unstructured.Unstructured) {
+	log := logger.GetLogger(ctx)
+	shouldAbort := false
+	successfulMigrations = make([]*unstructured.Unstructured, 0)
+	unsuccessfulMigrations = make([]*unstructured.Unstructured, 0)
+	for _, pvc := range pvcList {
+		pvcName := pvc.GetName()
+		pvcNamespace := pvc.GetNamespace()
+		if shouldAbort {
+			log.Infof("Migration for PVC %v has been aborted.", pvcName)
+			_, err := removeTargetSPAnnotationOnPVC(ctx, pvcName, pvcNamespace)
+			if err != nil {
+				log.Errorf("Failed to remove target SP annotation from PVC %v. Error: %v", pvcName, err)
+			}
+			unsuccessfulMigrations = append(unsuccessfulMigrations, pvc)
+			continue
+		}
+
+		// check if disk decomm. of source StoragePool has been aborted/ terminated
+		sourceSPName, found, err := unstructured.NestedString(pvc.Object, "metadata", "annotations", k8scloudoperator.StoragePoolAnnotationKey)
+		if !found || err != nil || sourceSPName == "" {
+			// log the error and assume that source SP is under disk decommission
+			log.Warnf("Could not get source StoragePool name for PVC %v. Error: %v", pvcName, err)
+		} else {
+			drainMode, found, err := getDrainMode(ctx, sourceSPName)
+			if (!found || (drainMode != fullDataEvacuationMM && drainMode != ensureAccessibilityMM)) && err == nil {
+				log.Infof("Disk decommission of StoragePool %v has been aborted/ terminated. Aborting migration of %v", sourceSPName, pvcName)
+				_, err := removeTargetSPAnnotationOnPVC(ctx, pvcName, pvcNamespace)
+				if err != nil {
+					log.Errorf("Failed to remove target SP annotation from PVC %v. Error: %v", pvcName, err)
+				}
+				unsuccessfulMigrations = append(unsuccessfulMigrations, pvc)
+				if abortOnFirstFailure {
+					shouldAbort = true
+				}
+				continue
+			}
+		}
+
+		done, err := m.migrateVolume(ctx, pvc)
+		if !done || err != nil {
+			log.Errorf("Error while migrating PVC %v. Error: %v", pvcName, err)
+			unsuccessfulMigrations = append(unsuccessfulMigrations, pvc)
+			if abortOnFirstFailure {
+				shouldAbort = true
+			}
+			continue
+		}
+		successfulMigrations = append(successfulMigrations, pvc)
+	}
+	log.Infof("Total number of successful migrations: %v, unsuccessful migrations: %v", len(successfulMigrations), len(unsuccessfulMigrations))
+	return successfulMigrations, unsuccessfulMigrations
+}
+
+func updateSourceSPAnnotationOnPVC(ctx context.Context, pvcName, pvcNamespace, newSourceSPName string) error {
+	log := logger.GetLogger(ctx)
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]string{
+				k8scloudoperator.StoragePoolAnnotationKey: newSourceSPName,
+			},
+		},
+	}
+	patchBytes, _ := json.Marshal(patch)
+
+	task := func() (done bool, _ error) {
+		pvcResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}
+		k8sDynamicClient, _, err := getSPClient(ctx)
+		if err != nil {
+			return false, err
+		}
+
+		updatedPVC, err := k8sDynamicClient.Resource(pvcResource).Namespace(pvcNamespace).Patch(ctx, pvcName, k8stypes.MergePatchType, patchBytes, metav1.PatchOptions{})
+		if err != nil {
+			log.Errorf("Failed to update current StoragePool label to %v for pvc %v", newSourceSPName, pvcName)
+			return false, err
+		}
+		log.Debugf("Successfully updated source StoragePool label for PVC %v", updatedPVC.GetName())
+		return true, nil
+	}
+	baseDuration := time.Duration(100) * time.Millisecond
+	thresholdDuration := time.Duration(10) * time.Second
+	_, err := ExponentialBackoff(task, baseDuration, thresholdDuration, 1.5, 15)
+	return err
+}
+
+func removeTargetSPAnnotationOnPVC(ctx context.Context, pvcName, pvcNamespace string) (*unstructured.Unstructured, error) {
+	log := logger.GetLogger(ctx)
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				targetSPAnnotationKey: nil,
+			},
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return nil, err
+	}
+
+	pvcResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}
+	k8sDynamicClient, _, err := getSPClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedPVC, err := k8sDynamicClient.Resource(pvcResource).Namespace(pvcNamespace).Patch(ctx, pvcName, k8stypes.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("Successfully removed target StoragePool information from %v. Updated PVC: %v", pvcName, updatedPVC.GetName())
+	return updatedPVC, nil
+}

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -47,9 +47,6 @@ const (
 	// default interval for csi volume health
 	defaultVolumeHealthIntervalInMin = 5
 
-	// default interval for syncer to check if the feature is enabled or not
-	defaultFeatureEnablementCheckInterval = 1 * time.Minute
-
 	// default resync period for volume health reconciler
 	volumeHealthResyncPeriod = 10 * time.Minute
 	// default retry start interval time for volume health reconciler

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -2,7 +2,6 @@ package syncer
 
 import (
 	"context"
-	"fmt"
 
 	"k8s.io/client-go/tools/cache"
 
@@ -10,17 +9,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
 	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
 	volumes "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
-)
-
-const (
-	// PVC annotation key to specify storage class from which PV should be provisioned
-	scNameAnnotationKey = "volume.beta.kubernetes.io/storage-class"
 )
 
 // getPVsInBoundAvailableOrReleased return PVs in Bound, Available or Released state
@@ -229,19 +224,6 @@ func isValidvSphereVolume(ctx context.Context, pvMetadata metav1.ObjectMeta) boo
 		}
 	}
 	return false
-}
-
-// GetSCNameFromPVC gets name of the storage class from provided PVC
-func GetSCNameFromPVC(pvc *v1.PersistentVolumeClaim) (string, error) {
-	scName := pvc.Spec.StorageClassName
-	if scName == nil || *scName == "" {
-		scNameFromAnnotation := pvc.Annotations[scNameAnnotationKey]
-		if scNameFromAnnotation == "" {
-			return "", fmt.Errorf("storage class name not specified in PVC")
-		}
-		scName = &scNameFromAnnotation
-	}
-	return *scName, nil
 }
 
 // IsMultiAttachAllowed helps check accessModes on the PV and return true if volume can be attached to

--- a/pkg/syncer/util_test.go
+++ b/pkg/syncer/util_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/google/uuid"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/k8scloudoperator"
 )
 
 var (
@@ -117,7 +119,7 @@ func TestGetSCNameFromPVC(t *testing.T) {
 	t.Log("Verifying GetSCNameFromPVC for case where SC name is provided through only Spec.StorageClassName")
 	pvcName := testPVCName + "-" + uuid.New().String()
 	pvc := getPersistentVolumeClaimSpec(pvcName, namespace, pvcLabel, "", specSCName)
-	scName, err := GetSCNameFromPVC(pvc)
+	scName, err := k8scloudoperator.GetSCNameFromPVC(pvc)
 	err = verifySCName(scName, err, specSCName, nil)
 	if err != nil {
 		t.Error(err)
@@ -127,8 +129,8 @@ func TestGetSCNameFromPVC(t *testing.T) {
 	t.Log("Verifying GetSCNameFromPVC for case where SC name is provided through only Metadata.Annotation")
 	pvcName = testPVCName + "-" + uuid.New().String()
 	pvc = getPersistentVolumeClaimSpec(pvcName, namespace, pvcLabel, "", "")
-	pvc.Annotations = map[string]string{scNameAnnotationKey: annotatedSCName}
-	scName, err = GetSCNameFromPVC(pvc)
+	pvc.Annotations = map[string]string{k8scloudoperator.ScNameAnnotationKey: annotatedSCName}
+	scName, err = k8scloudoperator.GetSCNameFromPVC(pvc)
 	err = verifySCName(scName, err, annotatedSCName, nil)
 	if err != nil {
 		t.Error(err)
@@ -138,8 +140,8 @@ func TestGetSCNameFromPVC(t *testing.T) {
 	t.Log("Verifying GetSCNameFromPVC for case where SC name is provided through both Spec.StorageClassName and Metadata.Annotation")
 	pvcName = testPVCName + "-" + uuid.New().String()
 	pvc = getPersistentVolumeClaimSpec(pvcName, namespace, pvcLabel, "", specSCName)
-	pvc.Annotations = map[string]string{scNameAnnotationKey: annotatedSCName}
-	scName, err = GetSCNameFromPVC(pvc)
+	pvc.Annotations = map[string]string{k8scloudoperator.ScNameAnnotationKey: annotatedSCName}
+	scName, err = k8scloudoperator.GetSCNameFromPVC(pvc)
 	err = verifySCName(scName, err, specSCName, nil)
 	if err != nil {
 		t.Error(err)
@@ -149,8 +151,8 @@ func TestGetSCNameFromPVC(t *testing.T) {
 	t.Log("Verifying GetSCNameFromPVC for case where SC name is provided through neither Spec.StorageClassName nor Metadata.Annotation")
 	pvcName = testPVCName + "-" + uuid.New().String()
 	pvc = getPersistentVolumeClaimSpec(pvcName, namespace, pvcLabel, "", "")
-	expError := fmt.Errorf("storage class name not specified in PVC")
-	scName, err = GetSCNameFromPVC(pvc)
+	expError := fmt.Errorf("storage class name not specified in PVC %q", pvcName)
+	scName, err = k8scloudoperator.GetSCNameFromPVC(pvc)
 	err = verifySCName(scName, err, "", expError)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR introduces disk decommission controller which watches StoragePool for any disk decomm request through /spec/parameters/decommMode field. It is responsible to make progress on decommission request by getting a migration plan which specifies for each CNS volume on the given StoragePool, which datastore(SP) it should migrate to. Disk Decommission Controller then feeds this migration plan to migration controller which then calls the CNS Relocate API to migrate each PVC to its assigned StoragePool.

**Special notes for your reviewer**:
**Test:** Manual testing done by triggering the disk decommission workflow by adding `/spec/parameter/decommMode` field with value `evacuateAll` to a StoragePool object. Execution logs captures migration of 1 pvc on that SP.
```
2020-10-19T08:43:04.911Z        INFO    common/util.go:318      Connecting to K8s Cloud Operator Service on port 29000
2020-10-19T08:43:05.229Z        DEBUG   k8scloudoperator/k8scloudoperator.go:334        received GetStorageVMotionPlan for StoragePool storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t6-l0 and maintenance mode evacuateAll
2020-10-19T08:43:05.351Z        INFO    k8scloudoperator/placement.go:304       Starting placement for PVC vsand-pvc, Topology [wdc-rdops-vm08-dhcp-196-224.eng.vmware.com]
2020-10-19T08:43:05.353Z        DEBUG   k8scloudoperator/placement.go:504       storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t2-l0 is healthy
2020-10-19T08:43:05.353Z        DEBUG   k8scloudoperator/placement.go:504       storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t5-l0 is healthy
2020-10-19T08:43:05.353Z        DEBUG   k8scloudoperator/placement.go:522       storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t5-l0 is under disk decommission with status ensureAccessibility
2020-10-19T08:43:05.353Z        DEBUG   k8scloudoperator/placement.go:504       storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t6-l0 is healthy
2020-10-19T08:43:05.353Z        DEBUG   k8scloudoperator/placement.go:522       storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t6-l0 is under disk decommission with status evacuateAll
2020-10-19T08:43:05.356Z        DEBUG   k8scloudoperator/placement.go:504       storagepool-vsandirect-10.92.214.218-mpx.vmhba0-c0-t2-l0 is healthy
2020-10-19T08:43:05.357Z        DEBUG   k8scloudoperator/placement.go:504       storagepool-vsandirect-10.92.214.218-mpx.vmhba0-c0-t5-l0 is healthy
2020-10-19T08:43:05.358Z        DEBUG   k8scloudoperator/placement.go:504       storagepool-vsandirect-10.92.214.218-mpx.vmhba0-c0-t6-l0 is healthy
2020-10-19T08:43:05.358Z        DEBUG   k8scloudoperator/placement.go:504       storagepool-vsandirect-10.92.217.162-mpx.vmhba0-c0-t2-l0 is healthy
2020-10-19T08:43:05.361Z        DEBUG   k8scloudoperator/placement.go:504       storagepool-vsandirect-10.92.217.162-mpx.vmhba0-c0-t5-l0 is healthy
2020-10-19T08:43:05.361Z        DEBUG   k8scloudoperator/placement.go:504       storagepool-vsandirect-10.92.217.162-mpx.vmhba0-c0-t6-l0 is healthy
2020-10-19T08:43:05.362Z        DEBUG   k8scloudoperator/placement.go:504       storagepool-vsandirect-10.92.218.55-mpx.vmhba0-c0-t2-l0 is healthy
2020-10-19T08:43:05.363Z        DEBUG   k8scloudoperator/placement.go:504       storagepool-vsandirect-10.92.218.55-mpx.vmhba0-c0-t5-l0 is healthy
2020-10-19T08:43:05.363Z        DEBUG   k8scloudoperator/placement.go:504       storagepool-vsandirect-10.92.218.55-mpx.vmhba0-c0-t6-l0 is healthy
2020-10-19T08:43:05.363Z        INFO    k8scloudoperator/placement.go:488       TotalPools:17, Usable:1. Pools removed because not local:5, SC mis-match:0, Unhealthy: 0, topology mis-match: 9, under disk decommission: 2, out of capacity: 0
2020-10-19T08:43:05.364Z        INFO    k8scloudoperator/placement.go:645       Removed because of: affinity rules:0,  out of capacity:0. Usable Pools:1, Pools already used at least once:0
2020-10-19T08:43:05.366Z        DEBUG   k8scloudoperator/placement.go:173       volumeToSPMap: map[pvc-03167f18-3fa9-4a11-bdf6-3d330184368e:storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t2-l0]
2020-10-19T08:43:05.370Z        INFO    wcp/controller_helper.go:204    Got storage vMotion plan: map[pvc-03167f18-3fa9-4a11-bdf6-3d330184368e:storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t2-l0] from K8sCloudOperator gRPC service
2020-10-19T08:43:05.464Z        DEBUG   storagepool/util.go:360 Successfully updated target StoragePool information to storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t2-l0. Updated PVC: vsand-pvc
2020-10-19T08:43:05.528Z        DEBUG   storagepool/migrationController.go:146  Migrating volume 47ff3ee2-95b9-4edf-9597-f22203c3d53b to SP storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t2-l0
2020-10-19T08:43:05.596Z        INFO    volume/manager.go:94    Retrieving existing volume.defaultManager...
2020-10-19T08:43:05.692Z        INFO    storagepool/migrationController.go:76   Return from CNS Relocate API, task: Task:task-1049, Error: <nil>
2020-10-19T08:43:10.511Z        INFO    storagepool/migrationController.go:154  Successfully migrated pvc vsand-pvc to StoragePool storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t2-l0
2020-10-19T08:43:10.587Z        DEBUG   storagepool/migrationController.go:277  Successfully removed target StoragePool information from vsand-pvc. Updated PVC: vsand-pvc
2020-10-19T08:43:10.589Z        INFO    storagepool/migrationController.go:218  Total number of successful migrations: 1, unsuccessful migrations: 0
2020-10-19T08:43:10.626Z        DEBUG   storagepool/migrationController.go:245  Successfully updated source StoragePool label for PVC vsand-pvc
2020-10-19T08:43:10.681Z        INFO    k8scloudoperator/placement.go:287       No volume present in storagePool storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t6-l0 to migrate.
2020-10-19T08:43:10.681Z        INFO    wcp/controller_helper.go:204    Got storage vMotion plan: map[] from K8sCloudOperator gRPC service
2020-10-19T08:43:10.681Z        INFO    storagepool/diskDecommissionController.go:94    Successfully decommission disk storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t6-l0
2020-10-19T08:43:10.787Z        DEBUG   storagepool/util.go:305 Successfully updated drain status to done in StoragePool storagepool-vsandirect-10.92.196.224-mpx.vmhba0-c0-t6-l0
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add vsanD disk decommission controller in syncer container
```
