### PR TITLE
Allow multiple PV/PVC's to reference same volumeHandle

### DIFF
--- a/docs/book/features/block_volume.md
+++ b/docs/book/features/block_volume.md
@@ -250,6 +250,8 @@ There are many ways to create static PV and PVC binding. Example: Label matching
 
 Static Volume Provisioning is supported only in Vanilla Kubernetes clusters but not in Supervisor clusters
 
+**NOTE:** For Block volumes, vSphere Cloud Native Storage (CNS) only allows one PV in the Kubernetes cluster to refer to a storage disk. Creating multiple PV's using the same Block Volume Handle is not supported.
+
 ### Use Cases of Static Provisioning<a id="static_volume_provisioning_use_case"></a>
 
 Following are the common use cases for static volume provisioning:

--- a/docs/book/features/file_volume.md
+++ b/docs/book/features/file_volume.md
@@ -179,3 +179,5 @@ spec:
 ```
 
 The `labels` key-value pair `static-pv-label-key: static-pv-label-value` used in PV `metadata` and PVC `selector` aid in matching the PVC to the PV during static provisioning. Also, remember to retain the `file:` prefix of the vSAN file share while filling up the `volumeHandle` field in PV spec.
+
+**NOTE:** For File volumes, CNS supports multiple PV's referring to the same file-share volume.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This fix allows multiple PV/PVC's to point to the same volume handle in full sync. This change also changes the name of variables:
- `pvToK8sEntityMetadata` to `volumeToK8sEntityMetadataMap`
- `volumeToCnsEntityMetadata` to `volumeToCnsEntityMetadata`

Since the keys of these maps are `volumeID` and not `pvName`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #431

**Special notes for your reviewer**:

Full sync e2e tests for vanilla block:

```
Ran 7 of 106 Specs in 2702.685 seconds
SUCCESS! -- 7 Passed | 0 Failed | 0 Pending | 99 Skipped
PASS
```

Full sync e2e tests for vanilla file:
```
Ran 1 of 106 Specs in 155.917 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 105 Skipped
PASS
```

Manual test:
1. Create two PV/PVCs pointing to same volume handle:
```
root@k8s-master-18:~# kubectl get pvc
NAME                         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS              AGE
example-vanilla-file-pvc     Bound    pvc-a0a3af6e-17a3-4c37-adec-965827b49dc4   1Mi        RWX            example-vanilla-file-sc   3d3h
static-file-share-pvc-name   Bound    static-file-share-pv-name                  1Mi        RWX                                      3d3h
```

2. Verified across three full sync cycles that volume is not updated:
```
{"log":"2020-10-16T08:36:50.099Z\u0009INFO\u0009syncer/fullsync.go:420\u0009FullSync: update is not required for volume: \"c2fe455f-b924-4846-9333-8c6a15ee4551\"\u0009{\"TraceId\": \"bf94253b-2c47-491c-b930-74dc19e7cea3\"}\n","stream":"stderr","time":"2020-10-16T08:36:50.101615348Z"}
...
{"log":"2020-10-16T08:38:49.636Z\u0009INFO\u0009syncer/fullsync.go:420\u0009FullSync: update is not required for volume: \"file:a7e8885e-7da6-4ac9-8f58-f483626e0fd9\"\u0009{\"TraceId\": \"2dc0212f-9766-46f7-b6ed-516ef935223b\"}\n","stream":"stderr","time":"2020-10-16T08:38:49.645286968Z"}
...
{"log":"2020-10-16T08:40:49.711Z\u0009INFO\u0009syncer/fullsync.go:420\u0009FullSync: update is not required for volume: \"c2fe455f-b924-4846-9333-8c6a15ee4551\"\u0009{\"TraceId\": \"a780720a-dc1c-4c01-92d1-a5aaf4012997\"}\n","stream":"stderr","time":"2020-10-16T08:40:49.712751173Z"}
```

Verify that CNS UI contains metadata for both volumes:
<img width="936" alt="Screen Shot 2020-10-16 at 4 36 53 PM" src="https://user-images.githubusercontent.com/5894281/96322439-ee8f1980-0fcd-11eb-870d-9b4641a072c2.png">


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Allow multiple PV's to reference the same volume handle in Full Sync. 
```
