### PR TITLE
Take in Feature state switch info through CLI 

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -26,6 +26,7 @@ import (
 	cnstypes "github.com/vmware/govmomi/cns/types"
 
 	"sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer"
@@ -47,6 +48,11 @@ var (
 	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")
 	printVersion            = flag.Bool("version", false, "Print syncer version and exit")
 	operationMode           = flag.String("operation-mode", operationModeMetaDataSync, "specify operation mode METADATA_SYNC or WEBHOOK_SERVER")
+
+	supervisorFSSName      = flag.String("supervisor-fss-name", "", "Name of the feature state switch configmap in supervisor cluster")
+	supervisorFSSNamespace = flag.String("supervisor-fss-namespace", "", "Namespace of the feature state switch configmap in supervisor cluster")
+	internalFSSName        = flag.String("fss-name", "", "Name of the feature state switch configmap")
+	internalFSSNamespace   = flag.String("fss-namespace", "", "Namespace of the feature state switch configmap")
 )
 
 // main for vsphere syncer
@@ -61,10 +67,14 @@ func main() {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Infof("Version : %s", syncer.Version)
 
+	// Set CO agnostic init params
 	clusterFlavor, err := config.GetClusterFlavor(ctx)
 	if err != nil {
 		log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
 	}
+	commonco.SetInitParams(ctx, clusterFlavor, &syncer.COInitParams, *supervisorFSSName, *supervisorFSSNamespace,
+		*internalFSSName, *internalFSSNamespace)
+	admissionhandler.COInitParams = &syncer.COInitParams
 
 	if *operationMode == operationModeWebHookServer {
 		log.Infof("Starting container with operation mode: %v", operationModeWebHookServer)
@@ -94,7 +104,7 @@ func main() {
 			}()
 		}
 		// Initialize syncer components that are dependant on the outcome of leader election, if enabled.
-		run = initSyncerComponents(ctx, clusterFlavor, configInfo)
+		run = initSyncerComponents(ctx, clusterFlavor, configInfo, &syncer.COInitParams)
 
 		if !*enableLeaderElection {
 			run(context.TODO())
@@ -122,13 +132,13 @@ func main() {
 // initSyncerComponents initializes syncer components that are dependant on the leader election algorithm.
 // This function is only called by the leader instance of vsphere-syncer, if enabled.
 // TODO: Change name from initSyncerComponents to init<Name>Components where <Name> will be the name of this container
-func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, configInfo *types.ConfigInfo) func(ctx context.Context) {
+func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, configInfo *types.ConfigInfo, coInitParams *interface{}) func(ctx context.Context) {
 	return func(ctx context.Context) {
 		log := logger.GetLogger(ctx)
 		// Initialize CNS Operator for Supervisor clusters
 		if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 			go func() {
-				if err := storagepool.InitStoragePoolService(ctx, configInfo); err != nil {
+				if err := storagepool.InitStoragePoolService(ctx, configInfo, coInitParams); err != nil {
 					log.Errorf("Error initializing StoragePool Service. Error: %+v", err)
 					os.Exit(1)
 				}

--- a/example/vanilla-k8s-block-driver/vsphere.conf
+++ b/example/vanilla-k8s-block-driver/vsphere.conf
@@ -10,9 +10,3 @@ password = "vcenter password"
 port = "443"
 datacenters = "list of comma separated datacenter paths where node VMs are present"
 
-# InternalFeatureStatesConfig holds the details about internal feature states configmap.
-# Default feature states configmap name is set to "internal-feature-states.csi.vsphere.vmware.com"  and namespace is set to "kube-system"
-# Provide the configmap name and namespace details only when feature states configmap is not in the default namespace
-[InternalFeatureStatesConfig]
-name = "internal-feature-states.csi.vsphere.vmware.com"
-namespace = "kube-system"

--- a/manifests/dev/vsphere-7.0u1/guestcluster/1.15/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u1/guestcluster/1.15/pvcsi.yaml
@@ -122,6 +122,11 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: vmware.io/vsphere-csi:<image_tag>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -150,6 +155,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
             - mountPath: /etc/cloud/pvcsi-provider
               name: pvcsi-provider-volume
@@ -163,6 +170,10 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -173,6 +184,8 @@ spec:
               value: "GUEST_CLUSTER"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
           - mountPath: /etc/cloud/pvcsi-provider
             name: pvcsi-provider-volume
@@ -269,6 +282,11 @@ spec:
             mountPath: /registration
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
+        args:
+          - "--supervisor-fss-name=csi-feature-states"
+          - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "IfNotPresent"
         env:
         - name: NODE_NAME
@@ -285,6 +303,8 @@ spec:
           value: "GUEST_CLUSTER"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          value: {{ .PVCSINamespace }}
         securityContext:
           privileged: true
           capabilities:

--- a/manifests/dev/vsphere-7.0u1/guestcluster/1.16/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u1/guestcluster/1.16/pvcsi.yaml
@@ -128,6 +128,11 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: vmware.io/vsphere-csi:<image_tag>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -158,6 +163,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
             - mountPath: /etc/cloud/pvcsi-provider
               name: pvcsi-provider-volume
@@ -171,6 +178,10 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -181,6 +192,8 @@ spec:
               value: "GUEST_CLUSTER"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
           - mountPath: /etc/cloud/pvcsi-provider
             name: pvcsi-provider-volume
@@ -290,6 +303,11 @@ spec:
             mountPath: /registration
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
+        args:
+          - "--supervisor-fss-name=csi-feature-states"
+          - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "IfNotPresent"
         env:
         - name: NODE_NAME
@@ -306,6 +324,8 @@ spec:
           value: "GUEST_CLUSTER"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          value: {{ .PVCSINamespace }}
         securityContext:
           privileged: true
           capabilities:

--- a/manifests/dev/vsphere-7.0u1/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u1/guestcluster/1.17/pvcsi.yaml
@@ -129,6 +129,11 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: vmware.io/vsphere-csi:<image_tag>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -159,6 +164,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
             - mountPath: /etc/cloud/pvcsi-provider
               name: pvcsi-provider-volume
@@ -172,6 +179,10 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -182,6 +193,8 @@ spec:
               value: "GUEST_CLUSTER"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
           - mountPath: /etc/cloud/pvcsi-provider
             name: pvcsi-provider-volume
@@ -291,6 +304,11 @@ spec:
             mountPath: /registration
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
+        args:
+          - "--supervisor-fss-name=csi-feature-states"
+          - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "IfNotPresent"
         env:
         - name: NODE_NAME
@@ -307,6 +325,8 @@ spec:
           value: "GUEST_CLUSTER"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          value: {{ .PVCSINamespace }}
         securityContext:
           privileged: true
           capabilities:

--- a/manifests/dev/vsphere-7.0u1/supervisorcluster/k8s-1.15/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/supervisorcluster/k8s-1.15/deploy/vsphere-csi-controller-deployment.yaml
@@ -73,6 +73,9 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: vsphere-csi-controller
           image: vmware/vsphere-csi:<vsphere_csi_ver>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -98,6 +101,10 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp
@@ -119,6 +126,8 @@ spec:
           image: vmware/syncer:<syncer_ver>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
@@ -136,6 +145,10 @@ spec:
               value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp
@@ -149,4 +162,3 @@ spec:
           hostPath:
             path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
             type: DirectoryOrCreate
-

--- a/manifests/dev/vsphere-7.0u1/supervisorcluster/k8s-1.16/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/supervisorcluster/k8s-1.16/deploy/vsphere-csi-controller-deployment.yaml
@@ -90,6 +90,9 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: vmware/vsphere-csi:<vsphere_csi_ver>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -115,6 +118,10 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp
@@ -136,6 +143,8 @@ spec:
           image: vmware/syncer:<syncer_ver>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
@@ -155,6 +164,10 @@ spec:
               value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/generate-signed-webhook-certs.sh
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/generate-signed-webhook-certs.sh
@@ -136,13 +136,6 @@ cat <<eof >"${tmpdir}"/webhook.config
 port = "8443"
 cert-file = "/etc/webhook/cert.pem"
 key-file = "/etc/webhook/key.pem"
-
-# InternalFeatureStatesConfig holds the details about internal feature states configmap.
-# Default feature states configmap name is set to "internal-feature-states.csi.vsphere.vmware.com"  and namespace is set to "kube-system"
-# Provide the configmap name and namespace details only when feature states configmap is not in the default namespace
-[InternalFeatureStatesConfig]
-name = "internal-feature-states.csi.vsphere.vmware.com"
-namespace = "${namespace}"
 eof
 
 

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
@@ -94,12 +94,18 @@ spec:
           image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
           args:
             - "--operation-mode=WEBHOOK_SERVER"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: WEBHOOK_CONFIG_PATH
               value: "/etc/webhook/webhook.config"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/webhook
               name: webhook-certs

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -52,6 +52,9 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
@@ -66,6 +69,10 @@ spec:
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
@@ -96,6 +103,8 @@ spec:
           image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
           args:
             - "--leader-election"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -108,6 +117,10 @@ spec:
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -49,6 +49,9 @@ spec:
           timeoutSeconds: 5
       - name: vsphere-csi-node
         image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
+        args:
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME
@@ -68,6 +71,10 @@ spec:
           value: "true"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           privileged: true
           capabilities:

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -153,6 +153,11 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: vmware.io/vsphere-csi:<image_tag>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -183,6 +188,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
             - mountPath: /etc/cloud/pvcsi-provider
               name: pvcsi-provider-volume
@@ -196,6 +203,10 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -206,6 +217,8 @@ spec:
               value: "GUEST_CLUSTER"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
           - mountPath: /etc/cloud/pvcsi-provider
             name: pvcsi-provider-volume
@@ -319,6 +332,11 @@ spec:
             mountPath: /registration
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
+        args:
+          - "--supervisor-fss-name=csi-feature-states"
+          - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "IfNotPresent"
         env:
         - name: NODE_NAME
@@ -335,10 +353,8 @@ spec:
           value: "GUEST_CLUSTER"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
-        - name: CSI_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+        - name: CSI_NAMESPACE
+          value: {{ .PVCSINamespace }}
         securityContext:
           privileged: true
           capabilities:
@@ -356,9 +372,6 @@ spec:
           mountPath: /sys/block
         - name: sys-devices-dir
           mountPath: /sys/devices
-        - name: pvcsi-config-volume
-          mountPath: /etc/cloud/pvcsi-config
-          readOnly: true
       - name: liveness-probe
         image: vmware.io/csi-livenessprobe/csi-livenessprobe:<image_tag>
         args:
@@ -391,9 +404,6 @@ spec:
         hostPath:
           path: /sys/devices
           type: Directory
-      - name: pvcsi-config-volume
-        configMap:
-          name: pvcsi-config
       tolerations:
         - effect: NoExecute
           operator: Exists
@@ -408,12 +418,6 @@ data:
     port = "{{ .SupervisorMasterPort }}"
     tanzukubernetescluster-uid = "{{ .TanzuKubernetesClusterUID }}"
     tanzukubernetescluster-name = "{{ .TanzuKubernetesClusterName }}"
-    [FeatureStatesConfig]
-    name = "csi-feature-states"
-    namespace = "{{ .PVCSINamespace }}"
-    [InternalFeatureStatesConfig]
-    name = "internal-feature-states.csi.vsphere.vmware.com"
-    namespace = "{{ .PVCSINamespace }}"
 kind: ConfigMap
 metadata:
   name: pvcsi-config

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -153,6 +153,11 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: vmware.io/vsphere-csi:<image_tag>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -183,6 +188,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
             - mountPath: /etc/cloud/pvcsi-provider
               name: pvcsi-provider-volume
@@ -196,6 +203,10 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -206,6 +217,8 @@ spec:
               value: "GUEST_CLUSTER"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
           - mountPath: /etc/cloud/pvcsi-provider
             name: pvcsi-provider-volume
@@ -319,6 +332,11 @@ spec:
             mountPath: /registration
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
+        args:
+          - "--supervisor-fss-name=csi-feature-states"
+          - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "IfNotPresent"
         env:
         - name: NODE_NAME
@@ -335,10 +353,8 @@ spec:
           value: "GUEST_CLUSTER"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
-        - name: CSI_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+        - name: CSI_NAMESPACE
+          value: {{ .PVCSINamespace }}
         securityContext:
           privileged: true
           capabilities:
@@ -356,9 +372,6 @@ spec:
           mountPath: /sys/block
         - name: sys-devices-dir
           mountPath: /sys/devices
-        - name: pvcsi-config-volume
-          mountPath: /etc/cloud/pvcsi-config
-          readOnly: true
       - name: liveness-probe
         image: vmware.io/csi-livenessprobe/csi-livenessprobe:<image_tag>
         args:
@@ -391,9 +404,6 @@ spec:
         hostPath:
           path: /sys/devices
           type: Directory
-      - name: pvcsi-config-volume
-        configMap:
-          name: pvcsi-config
       tolerations:
         - effect: NoExecute
           operator: Exists
@@ -408,12 +418,6 @@ data:
     port = "{{ .SupervisorMasterPort }}"
     tanzukubernetescluster-uid = "{{ .TanzuKubernetesClusterUID }}"
     tanzukubernetescluster-name = "{{ .TanzuKubernetesClusterName }}"
-    [FeatureStatesConfig]
-    name = "csi-feature-states"
-    namespace = "{{ .PVCSINamespace }}"
-    [InternalFeatureStatesConfig]
-    name = "internal-feature-states.csi.vsphere.vmware.com"
-    namespace = "{{ .PVCSINamespace }}"
 kind: ConfigMap
 metadata:
   name: pvcsi-config

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -153,6 +153,11 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: vmware.io/vsphere-csi:<image_tag>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -183,6 +188,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
             - mountPath: /etc/cloud/pvcsi-provider
               name: pvcsi-provider-volume
@@ -196,6 +203,10 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -206,6 +217,8 @@ spec:
               value: "GUEST_CLUSTER"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
           - mountPath: /etc/cloud/pvcsi-provider
             name: pvcsi-provider-volume
@@ -319,6 +332,11 @@ spec:
             mountPath: /registration
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
+        args:
+          - "--supervisor-fss-name=csi-feature-states"
+          - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "IfNotPresent"
         env:
         - name: NODE_NAME
@@ -335,10 +353,8 @@ spec:
           value: "GUEST_CLUSTER"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
-        - name: CSI_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+        - name: CSI_NAMESPACE
+          value: {{ .PVCSINamespace }}
         securityContext:
           privileged: true
           capabilities:
@@ -356,9 +372,6 @@ spec:
           mountPath: /sys/block
         - name: sys-devices-dir
           mountPath: /sys/devices
-        - name: pvcsi-config-volume
-          mountPath: /etc/cloud/pvcsi-config
-          readOnly: true
       - name: liveness-probe
         image: vmware.io/csi-livenessprobe/csi-livenessprobe:<image_tag>
         args:
@@ -391,9 +404,6 @@ spec:
         hostPath:
           path: /sys/devices
           type: Directory
-      - name: pvcsi-config-volume
-        configMap:
-          name: pvcsi-config
       tolerations:
         - effect: NoExecute
           operator: Exists
@@ -408,12 +418,6 @@ data:
     port = "{{ .SupervisorMasterPort }}"
     tanzukubernetescluster-uid = "{{ .TanzuKubernetesClusterUID }}"
     tanzukubernetescluster-name = "{{ .TanzuKubernetesClusterName }}"
-    [FeatureStatesConfig]
-    name = "csi-feature-states"
-    namespace = "{{ .PVCSINamespace }}"
-    [InternalFeatureStatesConfig]
-    name = "internal-feature-states.csi.vsphere.vmware.com"
-    namespace = "{{ .PVCSINamespace }}"
 kind: ConfigMap
 metadata:
   name: pvcsi-config

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/deploy/vsphere-csi-controller-deployment.yaml
@@ -91,6 +91,9 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: vmware/vsphere-csi:<vsphere_csi_ver>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -116,6 +119,10 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp
@@ -137,6 +144,8 @@ spec:
           image: vmware/syncer:<syncer_ver>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
@@ -160,6 +169,10 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/deploy/vsphere-csi-controller-deployment.yaml
@@ -91,6 +91,9 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: vmware/vsphere-csi:<vsphere_csi_ver>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -116,6 +119,10 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp
@@ -137,6 +144,8 @@ spec:
           image: vmware/syncer:<syncer_ver>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
@@ -160,6 +169,10 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
@@ -92,6 +92,9 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: vmware/vsphere-csi:<vsphere_csi_ver>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -117,6 +120,10 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp
@@ -138,6 +145,8 @@ spec:
           image: vmware/syncer:<syncer_ver>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
@@ -161,6 +170,10 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/generate-signed-webhook-certs.sh
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/generate-signed-webhook-certs.sh
@@ -136,13 +136,6 @@ cat <<eof >"${tmpdir}"/webhook.config
 port = "8443"
 cert-file = "/etc/webhook/cert.pem"
 key-file = "/etc/webhook/key.pem"
-
-# InternalFeatureStatesConfig holds the details about internal feature states configmap.
-# Default feature states configmap name is set to "internal-feature-states.csi.vsphere.vmware.com"  and namespace is set to "kube-system"
-# Provide the configmap name and namespace details only when feature states configmap is not in the default namespace
-[InternalFeatureStatesConfig]
-name = "internal-feature-states.csi.vsphere.vmware.com"
-namespace = "${namespace}"
 eof
 
 

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/validatingwebhook.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/validatingwebhook.yaml
@@ -94,12 +94,18 @@ spec:
           image: gcr.io/cloud-provider-vsphere/csi/release/syncer:<syncer-image-tag-with-webhook-support>
           args:
             - "--operation-mode=WEBHOOK_SERVER"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: WEBHOOK_CONFIG_PATH
               value: "/etc/webhook/webhook.config"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/webhook
               name: webhook-certs

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -55,6 +55,9 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
@@ -69,6 +72,10 @@ spec:
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
@@ -99,6 +106,8 @@ spec:
           image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
           args:
             - "--leader-election"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -111,6 +120,10 @@ spec:
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -50,6 +50,9 @@ spec:
           timeoutSeconds: 5
       - name: vsphere-csi-node
         image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
+        args:
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME
@@ -69,7 +72,7 @@ spec:
           value: "true"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
-        - name: CSI_POD_NAMESPACE
+        - name: CSI_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -96,8 +99,6 @@ spec:
           mountPath: /sys/block
         - name: sys-devices-dir
           mountPath: /sys/devices
-        - name: vsphere-config-volume
-          mountPath: /etc/cloud
         ports:
           - containerPort: 9808
             name: healthz
@@ -143,9 +144,6 @@ spec:
         hostPath:
           path: /sys/devices
           type: Directory
-      - name: vsphere-config-volume
-        secret:
-          secretName: vsphere-config-secret
       tolerations:
         - effect: NoExecute
           operator: Exists

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -319,22 +319,6 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 		}
 	}
 
-	// Validate FeatureStateConfig used in Supervisor cluster
-	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload && cfg.FeatureStatesConfig.Name == "" && cfg.FeatureStatesConfig.Namespace == "" {
-		// Feature states config info is not provided in vsphere conf in project pacific, use defaults for supervisor cluster
-		log.Infof("No feature states config information is provided in the Config. Using default config map name: %s and namespace: %s",
-			DefaultSupervisorFSSConfigMapName, DefaultCSINamespace)
-		cfg.FeatureStatesConfig.Name = DefaultSupervisorFSSConfigMapName
-		cfg.FeatureStatesConfig.Namespace = DefaultCSINamespace
-	}
-	// Validate InternalFeatureStateConfig used in vanilla cluster
-	if clusterFlavor == cnstypes.CnsClusterFlavorVanilla && cfg.InternalFeatureStatesConfig.Name == "" && cfg.InternalFeatureStatesConfig.Namespace == "" {
-		// If feature states config info is not provided in vsphere conf, use defaults for vanilla k8s cluster
-		log.Infof("No feature states config information is provided in the Config. Using default config map name: %s and namespace: %s",
-			DefaultInternalFSSConfigMapName, DefaultCSINamespaceVanillaK8s)
-		cfg.InternalFeatureStatesConfig.Name = DefaultInternalFSSConfigMapName
-		cfg.InternalFeatureStatesConfig.Namespace = DefaultCSINamespaceVanillaK8s
-	}
 	if cfg.Global.CnsRegisterVolumesCleanupIntervalInMin == 0 {
 		cfg.Global.CnsRegisterVolumesCleanupIntervalInMin = DefaultCnsRegisterVolumesCleanupIntervalInMin
 	}
@@ -473,16 +457,6 @@ func GetGCconfig(ctx context.Context, cfgPath string) (*Config, error) {
 	// Set default GCPort if Port is still empty
 	if cfg.GC.Port == "" {
 		cfg.GC.Port = DefaultGCPort
-	}
-	// Set default fss configmap name if SV FSS configmap info is not available in GC Config
-	if cfg.InternalFeatureStatesConfig.Name == "" && cfg.InternalFeatureStatesConfig.Namespace == "" {
-		cfg.InternalFeatureStatesConfig.Name = DefaultInternalFSSConfigMapName
-		cfg.InternalFeatureStatesConfig.Namespace = DefaultCSINamespace
-	}
-
-	if cfg.FeatureStatesConfig.Name == "" && cfg.FeatureStatesConfig.Namespace == "" {
-		cfg.FeatureStatesConfig.Name = DefaultSupervisorFSSConfigMapName
-		cfg.FeatureStatesConfig.Namespace = DefaultCSINamespace
 	}
 	return cfg, nil
 }

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -71,18 +71,12 @@ type Config struct {
 		Zone   string `gcfg:"zone"`
 		Region string `gcfg:"region"`
 	}
-	// FeatureStatesConfig contains feature states configmap info specific to supervisor cluster
-	FeatureStatesConfig FeatureStatesConfigInfo
-
-	// InternalFeatureStatesConfig contains feature states configmap info specific to pvCSI and vanilla drivers
-	// NOTE: Do not edit this. Only to be used for dev and testing purposes.
-	InternalFeatureStatesConfig FeatureStatesConfigInfo
 }
 
-// FeatureStatesConfigInfo is the details about feature states configmap
+// FeatureStatesConfigInfo contains the details about feature states configmap
 type FeatureStatesConfigInfo struct {
-	Name      string `gcfg:"name"`
-	Namespace string `gcfg:"namespace"`
+	Name      string
+	Namespace string
 }
 
 // NetPermissionConfig consists of information used to restrict the

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -27,6 +27,10 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
+// ContainerOrchestratorUtility represents the singleton instance of
+// container orchestrator interface
+var ContainerOrchestratorUtility COCommonInterface
+
 // COCommonInterface provides functionality to define
 // container orchestrator related implementation to read resources/objects
 type COCommonInterface interface {

--- a/pkg/csi/service/common/commonco/utils.go
+++ b/pkg/csi/service/common/commonco/utils.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commonco
+
+import (
+	"context"
+	"strings"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+
+	csiconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+)
+
+// SetInitParams initializes the parameters required to create a container agnostic orchestrator instance
+func SetInitParams(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, initParams *interface{},
+	supervisorFSSName, supervisorFSSNamespace, internalFSSName, internalFSSNamespace string) {
+	log := logger.GetLogger(ctx)
+	// Set default values for FSS, if not given and initiate CO-agnostic init params
+	switch clusterFlavor {
+	case cnstypes.CnsClusterFlavorWorkload:
+		if strings.TrimSpace(supervisorFSSName) == "" {
+			log.Infof("Defaulting feature states configmap name to %q", csiconfig.DefaultSupervisorFSSConfigMapName)
+			supervisorFSSName = csiconfig.DefaultSupervisorFSSConfigMapName
+		}
+		if strings.TrimSpace(supervisorFSSNamespace) == "" {
+			log.Infof("Defaulting feature states configmap namespace to %q", csiconfig.DefaultCSINamespace)
+			supervisorFSSNamespace = csiconfig.DefaultCSINamespace
+		}
+		*initParams = k8sorchestrator.K8sSupervisorInitParams{
+			SupervisorFeatureStatesConfigInfo: csiconfig.FeatureStatesConfigInfo{
+				Name:      supervisorFSSName,
+				Namespace: supervisorFSSNamespace,
+			},
+		}
+	case cnstypes.CnsClusterFlavorVanilla:
+		if strings.TrimSpace(internalFSSName) == "" {
+			log.Infof("Defaulting feature states configmap name to %q", csiconfig.DefaultInternalFSSConfigMapName)
+			internalFSSName = csiconfig.DefaultInternalFSSConfigMapName
+		}
+		if strings.TrimSpace(internalFSSNamespace) == "" {
+			log.Infof("Defaulting feature states configmap namespace to %q", csiconfig.DefaultCSINamespaceVanillaK8s)
+			internalFSSNamespace = csiconfig.DefaultCSINamespaceVanillaK8s
+		}
+		*initParams = k8sorchestrator.K8sVanillaInitParams{
+			InternalFeatureStatesConfigInfo: csiconfig.FeatureStatesConfigInfo{
+				Name:      internalFSSName,
+				Namespace: internalFSSNamespace,
+			},
+		}
+	case cnstypes.CnsClusterFlavorGuest:
+		if strings.TrimSpace(supervisorFSSName) == "" {
+			log.Infof("Defaulting supervisor feature states configmap name to %q", csiconfig.DefaultSupervisorFSSConfigMapName)
+			supervisorFSSName = csiconfig.DefaultSupervisorFSSConfigMapName
+		}
+		if strings.TrimSpace(supervisorFSSNamespace) == "" {
+			log.Infof("Defaulting supervisor feature states configmap namespace to %q", csiconfig.DefaultCSINamespace)
+			supervisorFSSNamespace = csiconfig.DefaultCSINamespace
+		}
+		if strings.TrimSpace(internalFSSName) == "" {
+			log.Infof("Defaulting internal feature states configmap name to %q", csiconfig.DefaultInternalFSSConfigMapName)
+			internalFSSName = csiconfig.DefaultInternalFSSConfigMapName
+		}
+		if strings.TrimSpace(internalFSSNamespace) == "" {
+			log.Infof("Defaulting internal feature states configmap namespace to %q", csiconfig.DefaultCSINamespace)
+			internalFSSNamespace = csiconfig.DefaultCSINamespace
+		}
+		*initParams = k8sorchestrator.K8sGuestInitParams{
+			InternalFeatureStatesConfigInfo: csiconfig.FeatureStatesConfigInfo{
+				Name:      internalFSSName,
+				Namespace: internalFSSNamespace,
+			},
+			SupervisorFeatureStatesConfigInfo: csiconfig.FeatureStatesConfigInfo{
+				Name:      supervisorFSSName,
+				Namespace: supervisorFSSNamespace,
+			},
+		}
+	default:
+		log.Fatalf("Unrecognised cluster flavor %q. Container orchestrator init params not initialized.", clusterFlavor)
+	}
+	log.Debugf("Container orchestrator init params: %+v", *initParams)
+}

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -26,13 +26,6 @@ import (
 	"strconv"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8svol "k8s.io/kubernetes/pkg/volume"
-
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
-
 	"github.com/akutz/gofsutil"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	csictx "github.com/rexray/gocsi/context"
@@ -41,9 +34,12 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/util/resizefs"
+	k8svol "k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util/fs"
-
 	utilexec "k8s.io/utils/exec"
 	"k8s.io/utils/mount"
 
@@ -51,6 +47,7 @@ import (
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
 
@@ -59,8 +56,6 @@ const (
 	blockPrefix = "wwn-0x"
 	dmiDir      = "/sys/class/dmi"
 )
-
-var containerOrchestratorUtility commonco.COCommonInterface
 
 type nodeStageParams struct {
 	// volID is the identifier for the underlying volume
@@ -778,7 +773,7 @@ func (s *service) NodeExpandVolume(
 		Exec:      realExec,
 	}
 
-	if containerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend) {
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend) {
 		// Fetch the current block size
 		currentBlockSizeBytes, err := getBlockSizeBytes(mounter, dev.RealDev)
 		if err != nil {

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -43,11 +43,13 @@ import (
 	"github.com/zekroTJA/timedmap"
 	clientset "k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
+
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
 )
 
@@ -308,7 +310,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 				vcenter: vcenter,
 			},
 		}
-		containerOrchestratorUtility, err = unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+		commonco.ContainerOrchestratorUtility, err = unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
 		if err != nil {
 			t.Fatalf("Failed to create co agnostic interface. err=%v", err)
 		}

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -43,7 +43,6 @@ import (
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
@@ -64,7 +63,6 @@ type controller struct {
 	vmWatcher                 *cache.ListWatch
 	supervisorNamespace       string
 	tanzukubernetesClusterUID string
-	coCommonInterface         commonco.COCommonInterface
 }
 
 // New creates a CNS controller
@@ -108,22 +106,6 @@ func (c *controller) Init(config *cnsconfig.Config) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Errorf("failed to create fsnotify watcher. err=%v", err)
-		return err
-	}
-
-	// Initialize CO common interface
-	clusterFlavor, err := cnsconfig.GetClusterFlavor(ctx)
-	if err != nil {
-		log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
-		return err
-	}
-	k8sInitParams := k8sorchestrator.K8sGuestInitParams{
-		InternalFeatureStatesConfigInfo:   config.InternalFeatureStatesConfig,
-		SupervisorFeatureStatesConfigInfo: config.FeatureStatesConfig,
-	}
-	c.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor, k8sInitParams)
-	if err != nil {
-		log.Errorf("Failed to create CO agnostic interface. err=%v", err)
 		return err
 	}
 
@@ -551,7 +533,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	*csi.ControllerExpandVolumeResponse, error) {
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
-	if !c.coCommonInterface.IsFSSEnabled(ctx, common.VolumeExtend) {
+	if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.VolumeExtend) {
 		msg := "ExpandVolume feature is disabled on the cluster."
 		log.Warn(msg)
 		return nil, status.Error(codes.Unimplemented, msg)
@@ -566,7 +548,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	volumeID := req.GetVolumeId()
 	volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 
-	if !c.coCommonInterface.IsFSSEnabled(ctx, common.OnlineVolumeExtend) {
+	if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend) {
 		vmList := &vmoperatortypes.VirtualMachineList{}
 		err = c.vmOperatorClient.List(ctx, vmList, client.InNamespace(c.supervisorNamespace))
 		if err != nil {

--- a/pkg/syncer/admissionhandler/config.go
+++ b/pkg/syncer/admissionhandler/config.go
@@ -22,7 +22,6 @@ import (
 
 	"gopkg.in/gcfg.v1"
 
-	commonconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
@@ -36,8 +35,6 @@ const (
 type config struct {
 	// WebHookConfig contains the detail about webhook - certfile, keyfile, port etc.
 	WebHookConfig webHookConfig
-	// InternalFeatureStatesConfig is the details about feature states configmap
-	InternalFeatureStatesConfig commonconfig.FeatureStatesConfigInfo
 }
 
 // webHookConfig holds webhook configuration using which webhook http server will be created

--- a/pkg/syncer/admissionhandler/validatestorageclass.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass.go
@@ -48,7 +48,7 @@ const (
 
 // validateStorageClass helps validate AdmissionReview requests for StroageClass
 func validateStorageClass(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-	if k8s != nil && !k8s.IsFSSEnabled(ctx, common.CSIMigration) {
+	if containerOrchestratorUtility != nil && !containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
 		// if CSI migration is disabled and webhook is running
 		// skip validation for StorageClass
 		return &admissionv1.AdmissionResponse{

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -18,7 +18,6 @@ package syncer
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -45,7 +44,6 @@ import (
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
@@ -57,6 +55,9 @@ var (
 	// volumeMigrationService holds the pointer to VolumeMigration instance
 	volumeMigrationService        migration.VolumeMigrationService
 	onceForVolumeResizeReconciler sync.Once
+	// COInitParams stores the input params required for initiating the
+	// CO agnostic orchestrator for the syncer container
+	COInitParams interface{}
 )
 
 // newInformer returns uninitialized metadataSyncInformer
@@ -126,27 +127,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 	}
 
 	// Initialize the k8s orchestrator interface
-	var k8sInitParams interface{}
-	if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-		k8sInitParams = k8sorchestrator.K8sVanillaInitParams{
-			InternalFeatureStatesConfigInfo: metadataSyncer.configInfo.Cfg.InternalFeatureStatesConfig,
-		}
-	} else if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
-		k8sInitParams = k8sorchestrator.K8sSupervisorInitParams{
-			SupervisorFeatureStatesConfigInfo: metadataSyncer.configInfo.Cfg.FeatureStatesConfig,
-		}
-	} else if clusterFlavor == cnstypes.CnsClusterFlavorGuest {
-		k8sInitParams = k8sorchestrator.K8sGuestInitParams{
-			InternalFeatureStatesConfigInfo:   metadataSyncer.configInfo.Cfg.InternalFeatureStatesConfig,
-			SupervisorFeatureStatesConfigInfo: metadataSyncer.configInfo.Cfg.FeatureStatesConfig,
-		}
-	} else {
-		msg := fmt.Sprintf("unrecognized cluster flavor %q", clusterFlavor)
-		log.Error(msg)
-		return errors.New(msg)
-	}
-
-	metadataSyncer.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor, k8sInitParams)
+	metadataSyncer.coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor, COInitParams)
 	if err != nil {
 		log.Errorf("Failed to create CO agnostic interface. Error: %v", err)
 		return err

--- a/pkg/syncer/storagepool/service.go
+++ b/pkg/syncer/storagepool/service.go
@@ -30,7 +30,6 @@ import (
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	commontypes "sigs.k8s.io/vsphere-csi-driver/pkg/syncer/types"
 )
@@ -50,7 +49,7 @@ var (
 
 // InitStoragePoolService initializes the StoragePool service that updates
 // vSphere Datastore information into corresponding k8s StoragePool resources.
-func InitStoragePoolService(ctx context.Context, configInfo *commontypes.ConfigInfo) error {
+func InitStoragePoolService(ctx context.Context, configInfo *commontypes.ConfigInfo, coInitParams *interface{}) error {
 	log := logger.GetLogger(ctx)
 	log.Infof("Initializing Storage Pool Service")
 
@@ -107,10 +106,7 @@ func InitStoragePoolService(ctx context.Context, configInfo *commontypes.ConfigI
 		defer diskDecommEnablementTicker.Stop()
 		clusterFlavor := cnstypes.CnsClusterFlavorWorkload
 		for ; true; <-diskDecommEnablementTicker.C {
-			k8sInitParams := k8sorchestrator.K8sSupervisorInitParams{
-				SupervisorFeatureStatesConfigInfo: configInfo.Cfg.FeatureStatesConfig,
-			}
-			coCommonInterface, _ := commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor, k8sInitParams)
+			coCommonInterface, _ := commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor, *coInitParams)
 			if !coCommonInterface.IsFSSEnabled(ctx, common.VSANDirectDiskDecommission) {
 				log.Infof("VSANDirectDiskDecommission feature is disabled on the cluster")
 			} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Going forward, we want to communicate feature state switch info to the controller, syncer and node containers using CLI arguments. These values will no longer be available in the conf files. This is required when we intend to read FSS values in the node pod but do not want to read the conf file containing other important information (like vsphere credentials) to fetch FSS info. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: 2 commits will be created by this PR - one containing all the YAML changes and the other containing code changes.

Testing done - 
When FSS info is mentioned in CLI: (controller init logs)
```
2020-11-10T22:02:05.618Z	INFO	logger/logger.go:37	Setting default log level to :"DEVELOPMENT"
2020-11-10T22:02:05.662Z	INFO	vsphere-csi/main.go:54	Version : v2.1.0-rc.1-237-gc172033	{"TraceId": "3aacca1a-5066-43af-9408-39a3b6f92528"}
2020-11-10T22:02:05.662Z	DEBUG	commonco/utils.go:96	Container orchestrator init params: {InternalFeatureStatesConfigInfo:{Name:internal-feature-states.csi.vsphere.vmware.com Namespace:kube-system}}	{"TraceId": "3aacca1a-5066-43af-9408-39a3b6f92528"}
```

When FSS info is skipped in CLI: (admission webhook init logs)
```
{"level":"info","time":"2020-11-10T21:50:12.89566177Z","caller":"logger/logger.go:37","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2020-11-10T21:50:12.896181748Z","caller":"syncer/main.go:68","msg":"Version : v2.1.0-rc.1-237-gc172033","TraceId":"232519e9-9915-4a24-80f7-0ae2958e2754"}
{"level":"info","time":"2020-11-10T21:50:12.896518735Z","caller":"commonco/utils.go:53","msg":"Defaulting feature states configmap name to \"internal-feature-states.csi.vsphere.vmware.com\"","TraceId":"232519e9-9915-4a24-80f7-0ae2958e2754"}
{"level":"info","time":"2020-11-10T21:50:12.896562815Z","caller":"commonco/utils.go:57","msg":"Defaulting feature states configmap namespace to \"kube-system\"","TraceId":"232519e9-9915-4a24-80f7-0ae2958e2754"}
{"level":"info","time":"2020-11-10T21:50:12.896584033Z","caller":"syncer/main.go:80","msg":"Starting container with operation mode: WEBHOOK_SERVER","TraceId":"232519e9-9915-4a24-80f7-0ae2958e2754"}
{"level":"info","time":"2020-11-10T21:50:12.89747734Z","caller":"k8sorchestrator/k8sorchestrator.go:87","msg":"Initializing k8sOrchestratorInstance","TraceId":"232519e9-9915-4a24-80f7-0ae2958e2754"}
{"level":"info","time":"2020-11-10T21:50:12.897545088Z","caller":"kubernetes/kubernetes.go:83","msg":"k8s client using in-cluster config","TraceId":"232519e9-9915-4a24-80f7-0ae2958e2754"}
{"level":"info","time":"2020-11-10T21:50:12.898396097Z","caller":"kubernetes/kubernetes.go:267","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"232519e9-9915-4a24-80f7-0ae2958e2754"}
{"level":"info","time":"2020-11-10T21:50:12.913598231Z","caller":"k8sorchestrator/k8sorchestrator.go:185","msg":"New internal feature states values stored successfully: map[csi-auth-check:false csi-migration:true]","TraceId":"232519e9-9915-4a24-80f7-0ae2958e2754"}
{"level":"info","time":"2020-11-10T21:50:12.914399251Z","caller":"k8sorchestrator/k8sorchestrator.go:105","msg":"k8sOrchestratorInstance initialized","TraceId":"232519e9-9915-4a24-80f7-0ae2958e2754"}
{"level":"info","time":"2020-11-10T21:50:12.914889465Z","caller":"admissionhandler/admissionhandler.go:171","msg":"Webhook server started","TraceId":"232519e9-9915-4a24-80f7-0ae2958e2754"}
{"level":"info","time":"2020-11-10T21:50:12.925197027Z","caller":"k8sorchestrator/k8sorchestrator.go:228","msg":"New feature states values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[csi-auth-check:false csi-migration:true]","TraceId":"570e5cf4-b34b-4597-85b0-59a4164a8fb3"}
```

Testing done on Vanilla and supervisor clusters.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Take in Feature state switch info through CLI instead of using the conf file
```
