### PR TITLE
Add PVC metadata for third-party stateful services

### DIFF
--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -298,16 +298,13 @@ func (k8sCloudOperator *k8sCloudOperator) PlacePersistenceVolumeClaim(ctx contex
 	if err != nil {
 		return out, err
 	}
+
 	spTypes, present := sc.Annotations[spTypeAnnotationKey]
 	if !present || (!strings.Contains(spTypes, vsanDirectType) && !strings.Contains(spTypes, vsanSnaType)) {
 		log.Debug("storage class is not of type vsan direct or vsan-sna, aborting placement")
 		return out, nil
 	}
-	// Validate accessibility requirements
-	if req.AccessibilityRequirements == nil {
-		return out, fmt.Errorf("invalid accessibility requirements input provided")
-	}
-	log.Infof("Get info of topology from input %s", req.AccessibilityRequirements)
+
 	log.Debugf("Enter placementEngine %s", req)
 	err = PlacePVConStoragePool(ctx, k8sCloudOperator.k8sClient, req.AccessibilityRequirements, pvc, spTypes)
 	if err != nil {

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -44,6 +44,10 @@ const (
 
 	// key for HealthStatus annotation on PVC
 	annVolumeHealth = "volumehealth.storage.kubernetes.io/health"
+
+	// key for expressing timestamp for volume health annotation
+	annVolumeHealthTS = "volumehealth.storage.kubernetes.io/health-timestamp"
+
 	// default interval for csi volume health
 	defaultVolumeHealthIntervalInMin = 5
 

--- a/pkg/syncer/volume_health.go
+++ b/pkg/syncer/volume_health.go
@@ -19,6 +19,7 @@ package syncer
 import (
 	"context"
 	"fmt"
+	"time"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
@@ -88,11 +89,15 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 				if err != nil {
 					log.Errorf("csiGetVolumeHealthStatus: invalid health status %q for volume %q", vol.HealthStatus, vol.VolumeId.Id)
 				}
-				if val, found := pvc.Annotations[annVolumeHealth]; !found || val != volHealthStatus {
+				val, found := pvc.Annotations[annVolumeHealth]
+				_, foundAnnHealthTS := pvc.Annotations[annVolumeHealthTS]
+				if !found || val != volHealthStatus || !foundAnnHealthTS {
 					// VolumeHealth annotation on pvc is changed, set it to new value
 					log.Debugf("csiGetVolumeHealthStatus: update volume health annotation for pvc %s/%s from old value %s to new value %s",
 						pvc.Namespace, pvc.Name, val, volHealthStatus)
 					metav1.SetMetaDataAnnotation(&pvc.ObjectMeta, annVolumeHealth, volHealthStatus)
+					metav1.SetMetaDataAnnotation(&pvc.ObjectMeta, annVolumeHealthTS, time.Now().Format(time.UnixDate))
+					log.Infof("set annotation for health to %s at time %s", volHealthStatus, time.Now().Format(time.UnixDate))
 					_, err := k8sclient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(ctx, pvc, metav1.UpdateOptions{})
 					if err != nil {
 						if apierrors.IsConflict(err) {
@@ -105,6 +110,8 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 									"get from API server from old value %s to new value %s",
 									newPvc.Namespace, newPvc.Name, val, volHealthStatus)
 								metav1.SetMetaDataAnnotation(&newPvc.ObjectMeta, annVolumeHealth, volHealthStatus)
+								metav1.SetMetaDataAnnotation(&newPvc.ObjectMeta, annVolumeHealthTS, time.Now().Format(time.UnixDate))
+								log.Infof("set annotation for health to %s at time %s", volHealthStatus, time.Now().Format(time.UnixDate))
 								_, err := k8sclient.CoreV1().PersistentVolumeClaims(newPvc.Namespace).Update(ctx, newPvc, metav1.UpdateOptions{})
 								if err != nil {
 									log.Errorf("csiGetVolumeHealthStatus: Failed to update pvc %s/%s with err:%+v",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds two pieces of metadata to the PVC
1. it adds a timestamp expressing when the pvc health was last updated.
2. In case of placement failure for host local PVCs, it adds an annotation expressing why placement failed. This can be used by observers to decide what needs to change for the placement to succeed.

Testing 
Created PVCs on full datastore and saw the storage pool annotation show
Annotations: failure-domain.beta.vmware.com/storagepool: FAILED_PLACEMENT-NotEnoughResources

PVC created properly also now show the health TS annotation
volumehealth.storage.kubernetes.io/health: accessible volumehealth.storage.kubernetes.io/health-timestamp: Tue Sep 22 16:56:28 UTC 2020

Creating a new pull request because of git mishaps.