### PR TITLE
Upgrade the external-attacher to v2.0.0

### DIFF
--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -40,7 +40,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
@@ -144,7 +144,6 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
-            - "--leader-election-type=leases"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -40,7 +40,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
@@ -144,7 +144,6 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
-            - "--leader-election-type=leases"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -40,7 +40,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
@@ -144,7 +144,6 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
-            - "--leader-election-type=leases"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently, we are using external-attacher V1.1.1 for TKG and WCP which has an issue: when the detach fails for some reason and return `codes.Internal`, the external-attacher marks completed and delete the volumeattachement in TKG instead of keeping trying detach.  This issue is fixed from 2.0 version in external-attacher.

This PR helps to upgrade the external-attacher to v2.0.0 by adding RBAC rules: `patch` for `["volumeattachments"]` and also removed the deprecated value `-leader-election-type` for 2.0 version from the PVCSI yaml.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I have manually verified the PVCSI yaml with the above changes and external-attacher v2.0.0 image can solve the issue. When the detach fails, it keeps calling ControllerUnpublishVolume  and the  volumeattachement in TKG also persists.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Upgrade the external-attacher for pvCSI to v2.0.0
```
