### PR TITLE
Make auth check interval configurable.

### DIFF
--- a/example/vanilla-k8s-block-driver/vsphere.conf
+++ b/example/vanilla-k8s-block-driver/vsphere.conf
@@ -1,6 +1,7 @@
 [Global]
 cluster-id = "unique-kubernetes-cluster-id"
 volumemigration-cr-cleanup-intervalinmin = "120"
+csi-auth-check-intervalinmin = "5"
 
 [VirtualCenter "1.2.3.4"]
 insecure-flag = "true"

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -66,6 +66,9 @@ const (
 	// interval after which stale CnsVSphereVolumeMigration CRs will be cleaned up.
 	// Current default value is set to 2 hours
 	DefaultVolumeMigrationCRCleanupIntervalInMin = 120
+
+	// DefaultCSIAuthCheckIntervalInMin is the default time interval that to refresh DatastoreIgnoreMap
+	DefaultCSIAuthCheckIntervalInMin = 5
 )
 
 // Errors
@@ -335,6 +338,9 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 	}
 	if cfg.Global.VolumeMigrationCRCleanupIntervalInMin == 0 {
 		cfg.Global.VolumeMigrationCRCleanupIntervalInMin = DefaultVolumeMigrationCRCleanupIntervalInMin
+	}
+	if cfg.Global.CSIAuthCheckIntervalInMin == 0 {
+		cfg.Global.CSIAuthCheckIntervalInMin = DefaultCSIAuthCheckIntervalInMin
 	}
 	return nil
 }

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -51,6 +51,9 @@ type Config struct {
 		VCClientTimeout int `gcfg:"vc-client-timeout"`
 		// Cluster Distribution Name
 		ClusterDistribution string `gcfg:"cluster-distribution"`
+
+		//CSIAuthCheckIntervalInMin specifies the interval that the auth check for datastores will be trigger
+		CSIAuthCheckIntervalInMin int `gcfg:"csi-auth-check-intervalinmin"`
 	}
 
 	// Multiple sets of Net Permissions applied to all file shares

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -103,10 +103,10 @@ func (authManager *AuthManager) refreshDatastoreIgnoreMap() {
 }
 
 // ComputeDatastoreIgnoreMap refreshes DatastoreIgnoreMapForBlockVolumes periodically
-func ComputeDatastoreIgnoreMap(authManager *AuthManager) {
+func ComputeDatastoreIgnoreMap(authManager *AuthManager, authCheckInterval int) {
 	log := logger.GetLoggerWithNoContext()
 	log.Info("auth manager: ComputeDatastoreIgnoreMap enter")
-	ticker := time.NewTicker(time.Duration(DefaultIgnoreDsIntervalInMinutes) * time.Minute)
+	ticker := time.NewTicker(time.Duration(authCheckInterval) * time.Minute)
 	for range ticker.C {
 		authManager.refreshDatastoreIgnoreMap()
 	}

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -180,9 +180,6 @@ const (
 
 	// SysReadPriv is the privilege to view an entity
 	SysReadPriv = "System.Read"
-
-	// DefaultIgnoreDsIntervalInMinutes is the default interval to compute DatastoreIgnoreMap
-	DefaultIgnoreDsIntervalInMinutes = 5
 )
 
 // Supported container orchestrators

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -181,7 +181,7 @@ func (c *controller) Init(config *cnsconfig.Config) error {
 			return err
 		}
 		c.authMgr = authMgr
-		go common.ComputeDatastoreIgnoreMap(authMgr.(*common.AuthManager))
+		go common.ComputeDatastoreIgnoreMap(authMgr.(*common.AuthManager), config.Global.CSIAuthCheckIntervalInMin)
 	}
 
 	watcher, err := fsnotify.NewWatcher()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
This change is to make the auth check interval configurable.
**What this PR does / why we need it**:
With this change, user can configure the auth check iterval.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Test Setup:
In vsphere.conf file, set the auth check interval to 2 minutes
```
[Global]
 
cluster-id = "unique-kubernetes-cluster-id"
 
csi-auth-check-intervalinmin = "2"
...
```
Use this vsphere.conf to deploy CSI.
Check the CSI log, the auth check is triggered at 2 minutes interval
```
2020-10-16T23:49:05.838Z        DEBUG   common/authmanager.go:99        auth manager: datastoreIgnoreMapForBlockVolumes is updated to map[ds:///vmfs/volumes/f31142bc-65e6524d/:Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/f31142bc-65e6524d/]        {"TraceId": "97f5471b-1b06-4b9e-bd71-66180b351382"}


2020-10-16T23:51:05.866Z        DEBUG   common/authmanager.go:99        auth manager: datastoreIgnoreMapForBlockVolumes is updated to map[ds:///vmfs/volumes/f31142bc-65e6524d/:Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/f31142bc-65e6524d/]        {"TraceId": "0f13c5b2-faed-4071-80f5-6e9c95b192e1"}

2020-10-16T23:53:06.805Z        DEBUG   common/authmanager.go:99        auth manager: datastoreIgnoreMapForBlockVolumes is updated to map[ds:///vmfs/volumes/f31142bc-65e6524d/:Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/f31142bc-65e6524d/]        {"TraceId": "7623f98d-f0de-4ce0-af67-6f2ed905f3f4"}
```
Create a PVC, and PVC create succeed.
```
root@k8s-master:~# kubectl create -f pvc1.yaml
persistentvolumeclaim/example-vanilla-block-pvc1 created

root@k8s-master:~# kubectl get pvc
NAME                         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS               AGE
example-vanilla-block-pvc    Bound    pvc-896cb635-cd45-4090-a0ed-6d8f833577f0   200Mi      RWO            example-vanilla-block-sc   7d1h
example-vanilla-block-pvc1   Bound    pvc-1bcc4c31-37bb-45b7-aabe-d2896993f42c   200Mi      RWO            example-vanilla-block-sc   50s

```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
