### PR TITLE
Fix metadatasyncer ReloadConfiguration() to use the same VC instance

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -208,7 +208,7 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(request reconcile.Request) (rec
 	}
 	// Get node VM by nodeUUID
 	var dc *vsphere.Datacenter
-	vcenter, err := types.GetVirtualCenterInstance(ctx, r.configInfo)
+	vcenter, err := types.GetVirtualCenterInstance(ctx, r.configInfo, false)
 	if err != nil {
 		msg := fmt.Sprintf("failed to get virtual center instance with error: %v", err)
 		instance.Status.Error = err.Error()

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -183,7 +183,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
 
-	vc, err := types.GetVirtualCenterInstance(ctx, r.configInfo)
+	vc, err := types.GetVirtualCenterInstance(ctx, r.configInfo, false)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to get virtual center instance with error: %+v", err)
 		log.Error(msg)

--- a/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
@@ -304,7 +304,7 @@ func (r *ReconcileCnsVolumeMetadata) Reconcile(request reconcile.Request) (recon
 func (r *ReconcileCnsVolumeMetadata) updateCnsMetadata(ctx context.Context, instance *cnsv1alpha1.CnsVolumeMetadata, deleteFlag bool) bool {
 	log := logger.GetLogger(ctx)
 	log.Debugf("ReconcileCnsVolumeMetadata: Calling updateCnsMetadata for instance %q with delete flag %v", instance.Name, deleteFlag)
-	vCenter, err := types.GetVirtualCenterInstance(ctx, r.configInfo)
+	vCenter, err := types.GetVirtualCenterInstance(ctx, r.configInfo, false)
 	if err != nil {
 		log.Errorf("ReconcileCnsVolumeMetadata: Failed to get virtual center instance. Err: %v", err)
 		return false

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -60,7 +60,7 @@ func InitCnsOperator(configInfo *types.ConfigInfo) error {
 	log.Infof("Initializing CNS Operator")
 	cnsOperator := &cnsOperator{}
 	cnsOperator.configInfo = configInfo
-	vCenter, err := types.GetVirtualCenterInstance(ctx, cnsOperator.configInfo)
+	vCenter, err := types.GetVirtualCenterInstance(ctx, cnsOperator.configInfo, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -18,6 +18,7 @@ package syncer
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -152,7 +153,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 	} else {
 		// Initialize volume manager with vcenter credentials
 		// if metadata syncer is being intialized for Vanilla or Supervisor clusters
-		vCenter, err := types.GetVirtualCenterInstance(ctx, configInfo)
+		vCenter, err := types.GetVirtualCenterInstance(ctx, configInfo, false)
 		if err != nil {
 			return err
 		}
@@ -182,8 +183,11 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				log.Debugf("fsnotify event: %q", event.String())
 				if event.Op&fsnotify.Remove == fsnotify.Remove {
 					log.Infof("Reloading Configuration")
-					ReloadConfiguration(ctx, metadataSyncer)
-					log.Infof("Successfully reloaded configuration from: %q", cfgPath)
+					if err := ReloadConfiguration(ctx, metadataSyncer); err != nil {
+						log.Errorf("failed to reload configuration from: %q. Current configuration unchanged.", cfgPath)
+					} else {
+						log.Infof("Successfully reloaded configuration from: %q", cfgPath)
+					}
 				}
 			case err, ok := <-watcher.Errors:
 				if !ok {
@@ -335,63 +339,68 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 }
 
 // ReloadConfiguration reloads configuration from the secret, and update controller's cached configs
-func ReloadConfiguration(ctx context.Context, metadataSyncer *metadataSyncInformer) {
+func ReloadConfiguration(ctx context.Context, metadataSyncer *metadataSyncInformer) error {
 	log := logger.GetLogger(ctx)
 	cfg, err := common.GetConfig(ctx)
 	if err != nil {
-		log.Errorf("failed to read config. Error: %+v", err)
-		return
+		msg := fmt.Sprintf("failed to read config. Error: %+v", err)
+		log.Error(msg)
+		return errors.New(msg)
 	}
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		var err error
 		restClientConfig := k8s.GetRestClientConfigForSupervisor(ctx, cfg.GC.Endpoint, metadataSyncer.configInfo.Cfg.GC.Port)
 		metadataSyncer.cnsOperatorClient, err = k8s.NewClientForGroup(ctx, restClientConfig, cnsoperatorv1alpha1.GroupName)
 		if err != nil {
-			log.Errorf("failed to create cns operator client. Err: %v", err)
-			return
+			msg := fmt.Sprintf("failed to create cns operator client. Err: %v", err)
+			log.Error(msg)
+			return errors.New(msg)
 		}
 
 		metadataSyncer.supervisorClient, err = k8s.NewSupervisorClient(ctx, restClientConfig)
 		if err != nil {
-			log.Errorf("Failed to create supervisorClient. Error: %+v", err)
-			return
+			msg := fmt.Sprintf("failed to create supervisorClient. Error: %+v", err)
+			log.Error(msg)
+			return errors.New(msg)
 		}
 	} else {
 		newVCConfig, err := cnsvsphere.GetVirtualCenterConfig(ctx, cfg)
 		if err != nil {
-			log.Errorf("failed to get VirtualCenterConfig. err=%v", err)
-			return
+			msg := fmt.Sprintf("failed to get VirtualCenterConfig. err=%v", err)
+			log.Error(msg)
+			return errors.New(msg)
 		}
 		if newVCConfig != nil {
 			var vcenter *cnsvsphere.VirtualCenter
 			if metadataSyncer.configInfo.Cfg.Global.VCenterIP != newVCConfig.Host ||
 				metadataSyncer.configInfo.Cfg.Global.User != newVCConfig.Username ||
 				metadataSyncer.configInfo.Cfg.Global.Password != newVCConfig.Password {
-				vcManager := cnsvsphere.GetVirtualCenterManager(ctx)
-				log.Debugf("Unregistering virtual center: %q from virtualCenterManager", metadataSyncer.configInfo.Cfg.Global.VCenterIP)
-				err = vcManager.UnregisterAllVirtualCenters(ctx)
-				if err != nil {
-					log.Errorf("failed to unregister vcenter with virtualCenterManager.")
-					return
+
+				// Verify if new configuration has valid credentials by connecting to vCenter.
+				// Proceed only if the connection succeeds, else return error.
+				newVC := &cnsvsphere.VirtualCenter{Config: newVCConfig}
+				if err = newVC.Connect(ctx); err != nil {
+					msg := fmt.Sprintf("failed to connect to VirtualCenter host: %s using new credentials, Err: %+v", newVCConfig.Host, err)
+					log.Error(msg)
+					return errors.New(msg)
 				}
-				log.Debugf("Registering virtual center: %q with virtualCenterManager", newVCConfig.Host)
-				vcenter, err = vcManager.RegisterVirtualCenter(ctx, newVCConfig)
+
+				// Reset virtual center singleton instance by passing reload flag as true
+				log.Info("Obtaining new vCenterInstance using new credentials")
+				vcenter, err = types.GetVirtualCenterInstance(ctx, &types.ConfigInfo{Cfg: cfg}, true)
 				if err != nil {
-					log.Errorf("failed to register VC with virtualCenterManager. err=%v", err)
-					return
-				}
-				// connect to vCenter using new config to ensure new configuration has
-				// valid credentials
-				err := vcenter.Connect(ctx)
-				if err != nil {
-					log.Errorf("Failed to connect to VirtualCenter with new config. err=%v", err)
-					return
+					msg := fmt.Sprintf("failed to get VirtualCenter. err=%v", err)
+					log.Error(msg)
+					return errors.New(msg)
 				}
 			} else {
-				vcenter, err = types.GetVirtualCenterInstance(ctx, &types.ConfigInfo{Cfg: cfg})
+				// If it's not a VC host or VC credentials update, same singleton instance can be used
+				// and it's Config field can be updated
+				vcenter, err = types.GetVirtualCenterInstance(ctx, &types.ConfigInfo{Cfg: cfg}, false)
 				if err != nil {
-					log.Errorf("failed to get VirtualCenter. err=%v", err)
-					return
+					msg := fmt.Sprintf("failed to get VirtualCenter. err=%v", err)
+					log.Error(msg)
+					return errors.New(msg)
 				}
 				vcenter.Config = newVCConfig
 			}
@@ -406,6 +415,7 @@ func ReloadConfiguration(ctx context.Context, metadataSyncer *metadataSyncInform
 			log.Infof("updated metadataSyncer.configInfo")
 		}
 	}
+	return nil
 }
 
 // pvcUpdated updates persistent volume claim metadata on VC when pvc labels on K8S cluster have been updated

--- a/pkg/syncer/storagepool/service.go
+++ b/pkg/syncer/storagepool/service.go
@@ -75,7 +75,7 @@ func InitStoragePoolService(ctx context.Context, configInfo *commontypes.ConfigI
 	}
 
 	// Get VC connection
-	vc, err := commontypes.GetVirtualCenterInstance(ctx, configInfo)
+	vc, err := commontypes.GetVirtualCenterInstance(ctx, configInfo, false)
 	if err != nil {
 		log.Errorf("Failed to get vCenter from ConfigInfo. Err: %+v", err)
 		return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR has following changes:
1. Replace Once.Do() pattern in GetVirtualCenterInstance method, as we cannot reload the VC configuration using Once.Do().
Add a boolean flag to this method to indicate if we want to establish a new VC connection, and discard the old instance.

2. Change ReloadConfiguration() in metadatasyncer to use the same VC instance. 
Currently, if we change configuration for VC host or VC creds, ReloadConfiguration creates a new VC instance which is not being shared across the application. The other callers to GetVirtualCenterInstance in commontypes.go would still see an instance with old credentials.

3.ReloadConfiguration() returns an error instead of silently returning earlier. The caller of this function handles it now.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Manually tested and verified the memory location of VC instances in the below flow. Please note the memory address of VC instance in below debug logs

Current behavior
```
1. InitMetadatasyncer (initializes the VC instance in GetVirtualCenterInstance)
{"level":"debug","time":"2020-10-29T18:41:18.446884833Z","caller":"syncer/metadatasyncer.go:175","msg":"VCInstance details - Address:0xc0007a4ea0}

2. Invoke CNSRegisterVolume (should use the same instance)
{"level":"debug","time":"2020-10-29T18:45:17.714768815Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:187","msg":"VCInstance details - Address:0xc0007a4ea0}

3. ReloadConfiguration (update secret to have new VC credentials)
{"level":"debug","time":"2020-10-29T20:02:42.962493013Z","caller":"syncer/metadatasyncer.go:410","msg":"VCInstance details - Address:0xc000e3e6c0}

4. Invoke CNSRegisterVolume (should have used the new instance, but it's still pointing to the old instance)
{"level":"debug","time":"2020-10-29T20:10:58.801131323Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:187","msg":"VCInstance details - Address:0xc0007a4ea0}
```


New behavior
```
1. InitMetadatasyncer (initializes the VC instance in GetVirtualCenterInstance)
{"level":"debug","time":"2020-10-30T01:16:10.622767598Z","caller":"syncer/metadatasyncer.go:175","msg":"VCInstance details - Address:0xc00057dfb0}

2. Invoke CNSRegisterVolume (should use the same instance)
{"level":"debug","time":"2020-10-30T01:20:09.417888934Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:187","msg":"VCInstance details - Address:0xc00057dfb0}

3. ReloadConfiguration (update secret to have new VC credentials)
{"level":"debug","time":"2020-10-30T02:09:04.120223862Z","caller":"syncer/metadatasyncer.go:402","msg":"VCInstance details - Address:0xc0006f0ba0}

4. Invoke CNSRegisterVolume (using the new instance)
{"level":"debug","time":"2020-10-30T02:42:03.970826626Z","caller":"cnsregistervolume/cnsregistervolume_controller.go:187","msg":"VCInstance details - Address:0xc0006f0ba0}
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix metadatasyncer ReloadConfiguration() to use the same VC instance
```
