### PR TITLE
Add valid vSphere volume check for update pod metadata

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1110,6 +1110,9 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 					log.Errorf("failed to get volume id for volume name: %q with err=%v", pv.Name, err)
 					continue
 				}
+			} else {
+				log.Debugf("Volume %q is not a valid vSphere volume for the pod %q", volume.PersistentVolumeClaim.ClaimName, pod.Name)
+				return
 			}
 		} else {
 			// Inline migrated volumes with no PVC


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is addressing the issue where migration is enabled for CSI driver but migration feature gates are disabled on kubelet. And when user creates & deletes a pod using VCP volume we need to check if the volume is a valid migrated VCP volume before calling updatePodMetadata.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
`Testing:`

Enabled CSI migration feature state only for the CSI driver and created a pod using VCP volume and verified the below logs. Also verified that volumes attached to the pod are not migrated and no entry is seen on CNS UI
```
2020-12-01T00:34:38.220Z	DEBUG	syncer/metadatasyncer.go:726	PodDeleted: Pod example-vanilla-block-pod calling updatePodMetadata	{"TraceId": "0606ac36-cc92-4951-8f14-ad0cd891ca43"}
2020-12-01T00:34:38.220Z	DEBUG	syncer/util.go:112	Pod example-vanilla-block-pod has a valid vSphereVolume but the volume is not migrated	{"TraceId": "0606ac36-cc92-4951-8f14-ad0cd891ca43"}
2020-12-01T00:34:38.220Z	WARN	syncer/metadatasyncer.go:1114	Volume "vcppvc" is not a valid vSphere volume for the pod "example-vanilla-block-pod"	{"TraceId": "0606ac36-cc92-4951-8f14-ad0cd891ca43"}
```
Disabled CSI migration feature state for the CSI driver and created a pod using VCP volume and verified the below logs. Also verified that volumes attached to the pod are not migrated and no entry is seen on CNS UI
```
2020-12-01T00:36:48.245Z	DEBUG	syncer/metadatasyncer.go:726	PodDeleted: Pod example-vanilla-block-pod calling updatePodMetadata	{"TraceId": "e3ccf56f-f5fc-4656-b33a-73afb9211eab"}
2020-12-01T00:36:48.246Z	WARN	syncer/util.go:116	csi-migration feature switch is disabled. Cannot update vSphere volume metadata pvc-ae75a490-cd06-47a3-aaaa-394f6bfb88cb for the pod example-vanilla-block-pod	{"TraceId": "e3ccf56f-f5fc-4656-b33a-73afb9211eab"}
2020-12-01T00:36:48.249Z	WARN	syncer/metadatasyncer.go:1114	Volume "vcppvc" is not a valid vSphere volume for the pod "example-vanilla-block-pod"	{"TraceId": "e3ccf56f-f5fc-4656-b33a-73afb9211eab"}
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix update Pod metadata method to check for valid migrated vSphere volume 
```
