### PR TITLE
cherry-pick commits to release 2.1 branch

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -43,9 +43,10 @@ const operationModeWebHookServer = "WEBHOOK_SERVER"
 const operationModeMetaDataSync = "METADATA_SYNC"
 
 var (
-	enableLeaderElection = flag.Bool("leader-election", false, "Enable leader election.")
-	printVersion         = flag.Bool("version", false, "Print syncer version and exit")
-	operationMode        = flag.String("operation-mode", operationModeMetaDataSync, "specify operation mode METADATA_SYNC or WEBHOOK_SERVER")
+	enableLeaderElection    = flag.Bool("leader-election", false, "Enable leader election.")
+	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")
+	printVersion            = flag.Bool("version", false, "Print syncer version and exit")
+	operationMode           = flag.String("operation-mode", operationModeMetaDataSync, "specify operation mode METADATA_SYNC or WEBHOOK_SERVER")
 )
 
 // main for vsphere syncer
@@ -104,6 +105,10 @@ func main() {
 			}
 			lockName := "vsphere-syncer"
 			le := leaderelection.NewLeaderElection(k8sClient, lockName, run)
+
+			if *leaderElectionNamespace != "" {
+				le.WithNamespace(*leaderElectionNamespace)
+			}
 
 			if err := le.Run(); err != nil {
 				log.Fatalf("Error initializing leader election: %v", err)

--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -47,8 +47,8 @@ func ValidateCreateVolumeRequest(ctx context.Context, req *csi.CreateVolumeReque
 	if len(volCaps) == 0 {
 		return status.Error(codes.InvalidArgument, "Volume capabilities not provided")
 	}
-	if !IsValidVolumeCapabilities(ctx, volCaps) {
-		return status.Error(codes.InvalidArgument, "Volume capabilities not supported")
+	if err := IsValidVolumeCapabilities(ctx, volCaps); err != nil {
+		return status.Errorf(codes.InvalidArgument, "Volume capability not supported. Err: %+v", err)
 	}
 	return nil
 }
@@ -87,8 +87,8 @@ func ValidateControllerPublishVolumeRequest(ctx context.Context, req *csi.Contro
 		return status.Error(codes.InvalidArgument, "Volume capability not provided")
 	}
 	caps := []*csi.VolumeCapability{volCap}
-	if !IsValidVolumeCapabilities(ctx, caps) {
-		return status.Error(codes.InvalidArgument, "Volume capability not supported")
+	if err := IsValidVolumeCapabilities(ctx, caps); err != nil {
+		return status.Errorf(codes.InvalidArgument, "Volume capability not supported. Err: %+v", err)
 	}
 	return nil
 }

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -116,7 +116,7 @@ func TestValidVolumeCapabilitiesForBlock(t *testing.T) {
 			},
 		},
 	}
-	if !IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("Block VolCap = %+v failed validation!", volCap)
 	}
 	// fstype=empty and mode=SINGLE_NODE_WRITER
@@ -130,7 +130,7 @@ func TestValidVolumeCapabilitiesForBlock(t *testing.T) {
 			},
 		},
 	}
-	if !IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("Block VolCap = %+v failed validation!", volCap)
 	}
 }
@@ -149,7 +149,7 @@ func TestInvalidVolumeCapabilitiesForBlock(t *testing.T) {
 			},
 		},
 	}
-	if IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err == nil {
 		t.Errorf("Invalid Block VolCap = %+v passed validation!", volCap)
 	}
 
@@ -166,7 +166,7 @@ func TestInvalidVolumeCapabilitiesForBlock(t *testing.T) {
 			},
 		},
 	}
-	if IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err == nil {
 		t.Errorf("Invalid Block VolCap = %+v passed validation!", volCap)
 	}
 }
@@ -185,7 +185,7 @@ func TestValidVolumeCapabilitiesForFile(t *testing.T) {
 			},
 		},
 	}
-	if !IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("File VolCap = %+v failed validation!", volCap)
 	}
 
@@ -202,7 +202,7 @@ func TestValidVolumeCapabilitiesForFile(t *testing.T) {
 			},
 		},
 	}
-	if !IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("File VolCap = %+v failed validation!", volCap)
 	}
 
@@ -219,7 +219,7 @@ func TestValidVolumeCapabilitiesForFile(t *testing.T) {
 			},
 		},
 	}
-	if !IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("File VolCap = %+v failed validation!", volCap)
 	}
 }
@@ -238,7 +238,7 @@ func TestInvalidVolumeCapabilitiesForFile(t *testing.T) {
 			},
 		},
 	}
-	if IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err == nil {
 		t.Errorf("Invalid file VolCap = %+v passed validation!", volCap)
 	}
 
@@ -255,7 +255,7 @@ func TestInvalidVolumeCapabilitiesForFile(t *testing.T) {
 			},
 		},
 	}
-	if IsValidVolumeCapabilities(ctx, volCap) {
+	if err := IsValidVolumeCapabilities(ctx, volCap); err == nil {
 		t.Errorf("Invalid file VolCap = %+v passed validation!", volCap)
 	}
 }

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -517,6 +517,10 @@ func getDsToFileServiceEnabledMap(ctx context.Context, vc *vsphere.VirtualCenter
 		finder.SetDatacenter(datacenter.Datacenter)
 		clusterComputeResource, err := finder.ClusterComputeResourceList(ctx, "*")
 		if err != nil {
+			if _, ok := err.(*find.NotFoundError); ok {
+				log.Debugf("No clusterComputeResource found in dc: %+v. error: %+v", datacenter, err)
+				continue
+			}
 			log.Errorf("Error occurred while getting clusterComputeResource. error: %+v", err)
 			return nil, err
 		}

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -472,7 +472,7 @@ func (c *controller) ValidateVolumeCapabilities(ctx context.Context, req *csi.Va
 	log.Infof("ControllerGetCapabilities: called with args %+v", *req)
 	volCaps := req.GetVolumeCapabilities()
 	var confirmed *csi.ValidateVolumeCapabilitiesResponse_Confirmed
-	if common.IsValidVolumeCapabilities(ctx, volCaps) {
+	if err := common.IsValidVolumeCapabilities(ctx, volCaps); err == nil {
 		confirmed = &csi.ValidateVolumeCapabilitiesResponse_Confirmed{VolumeCapabilities: volCaps}
 	}
 	return &csi.ValidateVolumeCapabilitiesResponse{

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -640,7 +640,7 @@ func (c *controller) ValidateVolumeCapabilities(ctx context.Context, req *csi.Va
 	log.Infof("ValidateVolumeCapabilities: called with args %+v", *req)
 	volCaps := req.GetVolumeCapabilities()
 	var confirmed *csi.ValidateVolumeCapabilitiesResponse_Confirmed
-	if common.IsValidVolumeCapabilities(ctx, volCaps) {
+	if err := common.IsValidVolumeCapabilities(ctx, volCaps); err == nil {
 		confirmed = &csi.ValidateVolumeCapabilitiesResponse_Confirmed{VolumeCapabilities: volCaps}
 	}
 	return &csi.ValidateVolumeCapabilitiesResponse{

--- a/tests/e2e/vsphere_file_volume_basic.go
+++ b/tests/e2e/vsphere_file_volume_basic.go
@@ -234,7 +234,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] Basic Testing", func() {
 		ginkgo.By(fmt.Sprintf("Expect claim to fail as the access mode %q is not supported for File volumes", accessMode))
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute/2)
 		gomega.Expect(err).To(gomega.HaveOccurred())
-		expectedErrMsg := "Volume capabilities not supported"
+		expectedErrMsg := "NFS fstype not supported for ReadWriteOnce volume creation"
 		ginkgo.By(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
 		isFailureFound := checkEventsforError(client, namespace, metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvclaim.Name)}, expectedErrMsg)
 		gomega.Expect(isFailureFound).To(gomega.BeTrue(), "Unable to verify pvc create failure")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is cherry-picking the following PRs to release 2.1 branch.

- Add volume capabilities validation in Vanilla Create Volume Request -  https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/459
- Fix for vanilla file services solution in a VC deployment when there is no cluster available in a datacenter - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/460
- add leaderElectionNamespace to syncer container - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/469


**Special notes for your reviewer**:
@chethanv28 @BaluDontu I have included your changes made on the master branch which are applicable to release 2.1 in this PR.

Make Check

```
% export DO_DOCKER=1
% make check        
hack/check-format.sh
go: finding golang.org/x/tools latest
hack/check-lint.sh
go: finding golang.org/x/lint latest

hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
hack/check-vet.sh
hack/check-golangci-lint.sh
Unable to find image 'golangci/golangci-lint:v1.29.0' locally
v1.29.0: Pulling from golangci/golangci-lint
e9afc4f90ab0: Pull complete 
989e6b19a265: Pull complete 
af14b6c2f878: Pull complete 
5573c4b30949: Pull complete 
d4020e2aa747: Pull complete 
abca02d9b237: Pull complete 
0d6cba09e61d: Pull complete 
5c45448c660a: Pull complete 
Digest: sha256:7c3d842eea4d04b95cf7085c900937c884fbc639455f49ce98179ed48eadfede
Status: Downloaded newer image for golangci/golangci-lint:v1.29.0
level=info msg="[config_reader] Config search paths: [./ /app /]"
level=info msg="[lintersdb] Active 10 linters: [deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck]"
level=info msg="[loader] Go packages loading at mode 575 (files|imports|name|types_sizes|compiled_files|deps|exports_file) took 1m36.5267027s"
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 91.6704ms"
level=info msg="[linters context/goanalysis] analyzers took 2m45.1964508s with top 10 stages: buildir: 2m25.2373536s, inspect: 3.3430832s, printf: 2.5405024s, fact_deprecated: 2.2448738s, ctrlflow: 2.2410067s, fact_purity: 1.7499701s, ineffassign: 578.7628ms, isgenerated: 305.8913ms, S1038: 191.961ms, S1039: 184.222ms"
level=info msg="[linters context/goanalysis] analyzers took 11.3091738s with top 10 stages: buildir: 10.5270721s, U1000: 782.1017ms"
level=info msg="[runner] Issues before processing: 54, after processing: 0"
level=info msg="[runner] Processors filtering stat (out/in): identifier_marker: 10/10, path_prettifier: 54/54, autogenerated_exclude: 10/54, exclude: 0/10, cgo: 54/54, filename_unadjuster: 54/54, skip_files: 54/54, skip_dirs: 54/54"
level=info msg="[runner] processing took 9.7779ms with stages: autogenerated_exclude: 8.5317ms, exclude: 570.7µs, path_prettifier: 190.5µs, identifier_marker: 181.9µs, skip_dirs: 95.6µs, cgo: 21.2µs, nolint: 14.7µs, max_same_issues: 14.5µs, uniq_by_line: 13.8µs, path_shortener: 13.5µs, sort_results: 13.5µs, exclude-rules: 13.5µs, max_per_file_from_linter: 13.4µs, severity-rules: 13.3µs, source_code: 13.3µs, filename_unadjuster: 12.7µs, skip_files: 12.7µs, max_from_linter: 12.7µs, path_prefixer: 12.4µs, diff: 12.3µs"
level=info msg="[runner] linters took 29.4660145s with stages: goanalysis_metalinter: 26.8296089s, unused: 2.6258432s"
level=info msg="File cache stats: 0 entries of total size 0B"
level=info msg="Memory: 1217 samples, avg is 294.0MB, max is 1559.5MB"
level=info msg="Execution took 2m6.1130233s"
```

Build check

```
% make build-bins
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.Version=v2.1.0-rc.1-74-g64325084"' -o /Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/.build/bin/vsphere-csi.linux_amd64 cmd/vsphere-csi/main.go
go: creating new go.mod: module tmp
go: finding sigs.k8s.io v0.2.5
go: finding sigs.k8s.io/controller-tools/cmd v0.2.5
go: finding sigs.k8s.io/controller-tools/cmd/controller-gen v0.2.5
/Users/divyenp/go/bin/controller-gen crd:trivialVersions=true paths=./pkg/apis/storagepool/... output:crd:dir=pkg/apis/storagepool/config
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/pkg/syncer.Version=v2.1.0-rc.1-74-g64325084"' -o /Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/.build/bin/syncer.linux_amd64 cmd/syncer/main.go
```

Unit tests logs

```
% make unit-test 
env -u VSPHERE_SERVER -u VSPHERE_DATACENTER -u VSPHERE_PASSWORD -u VSPHERE_USER -u VSPHERE_STORAGE_POLICY_NAME -u KUBECONFIG -u WCP_ENDPOINT -u WCP_PORT -u WCP_NAMESPACE -u TOKEN -u CERTIFICATE go test -v -count=1 ./pkg/common/config ./pkg/csi/service ./pkg/csi/service/common ./pkg/csi/service/common/commonco/k8sorchestrator ./pkg/csi/service/vanilla ./pkg/csi/service/wcp ./pkg/csi/service/wcpguest ./pkg/syncer ./pkg/syncer/admissionhandler
=== RUN   TestValidateConfigWithNoNetPermissionParams
{"level":"info","time":"2020-10-30T09:58:33.64269-07:00","caller":"config/config.go:296","msg":"No Net Permissions given in Config. Using default permissions."}
{"level":"info","time":"2020-10-30T09:58:33.642981-07:00","caller":"config/config.go:328","msg":"No feature states config information is provided in the Config. Using default config map name: internal-feature-states.csi.vsphere.vmware.com and namespace: kube-system"}
--- PASS: TestValidateConfigWithNoNetPermissionParams (0.00s)
=== RUN   TestValidateConfigWithMultipleNetPermissionParams
{"level":"info","time":"2020-10-30T09:58:33.643133-07:00","caller":"config/config.go:328","msg":"No feature states config information is provided in the Config. Using default config map name: internal-feature-states.csi.vsphere.vmware.com and namespace: kube-system"}
--- PASS: TestValidateConfigWithMultipleNetPermissionParams (0.00s)
=== RUN   TestValidateConfigWithInvalidPermissions
{"level":"error","time":"2020-10-30T09:58:33.64395-07:00","caller":"config/config.go:305","msg":"Invalid value WRITE_ONLY for Permissions under NetPermission Config A","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/common/config/config.go:305\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.TestValidateConfigWithInvalidPermissions\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/common/config/config_test.go:143\ntesting.tRunner\n\t/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909"}
--- PASS: TestValidateConfigWithInvalidPermissions (0.00s)
=== RUN   TestValidateConfigWithInvalidClusterId
{"level":"error","time":"2020-10-30T09:58:33.644156-07:00","caller":"config/config.go:257","msg":"cluster id must not exceed 64 characters","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/common/config/config.go:257\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.TestValidateConfigWithInvalidClusterId\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/common/config/config_test.go:155\ntesting.tRunner\n\t/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909"}
--- PASS: TestValidateConfigWithInvalidClusterId (0.00s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/common/config	0.408s
=== RUN   TestGetDisk
=== RUN   TestGetDisk/#00
=== PAUSE TestGetDisk/#00
=== RUN   TestGetDisk/#01
=== PAUSE TestGetDisk/#01
=== CONT  TestGetDisk/#00
=== CONT  TestGetDisk/#01
--- PASS: TestGetDisk (0.00s)
    --- PASS: TestGetDisk/#00 (0.00s)
    --- PASS: TestGetDisk/#01 (0.00s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/csi/service	0.883s
=== RUN   TestIsFileVolumeRequestForBlock
--- PASS: TestIsFileVolumeRequestForBlock (0.00s)
=== RUN   TestIsFileVolumeRequestForBlockWithUnsetFsType
--- PASS: TestIsFileVolumeRequestForBlockWithUnsetFsType (0.00s)
=== RUN   TestIsFileVolumeRequestForFile
--- PASS: TestIsFileVolumeRequestForFile (0.00s)
=== RUN   TestValidVolumeCapabilitiesForBlock
--- PASS: TestValidVolumeCapabilitiesForBlock (0.00s)
=== RUN   TestInvalidVolumeCapabilitiesForBlock
--- PASS: TestInvalidVolumeCapabilitiesForBlock (0.00s)
=== RUN   TestValidVolumeCapabilitiesForFile
--- PASS: TestValidVolumeCapabilitiesForFile (0.00s)
=== RUN   TestInvalidVolumeCapabilitiesForFile
--- PASS: TestInvalidVolumeCapabilitiesForFile (0.00s)
=== RUN   TestParseStorageClassParamsWithDeprecatedFSType
{"level":"warn","time":"2020-10-30T09:58:39.576475-07:00","caller":"common/util.go:216","msg":"param 'fstype' is deprecated, please use 'csi.storage.k8s.io/fstype' instead"}
--- PASS: TestParseStorageClassParamsWithDeprecatedFSType (0.00s)
=== RUN   TestParseStorageClassParamsWithValidParams
--- PASS: TestParseStorageClassParamsWithValidParams (0.02s)
=== RUN   TestParseStorageClassParamsWithMigrationEnabledNagative
--- PASS: TestParseStorageClassParamsWithMigrationEnabledNagative (0.00s)
    util_test.go:324: expected err received. err: vSphere CSI driver does not support creating volume using in-tree vSphere volume plugin parameter key:objectspacereservation-migrationparam, value:50
=== RUN   TestParseStorageClassParamsWithDiskFormatMigrationEnableNegative
--- PASS: TestParseStorageClassParamsWithDiskFormatMigrationEnableNegative (0.00s)
    util_test.go:337: expected err received. err: invalid parameter. key:diskformat-migrationparam, value:thick
=== RUN   TestParseStorageClassParamsWithDiskFormatMigrationEnablePositive
--- PASS: TestParseStorageClassParamsWithDiskFormatMigrationEnablePositive (0.00s)
=== RUN   TestParseStorageClassParamsWithMigrationEnabledPositive
--- PASS: TestParseStorageClassParamsWithMigrationEnabledPositive (0.00s)
=== RUN   TestParseStorageClassParamsWithMigrationDisabled
--- PASS: TestParseStorageClassParamsWithMigrationDisabled (0.00s)
    util_test.go:391: expected err received. err: Invalid param: "csimigration" and value: "true"
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common	0.373s
=== RUN   TestIsFSSEnabledInGcWithSync
{"level":"info","time":"2020-10-30T09:58:44.986283-07:00","caller":"k8sorchestrator/k8sorchestrator.go:322","msg":"volume-health feature state set to false in internal-feature-states.csi.vsphere.vmware.com ConfigMap"}
--- PASS: TestIsFSSEnabledInGcWithSync (0.00s)
=== RUN   TestIsFSSEnabledInGcWithoutSync
{"level":"info","time":"2020-10-30T09:58:44.98686-07:00","caller":"k8sorchestrator/k8sorchestrator.go:322","msg":"volume-extend feature state set to false in internal-feature-states.csi.vsphere.vmware.com ConfigMap"}
{"level":"info","time":"2020-10-30T09:58:44.987486-07:00","caller":"k8sorchestrator/k8sorchestrator.go:338","msg":"volume-health feature state set to false in csi-feature-states ConfigMap"}
--- PASS: TestIsFSSEnabledInGcWithoutSync (0.00s)
=== RUN   TestIsFSSEnabledInGcWrongValues
{"level":"error","time":"2020-10-30T09:58:44.98797-07:00","caller":"k8sorchestrator/k8sorchestrator.go:317","msg":"Error while converting volume-extend feature state value: false to boolean. Setting the feature state to false","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.(*K8sOrchestrator).IsFSSEnabled\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:317\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.TestIsFSSEnabledInGcWrongValues\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go:140\ntesting.tRunner\n\t/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909"}
--- PASS: TestIsFSSEnabledInGcWrongValues (0.00s)
=== RUN   TestIsFSSEnabledInSV
{"level":"error","time":"2020-10-30T09:58:44.988308-07:00","caller":"k8sorchestrator/k8sorchestrator.go:305","msg":"Error while converting csi-migration feature state value: false to boolean. Setting the feature state to false","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.(*K8sOrchestrator).IsFSSEnabled\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:305\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.TestIsFSSEnabledInSV\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go:176\ntesting.tRunner\n\t/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909"}
--- PASS: TestIsFSSEnabledInSV (0.00s)
=== RUN   TestIsFSSEnabledInVanilla
{"level":"error","time":"2020-10-30T09:58:44.989806-07:00","caller":"k8sorchestrator/k8sorchestrator.go:293","msg":"Error while converting volume-health feature state value: false to boolean. Setting the feature state to false","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.(*K8sOrchestrator).IsFSSEnabled\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:293\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.TestIsFSSEnabledInVanilla\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go:214\ntesting.tRunner\n\t/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909"}
--- PASS: TestIsFSSEnabledInVanilla (0.00s)
=== RUN   TestIsFSSEnabledWithWrongClusterFlavor
--- PASS: TestIsFSSEnabledWithWrongClusterFlavor (0.00s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator	1.026s
=== RUN   TestCreateVolumeWithStoragePolicy
{"level":"error","time":"2020-10-30T09:58:46.658392-07:00","caller":"config/config.go:252","msg":"no Virtual Center hosts defined","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/common/config/config.go:252\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.FromEnv\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/common/config/config.go:236\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.configFromEnvOrSim\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:138\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.getControllerTest.func1\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:232\nsync.(*Once).doSlow\n\t/usr/local/Cellar/go/1.13.4/libexec/src/sync/once.go:66\nsync.(*Once).Do\n\t/usr/local/Cellar/go/1.13.4/libexec/src/sync/once.go:57\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.getControllerTest\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:229\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.TestCreateVolumeWithStoragePolicy\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:300\ntesting.tRunner\n\t/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909"}
{"level":"info","time":"2020-10-30T09:58:46.686008-07:00","caller":"vsphere/utils.go:125","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2020-10-30T09:58:46.686054-07:00","caller":"vsphere/virtualcentermanager.go:64","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2020-10-30T09:58:46.686065-07:00","caller":"vsphere/virtualcentermanager.go:66","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2020-10-30T09:58:46.686094-07:00","caller":"vsphere/virtualcentermanager.go:110","msg":"Successfully registered VC \"127.0.0.1\""}
{"level":"info","time":"2020-10-30T09:58:46.691209-07:00","caller":"vsphere/virtualcenter.go:153","msg":"New session ID for 'user' = 1e88f99f-adaa-48d8-8745-d857bf002b15"}
{"level":"info","time":"2020-10-30T09:58:46.69157-07:00","caller":"volume/manager.go:98","msg":"Initializing new volume.defaultManager..."}
{"level":"info","time":"2020-10-30T09:58:46.69202-07:00","caller":"vanilla/controller.go:509","msg":"CreateVolume: called with args {Name:test-pvc-035d73f1-32fe-4737-a4a1-a59e4fccadf5 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[storagepolicyname:vSAN Default Storage Policy] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"7bbefb39-d8ac-4056-b85e-d8e8c47c1f16"}
{"level":"info","time":"2020-10-30T09:58:46.70096-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pvc-035d73f1-32fe-4737-a4a1-a59e4fccadf5\", opId: \"\"","TraceId":"7bbefb39-d8ac-4056-b85e-d8e8c47c1f16"}
{"level":"info","time":"2020-10-30T09:58:46.701001-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-035d73f1-32fe-4737-a4a1-a59e4fccadf5\", opId: \"\", volumeID: \"3acbdf91-7b69-4c45-8d02-57083c80137f\"","TraceId":"7bbefb39-d8ac-4056-b85e-d8e8c47c1f16"}
{"level":"info","time":"2020-10-30T09:58:46.705042-07:00","caller":"vanilla/controller.go:535","msg":"DeleteVolume: called with args: {VolumeId:3acbdf91-7b69-4c45-8d02-57083c80137f Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"184f3cbf-dbab-4d32-a053-c78ef05e30ab"}
{"level":"info","time":"2020-10-30T09:58:46.706739-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"3acbdf91-7b69-4c45-8d02-57083c80137f\", opId: \"\"","TraceId":"184f3cbf-dbab-4d32-a053-c78ef05e30ab"}
{"level":"info","time":"2020-10-30T09:58:46.70676-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"3acbdf91-7b69-4c45-8d02-57083c80137f\", opId: \"\"","TraceId":"184f3cbf-dbab-4d32-a053-c78ef05e30ab"}
--- PASS: TestCreateVolumeWithStoragePolicy (0.05s)
=== RUN   TestExtendVolume
{"level":"info","time":"2020-10-30T09:58:46.707126-07:00","caller":"vanilla/controller.go:509","msg":"CreateVolume: called with args {Name:test-pvc-37b7cc23-2747-45e9-8d70-e62f335de801 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"e9021244-7409-45da-897f-f511aa37ebff"}
{"level":"info","time":"2020-10-30T09:58:46.711435-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pvc-37b7cc23-2747-45e9-8d70-e62f335de801\", opId: \"\"","TraceId":"e9021244-7409-45da-897f-f511aa37ebff"}
{"level":"info","time":"2020-10-30T09:58:46.711452-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-37b7cc23-2747-45e9-8d70-e62f335de801\", opId: \"\", volumeID: \"2081eb8e-542c-4b14-a0ce-ee0aa47a7c59\"","TraceId":"e9021244-7409-45da-897f-f511aa37ebff"}
{"level":"info","time":"2020-10-30T09:58:46.712206-07:00","caller":"vanilla/controller.go:768","msg":"ControllerExpandVolume: called with args {VolumeId:2081eb8e-542c-4b14-a0ce-ee0aa47a7c59 CapacityRange:required_bytes:2147483648  Secrets:map[] VolumeCapability:access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"17c1a6c5-1d2a-42f4-9e96-96b8d7a83b18"}
{"level":"info","time":"2020-10-30T09:58:46.712228-07:00","caller":"node/manager.go:75","msg":"Initializing node.defaultManager...","TraceId":"17c1a6c5-1d2a-42f4-9e96-96b8d7a83b18"}
{"level":"info","time":"2020-10-30T09:58:46.712237-07:00","caller":"node/manager.go:79","msg":"node.defaultManager initialized","TraceId":"17c1a6c5-1d2a-42f4-9e96-96b8d7a83b18"}
{"level":"info","time":"2020-10-30T09:58:46.714211-07:00","caller":"common/vsphereutil.go:397","msg":"Requested size 2048 Mb is greater than current size for volumeID: \"2081eb8e-542c-4b14-a0ce-ee0aa47a7c59\". Need volume expansion.","TraceId":"17c1a6c5-1d2a-42f4-9e96-96b8d7a83b18"}
{"level":"info","time":"2020-10-30T09:58:46.714566-07:00","caller":"volume/manager.go:571","msg":"Calling CnsClient.ExtendVolume: VolumeID [\"2081eb8e-542c-4b14-a0ce-ee0aa47a7c59\"] Size [2048] cnsExtendSpecList [[]types.CnsVolumeExtendSpec{types.CnsVolumeExtendSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:\"2081eb8e-542c-4b14-a0ce-ee0aa47a7c59\"}, CapacityInMb:2048}}]","TraceId":"17c1a6c5-1d2a-42f4-9e96-96b8d7a83b18"}
{"level":"info","time":"2020-10-30T09:58:46.715862-07:00","caller":"volume/manager.go:587","msg":"ExpandVolume: volumeID: \"2081eb8e-542c-4b14-a0ce-ee0aa47a7c59\", opId: \"\"","TraceId":"17c1a6c5-1d2a-42f4-9e96-96b8d7a83b18"}
{"level":"info","time":"2020-10-30T09:58:46.715876-07:00","caller":"volume/manager.go:605","msg":"ExpandVolume: Volume expanded successfully. volumeID: \"2081eb8e-542c-4b14-a0ce-ee0aa47a7c59\", opId: \"\"","TraceId":"17c1a6c5-1d2a-42f4-9e96-96b8d7a83b18"}
{"level":"info","time":"2020-10-30T09:58:46.715884-07:00","caller":"common/vsphereutil.go:403","msg":"Successfully expanded volume for volumeid \"2081eb8e-542c-4b14-a0ce-ee0aa47a7c59\" to new size 2048 Mb.","TraceId":"17c1a6c5-1d2a-42f4-9e96-96b8d7a83b18"}
{"level":"info","time":"2020-10-30T09:58:46.716247-07:00","caller":"vanilla/controller.go:535","msg":"DeleteVolume: called with args: {VolumeId:2081eb8e-542c-4b14-a0ce-ee0aa47a7c59 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"0925f656-f0b1-4da3-be80-cb57f23ced6f"}
{"level":"info","time":"2020-10-30T09:58:46.717732-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"2081eb8e-542c-4b14-a0ce-ee0aa47a7c59\", opId: \"\"","TraceId":"0925f656-f0b1-4da3-be80-cb57f23ced6f"}
{"level":"info","time":"2020-10-30T09:58:46.717745-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"2081eb8e-542c-4b14-a0ce-ee0aa47a7c59\", opId: \"\"","TraceId":"0925f656-f0b1-4da3-be80-cb57f23ced6f"}
--- PASS: TestExtendVolume (0.01s)
    controller_test.go:479: ControllerExpandVolume will be called with req +{2081eb8e-542c-4b14-a0ce-ee0aa47a7c59 required_bytes:2147483648  map[] access_mode:<mode:SINGLE_NODE_WRITER >  {} [] 0}
    controller_test.go:487: ControllerExpandVolume succeeded: volume is expanded to requested size 2147483648
=== RUN   TestMigratedExtendVolume
{"level":"info","time":"2020-10-30T09:58:46.718222-07:00","caller":"vanilla/controller.go:768","msg":"ControllerExpandVolume: called with args {VolumeId:[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk CapacityRange:required_bytes:1024  Secrets:map[] VolumeCapability:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"5f4acf36-0b1a-4afd-abb1-a88bde6c5796"}
{"level":"error","time":"2020-10-30T09:58:46.718236-07:00","caller":"vanilla/controller.go:772","msg":"Cannot expand migrated vSphere volume. :\"[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk\"","TraceId":"5f4acf36-0b1a-4afd-abb1-a88bde6c5796","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.(*controller).ControllerExpandVolume\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/vanilla/controller.go:772\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.TestMigratedExtendVolume\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:536\ntesting.tRunner\n\t/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909"}
--- PASS: TestMigratedExtendVolume (0.00s)
    controller_test.go:535: ControllerExpandVolume will be called with req +{[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk required_bytes:1024  map[] <nil> {} [] 0}
    controller_test.go:538: Expected error received. migrated volume with VMDK path can not be expanded
=== RUN   TestCompleteControllerFlow
{"level":"info","time":"2020-10-30T09:58:46.718333-07:00","caller":"vanilla/controller.go:509","msg":"CreateVolume: called with args {Name:test-pvc-2566eb37-3e78-4bae-8c79-efb4921c46c3 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"b62ad98a-4f3b-43f6-95c1-aebc4b83d787"}
{"level":"info","time":"2020-10-30T09:58:46.722626-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pvc-2566eb37-3e78-4bae-8c79-efb4921c46c3\", opId: \"\"","TraceId":"b62ad98a-4f3b-43f6-95c1-aebc4b83d787"}
{"level":"info","time":"2020-10-30T09:58:46.722642-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-2566eb37-3e78-4bae-8c79-efb4921c46c3\", opId: \"\", volumeID: \"88c0e4a4-cd76-4f99-984d-730925bf02df\"","TraceId":"b62ad98a-4f3b-43f6-95c1-aebc4b83d787"}
{"level":"info","time":"2020-10-30T09:58:46.723276-07:00","caller":"vanilla/controller.go:592","msg":"ControllerPublishVolume: called with args {VolumeId:88c0e4a4-cd76-4f99-984d-730925bf02df NodeId:DC0_C0_RP0_VM1 VolumeCapability:access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"3e86fb64-7e4e-4b1c-8b6d-dc4cd7b9efea"}
{"level":"info","time":"2020-10-30T09:58:46.724763-07:00","caller":"volume/manager.go:301","msg":"AttachVolume: volumeID: \"88c0e4a4-cd76-4f99-984d-730925bf02df\", vm: \"VirtualMachine:vm-57 [VirtualCenterHost: , UUID: , Datacenter: <nil>]\", opId: \"\"","TraceId":"3e86fb64-7e4e-4b1c-8b6d-dc4cd7b9efea"}
{"level":"info","time":"2020-10-30T09:58:46.724789-07:00","caller":"volume/manager.go:334","msg":"AttachVolume: Volume attached successfully. volumeID: \"88c0e4a4-cd76-4f99-984d-730925bf02df\", opId: \"\", vm: \"VirtualMachine:vm-57 [VirtualCenterHost: , UUID: , Datacenter: <nil>]\", diskUUID: \"6000c298595bf4575739e9105b2c0c2d\"","TraceId":"3e86fb64-7e4e-4b1c-8b6d-dc4cd7b9efea"}
{"level":"info","time":"2020-10-30T09:58:46.724852-07:00","caller":"vanilla/controller.go:686","msg":"ControllerUnpublishVolume: called with args {VolumeId:88c0e4a4-cd76-4f99-984d-730925bf02df NodeId:DC0_C0_RP0_VM1 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"f634c334-b928-41ed-8cf6-0dfcfa15d6f6"}
{"level":"info","time":"2020-10-30T09:58:46.728032-07:00","caller":"volume/manager.go:392","msg":"DetachVolume: volumeID: \"88c0e4a4-cd76-4f99-984d-730925bf02df\", vm: \"VirtualMachine:vm-57 [VirtualCenterHost: , UUID: , Datacenter: <nil>]\", opId: \"\"","TraceId":"f634c334-b928-41ed-8cf6-0dfcfa15d6f6"}
{"level":"info","time":"2020-10-30T09:58:46.72806-07:00","caller":"volume/manager.go:422","msg":"DetachVolume: Volume detached successfully. volumeID: \"88c0e4a4-cd76-4f99-984d-730925bf02df\", vm: \"\", opId: \"VirtualMachine:vm-57 [VirtualCenterHost: , UUID: , Datacenter: <nil>]\"","TraceId":"f634c334-b928-41ed-8cf6-0dfcfa15d6f6"}
{"level":"info","time":"2020-10-30T09:58:46.728122-07:00","caller":"vanilla/controller.go:535","msg":"DeleteVolume: called with args: {VolumeId:88c0e4a4-cd76-4f99-984d-730925bf02df Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"12525a69-b2db-47cb-80d2-2b334f14d9db"}
{"level":"info","time":"2020-10-30T09:58:46.729537-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"88c0e4a4-cd76-4f99-984d-730925bf02df\", opId: \"\"","TraceId":"12525a69-b2db-47cb-80d2-2b334f14d9db"}
{"level":"info","time":"2020-10-30T09:58:46.729553-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"88c0e4a4-cd76-4f99-984d-730925bf02df\", opId: \"\"","TraceId":"12525a69-b2db-47cb-80d2-2b334f14d9db"}
--- PASS: TestCompleteControllerFlow (0.01s)
    controller_test.go:624: ControllerPublishVolume will be called with req +{88c0e4a4-cd76-4f99-984d-730925bf02df DC0_C0_RP0_VM1 access_mode:<mode:SINGLE_NODE_WRITER >  false map[] map[] {} [] 0}
    controller_test.go:630: ControllerPublishVolume succeed, diskUUID 6000c298595bf4575739e9105b2c0c2d is returned
    controller_test.go:637: ControllerUnpublishVolume will be called with req +{88c0e4a4-cd76-4f99-984d-730925bf02df DC0_C0_RP0_VM1 map[] {} [] 0}
    controller_test.go:642: ControllerUnpublishVolume succeed
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla	0.864s
=== RUN   TestWCPCreateVolumeWithStoragePolicy
{"level":"error","time":"2020-10-30T09:58:47.976666-07:00","caller":"config/config.go:252","msg":"no Virtual Center hosts defined","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/common/config/config.go:252\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.FromEnv\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/common/config/config.go:236\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp.configFromEnvOrSim\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:124\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp.getControllerTest.func1\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:134\nsync.(*Once).doSlow\n\t/usr/local/Cellar/go/1.13.4/libexec/src/sync/once.go:66\nsync.(*Once).Do\n\t/usr/local/Cellar/go/1.13.4/libexec/src/sync/once.go:57\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp.getControllerTest\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:131\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp.TestWCPCreateVolumeWithStoragePolicy\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:252\ntesting.tRunner\n\t/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909"}
{"level":"info","time":"2020-10-30T09:58:48.002505-07:00","caller":"vsphere/utils.go:125","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2020-10-30T09:58:48.002634-07:00","caller":"vsphere/virtualcentermanager.go:64","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2020-10-30T09:58:48.002646-07:00","caller":"vsphere/virtualcentermanager.go:66","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2020-10-30T09:58:48.002732-07:00","caller":"vsphere/virtualcentermanager.go:110","msg":"Successfully registered VC \"127.0.0.1\""}
{"level":"info","time":"2020-10-30T09:58:48.007422-07:00","caller":"vsphere/virtualcenter.go:153","msg":"New session ID for 'user' = 315ee310-c3b5-4c93-a5ef-72398bb5ab89"}
{"level":"info","time":"2020-10-30T09:58:48.00777-07:00","caller":"volume/manager.go:98","msg":"Initializing new volume.defaultManager..."}
{"level":"info","time":"2020-10-30T09:58:48.010485-07:00","caller":"wcp/controller.go:211","msg":"CreateVolume: called with args {Name:test-pvc-9819455d-2ead-4509-a9c0-eb81c17ab0e5 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[storagepolicyid:aa6d5a82-1c88-45da-85d3-3d74b91a5bad] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"0a4875cf-003f-43d9-9be6-b050c4e18ec4"}
{"level":"info","time":"2020-10-30T09:58:48.016332-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pvc-9819455d-2ead-4509-a9c0-eb81c17ab0e5\", opId: \"\"","TraceId":"0a4875cf-003f-43d9-9be6-b050c4e18ec4"}
{"level":"info","time":"2020-10-30T09:58:48.016352-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-9819455d-2ead-4509-a9c0-eb81c17ab0e5\", opId: \"\", volumeID: \"b23398a8-1fe8-4936-8056-2cffa8e51c83\"","TraceId":"0a4875cf-003f-43d9-9be6-b050c4e18ec4"}
{"level":"info","time":"2020-10-30T09:58:48.017249-07:00","caller":"wcp/controller.go:359","msg":"DeleteVolume: called with args: {VolumeId:b23398a8-1fe8-4936-8056-2cffa8e51c83 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"fc97531b-b393-4f22-9249-84698611c3ae"}
{"level":"info","time":"2020-10-30T09:58:48.019141-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"b23398a8-1fe8-4936-8056-2cffa8e51c83\", opId: \"\"","TraceId":"fc97531b-b393-4f22-9249-84698611c3ae"}
{"level":"info","time":"2020-10-30T09:58:48.019158-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"b23398a8-1fe8-4936-8056-2cffa8e51c83\", opId: \"\"","TraceId":"fc97531b-b393-4f22-9249-84698611c3ae"}
--- PASS: TestWCPCreateVolumeWithStoragePolicy (0.04s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp	1.374s
=== RUN   TestGuestClusterControllerFlow
{"level":"error","time":"2020-10-30T09:58:47.605856-07:00","caller":"config/config.go:486","msg":"no Supervisor Cluster endpoint defined in Guest Cluster config","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateGCConfig\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/common/config/config.go:486\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.FromEnvToGC\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/common/config/config.go:417\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.configFromEnvOrSim\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/wcpguest/controller_test.go:67\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.getControllerTest.func1\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/wcpguest/controller_test.go:83\nsync.(*Once).doSlow\n\t/usr/local/Cellar/go/1.13.4/libexec/src/sync/once.go:66\nsync.(*Once).Do\n\t/usr/local/Cellar/go/1.13.4/libexec/src/sync/once.go:57\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.getControllerTest\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/wcpguest/controller_test.go:80\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.TestGuestClusterControllerFlow\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/csi/service/wcpguest/controller_test.go:112\ntesting.tRunner\n\t/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909"}
{"level":"info","time":"2020-10-30T09:58:47.607333-07:00","caller":"wcpguest/controller.go:206","msg":"CreateVolume: called with args {Name:pvc-12345 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[svstorageclass:test-storageclass] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"5d23b1e9-fa20-4bc5-a3c7-8853e47e0bdf"}
{"level":"info","time":"2020-10-30T09:58:47.607652-07:00","caller":"wcpguest/controller_helper.go:188","msg":"Waiting up to 240 seconds for PersistentVolumeClaim -12345 in namespace test-namespace to have phase Bound","TraceId":"5d23b1e9-fa20-4bc5-a3c7-8853e47e0bdf"}
{"level":"info","time":"2020-10-30T09:58:48.610292-07:00","caller":"wcpguest/controller_helper.go:210","msg":"PersistentVolumeClaim -12345 in namespace test-namespace is in state Bound","TraceId":"5d23b1e9-fa20-4bc5-a3c7-8853e47e0bdf"}
{"level":"info","time":"2020-10-30T09:58:48.610627-07:00","caller":"wcpguest/controller.go:275","msg":"DeleteVolume: called with args: {VolumeId:-12345 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"74f85d35-178f-49e4-89f3-dbb6a8298f8f"}
{"level":"info","time":"2020-10-30T09:58:48.610654-07:00","caller":"wcpguest/controller.go:293","msg":"DeleteVolume: Volume deleted successfully. VolumeID: \"-12345\"","TraceId":"74f85d35-178f-49e4-89f3-dbb6a8298f8f"}
--- PASS: TestGuestClusterControllerFlow (2.01s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest	3.075s
=== RUN   TestSyncerWorkflows
{"level":"error","time":"2020-10-30T09:58:48.35956-07:00","caller":"config/config.go:252","msg":"no Virtual Center hosts defined","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/common/config/config.go:252\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.FromEnv\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/common/config/config.go:236\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer.configFromEnvOrSim\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/syncer/syncer_test.go:148\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer.TestSyncerWorkflows\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/syncer/syncer_test.go:161\ntesting.tRunner\n\t/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909"}
{"level":"info","time":"2020-10-30T09:58:48.384693-07:00","caller":"vsphere/utils.go:125","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2020-10-30T09:58:48.384803-07:00","caller":"vsphere/virtualcentermanager.go:64","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2020-10-30T09:58:48.384817-07:00","caller":"vsphere/virtualcentermanager.go:66","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2020-10-30T09:58:48.384905-07:00","caller":"vsphere/virtualcentermanager.go:110","msg":"Successfully registered VC \"127.0.0.1\""}
{"level":"info","time":"2020-10-30T09:58:48.389422-07:00","caller":"vsphere/virtualcenter.go:153","msg":"New session ID for 'user' = f8b57dfc-5885-4d53-818c-d0266b17037e"}
{"level":"info","time":"2020-10-30T09:58:48.38962-07:00","caller":"volume/manager.go:98","msg":"Initializing new volume.defaultManager..."}
{"level":"info","time":"2020-10-30T09:58:48.389773-07:00","caller":"volume/manager.go:95","msg":"Retrieving existing volume.defaultManager..."}
{"level":"info","time":"2020-10-30T09:58:48.396594-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pvc\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:58:48.39662-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc\", opId: \"\", volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\""}
{"level":"info","time":"2020-10-30T09:58:48.398748-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\"","TraceId":"637f8817-46fb-4232-ac23-c35440b314f7"}
{"level":"info","time":"2020-10-30T09:58:48.398772-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\"","TraceId":"637f8817-46fb-4232-ac23-c35440b314f7"}
{"level":"info","time":"2020-10-30T09:58:48.401134-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:58:48.401149-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:58:48.403021-07:00","caller":"syncer/metadatasyncer.go:918","msg":"PVUpdated: Verified volume: \"66576139-e909-41eb-ba28-fa753ac872ef\" is not marked as container volume in CNS. Calling CreateVolume with BackingID to mark volume as Container Volume.","TraceId":"53cb13f6-b025-425e-be57-70cdaa869157"}
{"level":"info","time":"2020-10-30T09:58:48.404833-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pv-fc8ac217-eee6-40b3-ab64-83063762555d\", opId: \"\"","TraceId":"53cb13f6-b025-425e-be57-70cdaa869157"}
{"level":"info","time":"2020-10-30T09:58:48.404847-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pv-fc8ac217-eee6-40b3-ab64-83063762555d\", opId: \"\", volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\"","TraceId":"53cb13f6-b025-425e-be57-70cdaa869157"}
{"level":"info","time":"2020-10-30T09:58:48.404855-07:00","caller":"syncer/metadatasyncer.go:947","msg":"PVUpdated: vSphere CSI Driver has successfully marked volume: \"66576139-e909-41eb-ba28-fa753ac872ef\" as the container volume.","TraceId":"53cb13f6-b025-425e-be57-70cdaa869157"}
{"level":"info","time":"2020-10-30T09:58:54.414801-07:00","caller":"syncer/metadatasyncer.go:784","msg":"PVCUpdated: volume \"66576139-e909-41eb-ba28-fa753ac872ef\" found","TraceId":"3c0fe391-e948-4b90-9a76-4db5c09d63bf"}
{"level":"info","time":"2020-10-30T09:58:54.418451-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\"","TraceId":"3c0fe391-e948-4b90-9a76-4db5c09d63bf"}
{"level":"info","time":"2020-10-30T09:58:54.418473-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\"","TraceId":"3c0fe391-e948-4b90-9a76-4db5c09d63bf"}
{"level":"info","time":"2020-10-30T09:58:54.421618-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\"","TraceId":"5e73981c-9dee-4fd9-9399-cbccf4350a62"}
{"level":"info","time":"2020-10-30T09:58:54.421635-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\"","TraceId":"5e73981c-9dee-4fd9-9399-cbccf4350a62"}
{"level":"info","time":"2020-10-30T09:58:54.424304-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\"","TraceId":"664101ad-ec0f-4da3-a9ad-a414d48fdce0"}
{"level":"info","time":"2020-10-30T09:58:54.424321-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\"","TraceId":"664101ad-ec0f-4da3-a9ad-a414d48fdce0"}
{"level":"info","time":"2020-10-30T09:58:55.435473-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\"","TraceId":"edd573e4-0582-43dc-8ff8-6a1fb4132d3a"}
{"level":"info","time":"2020-10-30T09:58:55.435507-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\"","TraceId":"edd573e4-0582-43dc-8ff8-6a1fb4132d3a"}
{"level":"info","time":"2020-10-30T09:58:55.438159-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\"","TraceId":"e0fc42e5-5780-49fb-a750-f5b87004c38b"}
{"level":"info","time":"2020-10-30T09:58:55.438179-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"66576139-e909-41eb-ba28-fa753ac872ef\", opId: \"\"","TraceId":"e0fc42e5-5780-49fb-a750-f5b87004c38b"}
{"level":"info","time":"2020-10-30T09:58:55.440664-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pv\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:58:55.440684-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pv\", opId: \"\", volumeID: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\""}
{"level":"info","time":"2020-10-30T09:58:56.442453-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"warn","time":"2020-10-30T09:58:56.446078-07:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS"}
{"level":"info","time":"2020-10-30T09:58:56.44635-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-10-30T09:58:56.446594-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-30T09:58:56.446656-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"warn","time":"2020-10-30T09:58:56.448843-07:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS"}
{"level":"info","time":"2020-10-30T09:58:56.451021-07:00","caller":"syncer/util.go:148","msg":"0 more volumes to be queried"}
{"level":"info","time":"2020-10-30T09:58:56.451042-07:00","caller":"syncer/util.go:150","msg":"Metadata retrieved for all requested volumes"}
{"level":"info","time":"2020-10-30T09:58:56.451051-07:00","caller":"syncer/fullsync.go:248","msg":"FullSync: fullSyncDeleteVolumes: Calling DeleteVolume for volume c6e332f4-a578-4596-80d2-d6ca13ea03c4 with delete disk false"}
{"level":"info","time":"2020-10-30T09:58:56.453319-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:58:56.453337-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:58:56.453398-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-30T09:58:57.458944-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"warn","time":"2020-10-30T09:58:57.4639-07:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS"}
{"level":"info","time":"2020-10-30T09:58:57.464243-07:00","caller":"syncer/fullsync.go:411","msg":"FullSync: Volume with id: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\" and name: \"test-pv-fb0cdb80-5116-48a2-a6db-1b7bb04154a2\" is added to cnsCreationMap"}
{"level":"info","time":"2020-10-30T09:58:57.464445-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-10-30T09:58:57.464512-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-30T09:58:57.464573-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"warn","time":"2020-10-30T09:58:57.467062-07:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS"}
{"level":"info","time":"2020-10-30T09:58:57.467171-07:00","caller":"syncer/fullsync.go:408","msg":"FullSync: create is required for volume: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\", as volume was present in cnsCreationMap across two full-sync cycles"}
{"level":"info","time":"2020-10-30T09:58:57.46732-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-10-30T09:58:57.471694-07:00","caller":"volume/manager.go:213","msg":"CreateVolume: VolumeName: \"test-pv-fb0cdb80-5116-48a2-a6db-1b7bb04154a2\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:58:57.471721-07:00","caller":"volume/manager.go:261","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pv-fb0cdb80-5116-48a2-a6db-1b7bb04154a2\", opId: \"\", volumeID: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\""}
{"level":"info","time":"2020-10-30T09:58:57.471737-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-30T09:58:58.477485-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"info","time":"2020-10-30T09:58:58.482608-07:00","caller":"syncer/util.go:148","msg":"0 more volumes to be queried"}
{"level":"info","time":"2020-10-30T09:58:58.482633-07:00","caller":"syncer/util.go:150","msg":"Metadata retrieved for all requested volumes"}
{"level":"info","time":"2020-10-30T09:58:58.483099-07:00","caller":"syncer/fullsync.go:417","msg":"FullSync: update is required for volume: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\""}
{"level":"info","time":"2020-10-30T09:58:58.483272-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-10-30T09:58:58.486572-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:58:58.486594-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:58:58.486609-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-30T09:58:59.489883-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"info","time":"2020-10-30T09:58:59.494683-07:00","caller":"syncer/util.go:148","msg":"0 more volumes to be queried"}
{"level":"info","time":"2020-10-30T09:58:59.494707-07:00","caller":"syncer/util.go:150","msg":"Metadata retrieved for all requested volumes"}
{"level":"info","time":"2020-10-30T09:58:59.49604-07:00","caller":"syncer/fullsync.go:417","msg":"FullSync: update is required for volume: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\""}
{"level":"info","time":"2020-10-30T09:58:59.496367-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-10-30T09:58:59.499461-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:58:59.499481-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:58:59.499495-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-30T09:59:00.503827-07:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"info","time":"2020-10-30T09:59:00.509477-07:00","caller":"syncer/util.go:148","msg":"0 more volumes to be queried"}
{"level":"info","time":"2020-10-30T09:59:00.509512-07:00","caller":"syncer/util.go:150","msg":"Metadata retrieved for all requested volumes"}
{"level":"info","time":"2020-10-30T09:59:00.510699-07:00","caller":"syncer/fullsync.go:417","msg":"FullSync: update is required for volume: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\""}
{"level":"info","time":"2020-10-30T09:59:00.511079-07:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-10-30T09:59:00.514373-07:00","caller":"volume/manager.go:525","msg":"UpdateVolumeMetadata: volumeID: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:59:00.514392-07:00","caller":"volume/manager.go:543","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:59:00.514404-07:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-10-30T09:59:00.518142-07:00","caller":"volume/manager.go:461","msg":"DeleteVolume: volumeID: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\", opId: \"\""}
{"level":"info","time":"2020-10-30T09:59:00.518163-07:00","caller":"volume/manager.go:479","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"c6e332f4-a578-4596-80d2-d6ca13ea03c4\", opId: \"\""}
--- PASS: TestSyncerWorkflows (12.16s)
    syncer_test.go:159: TestSyncerWorkflows: start
    syncer_test.go:277: TestMetadataSyncInformer start
    syncer_test.go:458: TestMetadataSyncInformer end
    syncer_test.go:610: TestFullSyncWorkflows start
    syncer_test.go:791: TestFullSyncWorkflows end
    syncer_test.go:247: TestSyncerWorkflows: end
=== RUN   TestValidMigratedAndLegacyVolume
--- PASS: TestValidMigratedAndLegacyVolume (0.00s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/syncer	13.782s
=== RUN   TestValidateStorageClassForAllowVolumeExpansion
{"level":"info","time":"2020-10-30T09:58:47.259206-07:00","caller":"admissionhandler/validatestorageclass.go:75","msg":"Validating StorageClass: \"sc\""}
{"level":"error","time":"2020-10-30T09:58:47.259324-07:00","caller":"admissionhandler/validatestorageclass.go:99","msg":"validation of StorageClass: \"sc\" Failed","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler.validateStorageClass\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/syncer/admissionhandler/validatestorageclass.go:99\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler.TestValidateStorageClassForAllowVolumeExpansion\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/syncer/admissionhandler/validatestorageclass_test.go:45\ntesting.tRunner\n\t/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909"}
--- PASS: TestValidateStorageClassForAllowVolumeExpansion (0.00s)
    validatestorageclass_test.go:49: TestValidateStorageClassForAllowVolumeExpansion Passed
=== RUN   TestValidateStorageClassForMigrationParameter
{"level":"info","time":"2020-10-30T09:58:47.259558-07:00","caller":"admissionhandler/validatestorageclass.go:75","msg":"Validating StorageClass: \"sc\""}
{"level":"error","time":"2020-10-30T09:58:47.259571-07:00","caller":"admissionhandler/validatestorageclass.go:99","msg":"validation of StorageClass: \"sc\" Failed","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler.validateStorageClass\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/syncer/admissionhandler/validatestorageclass.go:99\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler.TestValidateStorageClassForMigrationParameter\n\t/Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver/pkg/syncer/admissionhandler/validatestorageclass_test.go:60\ntesting.tRunner\n\t/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909"}
--- PASS: TestValidateStorageClassForMigrationParameter (0.00s)
    validatestorageclass_test.go:64: TestValidateStorageClassForMigrationParameter Passed
=== RUN   TestValidateStorageClassForValidStorageClass
{"level":"info","time":"2020-10-30T09:58:47.259741-07:00","caller":"admissionhandler/validatestorageclass.go:75","msg":"Validating StorageClass: \"sc\""}
{"level":"info","time":"2020-10-30T09:58:47.259752-07:00","caller":"admissionhandler/validatestorageclass.go:97","msg":"Validation of StorageClass: \"sc\" Passed"}
--- PASS: TestValidateStorageClassForValidStorageClass (0.00s)
    validatestorageclass_test.go:79: TestValidateStorageClassForValidStorageClass Passed
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler	1.173s
```



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
cherry-pick commits to release 2.1 branch
```
