### PR TITLE
Handle WaitForCacheSync errors

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -54,8 +53,7 @@ import (
 
 var (
 	// volumeMigrationService holds the pointer to VolumeMigration instance
-	volumeMigrationService        migration.VolumeMigrationService
-	onceForVolumeResizeReconciler sync.Once
+	volumeMigrationService migration.VolumeMigrationService
 	// COInitParams stores the input params required for initiating the
 	// CO agnostic orchestrator for the syncer container
 	COInitParams interface{}
@@ -1183,15 +1181,20 @@ func initResizeReconciler(ctx context.Context, tkgClient clientset.Interface, su
 		log.Errorf("resize: could not get supervisor namespace in which Tanzu Kubernetes Grid was deployed. Resize reconciler is not running for err: %v", err)
 		return err
 	}
-	onceForVolumeResizeReconciler.Do(func() {
-		log.Infof("initResizeReconciler is triggered")
-		informerFactory := informers.NewSharedInformerFactory(tkgClient, resizeResyncPeriod)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	log.Infof("initResizeReconciler is triggered")
+	// TODO: Refactor the code to use existing NewInformer function to get informerFactory
+	// https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/585
+	informerFactory := informers.NewSharedInformerFactory(tkgClient, resizeResyncPeriod)
 
-		rc := newResizeReconciler(tkgClient, supervisorClient, supervisorNamespace, resizeResyncPeriod, informerFactory,
-			workqueue.NewItemExponentialFailureRateLimiter(resizeRetryIntervalStart, resizeRetryIntervalMax),
-		)
-		informerFactory.Start(wait.NeverStop)
-		rc.Run(ctx, resizeWorkers)
-	})
+	rc, err := newResizeReconciler(tkgClient, supervisorClient, supervisorNamespace, resizeResyncPeriod, informerFactory,
+		workqueue.NewItemExponentialFailureRateLimiter(resizeRetryIntervalStart, resizeRetryIntervalMax),
+		stopCh,
+	)
+	if err != nil {
+		return err
+	}
+	rc.Run(ctx, resizeWorkers)
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
initResizeReconciler in metadatasyncer.go does not handle WaitForCacheSync errors. If there are any errors from resizeReconciler.Run, they are ignored. This change also remove the once.Do pattern in this function.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Test Result

Check the csi log, Resize Reconciler is initialized
```
{"level":"info","time":"2020-12-03T05:30:42.60189385Z","caller":"syncer/metadatasyncer.go:965","msg":"initResizeReconciler is triggered","TraceId":"1af048ad-dc99-4ea6-99be-6c90326b6cc2"}
{"level":"info","time":"2020-12-03T05:30:42.602809395Z","caller":"syncer/resize_reconciler.go:152","msg":"Resize reconciler: Start","TraceId":"1af048ad-dc99-4ea6-99be-6c90326b6cc2"}
```

1. create a pvc with 200Mi in GC
```
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl create -f pvc.yaml 
persistentvolumeclaim/example-vanilla-block-pvc created
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# 
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl get pvc
NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
example-vanilla-block-pvc   Bound    pvc-fb494106-3c33-4e7c-a27a-b6151baa67c6   200Mi      RWO            gc-storage-profile   37s
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                               STORAGECLASS         REASON   AGE
pvc-fb494106-3c33-4e7c-a27a-b6151baa67c6   200Mi      RWO            Delete           Bound    default/example-vanilla-block-pvc   gc-storage-profile            31s
```
2. check the pvc and pv in SV, all in bound status
```
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                                                           STORAGECLASS         REASON   AGE
pvc-8b39d1a8-0ed9-43ae-a3dd-38e27dd587af   200Mi      RWO            Delete           Bound    test-gc-e2e-demo-ns/bdb2c938-a439-4b2c-a487-0ab3f8858436-fb494106-3c33-4e7c-a27a-b6151baa67c6   gc-storage-profile            103s



root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl get pvc --all-namespaces
NAMESPACE             NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
test-gc-e2e-demo-ns   bdb2c938-a439-4b2c-a487-0ab3f8858436-fb494106-3c33-4e7c-a27a-b6151baa67c6   Bound    pvc-8b39d1a8-0ed9-43ae-a3dd-38e27dd587af   200Mi      RWO            gc-storage-profile   2m10s
```
3. check pv, pvc in GC, pv size changed to new size 500Mi, but pvc size remains 200Mi and has "FileSystemResizePending"
```
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl get pvc,pv
NAME                                              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
persistentvolumeclaim/example-vanilla-block-pvc   Bound    pvc-fb494106-3c33-4e7c-a27a-b6151baa67c6   200Mi      RWO            gc-storage-profile   4m53s

NAME                                                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                               STORAGECLASS         REASON   AGE
persistentvolume/pvc-fb494106-3c33-4e7c-a27a-b6151baa67c6   500Mi      RWO            Delete           Bound    default/example-vanilla-block-pvc   gc-storage-profile            4m44s
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# 
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl describe pvc example-vanilla-block-pvc
Name:          example-vanilla-block-pvc
Namespace:     default
StorageClass:  gc-storage-profile
Status:        Bound
Volume:        pvc-fb494106-3c33-4e7c-a27a-b6151baa67c6
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      200Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
Conditions:
  Type                      Status  LastProbeTime                     LastTransitionTime                Reason  Message
  ----                      ------  -----------------                 ------------------                ------  -------
  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Fri, 04 Dec 2020 00:49:21 +0000           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
Events:
  Type     Reason                    Age                    From                                                                                                 Message
  ----     ------                    ----                   ----                                                                                                 -------
  Normal   Provisioning              5m24s                  csi.vsphere.vmware.com_vsphere-csi-controller-66b875d646-965pz_8dad6699-3500-11eb-b91c-3e9de8bb3856  External provisioner is provisioning volume for claim "default/example-vanilla-block-pvc"
  Normal   ExternalProvisioning      5m22s (x2 over 5m25s)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Warning  ExternalExpanding         51s                    volume_expand                                                                                        Ignoring the PVC: didn't find a plugin capable of expanding the volume; waiting for an external controller to process this PVC.
  Normal   Resizing                  51s                    external-resizer csi.vsphere.vmware.com                                                              External resizer is resizing volume pvc-fb494106-3c33-4e7c-a27a-b6151baa67c6
  Normal   FileSystemResizeRequired  41s                    external-resizer csi.vsphere.vmware.com                                                              Require file system resize of volume on node
```
4. check pv,pvc in SV, pvc size remains 200Mi, also has "FileSystemResizePending"
```
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]#  kubectl get pvc,pv -n test-gc-e2e-demo-ns
NAME                                                                                              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
persistentvolumeclaim/bdb2c938-a439-4b2c-a487-0ab3f8858436-fb494106-3c33-4e7c-a27a-b6151baa67c6   Bound    pvc-8b39d1a8-0ed9-43ae-a3dd-38e27dd587af   200Mi      RWO            gc-storage-profile   5m50s

NAME                                                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                                                           STORAGECLASS         REASON   AGE
persistentvolume/pvc-8b39d1a8-0ed9-43ae-a3dd-38e27dd587af   500Mi      RWO            Delete           Bound    test-gc-e2e-demo-ns/bdb2c938-a439-4b2c-a487-0ab3f8858436-fb494106-3c33-4e7c-a27a-b6151baa67c6   gc-storage-profile            5m43s
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# 
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl describe pvc bdb2c938-a439-4b2c-a487-0ab3f8858436-fb494106-3c33-4e7c-a27a-b6151baa67c6  -n test-gc-e2e-demo-ns
Name:          bdb2c938-a439-4b2c-a487-0ab3f8858436-fb494106-3c33-4e7c-a27a-b6151baa67c6
Namespace:     test-gc-e2e-demo-ns
StorageClass:  gc-storage-profile
Status:        Bound
Volume:        pvc-8b39d1a8-0ed9-43ae-a3dd-38e27dd587af
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      200Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
Conditions:
  Type                      Status  LastProbeTime                     LastTransitionTime                Reason  Message
  ----                      ------  -----------------                 ------------------                ------  -------
  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Fri, 04 Dec 2020 00:49:21 +0000           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
Events:
  Type     Reason                    Age    From                                                                                          Message
  ----     ------                    ----   ----                                                                                          -------
  Normal   ExternalProvisioning      6m35s  persistentvolume-controller                                                                   waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   Provisioning              6m35s  csi.vsphere.vmware.com_422e16af36863b82a77a26dfcf979a3d_b3575404-3528-11eb-a85e-005056ae8f1c  External provisioner is provisioning volume for claim "test-gc-e2e-demo-ns/bdb2c938-a439-4b2c-a487-0ab3f8858436-fb494106-3c33-4e7c-a27a-b6151baa67c6"
  Warning  ExternalExpanding         2m2s   volume_expand                                                                                 Ignoring the PVC: didn't find a plugin capable of expanding the volume; waiting for an external controller to process this PVC.
  Normal   Resizing                  2m2s   external-resizer csi.vsphere.vmware.com                                                       External resizer is resizing volume pvc-8b39d1a8-0ed9-43ae-a3dd-38e27dd587af
  Normal   FileSystemResizeRequired  114s   external-resizer csi.vsphere.vmware.com                                                       Require file system resize of volume on node
```
5. attach a pod to pvc in GC
```
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl create -f pod.yaml 
pod/example-vanilla-block-pod created

root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl get pod
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   1/1     Running   0          36s
kuard                       1/1     Running   0          25h
```
6. After pod is running, check the pv and pvc in GC. Both pv and pvc size change to 500Mi, 
```
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl describe pvc example-vanilla-block-pvc
Name:          example-vanilla-block-pvc
Namespace:     default
StorageClass:  gc-storage-profile
Status:        Bound
Volume:        pvc-fb494106-3c33-4e7c-a27a-b6151baa67c6
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      500Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    example-vanilla-block-pod
Events:
  Type     Reason                      Age                From                                                                                                 Message
  ----     ------                      ----               ----                                                                                                 -------
  Normal   Provisioning                12m                csi.vsphere.vmware.com_vsphere-csi-controller-66b875d646-965pz_8dad6699-3500-11eb-b91c-3e9de8bb3856  External provisioner is provisioning volume for claim "default/example-vanilla-block-pvc"
  Normal   ExternalProvisioning        12m (x2 over 12m)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Warning  ExternalExpanding           8m14s              volume_expand                                                                                        Ignoring the PVC: didn't find a plugin capable of expanding the volume; waiting for an external controller to process this PVC.
  Normal   Resizing                    8m14s              external-resizer csi.vsphere.vmware.com                                                              External resizer is resizing volume pvc-fb494106-3c33-4e7c-a27a-b6151baa67c6
  Normal   FileSystemResizeRequired    8m4s               external-resizer csi.vsphere.vmware.com                                                              Require file system resize of volume on node
  Normal   FileSystemResizeSuccessful  3m3s               kubelet                                                                                              MountVolume.NodeExpandVolume succeeded for volume "pvc-fb494106-3c33-4e7c-a27a-b6151baa67c6"
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# 
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl get pv,pvc
NAME                                                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                               STORAGECLASS         REASON   AGE
persistentvolume/pvc-fb494106-3c33-4e7c-a27a-b6151baa67c6   500Mi      RWO            Delete           Bound    default/example-vanilla-block-pvc   gc-storage-profile            13m

NAME                                              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
persistentvolumeclaim/example-vanilla-block-pvc   Bound    pvc-fb494106-3c33-4e7c-a27a-b6151baa67c6   500Mi      RWO            gc-storage-profile   13m
```
7. check in SV, FileSystemPending is removed from PVC, and the size is expend to 500Mi
```
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl describe pvc bdb2c938-a439-4b2c-a487-0ab3f8858436-fb494106-3c33-4e7c-a27a-b6151baa67c6  -n test-gc-e2e-demo-ns
Name:          bdb2c938-a439-4b2c-a487-0ab3f8858436-fb494106-3c33-4e7c-a27a-b6151baa67c6
Namespace:     test-gc-e2e-demo-ns
StorageClass:  gc-storage-profile
Status:        Bound
Volume:        pvc-8b39d1a8-0ed9-43ae-a3dd-38e27dd587af
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      500Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
Events:
  Type     Reason                    Age   From                                                                                          Message
  ----     ------                    ----  ----                                                                                          -------
  Normal   ExternalProvisioning      15m   persistentvolume-controller                                                                   waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   Provisioning              15m   csi.vsphere.vmware.com_422e16af36863b82a77a26dfcf979a3d_b3575404-3528-11eb-a85e-005056ae8f1c  External provisioner is provisioning volume for claim "test-gc-e2e-demo-ns/bdb2c938-a439-4b2c-a487-0ab3f8858436-fb494106-3c33-4e7c-a27a-b6151baa67c6"
  Warning  ExternalExpanding         10m   volume_expand                                                                                 Ignoring the PVC: didn't find a plugin capable of expanding the volume; waiting for an external controller to process this PVC.
  Normal   Resizing                  10m   external-resizer csi.vsphere.vmware.com                                                       External resizer is resizing volume pvc-8b39d1a8-0ed9-43ae-a3dd-38e27dd587af
  Normal   FileSystemResizeRequired  10m   external-resizer csi.vsphere.vmware.com                                                       Require file system resize of volume on node


root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl get pvc -n test-gc-e2e-demo-ns
NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
bdb2c938-a439-4b2c-a487-0ab3f8858436-fb494106-3c33-4e7c-a27a-b6151baa67c6   Bound    pvc-8b39d1a8-0ed9-43ae-a3dd-38e27dd587af   500Mi      RWO            gc-storage-profile   19m
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# 
root@422e16af36863b82a77a26dfcf979a3d [ ~ ]# kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                                                           STORAGECLASS         REASON   AGE
pvc-8b39d1a8-0ed9-43ae-a3dd-38e27dd587af   500Mi      RWO            Delete           Bound    test-gc-e2e-demo-ns/bdb2c938-a439-4b2c-a487-0ab3f8858436-fb494106-3c33-4e7c-a27a-b6151baa67c6   gc-storage-profile            19m
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
