### PR TITLE
Set Default cluster flavor as VANILLA for config validation

### DIFF
--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"context"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -45,7 +46,7 @@ func init() {
 
 func TestValidateConfigWithNoNetPermissionParams(t *testing.T) {
 	cfg := &Config{VirtualCenter: idealVCConfig}
-
+	os.Setenv("CLUSTER_FLAVOR", "VANILLA")
 	expectedNetPermissions := map[string]*NetPermissionConfig{"#": GetDefaultNetPermission()}
 	expectedConfig := &Config{
 		VirtualCenter:  idealVCConfig,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixing broken Unit tests on ToT because of the changes here: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/473/files#diff-bc05587a7b67a6f398e87c7f94e95304a676b2f81fcb06dc4ad13f814b41c2c1R303

Looks like `DefaultNetPermissions` must be used only for Vanilla K8s. However, in the unit tests we do not set any cluster flavor in Init(). By setting the `CLUSTER_FLAVOR = VANILLA`, we can test `validateConfig` method successfully.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Before:

chethanv-a01:vsphere-csi-driver chethanv$ cd pkg/common/config/
chethanv-a01:config chethanv$ go test
```
$ go test
{"level":"info","time":"2020-11-11T20:02:04.377267-08:00","caller":"config/config.go:302","msg":"No Net Permissions given in Config. Using default permissions."}
--- FAIL: TestValidateConfigWithNoNetPermissionParams (0.00s)
    config_test.go:61: Expected: &{Global:{VCenterIP: ClusterID: User: Password: VCenterPort:443 InsecureFlag:false CAFile: Datacenters: CnsRegisterVolumesCleanupIntervalInMin:720 VolumeMigrationCRCleanupIntervalInMin:120 VCClientTimeout:0 ClusterDistribution: CSIAuthCheckIntervalInMin:5} NetPermissions:map[] VirtualCenter:map[1.1.1.1:0xc00009a360] GC:{Endpoint: Port: TanzuKubernetesClusterUID: TanzuKubernetesClusterName: ClusterDistribution:} Labels:{Zone: Region:}}
         Actual: &{Global:{VCenterIP: ClusterID: User: Password: VCenterPort: InsecureFlag:false CAFile: Datacenters: CnsRegisterVolumesCleanupIntervalInMin:0 VolumeMigrationCRCleanupIntervalInMin:0 VCClientTimeout:0 ClusterDistribution: CSIAuthCheckIntervalInMin:0} NetPermissions:map[#:0xc0000938f0] VirtualCenter:map[1.1.1.1:0xc00009a360] GC:{Endpoint: Port: TanzuKubernetesClusterUID: TanzuKubernetesClusterName: ClusterDistribution:} Labels:{Zone: Region:}}
{"level":"error","time":"2020-11-11T20:02:04.37953-08:00","caller":"config/config.go:313","msg":"Invalid value WRITE_ONLY for Permissions under NetPermission Config A","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:313\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.TestValidateConfigWithInvalidPermissions\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config_test.go:143\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
{"level":"error","time":"2020-11-11T20:02:04.380077-08:00","caller":"config/config.go:259","msg":"cluster id must not exceed 64 characters","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:259\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.TestValidateConfigWithInvalidClusterId\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config_test.go:155\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
FAIL
exit status 1
FAIL    sigs.k8s.io/vsphere-csi-driver/pkg/common/config        0.036s
```
After:

make unit-test
```
$ make unit-test
env -u VSPHERE_SERVER -u VSPHERE_DATACENTER -u VSPHERE_PASSWORD -u VSPHERE_USER -u VSPHERE_STORAGE_POLICY_NAME -u KUBECONFIG -u WCP_ENDPOINT -u WCP_PORT -u WCP_NAMESPACE -u TOKEN -u CERTIFICATE go test -v -count=1 ./pkg/common/config ./pkg/csi/service ./pkg/csi/service/common ./pkg/csi/service/common/commonco/k8sorchestrator ./pkg/csi/service/vanilla ./pkg/csi/service/wcp ./pkg/csi/service/wcpguest ./pkg/syncer ./pkg/syncer/admissionhandler
=== RUN   TestValidateConfigWithNoNetPermissionParams
{"level":"info","time":"2020-11-11T20:07:30.325553-08:00","caller":"config/config.go:302","msg":"No Net Permissions given in Config. Using default permissions."}
--- PASS: TestValidateConfigWithNoNetPermissionParams (0.00s)
=== RUN   TestValidateConfigWithMultipleNetPermissionParams
--- PASS: TestValidateConfigWithMultipleNetPermissionParams (0.00s)
=== RUN   TestValidateConfigWithInvalidPermissions
{"level":"error","time":"2020-11-11T20:07:30.32831-08:00","caller":"config/config.go:313","msg":"Invalid value WRITE_ONLY for Permissions under NetPermission Config A","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:313\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.TestValidateConfigWithInvalidPermissions\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config_test.go:145\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestValidateConfigWithInvalidPermissions (0.00s)
=== RUN   TestValidateConfigWithInvalidClusterId
{"level":"error","time":"2020-11-11T20:07:30.328895-08:00","caller":"config/config.go:259","msg":"cluster id must not exceed 64 characters","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:259\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.TestValidateConfigWithInvalidClusterId\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config_test.go:157\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestValidateConfigWithInvalidClusterId (0.00s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/common/config	0.041s
=== RUN   TestGetDisk
=== RUN   TestGetDisk/#00
=== PAUSE TestGetDisk/#00
=== RUN   TestGetDisk/#01
=== PAUSE TestGetDisk/#01
=== CONT  TestGetDisk/#00
=== CONT  TestGetDisk/#01
--- PASS: TestGetDisk (0.00s)
    --- PASS: TestGetDisk/#00 (0.00s)
    --- PASS: TestGetDisk/#01 (0.00s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/csi/service	0.055s
=== RUN   TestIsFileVolumeRequestForBlock
--- PASS: TestIsFileVolumeRequestForBlock (0.00s)
=== RUN   TestIsFileVolumeRequestForBlockWithUnsetFsType
--- PASS: TestIsFileVolumeRequestForBlockWithUnsetFsType (0.00s)
=== RUN   TestIsFileVolumeRequestForFile
--- PASS: TestIsFileVolumeRequestForFile (0.00s)
=== RUN   TestValidVolumeCapabilitiesForBlock
--- PASS: TestValidVolumeCapabilitiesForBlock (0.00s)
=== RUN   TestInvalidVolumeCapabilitiesForBlock
--- PASS: TestInvalidVolumeCapabilitiesForBlock (0.00s)
=== RUN   TestValidVolumeCapabilitiesForFile
--- PASS: TestValidVolumeCapabilitiesForFile (0.00s)
=== RUN   TestInvalidVolumeCapabilitiesForFile
--- PASS: TestInvalidVolumeCapabilitiesForFile (0.00s)
=== RUN   TestParseStorageClassParamsWithDeprecatedFSType
{"level":"warn","time":"2020-11-11T20:07:32.632022-08:00","caller":"common/util.go:216","msg":"param 'fstype' is deprecated, please use 'csi.storage.k8s.io/fstype' instead"}
--- PASS: TestParseStorageClassParamsWithDeprecatedFSType (0.00s)
=== RUN   TestParseStorageClassParamsWithValidParams
--- PASS: TestParseStorageClassParamsWithValidParams (0.00s)
=== RUN   TestParseStorageClassParamsWithMigrationEnabledNagative
--- PASS: TestParseStorageClassParamsWithMigrationEnabledNagative (0.00s)
    util_test.go:324: expected err received. err: vSphere CSI driver does not support creating volume using in-tree vSphere volume plugin parameter key:forceprovisioning-migrationparam, value:true
=== RUN   TestParseStorageClassParamsWithDiskFormatMigrationEnableNegative
--- PASS: TestParseStorageClassParamsWithDiskFormatMigrationEnableNegative (0.00s)
    util_test.go:337: expected err received. err: invalid parameter. key:diskformat-migrationparam, value:thick
=== RUN   TestParseStorageClassParamsWithDiskFormatMigrationEnablePositive
--- PASS: TestParseStorageClassParamsWithDiskFormatMigrationEnablePositive (0.00s)
=== RUN   TestParseStorageClassParamsWithMigrationEnabledPositive
--- PASS: TestParseStorageClassParamsWithMigrationEnabledPositive (0.00s)
=== RUN   TestParseStorageClassParamsWithMigrationDisabled
--- PASS: TestParseStorageClassParamsWithMigrationDisabled (0.00s)
    util_test.go:391: expected err received. err: Invalid param: "csimigration" and value: "true"
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common	0.040s
=== RUN   TestIsFSSEnabledInGcWithSync
{"level":"info","time":"2020-11-11T20:07:35.626237-08:00","caller":"k8sorchestrator/k8sorchestrator.go:324","msg":"volume-health feature state set to false in internal-feature-states.csi.vsphere.vmware.com ConfigMap"}
--- PASS: TestIsFSSEnabledInGcWithSync (0.00s)
=== RUN   TestIsFSSEnabledInGcWithoutSync
{"level":"info","time":"2020-11-11T20:07:35.627316-08:00","caller":"k8sorchestrator/k8sorchestrator.go:324","msg":"volume-extend feature state set to false in internal-feature-states.csi.vsphere.vmware.com ConfigMap"}
{"level":"info","time":"2020-11-11T20:07:35.62746-08:00","caller":"k8sorchestrator/k8sorchestrator.go:340","msg":"volume-health feature state set to false in csi-feature-states ConfigMap"}
--- PASS: TestIsFSSEnabledInGcWithoutSync (0.00s)
=== RUN   TestIsFSSEnabledInGcWrongValues
{"level":"error","time":"2020-11-11T20:07:35.627743-08:00","caller":"k8sorchestrator/k8sorchestrator.go:319","msg":"Error while converting volume-extend feature state value: false to boolean. Setting the feature state to false","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.(*K8sOrchestrator).IsFSSEnabled\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:319\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.TestIsFSSEnabledInGcWrongValues\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go:140\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestIsFSSEnabledInGcWrongValues (0.00s)
=== RUN   TestIsFSSEnabledInSV
{"level":"error","time":"2020-11-11T20:07:35.628986-08:00","caller":"k8sorchestrator/k8sorchestrator.go:307","msg":"Error while converting csi-migration feature state value: false to boolean. Setting the feature state to false","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.(*K8sOrchestrator).IsFSSEnabled\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:307\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.TestIsFSSEnabledInSV\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go:176\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestIsFSSEnabledInSV (0.00s)
=== RUN   TestIsFSSEnabledInVanilla
{"level":"error","time":"2020-11-11T20:07:35.629303-08:00","caller":"k8sorchestrator/k8sorchestrator.go:295","msg":"Error while converting volume-health feature state value: false to boolean. Setting the feature state to false","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.(*K8sOrchestrator).IsFSSEnabled\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:295\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator.TestIsFSSEnabledInVanilla\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go:214\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestIsFSSEnabledInVanilla (0.00s)
=== RUN   TestIsFSSEnabledWithWrongClusterFlavor
--- PASS: TestIsFSSEnabledWithWrongClusterFlavor (0.00s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator	0.080s
=== RUN   TestCreateVolumeWithStoragePolicy
{"level":"error","time":"2020-11-11T20:07:36.358249-08:00","caller":"config/config.go:254","msg":"no Virtual Center hosts defined","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:254\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.FromEnv\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:238\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.configFromEnvOrSim\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:144\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.getControllerTest.func1\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:258\nsync.(*Once).doSlow\n\t/usr/local/go/src/sync/once.go:66\nsync.(*Once).Do\n\t/usr/local/go/src/sync/once.go:57\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.getControllerTest\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:255\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.TestCreateVolumeWithStoragePolicy\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:329\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
{"level":"info","time":"2020-11-11T20:07:36.388969-08:00","caller":"vsphere/utils.go:126","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2020-11-11T20:07:36.389225-08:00","caller":"vsphere/virtualcentermanager.go:64","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2020-11-11T20:07:36.389239-08:00","caller":"vsphere/virtualcentermanager.go:66","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2020-11-11T20:07:36.389385-08:00","caller":"vsphere/virtualcentermanager.go:110","msg":"Successfully registered VC \"127.0.0.1\""}
{"level":"info","time":"2020-11-11T20:07:36.394116-08:00","caller":"vsphere/virtualcenter.go:153","msg":"New session ID for 'user' = 1244558f-0f2c-4fec-aece-487a6a3e3465"}
{"level":"info","time":"2020-11-11T20:07:36.394247-08:00","caller":"volume/manager.go:100","msg":"Initializing new volume.defaultManager..."}
{"level":"info","time":"2020-11-11T20:07:36.394886-08:00","caller":"vanilla/controller.go:554","msg":"CreateVolume: called with args {Name:test-pvc-61cffeeb-1b1b-4515-af8e-b46c7bc86e65 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[storagepolicyname:vSAN Default Storage Policy] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"eafbbafa-8827-484e-991f-860ba9ec7a43"}
{"level":"info","time":"2020-11-11T20:07:36.404573-08:00","caller":"volume/manager.go:215","msg":"CreateVolume: VolumeName: \"test-pvc-61cffeeb-1b1b-4515-af8e-b46c7bc86e65\", opId: \"\"","TraceId":"eafbbafa-8827-484e-991f-860ba9ec7a43"}
{"level":"info","time":"2020-11-11T20:07:36.4046-08:00","caller":"volume/manager.go:263","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-61cffeeb-1b1b-4515-af8e-b46c7bc86e65\", opId: \"\", volumeID: \"7d3e19cf-c363-46f6-a423-cddd331ff881\"","TraceId":"eafbbafa-8827-484e-991f-860ba9ec7a43"}
{"level":"info","time":"2020-11-11T20:07:36.408637-08:00","caller":"vanilla/controller.go:580","msg":"DeleteVolume: called with args: {VolumeId:7d3e19cf-c363-46f6-a423-cddd331ff881 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"4b37e5a5-48e8-4667-9a5c-99f81ef04862"}
{"level":"info","time":"2020-11-11T20:07:36.414988-08:00","caller":"volume/manager.go:463","msg":"DeleteVolume: volumeID: \"7d3e19cf-c363-46f6-a423-cddd331ff881\", opId: \"\"","TraceId":"4b37e5a5-48e8-4667-9a5c-99f81ef04862"}
{"level":"info","time":"2020-11-11T20:07:36.41503-08:00","caller":"volume/manager.go:481","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"7d3e19cf-c363-46f6-a423-cddd331ff881\", opId: \"\"","TraceId":"4b37e5a5-48e8-4667-9a5c-99f81ef04862"}
--- PASS: TestCreateVolumeWithStoragePolicy (0.06s)
=== RUN   TestCreateVolumeWithMultipleDatastores
{"level":"info","time":"2020-11-11T20:07:36.415668-08:00","caller":"vanilla/controller.go:554","msg":"CreateVolume: called with args {Name:test-pvc-d8731ace-8d1e-44f5-a0a9-d2610f427e52 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"39c71086-0cbb-4d82-9da2-bd72f19d420c"}
{"level":"info","time":"2020-11-11T20:07:36.42283-08:00","caller":"volume/manager.go:215","msg":"CreateVolume: VolumeName: \"test-pvc-d8731ace-8d1e-44f5-a0a9-d2610f427e52\", opId: \"\"","TraceId":"39c71086-0cbb-4d82-9da2-bd72f19d420c"}
{"level":"info","time":"2020-11-11T20:07:36.422856-08:00","caller":"volume/manager.go:263","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-d8731ace-8d1e-44f5-a0a9-d2610f427e52\", opId: \"\", volumeID: \"4b08f964-f190-42fa-98f3-3622bbc932f5\"","TraceId":"39c71086-0cbb-4d82-9da2-bd72f19d420c"}
{"level":"info","time":"2020-11-11T20:07:36.423353-08:00","caller":"vanilla/controller.go:580","msg":"DeleteVolume: called with args: {VolumeId:4b08f964-f190-42fa-98f3-3622bbc932f5 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"2c941058-a702-4fc9-a129-6fabe5ab5c37"}
{"level":"info","time":"2020-11-11T20:07:36.425357-08:00","caller":"volume/manager.go:463","msg":"DeleteVolume: volumeID: \"4b08f964-f190-42fa-98f3-3622bbc932f5\", opId: \"\"","TraceId":"2c941058-a702-4fc9-a129-6fabe5ab5c37"}
{"level":"info","time":"2020-11-11T20:07:36.425375-08:00","caller":"volume/manager.go:481","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"4b08f964-f190-42fa-98f3-3622bbc932f5\", opId: \"\"","TraceId":"2c941058-a702-4fc9-a129-6fabe5ab5c37"}
--- PASS: TestCreateVolumeWithMultipleDatastores (0.01s)
=== RUN   TestExtendVolume
{"level":"info","time":"2020-11-11T20:07:36.42592-08:00","caller":"vanilla/controller.go:554","msg":"CreateVolume: called with args {Name:test-pvc-de2f0ae0-f1fc-4c0e-bdb5-0cbb022ca1c4 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"f2e78fd9-ed07-4cf4-af85-f1ed31290fd9"}
{"level":"info","time":"2020-11-11T20:07:36.431234-08:00","caller":"volume/manager.go:215","msg":"CreateVolume: VolumeName: \"test-pvc-de2f0ae0-f1fc-4c0e-bdb5-0cbb022ca1c4\", opId: \"\"","TraceId":"f2e78fd9-ed07-4cf4-af85-f1ed31290fd9"}
{"level":"info","time":"2020-11-11T20:07:36.431283-08:00","caller":"volume/manager.go:263","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-de2f0ae0-f1fc-4c0e-bdb5-0cbb022ca1c4\", opId: \"\", volumeID: \"7a0ebdf3-c81d-4aee-ac89-c6c9e50dcd8a\"","TraceId":"f2e78fd9-ed07-4cf4-af85-f1ed31290fd9"}
{"level":"info","time":"2020-11-11T20:07:36.432401-08:00","caller":"vanilla/controller.go:813","msg":"ControllerExpandVolume: called with args {VolumeId:7a0ebdf3-c81d-4aee-ac89-c6c9e50dcd8a CapacityRange:required_bytes:2147483648  Secrets:map[] VolumeCapability:access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"8cab1b25-2a68-45e7-bdd1-fb79fa909b82"}
{"level":"info","time":"2020-11-11T20:07:36.432424-08:00","caller":"node/manager.go:75","msg":"Initializing node.defaultManager...","TraceId":"8cab1b25-2a68-45e7-bdd1-fb79fa909b82"}
{"level":"info","time":"2020-11-11T20:07:36.432434-08:00","caller":"node/manager.go:79","msg":"node.defaultManager initialized","TraceId":"8cab1b25-2a68-45e7-bdd1-fb79fa909b82"}
{"level":"info","time":"2020-11-11T20:07:36.433501-08:00","caller":"common/vsphereutil.go:484","msg":"Requested size 2048 Mb is greater than current size for volumeID: \"7a0ebdf3-c81d-4aee-ac89-c6c9e50dcd8a\". Need volume expansion.","TraceId":"8cab1b25-2a68-45e7-bdd1-fb79fa909b82"}
{"level":"info","time":"2020-11-11T20:07:36.433827-08:00","caller":"volume/manager.go:573","msg":"Calling CnsClient.ExtendVolume: VolumeID [\"7a0ebdf3-c81d-4aee-ac89-c6c9e50dcd8a\"] Size [2048] cnsExtendSpecList [[]types.CnsVolumeExtendSpec{types.CnsVolumeExtendSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:\"7a0ebdf3-c81d-4aee-ac89-c6c9e50dcd8a\"}, CapacityInMb:2048}}]","TraceId":"8cab1b25-2a68-45e7-bdd1-fb79fa909b82"}
{"level":"info","time":"2020-11-11T20:07:36.435263-08:00","caller":"volume/manager.go:589","msg":"ExpandVolume: volumeID: \"7a0ebdf3-c81d-4aee-ac89-c6c9e50dcd8a\", opId: \"\"","TraceId":"8cab1b25-2a68-45e7-bdd1-fb79fa909b82"}
{"level":"info","time":"2020-11-11T20:07:36.435281-08:00","caller":"volume/manager.go:607","msg":"ExpandVolume: Volume expanded successfully. volumeID: \"7a0ebdf3-c81d-4aee-ac89-c6c9e50dcd8a\", opId: \"\"","TraceId":"8cab1b25-2a68-45e7-bdd1-fb79fa909b82"}
{"level":"info","time":"2020-11-11T20:07:36.435296-08:00","caller":"common/vsphereutil.go:490","msg":"Successfully expanded volume for volumeid \"7a0ebdf3-c81d-4aee-ac89-c6c9e50dcd8a\" to new size 2048 Mb.","TraceId":"8cab1b25-2a68-45e7-bdd1-fb79fa909b82"}
{"level":"info","time":"2020-11-11T20:07:36.435833-08:00","caller":"vanilla/controller.go:580","msg":"DeleteVolume: called with args: {VolumeId:7a0ebdf3-c81d-4aee-ac89-c6c9e50dcd8a Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"83d2a74d-b5b8-45cc-b17a-2844b2b6fdeb"}
{"level":"info","time":"2020-11-11T20:07:36.437401-08:00","caller":"volume/manager.go:463","msg":"DeleteVolume: volumeID: \"7a0ebdf3-c81d-4aee-ac89-c6c9e50dcd8a\", opId: \"\"","TraceId":"83d2a74d-b5b8-45cc-b17a-2844b2b6fdeb"}
{"level":"info","time":"2020-11-11T20:07:36.437417-08:00","caller":"volume/manager.go:481","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"7a0ebdf3-c81d-4aee-ac89-c6c9e50dcd8a\", opId: \"\"","TraceId":"83d2a74d-b5b8-45cc-b17a-2844b2b6fdeb"}
--- PASS: TestExtendVolume (0.01s)
    controller_test.go:578: ControllerExpandVolume will be called with req +{7a0ebdf3-c81d-4aee-ac89-c6c9e50dcd8a required_bytes:2147483648  map[] access_mode:<mode:SINGLE_NODE_WRITER >  {} [] 0}
    controller_test.go:586: ControllerExpandVolume succeeded: volume is expanded to requested size 2147483648
=== RUN   TestMigratedExtendVolume
{"level":"info","time":"2020-11-11T20:07:36.437995-08:00","caller":"vanilla/controller.go:813","msg":"ControllerExpandVolume: called with args {VolumeId:[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk CapacityRange:required_bytes:1024  Secrets:map[] VolumeCapability:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"5226f296-3c97-47ad-9a0e-673fbddf5449"}
{"level":"error","time":"2020-11-11T20:07:36.438009-08:00","caller":"vanilla/controller.go:817","msg":"Cannot expand migrated vSphere volume. :\"[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk\"","TraceId":"5226f296-3c97-47ad-9a0e-673fbddf5449","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.(*controller).ControllerExpandVolume\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/vanilla/controller.go:817\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.TestMigratedExtendVolume\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/vanilla/controller_test.go:635\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestMigratedExtendVolume (0.00s)
    controller_test.go:634: ControllerExpandVolume will be called with req +{[vsanDatastore] 08281a5f-a21d-1eff-62d6-02009d0f19a1/004dbb1694f14e3598abef852b113e3b.vmdk required_bytes:1024  map[] <nil> {} [] 0}
    controller_test.go:637: Expected error received. migrated volume with VMDK path can not be expanded
=== RUN   TestCompleteControllerFlow
{"level":"info","time":"2020-11-11T20:07:36.43829-08:00","caller":"vanilla/controller.go:554","msg":"CreateVolume: called with args {Name:test-pvc-ccab65c2-5f2d-429c-9aa2-42dacc4b3b29 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"7def85c5-d6b8-4bf7-a0c9-8819df0b0be8"}
{"level":"info","time":"2020-11-11T20:07:36.44352-08:00","caller":"volume/manager.go:215","msg":"CreateVolume: VolumeName: \"test-pvc-ccab65c2-5f2d-429c-9aa2-42dacc4b3b29\", opId: \"\"","TraceId":"7def85c5-d6b8-4bf7-a0c9-8819df0b0be8"}
{"level":"info","time":"2020-11-11T20:07:36.443541-08:00","caller":"volume/manager.go:263","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-ccab65c2-5f2d-429c-9aa2-42dacc4b3b29\", opId: \"\", volumeID: \"9df6c5d9-0a1c-4e80-867b-53fba9c30927\"","TraceId":"7def85c5-d6b8-4bf7-a0c9-8819df0b0be8"}
{"level":"info","time":"2020-11-11T20:07:36.44419-08:00","caller":"vanilla/controller.go:637","msg":"ControllerPublishVolume: called with args {VolumeId:9df6c5d9-0a1c-4e80-867b-53fba9c30927 NodeId:DC0_H0_VM0 VolumeCapability:access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"74997ea5-406b-4f82-8208-678ae2bcc670"}
{"level":"info","time":"2020-11-11T20:07:36.445725-08:00","caller":"volume/manager.go:303","msg":"AttachVolume: volumeID: \"9df6c5d9-0a1c-4e80-867b-53fba9c30927\", vm: \"VirtualMachine:vm-66 [VirtualCenterHost: , UUID: , Datacenter: <nil>]\", opId: \"\"","TraceId":"74997ea5-406b-4f82-8208-678ae2bcc670"}
{"level":"info","time":"2020-11-11T20:07:36.445754-08:00","caller":"volume/manager.go:336","msg":"AttachVolume: Volume attached successfully. volumeID: \"9df6c5d9-0a1c-4e80-867b-53fba9c30927\", opId: \"\", vm: \"VirtualMachine:vm-66 [VirtualCenterHost: , UUID: , Datacenter: <nil>]\", diskUUID: \"6000c298595bf4575739e9105b2c0c2d\"","TraceId":"74997ea5-406b-4f82-8208-678ae2bcc670"}
{"level":"info","time":"2020-11-11T20:07:36.445827-08:00","caller":"vanilla/controller.go:731","msg":"ControllerUnpublishVolume: called with args {VolumeId:9df6c5d9-0a1c-4e80-867b-53fba9c30927 NodeId:DC0_H0_VM0 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"27e57c98-a562-455a-bc19-04d0ae07d1db"}
{"level":"info","time":"2020-11-11T20:07:36.448022-08:00","caller":"volume/manager.go:394","msg":"DetachVolume: volumeID: \"9df6c5d9-0a1c-4e80-867b-53fba9c30927\", vm: \"VirtualMachine:vm-63 [VirtualCenterHost: , UUID: , Datacenter: <nil>]\", opId: \"\"","TraceId":"27e57c98-a562-455a-bc19-04d0ae07d1db"}
{"level":"info","time":"2020-11-11T20:07:36.44805-08:00","caller":"volume/manager.go:424","msg":"DetachVolume: Volume detached successfully. volumeID: \"9df6c5d9-0a1c-4e80-867b-53fba9c30927\", vm: \"\", opId: \"VirtualMachine:vm-63 [VirtualCenterHost: , UUID: , Datacenter: <nil>]\"","TraceId":"27e57c98-a562-455a-bc19-04d0ae07d1db"}
{"level":"info","time":"2020-11-11T20:07:36.448122-08:00","caller":"vanilla/controller.go:580","msg":"DeleteVolume: called with args: {VolumeId:9df6c5d9-0a1c-4e80-867b-53fba9c30927 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"6903ef8c-9e19-47ab-9852-17c23d11664b"}
{"level":"info","time":"2020-11-11T20:07:36.450263-08:00","caller":"volume/manager.go:463","msg":"DeleteVolume: volumeID: \"9df6c5d9-0a1c-4e80-867b-53fba9c30927\", opId: \"\"","TraceId":"6903ef8c-9e19-47ab-9852-17c23d11664b"}
{"level":"info","time":"2020-11-11T20:07:36.45028-08:00","caller":"volume/manager.go:481","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"9df6c5d9-0a1c-4e80-867b-53fba9c30927\", opId: \"\"","TraceId":"6903ef8c-9e19-47ab-9852-17c23d11664b"}
--- PASS: TestCompleteControllerFlow (0.01s)
    controller_test.go:723: ControllerPublishVolume will be called with req +{9df6c5d9-0a1c-4e80-867b-53fba9c30927 DC0_H0_VM0 access_mode:<mode:SINGLE_NODE_WRITER >  false map[] map[] {} [] 0}
    controller_test.go:729: ControllerPublishVolume succeed, diskUUID 6000c298595bf4575739e9105b2c0c2d is returned
    controller_test.go:736: ControllerUnpublishVolume will be called with req +{9df6c5d9-0a1c-4e80-867b-53fba9c30927 DC0_H0_VM0 map[] {} [] 0}
    controller_test.go:741: ControllerUnpublishVolume succeed
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla	0.138s
=== RUN   TestWCPCreateVolumeWithStoragePolicy
{"level":"error","time":"2020-11-11T20:07:36.155098-08:00","caller":"config/config.go:254","msg":"no Virtual Center hosts defined","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:254\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.FromEnv\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:238\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp.configFromEnvOrSim\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:124\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp.getControllerTest.func1\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:134\nsync.(*Once).doSlow\n\t/usr/local/go/src/sync/once.go:66\nsync.(*Once).Do\n\t/usr/local/go/src/sync/once.go:57\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp.getControllerTest\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:131\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp.TestWCPCreateVolumeWithStoragePolicy\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:252\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
{"level":"info","time":"2020-11-11T20:07:36.188666-08:00","caller":"vsphere/utils.go:126","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2020-11-11T20:07:36.188794-08:00","caller":"vsphere/virtualcentermanager.go:64","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2020-11-11T20:07:36.18881-08:00","caller":"vsphere/virtualcentermanager.go:66","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2020-11-11T20:07:36.188914-08:00","caller":"vsphere/virtualcentermanager.go:110","msg":"Successfully registered VC \"127.0.0.1\""}
{"level":"info","time":"2020-11-11T20:07:36.194022-08:00","caller":"vsphere/virtualcenter.go:153","msg":"New session ID for 'user' = 49af64dd-22fa-4607-89bc-792df3fb73bb"}
{"level":"info","time":"2020-11-11T20:07:36.194429-08:00","caller":"volume/manager.go:100","msg":"Initializing new volume.defaultManager..."}
{"level":"info","time":"2020-11-11T20:07:36.19775-08:00","caller":"wcp/controller.go:413","msg":"CreateVolume: called with args {Name:test-pvc-fce23b98-4ecb-4bf3-a42f-b6352366a822 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[storagepolicyid:aa6d5a82-1c88-45da-85d3-3d74b91a5bad] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"35361899-ad88-4f3b-95de-7616376d4316"}
{"level":"info","time":"2020-11-11T20:07:36.205512-08:00","caller":"volume/manager.go:215","msg":"CreateVolume: VolumeName: \"test-pvc-fce23b98-4ecb-4bf3-a42f-b6352366a822\", opId: \"\"","TraceId":"35361899-ad88-4f3b-95de-7616376d4316"}
{"level":"info","time":"2020-11-11T20:07:36.205536-08:00","caller":"volume/manager.go:263","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc-fce23b98-4ecb-4bf3-a42f-b6352366a822\", opId: \"\", volumeID: \"b37d4de1-0f3c-4dac-8e68-c611f66358c3\"","TraceId":"35361899-ad88-4f3b-95de-7616376d4316"}
{"level":"info","time":"2020-11-11T20:07:36.206588-08:00","caller":"wcp/controller.go:439","msg":"DeleteVolume: called with args: {VolumeId:b37d4de1-0f3c-4dac-8e68-c611f66358c3 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"5aa03a0b-af5b-468d-b21d-bcd606eef261"}
{"level":"info","time":"2020-11-11T20:07:36.208873-08:00","caller":"volume/manager.go:463","msg":"DeleteVolume: volumeID: \"b37d4de1-0f3c-4dac-8e68-c611f66358c3\", opId: \"\"","TraceId":"5aa03a0b-af5b-468d-b21d-bcd606eef261"}
{"level":"info","time":"2020-11-11T20:07:36.208895-08:00","caller":"volume/manager.go:481","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"b37d4de1-0f3c-4dac-8e68-c611f66358c3\", opId: \"\"","TraceId":"5aa03a0b-af5b-468d-b21d-bcd606eef261"}
--- PASS: TestWCPCreateVolumeWithStoragePolicy (0.05s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcp	0.110s
=== RUN   TestGuestClusterControllerFlow
{"level":"error","time":"2020-11-11T20:07:36.05551-08:00","caller":"config/config.go:468","msg":"no Supervisor Cluster endpoint defined in Guest Cluster config","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateGCConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:468\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.FromEnvToGC\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:409\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.configFromEnvOrSim\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcpguest/controller_test.go:67\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.getControllerTest.func1\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcpguest/controller_test.go:83\nsync.(*Once).doSlow\n\t/usr/local/go/src/sync/once.go:66\nsync.(*Once).Do\n\t/usr/local/go/src/sync/once.go:57\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.getControllerTest\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcpguest/controller_test.go:80\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest.TestGuestClusterControllerFlow\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/csi/service/wcpguest/controller_test.go:112\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
{"level":"info","time":"2020-11-11T20:07:36.057327-08:00","caller":"wcpguest/controller.go:188","msg":"CreateVolume: called with args {Name:pvc-12345 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[svstorageclass:test-storageclass] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"8b5d54e1-71ea-40aa-ad48-f8a547ef0713"}
{"level":"info","time":"2020-11-11T20:07:36.057556-08:00","caller":"wcpguest/controller_helper.go:196","msg":"Waiting up to 240 seconds for PersistentVolumeClaim -12345 in namespace test-namespace to have phase Bound","TraceId":"8b5d54e1-71ea-40aa-ad48-f8a547ef0713"}
{"level":"info","time":"2020-11-11T20:07:37.056121-08:00","caller":"wcpguest/controller_helper.go:218","msg":"PersistentVolumeClaim -12345 in namespace test-namespace is in state Bound","TraceId":"8b5d54e1-71ea-40aa-ad48-f8a547ef0713"}
{"level":"info","time":"2020-11-11T20:07:37.056368-08:00","caller":"wcpguest/controller.go:257","msg":"DeleteVolume: called with args: {VolumeId:-12345 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"283b38a5-55d9-4755-808c-e8a09fbd67c2"}
{"level":"info","time":"2020-11-11T20:07:37.056389-08:00","caller":"wcpguest/controller.go:275","msg":"DeleteVolume: Volume deleted successfully. VolumeID: \"-12345\"","TraceId":"283b38a5-55d9-4755-808c-e8a09fbd67c2"}
--- PASS: TestGuestClusterControllerFlow (2.01s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/wcpguest	2.054s
=== RUN   TestSyncerWorkflows
{"level":"error","time":"2020-11-11T20:07:36.366078-08:00","caller":"config/config.go:254","msg":"no Virtual Center hosts defined","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/common/config.validateConfig\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:254\nsigs.k8s.io/vsphere-csi-driver/pkg/common/config.FromEnv\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/common/config/config.go:238\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer.configFromEnvOrSim\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/syncer/syncer_test.go:149\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer.TestSyncerWorkflows\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/syncer/syncer_test.go:162\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
{"level":"info","time":"2020-11-11T20:07:36.394445-08:00","caller":"vsphere/utils.go:126","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2020-11-11T20:07:36.394551-08:00","caller":"vsphere/virtualcentermanager.go:64","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2020-11-11T20:07:36.394567-08:00","caller":"vsphere/virtualcentermanager.go:66","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2020-11-11T20:07:36.394696-08:00","caller":"vsphere/virtualcentermanager.go:110","msg":"Successfully registered VC \"127.0.0.1\""}
{"level":"info","time":"2020-11-11T20:07:36.399386-08:00","caller":"vsphere/virtualcenter.go:153","msg":"New session ID for 'user' = fa709267-71f4-4d67-ba4d-df34d08fed43"}
{"level":"info","time":"2020-11-11T20:07:36.399619-08:00","caller":"volume/manager.go:100","msg":"Initializing new volume.defaultManager..."}
{"level":"info","time":"2020-11-11T20:07:36.399773-08:00","caller":"volume/manager.go:97","msg":"Retrieving existing volume.defaultManager..."}
{"level":"info","time":"2020-11-11T20:07:36.407491-08:00","caller":"volume/manager.go:215","msg":"CreateVolume: VolumeName: \"test-pvc\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:36.407527-08:00","caller":"volume/manager.go:263","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pvc\", opId: \"\", volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\""}
{"level":"info","time":"2020-11-11T20:07:36.41453-08:00","caller":"volume/manager.go:527","msg":"UpdateVolumeMetadata: volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\"","TraceId":"923924f2-1d43-4b4c-af29-cf016929ae9b"}
{"level":"info","time":"2020-11-11T20:07:36.414577-08:00","caller":"volume/manager.go:545","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\"","TraceId":"923924f2-1d43-4b4c-af29-cf016929ae9b"}
{"level":"info","time":"2020-11-11T20:07:36.418802-08:00","caller":"volume/manager.go:463","msg":"DeleteVolume: volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:36.418838-08:00","caller":"volume/manager.go:481","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:36.421794-08:00","caller":"syncer/metadatasyncer.go:898","msg":"PVUpdated: Verified volume: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\" is not marked as container volume in CNS. Calling CreateVolume with BackingID to mark volume as Container Volume.","TraceId":"e3218829-f18a-46bb-98fc-acdf30a4cbc8"}
{"level":"info","time":"2020-11-11T20:07:36.424458-08:00","caller":"volume/manager.go:215","msg":"CreateVolume: VolumeName: \"test-pv-2eae2c47-89cc-422f-a90c-2480f100f87a\", opId: \"\"","TraceId":"e3218829-f18a-46bb-98fc-acdf30a4cbc8"}
{"level":"info","time":"2020-11-11T20:07:36.424481-08:00","caller":"volume/manager.go:263","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pv-2eae2c47-89cc-422f-a90c-2480f100f87a\", opId: \"\", volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\"","TraceId":"e3218829-f18a-46bb-98fc-acdf30a4cbc8"}
{"level":"info","time":"2020-11-11T20:07:36.424492-08:00","caller":"syncer/metadatasyncer.go:927","msg":"PVUpdated: vSphere CSI Driver has successfully marked volume: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\" as the container volume.","TraceId":"e3218829-f18a-46bb-98fc-acdf30a4cbc8"}
{"level":"info","time":"2020-11-11T20:07:42.435211-08:00","caller":"syncer/metadatasyncer.go:764","msg":"PVCUpdated: volume \"e7ebbe33-f635-4f55-b7a5-133515e3612b\" found","TraceId":"09609f98-f54b-433a-a19e-33fb58e07cc9"}
{"level":"info","time":"2020-11-11T20:07:42.438501-08:00","caller":"volume/manager.go:527","msg":"UpdateVolumeMetadata: volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\"","TraceId":"09609f98-f54b-433a-a19e-33fb58e07cc9"}
{"level":"info","time":"2020-11-11T20:07:42.438528-08:00","caller":"volume/manager.go:545","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\"","TraceId":"09609f98-f54b-433a-a19e-33fb58e07cc9"}
{"level":"info","time":"2020-11-11T20:07:42.441453-08:00","caller":"volume/manager.go:527","msg":"UpdateVolumeMetadata: volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\"","TraceId":"f2e7edab-bddf-44a6-80f8-1c9345c3ecbc"}
{"level":"info","time":"2020-11-11T20:07:42.441472-08:00","caller":"volume/manager.go:545","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\"","TraceId":"f2e7edab-bddf-44a6-80f8-1c9345c3ecbc"}
{"level":"info","time":"2020-11-11T20:07:42.444303-08:00","caller":"volume/manager.go:527","msg":"UpdateVolumeMetadata: volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\"","TraceId":"b723a13e-f74b-4a66-b598-2e1c39d42810"}
{"level":"info","time":"2020-11-11T20:07:42.44432-08:00","caller":"volume/manager.go:545","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\"","TraceId":"b723a13e-f74b-4a66-b598-2e1c39d42810"}
{"level":"info","time":"2020-11-11T20:07:43.453265-08:00","caller":"volume/manager.go:527","msg":"UpdateVolumeMetadata: volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\"","TraceId":"69292edf-bc05-4c66-a921-d333dce655aa"}
{"level":"info","time":"2020-11-11T20:07:43.453291-08:00","caller":"volume/manager.go:545","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\"","TraceId":"69292edf-bc05-4c66-a921-d333dce655aa"}
{"level":"info","time":"2020-11-11T20:07:43.456476-08:00","caller":"volume/manager.go:463","msg":"DeleteVolume: volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\"","TraceId":"c966e38e-2d9d-492a-8b2a-3678a4983c93"}
{"level":"info","time":"2020-11-11T20:07:43.456509-08:00","caller":"volume/manager.go:481","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"e7ebbe33-f635-4f55-b7a5-133515e3612b\", opId: \"\"","TraceId":"c966e38e-2d9d-492a-8b2a-3678a4983c93"}
{"level":"info","time":"2020-11-11T20:07:43.46051-08:00","caller":"volume/manager.go:215","msg":"CreateVolume: VolumeName: \"test-pv\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:43.460556-08:00","caller":"volume/manager.go:263","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pv\", opId: \"\", volumeID: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\""}
{"level":"info","time":"2020-11-11T20:07:44.46171-08:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"warn","time":"2020-11-11T20:07:44.464329-08:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS"}
{"level":"info","time":"2020-11-11T20:07:44.46486-08:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-11-11T20:07:44.465158-08:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-11-11T20:07:44.465384-08:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"warn","time":"2020-11-11T20:07:44.468434-08:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS"}
{"level":"info","time":"2020-11-11T20:07:44.470851-08:00","caller":"syncer/util.go:149","msg":"0 more volumes to be queried"}
{"level":"info","time":"2020-11-11T20:07:44.47088-08:00","caller":"syncer/util.go:151","msg":"Metadata retrieved for all requested volumes"}
{"level":"info","time":"2020-11-11T20:07:44.470909-08:00","caller":"syncer/fullsync.go:248","msg":"FullSync: fullSyncDeleteVolumes: Calling DeleteVolume for volume 1a2c544f-db55-4716-93bd-52ed26f1b6e0 with delete disk false"}
{"level":"info","time":"2020-11-11T20:07:44.473629-08:00","caller":"volume/manager.go:463","msg":"DeleteVolume: volumeID: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:44.473647-08:00","caller":"volume/manager.go:481","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:44.473699-08:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-11-11T20:07:45.476789-08:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"warn","time":"2020-11-11T20:07:45.478453-08:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS"}
{"level":"info","time":"2020-11-11T20:07:45.478908-08:00","caller":"syncer/fullsync.go:411","msg":"FullSync: Volume with id: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\" and name: \"test-pv-34bcd989-7a08-4a5a-ad0a-cb1641e3603d\" is added to cnsCreationMap"}
{"level":"info","time":"2020-11-11T20:07:45.480063-08:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-11-11T20:07:45.480157-08:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-11-11T20:07:45.480209-08:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"warn","time":"2020-11-11T20:07:45.481664-08:00","caller":"syncer/fullsync.go:353","msg":"could not find any volume which is present in both k8s and in CNS"}
{"level":"info","time":"2020-11-11T20:07:45.481765-08:00","caller":"syncer/fullsync.go:408","msg":"FullSync: create is required for volume: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\", as volume was present in cnsCreationMap across two full-sync cycles"}
{"level":"info","time":"2020-11-11T20:07:45.482549-08:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-11-11T20:07:45.485756-08:00","caller":"volume/manager.go:215","msg":"CreateVolume: VolumeName: \"test-pv-34bcd989-7a08-4a5a-ad0a-cb1641e3603d\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:45.485776-08:00","caller":"volume/manager.go:263","msg":"CreateVolume: Volume created successfully. VolumeName: \"test-pv-34bcd989-7a08-4a5a-ad0a-cb1641e3603d\", opId: \"\", volumeID: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\""}
{"level":"info","time":"2020-11-11T20:07:45.485794-08:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-11-11T20:07:46.487109-08:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"info","time":"2020-11-11T20:07:46.49148-08:00","caller":"syncer/util.go:149","msg":"0 more volumes to be queried"}
{"level":"info","time":"2020-11-11T20:07:46.491509-08:00","caller":"syncer/util.go:151","msg":"Metadata retrieved for all requested volumes"}
{"level":"info","time":"2020-11-11T20:07:46.491976-08:00","caller":"syncer/fullsync.go:417","msg":"FullSync: update is required for volume: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\""}
{"level":"info","time":"2020-11-11T20:07:46.492673-08:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-11-11T20:07:46.496252-08:00","caller":"volume/manager.go:527","msg":"UpdateVolumeMetadata: volumeID: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:46.496272-08:00","caller":"volume/manager.go:545","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:46.496286-08:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-11-11T20:07:47.501474-08:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"info","time":"2020-11-11T20:07:47.504705-08:00","caller":"syncer/util.go:149","msg":"0 more volumes to be queried"}
{"level":"info","time":"2020-11-11T20:07:47.504731-08:00","caller":"syncer/util.go:151","msg":"Metadata retrieved for all requested volumes"}
{"level":"info","time":"2020-11-11T20:07:47.505605-08:00","caller":"syncer/fullsync.go:417","msg":"FullSync: update is required for volume: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\""}
{"level":"info","time":"2020-11-11T20:07:47.505992-08:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-11-11T20:07:47.509467-08:00","caller":"volume/manager.go:527","msg":"UpdateVolumeMetadata: volumeID: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:47.509488-08:00","caller":"volume/manager.go:545","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:47.509501-08:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-11-11T20:07:48.511492-08:00","caller":"syncer/fullsync.go:38","msg":"FullSync: start"}
{"level":"info","time":"2020-11-11T20:07:48.51621-08:00","caller":"syncer/util.go:149","msg":"0 more volumes to be queried"}
{"level":"info","time":"2020-11-11T20:07:48.516236-08:00","caller":"syncer/util.go:151","msg":"Metadata retrieved for all requested volumes"}
{"level":"info","time":"2020-11-11T20:07:48.516589-08:00","caller":"syncer/fullsync.go:417","msg":"FullSync: update is required for volume: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\""}
{"level":"info","time":"2020-11-11T20:07:48.517534-08:00","caller":"syncer/fullsync.go:228","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion."}
{"level":"info","time":"2020-11-11T20:07:48.52106-08:00","caller":"volume/manager.go:527","msg":"UpdateVolumeMetadata: volumeID: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:48.52108-08:00","caller":"volume/manager.go:545","msg":"UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:48.521092-08:00","caller":"syncer/fullsync.go:127","msg":"FullSync: end"}
{"level":"info","time":"2020-11-11T20:07:48.523873-08:00","caller":"volume/manager.go:463","msg":"DeleteVolume: volumeID: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\", opId: \"\""}
{"level":"info","time":"2020-11-11T20:07:48.523894-08:00","caller":"volume/manager.go:481","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"1a2c544f-db55-4716-93bd-52ed26f1b6e0\", opId: \"\""}
--- PASS: TestSyncerWorkflows (12.16s)
    syncer_test.go:160: TestSyncerWorkflows: start
    syncer_test.go:278: TestMetadataSyncInformer start
    syncer_test.go:459: TestMetadataSyncInformer end
    syncer_test.go:607: TestFullSyncWorkflows start
    syncer_test.go:788: TestFullSyncWorkflows end
    syncer_test.go:248: TestSyncerWorkflows: end
=== RUN   TestValidMigratedAndLegacyVolume
--- PASS: TestValidMigratedAndLegacyVolume (0.00s)
=== RUN   TestGetSCNameFromPVC
--- PASS: TestGetSCNameFromPVC (0.00s)
    util_test.go:105: testGetSCNameFromPVC: start
    util_test.go:119: Verifying GetSCNameFromPVC for case where SC name is provided through only Spec.StorageClassName
    util_test.go:129: Verifying GetSCNameFromPVC for case where SC name is provided through only Metadata.Annotation
    util_test.go:140: Verifying GetSCNameFromPVC for case where SC name is provided through both Spec.StorageClassName and Metadata.Annotation
    util_test.go:151: Verifying GetSCNameFromPVC for case where SC name is provided through neither Spec.StorageClassName nor Metadata.Annotation
    util_test.go:160: testGetSCNameFromPVC: end
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/syncer	12.204s
=== RUN   TestValidateStorageClassForAllowVolumeExpansion
{"level":"info","time":"2020-11-11T20:07:35.948656-08:00","caller":"admissionhandler/validatestorageclass.go:75","msg":"Validating StorageClass: \"sc\""}
{"level":"error","time":"2020-11-11T20:07:35.948791-08:00","caller":"admissionhandler/validatestorageclass.go:99","msg":"validation of StorageClass: \"sc\" Failed","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler.validateStorageClass\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/syncer/admissionhandler/validatestorageclass.go:99\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler.TestValidateStorageClassForAllowVolumeExpansion\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/syncer/admissionhandler/validatestorageclass_test.go:45\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestValidateStorageClassForAllowVolumeExpansion (0.00s)
    validatestorageclass_test.go:49: TestValidateStorageClassForAllowVolumeExpansion Passed
=== RUN   TestValidateStorageClassForMigrationParameter
{"level":"info","time":"2020-11-11T20:07:35.949031-08:00","caller":"admissionhandler/validatestorageclass.go:75","msg":"Validating StorageClass: \"sc\""}
{"level":"error","time":"2020-11-11T20:07:35.949049-08:00","caller":"admissionhandler/validatestorageclass.go:99","msg":"validation of StorageClass: \"sc\" Failed","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler.validateStorageClass\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/syncer/admissionhandler/validatestorageclass.go:99\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler.TestValidateStorageClassForMigrationParameter\n\t/Users/chethanv/Downloads/csi-external/vsphere-csi-driver/pkg/syncer/admissionhandler/validatestorageclass_test.go:60\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909"}
--- PASS: TestValidateStorageClassForMigrationParameter (0.00s)
    validatestorageclass_test.go:64: TestValidateStorageClassForMigrationParameter Passed
=== RUN   TestValidateStorageClassForValidStorageClass
{"level":"info","time":"2020-11-11T20:07:35.949219-08:00","caller":"admissionhandler/validatestorageclass.go:75","msg":"Validating StorageClass: \"sc\""}
{"level":"info","time":"2020-11-11T20:07:35.949235-08:00","caller":"admissionhandler/validatestorageclass.go:97","msg":"Validation of StorageClass: \"sc\" Passed"}
--- PASS: TestValidateStorageClassForValidStorageClass (0.00s)
    validatestorageclass_test.go:79: TestValidateStorageClassForValidStorageClass Passed
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/syncer/admissionhandler	0.056s
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix unit tests
```
