### PR TITLE
upgrade base images for driver and syncer

### DIFF
--- a/images/driver-base/Dockerfile
+++ b/images/driver-base/Dockerfile
@@ -15,13 +15,6 @@
 FROM photon:3.0
 LABEL "maintainers"="Divyen Patel <divyenp@vmware.com>, Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>, Xing Yang <yangxi@vmware.com>"
 
-RUN tdnf -y remove toybox
 RUN tdnf -y upgrade
-RUN tdnf -y install \
-  util-linux \
-  e2fsprogs \
-  xfsprogs \
-  btrfs-progs \
-  nfs-utils
 
 RUN tdnf clean all

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -19,7 +19,7 @@
 ARG GOLANG_IMAGE=golang:1.13
 
 # This build arg allows the specification of a custom base image.
-ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:v1.0.2-10-ga6fc92a
+ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest
 
 ################################################################################
 ##                              BUILD STAGE                                   ##
@@ -47,6 +47,20 @@ RUN go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-dr
 ################################################################################
 FROM ${BASE_IMAGE}
 LABEL "maintainers"="Divyen Patel <divyenp@vmware.com>, Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>, Xing Yang <yangxi@vmware.com>"
+
+# install nfs-utils, util-linux and e2fsprogs
+# nfs-utils  : The nfs-utils package contains simple nfs client service.
+# util-linux : Utilities for handling file systems, consoles, partitions.
+# e2fsprogs  : The E2fsprogs package contains the utilities for handling the ext file system.
+
+RUN tdnf -y install \
+  nfs-utils \
+  util-linux \
+  e2fsprogs
+
+
+# Remove cached data
+RUN tdnf clean all
 
 COPY --from=builder /build/vsphere-csi /bin/vsphere-csi
 

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -17,7 +17,7 @@
 ARG GOLANG_IMAGE=golang:1.13
 
 # This build arg allows the specification of a custom base image.
-ARG BASE_IMAGE=photon:3.0
+ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest
 
 ################################################################################
 ##                              BUILD STAGE                                   ##


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

### Changed `images/driver-base/Dockerfile`

- deleted removal of `RUN tdnf -y remove toybox`. This is adding up more space rather than helping to reduce docker image size.

```
RUN tdnf -y remove toybox
 ---> Running in 190528e5510e
Refreshing metadata for: 'VMware Photon Extras 3.0 (x86_64)'
Refreshing metadata for: 'VMware Photon Linux 3.0 (x86_64)'
Refreshing metadata for: 'VMware Photon Linux 3.0 (x86_64) Updates'

Installing:
gmp                      x86_64       6.1.2-3.ph3      photon-updates 524.08k 536656
grep                     x86_64       3.1-3.ph3        photon-updates 241.50k 247301
coreutils                x86_64       8.30-3.ph3       photon-updates   5.84M 6127774

Total installed size:   6.59M 6911731

Removing:
toybox                   x86_64       0.8.2-4.ph3      @System      380.08k 389206

Total installed size: 380.08k 389206
```

- removed installation of `e2fsprogs`, `xfsprogs`, `btrfs-progs` and `nfs-utils` from base image.

### Changed `images/driver/Dockerfile`

- set gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest as the base image
- added command to install `nfs-utils`, `util-linux` and `e2fsprogs` in the driver image


### Changed `images/syncer/Dockerfile`

- set gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest as the base image

**Special notes for your reviewer**:
I have pushed a new base image - `gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest` all photon packages upgraded to the latest.

**Updates needed in the older base image**

```
% docker run -it gcr.io/cloud-provider-vsphere/extra/csi-driver-base:v1.0.2-10-ga6fc92a sh
root [ / ]# tdnf upgrade

Installing:
zstd-libs                                                      x86_64                          1.4.5-1.ph3                               photon-updates                        912.98k 934888

Total installed size: 912.98k 934888

Upgrading:
util-linux-libs                                                x86_64                          2.32.1-3.ph3                              photon-updates                        723.08k 740432
util-linux                                                     x86_64                          2.32.1-3.ph3                              photon-updates                         5.27M 5528420
tdnf-cli-libs                                                  x86_64                          2.1.2-1.ph3                               photon-updates                          65.71k 67288
tdnf                                                           x86_64                          2.1.2-1.ph3                               photon-updates                        284.55k 291384
systemd                                                        x86_64                          239-29.ph3                                photon-updates                       20.20M 21182004
sqlite-libs                                                    x86_64                          3.32.1-2.ph3                              photon-updates                         1.14M 1192352
shadow-tools                                                   x86_64                          4.6-5.ph3                                 photon-updates                        162.42k 166320
shadow                                                         x86_64                          4.6-5.ph3                                 photon-updates                         1.82M 1904777
rpm-libs                                                       x86_64                          4.14.2-9.ph3                              photon-updates                        932.90k 955291
python3-libs                                                   x86_64                          3.7.5-7.ph3                               photon-updates                       22.96M 24079495
python3                                                        x86_64                          3.7.5-7.ph3                               photon-updates                         2.94M 3084254
photon-repos                                                   noarch                          3.0-5.ph3                                 photon-updates                            1.93k 1977
pcre-libs                                                      x86_64                          8.44-1.ph3                                photon-updates                        279.61k 286320
openssl                                                        x86_64                          1.0.2w-1.ph3                              photon-updates                         4.53M 4748913
nss-libs                                                       x86_64                          3.44-4.ph3                                photon-updates                         2.17M 2270728
nfs-utils                                                      x86_64                          2.3.3-3.ph3                               photon-updates                         1.25M 1311178
libmetalink                                                    x86_64                          0.1.3-2.ph3                               photon-updates                          68.32k 69960
grep                                                           x86_64                          3.1-3.ph3                                 photon-updates                        241.50k 247301
glibc                                                          x86_64                          2.28-8.ph3                                photon-updates                         8.79M 9220807
expat-libs                                                     x86_64                          2.2.9-2.ph3                               photon-updates                        205.41k 210336
expat                                                          x86_64                          2.2.9-2.ph3                               photon-updates                          69.37k 71033
e2fsprogs-libs                                                 x86_64                          1.45.5-3.ph3                              photon-updates                          58.37k 59768
e2fsprogs                                                      x86_64                          1.45.5-3.ph3                              photon-updates                         2.04M 2134224
device-mapper-libs                                             x86_64                          2.02.187-1.ph3                            photon-updates                        357.14k 365712
curl-libs                                                      x86_64                          7.61.1-8.ph3                              photon-updates                        528.69k 541376
curl                                                           x86_64                          7.61.1-8.ph3                              photon-updates                        228.12k 233595
coreutils                                                      x86_64                          8.30-3.ph3                                photon-updates                         5.84M 6127774
ca-certificates-pki                                            x86_64                          20190521-2.ph3                            photon-updates                        799.21k 818390
ca-certificates                                                x86_64                          20190521-2.ph3                            photon-updates                        773.22k 791779
bzip2-libs                                                     x86_64                          1.0.8-2.ph3                               photon-updates                          74.31k 76096

Total installed size:  84.67M 88779284
Is this ok [y/N]:

```

**No updates required for the latest base image**

```
 % docker run -it gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest sh
sh-4.4#
sh-4.4# bash
root [ / ]# tdnf upgrade
Refreshing metadata for: 'VMware Photon Extras 3.0 (x86_64)'
Refreshing metadata for: 'VMware Photon Linux 3.0 (x86_64)'
Refreshing metadata for: 'VMware Photon Linux 3.0 (x86_64) Updates'
Nothing to do.                           19181   100%
root [ / ]# 
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
upgrade base images for driver and syncer
```
