### PR TITLE
Support NoMigration mode for vSAN direct disk decommission

### DIFF
--- a/pkg/syncer/storagepool/intended_state.go
+++ b/pkg/syncer/storagepool/intended_state.go
@@ -105,7 +105,7 @@ func newIntendedState(ctx context.Context, ds *cnsvsphere.DatastoreInfo,
 
 	// get datastore properties like capacity, freeSpace, dsURL, dsType, accessible, inMM, containerID
 	dsProps := getDatastoreProperties(ctx, ds)
-	if dsProps.capacity == nil || dsProps.freeSpace == nil {
+	if dsProps == nil || dsProps.capacity == nil || dsProps.freeSpace == nil {
 		err := fmt.Errorf("error fetching datastore properties for %v", ds.Reference().Value)
 		log.Error(err)
 		return nil, err

--- a/pkg/syncer/storagepool/util.go
+++ b/pkg/syncer/storagepool/util.go
@@ -285,7 +285,7 @@ func updateDrainStatus(ctx context.Context, storagePoolName string, newStatus st
 		}
 		drainMode, _, _ := unstructured.NestedString(sp.Object, "spec", "parameters", drainModeField)
 
-		if drainMode == fullDataEvacuationMM || drainMode == ensureAccessibilityMM {
+		if drainMode == fullDataEvacuationMM || drainMode == ensureAccessibilityMM || drainMode == noMigrationMM {
 			var patch map[string]interface{}
 			if newStatus == drainFailStatus {
 				log.Infof("Errorstring: %v", errorString)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds support for NoMigration mode for vSAN direct disk decommission. It detaches volumes present on the given StoragePool which are in use by the podVMs.

**Special notes for your reviewer**:
**tests:** Manual testing done by creating a sample persistent service instant having 2 PVCs per pod and triggering disk decommission operation by adding field `/spec/parameters/decommMode: noMigration` to StoragePool CR. Relevant logs: 
```
2020-11-03T13:05:38.302Z        INFO    storagepool/diskDecommissionController.go:334   Got enter disk decommission request for StoragePool storagepool-vsandirect-10.92.248.182-mpx.vmhba0-c0-t2-l0 with MM noMigration
2020-11-03T13:05:38.316Z        INFO    kubernetes/kubernetes.go:83     k8s client using in-cluster config
2020-11-03T13:05:38.316Z        INFO    kubernetes/kubernetes.go:267    Setting client QPS to 100.000000 and Burst to 100.
2020-11-03T13:05:38.437Z        INFO    volume/manager.go:97    Retrieving existing volume.defaultManager...
2020-11-03T13:05:38.437Z        DEBUG   storagepool/diskDecommissionController.go:122   vSphere CSI driver is detaching volume: c3acf320-b70e-4673-aed2-75676443b5d3 from vm:
2020-11-03T13:05:39.187Z        INFO    volume/manager.go:394   DetachVolume: volumeID: "c3acf320-b70e-4673-aed2-75676443b5d3", vm: "VirtualMachine:vm-98 [VirtualCenterHost: wdc-rdops-vm09-dhcp-236-43.eng.vmware.com, UUID: 501995da-a293-f161-7d97-028cabe3ff02, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-52, VirtualCenterHost: wdc-rdops-vm09-dhcp-236-43.eng.vmware.com]]", opId: "4f46f87c"
2020-11-03T13:05:39.187Z        INFO    volume/manager.go:424   DetachVolume: Volume detached successfully. volumeID: "c3acf320-b70e-4673-aed2-75676443b5d3", vm: "4f46f87c", opId: "VirtualMachine:vm-98 [VirtualCenterHost: wdc-rdops-vm09-dhcp-236-43.eng.vmware.com, UUID: 501995da-a293-f161-7d97-028cabe3ff02, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-52, VirtualCenterHost: wdc-rdops-vm09-dhcp-236-43.eng.vmware.com]]"
2020-11-03T13:05:39.187Z        DEBUG   storagepool/diskDecommissionController.go:128   Successfully detached disk c3acf320-b70e-4673-aed2-75676443b5d3 from VM VirtualMachine:vm-98 [VirtualCenterHost: wdc-rdops-vm09-dhcp-236-43.eng.vmware.com, UUID: 501995da-a293-f161-7d97-028cabe3ff02, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-52, VirtualCenterHost: wdc-rdops-vm09-dhcp-236-43.eng.vmware.com]].
2020-11-03T13:05:39.200Z        INFO    volume/manager.go:97    Retrieving existing volume.defaultManager...
2020-11-03T13:05:39.200Z        DEBUG   storagepool/diskDecommissionController.go:122   vSphere CSI driver is detaching volume: 8238b117-9a12-4b26-9f38-ea24446060ab from vm:
2020-11-03T13:05:39.678Z        INFO    volume/manager.go:394   DetachVolume: volumeID: "8238b117-9a12-4b26-9f38-ea24446060ab", vm: "VirtualMachine:vm-98 [VirtualCenterHost: wdc-rdops-vm09-dhcp-236-43.eng.vmware.com, UUID: 501995da-a293-f161-7d97-028cabe3ff02, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-52, VirtualCenterHost: wdc-rdops-vm09-dhcp-236-43.eng.vmware.com]]", opId: "4f46f87d"
2020-11-03T13:05:39.678Z        INFO    volume/manager.go:424   DetachVolume: Volume detached successfully. volumeID: "8238b117-9a12-4b26-9f38-ea24446060ab", vm: "4f46f87d", opId: "VirtualMachine:vm-98 [VirtualCenterHost: wdc-rdops-vm09-dhcp-236-43.eng.vmware.com, UUID: 501995da-a293-f161-7d97-028cabe3ff02, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-52, VirtualCenterHost: wdc-rdops-vm09-dhcp-236-43.eng.vmware.com]]"
2020-11-03T13:05:39.678Z        DEBUG   storagepool/diskDecommissionController.go:128   Successfully detached disk 8238b117-9a12-4b26-9f38-ea24446060ab from VM VirtualMachine:vm-98 [VirtualCenterHost: wdc-rdops-vm09-dhcp-236-43.eng.vmware.com, UUID: 501995da-a293-f161-7d97-028cabe3ff02, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-52, VirtualCenterHost: wdc-rdops-vm09-dhcp-236-43.eng.vmware.com]].
2020-11-03T13:05:39.678Z        INFO    storagepool/diskDecommissionController.go:169   Successfully decommission disk storagepool-vsandirect-10.92.248.182-mpx.vmhba0-c0-t2-l0 with MM noMigration
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
