### PR TITLE
Avoid e2e test names collision

### DIFF
--- a/tests/e2e/gc_cns_nodevm_attachment.go
+++ b/tests/e2e/gc_cns_nodevm_attachment.go
@@ -357,7 +357,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 			13- Delete PVCs.
 	*/
 
-	ginkgo.It("Detach Statefulset testing with default podManagementPolicy", func() {
+	ginkgo.It("Verify CnsNodeVmAttachment CRD for Statefulset pods in guest cluster with default podManagementPolicy", func() {
 
 		ginkgo.By("Creating StorageClass for Statefulset")
 		scParameters[svStorageClassName] = storagePolicyName
@@ -369,8 +369,6 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
-
-		//statefulsetTester := fpod.NewStatefulSetTester(client)
 
 		ginkgo.By("Creating service")
 		CreateService(namespace, client)
@@ -389,14 +387,12 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(), "Number of Pods in the statefulset should match with number of replicas")
 
 		// Get the list of Volumes attached to Pods before scale down
-		//var volumesBeforeScaleDown []string
 		for _, sspod := range ssPodsBeforeScaleDown.Items {
 			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			for _, volumespec := range sspod.Spec.Volumes {
 				if volumespec.PersistentVolumeClaim != nil {
 					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
-					//volumesBeforeScaleDown = append(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)
 					ginkgo.By("Verify CnsNodeVmAttachment CRD is created")
 					volumeID := pv.Spec.CSI.VolumeHandle
 					// svcPVCName refers to PVC Name in the supervisor cluster

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1935,14 +1935,14 @@ func waitForNamespaceToGetDeleted(ctx context.Context, c clientset.Interface, na
 
 // waitForCNSRegisterVolumeToGetCreated waits for a cnsRegisterVolume to get created or until timeout occurs, whichever comes first.
 func waitForCNSRegisterVolumeToGetCreated(ctx context.Context, restConfig *rest.Config, namespace string, cnsRegisterVolume *cnsregistervolumev1alpha1.CnsRegisterVolume, Poll, timeout time.Duration) error {
-	framework.Logf("Waiting up to %v for CnsRegisterVolume %s to get created", timeout, cnsRegisterVolume)
+	framework.Logf("Waiting up to %v for CnsRegisterVolume %+v to get created", timeout, cnsRegisterVolume)
 
 	cnsRegisterVolumeName := cnsRegisterVolume.GetName()
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(Poll) {
 		cnsRegisterVolume = getCNSRegistervolume(ctx, restConfig, cnsRegisterVolume)
 		flag := cnsRegisterVolume.Status.Registered
 		if !flag {
-			framework.Logf("cnsRegisterVolume %s found and Registered status is  =%s (%v)", cnsRegisterVolumeName, flag, time.Since(start))
+			framework.Logf("cnsRegisterVolume %s found and Registered status is = %t", cnsRegisterVolumeName, flag)
 			continue
 		} else {
 			return nil
@@ -1954,13 +1954,13 @@ func waitForCNSRegisterVolumeToGetCreated(ctx context.Context, restConfig *rest.
 
 // waitForCNSRegisterVolumeToGetDeleted waits for a cnsRegisterVolume to get deleted or until timeout occurs, whichever comes first.
 func waitForCNSRegisterVolumeToGetDeleted(ctx context.Context, restConfig *rest.Config, namespace string, cnsRegisterVolume *cnsregistervolumev1alpha1.CnsRegisterVolume, Poll, timeout time.Duration) error {
-	framework.Logf("Waiting up to %v for cnsRegisterVolume %s to get deleted", timeout, cnsRegisterVolume)
+	framework.Logf("Waiting up to %v for cnsRegisterVolume %+v to get deleted", timeout, cnsRegisterVolume)
 
 	cnsRegisterVolumeName := cnsRegisterVolume.GetName()
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(Poll) {
 		flag := queryCNSRegisterVolume(ctx, restConfig, cnsRegisterVolumeName, namespace)
 		if flag {
-			framework.Logf("CnsRegisterVolume %s is not yet deleted. Deletion flag status  =%s (%v)", cnsRegisterVolumeName, flag, time.Since(start))
+			framework.Logf("CnsRegisterVolume %s is not yet deleted. Deletion flag status = %t", cnsRegisterVolumeName, flag)
 			continue
 		}
 		return nil

--- a/tests/e2e/volume_health_test.go
+++ b/tests/e2e/volume_health_test.go
@@ -812,7 +812,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 	*/
 
-	ginkgo.It("[csi-supervisor] Verify Volume health on Statefulset", func() {
+	ginkgo.It("[csi-supervisor] Verify Volume health on Statefulset in Supervisor", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -1073,7 +1073,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 	*/
 
-	ginkgo.It("[csi-guest] In Guest Cluster Verify Volume health on Statefulset", func() {
+	ginkgo.It("[csi-guest] Verify Volume health on a statefulset in Guest Cluster", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is just renaming a test case to avoid test case name collision and fixing few format specifiers. 
Observed these issues while running e2e tests manually.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Before:
`found and Registered status is  =%!s(bool=false) (12.348222322s)`

After:
`found and Registered status is = false`

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Rename a test case for guest cluster to avoid name collision with supervisor test case and use correct format specifiers in log messages
```
