### PR TITLE
Add default-fs parameter to provisioner args

### DIFF
--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -119,6 +119,7 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--default-fstype=ext4"
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -123,6 +123,7 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--leader-election"
+            - "--default-fstype=ext4"
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"

--- a/manifests/v2.0.1/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.0.1/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -111,6 +111,7 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--default-fstype=ext4"
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"

--- a/manifests/v2.0.1/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.0.1/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -124,6 +124,7 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--default-fstype=ext4"
             # needed only for topology aware setups
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a default fs type parameter to external provisioner. With v2.0.0, provisioner sends an empty fs type parameter if none is specified, instead of defaulting to `ext4`. Reference: https://github.com/kubernetes-csi/external-provisioner/issues/328
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/370

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add default-fs parameter to provisioner args
```
