### PR TITLE
E2e Test for static provisioning of file volume

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
-	golang.org/x/tools v0.0.0-20201013053347-2db1cd791039 // indirect
+	golang.org/x/tools v0.0.0-20201015182029-a5d9e455e9c4 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/grpc v1.26.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/go.sum
+++ b/go.sum
@@ -645,6 +645,7 @@ github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJ
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware-tanzu/vm-operator-api v0.1.3 h1:4vxewu0jAN3fSoCBI6FhjmRGJ7ci0R2WNu/I6hacTYs=
 github.com/vmware-tanzu/vm-operator-api v0.1.3/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
+github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.23.2-0.20200915235406-49b4974659e1 h1:cOmmloKpYtLP8sHzFK9g841PXQzjIB6abTdz7uvrakI=
 github.com/vmware/govmomi v0.23.2-0.20200915235406-49b4974659e1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
@@ -852,6 +853,8 @@ golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201013053347-2db1cd791039 h1:kLBxO4OPBgPwjg8Vvu+/0DCHIfDwYIGNFcD66NU9kpo=
 golang.org/x/tools v0.0.0-20201013053347-2db1cd791039/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201015182029-a5d9e455e9c4 h1:rQWkJiVIyJ3PgiSHL+RXc8xbrK8duU6jG5eeZ9G7nk8=
+golang.org/x/tools v0.0.0-20201015182029-a5d9e455e9c4/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/tests/e2e/csi_static_provisioning_file_basic.go
+++ b/tests/e2e/csi_static_provisioning_file_basic.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
+
+	"strings"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"github.com/vmware/govmomi/cns"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	vsanfstypes "github.com/vmware/govmomi/vsan/vsanfs/types"
+	v1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+)
+
+var _ = ginkgo.Describe("[csi-file-vanilla] Basic File Volume Static Provisioning", func() {
+	f := framework.NewDefaultFramework("e2e-csifilestaticprovision")
+
+	var (
+		client            clientset.Interface
+		datastoreURL      string
+		defaultDatacenter *object.Datacenter
+		defaultDatastore  *object.Datastore
+		namespace         string
+		pv                *v1.PersistentVolume
+		pvc               *v1.PersistentVolumeClaim
+	)
+
+	ginkgo.BeforeEach(func() {
+		bootstrap()
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		var datacenters []string
+		datastoreURL = GetAndExpectStringEnvVar(fileServiceEnabledDatastore)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		finder := find.NewFinder(e2eVSphere.Client.Client, false)
+		cfg, err := getConfig()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		dcList := strings.Split(cfg.Global.Datacenters, ",")
+		for _, dc := range dcList {
+			dcName := strings.TrimSpace(dc)
+			if dcName != "" {
+				datacenters = append(datacenters, dcName)
+			}
+		}
+
+		for _, dc := range datacenters {
+			defaultDatacenter, err = finder.Datacenter(ctx, dc)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			finder.SetDatacenter(defaultDatacenter)
+			defaultDatastore, err = getDatastoreByURL(ctx, datastoreURL, defaultDatacenter)
+			if err == nil {
+				break
+			}
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Datastore is not found in the datacenter list")
+	})
+
+	/*
+		This test verifies the static provisioning workflow.
+
+		Test Steps:
+		1. Create File share and get the file share id.
+		2. Create PV Spec with volumeID set to file share ID created in Step-1, and PersistentVolumeReclaimPolicy is set to Delete.
+		3. Create PVC with the storage request set to PV's storage capacity.
+		4. Wait for PV and PVC to bound.
+		5. Create a POD.
+		6. Verify volume is attached to the node and volume is accessible in the pod by creating a file inside volume.
+		7. Verify container volume metadata is present in CNS cache.
+		8. Delete POD.
+		9. Delete PVC.
+		10. Verify PV is deleted automatically.
+	*/
+	ginkgo.It("Verify basic static provisioning workflow", func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ginkgo.By("Creating file share")
+		task, err := e2eVSphere.createCnsVolume(ctx, []cnstypes.CnsVolumeCreateSpec{*getFileShareCreateSpec(defaultDatastore.Reference())})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		taskInfo, err := cns.GetTaskInfo(ctx, task)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		fileShareVolumeID := taskResult.GetCnsVolumeOperationResult().VolumeId.Id
+
+		// Deleting the volume with deleteDisk set to false
+		ginkgo.By("Deleting the fileshare with deleteDisk set to false")
+		task, err = e2eVSphere.deleteCnsVolume(ctx, fileShareVolumeID, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		taskInfo, err = cns.GetTaskInfo(ctx, task)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		_, err = cns.GetTaskResult(ctx, taskInfo)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		staticPVLabels := make(map[string]string)
+		staticPVLabels["fileshare-id"] = strings.TrimPrefix(fileShareVolumeID, "file:")
+
+		ginkgo.By("Creating the PV")
+		pv = getPersistentVolumeSpecForFileShare(fileShareVolumeID, v1.PersistentVolumeReclaimDelete, staticPVLabels, v1.ReadOnlyMany)
+		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
+		if err != nil {
+			return
+		}
+		err = e2eVSphere.waitForCNSVolumeToBeCreated(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Creating the PVC")
+		pvc = getPersistentVolumeClaimSpecForFileShare(namespace, staticPVLabels, v1.ReadOnlyMany)
+		pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Wait for PV and PVC to Bind
+		framework.ExpectNoError(fpv.WaitOnPVandPVC(client, namespace, pv, pvc))
+
+		defer func() {
+			ginkgo.By("Deleting the PV Claim")
+			framework.ExpectNoError(fpv.DeletePersistentVolumeClaim(client, pvc.Name, namespace), "Failed to delete PVC", pvc.Name)
+			ginkgo.By("Verify PV should be deleted automatically")
+			framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
+
+			ginkgo.By("Verify fileshare volume got deleted")
+			framework.ExpectNoError(e2eVSphere.waitForCNSVolumeToBeDeleted(fileShareVolumeID))
+		}()
+
+		ginkgo.By("Creating the Pod")
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaims = append(pvclaims, pvc)
+		pod, err := fpod.CreatePod(client, namespace, nil, pvclaims, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		fmt.Printf("Pod creation successful.")
+
+		defer func() {
+			ginkgo.By("Deleting the Pod")
+			framework.ExpectNoError(fpod.DeletePodWithWait(client, pod), "Failed to delete pod", pod.Name)
+		}()
+
+		ginkgo.By("Verify the volume is accessible and available to the pod by creating an empty file")
+		filepath := filepath.Join("/mnt/volume1", "/emptyFile.txt")
+		_, err = framework.LookForStringInPodExec(namespace, pod.Name, []string{"/bin/touch", filepath}, "", time.Minute)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify container volume metadata is matching the one in CNS cache")
+		err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle, pvc.Name, pv.ObjectMeta.Name, pod.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	})
+})
+
+func getFileShareCreateSpec(datastore types.ManagedObjectReference) *cnstypes.CnsVolumeCreateSpec {
+	netPermissions := vsanfstypes.VsanFileShareNetPermission{
+		Ips:         "*",
+		Permissions: vsanfstypes.VsanFileShareAccessTypeREAD_WRITE,
+		AllowRoot:   true,
+	}
+	containerCluster := &cnstypes.CnsContainerCluster{
+		ClusterType:   string(cnstypes.CnsClusterTypeKubernetes),
+		ClusterId:     e2eVSphere.Config.Global.ClusterID,
+		VSphereUser:   e2eVSphere.Config.Global.User,
+		ClusterFlavor: string(cnstypes.CnsClusterFlavorVanilla),
+	}
+	var containerClusterArray []cnstypes.CnsContainerCluster
+	containerClusterArray = append(containerClusterArray, *containerCluster)
+	createSpec := &cnstypes.CnsVolumeCreateSpec{
+		Name:       "testFileSharex",
+		VolumeType: common.FileVolumeType,
+		Datastores: []types.ManagedObjectReference{datastore},
+		BackingObjectDetails: &cnstypes.CnsVsanFileShareBackingDetails{
+			CnsFileBackingDetails: cnstypes.CnsFileBackingDetails{
+				CnsBackingObjectDetails: cnstypes.CnsBackingObjectDetails{
+					CapacityInMb: fileSizeInMb,
+				},
+			},
+		},
+		Metadata: cnstypes.CnsVolumeMetadata{
+			ContainerCluster:      *containerCluster,
+			ContainerClusterArray: containerClusterArray,
+		},
+		CreateSpec: &cnstypes.CnsVSANFileCreateSpec{
+			SoftQuotaInMb: fileSizeInMb,
+			Permission:    []vsanfstypes.VsanFileShareNetPermission{netPermissions},
+		},
+	}
+	return createSpec
+}

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -64,6 +64,8 @@ const (
 	ext3FSType                                 = "ext3"
 	ext4FSType                                 = "ext4"
 	fcdName                                    = "BasicStaticFCD"
+	fileServiceEnabledDatastore                = "FILE_SERVICE_ENABLED_DATASTORE"
+	fileSizeInMb                               = int64(2048)
 	healthGreen                                = "green"
 	healthRed                                  = "red"
 	healthStatusAccessible                     = "accessible"

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -56,6 +56,46 @@ const (
 	virtualDiskUUID = "virtualDiskUUID"
 )
 
+func (vs *vSphere) createCnsVolume(ctx context.Context, createSpecList []cnstypes.CnsVolumeCreateSpec) (*object.Task, error) {
+	connect(ctx, vs)
+	err := connectCns(ctx, vs)
+	if err != nil {
+		return nil, err
+	}
+	req := cnstypes.CnsCreateVolume{
+		This:        cnsVolumeManagerInstance,
+		CreateSpecs: createSpecList,
+	}
+	res, err := cnsmethods.CnsCreateVolume(ctx, vs.CnsClient.Client, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(vs.Client.Client, res.Returnval), nil
+}
+
+func (vs *vSphere) deleteCnsVolume(ctx context.Context, fileShareID string, delete bool) (*object.Task, error) {
+	connect(ctx, vs)
+	err := connectCns(ctx, vs)
+	if err != nil {
+		return nil, err
+	}
+	var cnsVolumeIDList []cnstypes.CnsVolumeId
+	cnsVolumeID := cnstypes.CnsVolumeId{
+		Id: fileShareID,
+	}
+	cnsVolumeIDList = append(cnsVolumeIDList, cnsVolumeID)
+	req := cnstypes.CnsDeleteVolume{
+		This:       cnsVolumeManagerInstance,
+		VolumeIds:  cnsVolumeIDList,
+		DeleteDisk: delete,
+	}
+	res, err := cnsmethods.CnsDeleteVolume(ctx, vs.CnsClient.Client, &req)
+	if err != nil {
+		return nil, err
+	}
+	return object.NewTask(vs.Client.Client, res.Returnval), nil
+}
+
 // queryCNSVolumeWithResult Call CnsQueryVolume and returns CnsQueryResult to client
 func (vs *vSphere) queryCNSVolumeWithResult(fcdID string) (*cnstypes.CnsQueryResult, error) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
To Verify Pod can be created with statically provisioned fileshare

TDS : https://confluence.eng.vmware.com/display/CNAS/Test+Design+Spec+-+File+CSI Mount/Unmount Volume Test Case No. 4

1. Create File share and get the file share id.
2. Create PV Spec with volumeID set to file share ID created in Step-1, and PersistentVolumeReclaimPolicy is set to Delete.
3. Create PVC with the storage request set to PV's storage capacity.
4. Wait for PV and PVC to bound.
5. Create a POD.
6. Verify volume is attached to the node and volume is accessible in the pod by creating a file inside volume.
7. Verify container volume metadata is present in CNS cache.
8. Delete POD.
9. Delete PVC.
10. Verify PV is deleted automatically.