### PR TITLE
Stop creating vsan-sna StoragePools for remote vSAN datastore

### DIFF
--- a/pkg/syncer/storagepool/listener.go
+++ b/pkg/syncer/storagepool/listener.go
@@ -232,7 +232,8 @@ func ReconcileAllStoragePools(ctx context.Context, scWatchCntlr *StorageClassWat
 			continue
 		}
 
-		if intendedState.dsType == "cns.vmware.com/vsan" {
+		// create vsan-sna StoragePools for local vsan datastore
+		if intendedState.dsType == vsanDsType && !intendedState.isRemoteVsan {
 			err := spCtl.updateVsanSnaIntendedState(ctx, intendedState, validStoragePoolNames, scWatchCntlr)
 			if err != nil {
 				log.Errorf("Error updating intended state of vSAN SNA StoragePools. Err: %v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
With the vSAN HCI Mesh feature, when a remote vSAN datastore is mounted on to the current cluster, the StoragePool controller creates vsan-sna StoragePool instances for the remote datastore as well. This is wrong since that capacity is not local to the hosts in this cluster.

To fix this, the controller should stop creating vsan-sna StoragePools. The remote vSAN datastore will still have a single StoragePool that represents the shared storage capacity that can be used to place Volumes. However the remote capacity will not be treated as vsan-sna local capacity.

### Testing done
**Test setup**
1. Create two vSAN clusters in a Datacenter
2. Go to vSAN "Datastore Sharing" on the VC UI for the 1st cluster and mount the 2nd vSAN datastore as a remote datastore
3. So now the 1st cluster that is WCP enabled has the local `vsanDatastore` and remote `vsanDatastore (1)` mounted.

**Before fix**
```
root@4207a2f1462ac4b9e4591c478a3f2228 [ ~ ]# kubectl get storagepool
NAME                                                                    AGE
storagepool-vsandatastore                                               15d
storagepool-vsandatastore-1                                             25h
storagepool-vsandatastore-1-wdc-rdops-vm04-dhcp-33-237.eng.vmware.com   25h
storagepool-vsandatastore-1-wdc-rdops-vm04-dhcp-36-141.eng.vmware.com   25h
storagepool-vsandatastore-1-wdc-rdops-vm04-dhcp-57-130.eng.vmware.com   25h
storagepool-vsandatastore-wdc-rdops-vm04-dhcp-33-237.eng.vmware.com     5d16h
storagepool-vsandatastore-wdc-rdops-vm04-dhcp-36-141.eng.vmware.com     5d16h
storagepool-vsandatastore-wdc-rdops-vm04-dhcp-57-130.eng.vmware.com     5d16h
storagepool-vsandirect-10.92.33.237-mpx.vmhba0-c0-t2-l0                 15d
storagepool-vsandirect-10.92.36.141-mpx.vmhba0-c0-t2-l0                 15d
storagepool-vsandirect-10.92.57.130-mpx.vmhba0-c0-t2-l0                 15d
```

Note that the vsan-sna StoragePools of the vsandatastore-1 like `storagepool-vsandatastore-1-wdc-rdops-vm04-dhcp-33-237.eng.vmware.com` are present. These should not be created by the controller.

**After fix**
```
root@4207a2f1462ac4b9e4591c478a3f2228 [ ~ ]# kubectl get storagepool
NAME                                                                  AGE
storagepool-vsandatastore                                             15d
storagepool-vsandatastore-1                                           27h
storagepool-vsandatastore-wdc-rdops-vm04-dhcp-33-237.eng.vmware.com   7s
storagepool-vsandatastore-wdc-rdops-vm04-dhcp-36-141.eng.vmware.com   7s
storagepool-vsandatastore-wdc-rdops-vm04-dhcp-57-130.eng.vmware.com   7s
storagepool-vsandirect-10.92.33.237-mpx.vmhba0-c0-t2-l0               15d
storagepool-vsandirect-10.92.36.141-mpx.vmhba0-c0-t2-l0               15d
storagepool-vsandirect-10.92.57.130-mpx.vmhba0-c0-t2-l0               15d
```

Note that the vsan-sna StoragePools for the local vsan datastore is still created, but the vsan-sna StoragePools for the remote mounted datastore alone is not created any more.

Also, the contents of the StoragePool remain unchanged for those that are present.

