### PR TITLE
update yamls to set new v2.1.0-rc.2 images

### DIFF
--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
@@ -80,7 +80,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
           args:
             - "--leader-election"
           imagePullPolicy: "Always"

--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -42,7 +42,7 @@ spec:
         - name: registration-dir
           mountPath: /registration
       - name: vsphere-csi-node
-        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.1
+        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
@@ -93,7 +93,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
           args:
             - "--leader-election"
           imagePullPolicy: "Always"

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -42,7 +42,7 @@ spec:
         - name: registration-dir
           mountPath: /registration
       - name: vsphere-csi-node
-        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.1
+        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
@@ -91,7 +91,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:<syncer-image-tag-with-webhook-support>
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
           args:
             - "--operation-mode=WEBHOOK_SERVER"
           imagePullPolicy: "Always"

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
@@ -93,7 +93,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
           args:
             - "--leader-election"
           imagePullPolicy: "Always"

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -48,7 +48,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: vsphere-csi-node
-        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.1
+        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
@@ -96,7 +96,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
           args:
             - "--leader-election"
           imagePullPolicy: "Always"

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -49,7 +49,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: vsphere-csi-node
-        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.1
+        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
update deployment yamls to set new `v2.1.0-rc.2` images

**Special notes for your reviewer**:
[v2.1.0-rc.2](https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.1.0-rc.2) is cut and k8s prow has pushed new images
here is the log - https://storage.googleapis.com/kubernetes-jenkins/logs/post-vsphere-csi-driver-release/1324828592458174464/build-log.txt


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
update yamls to set new v2.1.0-rc.2 images
```
