### PR TITLE
Add missing error check in storagepool service

### DIFF
--- a/pkg/syncer/storagepool/service.go
+++ b/pkg/syncer/storagepool/service.go
@@ -105,7 +105,11 @@ func InitStoragePoolService(ctx context.Context, configInfo *commontypes.ConfigI
 		defer diskDecommEnablementTicker.Stop()
 		clusterFlavor := cnstypes.CnsClusterFlavorWorkload
 		for ; true; <-diskDecommEnablementTicker.C {
-			coCommonInterface, _ := commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor, *coInitParams)
+			coCommonInterface, err := commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor, *coInitParams)
+			if err != nil {
+				log.Errorf("Failed to create CO agnostic interface. Error: %v", err)
+				continue
+			}
 			if !coCommonInterface.IsFSSEnabled(ctx, common.VSANDirectDiskDecommission) {
 				log.Infof("VSANDirectDiskDecommission feature is disabled on the cluster")
 			} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding error checks in storagepoolservice init. Found that it was missing from original PR: #425 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add missing error checks in StoragePool service init
```
