### PR TITLE
Retrieve datastoreURL from PlacementResults for topology support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,8 @@ require (
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.3
-	github.com/vmware/govmomi v0.23.2-0.20201015235820-81318771d0e0
+	github.com/vmware/govmomi v0.23.2-0.20201031083551-1cfa19267614
+	github.com/zekroTJA/timedmap v1.1.2
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect

--- a/go.sum
+++ b/go.sum
@@ -646,8 +646,8 @@ github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmF
 github.com/vmware-tanzu/vm-operator-api v0.1.3 h1:4vxewu0jAN3fSoCBI6FhjmRGJ7ci0R2WNu/I6hacTYs=
 github.com/vmware-tanzu/vm-operator-api v0.1.3/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/vmware/govmomi v0.23.2-0.20201015235820-81318771d0e0 h1:vFYRzFxHXDERRZ3nLuLHEvTP1oZwu+tgSb8XHSki2tU=
-github.com/vmware/govmomi v0.23.2-0.20201015235820-81318771d0e0/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.23.2-0.20201031083551-1cfa19267614 h1:Pw/uggJO55NA442TyCmY9BQmaw66xJsf9pvUr1ijPqM=
+github.com/vmware/govmomi v0.23.2-0.20201031083551-1cfa19267614/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -364,7 +364,7 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volu
 		}
 		log.Debugf("retrieved all datacenters %v from vCenter", datacenterPaths)
 	}
-	var volumeID *cnstypes.CnsVolumeId
+	var volumeInfo *cnsvolume.CnsVolumeInfo
 	var storagePolicyID string
 	if volumeSpec.StoragePolicyName != "" {
 		log.Debugf("Obtaining storage policy ID for storage policy name: %q", volumeSpec.StoragePolicyName)
@@ -401,21 +401,21 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volu
 		createSpec.BackingObjectDetails = &cnstypes.CnsBlockBackingDetails{BackingDiskUrlPath: backingDiskURLPath}
 		log.Infof("Registering volume: %q using backingDiskURLPath :%q", volumeSpec.VolumePath, backingDiskURLPath)
 		log.Debugf("vSphere CSI driver registering volume %q with create spec %+v", volumeSpec.VolumePath, spew.Sdump(createSpec))
-		volumeID, err = (*volumeMigration.volumeManager).CreateVolume(ctx, createSpec)
+		volumeInfo, err = (*volumeMigration.volumeManager).CreateVolume(ctx, createSpec)
 		if err != nil {
 			log.Warnf("failed to register volume %q with createSpec: %v. error: %+v", volumeSpec.VolumePath, createSpec, err)
 		} else {
 			break
 		}
 	}
-	if volumeID != nil {
-		log.Infof("Successfully registered volume %q as container volume with ID: %q", volumeSpec.VolumePath, volumeID.Id)
+	if volumeInfo != nil {
+		log.Infof("Successfully registered volume %q as container volume with ID: %q", volumeSpec.VolumePath, volumeInfo.VolumeID.Id)
 	} else {
 		msg := fmt.Sprintf("registration failed for volumeSpec: %v", volumeSpec)
 		log.Error(msg)
 		return "", errors.New(msg)
 	}
-	return volumeID.Id, nil
+	return volumeInfo.VolumeID.Id, nil
 }
 
 // cleanupStaleCRDInstances helps in cleaning up stale volume migration CRD instances

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -304,7 +304,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	}
 
 	candidateDatastores := append(sharedDatastores, vsanDirectDatastores...)
-	volumeID, err := common.CreateBlockVolumeUtil(ctx, cnstypes.CnsClusterFlavorWorkload, c.manager, &createVolumeSpec, candidateDatastores)
+	volumeInfo, err := common.CreateBlockVolumeUtil(ctx, cnstypes.CnsClusterFlavorWorkload, c.manager, &createVolumeSpec, candidateDatastores)
 	if err != nil {
 		msg := fmt.Sprintf("failed to create volume. Error: %+v", err)
 		log.Error(msg)
@@ -315,7 +315,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	attributes[common.AttributeDiskType] = common.DiskTypeBlockVolume
 	resp := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId:      volumeID,
+			VolumeId:      volumeInfo.VolumeID.Id,
 			CapacityBytes: int64(units.FileSize(volSizeMB * common.MbInBytes)),
 			VolumeContext: attributes,
 		},

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -199,7 +199,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(request reconcile.Request) (recon
 	log.Infof("Creating CNS volume: %+v for CnsRegisterVolume request with name: %q on namespace: %q",
 		instance, instance.Name, instance.Namespace)
 	log.Debugf("CNS Volume create spec is: %+v", createSpec)
-	vol, err := r.volumeManager.CreateVolume(ctx, createSpec)
+	volInfo, err := r.volumeManager.CreateVolume(ctx, createSpec)
 	if err != nil {
 		msg := "failed to create CNS volume"
 		log.Errorf(msg)
@@ -207,7 +207,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
 
-	volumeID = vol.Id
+	volumeID = volInfo.VolumeID.Id
 	log.Infof("Created CNS volume with volumeID: %s", volumeID)
 
 	pvName = staticPvNamePrefix + volumeID


### PR DESCRIPTION
This PR is to Retrieve datastoreURL from PlacementResults for topology support. With old version of CNS, CreateVolume does not return the datastoreURL where the volume is provisioned. Therefore, we need invoke a QueryVolume API to get the datastoreURL for topology support. With new version of CNS, CreateVolume returns PlacementResults which provides the datastoreURL where the volume is provisioned and we can retrieve it from PlacementResults.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
TestSetup:
(1) K8s cluster with 4 nodes (1 master and 3 work nodes). create region "region-1" on "VSAN-DC" and two zones "zone-a", "zone-b".
```
root@k8s-master-88:~# kubectl get nodes -L failure-domain.beta.kubernetes.io/zone -L failure-domain.beta.kubernetes.io/region
NAME            STATUS   ROLES    AGE   VERSION   ZONE     REGION
k8s-master-88   Ready    master   30d   v1.16.3   zone-a   region-1
k8s-node-0237   Ready    <none>   30d   v1.16.3   zone-a   region-1
k8s-node-04     Ready    <none>   30d   v1.16.3   zone-b   region-1
k8s-node-0985   Ready    <none>   30d   v1.16.3   zone-b   region-1
```
(2) deploy CCM and CSI with region/zone support

Test Steps:
1. create sc with region/zone support
```
root@k8s-master-88:~# kubectl describe sc
Name:                  example-vanilla-block-sc
IsDefaultClass:        Yes
Annotations:           storageclass.kubernetes.io/is-default-class=true
Provisioner:           csi.vsphere.vmware.com
Parameters:            <none>
AllowVolumeExpansion:  <unset>
MountOptions:          <none>
ReclaimPolicy:         Delete
VolumeBindingMode:     Immediate
AllowedTopologies:
  Term 0:              failure-domain.beta.kubernetes.io/zone in [zone-a]
                       failure-domain.beta.kubernetes.io/region in [region-1]
Events:                <none>
```

2. create a pvc using the above sc
```
root@k8s-master-88:~# kubectl create -f pvc5.yaml

root@k8s-master-88:~# kubectl get pvc
NAME                         STATUS   VOLUME                                                                                                                 CAPACITY   ACCESS MODES   STORAGECLASS               AGE
example-vanilla-block-pvc    Bound    pvc-bfab1faf-04db-4a2a-83b2-1e44a6cdd740                                                                               200Mi      RWO            example-vanilla-block-sc   29d
example-vanilla-block-pvc1   Bound    pvc-3138fc0f-3998-4425-8ac2-a87049e56651                                                                               200Mi      RWO            example-vanilla-block-sc   29d
example-vanilla-block-pvc2   Bound    pvc-0836bc6b-8da7-4133-a94b-eede0b96bf33                                                                               200Mi      RWO            example-vanilla-block-sc   29d
example-vanilla-block-pvc3   Bound    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1ee988f6-d7c2-4d8b-a3ee-54d71132c4b1   200Mi      RWO            example-vanilla-block-sc   14d
example-vanilla-block-pvc4   Bound    pvc-d08616bd-8312-401b-a12b-7c4e32596410                                                                               200Mi      RWO            example-vanilla-block-sc   2d1h
example-vanilla-block-pvc5   Bound    pvc-a4251ab6-d9dd-4d56-95d7-6d11add72b0a                                                                               200Mi      RWO            example-vanilla-block-sc   35m

root@k8s-master-88:~# kubectl get pv
NAME                                                                                                                   CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                STORAGECLASS               REASON   AGE
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1ee988f6-d7c2-4d8b-a3ee-54d71132c4b1   200Mi      RWO            Delete           Bound    default/example-vanilla-block-pvc3   example-vanilla-block-sc            14d
pvc-0836bc6b-8da7-4133-a94b-eede0b96bf33                                                                               200Mi      RWO            Delete           Bound    default/example-vanilla-block-pvc2   example-vanilla-block-sc            29d
pvc-3138fc0f-3998-4425-8ac2-a87049e56651                                                                               200Mi      RWO            Delete           Bound    default/example-vanilla-block-pvc1   example-vanilla-block-sc            29d
pvc-a4251ab6-d9dd-4d56-95d7-6d11add72b0a                                                                               200Mi      RWO            Delete           Bound    default/example-vanilla-block-pvc5   example-vanilla-block-sc            53s
pvc-bfab1faf-04db-4a2a-83b2-1e44a6cdd740                                                                               200Mi      RWO            Delete           Bound    default/example-vanilla-block-pvc    example-vanilla-block-sc            29d
pvc-d08616bd-8312-401b-a12b-7c4e32596410                                                                               200Mi      RWO            Delete           Bound    default/example-vanilla-block-pvc4   example-vanilla-block-sc            2d1h

```

3. decsribe this pv, it is created on region-1/zone-a which is specified in sc.

```
root@k8s-master-88:~# kubectl describe pv pvc-a4251ab6-d9dd-4d56-95d7-6d11add72b0a
Name:              pvc-a4251ab6-d9dd-4d56-95d7-6d11add72b0a
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      example-vanilla-block-sc
Status:            Bound
Claim:             default/example-vanilla-block-pvc5
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          200Mi
Node Affinity:
  Required Terms:
    Term 0:        failure-domain.beta.kubernetes.io/zone in [zone-a]
                   failure-domain.beta.kubernetes.io/region in [region-1]
Message:
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    VolumeHandle:      c405ed03-9ae8-4f6a-916b-cc6d7a199786
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1604013477217-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```
4. create pod using this pvc, this pod is scheduled on node k8s-node-0237, which is in region-1/zone-a.
```
root@k8s-master-88:~# kubectl create -f pod.yaml
pod/example-vanilla-block-pod created

root@k8s-master-88:~# kubectl get pod -o wide
NAME                        READY   STATUS              RESTARTS   AGE   IP       NODE            NOMINATED NODE   READINESS GATES
example-vanilla-block-pod   0/1     ContainerCreating   0          38s   <none>   k8s-node-0237   <none>           <none>

root@k8s-master-88:~# kubectl get nodes -L failure-domain.beta.kubernetes.io/zone -L failure-domain.beta.kubernetes.io/region
NAME            STATUS   ROLES    AGE   VERSION   ZONE     REGION
k8s-master-88   Ready    master   30d   v1.16.3   zone-a   region-1
k8s-node-0237   Ready    <none>   30d   v1.16.3   zone-a   region-1
k8s-node-04     Ready    <none>   30d   v1.16.3   zone-b   region-1
k8s-node-0985   Ready    <none>   30d   v1.16.3   zone-b   region-1
```

Related CSI log:
```
2020-10-29T23:18:00.357Z        DEBUG   vanilla/nodes.go:189    Obtained shared datastores : [] for topology: segments:<key:"failure-domain.beta.kubernetes.io/region" value:"region-1" > segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"zone-a" >       {"TraceId": "f5f15076-f3b8-4b44-b59f-bdf2cfeb095b"}
2020-10-29T23:18:00.357Z        DEBUG   vanilla/controller.go:391       Shared datastores [[Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/5f738a16-78b2ab84-0503-0200ac0f5559/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/5f738a17-0b3d38a8-bcbb-0200ac0f5559/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/vsan:52b2a856546dad28-790edbe992ed4030/]] retrieved for topologyRequirement [requisite:<segments:<key:"failure-domain.beta.kubernetes.io/region" value:"region-1" > segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"zone-a" > > preferred:<segments:<key:"failure-domain.beta.kubernetes.io/region" value:"region-1" > segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"zone-a" > > ] with datastoreTopologyMap [+map[ds:///vmfs/volumes/5f738a16-78b2ab84-0503-0200ac0f5559/:[map[failure-domain.beta.kubernetes.io/region:region-1 failure-domain.beta.kubernetes.io/zone:zone-a]] ds:///vmfs/volumes/5f738a17-0b3d38a8-bcbb-0200ac0f5559/:[map[failure-domain.beta.kubernetes.io/region:region-1 failure-domain.beta.kubernetes.io/zone:zone-a]] ds:///vmfs/volumes/vsan:52b2a856546dad28-790edbe992ed4030/:[map[failure-domain.beta.kubernetes.io/region:region-1 failure-domain.beta.kubernetes.io/zone:zone-a]]]] {"TraceId": "f5f15076-f3b8-4b44-b59f-bdf2cfeb095b"}

2020-10-29T23:18:00.360Z        DEBUG   common/vsphereutil.go:172       vSphere CSI driver creating volume pvc-a4251ab6-d9dd-4d56-95d7-6d11add72b0a with create spec (*types.CnsVolumeCreateSpec)(0xc0007440f0)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-a4251ab6-d9dd-4d56-95d7-6d11add72b0a",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=3 cap=4) {
  (types.ManagedObjectReference) Datastore:datastore-34,
  (types.ManagedObjectReference) Datastore:datastore-35,
  (types.ManagedObjectReference) Datastore:datastore-36
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=15) "demo-cluster-id",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA",
   ClusterDistribution: (string) ""
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=15) "demo-cluster-id",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA",
    ClusterDistribution: (string) ""
   }
  }
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc0007d2810)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 200
  },
  BackingDiskId: (string) "",
  BackingDiskUrlPath: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) <nil>,
 CreateSpec: (types.BaseCnsBaseCreateSpec) <nil>
})
        {"TraceId": "f5f15076-f3b8-4b44-b59f-bdf2cfeb095b"}
...

2020-10-29T23:18:03.560Z        INFO    volume/manager.go:222   CreateVolume: VolumeName: "pvc-a4251ab6-d9dd-4d56-95d7-6d11add72b0a", opId: "8eca0111"  {"TraceId": "f5f15076-f3b8-4b44-b59f-bdf2cfeb095b"}
2020-10-29T23:18:03.561Z        INFO    volume/manager.go:286   CreateVolume: Volume created successfully. VolumeName: "pvc-a4251ab6-d9dd-4d56-95d7-6d11add72b0a", opId: "8eca0111", volumeID: "c405ed03-9ae8-4f6a-916b-cc6d7a199786"   {"TraceId": "f5f15076-f3b8-4b44-b59f-bdf2cfeb095b"}
2020-10-29T23:18:03.562Z        DEBUG   volume/manager.go:287   CreateVolume volumeId c405ed03-9ae8-4f6a-916b-cc6d7a199786 is on datastore ds:///vmfs/volumes/vsan:52b2a856546dad28-790edbe992ed4030/   {"TraceId": "f5f15076-f3b8-4b44-b59f-bdf2cfeb095b"}
2020-10-29T23:18:03.562Z        DEBUG   vanilla/controller.go:482       Volume: c405ed03-9ae8-4f6a-916b-cc6d7a199786 is provisioned on the datastore: ds:///vmfs/volumes/vsan:52b2a856546dad28-790edbe992ed4030/        {"TraceId": "f5f15076-f3b8-4b44-b59f-bdf2cfeb095b"}
2020-10-29T23:18:03.562Z        DEBUG   vanilla/controller.go:487       volumeAccessibleTopology: [map[failure-domain.beta.kubernetes.io/region:region-1 failure-domain.beta.kubernetes.io/zone:zone-a]] is selected for datastore: ds:///vmfs/volumes/vsan:52b2a856546dad28-790edbe992ed4030/  {"TraceId": "f5f15076-f3b8-4b44-b59f-bdf2cfeb095b"}

```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
