### PR TITLE
Replace hostPath with emptyDir for socket-dir in all manifests

### DIFF
--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -137,14 +137,10 @@ spec:
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
           imagePullPolicy: "IfNotPresent"
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "GUEST_CLUSTER"
             - name: X_CSI_MODE
@@ -176,7 +172,7 @@ spec:
             - mountPath: /etc/cloud/pvcsi-config
               name: pvcsi-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: vmware.io/syncer:<image_tag>
@@ -212,9 +208,9 @@ spec:
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: csi-provisioner
           image: vmware.io/csi-provisioner/csi-provisioner:<image_tag>
@@ -255,9 +251,7 @@ spec:
           configMap:
             name: pvcsi-config
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -137,14 +137,10 @@ spec:
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
           imagePullPolicy: "IfNotPresent"
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "GUEST_CLUSTER"
             - name: X_CSI_MODE
@@ -176,7 +172,7 @@ spec:
             - mountPath: /etc/cloud/pvcsi-config
               name: pvcsi-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: vmware.io/syncer:<image_tag>
@@ -212,9 +208,9 @@ spec:
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: csi-provisioner
           image: vmware.io/csi-provisioner/csi-provisioner:<image_tag>
@@ -255,9 +251,7 @@ spec:
           configMap:
             name: pvcsi-config
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -137,14 +137,10 @@ spec:
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
           imagePullPolicy: "IfNotPresent"
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "GUEST_CLUSTER"
             - name: X_CSI_MODE
@@ -176,7 +172,7 @@ spec:
             - mountPath: /etc/cloud/pvcsi-config
               name: pvcsi-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: vmware.io/syncer:<image_tag>
@@ -212,9 +208,9 @@ spec:
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: csi-provisioner
           image: vmware.io/csi-provisioner/csi-provisioner:<image_tag>
@@ -255,9 +251,7 @@ spec:
           configMap:
             name: pvcsi-config
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/deploy/vsphere-csi-controller-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - "--enable-hostlocal-placement=true"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-attacher
           image: vmware/csi-attacher/csi-attacher:v1.1.1
           args:
@@ -63,7 +63,7 @@ spec:
             - "--leader-election-type=leases"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -71,7 +71,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-resizer
           image: vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.0.0
           imagePullPolicy: IfNotPresent
@@ -94,13 +94,9 @@ spec:
           args:
             - "--supervisor-fss-name=csi-feature-states"
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
             - name: X_CSI_MODE
@@ -128,7 +124,7 @@ spec:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: liveness-probe
           image: vmware/csi-livenessprobe/csi-livenessprobe:v1.1.0
@@ -136,9 +132,9 @@ spec:
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: vmware/syncer:<syncer_ver>
@@ -183,9 +179,7 @@ spec:
           secret:
             secretName: vsphere-config-secret
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
 ---
 apiVersion: v1
 data:

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/deploy/vsphere-csi-controller-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - "--enable-hostlocal-placement=true"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-attacher
           image: vmware/csi-attacher/csi-attacher:v1.1.1
           args:
@@ -63,7 +63,7 @@ spec:
             - "--leader-election-type=leases"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -71,7 +71,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-resizer
           image: vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.0.0
           imagePullPolicy: IfNotPresent
@@ -94,13 +94,9 @@ spec:
           args:
             - "--supervisor-fss-name=csi-feature-states"
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
             - name: X_CSI_MODE
@@ -128,7 +124,7 @@ spec:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: liveness-probe
           image: vmware/csi-livenessprobe/csi-livenessprobe:v1.1.0
@@ -136,9 +132,9 @@ spec:
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: vmware/syncer:<syncer_ver>
@@ -183,9 +179,7 @@ spec:
           secret:
             secretName: vsphere-config-secret
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
 ---
 apiVersion: v1
 data:

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - "--enable-hostlocal-placement=true"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-attacher
           image: vmware/csi-attacher/csi-attacher:v1.1.1
           args:
@@ -63,7 +63,7 @@ spec:
             - "--leader-election-type=leases"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -71,7 +71,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-resizer
           image: vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.0.0
           imagePullPolicy: IfNotPresent
@@ -95,13 +95,9 @@ spec:
           args:
             - "--supervisor-fss-name=csi-feature-states"
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
             - name: X_CSI_MODE
@@ -129,7 +125,7 @@ spec:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: liveness-probe
           image: vmware/csi-livenessprobe/csi-livenessprobe:v1.1.0
@@ -137,9 +133,9 @@ spec:
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: vmware/syncer:<syncer_ver>
@@ -184,9 +180,7 @@ spec:
           secret:
             secretName: vsphere-config-secret
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
 ---
 apiVersion: v1
 data:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR replaces `hostPath` with `emptyDir` for socket-dir so that vsphere-csi-controller does not need to run as a privileged container on the node. 
The PR contains two commits:

1. For dev manifests
2. For v2.0.1 manifests, which can be cherry picked to the release branch

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #307 and #290

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Replace hostPath with emptyDir for socket-dir.
```
