### PR TITLE
Handle volume creation failure in cnsregistervolume controller

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -201,11 +201,15 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(request reconcile.Request) (recon
 	log.Debugf("CNS Volume create spec is: %+v", createSpec)
 	vol, err := r.volumeManager.CreateVolume(ctx, createSpec)
 	if err != nil {
-		volumeID = instance.Spec.VolumeID
-	} else {
-		volumeID = vol.Id
-		log.Infof("Created CNS volume with volumeID: %s", volumeID)
+		msg := "failed to create CNS volume"
+		log.Errorf(msg)
+		setInstanceError(ctx, r, instance, msg)
+		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
+
+	volumeID = vol.Id
+	log.Infof("Created CNS volume with volumeID: %s", volumeID)
+
 	pvName = staticPvNamePrefix + volumeID
 	// Query volume
 	log.Infof("Querying volume: %s for CnsRegisterVolume request with name: %q on namespace: %q",

--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -1115,7 +1115,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		ginkgo.By("Verify the error message, when vsanhealth is down")
 		cnsRegisterVolume = getCNSRegistervolume(ctx, restConfig, cnsRegisterVolume)
 		actualErrorMsg := cnsRegisterVolume.Status.Error
-		expectedErrorMsg := "Unable to find the volume in CNS"
+		expectedErrorMsg := "failed to create CNS volume"
 		if actualErrorMsg != expectedErrorMsg {
 			log.Errorf("Expected error message : ", expectedErrorMsg)
 			log.Errorf("Actual error message : ", actualErrorMsg)
@@ -1204,7 +1204,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		ginkgo.By("Verify the error message, when SPSService is down, CRD should not be successful")
 		cnsRegisterVolume = getCNSRegistervolume(ctx, restConfig, cnsRegisterVolume)
 		actualErrorMsg := cnsRegisterVolume.Status.Error
-		expectedErrorMsg := "CNS Volume: " + fcdID + " not found"
+		expectedErrorMsg := "failed to create CNS volume"
 		if actualErrorMsg != expectedErrorMsg {
 			log.Errorf("Expected error message : ", expectedErrorMsg)
 			log.Errorf("Actual error message : ", actualErrorMsg)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds error handling in CnsRegisterVolume controller if volume manager fails volume creation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This change is dependent on a CNS api change to throw CnsAlreadyRegisteredFault for all already existing volumes(both FCD and VMDK-based)
If CNS throws that error, then volume manager handles it (see code snippet below). This way, all other kinds of volume creation errors can be appropriately recorded in CnsRegisterVolume controller.
https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/fefbcaf73db7de9c946814958cd3d806a4fc1f8c/pkg/common/cns-lib/volume/manager.go#L217-L223



Tested with a sandbox VC build that contains the upstream CNS change. Notice the syncer logs capturing `CreateVolume: Volume is already registered with CNS. VolumeName:...` for an existing FCD volume.

```
root@4211b62565b9d9ac73c8380603f7a368 [ ~/manifests ]# kubectl apply -f cns-rv.yaml -n playground-ns
cnsregistervolume.cns.vmware.com/import-db created

root@4211b62565b9d9ac73c8380603f7a368 [ ~/manifests ]# kubectl get pvc -n playground-ns
NAME                        STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS                AGE
static-pvc                  Bound    static-pv-1c4bb12e-fcc8-4202-901a-1ee0b3c1da57   1Gi        RWO            wcpglobal-storage-profile   4m17s
```

Syncer logs:
```
{"level":"info","time":"2020-10-19T22:12:16.283779731Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:168","msg":"Reconciling CnsRegisterVolume with instance: \"import-db\" from namespace: \"playground-ns\". timeout \"1s\" seconds","TraceId":"e4744f52-8ce4-48ec-95fa-e44533c720d6"}
.
.
{"level":"info","time":"2020-10-19T22:12:16.452139286Z","caller":"volume/manager.go:201","msg":"CreateVolume: VolumeName: \"static-pv-1c4bb12e-fcc8-4202-901a-1ee0b3c1da57\", opId: \"6205b7e4\"","TraceId":"e4744f52-8ce4-48ec-95fa-e44533c720d6"}
{"level":"info","time":"2020-10-19T22:12:16.452212908Z","caller":"volume/manager.go:219","msg":"CreateVolume: Volume is already registered with CNS. VolumeName: \"static-pv-1c4bb12e-fcc8-4202-901a-1ee0b3c1da57\", volumeID: \"1c4bb12e-fcc8-4202-901a-1ee0b3c1da57\", opId: \"6205b7e4\"","TraceId":"e4744f52-8ce4-48ec-95fa-e44533c720d6"}
{"level":"info","time":"2020-10-19T22:12:16.452224183Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:211","msg":"Created CNS volume with volumeID: 1c4bb12e-fcc8-4202-901a-1ee0b3c1da57","TraceId":"e4744f52-8ce4-48ec-95fa-e44533c720d6"}
.
.
{"level":"info","time":"2020-10-19T22:12:29.538267901Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:378","msg":"Successfully registered the volume on namespace: playground-ns","TraceId":"e4744f52-8ce4-48ec-95fa-e44533c720d6"}
```

Please note if CSI contains this change, and CNS doesn't have the corresponding change, static volume provisioning in WCP will fail for FCD-based volumes.

Tests run:
Ran CNSRegisterVolume tests with updated test cases on a sandboxed VC build with related CNS changes.
Out of 11, 9 passed in the first run. The other 2 passed in the subsequent run.
Gist - https://gist.github.com/gohilankit/ebe458a94bf374b893e36afe1f501159

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Handle volume creation failure in cnsregistervolume controller
```