### PR TITLE
Push CI images with latest tag and update dev manifests.

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -96,6 +96,7 @@ function build_images() {
       # A non-PR, non-release build. This is usually a build off of master
       CSI_IMAGE_NAME=${CSI_IMAGE_CI}
       SYNCER_IMAGE_NAME=${SYNCER_IMAGE_CI}
+      LATEST="latest"
       ;;
     pr)
       # A PR build

--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
+          image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
@@ -80,7 +80,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
+          image: gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest
           args:
             - "--leader-election"
           imagePullPolicy: "Always"

--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -42,7 +42,7 @@ spec:
         - name: registration-dir
           mountPath: /registration
       - name: vsphere-csi-node
-        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
+        image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
+          image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
@@ -93,7 +93,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
+          image: gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest
           args:
             - "--leader-election"
           imagePullPolicy: "Always"

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -42,7 +42,7 @@ spec:
         - name: registration-dir
           mountPath: /registration
       - name: vsphere-csi-node
-        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
+        image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
@@ -91,7 +91,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
+          image: gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
+          image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -100,7 +100,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
+          image: gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -48,7 +48,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: vsphere-csi-node
-        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
+        image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
         args:
           - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
           - "--fss-namespace=$(CSI_NAMESPACE)"

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/validatingwebhook.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/validatingwebhook.yaml
@@ -91,7 +91,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:<syncer-image-tag-with-webhook-support>
+          image: gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
+          image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -103,7 +103,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0-rc.2
+          image: gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -49,7 +49,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: vsphere-csi-node
-        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0-rc.2
+        image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
         args:
           - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
           - "--fss-namespace=$(CSI_NAMESPACE)"


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR pushes a CI image tagged as `latest` to the image registry. The `latest` tag will be used to point to the top commit merged into main branch. 
Dev manifests will now point to the latest merged onto the main branch. 

Running `make images` will now tag two images for syncer and driver:
```
a$ docker images
REPOSITORY                                            TAG                              IMAGE ID            CREATED             SIZE
gcr.io/cloud-provider-vsphere/csi/ci/syncer           latest                           acf01d1b7e6c        3 hours ago         202MB
gcr.io/cloud-provider-vsphere/csi/ci/syncer           v2.1.0-rc.1-236-ge0f5e51-dirty   acf01d1b7e6c        3 hours ago         202MB
gcr.io/cloud-provider-vsphere/csi/ci/driver           latest                           d6a001a00d1a        3 hours ago         391MB
gcr.io/cloud-provider-vsphere/csi/ci/driver           v2.1.0-rc.1-236-ge0f5e51-dirty   d6a001a00d1a        3 hours ago         391MB

```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Push CI images with latest tag and update dev manifests.
```
