### PR TITLE
Create file volumes in TKG clusters

### DIFF
--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -401,6 +401,7 @@ data:
   "volume-extend": "true"
   "volume-health": "true"
   "online-volume-extend": "false"
+  "file-volume": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -401,6 +401,7 @@ data:
   "volume-extend": "true"
   "volume-health": "true"
   "online-volume-extend": "false"
+  "file-volume": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -401,6 +401,7 @@ data:
   "volume-extend": "true"
   "volume-health": "true"
   "online-volume-extend": "false"
+  "file-volume": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -39,6 +39,7 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 				"volume-extend": "true",
 				"volume-health": "true",
 				"csi-migration": "true",
+				"file-volume":   "true",
 			},
 		}
 		return fakeCO, nil

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -237,7 +237,11 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return nil, status.Errorf(codes.Internal, msg)
 	}
 	attributes := make(map[string]string)
-	attributes[common.AttributeDiskType] = common.DiskTypeBlockVolume
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.FileVolume) && common.IsFileVolumeRequest(ctx, req.GetVolumeCapabilities()) {
+		attributes[common.AttributeDiskType] = common.DiskTypeFileVolume
+	} else {
+		attributes[common.AttributeDiskType] = common.DiskTypeBlockVolume
+	}
 	resp := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:      supervisorPVCName,

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
@@ -73,8 +74,8 @@ func validateGuestClusterCreateVolumeRequest(ctx context.Context, req *csi.Creat
 		msg := fmt.Sprintf("Volume parameter %s is not set in the req", common.AttributeSupervisorStorageClass)
 		return status.Error(codes.InvalidArgument, msg)
 	}
-	// Fail file volume creation
-	if common.IsFileVolumeRequest(ctx, req.GetVolumeCapabilities()) {
+	// Fail file volume creation if file volume feature gate is disabled
+	if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.FileVolume) && common.IsFileVolumeRequest(ctx, req.GetVolumeCapabilities()) {
 		return status.Error(codes.InvalidArgument, "File volume not supported.")
 	}
 	return common.ValidateCreateVolumeRequest(ctx, req)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR makes modifications to add support for creating PVC's with RWX AccessMode in TKG clusters. 
/kind feature


Testing:
1. Create a PVC with RWX AccessMode:
```
root@422532e72d1290ac98e64ed26d2ef627 [ ~ ]# cat pvc.yaml 
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: example-vanilla-block-pvc
spec:
  accessModes:
    - ReadWriteMany
  resources:
    requests:
      storage: 1Mi
  storageClassName: test-gc-storage-profile-gvtdoyn
root@422532e72d1290ac98e64ed26d2ef627 [ ~ ]# kubectl create -f pvc.yaml 
persistentvolumeclaim/example-vanilla-block-pvc created
```

2. Verify that TKG PVC is in Bound state:

```
NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                      AGE
example-vanilla-block-pvc   Bound    pvc-2ec52e6a-b224-4653-9fe6-a5936cb8623b   1Mi        RWX            test-gc-storage-profile-gvtdoyn   30s
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add support for creating PVC's with RWX AccessMode in TKG clusters.
```
