### PR TITLE
upgrade driver documentation

### DIFF
--- a/docs/book/SUMMARY.md
+++ b/docs/book/SUMMARY.md
@@ -9,6 +9,7 @@
 * Driver Deployment
   * [Prerequisites](driver-deployment/prerequisites.md)
   * [Installation](driver-deployment/installation.md)
+  * [Upgrade](driver-deployment/upgrade.md)
   * [Deployment with Zones](driver-deployment/deploying_csi_with_zones.md)
 * Features
   * [Block Volume](features/block_volume.md)

--- a/docs/book/driver-deployment/upgrade.md
+++ b/docs/book/driver-deployment/upgrade.md
@@ -1,0 +1,30 @@
+<!-- markdownlint-disable MD033 -->
+# vSphere CSI Driver - Upgrade
+
+**Note: To upgrade "vSphere with Tanzu" follow vSphere documentation. Following instructions are applicable to native vanilla Kubernetes Cluster deployed on vSphere.**
+
+Each release of vSphere CSI driver has a different set of RBAC rules and deployment YAML files depending on the version of the vCenter on which Kubernetes Cluster is deployed.
+
+To upgrade from one release to another release of vSphere CSI driver, we recommend to completely delete the driver using the original YAML files, you have used to deploy the driver and then use new YAML files to re-install the vSphere CSI driver.
+
+For example, if you want to upgrade driver from `v2.0.0` release to `v2.0.1` release deployed on the Kubernetes Cluster installed on `vSphere 67u3` release
+
+Uninstall `v2.0.0` driver
+
+```bash
+kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/v2.0.0/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/v2.0.0/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
+kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/v2.0.0/vsphere-67u3/vanilla/rbac/vsphere-csi-controller-rbac.yaml
+```
+
+Wait for vSphere CSI Controller Pod and vSphere CSI Nodes Pods to be completely deleted.
+
+Install `v2.0.1` driver
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/v2.0.1/vsphere-67u3/vanilla/rbac/vsphere-csi-controller-rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/v2.0.1/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/v2.0.1/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
+```
+
+We also recommend you to follow our [installation guide](installation.md) to refer to updated instruction and encourage you to go through all [pre-requisites](prerequisites.md) for newer releases of the vSphere CSI driver.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding instructions for upgrading the vanilla vSphere CSI driver from one release to another release.

**Which issue this PR fixes**

fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/366

Preview link - https://deploy-preview-439--kubernetes-sigs-vsphere-csi-driver.netlify.app/driver-deployment/upgrade.html

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
upgrade driver documentation
```
