### PR TITLE
Change the image prefix for external-attacher

### DIFF
--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -138,7 +138,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: csi-attacher
-          image: vmware.io/csi-attacher/csi-attacher:<image_tag>
+          image: vmware.io/csi-attacher:<image_tag>
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -138,7 +138,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: csi-attacher
-          image: vmware.io/csi-attacher/csi-attacher:<image_tag>
+          image: vmware.io/csi-attacher:<image_tag>
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -138,7 +138,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: csi-attacher
-          image: vmware.io/csi-attacher/csi-attacher:<image_tag>
+          image: vmware.io/csi-attacher:<image_tag>
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is to change the prefix for external-attacher from `vmware.io/csi-attacher/csi-attacher:<image_tag>` to `vmware.io/csi-attacher:<image_tag>`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Manually verified.

When using `vmware.io/csi-attacher/csi-attacher:<image_tag>`
Logs:
```
Events:
  Type     Reason   Age                   From                                                  Message
  ----     ------   ----                  ----                                                  -------
  Normal   BackOff  11m (x426 over 105m)  kubelet, test-cluster-e2e-script-control-plane-dgx6m  Back-off pulling image "vmware.io/csi-attacher/csi-attacher:v2.1.0-3584569-35f04ee"
  Warning  Failed   70s (x470 over 105m)  kubelet, test-cluster-e2e-script-control-plane-dgx6m  Error: ImagePullBackOff
```
When using `vmware.io/csi-attacher:<image_tag>`
Logs:
```
rmal   Pulled     16m (x3 over 22m)  kubelet, test-cluster-e2e-script-control-plane-dgx6m  Container image "vmware.io/csi-attacher:v2.1.0-3584569-35f04ee" already present on machine
  Normal   Started    16m (x3 over 22m)  kubelet, test-cluster-e2e-script-control-plane-dgx6m  Started container csi-attacher
  Normal   Created    16m (x3 over 22m)  kubelet, test-cluster-e2e-script-control-plane-dgx6m  Created container csi-attacher
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
