### PR TITLE
Add validation for cluster id to not exceed 64 chars

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -78,6 +78,10 @@ var (
 	// define any vCenters.
 	ErrMissingVCenter = errors.New("no Virtual Center hosts defined")
 
+	// ErrClusterIdCharLimit is returned when the provided cluster id is more
+	// than 64 characters.
+	ErrClusterIDCharLimit = errors.New("cluster id must not exceed 64 characters")
+
 	// ErrMissingEndpoint is returned when the provided configuration does not
 	// define any endpoints.
 	ErrMissingEndpoint = errors.New("no Supervisor Cluster endpoint defined in Guest Cluster config")
@@ -241,6 +245,11 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 	if len(cfg.VirtualCenter) == 0 {
 		log.Error(ErrMissingVCenter)
 		return ErrMissingVCenter
+	}
+	// Cluster ID should not exceed 64 characters.
+	if len(cfg.Global.ClusterID) > 64 {
+		log.Error(ErrClusterIDCharLimit)
+		return ErrClusterIDCharLimit
 	}
 	for vcServer, vcConfig := range cfg.VirtualCenter {
 		log.Debugf("Initializing vc server %s", vcServer)

--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -146,6 +146,18 @@ func TestValidateConfigWithInvalidPermissions(t *testing.T) {
 	}
 }
 
+func TestValidateConfigWithInvalidClusterId(t *testing.T) {
+	cfg := &Config{
+		VirtualCenter: idealVCConfig,
+	}
+	cfg.Global.ClusterID = "test-cluster-with-a-long-name-with-more-than-sixty-four-characters"
+
+	err := validateConfig(ctx, cfg)
+	if err == nil {
+		t.Errorf("Expected error due to invalid cluster id. Config given - %+v", *cfg)
+	}
+}
+
 func isConfigEqual(actual *Config, expected *Config) bool {
 	// TODO: Compare Global struct
 	// Compare VC Config


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fails CSI controller init if cluster-id provided in the config exceeds 64 characters. Currently if more than 64 chars are allowed, CNS control plane cannot store volumes that exceeds this character count limit leading to query, update metadata failures in CNS that eventually leads to ControllerUnpublishVolume failures in CSI.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #319 

**Special notes for your reviewer**:
Currently if a controller is started with cluster-id greater than 64 characters, and a pod with a PVC is first created and then deleted, the volume fails detaching. This is due to a CNS limitation.
```
2020-10-14T19:57:30.099Z	INFO	vanilla/controller.go:536	ControllerUnpublishVolume: called with args {VolumeId:a64d4573-2e74-4938-846e-869ddcc2a6ac NodeId:k8s-node-0940 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "56a10bf3-4967-4e69-8c98-e59edb1bc28e"}
2020-10-14T19:57:30.112Z	ERROR	vanilla/controller.go:560	volumeID "a64d4573-2e74-4938-846e-869ddcc2a6ac" not found in QueryVolume	{"TraceId": "56a10bf3-4967-4e69-8c98-e59edb1bc28e"}
.
.
```

With this fix, the controller cannot be initialized when cluster-id exceeds character limit"
```
root@k8s-master-81:~# kubectl get pods -n kube-system
vsphere-csi-controller-644f658cfd-vvnc7   5/6     CrashLoopBackOff   1          20s
```
```
root@k8s-master-81:~# kubectl logs vsphere-csi-controller-644f658cfd-vvnc7 -c vsphere-csi-controller -n kube-system
2020-10-14T22:24:48.787Z	ERROR	config/config.go:369	failed to parse config. Err: cluster id must not exceed 64 characters	{"TraceId": "68d89e9a-099d-46ba-a323-e02198c4ef20"}
.
.
2020-10-14T22:24:48.787Z	ERROR	service/service.go:118	failed to read config. Error: cluster id must not exceed 64 characters	{"TraceId": "68d89e9a-099d-46ba-a323-e02198c4ef20"}
sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.(*service).BeforeServe
.
.
2020-10-14T22:24:48.787Z	INFO	service/service.go:106	configured: "csi.vsphere.vmware.com" with clusterFlavor: "VANILLA" and mode: "controller"	{"TraceId": "68d89e9a-099d-46ba-a323-e02198c4ef20"}
time="2020-10-14T22:24:48Z" level=info msg="removed sock file" path=/var/lib/csi/sockets/pluginproxy/csi.sock
time="2020-10-14T22:24:48Z" level=fatal msg="grpc failed" error="cluster id must not exceed 64 characters"
```



