### PR TITLE
Revert TKGS CSIDriver version from v1 to v1beta1 

### DIFF
--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -253,7 +253,7 @@ spec:
         - name: socket-dir
           emptyDir: {}
 ---
-apiVersion: storage.k8s.io/v1
+apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: csi.vsphere.vmware.com


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
To handle rolling upgrade of TKGS from 1.17.x to 1.18.x, we need to revert `CSIDriver` API version from `v1` to `v1beta1`. In TKGS upgrade scenarios, all resources are upgraded before the kubernetes version, and any failures block the entire process. Since 1.17.x does not recognise `v1`, upgrades fail. 

Testing:

1. Create CSIDriver with `v1beta1` version:

```
root@4227a9aae7fbe3ed6e566e224b92da7b [ ~ ]# cat csidriver.yaml 
apiVersion: storage.k8s.io/v1beta1
kind: CSIDriver
metadata:
  name: csi.vsphere.vmware.com
spec:
  attachRequired: true
  podInfoOnMount: false
root@4227a9aae7fbe3ed6e566e224b92da7b [ ~ ]# kubectl create -f csidriver.yaml 
csidriver.storage.k8s.io/csi.vsphere.vmware.com created
```

2. Create PVC and Pod:

```
root@4227a9aae7fbe3ed6e566e224b92da7b [ ~ ]# kubectl create -f pvc.yaml 
persistentvolumeclaim/example-block-pvc created
root@4227a9aae7fbe3ed6e566e224b92da7b [ ~ ]# kubectl get pvc
NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
example-block-pvc   Bound    pvc-f786c355-e059-4140-a607-b784f1655160   1Mi        RWO            gc-storage-profile   18s

root@4227a9aae7fbe3ed6e566e224b92da7b [ ~ ]# kubectl create -f pod.yaml 
pod/example-block-pod created
root@4227a9aae7fbe3ed6e566e224b92da7b [ ~ ]# kubectl get pod
NAME                        READY   STATUS    RESTARTS   AGE
example-block-pod   1/1     Running   0          27s
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Revert TKGS CSIDriver version from v1 to v1beta1 
```
