### PR TITLE
Handle SVC PVC Delete events in volume health reconciler.

### DIFF
--- a/pkg/syncer/volume_health_reconciler.go
+++ b/pkg/syncer/volume_health_reconciler.go
@@ -157,6 +157,7 @@ func NewVolumeHealthReconciler(
 	svcPVCInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    rc.svcAddPVC,
 		UpdateFunc: rc.svcUpdatePVC,
+		DeleteFunc: rc.svcAddPVC,
 	}, resyncPeriod)
 
 	tkgPVInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
@@ -326,19 +327,19 @@ func (rc *volumeHealthReconciler) syncPVC(key string) error {
 
 	svcPVC, err := rc.svcPVCLister.PersistentVolumeClaims(namespace).Get(name)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			log.Infof("PVC %s/%s is deleted, no need to process it", namespace, name)
-			return nil
+		if !k8serrors.IsNotFound(err) {
+			log.Errorf("syncPVC: Get PVC %s/%s failed: %v", namespace, name, err)
+			return err
 		}
-		log.Errorf("Get PVC %s/%s failed: %v", namespace, name, err)
-		return err
+		log.Infof("syncPVC: Supervisor Cluster PVC %s/%s is deleted, process any left over TKG PVCs", namespace, name)
+	} else {
+		log.Infof("syncPVC: Found Supervisor Cluster PVC: %s/%s", svcPVC.Namespace, svcPVC.Name)
 	}
-	log.Infof("syncPVC: Found Supervisor Cluster PVC: %s/%s", svcPVC.Namespace, svcPVC.Name)
 
 	// The input PVC is a Supervisor Cluster PVC
 	// Find list of Tanzu Kubernetes Grid PV's referencing this PVC
 	// Find corresponding Tanzu Kubernetes Grid PVCs and update them
-	tkgPVList, err := rc.findTKGPVforSupervisorPVC(ctx, svcPVC)
+	tkgPVList, err := rc.findTKGPVforSupervisorPVC(ctx, name, namespace)
 	if err != nil {
 		return err
 	}
@@ -365,13 +366,13 @@ func (rc *volumeHealthReconciler) syncPVC(key string) error {
 
 // find list of PV's in TKG that matches PVC in supervisor cluster
 // Returns list of pointers to PV's in TKG
-func (rc *volumeHealthReconciler) findTKGPVforSupervisorPVC(ctx context.Context, svcPVC *v1.PersistentVolumeClaim) ([]*v1.PersistentVolume, error) {
+func (rc *volumeHealthReconciler) findTKGPVforSupervisorPVC(ctx context.Context, pvcName, pvcNamespace string) ([]*v1.PersistentVolume, error) {
 	log := logger.GetLogger(ctx)
 	// For the SV PVC for which this event was triggered, find the TKG PV's that reference this PVC.
 	var tkgPVList []*v1.PersistentVolume
-	log.Debugf("findTKGPVforSupervisorPVC enter: Supervisor Cluster PVC %s/%s", svcPVC.Namespace, svcPVC.Name)
+	log.Debugf("findTKGPVforSupervisorPVC enter: Supervisor Cluster PVC %s/%s", pvcNamespace, pvcName)
 
-	pvNames := rc.volumeHandleToPVs.get(svcPVC.Name)
+	pvNames := rc.volumeHandleToPVs.get(pvcName)
 	if len(pvNames) == 0 {
 		return nil, nil
 	}
@@ -394,8 +395,9 @@ func (rc *volumeHealthReconciler) updateTKGPVC(ctx context.Context, svcPVC *v1.P
 	// compare the volume health annotation on the PVC in Tanzu Kubernetes Grid with the annotation on PVC in the Supervisor Cluster.
 	// If annotation is different, update the volume health annotation on the PVC in Tanzu Kubernetes Grid based on the one in Supervisor Cluster.
 	// If same, do nothing
+	// If the SVC PVC was deleted but TKG PVC exists, change annotation to inaccessible
 	// If update fails, the caller will add PVC in Supervisor Cluster back to RateLimited queue to retry.
-	log.Debugf("updateTKGPVC enter: Supervisor Cluster PVC %s/%s, Tanzu Kubernetes Grid PV %s", svcPVC.Namespace, svcPVC.Name, tkgPV.Name)
+	log.Debugf("updateTKGPVC enter: Tanzu Kubernetes Grid PV %s", tkgPV.Name)
 	tkgPVCObj, err := rc.tkgKubeClient.CoreV1().PersistentVolumeClaims(tkgPV.Spec.ClaimRef.Namespace).Get(ctx, tkgPV.Spec.ClaimRef.Name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error get pvc %s/%s from api server: %v", tkgPV.Spec.ClaimRef.Namespace, tkgPV.Spec.ClaimRef.Name, err)
@@ -404,9 +406,15 @@ func (rc *volumeHealthReconciler) updateTKGPVC(ctx context.Context, svcPVC *v1.P
 
 	// Check if annotation is the same on PVC in Tanzu Kubernetes Grid and Supervisor Cluster and copy from Supervisor Cluster if different
 	var tkgAnnValue, svcAnnValue string
-	tkgAnnValue, tkgFound := tkgPVCObj.ObjectMeta.Annotations[annVolumeHealth]
-	svcAnnValue, svcFound := svcPVC.ObjectMeta.Annotations[annVolumeHealth]
-	if !tkgFound && svcFound || tkgFound && svcFound && tkgAnnValue != svcAnnValue {
+	var tkgAnnFound, svcAnnFound bool
+	tkgAnnValue, tkgAnnFound = tkgPVCObj.ObjectMeta.Annotations[annVolumeHealth]
+	if svcPVC != nil {
+		svcAnnValue, svcAnnFound = svcPVC.ObjectMeta.Annotations[annVolumeHealth]
+	} else {
+		svcAnnValue = volHealthStatusInAccessible
+	}
+
+	if !tkgAnnFound && svcAnnFound || tkgAnnFound && svcAnnFound && tkgAnnValue != svcAnnValue || svcPVC == nil {
 		log.Infof("updateTKGPVC: Detected volume health annotation change. Need to update Tanzu Kubernetes Grid PVC %s/%s. Existing TKG PVC annotation: %s. New annotation: %s", tkgPVCObj.Namespace, tkgPVCObj.Name, tkgAnnValue, svcAnnValue)
 		tkgPVCClone := tkgPVCObj.DeepCopy()
 		metav1.SetMetaDataAnnotation(&tkgPVCClone.ObjectMeta, annVolumeHealth, svcAnnValue)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR handles SVC PVC Delete events in TKG volume health reconciler. 
If a SVC PVC that a TKG PV refers to is deleted out of band, the TKG PVC Volume health status is changed to `inaccessible`. 

Testing:
1. Create PVC in TKG and verify volume health status
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl  describe pvc
Name:          example-vanilla-block-pvc2
Namespace:     default
StorageClass:  gc-storage-profile
Status:        Bound
Volume:        pvc-f6a8b4df-3aad-4d61-a3f5-0e99a4a05cc6
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
```

2. Delete SV-PVC manually:
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl delete pvc -n test-gc-e2e-demo-ns 30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-f6a8b4df-3aad-4d61-a3f5-0e99a4a05cc6
persistentvolumeclaim "30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-f6a8b4df-3aad-4d61-a3f5-0e99a4a05cc6" deleted
```

3. Verify TKG PVC volume health status is changed:
```
root@422f45813bff2a241fdfeda9996a783b [ ~ ]# kubectl  describe pvc
Name:          example-vanilla-block-pvc2
Namespace:     default
StorageClass:  gc-storage-profile
Status:        Bound
Volume:        pvc-f6a8b4df-3aad-4d61-a3f5-0e99a4a05cc6
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: inaccessible
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
```

Logs:

```
{"level":"info","time":"2020-10-30T23:12:37.042583315Z","caller":"syncer/volume_health_reconciler.go:244","msg":"addPVC: add test-gc-e2e-demo-ns/30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-f6a8b4df-3aad-4d61-a3f5-0e99a4a05cc6 to claim queue","TraceId":"deddce73-eda7-49b3-b3d9-b05b137c651a"}
{"level":"info","time":"2020-10-30T23:12:37.044571206Z","caller":"syncer/volume_health_reconciler.go:335","msg":"syncPVC: Supervisor Cluster PVC test-gc-e2e-demo-ns/30f18ee8-caa1-4a92-9f8f-c1616e4b0a79-f6a8b4df-3aad-4d61-a3f5-0e99a4a05cc6 is deleted, process any left over TKG PVCs","TraceId":"c5fd7a10-261e-4529-8ffd-1d25ced16da5"}
{"level":"info","time":"2020-10-30T23:12:37.079271493Z","caller":"syncer/volume_health_reconciler.go:419","msg":"updateTKGPVC: Detected volume health annotation change. Need to update Tanzu Kubernetes Grid PVC default/example-vanilla-block-pvc2. Existing TKG PVC annotation: accessible. New annotation: inaccessible","TraceId":"c5fd7a10-261e-4529-8ffd-1d25ced16da5"}
{"level":"info","time":"2020-10-30T23:12:37.206700207Z","caller":"syncer/volume_health_reconciler.go:427","msg":"updateTKGPVC: Updated Tanzu Kubernetes Grid PVC default/example-vanilla-block-pvc2","TraceId":"c5fd7a10-261e-4529-8ffd-1d25ced16da5"}
{"level":"info","time":"2020-10-30T23:12:37.207655906Z","caller":"syncer/volume_health_reconciler.go:362","msg":"Updated Tanzu Kubernetes Grid PVC for PV pvc-f6a8b4df-3aad-4d61-a3f5-0e99a4a05cc6","TraceId":"c5fd7a10-261e-4529-8ffd-1d25ced16da5"}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #433

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Handle SVC PVC Delete events in volume health reconciler.
```
