### PR TITLE
Enable support for file volume functionality in WCP CSI and implement Create/Delete for file volumes in WCP CSI

### DIFF
--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/deploy/vsphere-csi-controller-deployment.yaml
@@ -178,6 +178,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "file-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/deploy/vsphere-csi-controller-deployment.yaml
@@ -178,6 +178,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "file-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
@@ -180,6 +180,7 @@ data:
   "volume-extend": "true"
   "volume-health": "true"
   "online-volume-extend": "false"
+  "file-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -22,8 +22,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+	vim25types "github.com/vmware/govmomi/vim25/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -32,19 +36,25 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
-// AuthorizationService exposes interfaces to support authorization check on datastores and get datastores which need to be
-// ignored by create volume
+// AuthorizationService exposes interfaces to support authorization check on datastores and get datastores
+// which will be used by create volume
 type AuthorizationService interface {
+	// GetDatastoreMapForBlockVolumes returns a map of datastore URL to datastore info for only those
+	// datastores the CSI VC user has Datastore.FileManagement privilege for.
+	GetDatastoreMapForBlockVolumes(ctx context.Context) map[string]*cnsvsphere.DatastoreInfo
 
-	// GetDatastoreIgnoreMapForBlockVolumes returns a map which maps datastore url to datastore info which user does not have Datastore.FileManagement privilege
-	GetDatastoreIgnoreMapForBlockVolumes(ctx context.Context) map[string]*cnsvsphere.DatastoreInfo
+	// GetDatastoreMapForFileVolumes returns a map of datastore URL to datastore info for only those
+	// datastores the CSI VC user has Host.Config.Storage privilege on vSAN cluster with vSAN FS enabled.
+	GetDatastoreMapForFileVolumes(ctx context.Context) map[string]*cnsvsphere.DatastoreInfo
 }
 
-// AuthManager maintains an internal map to track the datastores that need to be ignored by create volume
+// AuthManager maintains an internal map to track the datastores that need to be used by create volume
 type AuthManager struct {
-	// map the datastore url to datastore info which need to be ignored when invoking CNS CreateVolume API
-	datastoreIgnoreMapForBlockVolumes map[string]*cnsvsphere.DatastoreInfo
-	// this mutex is to make sure the update for datatoreIgnoreMap is mutually exclusive
+	// map the datastore url to datastore info which need to be used when invoking CNS CreateVolume API
+	datastoreMapForBlockVolumes map[string]*cnsvsphere.DatastoreInfo
+	// map the datastore url to datastore info which need to be used when invoking CNS CreateVolume API
+	datastoreMapForFileVolumes map[string]*cnsvsphere.DatastoreInfo
+	// this mutex is to make sure the update for datastoreMap is mutually exclusive
 	rwMutex sync.RWMutex
 	// vCenter Instance
 	vcenter *cnsvsphere.VirtualCenter
@@ -63,58 +73,96 @@ func GetAuthorizationService(ctx context.Context, vc *cnsvsphere.VirtualCenter) 
 		log.Info("Initializing authorization service...")
 
 		authManagerInstance = &AuthManager{
-
-			datastoreIgnoreMapForBlockVolumes: make(map[string]*cnsvsphere.DatastoreInfo),
-			rwMutex:                           sync.RWMutex{},
-			vcenter:                           vc,
+			datastoreMapForBlockVolumes: make(map[string]*cnsvsphere.DatastoreInfo),
+			datastoreMapForFileVolumes:  make(map[string]*cnsvsphere.DatastoreInfo),
+			rwMutex:                     sync.RWMutex{},
+			vcenter:                     vc,
 		}
-		authManagerInstance.refreshDatastoreIgnoreMap()
 	})
 
 	log.Info("authorization service initialized")
 	return authManagerInstance, nil
 }
 
-// GetDatastoreIgnoreMapForBlockVolumes returns a DatastoreIgnoreMapForBlockVolumes. This map maps datastore url to datastore info
-// which need to be ignored when creating block volume.
-func (authManager *AuthManager) GetDatastoreIgnoreMapForBlockVolumes(ctx context.Context) map[string]*cnsvsphere.DatastoreInfo {
-	datastoreIgnoreMapForBlockVolumes := make(map[string]*cnsvsphere.DatastoreInfo)
+// GetDatastoreMapForBlockVolumes returns a DatastoreMapForBlockVolumes. This map maps datastore url to datastore info
+// which need to be used when creating block volume.
+func (authManager *AuthManager) GetDatastoreMapForBlockVolumes(ctx context.Context) map[string]*cnsvsphere.DatastoreInfo {
+	datastoreMapForBlockVolumes := make(map[string]*cnsvsphere.DatastoreInfo)
 	authManager.rwMutex.RLock()
 	defer authManager.rwMutex.RUnlock()
-	for dsURL, dsInfo := range authManager.datastoreIgnoreMapForBlockVolumes {
-		datastoreIgnoreMapForBlockVolumes[dsURL] = dsInfo
+	for dsURL, dsInfo := range authManager.datastoreMapForBlockVolumes {
+		datastoreMapForBlockVolumes[dsURL] = dsInfo
 	}
-	return datastoreIgnoreMapForBlockVolumes
+	return datastoreMapForBlockVolumes
 }
 
-// refreshDatastoreIgnoreMap scans all datastores in vCenter to check privileges, and compute the DatastoreIgnoreMap
-func (authManager *AuthManager) refreshDatastoreIgnoreMap() {
+// GetDatastoreMapForFileVolumes returns a DatastoreMapForFileVolumes. This map maps datastore url to datastore info
+// which need to be used when creating file volume.
+func (authManager *AuthManager) GetDatastoreMapForFileVolumes(ctx context.Context) map[string]*cnsvsphere.DatastoreInfo {
+	datastoreMapForFileVolumes := make(map[string]*cnsvsphere.DatastoreInfo)
+	authManager.rwMutex.RLock()
+	defer authManager.rwMutex.RUnlock()
+	for dsURL, dsInfo := range authManager.datastoreMapForFileVolumes {
+		datastoreMapForFileVolumes[dsURL] = dsInfo
+	}
+	return datastoreMapForFileVolumes
+}
+
+// refreshDatastoreMapForBlockVolumes scans all datastores in vCenter to check privileges, and compute the
+// datastoreMapForBlockVolumes
+func (authManager *AuthManager) refreshDatastoreMapForBlockVolumes() {
 	ctx, log := logger.GetNewContextWithLogger()
-	log.Info("auth manager: refreshDatastoreIgnoreMap is triggered")
-	newDatastoreIgnoreMapForBlockVolumes, err := GenerateDatastoreIgnoreMapForBlockVolumes(ctx, authManager.vcenter)
+	log.Debug("auth manager: refreshDatastoreMapForBlockVolumes is triggered")
+	newDatastoreMapForBlockVolumes, err := GenerateDatastoreMapForBlockVolumes(ctx, authManager.vcenter)
 	if err == nil {
 		authManager.rwMutex.Lock()
 		defer authManager.rwMutex.Unlock()
-		authManager.datastoreIgnoreMapForBlockVolumes = newDatastoreIgnoreMapForBlockVolumes
-		log.Debugf("auth manager: datastoreIgnoreMapForBlockVolumes is updated to %v", newDatastoreIgnoreMapForBlockVolumes)
+		authManager.datastoreMapForBlockVolumes = newDatastoreMapForBlockVolumes
+		log.Debugf("auth manager: datastoreMapForBlockVolumes is updated to %v", newDatastoreMapForBlockVolumes)
 	} else {
-		log.Warnf("auth manager: failed to get updated datastoreIgnoreMapForBlockVolumes, Err: %v", err)
+		log.Warnf("auth manager: failed to get updated datastoreMapForBlockVolumes, Err: %v", err)
 	}
 }
 
-// ComputeDatastoreIgnoreMap refreshes DatastoreIgnoreMapForBlockVolumes periodically
-func ComputeDatastoreIgnoreMap(authManager *AuthManager, authCheckInterval int) {
+// refreshDatastoreMapForFileVolumes scans all vSAN datastores with vSAN FS enabled in vCenter to
+// check privileges, and compute the datastoreMapForFileVolumes
+func (authManager *AuthManager) refreshDatastoreMapForFileVolumes() {
+	ctx, log := logger.GetNewContextWithLogger()
+	log.Debug("auth manager: refreshDatastoreMapForFileVolumes is triggered")
+	newDatastoreMapForFileVolumes, err := GenerateDatastoreMapForFileVolumes(ctx, authManager.vcenter)
+	if err == nil {
+		authManager.rwMutex.Lock()
+		defer authManager.rwMutex.Unlock()
+		authManager.datastoreMapForFileVolumes = newDatastoreMapForFileVolumes
+		log.Debugf("auth manager: datastoreMapForFileVolumes is updated to %v", newDatastoreMapForFileVolumes)
+	} else {
+		log.Warnf("auth manager: failed to get updated datastoreMapForFileVolumes, Err: %v", err)
+	}
+}
+
+// ComputeDatastoreMapForBlockVolumes refreshes DatastoreMapForBlockVolumes periodically
+func ComputeDatastoreMapForBlockVolumes(authManager *AuthManager, authCheckInterval int) {
 	log := logger.GetLoggerWithNoContext()
-	log.Info("auth manager: ComputeDatastoreIgnoreMap enter")
+	log.Info("auth manager: ComputeDatastoreMapForBlockVolumes enter")
 	ticker := time.NewTicker(time.Duration(authCheckInterval) * time.Minute)
-	for range ticker.C {
-		authManager.refreshDatastoreIgnoreMap()
+	for ; true; <-ticker.C {
+		authManager.refreshDatastoreMapForBlockVolumes()
 	}
 }
 
-// GenerateDatastoreIgnoreMapForBlockVolumes scans all datastores in Vcenter and do privilege check on those datastoes
-// It will return datastores which does not have the privileges for creating volume
-func GenerateDatastoreIgnoreMapForBlockVolumes(ctx context.Context, vc *vsphere.VirtualCenter) (map[string]*cnsvsphere.DatastoreInfo, error) {
+// ComputeDatastoreMapForFileVolumes refreshes DatastoreMapForFileVolumes periodically
+func ComputeDatastoreMapForFileVolumes(authManager *AuthManager, authCheckInterval int) {
+	log := logger.GetLoggerWithNoContext()
+	log.Info("auth manager: ComputeDatastoreMapForFileVolumes enter")
+	ticker := time.NewTicker(time.Duration(authCheckInterval) * time.Minute)
+	for ; true; <-ticker.C {
+		authManager.refreshDatastoreMapForFileVolumes()
+	}
+}
+
+// GenerateDatastoreMapForBlockVolumes scans all datastores in Vcenter and do privilege check on those datastoes
+// It will return datastores which has the privileges for creating block volume
+func GenerateDatastoreMapForBlockVolumes(ctx context.Context, vc *vsphere.VirtualCenter) (map[string]*cnsvsphere.DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
 	// get all datastores from VC
 	dcList, err := vc.GetDatacenters(ctx)
@@ -126,6 +174,7 @@ func GenerateDatastoreIgnoreMapForBlockVolumes(ctx context.Context, vc *vsphere.
 	var dsURLTodsInfoMap map[string]*cnsvsphere.DatastoreInfo
 	var dsURLs []string
 	var dsInfos []*cnsvsphere.DatastoreInfo
+	var entities []types.ManagedObjectReference
 	for _, dc := range dcList {
 		dsURLTodsInfoMap, err = dc.GetAllDatastores(ctx)
 		if err != nil {
@@ -135,44 +184,230 @@ func GenerateDatastoreIgnoreMapForBlockVolumes(ctx context.Context, vc *vsphere.
 		for dsURL, dsInfo := range dsURLTodsInfoMap {
 			dsURLs = append(dsURLs, dsURL)
 			dsInfos = append(dsInfos, dsInfo)
+			dsMoRef := dsInfo.Reference()
+			entities = append(entities, dsMoRef)
 		}
 	}
 
-	log.Debugf("auth manager: dsURLs %v dsInfos %v", dsURLs, dsInfos)
-	dsIgnoreURLToInfoMap := make(map[string]*cnsvsphere.DatastoreInfo)
+	dsURLToInfoMap, err := getDatastoresWithBlockVolumePrivs(ctx, vc, dsURLs, dsInfos, entities)
+	if err != nil {
+		log.Errorf("failed to get datastores with required priv. Error: %+v", err)
+		return nil, err
+	}
+	return dsURLToInfoMap, nil
+}
+
+// GenerateDatastoreMapForFileVolumes scans all datastores in Vcenter and do privilege check on those datastoes
+// It will return datastores which has the privileges for creating file volume
+func GenerateDatastoreMapForFileVolumes(ctx context.Context, vc *vsphere.VirtualCenter) (map[string]*cnsvsphere.DatastoreInfo, error) {
+	log := logger.GetLogger(ctx)
+	// get all vSAN datastores from VC
+	vsanDsURLToInfoMap, err := vc.GetVsanDatastores(ctx)
+	if err != nil {
+		log.Errorf("failed to get vSAN datastores with error %+v", err)
+		return nil, err
+	}
+	var allvsanDatastoreUrls []string
+	for dsURL := range vsanDsURLToInfoMap {
+		allvsanDatastoreUrls = append(allvsanDatastoreUrls, dsURL)
+	}
+	fsEnabledMap, err := IsFileServiceEnabled(ctx, allvsanDatastoreUrls, vc)
+	if err != nil {
+		log.Errorf("failed to get if file service is enabled on vsan datastores with error %+v", err)
+		return nil, err
+	}
+
+	dsURLToInfoMap := make(map[string]*cnsvsphere.DatastoreInfo)
+	for dsURL, dsInfo := range vsanDsURLToInfoMap {
+		if val, ok := fsEnabledMap[dsURL]; ok {
+			if val {
+				dsURLToInfoMap[dsURL] = dsInfo
+			}
+		}
+	}
+	log.Debugf("dsURLToInfoMap is %+v", dsURLToInfoMap)
+	return dsURLToInfoMap, nil
+}
+
+// IsFileServiceEnabled checks if file service is enabled on the specified datastoreUrls.
+func IsFileServiceEnabled(ctx context.Context, datastoreUrls []string, vc *vsphere.VirtualCenter) (map[string]bool, error) {
+	// Compute this map during controller init. Re use the map every other time.
+	log := logger.GetLogger(ctx)
+	err := vc.Connect(ctx)
+	if err != nil {
+		log.Errorf("failed to connect to VirtualCenter. err=%v", err)
+		return nil, err
+	}
+	err = vc.ConnectVsan(ctx)
+	if err != nil {
+		log.Errorf("error occurred while connecting to VSAN, err: %+v", err)
+		return nil, err
+	}
+	// This gets the datastore to file service enabled map for all the vsan datastores.
+	dsToFileServiceEnabledMap, err := getDsToFileServiceEnabledMap(ctx, vc)
+	if err != nil {
+		log.Errorf("failed to query if file service is enabled on vsan datastores or not. error: %+v", err)
+		return nil, err
+	}
+	log.Debugf("dsToFileServiceEnabledMap is %+v", dsToFileServiceEnabledMap)
+	// Now create a map of datastores which are queried in the method.
+	dsToFSEnabledMapToReturn := make(map[string]bool)
+	for _, datastoreURL := range datastoreUrls {
+		if val, ok := dsToFileServiceEnabledMap[datastoreURL]; ok {
+			if !val {
+				msg := fmt.Sprintf("File service is not enabled on the datastore: %s", datastoreURL)
+				log.Debugf(msg)
+				dsToFSEnabledMapToReturn[datastoreURL] = false
+			} else {
+				msg := fmt.Sprintf("File service is enabled on the datastore: %s", datastoreURL)
+				log.Debugf(msg)
+				dsToFSEnabledMapToReturn[datastoreURL] = true
+			}
+		} else {
+			msg := fmt.Sprintf("File service is not enabled on the datastore: %s", datastoreURL)
+			log.Debugf(msg)
+			dsToFSEnabledMapToReturn[datastoreURL] = false
+		}
+	}
+	return dsToFSEnabledMapToReturn, nil
+}
+
+// getDatastoresWithBlockVolumePrivs gets datastores with required priv for CSI user
+func getDatastoresWithBlockVolumePrivs(ctx context.Context, vc *vsphere.VirtualCenter,
+	dsURLs []string, dsInfos []*cnsvsphere.DatastoreInfo, entities []types.ManagedObjectReference) (map[string]*cnsvsphere.DatastoreInfo, error) {
+	log := logger.GetLogger(ctx)
+	log.Debugf("auth manager: file - dsURLs %v dsInfos %v", dsURLs, dsInfos)
+	// dsURLToInfoMap will store a list of vSAN datastores with vSAN FS enabled for which
+	// CSI user has privilege to
+	dsURLToInfoMap := make(map[string]*cnsvsphere.DatastoreInfo)
 	// get authMgr
 	authMgr := object.NewAuthorizationManager(vc.Client.Client)
 	privIds := []string{DsPriv, SysReadPriv}
-	var entities []types.ManagedObjectReference
-	for _, dsInfo := range dsInfos {
-		// go through all datastores to build entities
-		dsMoRef := dsInfo.Datastore.Datastore.Reference()
-		entities = append(entities, dsMoRef)
-	}
 
-	var result []types.EntityPrivilege
 	userName := vc.Config.Username
 	// invoke authMgr function HasUserPrivilegeOnEntities
-	result, err = authMgr.HasUserPrivilegeOnEntities(ctx, entities, userName, privIds)
+	result, err := authMgr.HasUserPrivilegeOnEntities(ctx, entities, userName, privIds)
 	if err != nil {
 		log.Errorf("auth manager: failed to check privilege %v on entities %v for user %s", privIds, entities, userName)
 		return nil, err
 	}
 	log.Debugf("auth manager: HasUserPrivilegeOnEntities returns %v when checking privileges %v on entities %v for user %s", result, privIds, entities, userName)
 	for index, entityPriv := range result {
-		needIgnore := false
+		hasPriv := true
 		privAvails := entityPriv.PrivAvailability
 		for _, privAvail := range privAvails {
 			// required privilege is not grant for this entity
 			if !privAvail.IsGranted {
-				needIgnore = true
+				hasPriv = false
 				break
 			}
 		}
-		if needIgnore {
-			dsIgnoreURLToInfoMap[dsURLs[index]] = dsInfos[index]
-			log.Debugf("auth manager: datastore with URL %s  and name %s is added to dsIgnoreURLToInfoMap", dsInfos[index].Info.Name, dsURLs[index])
+		if hasPriv {
+			dsURLToInfoMap[dsURLs[index]] = dsInfos[index]
+			log.Debugf("auth manager: datastore with URL %s and name %s has privileges and is added to dsURLToInfoMap", dsInfos[index].Info.Name, dsURLs[index])
 		}
 	}
-	return dsIgnoreURLToInfoMap, nil
+	return dsURLToInfoMap, nil
+}
+
+// Creates a map of vsan datastores to file service status (enabled/disabled).
+func getDsToFileServiceEnabledMap(ctx context.Context, vc *vsphere.VirtualCenter) (map[string]bool, error) {
+	log := logger.GetLogger(ctx)
+	log.Debugf("Computing the cluster to file service status (enabled/disabled) map.")
+	datacenters, err := vc.ListDatacenters(ctx)
+	if err != nil {
+		log.Errorf("failed to find datacenters from VC: %+v, Error: %+v", vc.Config.Host, err)
+		return nil, err
+	}
+
+	dsToFileServiceEnabledMap := make(map[string]bool)
+	// Get clusters from datacenters
+	clusterComputeResources := []*object.ClusterComputeResource{}
+	for _, datacenter := range datacenters {
+		finder := find.NewFinder(datacenter.Datacenter.Client(), false)
+		finder.SetDatacenter(datacenter.Datacenter)
+		clusterComputeResource, err := finder.ClusterComputeResourceList(ctx, "*")
+		if err != nil {
+			if _, ok := err.(*find.NotFoundError); ok {
+				log.Debugf("No clusterComputeResource found in dc: %+v. error: %+v", datacenter, err)
+				continue
+			}
+			log.Errorf("Error occurred while getting clusterComputeResource. error: %+v", err)
+			return nil, err
+		}
+		clusterComputeResources = append(clusterComputeResources, clusterComputeResource...)
+	}
+
+	// Get Clusters with HostConfigStoragePriv
+	authMgr := object.NewAuthorizationManager(vc.Client.Client)
+	privIds := []string{HostConfigStoragePriv}
+	userName := vc.Config.Username
+	var entities []types.ManagedObjectReference
+	clusterComputeResourcesMap := make(map[string]*object.ClusterComputeResource)
+	for _, cluster := range clusterComputeResources {
+		entities = append(entities, cluster.Reference())
+		clusterComputeResourcesMap[cluster.Reference().Value] = cluster
+	}
+
+	// invoke authMgr function HasUserPrivilegeOnEntities
+	result, err := authMgr.HasUserPrivilegeOnEntities(ctx, entities, userName, privIds)
+	if err != nil {
+		log.Errorf("auth manager: failed to check privilege %v on entities %v for user %s", privIds, entities, userName)
+		return nil, err
+	}
+	log.Debugf("auth manager: HasUserPrivilegeOnEntities returns %v when checking privileges %v on entities %v for user %s", result, privIds, entities, userName)
+	clusterComputeResourceWithPriv := []*object.ClusterComputeResource{}
+	for _, entityPriv := range result {
+		hasPriv := true
+		privAvails := entityPriv.PrivAvailability
+		for _, privAvail := range privAvails {
+			// required privilege is not grant for this entity
+			if !privAvail.IsGranted {
+				hasPriv = false
+				break
+			}
+		}
+		if hasPriv {
+			clusterComputeResourceWithPriv = append(clusterComputeResourceWithPriv, clusterComputeResourcesMap[entityPriv.Entity.Value])
+		}
+	}
+	log.Debugf("Clusters with priv: %s are : %+v", HostConfigStoragePriv, clusterComputeResourceWithPriv)
+
+	// Get clusters which are vSAN and have vSAN FS enabled
+	pc := property.DefaultCollector(vc.Client.Client)
+	properties := []string{"info", "summary"}
+	// Get all the vsan datastores with vsan FS from these clusters and add it to map.
+	for _, cluster := range clusterComputeResourceWithPriv {
+		// Get the cluster config to know if file service is enabled on it or not.
+		config, err := vc.VsanClient.VsanClusterGetConfig(ctx, cluster.Reference())
+		if err != nil {
+			log.Errorf("failed to get the vsan cluster config. error: %+v", err)
+			return nil, err
+		}
+		log.Debugf("cluster: %+v has vSAN file services enabled: %t", cluster, config.FileServiceConfig.Enabled)
+		var dsList []vim25types.ManagedObjectReference
+		var dsMoList []mo.Datastore
+		datastores, err := cluster.Datastores(ctx)
+		if err != nil {
+			log.Errorf("Error occurred while getting datastores from clusters. error: %+v", err)
+			return nil, err
+		}
+		for _, datastore := range datastores {
+			dsList = append(dsList, datastore.Reference())
+		}
+		err = pc.Retrieve(ctx, dsList, properties, &dsMoList)
+		if err != nil {
+			log.Errorf("failed to get Datastore managed objects from datastore objects."+
+				" dsObjList: %+v, properties: %+v, err: %v", dsList, properties, err)
+			return nil, err
+		}
+		// TODO: ALso identify which vSAN datastore is management
+		// and which one is a workload datastore to support file volumes on VMC
+		for _, dsMo := range dsMoList {
+			if dsMo.Summary.Type == VsanDatastoreType {
+				dsToFileServiceEnabledMap[dsMo.Info.GetDatastoreInfo().Url] = config.FileServiceConfig.Enabled
+			}
+		}
+	}
+	return dsToFileServiceEnabledMap, nil
 }

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -175,11 +175,14 @@ const (
 	// InTreePluginName is the name of vsphere cloud provider in kubernetes
 	InTreePluginName = "kubernetes.io/vsphere-volume"
 
-	// DsPriv is the privilege need to wirte a that datastore
+	// DsPriv is the privilege need to write on that datastore
 	DsPriv = "Datastore.FileManagement"
 
 	// SysReadPriv is the privilege to view an entity
 	SysReadPriv = "System.Read"
+
+	// HostConfigStoragePriv is the privilege for file volumes
+	HostConfigStoragePriv = "Host.Config.Storage"
 )
 
 // Supported container orchestrators
@@ -203,4 +206,6 @@ const (
 	CSIAuthCheck = "csi-auth-check"
 	// VSANDirectDiskDecommission is feature flag for vsanD disk decommission
 	VSANDirectDiskDecommission = "vsan-direct-disk-decommission"
+	// FileVolume is feature flag name for file volume support in WCP
+	FileVolume = "file-volume"
 )

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -229,14 +229,24 @@ func (f *FakeNodeManager) GetSharedDatastoresInTopology(ctx context.Context, top
 	return nil, nil, nil
 }
 
-func (f *FakeAuthManager) GetDatastoreIgnoreMapForBlockVolumes(ctx context.Context) map[string]*cnsvsphere.DatastoreInfo {
-	datastoreIgnoreMap := make(map[string]*cnsvsphere.DatastoreInfo)
-	fmt.Print("FakeAuthManager: GetDatastoreIgnoreMapForBlockVolumes")
+func (f *FakeAuthManager) GetDatastoreMapForBlockVolumes(ctx context.Context) map[string]*cnsvsphere.DatastoreInfo {
+	datastoreMapForBlockVolumes := make(map[string]*cnsvsphere.DatastoreInfo)
+	fmt.Print("FakeAuthManager: GetDatastoreMapForBlockVolumes")
 	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
-		datastoreIgnoreMap, _ := common.GenerateDatastoreIgnoreMapForBlockVolumes(ctx, f.vcenter)
-		return datastoreIgnoreMap
+		datastoreMapForBlockVolumes, _ := common.GenerateDatastoreMapForBlockVolumes(ctx, f.vcenter)
+		return datastoreMapForBlockVolumes
 	}
-	return datastoreIgnoreMap
+	return datastoreMapForBlockVolumes
+}
+
+func (f *FakeAuthManager) GetDatastoreMapForFileVolumes(ctx context.Context) map[string]*cnsvsphere.DatastoreInfo {
+	datastoreMapForFileVolumes := make(map[string]*cnsvsphere.DatastoreInfo)
+	fmt.Print("FakeAuthManager: GetDatastoreMapForFileVolumes")
+	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
+		datastoreMapForFileVolumes, _ := common.GenerateDatastoreMapForFileVolumes(ctx, f.vcenter)
+		return datastoreMapForFileVolumes
+	}
+	return datastoreMapForFileVolumes
 }
 
 func getControllerTest(t *testing.T) *controllerTest {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/472

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
- WCP CSI file volume feature will be enabled only if `csi-auth-check` and `file-volume` features are enabled.
- Enhance auth manager to support file volumes. Auth manager will look for `host.Config.Storage` permission on vSAN clusters with vSAN FS enabled and `Datastore.FileManagement` permissions on vSAN datastores  for file volume provisioning. 
- Use auth manager for WCP CSI Create if `csi-auth-check` and `file-volume` features are enabled.
- Enhance Vanilla file volume solution to use auth manager for Vanilla CSI Create if `csi-auth-check` is enabled. If csi-auth-check is not enabled, continue to be use `TargetvSANFileShareDatastoreURLs` from vsphere.conf.
- Ensure VMC scenario works too because i have made lot of changes to auth manager for block volume support.

**Testing done for WCP CSI**:
1. When no vSAN cluster with `host.config.storage` permission is found on VC for the CSI user
```
2020-10-26T21:09:55.908Z	INFO	wcp/controller.go:124	CSIAuthCheck feature is enabled, loading AuthorizationService	{"TraceId": "fc334487-6d2c-4532-86fa-9f50ea648bef"}
2020-10-26T21:09:55.908Z	INFO	common/authmanager.go:73	Initializing authorization service...	{"TraceId": "fc334487-6d2c-4532-86fa-9f50ea648bef"}
2020-10-26T21:09:55.908Z	INFO	common/authmanager.go:83	authorization service initialized	{"TraceId": "fc334487-6d2c-4532-86fa-9f50ea648bef"}
2020-10-26T21:09:55.908Z	INFO	wcp/controller.go:155	Adding watch on path: "/etc/vmware/wcp"	{"TraceId": "fc334487-6d2c-4532-86fa-9f50ea648bef"}
2020-10-26T21:09:55.909Z	DEBUG	wcp/controller.go:135	Waiting for event on fsnotify watcher	{"TraceId": "fc334487-6d2c-4532-86fa-9f50ea648bef"}
2020-10-26T21:09:55.910Z	INFO	common/authmanager.go:156	auth manager: ComputeDatastoreMapForFileVolumes enter
2020-10-26T21:09:55.910Z	INFO	common/authmanager.go:131	auth manager: refreshDatastoreMapForFileVolumes is triggered	{"TraceId": "e1d906cc-a3a9-4911-b7e4-1ba8bb1a0285"}
2020-10-26T21:09:55.913Z	INFO	service/service.go:105	configured: "csi.vsphere.vmware.com" with clusterFlavor: "WORKLOAD" and mode: "controller"	{"TraceId": "21335b74-e729-4109-9a61-1510cd98184d"}
time="2020-10-26T21:09:55Z" level=info msg="identity service registered"
time="2020-10-26T21:09:55Z" level=info msg="controller service registered"
time="2020-10-26T21:09:55Z" level=info msg=serving endpoint="unix:///var/lib/csi/sockets/pluginproxy/csi.sock"
2020-10-26T21:09:56.001Z	INFO	k8sorchestrator/k8sorchestrator.go:224	New feature states values from "csi-feature-states" stored successfully: map[csi-auth-check:true file-volume:true volume-extend:true volume-health:true]	{"TraceId": "9d9961e4-afd3-4f32-846a-ac57b00eebc1"}
2020-10-26T21:09:56.065Z	INFO	wcp/controller.go:601	ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "e0de463e-74c6-46a8-a48b-da8c85c647a6"}
2020-10-26T21:09:56.080Z	DEBUG	common/authmanager.go:332	Computing the cluster to file service status (enabled/disabled) map.	{"TraceId": "e1d906cc-a3a9-4911-b7e4-1ba8bb1a0285"}
2020-10-26T21:09:56.231Z	INFO	wcp/controller.go:601	ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "a98d14ca-215c-405e-927b-228a10637ba9"}
2020-10-26T21:09:56.286Z	DEBUG	common/authmanager.go:351	No clusterComputeResource found in dc: Datacenter [Datacenter: Datacenter:datacenter-3 @ /test-vpx-1603233187-15533-hostpool, VirtualCenterHost: wdc-10-206-210-58.eng.vmware.com]. error: cluster '*' not found	{"TraceId": "e1d906cc-a3a9-4911-b7e4-1ba8bb1a0285"}
2020-10-26T21:09:56.413Z	INFO	wcp/controller.go:601	ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "762f617f-1cb2-4da0-8526-53ea0b669a6c"}
2020-10-26T21:09:56.437Z	DEBUG	common/authmanager.go:375	auth manager: HasUserPrivilegeOnEntities returns [{{} ClusterComputeResource:domain-c63 [{{} Host.Config.Storage false}]}] when checking privileges [Host.Config.Storage] on entities [ClusterComputeResource:domain-c63] for user iamnew@vsphere.local	{"TraceId": "e1d906cc-a3a9-4911-b7e4-1ba8bb1a0285"}
2020-10-26T21:09:56.437Z	DEBUG	common/authmanager.go:391	Clusters with priv: Host.Config.Storage are : []	{"TraceId": "e1d906cc-a3a9-4911-b7e4-1ba8bb1a0285"}
2020-10-26T21:09:56.437Z	DEBUG	common/authmanager.go:269	dsToFileServiceEnabledMap is map[]	{"TraceId": "e1d906cc-a3a9-4911-b7e4-1ba8bb1a0285"}
2020-10-26T21:09:56.437Z	DEBUG	common/authmanager.go:285	File service is not enabled on the datastore: ds:///vmfs/volumes/vsan:52153a4703fc79ce-a714c87ef630920b/	{"TraceId": "e1d906cc-a3a9-4911-b7e4-1ba8bb1a0285"}
2020-10-26T21:09:56.437Z	INFO	common/authmanager.go:238	No file service enabled vsan datastore with required privileges for CSI user is present in the environment.	{"TraceId": "e1d906cc-a3a9-4911-b7e4-1ba8bb1a0285"}
2020-10-26T21:09:56.437Z	DEBUG	common/authmanager.go:137	auth manager: datastoreMapForFileVolumes is updated to map[]	{"TraceId": "e1d906cc-a3a9-4911-b7e4-1ba8bb1a0285"}
```

2. Create PVC after step 2 when when no vSAN cluster with `host.config.storage` permission is found on VC for the CSI user. PVC creation fails as there is no datastore available to provision.
```
2020-10-26T21:13:29.318Z	INFO	wcp/controller.go:430	CreateVolume: called with args {Name:pvc-8ef0479d-a21f-491a-8e87-e49245a61e4c CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[storagePolicyID:4b505f67-32cd-462d-8caf-e5680dbf0313] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-223-28.eng.vmware.com" > > requisite:<segments:<key:"kubernetes.io/hostname" value:"422e0606bc44de51bee27f92ef3a4a17" > > requisite:<segments:<key:"kubernetes.io/hostname" value:"422eb6a8d21718ad0bb15a09376e7bb5" > > requisite:<segments:<key:"kubernetes.io/hostname" value:"422ede9d74dd2997bfae1291f16eed13" > > requisite:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-220-237.eng.vmware.com" > > requisite:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-223-16.eng.vmware.com" > > requisite:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-223-17.eng.vmware.com" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-223-17.eng.vmware.com" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-223-28.eng.vmware.com" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"422e0606bc44de51bee27f92ef3a4a17" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"422eb6a8d21718ad0bb15a09376e7bb5" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"422ede9d74dd2997bfae1291f16eed13" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-220-237.eng.vmware.com" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-223-16.eng.vmware.com" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "31240f3b-68f1-4bb2-87aa-1526686be685"}
2020-10-26T21:13:29.320Z	INFO	wcp/controller.go:363	Ignoring TopologyRequirement for file volume	{"TraceId": "31240f3b-68f1-4bb2-87aa-1526686be685"}
2020-10-26T21:13:29.321Z	DEBUG	wcp/controller.go:393	Filtered Datastores: map[]	{"TraceId": "31240f3b-68f1-4bb2-87aa-1526686be685"}
2020-10-26T21:13:29.321Z	ERROR	wcp/controller.go:400	No datastores found to create file volume	{"TraceId": "31240f3b-68f1-4bb2-87aa-1526686be685"}
```

3. Add `host.config.storage` permission for vSAN cluster is found on VC for the CSI user after step 2. Now auth manager identifies the vSAN datastore automatically at runtime.
```
2020-10-26T21:19:55.916Z	INFO	common/authmanager.go:131	auth manager: refreshDatastoreMapForFileVolumes is triggered	{"TraceId": "c906622d-fd28-47f1-99e4-4317d0c7f1fc"}
2020-10-26T21:19:56.246Z	DEBUG	common/authmanager.go:332	Computing the cluster to file service status (enabled/disabled) map.	{"TraceId": "c906622d-fd28-47f1-99e4-4317d0c7f1fc"}
2020-10-26T21:19:56.280Z	DEBUG	common/authmanager.go:351	No clusterComputeResource found in dc: Datacenter [Datacenter: Datacenter:datacenter-3 @ /test-vpx-1603233187-15533-hostpool, VirtualCenterHost: wdc-10-206-210-58.eng.vmware.com]. error: cluster '*' not found	{"TraceId": "c906622d-fd28-47f1-99e4-4317d0c7f1fc"}
2020-10-26T21:19:56.345Z	DEBUG	common/authmanager.go:375	auth manager: HasUserPrivilegeOnEntities returns [{{} ClusterComputeResource:domain-c63 [{{} Host.Config.Storage true}]}] when checking privileges [Host.Config.Storage] on entities [ClusterComputeResource:domain-c63] for user iamnew@vsphere.local	{"TraceId": "c906622d-fd28-47f1-99e4-4317d0c7f1fc"}
2020-10-26T21:19:56.347Z	DEBUG	common/authmanager.go:391	Clusters with priv: Host.Config.Storage are : [ClusterComputeResource:domain-c63 @ /test-vpx-1603233187-15533-wcp.wcp-app-platform-sanity/host/test-vpx-1603233187-15533-wcp.wcp-app-platform-sanity-cluster]	{"TraceId": "c906622d-fd28-47f1-99e4-4317d0c7f1fc"}
2020-10-26T21:19:56.510Z	DEBUG	common/authmanager.go:404	cluster: true has vSAN file services enabled: %!t(MISSING)	{"TraceId": "c906622d-fd28-47f1-99e4-4317d0c7f1fc"}
2020-10-26T21:19:56.571Z	DEBUG	common/authmanager.go:269	dsToFileServiceEnabledMap is map[ds:///vmfs/volumes/vsan:52153a4703fc79ce-a714c87ef630920b/:true]	{"TraceId": "c906622d-fd28-47f1-99e4-4317d0c7f1fc"}
2020-10-26T21:19:56.575Z	DEBUG	common/authmanager.go:280	File service is enabled on the datastore: ds:///vmfs/volumes/vsan:52153a4703fc79ce-a714c87ef630920b/	{"TraceId": "c906622d-fd28-47f1-99e4-4317d0c7f1fc"}
2020-10-26T21:19:56.578Z	DEBUG	common/authmanager.go:295	auth manager: file - dsURLs [ds:///vmfs/volumes/vsan:52153a4703fc79ce-a714c87ef630920b/] dsInfos [Datastore: Datastore:datastore-67, datastore URL: ds:///vmfs/volumes/vsan:52153a4703fc79ce-a714c87ef630920b/]	{"TraceId": "c906622d-fd28-47f1-99e4-4317d0c7f1fc"}
2020-10-26T21:19:56.617Z	DEBUG	common/authmanager.go:310	auth manager: HasUserPrivilegeOnEntities returns [{{} Datastore:datastore-67 [{{} Datastore.FileManagement true} {{} System.Read true}]}] when checking privileges [Datastore.FileManagement System.Read] on entities [Datastore:datastore-67] for user iamnew@vsphere.local	{"TraceId": "c906622d-fd28-47f1-99e4-4317d0c7f1fc"}
2020-10-26T21:19:56.617Z	DEBUG	common/authmanager.go:323	auth manager: vSAN datastore with URL vsanDatastore and name ds:///vmfs/volumes/vsan:52153a4703fc79ce-a714c87ef630920b/ has privileges and is added to dsURLToInfoMap	{"TraceId": "c906622d-fd28-47f1-99e4-4317d0c7f1fc"}
2020-10-26T21:19:56.618Z	DEBUG	common/authmanager.go:137	auth manager: datastoreMapForFileVolumes is updated to map[ds:///vmfs/volumes/vsan:52153a4703fc79ce-a714c87ef630920b/:Datastore: Datastore:datastore-67, datastore URL: ds:///vmfs/volumes/vsan:52153a4703fc79ce-a714c87ef630920b/]	{"TraceId": "c906622d-fd28-47f1-99e4-4317d0c7f1fc"}
```

4. Create PVC after Step 3 when `host.config.storage` permission for vSAN cluster is found on VC for the CSI user. PVC created successfully.
```
2020-10-26T21:23:50.262Z	INFO	wcp/controller.go:430	CreateVolume: called with args {Name:pvc-0b6b62b2-85bf-4c45-b671-1d1a7688b434 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[storagePolicyID:4b505f67-32cd-462d-8caf-e5680dbf0313] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-220-237.eng.vmware.com" > > requisite:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-223-16.eng.vmware.com" > > requisite:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-223-17.eng.vmware.com" > > requisite:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-223-28.eng.vmware.com" > > requisite:<segments:<key:"kubernetes.io/hostname" value:"422e0606bc44de51bee27f92ef3a4a17" > > requisite:<segments:<key:"kubernetes.io/hostname" value:"422eb6a8d21718ad0bb15a09376e7bb5" > > requisite:<segments:<key:"kubernetes.io/hostname" value:"422ede9d74dd2997bfae1291f16eed13" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-223-17.eng.vmware.com" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-223-28.eng.vmware.com" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"422e0606bc44de51bee27f92ef3a4a17" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"422eb6a8d21718ad0bb15a09376e7bb5" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"422ede9d74dd2997bfae1291f16eed13" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-220-237.eng.vmware.com" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"wdc-10-206-223-16.eng.vmware.com" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "c4057f5d-53ac-41fe-971b-4fc5397bd6a1"}
2020-10-26T21:23:50.268Z	INFO	wcp/controller.go:363	Ignoring TopologyRequirement for file volume	{"TraceId": "c4057f5d-53ac-41fe-971b-4fc5397bd6a1"}
2020-10-26T21:23:50.271Z	DEBUG	wcp/controller.go:393	Filtered Datastores: map[ds:///vmfs/volumes/vsan:52153a4703fc79ce-a714c87ef630920b/:Datastore: Datastore:datastore-67, datastore URL: ds:///vmfs/volumes/vsan:52153a4703fc79ce-a714c87ef630920b/]	{"TraceId": "c4057f5d-53ac-41fe-971b-4fc5397bd6a1"}
2020-10-26T21:23:50.371Z	DEBUG	common/vsphereutil.go:257	vSphere CSI driver creating volume "pvc-0b6b62b2-85bf-4c45-b671-1d1a7688b434" with create spec (*types.CnsVolumeCreateSpec)(0xc0003d00f0)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-0b6b62b2-85bf-4c45-b671-1d1a7688b434",
 VolumeType: (string) (len=4) "FILE",
 Datastores: ([]types.ManagedObjectReference) (len=1 cap=1) {
  (types.ManagedObjectReference) Datastore:datastore-67
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=10) "domain-c63",
   VSphereUser: (string) (len=20) "iamnew@vsphere.local",
   ClusterFlavor: (string) (len=8) "WORKLOAD",
   ClusterDistribution: (string) ""
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=10) "domain-c63",
    VSphereUser: (string) (len=20) "iamnew@vsphere.local",
    ClusterFlavor: (string) (len=8) "WORKLOAD",
    ClusterDistribution: (string) ""
   }
  }
 },
 BackingObjectDetails: (*types.CnsVsanFileShareBackingDetails)(0xc00038d5c0)({
  CnsFileBackingDetails: (types.CnsFileBackingDetails) {
   CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
    DynamicData: (types.DynamicData) {
    },
    CapacityInMb: (int64) 1024
   },
   BackingFileId: (string) ""
  },
  Name: (string) "",
  AccessPoints: ([]types.KeyValue) <nil>
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) (len=1 cap=1) {
  (*types.VirtualMachineDefinedProfileSpec)(0xc00038d600)({
   VirtualMachineProfileSpec: (types.VirtualMachineProfileSpec) {
    DynamicData: (types.DynamicData) {
    }
   },
   ProfileId: (string) (len=36) "4b505f67-32cd-462d-8caf-e5680dbf0313",
   ReplicationSpec: (*types.ReplicationSpec)(<nil>),
   ProfileData: (*types.VirtualMachineProfileRawData)(<nil>),
   ProfileParams: ([]types.KeyValue) <nil>
  })
 },
 CreateSpec: (*types.CnsVSANFileCreateSpec)(0xc0007b58a0)({
  CnsFileCreateSpec: (types.CnsFileCreateSpec) {
   CnsBaseCreateSpec: (types.CnsBaseCreateSpec) {
    DynamicData: (types.DynamicData) {
    }
   }
  },
  SoftQuotaInMb: (int64) 1024,
  Permission: ([]types.VsanFileShareNetPermission) {
  }
 })
})
	{"TraceId": "c4057f5d-53ac-41fe-971b-4fc5397bd6a1"}
2020-10-26T21:23:50.392Z	DEBUG	volume/manager.go:172	Update VSphereUser from iamnew@vsphere.local to VSPHERE.LOCAL\iamnew	{"TraceId": "c4057f5d-53ac-41fe-971b-4fc5397bd6a1"}
2020-10-26T21:24:17.463Z	INFO	volume/manager.go:215	CreateVolume: VolumeName: "pvc-0b6b62b2-85bf-4c45-b671-1d1a7688b434", opId: "178e1147"{"TraceId": "c4057f5d-53ac-41fe-971b-4fc5397bd6a1"}
2020-10-26T21:24:17.464Z	INFO	volume/manager.go:263	CreateVolume: Volume created successfully. VolumeName: "pvc-0b6b62b2-85bf-4c45-b671-1d1a7688b434", opId: "178e1147", volumeID: "file:3f064d7b-1d89-4f6f-a3a4-12cb54b785b3"	{"TraceId": "c4057f5d-53ac-41fe-971b-4fc5397bd6a1"}
```
```
root@422e0606bc44de51bee27f92ef3a4a17 [ ~ ]# kubectl get pvc example-vanilla-file-pv5c -n e2e-test-namespace
NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
example-vanilla-file-pv5c   Bound    pvc-0b6b62b2-85bf-4c45-b671-1d1a7688b434   1Gi        RWX            gold           61s
2:25
```
```
root@422e0606bc44de51bee27f92ef3a4a17 [ ~ ]# kubectl describe pv pvc-0b6b62b2-85bf-4c45-b671-1d1a7688b434
Name:            pvc-0b6b62b2-85bf-4c45-b671-1d1a7688b434
Labels:          <none>
Annotations:     pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    gold
Status:          Bound
Claim:           e2e-test-namespace/example-vanilla-file-pv5c
Reclaim Policy:  Delete
Access Modes:    RWX
VolumeMode:      Filesystem
Capacity:        1Gi
Node Affinity:   <none>
Message:         
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      file:3f064d7b-1d89-4f6f-a3a4-12cb54b785b3
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1603746596266-8081-csi.vsphere.vmware.com
                           type=vSphere CNS File Volume
Events:                <none>
```

**Testing done for Vanilla CSI**:
1. Create PVC with `csi-auth-check` enabled when when no vSAN cluster with `host.config.storage` permission is found on VC for the CSI user. PVC creation fails as there is no datastore available to provision. Please note here that when `csi-auth-check` is enabled, it will no longer use `TargetvSANFileShareDatastoreURLs` from vsphere.conf.
```
2020-10-27T23:57:18.835Z	INFO	vanilla/controller.go:571	CreateVolume: called with args {Name:pvc-29585c6f-9a8a-4eb5-875d-7016d51e470d CapacityRange:required_bytes:1048576  VolumeCapabilities:[mount:<fs_type:"nfs4" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[storagepolicyname:vSAN Default Storage Policy] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "53c74565-5be0-4bc3-b1c9-37d1c38db511"}
2020-10-27T23:57:18.835Z	DEBUG	vanilla/controller.go:905	Checking if vCenter version is of vsan 67u3 release	{"TraceId": "53c74565-5be0-4bc3-b1c9-37d1c38db511"}
2020-10-27T23:57:18.835Z	DEBUG	vanilla/controller.go:914	vCenter version is :"reserved"	{"TraceId": "53c74565-5be0-4bc3-b1c9-37d1c38db511"}
2020-10-27T23:57:18.836Z	DEBUG	vanilla/controller.go:526	Filtered Datastores: map[]	{"TraceId": "53c74565-5be0-4bc3-b1c9-37d1c38db511"}
2020-10-27T23:57:18.836Z	ERROR	vanilla/controller.go:533	No datastores found to create file volume	{"TraceId": "53c74565-5be0-4bc3-b1c9-37d1c38db511"}

```

2. Create PVC after Step 1 when `host.config.storage` permission for vSAN cluster is found on VC for the CSI user. PVC created successfully.
```
2020-10-28T00:01:37.222Z	INFO	vanilla/controller.go:571	CreateVolume: called with args {Name:pvc-2c872116-3071-4e18-a038-a1f2262b3a98 CapacityRange:required_bytes:1048576  VolumeCapabilities:[mount:<fs_type:"nfs4" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[storagepolicyname:vSAN Default Storage Policy] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "fbbcba34-351f-4aa1-95f3-d3fb806f82e4"}
2020-10-28T00:01:37.223Z	DEBUG	vanilla/controller.go:905	Checking if vCenter version is of vsan 67u3 release	{"TraceId": "fbbcba34-351f-4aa1-95f3-d3fb806f82e4"}
2020-10-28T00:01:37.223Z	DEBUG	vanilla/controller.go:914	vCenter version is :"reserved"	{"TraceId": "fbbcba34-351f-4aa1-95f3-d3fb806f82e4"}
2020-10-28T00:01:37.225Z	DEBUG	vanilla/controller.go:526	Filtered Datastores: map[ds:///vmfs/volumes/vsan:52f0b4870bdcea96-4be3229edf074554/:Datastore: Datastore:datastore-1011, datastore URL: ds:///vmfs/volumes/vsan:52f0b4870bdcea96-4be3229edf074554/]	{"TraceId": "fbbcba34-351f-4aa1-95f3-d3fb806f82e4"}
2020-10-28T00:01:37.340Z	DEBUG	common/vsphereutil.go:257	vSphere CSI driver creating volume "pvc-2c872116-3071-4e18-a038-a1f2262b3a98" with create spec (*types.CnsVolumeCreateSpec)(0xc0003a8000)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-2c872116-3071-4e18-a038-a1f2262b3a98",
 VolumeType: (string) (len=4) "FILE",
 Datastores: ([]types.ManagedObjectReference) (len=1 cap=1) {
  (types.ManagedObjectReference) Datastore:datastore-1011
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=34) "vSAN-FVT-Cluster1603811720.4810038",
   VSphereUser: (string) (len=21) "Testing@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA",
   ClusterDistribution: (string) ""
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=34) "vSAN-FVT-Cluster1603811720.4810038",
    VSphereUser: (string) (len=21) "Testing@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA",
    ClusterDistribution: (string) ""
   }
  }
 },
 BackingObjectDetails: (*types.CnsVsanFileShareBackingDetails)(0xc000bff400)({
  CnsFileBackingDetails: (types.CnsFileBackingDetails) {
   CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
    DynamicData: (types.DynamicData) {
    },
    CapacityInMb: (int64) 1
   },
   BackingFileId: (string) ""
  },
  Name: (string) "",
  AccessPoints: ([]types.KeyValue) <nil>
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) (len=1 cap=1) {
  (*types.VirtualMachineDefinedProfileSpec)(0xc000bff440)({
   VirtualMachineProfileSpec: (types.VirtualMachineProfileSpec) {
    DynamicData: (types.DynamicData) {
    }
   },
   ProfileId: (string) (len=36) "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
   ReplicationSpec: (*types.ReplicationSpec)(<nil>),
   ProfileData: (*types.VirtualMachineProfileRawData)(<nil>),
   ProfileParams: ([]types.KeyValue) <nil>
  })
 },
 CreateSpec: (*types.CnsVSANFileCreateSpec)(0xc000bf9e60)({
  CnsFileCreateSpec: (types.CnsFileCreateSpec) {
   CnsBaseCreateSpec: (types.CnsBaseCreateSpec) {
    DynamicData: (types.DynamicData) {
    }
   }
  },
  SoftQuotaInMb: (int64) 1,
  Permission: ([]types.VsanFileShareNetPermission) (len=1 cap=1) {
   (types.VsanFileShareNetPermission) {
    Ips: (string) (len=1) "*",
    Permissions: (types.VsanFileShareAccessType) (len=10) "NO_ACCESS",
    AllowRoot: (bool) true
   }
  }
 })
})
	{"TraceId": "fbbcba34-351f-4aa1-95f3-d3fb806f82e4"}
2020-10-28T00:01:37.350Z	DEBUG	volume/manager.go:172	Update VSphereUser from Testing@vsphere.local to VSPHERE.LOCAL\Testing	{"TraceId": "fbbcba34-351f-4aa1-95f3-d3fb806f82e4"}
2020-10-28T00:01:54.348Z	INFO	volume/manager.go:215	CreateVolume: VolumeName: "pvc-2c872116-3071-4e18-a038-a1f2262b3a98", opId: "921a8f95{"TraceId": "fbbcba34-351f-4aa1-95f3-d3fb806f82e4"}
2020-10-28T00:01:54.348Z	INFO	volume/manager.go:263	CreateVolume: Volume created successfully. VolumeName: "pvc-2c872116-3071-4e18-a038-a1f2262b3a98", opId: "921a8f95", volumeID: "file:327a6df1-b80d-42d8-ac41-ccad111c6f07"	{"TraceId": "fbbcba34-351f-4aa1-95f3-d3fb806f82e4"}
```

***Delete PVC***
```
2020-10-26T21:27:45.221Z	INFO	wcp/controller.go:456	DeleteVolume: called with args: {VolumeId:file:3f064d7b-1d89-4f6f-a3a4-12cb54b785b3 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "cc3dc048-e8f3-42bd-b40a-4fa053f5b149"}
2020-10-26T21:27:45.233Z	DEBUG	common/vsphereutil.go:463	vSphere CSI driver is deleting volume: file:3f064d7b-1d89-4f6f-a3a4-12cb54b785b3 with deleteDisk flag: true	{"TraceId": "cc3dc048-e8f3-42bd-b40a-4fa053f5b149"}
2020-10-26T21:28:13.540Z	INFO	volume/manager.go:463	DeleteVolume: volumeID: "file:3f064d7b-1d89-4f6f-a3a4-12cb54b785b3", opId: "178e1254"	{"TraceId": "cc3dc048-e8f3-42bd-b40a-4fa053f5b149"}
2020-10-26T21:28:13.540Z	INFO	volume/manager.go:481	DeleteVolume: Volume deleted successfully. volumeID: "file:3f064d7b-1d89-4f6f-a3a4-12cb54b785b3", opId: "178e1254"	{"TraceId": "cc3dc048-e8f3-42bd-b40a-4fa053f5b149"}
2020-10-26T21:28:13.540Z	DEBUG	common/vsphereutil.go:469	Successfully deleted disk for volumeid: file:3f064d7b-1d89-4f6f-a3a4-12cb54b785b3, deleteDisk flag: true	{"TraceId": "cc3dc048-e8f3-42bd-b40a-4fa053f5b149"}
```

cc @divyenpatel @chethanv28 @SandeepPissay 

**Release note**:
```release-note
Enable support for file volume functionality in WCP CSI and implement Create/Delete for file volumes in WCP CSI
```


