### PR TITLE
Fix for vanilla file services solution in a VC deployment when there is no cluster available in a datacenter

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -517,6 +517,10 @@ func getDsToFileServiceEnabledMap(ctx context.Context, vc *vsphere.VirtualCenter
 		finder.SetDatacenter(datacenter.Datacenter)
 		clusterComputeResource, err := finder.ClusterComputeResourceList(ctx, "*")
 		if err != nil {
+			if _, ok := err.(*find.NotFoundError); ok {
+				log.Debugf("No clusterComputeResource found in dc: %+v. error: %+v", datacenter, err)
+				continue
+			}
 			log.Errorf("Error occurred while getting clusterComputeResource. error: %+v", err)
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we fail if the datacenters doesn't have any clusters inside it - https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/csi/service/common/vsphereutil.go#L518. But it is also possible to have ESX hosts directly inside the DC without a cluster. In that case it gives following error

```
2020-10-20T23:18:51.772Z ERROR common/vsphereutil.go:610 Error occurred while getting clusterComputeResource. error: cluster '*' not found {"TraceId": "d1141ed4-40ac-430a-885c-6b07fbf47189"}
sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common.getDsToFileServiceEnabledMap
/build/pkg/csi/service/common/vsphereutil.go:610
sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common.IsFileServiceEnabled
/build/pkg/csi/service/common/vsphereutil.go:567
sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common.GenerateDatastoreMapForFileVolumes
/build/pkg/csi/service/common/authmanager.go:240
sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common.(*AuthManager).refreshDatastoreMapForFileVolumes
/build/pkg/csi/service/common/authmanager.go:129
sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common.ComputeDatastoreMapForFileVolumes
/build/pkg/csi/service/common/authmanager.go:156
```

This function is internally called via IsFileServiceEnabled as part vanilla CSI controller init - https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/csi/service/vanilla/controller.go#L133

since this is a valid deployment, this PR provides a fix for it.

This bug seems to exist from the time when vanilla file services solutions is released.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/455

**Release note**:
```release-note
Fix for vanilla file services solution in a VC deployment when there is no cluster available in a datacenter
```

cc @divyenpatel @chethanv28 
