### PR TITLE
Add namespace specific informers for the feature states configMap

### DIFF
--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
@@ -41,7 +41,7 @@ metadata:
   name: vsphere-csi-webhook
   namespace: kube-system
 ---
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vsphere-csi-webhook-role
@@ -51,16 +51,17 @@ rules:
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vsphere-csi-webhook-role-binding
+  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: vsphere-csi-webhook
     namespace: kube-system
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: vsphere-csi-webhook-role
   apiGroup: rbac.authorization.k8s.io
 ---

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -59,13 +59,6 @@ rules:
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
     resourceNames: ["vmware-system-privileged"]
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: vsphere-csi-node-cluster-role
-  namespace: {{ .PVCSINamespace }}
-rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
@@ -95,20 +88,6 @@ subjects:
 roleRef:
   kind: Role
   name: vsphere-csi-node-role
-  apiGroup: rbac.authorization.k8s.io
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: vsphere-csi-node-cluster-binding
-  namespace: {{ .PVCSINamespace }}
-subjects:
-  - kind: ServiceAccount
-    name: vsphere-csi-node
-    namespace: {{ .PVCSINamespace }}
-roleRef:
-  kind: ClusterRole
-  name: vsphere-csi-node-cluster-role
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Deployment

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -59,13 +59,6 @@ rules:
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
     resourceNames: ["vmware-system-privileged"]
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: vsphere-csi-node-cluster-role
-  namespace: {{ .PVCSINamespace }}
-rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
@@ -95,20 +88,6 @@ subjects:
 roleRef:
   kind: Role
   name: vsphere-csi-node-role
-  apiGroup: rbac.authorization.k8s.io
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: vsphere-csi-node-cluster-binding
-  namespace: {{ .PVCSINamespace }}
-subjects:
-  - kind: ServiceAccount
-    name: vsphere-csi-node
-    namespace: {{ .PVCSINamespace }}
-roleRef:
-  kind: ClusterRole
-  name: vsphere-csi-node-cluster-role
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Deployment

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -59,13 +59,6 @@ rules:
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
     resourceNames: ["vmware-system-privileged"]
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: vsphere-csi-node-cluster-role
-  namespace: {{ .PVCSINamespace }}
-rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
@@ -95,20 +88,6 @@ subjects:
 roleRef:
   kind: Role
   name: vsphere-csi-node-role
-  apiGroup: rbac.authorization.k8s.io
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: vsphere-csi-node-cluster-binding
-  namespace: {{ .PVCSINamespace }}
-subjects:
-  - kind: ServiceAccount
-    name: vsphere-csi-node
-    namespace: {{ .PVCSINamespace }}
-roleRef:
-  kind: ClusterRole
-  name: vsphere-csi-node-cluster-role
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Deployment

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/validatingwebhook.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/validatingwebhook.yaml
@@ -41,7 +41,7 @@ metadata:
   name: vsphere-csi-webhook
   namespace: kube-system
 ---
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vsphere-csi-webhook-role
@@ -51,16 +51,17 @@ rules:
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vsphere-csi-webhook-role-binding
+  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: vsphere-csi-webhook
     namespace: kube-system
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: vsphere-csi-webhook-role
   apiGroup: rbac.authorization.k8s.io
 ---

--- a/manifests/dev/vsphere-7.0u2/vanilla/rbac/vsphere-csi-node-rbac.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/rbac/vsphere-csi-node-rbac.yaml
@@ -4,26 +4,26 @@ metadata:
   name: vsphere-csi-node
   namespace: kube-system
 ---
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: vsphere-csi-node-cluster-role
+  name: vsphere-csi-node-role
   namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: vsphere-csi-node-cluster-binding
+  name: vsphere-csi-node-binding
   namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: vsphere-csi-node
     namespace: kube-system
 roleRef:
-  kind: ClusterRole
-  name: vsphere-csi-node-cluster-role
+  kind: Role
+  name: vsphere-csi-node-role
   apiGroup: rbac.authorization.k8s.io

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -112,10 +112,10 @@ func Newk8sOrchestrator(ctx context.Context, controllerClusterFlavor cnstypes.Cn
 func initFSS(ctx context.Context, k8sClient clientset.Interface, controllerClusterFlavor cnstypes.CnsClusterFlavor, params interface{}) error {
 	log := logger.GetLogger(ctx)
 	var (
-		fssConfigMap *v1.ConfigMap
-		err          error
+		fssConfigMap               *v1.ConfigMap
+		err                        error
+		configMapNamespaceToListen string
 	)
-
 	// Store configmap info in global variables to access later
 	if controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		k8sOrchestratorInstance.supervisorFSS.featureStates = make(map[string]string)
@@ -126,6 +126,7 @@ func initFSS(ctx context.Context, k8sClient clientset.Interface, controllerClust
 		}
 		k8sOrchestratorInstance.supervisorFSS.configMapName = svInitParams.SupervisorFeatureStatesConfigInfo.Name
 		k8sOrchestratorInstance.supervisorFSS.configMapNamespace = svInitParams.SupervisorFeatureStatesConfigInfo.Namespace
+		configMapNamespaceToListen = k8sOrchestratorInstance.supervisorFSS.configMapNamespace
 	}
 	if controllerClusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		k8sOrchestratorInstance.internalFSS.featureStates = make(map[string]string)
@@ -136,6 +137,7 @@ func initFSS(ctx context.Context, k8sClient clientset.Interface, controllerClust
 		}
 		k8sOrchestratorInstance.internalFSS.configMapName = vanillaInitParams.InternalFeatureStatesConfigInfo.Name
 		k8sOrchestratorInstance.internalFSS.configMapNamespace = vanillaInitParams.InternalFeatureStatesConfigInfo.Namespace
+		configMapNamespaceToListen = k8sOrchestratorInstance.internalFSS.configMapNamespace
 	}
 	if controllerClusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		k8sOrchestratorInstance.supervisorFSS.featureStates = make(map[string]string)
@@ -149,6 +151,10 @@ func initFSS(ctx context.Context, k8sClient clientset.Interface, controllerClust
 		k8sOrchestratorInstance.internalFSS.configMapNamespace = guestInitParams.InternalFeatureStatesConfigInfo.Namespace
 		k8sOrchestratorInstance.supervisorFSS.configMapName = guestInitParams.SupervisorFeatureStatesConfigInfo.Name
 		k8sOrchestratorInstance.supervisorFSS.configMapNamespace = guestInitParams.SupervisorFeatureStatesConfigInfo.Namespace
+		// As of now, TKGS is having both supervisor FSS and internal FSS in the same namespace.
+		// If the configmap's namespaces change in future, we may need listeners on different namespaces
+		// Until then, we will initialize configMapNamespaceToListen to internalFSS.configMapNamespace
+		configMapNamespaceToListen = k8sOrchestratorInstance.internalFSS.configMapNamespace
 	}
 
 	// Initialize supervisor FSS map values
@@ -189,9 +195,7 @@ func initFSS(ctx context.Context, k8sClient clientset.Interface, controllerClust
 
 	// Set up kubernetes resource listeners for k8s orchestrator
 	k8sOrchestratorInstance.informerManager = k8s.NewInformer(k8sClient)
-	// TODO: Restrict the Configmap listener to the CSI namespace.
-	// Refer to https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/464
-	k8sOrchestratorInstance.informerManager.AddConfigMapListener(
+	k8sOrchestratorInstance.informerManager.AddConfigMapListener(ctx, k8sClient, configMapNamespaceToListen,
 		// Add
 		func(obj interface{}) {
 			configMapAdded(obj)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding a filtered namespace specific informer for CSI feature states. This is needed to avoid unnecessary watchers and listeners on all configmaps in all namespaces. With this change the configmap informer will received updates only for the specific configmap in csi system namespaces

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #464 

**Special notes for your reviewer**:
Verified that the updates to configmaps other than csi feature states in csi namespaces are not received by the event handlers.
Verified that the updates to csi feature state configmaps continue to work as expected

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add Namespace specific filtered configmap informer in k8sOrchestrator package
```
