### PR TITLE
Add regex patterns for CnsRegisterVolume Spec params

### DIFF
--- a/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml
@@ -33,10 +33,12 @@ spec:
             pvcName:
               description: Name of the PVC
               type: string
+              pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
             volumeID:
               description: VolumeID indicates an existing vsphere volume to be imported
                 into Project Pacific cluster
               type: string
+              pattern: '^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$'
             accessMode:
               description: AccessMode contains the actual access mode the volume backing
                 the CnsRegisterVolume has
@@ -45,6 +47,7 @@ spec:
               description: DiskUrlPath is URL path to an existing block volume to be
                 imported into Project Pacific cluster.
               type: string
+              pattern: '^(http[s]?:\/\/)?([^\/\s]+\/folder\/)(.*)$'
           required:
           - pvcName
           type: object


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently CnsRegisterVolume Spec params doesn't have any validation rules. Adding validation rules for the params will esnure the CRD instance is not created in first place instead of creating it and failing it later by the CnsRegisterVolume controller.

Using the following regex patterns for the following params
1. pvcName - Following the rules for the resource name defined in https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
2. volumeID - UUID format
3. diskUrlPath - url format

```release-note
Add regex patterns for CnsRegisterVolume Spec params
```

**Testing done**
"cnsregistervolumes.cns.vmware.com" CRD is updated on deploying new CSI driver.

```
2020-10-16T22:33:16.870Z        INFO    kubernetes/kubernetes.go:345    "cnsregistervolumes.cns.vmware.com" CRD updated successfully    {"TraceId": "6a68b934-b973-43c8-a4e8-94dade4de261"}
```

1. pvcName is not in valid format
```
root@42168c19636add845e5e2e951ca754d8 [ ~ ]# cat ll.yaml 
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: import-mongodb-3
spec:
  pvcName: Mongo-pvc
  volumeID: fe1efbd0-79f7-4a2f-a8a9-69852e62225a
  accessMode: ReadWriteOnce

root@42168c19636add845e5e2e951ca754d8 [ ~ ]# kubectl create -f ll.yaml 
The CnsRegisterVolume "import-mongodb-3" is invalid: spec.pvcName: Invalid value: "": spec.pvcName in body should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
```

2. volumeID is not in proper format
```
root@42168c19636add845e5e2e951ca754d8 [ ~ ]# cat ll.yaml 
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: import-mongodb-3
spec:
  pvcName: mongo-pvc
  volumeID: fe1efbd0ddddddddd-79f7-4a2f-a8a9-69852e62225a
  accessMode: ReadWriteOnce

root@42168c19636add845e5e2e951ca754d8 [ ~ ]# kubectl create -f ll.yaml 
The CnsRegisterVolume "import-mongodb-3" is invalid: spec.volumeID: Invalid value: "": spec.volumeID in body should match '^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$'
```

cc @divyenpatel @chethanv28 @SandeepPissay 
