### PR TITLE
Assign full permissions for file volumes created in WCP

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -293,16 +293,15 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 			vcConfig.InsecureFlag = cfg.Global.InsecureFlag
 		}
 	}
-	clusterFlavor, err := GetClusterFlavor(ctx)
-	if err != nil {
-		return err
-	}
+
 	if cfg.NetPermissions == nil {
 		// If no net permissions are given, assume default
 		log.Info("No Net Permissions given in Config. Using default permissions.")
-		if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-			cfg.NetPermissions = map[string]*NetPermissionConfig{"#": GetDefaultNetPermission()}
-		}
+		// TODO:
+		// For now, adding full permissions for READ/WRITE for all file volumes on all flavors
+		// Later when ACLs are implemented for file volumes in WCP, give full permissions
+		// only for Vanilla and no permissions for WCP.
+		cfg.NetPermissions = map[string]*NetPermissionConfig{"#": GetDefaultNetPermission()}
 	} else {
 		for key, netPerm := range cfg.NetPermissions {
 			if netPerm.Permissions == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

Ideally we do not want any permission to be assigned to file volumes created on WCP. But as a first step, this PR will give full permissions to file volumes created on WCP until automatic ACL configuration is in place.

```release-note
Assign full permissions for file volumes created in WCP
```

Testing done:

1. make unit-test passes.
2. Create spec as part of volume creation.
```
2020-10-26T21:23:50.371Z	DEBUG	common/vsphereutil.go:257	vSphere CSI driver creating volume "pvc-0b6b62b2-85bf-4c45-b671-1d1a7688b434" with create spec (*types.CnsVolumeCreateSpec)(0xc0003d00f0)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-0b6b62b2-85bf-4c45-b671-1d1a7688b434",
 VolumeType: (string) (len=4) "FILE",
 Datastores: ([]types.ManagedObjectReference) (len=1 cap=1) {
  (types.ManagedObjectReference) Datastore:datastore-67
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=10) "domain-c63",
   VSphereUser: (string) (len=20) "iamnew@vsphere.local",
   ClusterFlavor: (string) (len=8) "WORKLOAD",
   ClusterDistribution: (string) ""
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=10) "domain-c63",
    VSphereUser: (string) (len=20) "iamnew@vsphere.local",
    ClusterFlavor: (string) (len=8) "WORKLOAD",
    ClusterDistribution: (string) ""
   }
  }
 },
 BackingObjectDetails: (*types.CnsVsanFileShareBackingDetails)(0xc00038d5c0)({
  CnsFileBackingDetails: (types.CnsFileBackingDetails) {
   CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
    DynamicData: (types.DynamicData) {
    },
    CapacityInMb: (int64) 1024
   },
   BackingFileId: (string) ""
  },
  Name: (string) "",
  AccessPoints: ([]types.KeyValue) <nil>
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) (len=1 cap=1) {
  (*types.VirtualMachineDefinedProfileSpec)(0xc00038d600)({
   VirtualMachineProfileSpec: (types.VirtualMachineProfileSpec) {
    DynamicData: (types.DynamicData) {
    }
   },
   ProfileId: (string) (len=36) "4b505f67-32cd-462d-8caf-e5680dbf0313",
   ReplicationSpec: (*types.ReplicationSpec)(<nil>),
   ProfileData: (*types.VirtualMachineProfileRawData)(<nil>),
   ProfileParams: ([]types.KeyValue) <nil>
  })
 },
 CreateSpec: (*types.CnsVSANFileCreateSpec)(0xc0007b58a0)({
  CnsFileCreateSpec: (types.CnsFileCreateSpec) {
   CnsBaseCreateSpec: (types.CnsBaseCreateSpec) {
    DynamicData: (types.DynamicData) {
    }
   }
  },
  SoftQuotaInMb: (int64) 1024,
  Permission: ([]types.VsanFileShareNetPermission) {
(types.VsanFileShareNetPermission) {
    Ips: (string) (len=1) "*",
    Permissions: (types.VsanFileShareAccessType) (len=10) "READ_WRITE",
    AllowRoot: (bool) true
   }
  }
 })
})
```

cc @chethanv28 @RaunakShah 