### PR TITLE
add thumprint support for vsphere csi driver

### DIFF
--- a/docs/book/driver-deployment/installation.md
+++ b/docs/book/driver-deployment/installation.md
@@ -54,13 +54,14 @@ Here is an example vSphere configuration file for block volumes, with dummy valu
 $ cat /etc/kubernetes/csi-vsphere.conf
 [Global]
 cluster-id = "<cluster-id>"
+ca-file = <ca file path> # optional, use with insecure-flag set to false
+thumbprint = "<cert thumbprint>" # optional, use with insecure-flag set to false without providing ca-file
 
 [VirtualCenter "<IP or FQDN>"]
 insecure-flag = "<true or false>"
 user = "<username>"
 password = "<password>"
 port = "<port>"
-ca-file = <ca file path> # optional, use with insecure-flag set to false
 datacenters = "<datacenter1-path>, <datacenter2-path>, ..."
 ```
 
@@ -80,6 +81,8 @@ Where the entries have the following meaning:
 
 - `ca-file` - path to a CA certificate in PEM format. It is an optional parameter.
 
+- `Thumbprint` - the certificate thumbprint. It is an optional parameter and is ignored when you're using insecure setups or when you provide `ca-file`
+
 - `datacenters` - list of all comma separated datacenter paths where kubernetes node VMs are present. When datacenter is located at the root, the name of datacenter is enough but when datacenter is placed in the folder, path needs to be specified as `folder/datacenter-name`.
 Please note since comma is used as a delimiter, the datacenter name itself must not contain a comma.
 
@@ -91,6 +94,7 @@ For file volumes, there are some extra parameters added to the config to help sp
 $ cat /etc/kubernetes/csi-vsphere.conf
 [Global]
 cluster-id = "<cluster-id>"
+ca-file = <ca file path> # optional, use with insecure-flag set to false
 
 [NetPermissions "A"]
 ips = "*"
@@ -118,7 +122,6 @@ insecure-flag = "<true or false>"
 user = "<username>"
 password = "<password>"
 port = "<port>"
-ca-file = <ca file path> # optional, use with insecure-flag set to false
 datacenters = "<datacenter1-path>, <datacenter2-path>, ..."
 targetvSANFileShareDatastoreURLs = "ds:///vmfs/volumes/vsan:52635b9067079319-95a7473222c4c9cd/" # Optional
 ```

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -133,9 +133,14 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 	}
 	vcClientTimeout = cfg.Global.VCClientTimeout
 
+	vcCAFile := cfg.Global.CAFile
+	vcThumbprint := cfg.Global.Thumbprint
+
 	vcConfig := &VirtualCenterConfig{
 		Host:                             host,
 		Port:                             port,
+		CAFile:                           vcCAFile,
+		Thumbprint:                       vcThumbprint,
 		Username:                         cfg.VirtualCenter[host].User,
 		Password:                         cfg.VirtualCenter[host].Password,
 		Insecure:                         cfg.VirtualCenter[host].InsecureFlag,

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -90,6 +90,9 @@ type VirtualCenterConfig struct {
 	// Insecure is enabled. Optional; if not configured, the system's CA
 	// certificates will be used.
 	CAFile string
+	// Thumbprint specifies the certificate thumbprint to use
+	// This has no effect if InsecureFlag is enabled.
+	Thumbprint string
 	// RoundTripperCount is the SOAP round tripper count. (retries = RoundTripperCount - 1)
 	RoundTripperCount int
 	// DatacenterPaths represents paths of datacenters on the virtual center.
@@ -122,6 +125,9 @@ func (vc *VirtualCenter) newClient(ctx context.Context) (*govmomi.Client, error)
 			log.Errorf("failed to load CA file: %v", err)
 			return nil, err
 		}
+	} else if len(vc.Config.Thumbprint) > 0 && !vc.Config.Insecure {
+		soapClient.SetThumbprint(url.Host, vc.Config.Thumbprint)
+		log.Debugf("using thumbprint %s for url %s ", vc.Config.Thumbprint, url.Host)
 	}
 	soapClient.Timeout = time.Duration(vc.Config.VCClientTimeout) * time.Minute
 	log.Debugf("Setting vCenter soap client timeout to %v", soapClient.Timeout)

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -38,6 +38,9 @@ type Config struct {
 		// InsecureFlag is enabled. Optional; if not configured, the system's CA
 		// certificates will be used.
 		CAFile string `gcfg:"ca-file"`
+		// Thumbprint specifies the certificate thumbprint to use
+		// This has no effect if InsecureFlag is enabled.
+		Thumbprint string `gcfg:"thumbprint"`
 		// Datacenter in which Node VMs are located.
 		Datacenters string `gcfg:"datacenters"`
 		// CnsRegisterVolumesCleanupIntervalInMin specifies the interval after which


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR adds:
- thumbprint support to align with CAPV and CPI
- plumb `CAFile` from the user config to the internal `VirtualCenterConfig` struct

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Add thumbprint support for the vsphere csi driver
```
