### PR TITLE
Cherrypick from master: Take in Feature state switch info through CLI

### DIFF
--- a/example/vanilla-k8s-block-driver/vsphere.conf
+++ b/example/vanilla-k8s-block-driver/vsphere.conf
@@ -9,9 +9,3 @@ password = "vcenter password"
 port = "443"
 datacenters = "list of comma separated datacenter paths where node VMs are present"
 
-# InternalFeatureStatesConfig holds the details about internal feature states configmap.
-# Default feature states configmap name is set to "internal-feature-states.csi.vsphere.vmware.com"  and namespace is set to "kube-system"
-# Provide the configmap name and namespace details only when feature states configmap is not in the default namespace
-[InternalFeatureStatesConfig]
-name = "internal-feature-states.csi.vsphere.vmware.com"
-namespace = "kube-system"

--- a/manifests/latest/vsphere-7.0u1/vanilla/deploy/generate-signed-webhook-certs.sh
+++ b/manifests/latest/vsphere-7.0u1/vanilla/deploy/generate-signed-webhook-certs.sh
@@ -136,13 +136,6 @@ cat <<eof >"${tmpdir}"/webhook.config
 port = "8443"
 cert-file = "/etc/webhook/cert.pem"
 key-file = "/etc/webhook/key.pem"
-
-# InternalFeatureStatesConfig holds the details about internal feature states configmap.
-# Default feature states configmap name is set to "internal-feature-states.csi.vsphere.vmware.com"  and namespace is set to "kube-system"
-# Provide the configmap name and namespace details only when feature states configmap is not in the default namespace
-[InternalFeatureStatesConfig]
-name = "internal-feature-states.csi.vsphere.vmware.com"
-namespace = "${namespace}"
 eof
 
 

--- a/manifests/latest/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
+++ b/manifests/latest/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
@@ -94,12 +94,18 @@ spec:
           image: gcr.io/cloud-provider-vsphere/csi/release/syncer:<syncer-image-tag-with-webhook-support>
           args:
             - "--operation-mode=WEBHOOK_SERVER"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: WEBHOOK_CONFIG_PATH
               value: "/etc/webhook/webhook.config"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/webhook
               name: webhook-certs

--- a/manifests/latest/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/latest/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -52,6 +52,9 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.1
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
@@ -66,6 +69,10 @@ spec:
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
@@ -96,6 +103,8 @@ spec:
           image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.1
           args:
             - "--leader-election"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -108,6 +117,10 @@ spec:
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume

--- a/manifests/latest/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/latest/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -49,6 +49,9 @@ spec:
           timeoutSeconds: 5
       - name: vsphere-csi-node
         image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.1
+        args:
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME
@@ -68,6 +71,10 @@ spec:
           value: "true"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           privileged: true
           capabilities:

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -310,26 +310,7 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 			}
 		}
 	}
-	clusterFlavor, err := GetClusterFlavor(ctx)
-	if err != nil {
-		return err
-	}
-	// Validate FeatureStateConfig used in Supervisor cluster
-	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload && cfg.FeatureStatesConfig.Name == "" && cfg.FeatureStatesConfig.Namespace == "" {
-		// Feature states config info is not provided in vsphere conf in project pacific, use defaults for supervisor cluster
-		log.Infof("No feature states config information is provided in the Config. Using default config map name: %s and namespace: %s",
-			DefaultSupervisorFSSConfigMapName, DefaultCSINamespace)
-		cfg.FeatureStatesConfig.Name = DefaultSupervisorFSSConfigMapName
-		cfg.FeatureStatesConfig.Namespace = DefaultCSINamespace
-	}
-	// Validate InternalFeatureStateConfig used in vanilla cluster
-	if clusterFlavor == cnstypes.CnsClusterFlavorVanilla && cfg.InternalFeatureStatesConfig.Name == "" && cfg.InternalFeatureStatesConfig.Namespace == "" {
-		// If feature states config info is not provided in vsphere conf, use defaults for vanilla k8s cluster
-		log.Infof("No feature states config information is provided in the Config. Using default config map name: %s and namespace: %s",
-			DefaultInternalFSSConfigMapName, DefaultCSINamespaceVanillaK8s)
-		cfg.InternalFeatureStatesConfig.Name = DefaultInternalFSSConfigMapName
-		cfg.InternalFeatureStatesConfig.Namespace = DefaultCSINamespaceVanillaK8s
-	}
+
 	if cfg.Global.CnsRegisterVolumesCleanupIntervalInMin == 0 {
 		cfg.Global.CnsRegisterVolumesCleanupIntervalInMin = DefaultCnsRegisterVolumesCleanupIntervalInMin
 	}
@@ -465,16 +446,6 @@ func GetGCconfig(ctx context.Context, cfgPath string) (*Config, error) {
 	// Set default GCPort if Port is still empty
 	if cfg.GC.Port == "" {
 		cfg.GC.Port = DefaultGCPort
-	}
-	// Set default fss configmap name if SV FSS configmap info is not available in GC Config
-	if cfg.InternalFeatureStatesConfig.Name == "" && cfg.InternalFeatureStatesConfig.Namespace == "" {
-		cfg.InternalFeatureStatesConfig.Name = DefaultInternalFSSConfigMapName
-		cfg.InternalFeatureStatesConfig.Namespace = DefaultCSINamespace
-	}
-
-	if cfg.FeatureStatesConfig.Name == "" && cfg.FeatureStatesConfig.Namespace == "" {
-		cfg.FeatureStatesConfig.Name = DefaultSupervisorFSSConfigMapName
-		cfg.FeatureStatesConfig.Namespace = DefaultCSINamespace
 	}
 	return cfg, nil
 }

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -66,18 +66,12 @@ type Config struct {
 		Zone   string `gcfg:"zone"`
 		Region string `gcfg:"region"`
 	}
-	// FeatureStatesConfig contains feature states configmap info specific to supervisor cluster
-	FeatureStatesConfig FeatureStatesConfigInfo
-
-	// InternalFeatureStatesConfig contains feature states configmap info specific to pvCSI and vanilla drivers
-	// NOTE: Do not edit this. Only to be used for dev and testing purposes.
-	InternalFeatureStatesConfig FeatureStatesConfigInfo
 }
 
-// FeatureStatesConfigInfo is the details about feature states configmap
+// FeatureStatesConfigInfo contains the details about feature states configmap
 type FeatureStatesConfigInfo struct {
-	Name      string `gcfg:"name"`
-	Namespace string `gcfg:"namespace"`
+	Name      string
+	Namespace string
 }
 
 // NetPermissionConfig consists of information used to restrict the

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -27,6 +27,10 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
+// ContainerOrchestratorUtility represents the singleton instance of
+// container orchestrator interface
+var ContainerOrchestratorUtility COCommonInterface
+
 // COCommonInterface provides functionality to define
 // container orchestrator related implementation to read resources/objects
 type COCommonInterface interface {

--- a/pkg/csi/service/common/commonco/utils.go
+++ b/pkg/csi/service/common/commonco/utils.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commonco
+
+import (
+	"context"
+	"strings"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+
+	csiconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+)
+
+// SetInitParams initializes the parameters required to create a container agnostic orchestrator instance
+func SetInitParams(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, initParams *interface{},
+	supervisorFSSName, supervisorFSSNamespace, internalFSSName, internalFSSNamespace string) {
+	log := logger.GetLogger(ctx)
+	// Set default values for FSS, if not given and initiate CO-agnostic init params
+	switch clusterFlavor {
+	case cnstypes.CnsClusterFlavorWorkload:
+		if strings.TrimSpace(supervisorFSSName) == "" {
+			log.Infof("Defaulting feature states configmap name to %q", csiconfig.DefaultSupervisorFSSConfigMapName)
+			supervisorFSSName = csiconfig.DefaultSupervisorFSSConfigMapName
+		}
+		if strings.TrimSpace(supervisorFSSNamespace) == "" {
+			log.Infof("Defaulting feature states configmap namespace to %q", csiconfig.DefaultCSINamespace)
+			supervisorFSSNamespace = csiconfig.DefaultCSINamespace
+		}
+		*initParams = k8sorchestrator.K8sSupervisorInitParams{
+			SupervisorFeatureStatesConfigInfo: csiconfig.FeatureStatesConfigInfo{
+				Name:      supervisorFSSName,
+				Namespace: supervisorFSSNamespace,
+			},
+		}
+	case cnstypes.CnsClusterFlavorVanilla:
+		if strings.TrimSpace(internalFSSName) == "" {
+			log.Infof("Defaulting feature states configmap name to %q", csiconfig.DefaultInternalFSSConfigMapName)
+			internalFSSName = csiconfig.DefaultInternalFSSConfigMapName
+		}
+		if strings.TrimSpace(internalFSSNamespace) == "" {
+			log.Infof("Defaulting feature states configmap namespace to %q", csiconfig.DefaultCSINamespaceVanillaK8s)
+			internalFSSNamespace = csiconfig.DefaultCSINamespaceVanillaK8s
+		}
+		*initParams = k8sorchestrator.K8sVanillaInitParams{
+			InternalFeatureStatesConfigInfo: csiconfig.FeatureStatesConfigInfo{
+				Name:      internalFSSName,
+				Namespace: internalFSSNamespace,
+			},
+		}
+	case cnstypes.CnsClusterFlavorGuest:
+		if strings.TrimSpace(supervisorFSSName) == "" {
+			log.Infof("Defaulting supervisor feature states configmap name to %q", csiconfig.DefaultSupervisorFSSConfigMapName)
+			supervisorFSSName = csiconfig.DefaultSupervisorFSSConfigMapName
+		}
+		if strings.TrimSpace(supervisorFSSNamespace) == "" {
+			log.Infof("Defaulting supervisor feature states configmap namespace to %q", csiconfig.DefaultCSINamespace)
+			supervisorFSSNamespace = csiconfig.DefaultCSINamespace
+		}
+		if strings.TrimSpace(internalFSSName) == "" {
+			log.Infof("Defaulting internal feature states configmap name to %q", csiconfig.DefaultInternalFSSConfigMapName)
+			internalFSSName = csiconfig.DefaultInternalFSSConfigMapName
+		}
+		if strings.TrimSpace(internalFSSNamespace) == "" {
+			log.Infof("Defaulting internal feature states configmap namespace to %q", csiconfig.DefaultCSINamespace)
+			internalFSSNamespace = csiconfig.DefaultCSINamespace
+		}
+		*initParams = k8sorchestrator.K8sGuestInitParams{
+			InternalFeatureStatesConfigInfo: csiconfig.FeatureStatesConfigInfo{
+				Name:      internalFSSName,
+				Namespace: internalFSSNamespace,
+			},
+			SupervisorFeatureStatesConfigInfo: csiconfig.FeatureStatesConfigInfo{
+				Name:      supervisorFSSName,
+				Namespace: supervisorFSSNamespace,
+			},
+		}
+	default:
+		log.Fatalf("Unrecognised cluster flavor %q. Container orchestrator init params not initialized.", clusterFlavor)
+	}
+	log.Debugf("Container orchestrator init params: %+v", *initParams)
+}

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -40,7 +40,6 @@ import (
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
@@ -63,10 +62,6 @@ type controller struct {
 // If volume is present in this map, then detach volume operation can be skipped.
 // TODO: Remove this when https://github.com/kubernetes/kubernetes/issues/84226 is fixed
 var deletedVolumes *timedmap.TimedMap
-
-// containerOrchestratorUtility is used for fetching CO specific utilities
-// For example: feature states are stored as a configmap resource in k8s
-var containerOrchestratorUtility commonco.COCommonInterface
 
 // volumeMigrationService holds the pointer to VolumeMigration instance
 var volumeMigrationService migration.VolumeMigrationService
@@ -159,18 +154,6 @@ func (c *controller) Init(config *cnsconfig.Config) error {
 	go cnsvolume.ClearTaskInfoObjects()
 	cfgPath := common.GetConfigPath(ctx)
 
-	// Initialize CO common utility
-	clusterFlavor, err := cnsconfig.GetClusterFlavor(ctx)
-	if err != nil {
-		log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
-		return err
-	}
-	containerOrchestratorUtility, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor,
-		k8sorchestrator.K8sVanillaInitParams{InternalFeatureStatesConfigInfo: config.InternalFeatureStatesConfig})
-	if err != nil {
-		log.Errorf("Failed to create CO agnostic interface. Error: %v", err)
-		return err
-	}
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Errorf("failed to create fsnotify watcher. err=%v", err)
@@ -208,7 +191,7 @@ func (c *controller) Init(config *cnsconfig.Config) error {
 	}
 	// deletedVolumes timedmap with clean up interval of 1 minute to remove expired entries
 	deletedVolumes = timedmap.New(1 * time.Minute)
-	if containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
 		log.Info("CSI Migration Feature is Enabled. Loading Volume Migration Service")
 		volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &c.manager.VolumeManager, config, false)
 		if err != nil {
@@ -281,7 +264,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
 
 	// Fetching the feature state for csi-migration before parsing storage class params
-	csiMigrationFeatureState := containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration)
+	csiMigrationFeatureState := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration)
 	scParams, err := common.ParseStorageClassParams(ctx, req.Parameters, csiMigrationFeatureState)
 	if err != nil {
 		msg := fmt.Sprintf("Parsing storage class parameters failed with error: %+v", err)
@@ -466,7 +449,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 	volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
 
 	// Fetching the feature state for csi-migration before parsing storage class params
-	csiMigrationFeatureState := containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration)
+	csiMigrationFeatureState := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration)
 	scParams, err := common.ParseStorageClassParams(ctx, req.Parameters, csiMigrationFeatureState)
 	if err != nil {
 		msg := fmt.Sprintf("Parsing storage class parameters failed with error: %+v", err)
@@ -541,7 +524,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	var volumePath string
 	if strings.Contains(req.VolumeId, ".vmdk") {
 		// in-tree volume support
-		if !containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
+		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
 			// Migration feature switch is disabled
 			msg := fmt.Sprintf("volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", req.VolumeId)
 			log.Error(msg)
@@ -635,7 +618,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 		// Block Volume
 		if strings.Contains(req.VolumeId, ".vmdk") {
 			// in-tree volume support
-			if !containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
+			if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
 				// Migration feature switch is disabled
 				msg := fmt.Sprintf("volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", req.VolumeId)
 				log.Error(msg)
@@ -717,7 +700,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		}
 	} else {
 		// in-tree volume support
-		if !containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
+		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
 			// Migration feature switch is disabled
 			msg := fmt.Sprintf("volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", req.VolumeId)
 			log.Error(msg)

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -43,11 +43,13 @@ import (
 	"github.com/zekroTJA/timedmap"
 	clientset "k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
+
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
 )
 
@@ -281,7 +283,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 				k8sClient:          k8sClient,
 			},
 		}
-		containerOrchestratorUtility, err = unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+		commonco.ContainerOrchestratorUtility, err = unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
 		if err != nil {
 			t.Fatalf("Failed to create co agnostic interface. err=%v", err)
 		}

--- a/pkg/syncer/admissionhandler/config.go
+++ b/pkg/syncer/admissionhandler/config.go
@@ -22,7 +22,6 @@ import (
 
 	"gopkg.in/gcfg.v1"
 
-	commonconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
@@ -36,8 +35,6 @@ const (
 type config struct {
 	// WebHookConfig contains the detail about webhook - certfile, keyfile, port etc.
 	WebHookConfig webHookConfig
-	// InternalFeatureStatesConfig is the details about feature states configmap
-	InternalFeatureStatesConfig commonconfig.FeatureStatesConfigInfo
 }
 
 // webHookConfig holds webhook configuration using which webhook http server will be created

--- a/pkg/syncer/admissionhandler/validatestorageclass.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass.go
@@ -48,7 +48,7 @@ const (
 
 // validateStorageClass helps validate AdmissionReview requests for StroageClass
 func validateStorageClass(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-	if k8s != nil && !k8s.IsFSSEnabled(ctx, common.CSIMigration) {
+	if containerOrchestratorUtility != nil && !containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
 		// if CSI migration is disabled and webhook is running
 		// skip validation for StorageClass
 		return &admissionv1.AdmissionResponse{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Cherry pick changes from master to 2.1 release branch for CLI changes on FSS

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: YAML changes for Supervisor and Guest cluster are not included. Refer to https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/487 for original PR on master.

Testing with Vanilla flavor- 
Controller debug logs - 
```
2020-11-11T20:52:25.704Z	INFO	logger/logger.go:37	Setting default log level to :"DEVELOPMENT"
2020-11-11T20:52:25.704Z	INFO	vsphere-csi/main.go:54	Version : v2.1.0-rc.2-1-gb1d5e4a	{"TraceId": "58eb7118-7041-41b5-b7b4-27a9d6b243c6"}
2020-11-11T20:52:25.705Z	DEBUG	commonco/utils.go:96	Container orchestrator init params: {InternalFeatureStatesConfigInfo:{Name:internal-feature-states.csi.vsphere.vmware.com Namespace:kube-system}}	{"TraceId": "58eb7118-7041-41b5-b7b4-27a9d6b243c6"}
2020-11-11T20:52:25.707Z	INFO	logger/logger.go:37	Setting default log level to :"DEVELOPMENT"
2020-11-11T20:52:25.707Z	INFO	k8sorchestrator/k8sorchestrator.go:87	Initializing k8sOrchestratorInstance	{"TraceId": "bf4daa54-ef8b-411c-b221-5ba11ea81c6e"}
2020-11-11T20:52:25.708Z	INFO	kubernetes/kubernetes.go:83	k8s client using in-cluster config	{"TraceId": "bf4daa54-ef8b-411c-b221-5ba11ea81c6e"}
2020-11-11T20:52:25.709Z	INFO	kubernetes/kubernetes.go:267	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "bf4daa54-ef8b-411c-b221-5ba11ea81c6e"}
2020-11-11T20:52:25.796Z	INFO	k8sorchestrator/k8sorchestrator.go:185	New internal feature states values stored successfully: map[csi-migration:false]	{"TraceId": "bf4daa54-ef8b-411c-b221-5ba11ea81c6e"}
2020-11-11T20:52:25.798Z	INFO	k8sorchestrator/k8sorchestrator.go:105	k8sOrchestratorInstance initialized	{"TraceId": "bf4daa54-ef8b-411c-b221-5ba11ea81c6e"}
```

Syncer Debug logs - 
```
2020-11-11T20:52:28.279Z	INFO	logger/logger.go:37	Setting default log level to :"DEVELOPMENT"
2020-11-11T20:52:28.280Z	INFO	syncer/main.go:68	Version : v2.1.0-rc.2-1-gb1d5e4a	{"TraceId": "dc504e27-5879-4b91-82ee-933e70da5961"}
2020-11-11T20:52:28.280Z	DEBUG	commonco/utils.go:96	Container orchestrator init params: {InternalFeatureStatesConfigInfo:{Name:internal-feature-states.csi.vsphere.vmware.com Namespace:kube-system}}	{"TraceId": "dc504e27-5879-4b91-82ee-933e70da5961"}
2020-11-11T20:52:28.280Z	INFO	syncer/main.go:85	Starting container with operation mode: METADATA_SYNC	{"TraceId": "dc504e27-5879-4b91-82ee-933e70da5961"}
2020-11-11T20:52:28.280Z	DEBUG	config/config.go:345	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "dc504e27-5879-4b91-82ee-933e70da5961"}
2020-11-11T20:52:28.281Z	DEBUG	config/config.go:261	Initializing vc server 10.184.163.246	{"TraceId": "dc504e27-5879-4b91-82ee-933e70da5961"}
2020-11-11T20:52:28.281Z	INFO	config/config.go:296	No Net Permissions given in Config. Using default permissions.	{"TraceId": "dc504e27-5879-4b91-82ee-933e70da5961"}
2020-11-11T20:52:28.281Z	INFO	kubernetes/kubernetes.go:83	k8s client using in-cluster config	{"TraceId": "dc504e27-5879-4b91-82ee-933e70da5961"}
2020-11-11T20:52:28.284Z	INFO	kubernetes/kubernetes.go:267	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "dc504e27-5879-4b91-82ee-933e70da5961"}
I1111 20:52:28.288409       1 leaderelection.go:242] attempting to acquire leader lease  kube-system/vsphere-syncer...
I1111 20:53:21.043876       1 leaderelection.go:252] successfully acquired lease kube-system/vsphere-syncer
2020-11-11T20:53:21.045Z	INFO	syncer/metadatasyncer.go:119	Initializing MetadataSyncer
2020-11-11T20:53:21.045Z	INFO	kubernetes/kubernetes.go:83	k8s client using in-cluster config
2020-11-11T20:53:21.046Z	INFO	kubernetes/kubernetes.go:267	Setting client QPS to 100.000000 and Burst to 100.
2020-11-11T20:53:21.047Z	INFO	k8sorchestrator/k8sorchestrator.go:87	Initializing k8sOrchestratorInstance
2020-11-11T20:53:21.047Z	INFO	kubernetes/kubernetes.go:83	k8s client using in-cluster config
2020-11-11T20:53:21.047Z	INFO	kubernetes/kubernetes.go:267	Setting client QPS to 100.000000 and Burst to 100.
2020-11-11T20:53:21.070Z	INFO	k8sorchestrator/k8sorchestrator.go:185	New internal feature states values stored successfully: map[csi-migration:false]
2020-11-11T20:53:21.073Z	INFO	k8sorchestrator/k8sorchestrator.go:105	k8sOrchestratorInstance initialized
```

Confirmed that Nodes do not initialize container orchestrator instance.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Take in Feature state switch info through CLI instead of using the conf file
```
