### PR TITLE
ControllerPublish volume for file volumes in pvCSI

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -179,6 +179,30 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 
 }
 
+// NewCnsFileAccessConfigWatcher creates a new ListWatch for VirtualMachines given rest client config
+func NewCnsFileAccessConfigWatcher(ctx context.Context, config *restclient.Config, namespace string) (*cache.ListWatch, error) {
+	var err error
+	log := logger.GetLogger(ctx)
+
+	scheme := runtime.NewScheme()
+	err = cnsoperatorv1alpha1.AddToScheme(scheme)
+	if err != nil {
+		log.Errorf("failed to add to scheme with err: %+v", err)
+	}
+	gvk := schema.GroupVersionKind{
+		Group:   cnsoperatorv1alpha1.SchemeGroupVersion.Group,
+		Version: cnsoperatorv1alpha1.SchemeGroupVersion.Version,
+		Kind:    cnsfileaccessconfigKind,
+	}
+
+	client, err := apiutils.RESTClientForGVK(gvk, config, serializer.NewCodecFactory(scheme))
+	if err != nil {
+		log.Errorf("failed to create RESTClient with err: %+v", err)
+		return nil, err
+	}
+	return cache.NewListWatchFromClient(client, cnsfileaccessconfigKind, namespace, fields.Everything()), nil
+}
+
 // NewVirtualMachineWatcher creates a new ListWatch for VirtualMachines given rest client config
 func NewVirtualMachineWatcher(ctx context.Context, config *restclient.Config, namespace string) (*cache.ListWatch, error) {
 	var err error

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -37,6 +37,8 @@ const (
 	minClientBurst = 5
 	// Kind for virtualmachine resources
 	virtualMachineKind = "virtualmachines"
+	// Kind for cnsfileaccessconfig resources
+	cnsfileaccessconfigKind = "cnsfileaccessconfigs"
 )
 
 // InformerManager is a service that notifies subscribers about changes


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
**This PR is still work in progress.**
It is  adding support for ControllerPublishVolume for file volumes in pvCSI

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Testing in progress and will upload the logs soon.

```
kubectl describe pod example-vanilla-file-pod-10
Name:         example-vanilla-file-pod-10
Namespace:    default
Priority:     0
Node:         test-cluster-e2e-script-gvtdoyn-workers-zkgpv-6545cf669f-7dd7f/10.244.0.36
Start Time:   Thu, 10 Dec 2020 08:55:12 +0000
Labels:       <none>
Annotations:  kubernetes.io/psp: vmware-system-privileged
Status:       Pending
IP:           
IPs:          <none>
Containers:
  test-container:
    Container ID:  
    Image:         gcr.io/google_containers/busybox:1.24
    Image ID:      
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/sh
      -c
      echo 'Hello! This is Pod1' >> /mnt/volume1/index.html && while true ; do sleep 2 ; done
    State:          Waiting
      Reason:       ContainerCreating
    Ready:          False
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /mnt/volume1 from test-volume (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-m64rg (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             False 
  ContainersReady   False 
  PodScheduled      True 
Volumes:
  test-volume:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  example-vanilla-block-pvc
    ReadOnly:   false
  default-token-m64rg:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-m64rg
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
                 node.kubernetes.io/unreachable:NoExecute for 300s
Events:
  Type     Reason                  Age                   From                                                                     Message
  ----     ------                  ----                  ----                                                                     -------
  Normal   Scheduled               6m20s                 default-scheduler                                                        Successfully assigned default/example-vanilla-file-pod-10 to test-cluster-e2e-script-gvtdoyn-workers-zkgpv-6545cf669f-7dd7f
  Normal   SuccessfulAttachVolume  6m3s                  attachdetach-controller                                                  AttachVolume.Attach succeeded for volume "pvc-687d2a39-5a33-444a-b23b-c60cc8b6a739"
```

```
2020-12-10T08:54:02.216Z	DEBUG	wcpguest/controller.go:433	observed update on cnsfileaccessconfig: &{TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:cnsfileaccessconfigs-1 GenerateName: Namespace:test-gc-e2e-demo-ns-gvtdoyn SelfLink:/apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns-gvtdoyn/cnsfileaccessconfigs/cnsfileaccessconfigs-1 UID:cb0488fc-fe7d-4dab-8a00-4e9fe225aad5 ResourceVersion:12015853 Generation:17 CreationTimestamp:2020-12-09 00:39:18 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[{Manager:kubectl Operation:Update APIVersion:cns.vmware.com/v1alpha1 Time:2020-12-10 08:54:33 +0000 UTC FieldsType:FieldsV1 FieldsV1:&FieldsV1{Raw:*[123 34 102 58 115 112 101 99 34 58 123 34 46 34 58 123 125 44 34 102 58 97 99 99 101 115 115 80 111 105 110 116 115 34 58 123 34 46 34 58 123 125 44 34 102 58 78 70 83 118 52 46 49 34 58 123 125 125 44 34 102 58 118 109 78 97 109 101 34 58 123 125 44 34 102 58 118 111 108 117 109 101 78 97 109 101 34 58 123 125 125 44 34 102 58 115 116 97 116 117 115 34 58 123 34 46 34 58 123 125 44 34 102 58 101 114 114 111 114 34 58 123 125 125 125],}}]} Spec:{VolumeName:pvc-1 VMName:45544545-4545-454554354 AccessPoints:map[NFSv4.1:h10-78-190-184.vsanfs3.testdomain:/vsanfs/52841396-28a2-19de-2836-b16b38858472]} Status:{Done:false AccessPoints:map[] Error:}}. checking if AccessPoints is set for volume: "3a78b6e7-4628-48de-88e5-2102028636ac-687d2a39-5a33-444a-b23b-c60cc8b6a739" 	{"TraceId": "9294a0dd-02d6-43d1-839b-21a6745d0b2a"}
2020-12-10T08:54:02.217Z	DEBUG	wcpguest/controller.go:443	publishInfo: h10-78-190-184.vsanfs3.testdomain:/vsanfs/52841396-28a2-19de-2836-b16b38858472.
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Implement ControllerPublishVolume for file volumes in pvCSI
```
