### PR TITLE
Add volume capabilities validation in Vanilla Create Volume Request

### DIFF
--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -47,8 +47,8 @@ func ValidateCreateVolumeRequest(ctx context.Context, req *csi.CreateVolumeReque
 	if len(volCaps) == 0 {
 		return status.Error(codes.InvalidArgument, "Volume capabilities not provided")
 	}
-	if !IsValidVolumeCapabilities(ctx, volCaps) {
-		return status.Error(codes.InvalidArgument, "Volume capabilities not supported")
+	if err := IsValidVolumeCapabilities(ctx, volCaps); err != nil {
+		return status.Errorf(codes.InvalidArgument, "Volume capability not supported. Err: %+v", err)
 	}
 	return nil
 }
@@ -87,8 +87,8 @@ func ValidateControllerPublishVolumeRequest(ctx context.Context, req *csi.Contro
 		return status.Error(codes.InvalidArgument, "Volume capability not provided")
 	}
 	caps := []*csi.VolumeCapability{volCap}
-	if !IsValidVolumeCapabilities(ctx, caps) {
-		return status.Error(codes.InvalidArgument, "Volume capability not supported")
+	if err := IsValidVolumeCapabilities(ctx, caps); err != nil {
+		return status.Errorf(codes.InvalidArgument, "Volume capability not supported. Err: %+v", err)
 	}
 	return nil
 }

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -116,7 +116,7 @@ func TestValidVolumeCapabilitiesForBlock(t *testing.T) {
 			},
 		},
 	}
-	if !IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("Block VolCap = %+v failed validation!", volCap)
 	}
 	// fstype=empty and mode=SINGLE_NODE_WRITER
@@ -130,7 +130,7 @@ func TestValidVolumeCapabilitiesForBlock(t *testing.T) {
 			},
 		},
 	}
-	if !IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("Block VolCap = %+v failed validation!", volCap)
 	}
 }
@@ -149,7 +149,7 @@ func TestInvalidVolumeCapabilitiesForBlock(t *testing.T) {
 			},
 		},
 	}
-	if IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err == nil {
 		t.Errorf("Invalid Block VolCap = %+v passed validation!", volCap)
 	}
 
@@ -166,7 +166,7 @@ func TestInvalidVolumeCapabilitiesForBlock(t *testing.T) {
 			},
 		},
 	}
-	if IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err == nil {
 		t.Errorf("Invalid Block VolCap = %+v passed validation!", volCap)
 	}
 }
@@ -185,7 +185,7 @@ func TestValidVolumeCapabilitiesForFile(t *testing.T) {
 			},
 		},
 	}
-	if !IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("File VolCap = %+v failed validation!", volCap)
 	}
 
@@ -202,7 +202,7 @@ func TestValidVolumeCapabilitiesForFile(t *testing.T) {
 			},
 		},
 	}
-	if !IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("File VolCap = %+v failed validation!", volCap)
 	}
 
@@ -219,7 +219,7 @@ func TestValidVolumeCapabilitiesForFile(t *testing.T) {
 			},
 		},
 	}
-	if !IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("File VolCap = %+v failed validation!", volCap)
 	}
 }
@@ -238,7 +238,7 @@ func TestInvalidVolumeCapabilitiesForFile(t *testing.T) {
 			},
 		},
 	}
-	if IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err == nil {
 		t.Errorf("Invalid file VolCap = %+v passed validation!", volCap)
 	}
 
@@ -255,7 +255,7 @@ func TestInvalidVolumeCapabilitiesForFile(t *testing.T) {
 			},
 		},
 	}
-	if IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err == nil {
 		t.Errorf("Invalid file VolCap = %+v passed validation!", volCap)
 	}
 }

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -542,8 +542,11 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	log.Infof("CreateVolume: called with args %+v", *req)
-
-	if common.IsFileVolumeRequest(ctx, req.GetVolumeCapabilities()) {
+	volumeCapabilities := req.GetVolumeCapabilities()
+	if err := common.IsValidVolumeCapabilities(ctx, volumeCapabilities); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Volume capability not supported. Err: %+v", err)
+	}
+	if common.IsFileVolumeRequest(ctx, volumeCapabilities) {
 		vsan67u3Release, err := isVsan67u3Release(ctx, c)
 		if err != nil {
 			log.Error("failed to get vcenter version to help identify if fileshare volume creation should be permitted or not. Error:%v", err)
@@ -848,7 +851,7 @@ func (c *controller) ValidateVolumeCapabilities(ctx context.Context, req *csi.Va
 	log.Infof("ControllerGetCapabilities: called with args %+v", *req)
 	volCaps := req.GetVolumeCapabilities()
 	var confirmed *csi.ValidateVolumeCapabilitiesResponse_Confirmed
-	if common.IsValidVolumeCapabilities(ctx, volCaps) {
+	if err := common.IsValidVolumeCapabilities(ctx, volCaps); err == nil {
 		confirmed = &csi.ValidateVolumeCapabilitiesResponse_Confirmed{VolumeCapabilities: volCaps}
 	}
 	return &csi.ValidateVolumeCapabilitiesResponse{

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -473,7 +473,7 @@ func (c *controller) ValidateVolumeCapabilities(ctx context.Context, req *csi.Va
 	log.Infof("ControllerGetCapabilities: called with args %+v", *req)
 	volCaps := req.GetVolumeCapabilities()
 	var confirmed *csi.ValidateVolumeCapabilitiesResponse_Confirmed
-	if common.IsValidVolumeCapabilities(ctx, volCaps) {
+	if err := common.IsValidVolumeCapabilities(ctx, volCaps); err == nil {
 		confirmed = &csi.ValidateVolumeCapabilitiesResponse_Confirmed{VolumeCapabilities: volCaps}
 	}
 	return &csi.ValidateVolumeCapabilitiesResponse{

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -666,7 +666,7 @@ func (c *controller) ValidateVolumeCapabilities(ctx context.Context, req *csi.Va
 	log.Infof("ValidateVolumeCapabilities: called with args %+v", *req)
 	volCaps := req.GetVolumeCapabilities()
 	var confirmed *csi.ValidateVolumeCapabilitiesResponse_Confirmed
-	if common.IsValidVolumeCapabilities(ctx, volCaps) {
+	if err := common.IsValidVolumeCapabilities(ctx, volCaps); err == nil {
 		confirmed = &csi.ValidateVolumeCapabilitiesResponse_Confirmed{VolumeCapabilities: volCaps}
 	}
 	return &csi.ValidateVolumeCapabilitiesResponse{

--- a/tests/e2e/vsphere_file_volume_basic.go
+++ b/tests/e2e/vsphere_file_volume_basic.go
@@ -234,7 +234,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] Basic Testing", func() {
 		ginkgo.By(fmt.Sprintf("Expect claim to fail as the access mode %q is not supported for File volumes", accessMode))
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute/2)
 		gomega.Expect(err).To(gomega.HaveOccurred())
-		expectedErrMsg := "Volume capabilities not supported"
+		expectedErrMsg := "NFS fstype not supported for ReadWriteOnce volume creation"
 		ginkgo.By(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
 		isFailureFound := checkEventsforError(client, namespace, metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvclaim.Name)}, expectedErrMsg)
 		gomega.Expect(isFailureFound).To(gomega.BeTrue(), "Unable to verify pvc create failure")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding a validation for create block volume request to avoid incorrect (SC - fstype : PVC- AccessMode) combination used in volume creation
For ex: Creating a block volume with fstype: nfs or nfs4

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

```
root@k8s-master:~# cat sc.yaml 
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: sc
  annotations:
    storageclass.kubernetes.io/is-default-class: "false"
provisioner: csi.vsphere.vmware.com
parameters:
  storagepolicyname: "vSAN Default Storage Policy"  # Optional Parameter
  csi.storage.k8s.io/fstype: "nfs4"            <<<<<<<<============


root@k8s-master:~# cat pvc-test.yaml 
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: pvc-test
spec:
  accessModes:
    - ReadWriteOnce                   <<<<<<<<============
  resources:
    requests:
      storage: 1Mi
  storageClassName: sc

# kubectl get pvc -A
NAMESPACE   NAME         STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
default     pvc-test     Pending                                                                        sc             8s

root@k8s-master:~# kubectl describe pvc pvc-test
Name:          pvc-test
Namespace:     default
StorageClass:  sc
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Mounted By:    <none>
Events:
  Type     Reason                Age                    From                                                                                                 Message
  ----     ------                ----                   ----                                                                                                 -------
  Normal   ExternalProvisioning  4m27s (x102 over 29m)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   Provisioning          70s (x14 over 29m)     csi.vsphere.vmware.com_vsphere-csi-controller-8496dc54c9-xkczs_ee5f6153-e388-45e6-965c-ca1035e6f40b  External provisioner is provisioning volume for claim "default/example-vanilla-block-pvc"
  Warning  ProvisioningFailed    70s (x14 over 29m)     csi.vsphere.vmware.com_vsphere-csi-controller-8496dc54c9-xkczs_ee5f6153-e388-45e6-965c-ca1035e6f40b  failed to provision volume with StorageClass "example-vanilla-file-sc": rpc error: code = InvalidArgument desc = Volume capability not supported. Err: NFS fstype not supported for ReadWriteOnce volume creation
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Validate access mode and fstype for CreateVolume workflow
```
