### PR TITLE
add leaderElectionNamespace to syncer container

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -43,9 +43,10 @@ const operationModeWebHookServer = "WEBHOOK_SERVER"
 const operationModeMetaDataSync = "METADATA_SYNC"
 
 var (
-	enableLeaderElection = flag.Bool("leader-election", false, "Enable leader election.")
-	printVersion         = flag.Bool("version", false, "Print syncer version and exit")
-	operationMode        = flag.String("operation-mode", operationModeMetaDataSync, "specify operation mode METADATA_SYNC or WEBHOOK_SERVER")
+	enableLeaderElection    = flag.Bool("leader-election", false, "Enable leader election.")
+	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")
+	printVersion            = flag.Bool("version", false, "Print syncer version and exit")
+	operationMode           = flag.String("operation-mode", operationModeMetaDataSync, "specify operation mode METADATA_SYNC or WEBHOOK_SERVER")
 )
 
 // main for vsphere syncer
@@ -104,6 +105,10 @@ func main() {
 			}
 			lockName := "vsphere-syncer"
 			le := leaderelection.NewLeaderElection(k8sClient, lockName, run)
+
+			if *leaderElectionNamespace != "" {
+				le.WithNamespace(*leaderElectionNamespace)
+			}
 
 			if err := le.Run(); err != nil {
 				log.Fatalf("Error initializing leader election: %v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 Syncer does not support specifying `--leader-election-namespace` like all other sidecar container images.
We have a use case where we want to run a CSI controller pod externally from the seed cluster in a different namespace. This requires adding support for specifying the namespace where leader election resources should to be created. 


**Which issue this PR fixes**
fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/397

**Special notes for your reviewer**:

**Testing done.**

Started syncer from the command line by supplying `-leader-election-namespace="kube-system"` flag and checked logs. Leader resources are successfully created in the specified namespace.

```
export VSPHERE_CSI_CONFIG="/root/install-csi-as-process/csi-vsphere.conf"
export LOGGER_LEVEL="PRODUCTION"
export INCLUSTER_CLIENT_QPS="100"
export INCLUSTER_CLIENT_BURST="100"
export FULL_SYNC_INTERVAL_MINUTES="30"
./syncer.linux_amd64 -kubeconfig=/root/.kube/config -leader-election -leader-election-namespace="kube-system" -operation-mode="METADATA_SYNC"

{"level":"info","time":"2020-10-27T17:02:14.160746661-07:00","caller":"logger/logger.go:37","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2020-10-27T17:02:14.161049634-07:00","caller":"syncer/main.go:62","msg":"Version : v2.1.0-rc.1-205-gcba3daaf","TraceId":"90c1c519-6286-48a7-90a8-12ab168c019c"}
{"level":"info","time":"2020-10-27T17:02:14.16111139-07:00","caller":"syncer/main.go:75","msg":"Starting container with operation mode: METADATA_SYNC","TraceId":"90c1c519-6286-48a7-90a8-12ab168c019c"}
{"level":"info","time":"2020-10-27T17:02:14.161731568-07:00","caller":"config/config.go:299","msg":"No Net Permissions given in Config. Using default permissions.","TraceId":"90c1c519-6286-48a7-90a8-12ab168c019c"}
{"level":"info","time":"2020-10-27T17:02:14.162037718-07:00","caller":"config/config.go:331","msg":"No feature states config information is provided in the Config. Using default config map name: internal-feature-states.csi.vsphere.vmware.com and namespace: kube-system","TraceId":"90c1c519-6286-48a7-90a8-12ab168c019c"}
{"level":"info","time":"2020-10-27T17:02:14.162128794-07:00","caller":"kubernetes/kubernetes.go:76","msg":"k8s client using kubeconfig from /root/.kube/config","TraceId":"90c1c519-6286-48a7-90a8-12ab168c019c"}
{"level":"info","time":"2020-10-27T17:02:14.165260211-07:00","caller":"kubernetes/kubernetes.go:267","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"90c1c519-6286-48a7-90a8-12ab168c019c"}
I1027 17:02:14.168651   29262 leaderelection.go:242] attempting to acquire leader lease  kube-system/vsphere-syncer...
I1027 17:02:14.191188   29262 leaderelection.go:252] successfully acquired lease kube-system/vsphere-syncer
{"level":"info","time":"2020-10-27T17:02:14.193618747-07:00","caller":"syncer/metadatasyncer.go:117","msg":"Initializing MetadataSyncer"}
{"level":"info","time":"2020-10-27T17:02:14.195321116-07:00","caller":"kubernetes/kubernetes.go:76","msg":"k8s client using kubeconfig from /root/.kube/config"}
{"level":"info","time":"2020-10-27T17:02:14.196467515-07:00","caller":"kubernetes/kubernetes.go:267","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2020-10-27T17:02:14.200997977-07:00","caller":"k8sorchestrator/k8sorchestrator.go:87","msg":"Initializing k8sOrchestratorInstance"}
{"level":"info","time":"2020-10-27T17:02:14.202847693-07:00","caller":"kubernetes/kubernetes.go:76","msg":"k8s client using kubeconfig from /root/.kube/config"}
{"level":"info","time":"2020-10-27T17:02:14.207591354-07:00","caller":"kubernetes/kubernetes.go:267","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2020-10-27T17:02:14.214601399-07:00","caller":"k8sorchestrator/k8sorchestrator.go:185","msg":"New internal feature states values stored successfully: map[csi-auth-check:false csi-migration:false]"}
{"level":"info","time":"2020-10-27T17:02:14.214803171-07:00","caller":"k8sorchestrator/k8sorchestrator.go:105","msg":"k8sOrchestratorInstance initialized"}
{"level":"info","time":"2020-10-27T17:02:14.215854355-07:00","caller":"vsphere/utils.go:126","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2020-10-27T17:02:14.215928795-07:00","caller":"vsphere/virtualcentermanager.go:64","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2020-10-27T17:02:14.215946553-07:00","caller":"vsphere/virtualcentermanager.go:66","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2020-10-27T17:02:14.215971083-07:00","caller":"vsphere/virtualcentermanager.go:110","msg":"Successfully registered VC \"10.182.138.171\""}
{"level":"info","time":"2020-10-27T17:02:14.235014635-07:00","caller":"k8sorchestrator/k8sorchestrator.go:228","msg":"New feature states values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[csi-auth-check:false csi-migration:false]","TraceId":"5a5a7e3b-c916-41f1-80e2-ff8c433feb74"}
{"level":"info","time":"2020-10-27T17:02:14.305004137-07:00","caller":"vsphere/virtualcenter.go:153","msg":"New session ID for 'VSPHERE.LOCAL\\Administrator' = 5299bafa-8df4-50f0-afd0-0965c9ee6fb0"}
{"level":"info","time":"2020-10-27T17:02:14.305810197-07:00","caller":"volume/manager.go:100","msg":"Initializing new volume.defaultManager..."}
{"level":"info","time":"2020-10-27T17:02:14.306043131-07:00","caller":"syncer/metadatasyncer.go:217","msg":"Adding watch on path: \"/root/install-csi-as-process\""}
{"level":"info","time":"2020-10-27T17:02:14.414022758-07:00","caller":"syncer/metadatasyncer.go:268","msg":"Initialized metadata syncer"}
{"level":"info","time":"2020-10-27T17:02:14.415147861-07:00","caller":"syncer/metadatasyncer.go:82","msg":"FullSync: fullSync interval is set to 30 minutes"}
{"level":"info","time":"2020-10-27T17:02:14.416996575-07:00","caller":"syncer/metadatasyncer.go:276","msg":"fullSync is triggered","TraceId":"a9f4a9d3-e466-4d31-9332-ecc0ee3cdde6"}
{"level":"info","time":"2020-10-27T17:02:14.417252415-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start","TraceId":"a9f4a9d3-e466-4d31-9332-ecc0ee3cdde6"}
{"level":"warn","time":"2020-10-27T17:02:14.441908942-07:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS","TraceId":"a9f4a9d3-e466-4d31-9332-ecc0ee3cdde6"}
{"level":"info","time":"2020-10-27T17:02:14.442139999-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion.","TraceId":"a9f4a9d3-e466-4d31-9332-ecc0ee3cdde6"}
{"level":"info","time":"2020-10-27T17:02:14.442338702-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end","TraceId":"a9f4a9d3-e466-4d31-9332-ecc0ee3cdde6"}


```


Attempted to start syncer from the command line by supplying `-leader-election-namespace="not-present"` flag and checked logs. Leader election failed as namespace `not-present` is not present in the kubernetes cluster.


```
./syncer.linux_amd64 -kubeconfig=/root/.kube/config -leader-election -leader-election-namespace="not-present" -operation-mode="METADATA_SYNC"
{"level":"info","time":"2020-10-27T17:05:04.908156466-07:00","caller":"logger/logger.go:37","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2020-10-27T17:05:04.912260477-07:00","caller":"syncer/main.go:62","msg":"Version : v2.1.0-rc.1-205-gcba3daaf","TraceId":"da97519a-f9a2-40f5-8ef3-c52a3db002fc"}
{"level":"info","time":"2020-10-27T17:05:04.913174841-07:00","caller":"syncer/main.go:75","msg":"Starting container with operation mode: METADATA_SYNC","TraceId":"da97519a-f9a2-40f5-8ef3-c52a3db002fc"}
{"level":"info","time":"2020-10-27T17:05:04.914060603-07:00","caller":"config/config.go:299","msg":"No Net Permissions given in Config. Using default permissions.","TraceId":"da97519a-f9a2-40f5-8ef3-c52a3db002fc"}
{"level":"info","time":"2020-10-27T17:05:04.91420501-07:00","caller":"config/config.go:331","msg":"No feature states config information is provided in the Config. Using default config map name: internal-feature-states.csi.vsphere.vmware.com and namespace: kube-system","TraceId":"da97519a-f9a2-40f5-8ef3-c52a3db002fc"}
{"level":"info","time":"2020-10-27T17:05:04.918333954-07:00","caller":"kubernetes/kubernetes.go:76","msg":"k8s client using kubeconfig from /root/.kube/config","TraceId":"da97519a-f9a2-40f5-8ef3-c52a3db002fc"}
{"level":"info","time":"2020-10-27T17:05:04.927946522-07:00","caller":"kubernetes/kubernetes.go:267","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"da97519a-f9a2-40f5-8ef3-c52a3db002fc"}
I1027 17:05:04.933308   29799 leaderelection.go:242] attempting to acquire leader lease  not-present/vsphere-syncer...
E1027 17:05:05.022414   29799 leaderelection.go:324] error initially creating leader election record: namespaces "not-present" not found
```

Also verified starting syncer from the command line by not supplying `-leader-election-namespace` flag and checked logs. Leader election resources are created in the default namespace. since I am running this command from kubernetes master and not from a Pod in a specific namespace.

```
./syncer.linux_amd64 -kubeconfig=/root/.kube/config -leader-election -operation-mode="METADATA_SYNC"
.
.
.
I1027 17:09:18.437534   30580 leaderelection.go:242] attempting to acquire leader lease  default/vsphere-syncer...
I1027 17:09:18.473009   30580 leaderelection.go:252] successfully acquired lease default/vsphere-syncer
.
.
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add leaderElectionNamespace to syncer container
```
