### PR TITLE
Fix for testcase "CSI - verify invalid fstype"

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -2103,12 +2103,12 @@ func createPod(client clientset.Interface, namespace string, nodeSelector map[st
 	// Waiting for pod to be running
 	err = fpod.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("pod %q is not Running: %v", pod.Name, err)
+		return pod, fmt.Errorf("pod %q is not Running: %v", pod.Name, err)
 	}
 	// get fresh pod info
 	pod, err = client.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("pod Get API error: %v", err)
+		return pod, fmt.Errorf("pod Get API error: %v", err)
 	}
 	return pod, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Fix for testcase "CSI - verify invalid fstype" which was throwing "nil pointer dereference" while creating POD

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:  There are few cases (1 in block vanilla and few in GC tests) where there is validation on the POD not on the error message, and if POD is nil , it throws "nil pointer dereference" , If POD has the reference pointer (though it is not in running state), It fails in the later stage with proper reason for failure.   

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
