### PR TITLE
Cherry pick recent commits to 2.1 branch

### DIFF
--- a/docs/book/features/block_volume.md
+++ b/docs/book/features/block_volume.md
@@ -250,6 +250,8 @@ There are many ways to create static PV and PVC binding. Example: Label matching
 
 Static Volume Provisioning is supported only in Vanilla Kubernetes clusters but not in Supervisor clusters
 
+**NOTE:** For Block volumes, vSphere Cloud Native Storage (CNS) only allows one PV in the Kubernetes cluster to refer to a storage disk. Creating multiple PV's using the same Block Volume Handle is not supported.
+
 ### Use Cases of Static Provisioning<a id="static_volume_provisioning_use_case"></a>
 
 Following are the common use cases for static volume provisioning:

--- a/docs/book/features/file_volume.md
+++ b/docs/book/features/file_volume.md
@@ -179,3 +179,5 @@ spec:
 ```
 
 The `labels` key-value pair `static-pv-label-key: static-pv-label-value` used in PV `metadata` and PVC `selector` aid in matching the PVC to the PV during static provisioning. Also, remember to retain the `file:` prefix of the vSAN file share while filling up the `volumeHandle` field in PV spec.
+
+**NOTE:** For File volumes, CNS supports multiple PV's referring to the same file-share volume.

--- a/example/vanilla-k8s-block-driver/vsphere.conf
+++ b/example/vanilla-k8s-block-driver/vsphere.conf
@@ -1,5 +1,6 @@
 [Global]
 cluster-id = "unique-kubernetes-cluster-id"
+volumemigration-cr-cleanup-intervalinmin = "120"
 
 [VirtualCenter "1.2.3.4"]
 insecure-flag = "true"

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -62,6 +62,10 @@ const (
 	// interval after which successful CnsRegisterVolumes will be cleaned up.
 	// Current default value is set to 12 hours
 	DefaultCnsRegisterVolumesCleanupIntervalInMin = 720
+	// DefaultVolumeMigrationCRCleanupIntervalInMin is the default time
+	// interval after which stale CnsVSphereVolumeMigration CRs will be cleaned up.
+	// Current default value is set to 2 hours
+	DefaultVolumeMigrationCRCleanupIntervalInMin = 120
 )
 
 // Errors
@@ -328,6 +332,9 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 	}
 	if cfg.Global.CnsRegisterVolumesCleanupIntervalInMin == 0 {
 		cfg.Global.CnsRegisterVolumesCleanupIntervalInMin = DefaultCnsRegisterVolumesCleanupIntervalInMin
+	}
+	if cfg.Global.VolumeMigrationCRCleanupIntervalInMin == 0 {
+		cfg.Global.VolumeMigrationCRCleanupIntervalInMin = DefaultVolumeMigrationCRCleanupIntervalInMin
 	}
 	return nil
 }

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -43,6 +43,9 @@ type Config struct {
 		// CnsRegisterVolumesCleanupIntervalInMin specifies the interval after which
 		// successful CnsRegisterVolumes will be cleaned up.
 		CnsRegisterVolumesCleanupIntervalInMin int `gcfg:"cnsregistervolumes-cleanup-intervalinmin"`
+		// VolumeMigrationCRCleanupIntervalInMin specifies the interval after which
+		// stale CnsVSphereVolumeMigration CRs will be cleaned up.
+		VolumeMigrationCRCleanupIntervalInMin int `gcfg:"volumemigration-cr-cleanup-intervalinmin"`
 		// VCClientTimeout specifies a time limit in minutes for requests made by client
 		// If not set, default will be 5 minutes
 		VCClientTimeout int `gcfg:"vc-client-timeout"`

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -210,7 +210,7 @@ func (c *controller) Init(config *cnsconfig.Config) error {
 	deletedVolumes = timedmap.New(1 * time.Minute)
 	if containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
 		log.Info("CSI Migration Feature is Enabled. Loading Volume Migration Service")
-		volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &c.manager.VolumeManager, config)
+		volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &c.manager.VolumeManager, config, false)
 		if err != nil {
 			log.Errorf("failed to get migration service. Err: %v", err)
 			return err
@@ -861,7 +861,7 @@ func initVolumeMigrationService(ctx context.Context, c *controller) error {
 	}
 	// In case if feature state switch is enabled after controller is deployed, we need to initialize the volumeMigrationService
 	var err error
-	volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &c.manager.VolumeManager, c.manager.CnsConfig)
+	volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &c.manager.VolumeManager, c.manager.CnsConfig, false)
 	if err != nil {
 		msg := fmt.Sprintf("failed to get migration service. Err: %v", err)
 		log.Error(msg)

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -98,16 +98,16 @@ func csiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) {
 		log.Errorf("FullSync: failed to queryAllVolume with err %+v", err)
 		return
 	}
-	// get map of "pv to EntityMetadata" in CNS and "pv to EntityMetadata" in kubernetes
-	pvToCnsEntityMetadataMap, pvToK8sEntityMetadataMap, err := fullSyncGetEntityMetadata(ctx, k8sPVs, queryAllResult.Volumes, pvToPVCMap, pvcToPodMap, metadataSyncer, migrationFeatureStateForFullSync)
+	// get map of "volume to EntityMetadata" in CNS and "volume to EntityMetadata" in kubernetes
+	volumeToCnsEntityMetadataMap, volumeToK8sEntityMetadataMap, err := fullSyncGetEntityMetadata(ctx, k8sPVs, queryAllResult.Volumes, pvToPVCMap, pvcToPodMap, metadataSyncer, migrationFeatureStateForFullSync)
 	if err != nil {
 		log.Errorf("FullSync: fullSyncGetEntityMetadata failed with err %+v", err)
 		return
 	}
-	log.Debugf("FullSync: pvToCnsEntityMetadataMap %+v \n pvToK8sEntityMetadataMap: %+v \n", spew.Sdump(pvToCnsEntityMetadataMap), spew.Sdump(pvToK8sEntityMetadataMap))
+	log.Debugf("FullSync: pvToCnsEntityMetadataMap %+v \n pvToK8sEntityMetadataMap: %+v \n", spew.Sdump(volumeToCnsEntityMetadataMap), spew.Sdump(volumeToK8sEntityMetadataMap))
 	// Get specs for create and update volume calls
 	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor)
-	createSpecArray, updateSpecArray := fullSyncGetVolumeSpecs(ctx, k8sPVs, pvToCnsEntityMetadataMap, pvToK8sEntityMetadataMap, containerCluster, metadataSyncer, migrationFeatureStateForFullSync)
+	createSpecArray, updateSpecArray := fullSyncGetVolumeSpecs(ctx, k8sPVs, volumeToCnsEntityMetadataMap, volumeToK8sEntityMetadataMap, containerCluster, metadataSyncer, migrationFeatureStateForFullSync)
 	volToBeDeleted, err := getVolumesToBeDeleted(ctx, queryAllResult.Volumes, k8sPVMap, metadataSyncer, migrationFeatureStateForFullSync)
 	if err != nil {
 		log.Errorf("FullSync: failed to get list of volumes to be deleted with err %+v", err)
@@ -307,12 +307,12 @@ func buildCnsMetadataList(ctx context.Context, pv *v1.PersistentVolume, pvToPVCM
 	return metadataList
 }
 
-// fullSyncGetEntityMetadata builds and return map of pv to EntityMetadata in CNS (pvToCnsEntityMetadataMap) and
-// map of pv to EntityMetadata in kubernetes (pvToK8sEntityMetadataMap)
+// fullSyncGetEntityMetadata builds and return map of volume to EntityMetadata in CNS (volumeToCnsEntityMetadataMap)
+// and map of volume to EntityMetadata in kubernetes (volumeToK8sEntityMetadataMap)
 func fullSyncGetEntityMetadata(ctx context.Context, pvList []*v1.PersistentVolume, cnsVolumeList []cnstypes.CnsVolume, pvToPVCMap pvcMap, pvcToPodMap podMap, metadataSyncer *metadataSyncInformer, migrationFeatureStateForFullSync bool) (map[string][]cnstypes.BaseCnsEntityMetadata, map[string][]cnstypes.BaseCnsEntityMetadata, error) {
 	log := logger.GetLogger(ctx)
-	pvToCnsEntityMetadataMap := make(map[string][]cnstypes.BaseCnsEntityMetadata)
-	pvToK8sEntityMetadataMap := make(map[string][]cnstypes.BaseCnsEntityMetadata)
+	volumeToCnsEntityMetadataMap := make(map[string][]cnstypes.BaseCnsEntityMetadata)
+	volumeToK8sEntityMetadataMap := make(map[string][]cnstypes.BaseCnsEntityMetadata)
 	cnsVolumeMap := make(map[string]bool)
 
 	for _, vol := range cnsVolumeList {
@@ -336,7 +336,11 @@ func fullSyncGetEntityMetadata(ctx context.Context, pvList []*v1.PersistentVolum
 			// Do nothing for other cases
 			continue
 		}
-		pvToK8sEntityMetadataMap[volumeHandle] = k8sMetadata
+		if metadata, ok := volumeToK8sEntityMetadataMap[volumeHandle]; ok {
+			volumeToK8sEntityMetadataMap[volumeHandle] = append(k8sMetadata, metadata...)
+		} else {
+			volumeToK8sEntityMetadataMap[volumeHandle] = k8sMetadata
+		}
 		if cnsVolumeMap[volumeHandle] {
 			// PV exist in both K8S and CNS cache, add to queryVolumeIds list to check if metadata has been
 			// changed or not
@@ -347,7 +351,7 @@ func fullSyncGetEntityMetadata(ctx context.Context, pvList []*v1.PersistentVolum
 	// volumes in the queryFilter.VolumeIds should be one which is present in both k8s and in CNS.
 	if len(queryVolumeIds) == 0 {
 		log.Warn("could not find any volume which is present in both k8s and in CNS")
-		return pvToCnsEntityMetadataMap, pvToK8sEntityMetadataMap, nil
+		return volumeToCnsEntityMetadataMap, volumeToK8sEntityMetadataMap, nil
 	}
 	allQueryResults, err := fullSyncGetQueryResults(ctx, queryVolumeIds, metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.volumeManager)
 	if err != nil {
@@ -364,15 +368,15 @@ func fullSyncGetEntityMetadata(ctx context.Context, pvList []*v1.PersistentVolum
 					cnsMetadata = append(cnsMetadata, metadata)
 				}
 			}
-			pvToCnsEntityMetadataMap[volume.VolumeId.Id] = cnsMetadata
+			volumeToCnsEntityMetadataMap[volume.VolumeId.Id] = cnsMetadata
 		}
 	}
-	return pvToCnsEntityMetadataMap, pvToK8sEntityMetadataMap, nil
+	return volumeToCnsEntityMetadataMap, volumeToK8sEntityMetadataMap, nil
 }
 
 // fullSyncGetVolumeSpecs return list of CnsVolumeCreateSpec for volumes which needs to be created in CNS and a list of
 // CnsVolumeMetadataUpdateSpec for volumes which needs to be updated in CNS.
-func fullSyncGetVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, pvToCnsEntityMetadataMap map[string][]cnstypes.BaseCnsEntityMetadata, pvToK8sEntityMetadataMap map[string][]cnstypes.BaseCnsEntityMetadata, containerCluster cnstypes.CnsContainerCluster, metadataSyncer *metadataSyncInformer, migrationFeatureStateForFullSync bool) ([]cnstypes.CnsVolumeCreateSpec, []cnstypes.CnsVolumeMetadataUpdateSpec) {
+func fullSyncGetVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, volumeToCnsEntityMetadataMap map[string][]cnstypes.BaseCnsEntityMetadata, volumeToK8sEntityMetadataMap map[string][]cnstypes.BaseCnsEntityMetadata, containerCluster cnstypes.CnsContainerCluster, metadataSyncer *metadataSyncInformer, migrationFeatureStateForFullSync bool) ([]cnstypes.CnsVolumeCreateSpec, []cnstypes.CnsVolumeMetadataUpdateSpec) {
 	log := logger.GetLogger(ctx)
 	var createSpecArray []cnstypes.CnsVolumeCreateSpec
 	var updateSpecArray []cnstypes.CnsVolumeMetadataUpdateSpec
@@ -391,8 +395,8 @@ func fullSyncGetVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, 
 		} else {
 			volumeHandle = pv.Spec.CSI.VolumeHandle
 		}
-		pvToCnsEntityMetadata, presentInCNS := pvToCnsEntityMetadataMap[volumeHandle]
-		pvToK8sEntityMetadata, presentInK8S := pvToK8sEntityMetadataMap[volumeHandle]
+		volumeToCnsEntityMetadata, presentInCNS := volumeToCnsEntityMetadataMap[volumeHandle]
+		volumeToK8sEntityMetadata, presentInK8S := volumeToK8sEntityMetadataMap[volumeHandle]
 
 		if !presentInK8S {
 			log.Infof("FullSync: Skipping volume: %s with VolumeId %q. Volume is not present in the k8s", pv.Name, volumeHandle)
@@ -409,7 +413,7 @@ func fullSyncGetVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, 
 			}
 		} else {
 			// volume exist in K8S and CNS, Check if update is required.
-			if isUpdateRequired(ctx, pvToK8sEntityMetadata, pvToCnsEntityMetadata) {
+			if isUpdateRequired(ctx, volumeToK8sEntityMetadata, volumeToCnsEntityMetadata) {
 				log.Infof("FullSync: update is required for volume: %q", volumeHandle)
 				operationType = "updateVolume"
 			} else {
@@ -430,7 +434,7 @@ func fullSyncGetVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, 
 				Metadata: cnstypes.CnsVolumeMetadata{
 					ContainerCluster:      containerCluster,
 					ContainerClusterArray: []cnstypes.CnsContainerCluster{containerCluster},
-					EntityMetadata:        pvToK8sEntityMetadataMap[volumeHandle],
+					EntityMetadata:        volumeToK8sEntityMetadataMap[volumeHandle],
 				},
 			}
 			if volumeType == common.BlockVolumeType {
@@ -457,11 +461,11 @@ func fullSyncGetVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, 
 					ContainerCluster:      containerCluster,
 					ContainerClusterArray: []cnstypes.CnsContainerCluster{containerCluster},
 					// Update metadata in CNS with the new metadata present in K8S
-					EntityMetadata: pvToK8sEntityMetadataMap[volumeHandle],
+					EntityMetadata: volumeToK8sEntityMetadataMap[volumeHandle],
 				},
 			}
 			// Delete metadata in CNS which is not present in K8S
-			for _, oldMetadata := range pvToCnsEntityMetadataMap[volumeHandle] {
+			for _, oldMetadata := range volumeToCnsEntityMetadataMap[volumeHandle] {
 				oldEntityName := oldMetadata.(*cnstypes.CnsKubernetesEntityMetadata).EntityName
 				oldEntityNameSpace := oldMetadata.(*cnstypes.CnsKubernetesEntityMetadata).Namespace
 				oldEntityType := oldMetadata.(*cnstypes.CnsKubernetesEntityMetadata).EntityType

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -250,7 +250,7 @@ func initVolumeMigrationService(ctx context.Context, metadataSyncer *metadataSyn
 		return nil
 	}
 	var err error
-	volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &metadataSyncer.volumeManager, metadataSyncer.configInfo.Cfg)
+	volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &metadataSyncer.volumeManager, metadataSyncer.configInfo.Cfg, true)
 	if err != nil {
 		log.Errorf("failed to get migration service. Err: %v", err)
 		return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is cherry-picking changes labeled as release-2.1.0-candidate as of Oct 21 2020 from master to release 2.1 branch

**Special notes for your reviewer**:
Merged PRs marked as release-2.1.0-candidate, excluding PRs already cherry picked and PRs https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/372, https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/400)
https://github.com/kubernetes-sigs/vsphere-csi-driver/pulls?q=is%3Apr+label%3Arelease-2.1.0-candidate+is%3Aclosed+-label%3Arelease-2.1.0-cherry-picked

Build check
```
$ make build-bins
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.Version=v2.1.0-rc.1-70-gca5ff89-dirty"' -o /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/.build/bin/vsphere-csi.linux_amd64 cmd/vsphere-csi/main.go
go: creating new go.mod: module tmp
go: finding sigs.k8s.io/controller-tools/cmd v0.2.5
go: finding sigs.k8s.io v0.2.5
go: finding sigs.k8s.io/controller-tools/cmd/controller-gen v0.2.5
/Users/chethanv/go/bin/controller-gen crd:trivialVersions=true paths=./pkg/apis/storagepool/... output:crd:dir=pkg/apis/storagepool/config
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/pkg/syncer.Version=v2.1.0-rc.1-70-gca5ff89-dirty"' -o /Users/chethanv/Downloads/csi-external/vsphere-csi-driver/.build/bin/syncer.linux_amd64 cmd/syncer/main.go
```

Unit tests
```
chethanv-a01:vsphere-csi-driver chethanv$ make unit-test
env -u VSPHERE_SERVER -u VSPHERE_DATACENTER -u VSPHERE_PASSWORD -u VSPHERE_USER -u VSPHERE_STORAGE_POLICY_NAME -u KUBECONFIG -u WCP_ENDPOINT -u WCP_PORT -u WCP_NAMESPACE -u TOKEN -u CERTIFICATE go test -v -count=1 ./pkg/common/config ./pkg/csi/service ./pkg/csi/service/common ./pkg/csi/service/common/commonco/k8sorchestrator ./pkg/csi/service/vanilla ./pkg/csi/service/wcp ./pkg/csi/service/wcpguest ./pkg/syncer ./pkg/syncer/admissionhandler
=== RUN   TestValidateConfigWithNoNetPermissionParams
{"level":"info","time":"2020-10-21T16:43:27.886024-07:00","caller":"config/config.go:296","msg":"No Net Permissions given in Config. Using default permissions."}
{"level":"info","time":"2020-10-21T16:43:27.886401-07:00","caller":"config/config.go:328","msg":"No feature states config information is provided in the Config. Using default config map name: internal-feature-states.csi.vsphere.vmware.com and namespace: kube-system"}
--- PASS: TestValidateConfigWithNoNetPermissionParams (0.00s)
=== RUN   TestValidateConfigWithMultipleNetPermissionParams
{"level":"info","time":"2020-10-21T16:43:27.886678-07:00","caller":"config/config.go:328","msg":"No feature states config information is provided in the Config. Using default config map name: internal-feature-states.csi.vsphere.vmware.com and namespace: kube-system"}
--- PASS: TestValidateConfigWithMultipleNetPermissionParams (0.00s)
=== RUN   TestValidateConfigWithInvalidPermissions
{"level":"error","time":"2020-10-21T16:43:27.889111-07:00","caller":"config/config.go:305","msg":"Invalid value WRITE_ONLY for Permissions under NetPermission Config A","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:305\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.TestValidateConfigWithInvalidPermissions\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config_test.go:143\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestValidateConfigWithInvalidPermissions (0.00s)
=== RUN   TestValidateConfigWithInvalidClusterId
{"level":"error","time":"2020-10-21T16:43:27.889561-07:00","caller":"config/config.go:257","msg":"cluster id must not exceed 64 characters","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:257\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.TestValidateConfigWithInvalidClusterId\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config_test.go:155\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestValidateConfigWithInvalidClusterId (0.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/pkg/common/config        0.076s
=== RUN   TestGetDisk
=== RUN   TestGetDisk/#00
=== PAUSE TestGetDisk/#00
=== RUN   TestGetDisk/#01
=== PAUSE TestGetDisk/#01
=== CONT  TestGetDisk/#00
=== CONT  TestGetDisk/#01
--- PASS: TestGetDisk (0.00s)
    --- PASS: TestGetDisk/#00 (0.00s)
    --- PASS: TestGetDisk/#01 (0.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/pkg/csi/service  0.067s
=== RUN   TestIsFileVolumeRequestForBlock
--- PASS: TestIsFileVolumeRequestForBlock (0.00s)
=== RUN   TestIsFileVolumeRequestForBlockWithUnsetFsType
--- PASS: TestIsFileVolumeRequestForBlockWithUnsetFsType (0.00s)
=== RUN   TestIsFileVolumeRequestForFile
--- PASS: TestIsFileVolumeRequestForFile (0.00s)
=== RUN   TestValidVolumeCapabilitiesForBlock
--- PASS: TestValidVolumeCapabilitiesForBlock (0.00s)
=== RUN   TestInvalidVolumeCapabilitiesForBlock
--- PASS: TestInvalidVolumeCapabilitiesForBlock (0.00s)
=== RUN   TestValidVolumeCapabilitiesForFile
--- PASS: TestValidVolumeCapabilitiesForFile (0.00s)
=== RUN   TestInvalidVolumeCapabilitiesForFile
--- PASS: TestInvalidVolumeCapabilitiesForFile (0.00s)
=== RUN   TestParseStorageClassParamsWithDeprecatedFSType
{"level":"warn","time":"2020-10-21T16:43:35.468026-07:00","caller":"common/util.go:216","msg":"param 'fstype' is deprecated, please use 'csi.storage.k8s.io/fstype' instead"}
--- PASS: TestParseStorageClassParamsWithDeprecatedFSType (0.00s)
=== RUN   TestParseStorageClassParamsWithValidParams
--- PASS: TestParseStorageClassParamsWithValidParams (0.00s)
=== RUN   TestParseStorageClassParamsWithMigrationEnabledNagative
--- PASS: TestParseStorageClassParamsWithMigrationEnabledNagative (0.01s)
    util_test.go:324: expected err received. err: vSphere CSI driver does not support creating volume using in-tree vSphere volume plugin parameter key:iopslimit-migrationparam, value:16
=== RUN   TestParseStorageClassParamsWithDiskFormatMigrationEnableNegative
--- PASS: TestParseStorageClassParamsWithDiskFormatMigrationEnableNegative (0.00s)
    util_test.go:337: expected err received. err: invalid parameter. key:diskformat-migrationparam, value:thick
=== RUN   TestParseStorageClassParamsWithDiskFormatMigrationEnablePositive
--- PASS: TestParseStorageClassParamsWithDiskFormatMigrationEnablePositive (0.00s)
=== RUN   TestParseStorageClassParamsWithMigrationEnabledPositive
--- PASS: TestParseStorageClassParamsWithMigrationEnabledPositive (0.00s)
=== RUN   TestParseStorageClassParamsWithMigrationDisabled
--- PASS: TestParseStorageClassParamsWithMigrationDisabled (0.00s)
    util_test.go:391: expected err received. err: Invalid param: "csimigration" and value: "true"
PASS
ok      sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common   0.081s
=== RUN   TestIsFSSEnabledInGcWithSync
{"level":"info","time":"2020-10-21T16:43:44.033544-07:00","caller":"k8sorchestrator/k8sorchestrator.go:322","msg":"volume-health feature state set to false in internal-feature-states.csi.vsphere.vmware.com ConfigMap"}
--- PASS: TestIsFSSEnabledInGcWithSync (0.00s)
=== RUN   TestIsFSSEnabledInGcWithoutSync
{"level":"info","time":"2020-10-21T16:43:44.034022-07:00","caller":"k8sorchestrator/k8sorchestrator.go:322","msg":"volume-extend feature state set to false in internal-feature-states.csi.vsphere.vmware.com ConfigMap"}
{"level":"info","time":"2020-10-21T16:43:44.03487-07:00","caller":"k8sorchestrator/k8sorchestrator.go:338","msg":"volume-health feature state set to false in csi-feature-states ConfigMap"}
--- PASS: TestIsFSSEnabledInGcWithoutSync (0.00s)
=== RUN   TestIsFSSEnabledInGcWrongValues
{"level":"error","time":"2020-10-21T16:43:44.035133-07:00","caller":"k8sorchestrator/k8sorchestrator.go:317","msg":"Error while converting volume-extend feature state value: false to boolean. Setting the feature state to false","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.(*K8sOrchestrator).IsFSSEnabled\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:317\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.TestIsFSSEnabledInGcWrongValues\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go:140\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestIsFSSEnabledInGcWrongValues (0.00s)
=== RUN   TestIsFSSEnabledInSV
{"level":"error","time":"2020-10-21T16:43:44.036722-07:00","caller":"k8sorchestrator/k8sorchestrator.go:305","msg":"Error while converting csi-migration feature state value: false to boolean. Setting the feature state to false","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.(*K8sOrchestrator).IsFSSEnabled\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:305\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.TestIsFSSEnabledInSV\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go:176\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestIsFSSEnabledInSV (0.00s)
=== RUN   TestIsFSSEnabledInVanilla
{"level":"error","time":"2020-10-21T16:43:44.037014-07:00","caller":"k8sorchestrator/k8sorchestrator.go:293","msg":"Error while converting volume-health feature state value: false to boolean. Setting the feature state to false","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.(*K8sOrchestrator).IsFSSEnabled\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:293\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.TestIsFSSEnabledInVanilla\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go:214\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestIsFSSEnabledInVanilla (0.00s)
=== RUN   TestIsFSSEnabledWithWrongClusterFlavor
--- PASS: TestIsFSSEnabledWithWrongClusterFlavor (0.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator  0.081s
=== RUN   TestCreateVolumeWithStoragePolicy
{"level":"error","time":"2020-10-21T16:43:44.598716-07:00","caller":"config/config.go:252","msg":"no Virtual Center hosts defined","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:252\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.FromEnv\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:236\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.configFromEnvOrSim\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:138\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.getControllerTest.func1\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:232\nsync.(*Once).doSlow\n\t/usr/local/go/src/sync/once.go:66\nsync.(*Once).Do\n\t/usr/local/go/src/sync/once.go:57\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.getControllerTest\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:229\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.TestCreateVolumeWithStoragePolicy\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:300\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
{"level":"info","time":"2020-10-21T16:43:44.649856-07:00","caller":"vsphere/utils.go:125","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2020-10-21T16:43:44.64997-07:00","caller":"vsphere/virtualcentermanager.go:64","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2020-10-21T16:43:44.650003-07:00","caller":"vsphere/virtualcentermanager.go:66","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2020-10-21T16:43:44.65021-07:00","caller":"vsphere/virtualcentermanager.go:110","msg":"Successfully registered VC \"127.0.0.1\""}
{"level":"info","time":"2020-10-21T16:43:44.660094-07:00","caller":"vsphere/virtualcenter.go:153","msg":"New session ID for 'user' = 8b6a639f-d710-4349-9b91-1012ed6356e6"}
{"level":"info","time":"2020-10-21T16:43:44.660698-07:00","caller":"volume/manager.go:98","msg":"Initializing new volume.defaultManager..."}
{"level":"info","time":"2020-10-21T16:43:44.66189-07:00","caller":"vanilla/controller.go:509","msg":"CreateVolume: called with args {Name:test-pvc-264ca114-24fd-4ab6-a393-a6179cf686d2 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[storagepolicyname:vSAN Default Storage Policy] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"82af9f20-fec5-4ee9-9c05-e9519bef32ad"}
{"level":"info","time":"2020-10-21T16:43:44.680823-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pvc-264ca114-24fd-4ab6-a393-a6179cf686d2\", opId: \"\"","TraceId":"82af9f20-fec5-4ee9-9c05-e9519bef32ad"}
{"level":"info","time":"2020-10-21T16:43:44.680864-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-264ca114-24fd-4ab6-a393-a6179cf686d2\", opId: \"\", volumeID: \"924a9feb-0408-44c3-91aa-c934662fa6ee\"","TraceId":"82af9f20-fec5-4ee9-9c05-e9519bef32ad"}
{"level":"info","time":"2020-10-21T16:43:44.686999-07:00","caller":"vanilla/controller.go:532","msg":"DeleteVolume: called with args: {VolumeId:924a9feb-0408-44c3-91aa-c934662fa6ee Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"d3f8b400-a1ce-4ff7-b59b-7d2dbe0a9e91"}
{"level":"info","time":"2020-10-21T16:43:44.69061-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"924a9feb-0408-44c3-91aa-c934662fa6ee\", opId: \"\"","TraceId":"d3f8b400-a1ce-4ff7-b59b-7d2dbe0a9e91"}
{"level":"info","time":"2020-10-21T16:43:44.690643-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"924a9feb-0408-44c3-91aa-c934662fa6ee\", opId: \"\"","TraceId":"d3f8b400-a1ce-4ff7-b59b-7d2dbe0a9e91"}
--- PASS: TestCreateVolumeWithStoragePolicy (0.09s)
=== RUN   TestExtendVolume
{"level":"info","time":"2020-10-21T16:43:44.691303-07:00","caller":"vanilla/controller.go:509","msg":"CreateVolume: called with args {Name:test-pvc-c55fd05d-57f0-45ba-8d06-0832e883bb72 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"66a0dac0-9c3d-4a82-acfb-d6d98a729c8f"}
{"level":"info","time":"2020-10-21T16:43:44.69991-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pvc-c55fd05d-57f0-45ba-8d06-0832e883bb72\", opId: \"\"","TraceId":"66a0dac0-9c3d-4a82-acfb-d6d98a729c8f"}
{"level":"info","time":"2020-10-21T16:43:44.699943-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-c55fd05d-57f0-45ba-8d06-0832e883bb72\", opId: \"\", volumeID: \"0d7b6874-127c-4817-b611-406d332def5a\"","TraceId":"66a0dac0-9c3d-4a82-acfb-d6d98a729c8f"}
{"level":"info","time":"2020-10-21T16:43:44.701073-07:00","caller":"vanilla/controller.go:765","msg":"ControllerExpandVolume: called with args {VolumeId:0d7b6874-127c-4817-b611-406d332def5a CapacityRange:required_bytes:2147483648  Secrets:map[] VolumeCapability:access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"dec1e923-56c0-4529-b0ff-c81a9ba4c6bc"}
{"level":"info","time":"2020-10-21T16:43:44.701103-07:00","caller":"node/manager.go:75","msg":"Initializing node.defaultManager...","TraceId":"dec1e923-56c0-4529-b0ff-c81a9ba4c6bc"}
{"level":"info","time":"2020-10-21T16:43:44.701118-07:00","caller":"node/manager.go:79","msg":"node.defaultManager initialized","TraceId":"dec1e923-56c0-4529-b0ff-c81a9ba4c6bc"}
{"level":"info","time":"2020-10-21T16:43:44.702899-07:00","caller":"common/vsphereutil.go:397","msg":"Requested size 2048 Mb is greater than current size for volumeID: \"0d7b6874-127c-4817-b611-406d332def5a\". Need volume expansion.","TraceId":"dec1e923-56c0-4529-b0ff-c81a9ba4c6bc"}
{"level":"info","time":"2020-10-21T16:43:44.703422-07:00","caller":"volume/manager.go:571","msg":"Calling CnsClient.ExtendVolume: VolumeID [\"0d7b6874-127c-4817-b611-406d332def5a\"] Size [2048] cnsExtendSpecList [[]types.CnsVolumeExtendSpec{types.CnsVolumeExtendSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:\"0d7b6874-127c-4817-b611-406d332def5a\"}, CapacityInMb:2048}}]","TraceId":"dec1e923-56c0-4529-b0ff-c81a9ba4c6bc"}
{"level":"info","time":"2020-10-21T16:43:44.706943-07:00","caller":"volume/manager.go:587","msg":"ExpandVolume: volumeID: \"0d7b6874-127c-4817-b611-406d332def5a\", opId: \"\"","TraceId":"dec1e923-56c0-4529-b0ff-c81a9ba4c6bc"}
{"level":"info","time":"2020-10-21T16:43:44.706976-07:00","caller":"volume/manager.go:605","msg":"ExpandVolume: Volume expanded successfully. volumeID: \"0d7b6874-127c-4817-b611-406d332def5a\", opId: \"\"","TraceId":"dec1e923-56c0-4529-b0ff-c81a9ba4c6bc"}
{"level":"info","time":"2020-10-21T16:43:44.70699-07:00","caller":"common/vsphereutil.go:403","msg":"Successfully expanded volume for volumeid \"0d7b6874-127c-4817-b611-406d332def5a\" to new size 2048 Mb.","TraceId":"dec1e923-56c0-4529-b0ff-c81a9ba4c6bc"}
{"level":"info","time":"2020-10-21T16:43:44.707638-07:00","caller":"vanilla/controller.go:532","msg":"DeleteVolume: called with args: {VolumeId:0d7b6874-127c-4817-b611-406d332def5a Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"9b2a8b03-8c41-4b17-af1e-8581f6181fba"}
{"level":"info","time":"2020-10-21T16:43:44.712501-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"0d7b6874-127c-4817-b611-406d332def5a\", opId: \"\"","TraceId":"9b2a8b03-8c41-4b17-af1e-8581f6181fba"}
{"level":"info","time":"2020-10-21T16:43:44.712537-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"0d7b6874-127c-4817-b611-406d332def5a\", opId: \"\"","TraceId":"9b2a8b03-8c41-4b17-af1e-8581f6181fba"}
--- PASS: TestExtendVolume (0.02s)
    controller_test.go:479: ControllerExpandVolume will be called with req +{0d7b6874-127c-4817-b611-406d332def5a required_bytes:2147483648  map[] access_mode:<mode:SINGLE_NODE_WRITER >  {} [] 0}
    controller_test.go:487: ControllerExpandVolume succeeded: volume is expanded to requested size 2147483648
=== RUN   TestMigratedExtendVolume
{"level":"info","time":"2020-10-21T16:43:44.713236-07:00","caller":"vanilla/controller.go:765","msg":"ControllerExpandVolume: called with args {VolumeId:[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk CapacityRange:required_bytes:1024  Secrets:map[] VolumeCapability:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"1fd6989c-432b-474e-998c-da98ac3a1fe6"}
{"level":"error","time":"2020-10-21T16:43:44.71326-07:00","caller":"vanilla/controller.go:769","msg":"Cannot expand migrated vSphere volume. :\"[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk\"","TraceId":"1fd6989c-432b-474e-998c-da98ac3a1fe6","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.(*controller).ControllerExpandVolume\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/vanilla/controller.go:769\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.TestMigratedExtendVolume\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:536\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestMigratedExtendVolume (0.00s)
    controller_test.go:535: ControllerExpandVolume will be called with req +{[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk required_bytes:1024  map[] <nil> {} [] 0}
    controller_test.go:538: Expected error received. migrated volume with VMDK path can not be expanded
=== RUN   TestCompleteControllerFlow
{"level":"info","time":"2020-10-21T16:43:44.713445-07:00","caller":"vanilla/controller.go:509","msg":"CreateVolume: called with args {Name:test-pvc-4cb9674e-5d8a-4f63-9004-b0bd63fa2bb2 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"73311492-bca3-4686-abb0-5578a1f655cd"}
{"level":"info","time":"2020-10-21T16:43:44.721509-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pvc-4cb9674e-5d8a-4f63-9004-b0bd63fa2bb2\", opId: \"\"","TraceId":"73311492-bca3-4686-abb0-5578a1f655cd"}
{"level":"info","time":"2020-10-21T16:43:44.721544-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-4cb9674e-5d8a-4f63-9004-b0bd63fa2bb2\", opId: \"\", volumeID: \"bed18aea-9268-441f-81b2-3c32e45f7cba\"","TraceId":"73311492-bca3-4686-abb0-5578a1f655cd"}
{"level":"info","time":"2020-10-21T16:43:44.72281-07:00","caller":"vanilla/controller.go:589","msg":"ControllerPublishVolume: called with args {VolumeId:bed18aea-9268-441f-81b2-3c32e45f7cba NodeId:DC0_C0_RP0_VM1 VolumeCapability:access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"310d077a-f7f2-46a9-95e4-a75a0969cbb4"}
{"level":"info","time":"2020-10-21T16:43:44.726618-07:00","caller":"volume/manager.go:301","msg":"AttachVolume: volumeID: \"bed18aea-9268-441f-81b2-3c32e45f7cba\", vm: \"VirtualMachine:vm-60 [VirtualCenterHost: , UUID: , Datacenter: <nil>]\", opId: \"\"","TraceId":"310d077a-f7f2-46a9-95e4-a75a0969cbb4"}
{"level":"info","time":"2020-10-21T16:43:44.726675-07:00","caller":"volume/manager.go:334","msg":"AttachVolume: Volume attached successfully. volumeID: \"bed18aea-9268-441f-81b2-3c32e45f7cba\", opId: \"\", vm: \"VirtualMachine:vm-60 [VirtualCenterHost: , UUID: , Datacenter: <nil>]\", diskUUID: \"6000c298595bf4575739e9105b2c0c2d\"","TraceId":"310d077a-f7f2-46a9-95e4-a75a0969cbb4"}
{"level":"info","time":"2020-10-21T16:43:44.727193-07:00","caller":"vanilla/controller.go:683","msg":"ControllerUnpublishVolume: called with args {VolumeId:bed18aea-9268-441f-81b2-3c32e45f7cba NodeId:DC0_C0_RP0_VM1 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"46460b3a-9ae1-4c0f-858f-7f583e4e46f4"}
{"level":"info","time":"2020-10-21T16:43:44.732551-07:00","caller":"volume/manager.go:392","msg":"DetachVolume: volumeID: \"bed18aea-9268-441f-81b2-3c32e45f7cba\", vm: \"VirtualMachine:vm-60 [VirtualCenterHost: , UUID: , Datacenter: <nil>]\", opId: \"\"","TraceId":"46460b3a-9ae1-4c0f-858f-7f583e4e46f4"}
{"level":"info","time":"2020-10-21T16:43:44.732599-07:00","caller":"volume/manager.go:422","msg":"DetachVolume: Volume detached successfully. volumeID: \"bed18aea-9268-441f-81b2-3c32e45f7cba\", vm: \"\", opId: \"VirtualMachine:vm-60 [VirtualCenterHost: , UUID: , Datacenter: <nil>]\"","TraceId":"46460b3a-9ae1-4c0f-858f-7f583e4e46f4"}
{"level":"info","time":"2020-10-21T16:43:44.732709-07:00","caller":"vanilla/controller.go:532","msg":"DeleteVolume: called with args: {VolumeId:bed18aea-9268-441f-81b2-3c32e45f7cba Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"fcefe6b1-9e6f-4b32-845e-c18b47818369"}
{"level":"info","time":"2020-10-21T16:43:44.735343-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"bed18aea-9268-441f-81b2-3c32e45f7cba\", opId: \"\"","TraceId":"fcefe6b1-9e6f-4b32-845e-c18b47818369"}
{"level":"info","time":"2020-10-21T16:43:44.735379-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"bed18aea-9268-441f-81b2-3c32e45f7cba\", opId: \"\"","TraceId":"fcefe6b1-9e6f-4b32-845e-c18b47818369"}
--- PASS: TestCompleteControllerFlow (0.02s)
    controller_test.go:624: ControllerPublishVolume will be called with req +{bed18aea-9268-441f-81b2-3c32e45f7cba DC0_C0_RP0_VM1 access_mode:<mode:SINGLE_NODE_WRITER >  false map[] map[] {} [] 0}
    controller_test.go:630: ControllerPublishVolume succeed, diskUUID 6000c298595bf4575739e9105b2c0c2d is returned
    controller_test.go:637: ControllerUnpublishVolume will be called with req +{bed18aea-9268-441f-81b2-3c32e45f7cba DC0_C0_RP0_VM1 map[] {} [] 0}
    controller_test.go:642: ControllerUnpublishVolume succeed
PASS
ok      sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla  0.202s
=== RUN   TestWCPCreateVolumeWithStoragePolicy
{"level":"error","time":"2020-10-21T16:43:44.627788-07:00","caller":"config/config.go:252","msg":"no Virtual Center hosts defined","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:252\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.FromEnv\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:236\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp.configFromEnvOrSim\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:124\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp.getControllerTest.func1\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:134\nsync.(*Once).doSlow\n\t/usr/local/go/src/sync/once.go:66\nsync.(*Once).Do\n\t/usr/local/go/src/sync/once.go:57\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp.getControllerTest\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:131\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp.TestWCPCreateVolumeWithStoragePolicy\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:252\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
{"level":"info","time":"2020-10-21T16:43:44.681977-07:00","caller":"vsphere/utils.go:125","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2020-10-21T16:43:44.682095-07:00","caller":"vsphere/virtualcentermanager.go:64","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2020-10-21T16:43:44.682118-07:00","caller":"vsphere/virtualcentermanager.go:66","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2020-10-21T16:43:44.682316-07:00","caller":"vsphere/virtualcentermanager.go:110","msg":"Successfully registered VC \"127.0.0.1\""}
{"level":"info","time":"2020-10-21T16:43:44.690596-07:00","caller":"vsphere/virtualcenter.go:153","msg":"New session ID for 'user' = 7c2d29e1-f1ae-465a-a581-3ae30fb8a97b"}
{"level":"info","time":"2020-10-21T16:43:44.691183-07:00","caller":"volume/manager.go:98","msg":"Initializing new volume.defaultManager..."}
{"level":"info","time":"2020-10-21T16:43:44.696605-07:00","caller":"wcp/controller.go:211","msg":"CreateVolume: called with args {Name:test-pvc-39f60881-aef5-4002-b2c6-c8720aa946e0 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[storagepolicyid:aa6d5a82-1c88-45da-85d3-3d74b91a5bad] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"e8be4ea0-eb8a-4905-be6a-d4a3968c66d0"}
{"level":"info","time":"2020-10-21T16:43:44.70858-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pvc-39f60881-aef5-4002-b2c6-c8720aa946e0\", opId: \"\"","TraceId":"e8be4ea0-eb8a-4905-be6a-d4a3968c66d0"}
{"level":"info","time":"2020-10-21T16:43:44.708705-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-39f60881-aef5-4002-b2c6-c8720aa946e0\", opId: \"\", volumeID: \"fee55647-55fb-401e-afea-2d3a3868e048\"","TraceId":"e8be4ea0-eb8a-4905-be6a-d4a3968c66d0"}
{"level":"info","time":"2020-10-21T16:43:44.710381-07:00","caller":"wcp/controller.go:359","msg":"DeleteVolume: called with args: {VolumeId:fee55647-55fb-401e-afea-2d3a3868e048 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"d0b64af0-cb3e-47c2-97b4-9bbd0db0b337"}
{"level":"info","time":"2020-10-21T16:43:44.714675-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"fee55647-55fb-401e-afea-2d3a3868e048\", opId: \"\"","TraceId":"d0b64af0-cb3e-47c2-97b4-9bbd0db0b337"}
{"level":"info","time":"2020-10-21T16:43:44.714713-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"fee55647-55fb-401e-afea-2d3a3868e048\", opId: \"\"","TraceId":"d0b64af0-cb3e-47c2-97b4-9bbd0db0b337"}
--- PASS: TestWCPCreateVolumeWithStoragePolicy (0.09s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp      0.154s
=== RUN   TestGuestClusterControllerFlow
{"level":"error","time":"2020-10-21T16:43:44.66-07:00","caller":"config/config.go:486","msg":"no Supervisor Cluster endpoint defined in Guest Cluster config","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateGCConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:486\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.FromEnvToGC\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:417\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.configFromEnvOrSim\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcpguest/controller_test.go:67\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.getControllerTest.func1\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcpguest/controller_test.go:83\nsync.(*Once).doSlow\n\t/usr/local/go/src/sync/once.go:66\nsync.(*Once).Do\n\t/usr/local/go/src/sync/once.go:57\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.getControllerTest\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcpguest/controller_test.go:80\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.TestGuestClusterControllerFlow\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcpguest/controller_test.go:112\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
{"level":"info","time":"2020-10-21T16:43:44.662984-07:00","caller":"wcpguest/controller.go:206","msg":"CreateVolume: called with args {Name:pvc-12345 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[svstorageclass:test-storageclass] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"e01dede1-6de4-4ebe-80d1-ec63364dd953"}
{"level":"info","time":"2020-10-21T16:43:44.663343-07:00","caller":"wcpguest/controller_helper.go:188","msg":"Waiting up to 240 seconds for PersistentVolumeClaim -12345 in namespace test-namespace to have phase Bound","TraceId":"e01dede1-6de4-4ebe-80d1-ec63364dd953"}
{"level":"info","time":"2020-10-21T16:43:45.660491-07:00","caller":"wcpguest/controller_helper.go:210","msg":"PersistentVolumeClaim -12345 in namespace test-namespace is in state Bound","TraceId":"e01dede1-6de4-4ebe-80d1-ec63364dd953"}
{"level":"info","time":"2020-10-21T16:43:45.660947-07:00","caller":"wcpguest/controller.go:275","msg":"DeleteVolume: called with args: {VolumeId:-12345 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"71af6a22-f7c8-4edf-b5a1-3847f7a4367e"}
{"level":"info","time":"2020-10-21T16:43:45.660992-07:00","caller":"wcpguest/controller.go:293","msg":"DeleteVolume: Volume deleted successfully. VolumeID: \"-12345\"","TraceId":"71af6a22-f7c8-4edf-b5a1-3847f7a4367e"}
--- PASS: TestGuestClusterControllerFlow (2.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest 2.186s
=== RUN   TestSyncerWorkflows
{"level":"error","time":"2020-10-21T16:43:44.671565-07:00","caller":"config/config.go:252","msg":"no Virtual Center hosts defined","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:252\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.FromEnv\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:236\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer.configFromEnvOrSim\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/syncer/syncer_test.go:148\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer.TestSyncerWorkflows\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/syncer/syncer_test.go:161\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
{"level":"info","time":"2020-10-21T16:43:44.719741-07:00","caller":"vsphere/utils.go:125","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2020-10-21T16:43:44.719973-07:00","caller":"vsphere/virtualcentermanager.go:64","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2020-10-21T16:43:44.720001-07:00","caller":"vsphere/virtualcentermanager.go:66","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2020-10-21T16:43:44.720184-07:00","caller":"vsphere/virtualcentermanager.go:110","msg":"Successfully registered VC \"127.0.0.1\""}
{"level":"info","time":"2020-10-21T16:43:44.728941-07:00","caller":"vsphere/virtualcenter.go:153","msg":"New session ID for 'user' = 71c6e186-45cf-41a8-a796-cc1f569aa27a"}
{"level":"info","time":"2020-10-21T16:43:44.729288-07:00","caller":"volume/manager.go:98","msg":"Initializing new volume.defaultManager..."}
{"level":"info","time":"2020-10-21T16:43:44.729523-07:00","caller":"volume/manager.go:95","msg":"Retrieving existing volume.defaultManager..."}
{"level":"info","time":"2020-10-21T16:43:44.741139-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pvc\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:44.741186-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc\", opId: \"\", volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\""}
{"level":"info","time":"2020-10-21T16:43:44.745154-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\"","TraceId":"f7217c9e-93c1-4419-943b-bf182f629e94"}
{"level":"info","time":"2020-10-21T16:43:44.745192-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\"","TraceId":"f7217c9e-93c1-4419-943b-bf182f629e94"}
{"level":"info","time":"2020-10-21T16:43:44.749436-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:44.749469-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:44.752654-07:00","caller":"syncer/metadatasyncer.go:918","msg":"PVUpdated: Verified volume: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\" is not marked as container volume in CNS. Calling CreateVolume with BackingID to mark volume as Container Volume.","TraceId":"18e0f7c7-33ce-4381-967b-6d008a58fc49"}
{"level":"info","time":"2020-10-21T16:43:44.755622-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pv-22606386-37ea-47b4-a990-3402958a21d6\", opId: \"\"","TraceId":"18e0f7c7-33ce-4381-967b-6d008a58fc49"}
{"level":"info","time":"2020-10-21T16:43:44.755651-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pv-22606386-37ea-47b4-a990-3402958a21d6\", opId: \"\", volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\"","TraceId":"18e0f7c7-33ce-4381-967b-6d008a58fc49"}
{"level":"info","time":"2020-10-21T16:43:44.755666-07:00","caller":"syncer/metadatasyncer.go:947","msg":"PVUpdated: vSphere CSI Driver has successfully marked volume: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\" as the container volume.","TraceId":"18e0f7c7-33ce-4381-967b-6d008a58fc49"}
{"level":"info","time":"2020-10-21T16:43:50.759428-07:00","caller":"syncer/metadatasyncer.go:784","msg":"PVCUpdated: volume \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\" found","TraceId":"63a2a104-9266-4b1d-bc44-a85a7268326d"}
{"level":"info","time":"2020-10-21T16:43:50.764355-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\"","TraceId":"63a2a104-9266-4b1d-bc44-a85a7268326d"}
{"level":"info","time":"2020-10-21T16:43:50.764398-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\"","TraceId":"63a2a104-9266-4b1d-bc44-a85a7268326d"}
{"level":"info","time":"2020-10-21T16:43:50.77004-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\"","TraceId":"63ae9cca-cbcc-4a6c-9d36-5b42d637a40a"}
{"level":"info","time":"2020-10-21T16:43:50.770103-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\"","TraceId":"63ae9cca-cbcc-4a6c-9d36-5b42d637a40a"}
{"level":"info","time":"2020-10-21T16:43:50.776165-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\"","TraceId":"bad16bae-5d74-460a-8ceb-297e343f4de5"}
{"level":"info","time":"2020-10-21T16:43:50.77621-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\"","TraceId":"bad16bae-5d74-460a-8ceb-297e343f4de5"}
{"level":"info","time":"2020-10-21T16:43:51.786864-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\"","TraceId":"5d8ced31-d379-4d64-a096-00ad90483f18"}
{"level":"info","time":"2020-10-21T16:43:51.786915-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\"","TraceId":"5d8ced31-d379-4d64-a096-00ad90483f18"}
{"level":"info","time":"2020-10-21T16:43:51.791402-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\"","TraceId":"700ad6cf-0f3b-42ab-8e6b-97fce7fea598"}
{"level":"info","time":"2020-10-21T16:43:51.791443-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"f8b10064-ab6d-47fb-83b7-f9e69f07a2c8\", opId: \"\"","TraceId":"700ad6cf-0f3b-42ab-8e6b-97fce7fea598"}
{"level":"info","time":"2020-10-21T16:43:51.797017-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pv\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:51.797067-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pv\", opId: \"\", volumeID: \"b88e8770-3757-4d6c-ac4d-670428cd34be\""}
{"level":"info","time":"2020-10-21T16:43:52.798074-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"warn","time":"2020-10-21T16:43:52.801676-07:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS"}
{"level":"info","time":"2020-10-21T16:43:52.802541-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-10-21T16:43:52.802862-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-21T16:43:52.803134-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"warn","time":"2020-10-21T16:43:52.806978-07:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS"}
{"level":"info","time":"2020-10-21T16:43:52.809889-07:00","caller":"syncer/util.go:148","msg":"0 more volumes to be queried"}
{"level":"info","time":"2020-10-21T16:43:52.809918-07:00","caller":"syncer/util.go:150","msg":"Metadata retrieved for all requested volumes"}
{"level":"info","time":"2020-10-21T16:43:52.809928-07:00","caller":"syncer/fullsync.go:248","msg":"FullSync: fullSyncDeleteVolumes: Calling DeleteVolume for volume b88e8770-3757-4d6c-ac4d-670428cd34be with delete disk false"}
{"level":"info","time":"2020-10-21T16:43:52.813757-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"b88e8770-3757-4d6c-ac4d-670428cd34be\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:52.813803-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"b88e8770-3757-4d6c-ac4d-670428cd34be\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:52.813908-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-21T16:43:53.81932-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"warn","time":"2020-10-21T16:43:53.822554-07:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS"}
{"level":"info","time":"2020-10-21T16:43:53.823118-07:00","caller":"syncer/fullsync.go:411","msg":"FullSync: Volume with id: \"b88e8770-3757-4d6c-ac4d-670428cd34be\" and name: \"test-pv-8d9c4b87-003f-4cdf-8a0d-127f46d33370\" is added to cnsCreationMap"}
{"level":"info","time":"2020-10-21T16:43:53.824817-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-10-21T16:43:53.824931-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-21T16:43:53.825024-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"warn","time":"2020-10-21T16:43:53.827279-07:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS"}
{"level":"info","time":"2020-10-21T16:43:53.82749-07:00","caller":"syncer/fullsync.go:408","msg":"FullSync: create is required for volume: \"b88e8770-3757-4d6c-ac4d-670428cd34be\", as volume was present in cnsCreationMap across two full-sync cycles"}
{"level":"info","time":"2020-10-21T16:43:53.828045-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-10-21T16:43:53.834677-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pv-8d9c4b87-003f-4cdf-8a0d-127f46d33370\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:53.834731-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pv-8d9c4b87-003f-4cdf-8a0d-127f46d33370\", opId: \"\", volumeID: \"b88e8770-3757-4d6c-ac4d-670428cd34be\""}
{"level":"info","time":"2020-10-21T16:43:53.834766-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-21T16:43:54.836103-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"info","time":"2020-10-21T16:43:54.842008-07:00","caller":"syncer/util.go:148","msg":"0 more volumes to be queried"}
{"level":"info","time":"2020-10-21T16:43:54.842053-07:00","caller":"syncer/util.go:150","msg":"Metadata retrieved for all requested volumes"}
{"level":"info","time":"2020-10-21T16:43:54.842811-07:00","caller":"syncer/fullsync.go:417","msg":"FullSync: update is required for volume: \"b88e8770-3757-4d6c-ac4d-670428cd34be\""}
{"level":"info","time":"2020-10-21T16:43:54.843119-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-10-21T16:43:54.849848-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"b88e8770-3757-4d6c-ac4d-670428cd34be\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:54.849921-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"b88e8770-3757-4d6c-ac4d-670428cd34be\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:54.849963-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-21T16:43:55.851246-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"info","time":"2020-10-21T16:43:55.857385-07:00","caller":"syncer/util.go:148","msg":"0 more volumes to be queried"}
{"level":"info","time":"2020-10-21T16:43:55.857433-07:00","caller":"syncer/util.go:150","msg":"Metadata retrieved for all requested volumes"}
{"level":"info","time":"2020-10-21T16:43:55.85823-07:00","caller":"syncer/fullsync.go:417","msg":"FullSync: update is required for volume: \"b88e8770-3757-4d6c-ac4d-670428cd34be\""}
{"level":"info","time":"2020-10-21T16:43:55.858502-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-10-21T16:43:55.865249-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"b88e8770-3757-4d6c-ac4d-670428cd34be\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:55.865302-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"b88e8770-3757-4d6c-ac4d-670428cd34be\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:55.865332-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-21T16:43:56.867892-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"info","time":"2020-10-21T16:43:56.87288-07:00","caller":"syncer/util.go:148","msg":"0 more volumes to be queried"}
{"level":"info","time":"2020-10-21T16:43:56.87291-07:00","caller":"syncer/util.go:150","msg":"Metadata retrieved for all requested volumes"}
{"level":"info","time":"2020-10-21T16:43:56.873271-07:00","caller":"syncer/fullsync.go:417","msg":"FullSync: update is required for volume: \"b88e8770-3757-4d6c-ac4d-670428cd34be\""}
{"level":"info","time":"2020-10-21T16:43:56.873502-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-10-21T16:43:56.8776-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"b88e8770-3757-4d6c-ac4d-670428cd34be\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:56.877629-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"b88e8770-3757-4d6c-ac4d-670428cd34be\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:56.87766-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-21T16:43:56.882786-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"b88e8770-3757-4d6c-ac4d-670428cd34be\", opId: \"\""}
{"level":"info","time":"2020-10-21T16:43:56.882822-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"b88e8770-3757-4d6c-ac4d-670428cd34be\", opId: \"\""}
--- PASS: TestSyncerWorkflows (12.21s)
    syncer_test.go:159: TestSyncerWorkflows: start
    syncer_test.go:277: TestMetadataSyncInformer start
    syncer_test.go:458: TestMetadataSyncInformer end
    syncer_test.go:610: TestFullSyncWorkflows start
    syncer_test.go:791: TestFullSyncWorkflows end
    syncer_test.go:247: TestSyncerWorkflows: end
=== RUN   TestValidMigratedAndLegacyVolume
--- PASS: TestValidMigratedAndLegacyVolume (0.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/pkg/syncer       12.288s
=== RUN   TestValidateStorageClassForAllowVolumeExpansion
{"level":"info","time":"2020-10-21T16:43:44.007062-07:00","caller":"admissionhandler/validatestorageclass.go:75","msg":"Validating StorageClass: \"sc\""}
{"level":"error","time":"2020-10-21T16:43:44.007265-07:00","caller":"admissionhandler/validatestorageclass.go:99","msg":"validation of StorageClass: \"sc\" Failed","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler.validateStorageClass\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/syncer/admissionhandler/validatestorageclass.go:99\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler.TestValidateStorageClassForAllowVolumeExpansion\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/syncer/admissionhandler/validatestorageclass_test.go:45\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestValidateStorageClassForAllowVolumeExpansion (0.00s)
    validatestorageclass_test.go:49: TestValidateStorageClassForAllowVolumeExpansion Passed
=== RUN   TestValidateStorageClassForMigrationParameter
{"level":"info","time":"2020-10-21T16:43:44.008387-07:00","caller":"admissionhandler/validatestorageclass.go:75","msg":"Validating StorageClass: \"sc\""}
{"level":"error","time":"2020-10-21T16:43:44.008463-07:00","caller":"admissionhandler/validatestorageclass.go:99","msg":"validation of StorageClass: \"sc\" Failed","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler.validateStorageClass\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/syncer/admissionhandler/validatestorageclass.go:99\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler.TestValidateStorageClassForMigrationParameter\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/syncer/admissionhandler/validatestorageclass_test.go:60\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestValidateStorageClassForMigrationParameter (0.00s)
    validatestorageclass_test.go:64: TestValidateStorageClassForMigrationParameter Passed
=== RUN   TestValidateStorageClassForValidStorageClass
{"level":"info","time":"2020-10-21T16:43:44.00876-07:00","caller":"admissionhandler/validatestorageclass.go:75","msg":"Validating StorageClass: \"sc\""}
{"level":"info","time":"2020-10-21T16:43:44.008805-07:00","caller":"admissionhandler/validatestorageclass.go:97","msg":"Validation of StorageClass: \"sc\" Passed"}
--- PASS: TestValidateStorageClassForValidStorageClass (0.00s)
    validatestorageclass_test.go:79: TestValidateStorageClassForValidStorageClass Passed
PASS
ok      sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler      0.074s
```

make check
```
$ make check
hack/check-format.sh
go: finding golang.org/x/tools latest
go: downloading golang.org/x/tools v0.0.0-20201021214918-23787c007979
go: extracting golang.org/x/tools v0.0.0-20201021214918-23787c007979
hack/check-lint.sh
go: finding golang.org/x/lint latest

hack/check-mdlint.sh
Unable to find image 'gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.17.0' locally
0.17.0: Pulling from cluster-api-provider-vsphere/extra/mdlint
e8d8785a314f: Pull complete 
5f5edd681dcb: Pull complete 
3e010093287c: Pull complete 
1cba7e5ecfd4: Pull complete 
7fad9aaafb99: Pull complete 
50a85cb077a8: Pull complete 
Digest: sha256:1148fab985b6808a78fbdd27a2e66d2b0b8de4a2c15dfe339ada8793b20816ce
Status: Downloaded newer image for gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.17.0
hack/check-shell.sh
Unable to find image 'gcr.io/cluster-api-provider-vsphere/extra/shellcheck:latest' locally
latest: Pulling from cluster-api-provider-vsphere/extra/shellcheck
75cb2ebf3b3c: Pull complete 
d8cc84507434: Pull complete 
cd376a308b24: Pull complete 
7852a05dcd82: Pull complete 
Digest: sha256:23b8cfc08f7279f334fc60dcf3d60f9e9889f1bb14e8268cf045e89d3abf64cc
Status: Downloaded newer image for gcr.io/cluster-api-provider-vsphere/extra/shellcheck:latest
hack/check-staticcheck.sh
hack/check-vet.sh
hack/check-golangci-lint.sh
INFO [config_reader] Config search paths: [./ /Users/chethanv/Downloads/csi-external/vsphere-csi-driver /Users/chethanv/Downloads/csi-external /Users/chethanv/Downloads /Users/chethanv /Users /] 
INFO [lintersdb] Active 10 linters: [deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|exports_file|files|types_sizes|compiled_files|imports|name) took 3.354851359s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 56.87746ms 
INFO [linters context/goanalysis] analyzers took 4m3.768096148s with top 10 stages: buildir: 3m19.107736815s, fact_deprecated: 2.5337428s, inspect: 2.477683197s, printf: 2.151135414s, ctrlflow: 1.875377817s, fact_purity: 1.183903034s, ineffassign: 974.011434ms, S1038: 847.098544ms, S1039: 820.935355ms, SA1004: 638.958961ms 
INFO [linters context/goanalysis] analyzers took 23.322233893s with top 10 stages: buildir: 21.573947608s, U1000: 1.748286285s 
INFO [runner] Issues before processing: 54, after processing: 0 
INFO [runner] Processors filtering stat (out/in): cgo: 54/54, filename_unadjuster: 54/54, skip_dirs: 54/54, identifier_marker: 10/10, exclude: 0/10, skip_files: 54/54, autogenerated_exclude: 10/54, path_prettifier: 54/54 
INFO [runner] processing took 3.238696ms with stages: autogenerated_exclude: 1.185812ms, path_prettifier: 772.092µs, exclude: 703.682µs, identifier_marker: 308.78µs, skip_dirs: 231.409µs, cgo: 16.176µs, nolint: 7.327µs, filename_unadjuster: 5.593µs, max_same_issues: 1.464µs, source_code: 1.043µs, uniq_by_line: 799ns, max_from_linter: 705ns, diff: 578ns, path_shortener: 535ns, exclude-rules: 524ns, skip_files: 514ns, severity-rules: 450ns, sort_results: 428ns, path_prefixer: 419ns, max_per_file_from_linter: 366ns 
INFO [runner] linters took 31.018759117s with stages: goanalysis_metalinter: 26.223463654s, unused: 4.791887703s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 293 samples, avg is 988.8MB, max is 1357.6MB 
INFO Execution took 34.465370863s  
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
cherry-pick recent commits to release 2.1 branch
```
