### PR TITLE
[cherry-pick-to-2.1] upgrade base images for driver and syncer

### DIFF
--- a/images/driver-base/Dockerfile
+++ b/images/driver-base/Dockerfile
@@ -15,13 +15,6 @@
 FROM photon:3.0
 LABEL "maintainers"="Divyen Patel <divyenp@vmware.com>, Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>, Xing Yang <yangxi@vmware.com>"
 
-RUN tdnf -y remove toybox
 RUN tdnf -y upgrade
-RUN tdnf -y install \
-  util-linux \
-  e2fsprogs \
-  xfsprogs \
-  btrfs-progs \
-  nfs-utils
 
 RUN tdnf clean all

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -19,7 +19,7 @@
 ARG GOLANG_IMAGE=golang:1.13
 
 # This build arg allows the specification of a custom base image.
-ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:v1.0.2-10-ga6fc92a
+ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest
 
 ################################################################################
 ##                              BUILD STAGE                                   ##
@@ -47,6 +47,20 @@ RUN go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-dr
 ################################################################################
 FROM ${BASE_IMAGE}
 LABEL "maintainers"="Divyen Patel <divyenp@vmware.com>, Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>, Xing Yang <yangxi@vmware.com>"
+
+# install nfs-utils, util-linux and e2fsprogs
+# nfs-utils  : The nfs-utils package contains simple nfs client service.
+# util-linux : Utilities for handling file systems, consoles, partitions.
+# e2fsprogs  : The E2fsprogs package contains the utilities for handling the ext file system.
+
+RUN tdnf -y install \
+  nfs-utils \
+  util-linux \
+  e2fsprogs
+
+
+# Remove cached data
+RUN tdnf clean all
 
 COPY --from=builder /build/vsphere-csi /bin/vsphere-csi
 

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -17,7 +17,7 @@
 ARG GOLANG_IMAGE=golang:1.13
 
 # This build arg allows the specification of a custom base image.
-ARG BASE_IMAGE=photon:3.0
+ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest
 
 ################################################################################
 ##                              BUILD STAGE                                   ##


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is cherry-picking https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/481 from master to release-2.1 branch.
We need to include the latest updates in our base image for the upcoming release of CSI driver.


**Special notes for your reviewer**:
Verified building images using ` make images` with this PR. No issue observed.

**Release note**:
```release-note
upgrade base images for driver and syncer
```
