### PR TITLE
Cherry-pick from master: Add valid vsphere volume check for update pod metadata

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1101,6 +1101,9 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 					log.Errorf("failed to get volume id for volume name: %q with err=%v", pv.Name, err)
 					continue
 				}
+			} else {
+				log.Debugf("Volume %q is not a valid vSphere volume for the pod %q", volume.PersistentVolumeClaim.ClaimName, pod.Name)
+				return
 			}
 		} else {
 			// Inline migrated volumes with no PVC

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -102,16 +102,28 @@ func IsValidVolume(ctx context.Context, volume v1.Volume, pod *v1.Pod, metadataS
 		log.Errorf("Error getting Persistent Volume for PVC %s in volume %s with err: %v", pvc.Name, volume.Name, err)
 		return false, nil, nil
 	}
-
-	// Verify if pv is vsphere csi volume
-	if (pv.Spec.CSI == nil || pv.Spec.CSI.Driver != csitypes.Name) && (metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume == nil) {
-		log.Debugf("Pod %s does not have a valid vSphereVolume. Ignoring the pod update", pod.Name)
-		return false, nil, nil
-	}
-	//Verify if pv is vsphere volume and migration flag is disabled
-	if !metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil {
-		log.Warnf("%s feature switch is disabled. Cannot update vSphere volume metadata %s for the pod %s", common.CSIMigration, pv.Name, pod.Name)
-		return false, nil, nil
+	if pv.Spec.CSI == nil {
+		// Verify volume is a in-tree VCP volume
+		if pv.Spec.VsphereVolume != nil {
+			// Check if migration feature switch is enabled
+			if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
+				if !isValidvSphereVolume(ctx, pv.ObjectMeta) {
+					log.Debugf("Pod %s in namespace %s has a valid vSphereVolume but the volume is not migrated", pod.Name, pod.Namespace)
+					return false, nil, nil
+				}
+			} else {
+				log.Debugf("%s feature switch is disabled. Cannot update vSphere volume metadata %s for the pod %s in namespace %s", common.CSIMigration, pv.Name, pod.Name, pod.Namespace)
+				return false, nil, nil
+			}
+		} else {
+			log.Debugf("Volume %q is not a valid vSphere volume", pv.Name)
+			return false, nil, nil
+		}
+	} else {
+		if pv.Spec.CSI.Driver != csitypes.Name {
+			log.Debugf("Pod %s in namespace %s has a volume %s which is not provisioned by vSphere CSI driver", pod.Name, pod.Namespace, pv.Name)
+			return false, nil, nil
+		}
 	}
 	return true, pv, pvc
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry-picking recent migration bug fix to 2.1

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Testing is done as part of the original PR to master. Refer: #509 
No conflicts were observed while cherry-picking.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherry-picking migration bug fixes to 2.1
```
