### PR TITLE
Update v1.0.3-rc.1 images in driver deployment yaml files

### DIFF
--- a/manifests/deploy/vsphere-csi-controller-ss.yaml
+++ b/manifests/deploy/vsphere-csi-controller-ss.yaml
@@ -39,11 +39,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.3-rc.1
           args:
             - "--v=4"
           imagePullPolicy: "Always"
@@ -83,7 +79,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.2
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.3-rc.1
           args:
             - "--v=2"
           imagePullPolicy: "Always"

--- a/manifests/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/deploy/vsphere-csi-node-ds.yaml
@@ -40,7 +40,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.3-rc.1
           imagePullPolicy: "Always"
           env:
             - name: NODE_NAME


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is updating the rc images names for driver and syncer in the manifests folder
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
```
root@k8s-master:~# cat chethan/driver.yaml | grep image:
          image: quay.io/k8scsi/csi-attacher:v1.1.1
          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.3-rc.1
          image: quay.io/k8scsi/livenessprobe:v1.1.0
          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.3-rc.1
          image: quay.io/k8scsi/csi-provisioner:v1.2.2
root@k8s-master:~# kubectl logs vsphere-csi-controller-0 -c vsphere-csi-controller -n kube-system -f
I1211 01:23:47.912582       1 config.go:261] GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
I1211 01:23:47.912924       1 config.go:206] Initializing vc server 10.92.184.51
I1211 01:23:47.912942       1 controller.go:73] Initializing CNS controller
I1211 01:23:47.913029       1 virtualcentermanager.go:63] Initializing defaultVirtualCenterManager...
I1211 01:23:47.913036       1 virtualcentermanager.go:65] Successfully initialized defaultVirtualCenterManager
I1211 01:23:47.913051       1 virtualcentermanager.go:107] Successfully registered VC "10.92.184.51"
I1211 01:23:47.913068       1 manager.go:80] Initializing volume.volumeManager...
I1211 01:23:47.913072       1 manager.go:84] volume.volumeManager initialized
I1211 01:23:47.972160       1 virtualcenter.go:145] New session ID for 'VSPHERE.LOCAL\Administrator' = 52b3d050-c290-9181-dfbe-94c16d9d8306
I1211 01:23:47.972204       1 kubernetes.go:56] k8s client using in-cluster config
I1211 01:23:47.974450       1 manager.go:74] Initializing node.nodeManager...
I1211 01:23:47.974514       1 manager.go:78] node.nodeManager initialized
I1211 01:23:47.974526       1 kubernetes.go:56] k8s client using in-cluster config
I1211 01:23:47.974725       1 reflector.go:123] Starting reflector *v1.VolumeAttachment (0s) from pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflector.go:94
I1211 01:23:47.974776       1 reflector.go:161] Listing and watching *v1.VolumeAttachment from pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflector.go:94
I1211 01:23:47.976167       1 reflector.go:123] Starting reflector *v1.PersistentVolume (0s) from pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflector.go:94
I1211 01:23:47.976234       1 reflector.go:161] Listing and watching *v1.PersistentVolume from pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflector.go:94
I1211 01:23:47.978541       1 service.go:88] configured: csi.vsphere.vmware.com with map[mode:controller]
time="2020-12-11T01:23:47Z" level=info msg="identity service registered"
time="2020-12-11T01:23:47Z" level=info msg="controller service registered"
time="2020-12-11T01:23:47Z" level=info msg=serving endpoint="unix:///csi/csi.sock"
I1211 01:23:47.978898       1 reflector.go:123] Starting reflector *v1.Node (0s) from pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflector.go:94
I1211 01:23:47.978912       1 reflector.go:161] Listing and watching *v1.Node from pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflector.go:94
I1211 01:23:48.011304       1 manager.go:101] Successfully registered node: "k8s-master" with nodeUUID "420af25e-3dab-7091-e799-63762474e20a"
I1211 01:23:48.013601       1 virtualmachine.go:126] Initiating asynchronous datacenter listing with uuid 420af25e-3dab-7091-e799-63762474e20a
I1211 01:23:48.022368       1 datacenter.go:148] Publishing datacenter Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]
I1211 01:23:48.022544       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1211 01:23:48.022552       1 virtualmachine.go:163] AsyncGetAllDatacenters with uuid 420af25e-3dab-7091-e799-63762474e20a sent a dc Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]
I1211 01:23:48.022916       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1211 01:23:48.023110       1 virtualmachine.go:158] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1211 01:23:48.023365       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1211 01:23:48.023470       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1211 01:23:48.023573       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1211 01:23:48.023612       1 virtualmachine.go:158] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1211 01:23:48.028466       1 virtualmachine.go:178] Found VM VirtualMachine:vm-67 [VirtualCenterHost: 10.92.184.51, UUID: 420af25e-3dab-7091-e799-63762474e20a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]] given uuid 420af25e-3dab-7091-e799-63762474e20a on DC Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51], canceling context
I1211 01:23:48.029141       1 virtualmachine.go:190] Returning VM VirtualMachine:vm-67 [VirtualCenterHost: 10.92.184.51, UUID: 420af25e-3dab-7091-e799-63762474e20a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]] for UUID 420af25e-3dab-7091-e799-63762474e20a
I1211 01:23:48.029332       1 manager.go:120] Successfully discovered node with nodeUUID 420af25e-3dab-7091-e799-63762474e20a in vm VirtualMachine:vm-67 [VirtualCenterHost: 10.92.184.51, UUID: 420af25e-3dab-7091-e799-63762474e20a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]]
I1211 01:23:48.029362       1 manager.go:107] Successfully discovered node: "k8s-master" with nodeUUID "420af25e-3dab-7091-e799-63762474e20a"
I1211 01:23:48.029453       1 manager.go:101] Successfully registered node: "k8s-node1" with nodeUUID "420a12a4-f6c2-d64f-4581-1cc2338db2cc"
I1211 01:23:48.029657       1 virtualmachine.go:126] Initiating asynchronous datacenter listing with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1211 01:23:48.037539       1 datacenter.go:148] Publishing datacenter Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]
I1211 01:23:48.037674       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1211 01:23:48.037909       1 virtualmachine.go:163] AsyncGetAllDatacenters with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc sent a dc Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]
I1211 01:23:48.038439       1 virtualmachine.go:158] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1211 01:23:48.038481       1 virtualmachine.go:158] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1211 01:23:48.038496       1 virtualmachine.go:158] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1211 01:23:48.038570       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1211 01:23:48.038605       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1211 01:23:48.038694       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1211 01:23:48.041465       1 virtualmachine.go:178] Found VM VirtualMachine:vm-68 [VirtualCenterHost: 10.92.184.51, UUID: 420a12a4-f6c2-d64f-4581-1cc2338db2cc, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]] given uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc on DC Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51], canceling context
I1211 01:23:48.041788       1 virtualmachine.go:190] Returning VM VirtualMachine:vm-68 [VirtualCenterHost: 10.92.184.51, UUID: 420a12a4-f6c2-d64f-4581-1cc2338db2cc, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]] for UUID 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1211 01:23:48.041938       1 manager.go:120] Successfully discovered node with nodeUUID 420a12a4-f6c2-d64f-4581-1cc2338db2cc in vm VirtualMachine:vm-68 [VirtualCenterHost: 10.92.184.51, UUID: 420a12a4-f6c2-d64f-4581-1cc2338db2cc, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]]
I1211 01:23:48.042151       1 manager.go:107] Successfully discovered node: "k8s-node1" with nodeUUID "420a12a4-f6c2-d64f-4581-1cc2338db2cc"
I1211 01:23:48.210209       1 controller.go:413] ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I1211 01:23:55.746074       1 controller.go:413] ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
^C
root@k8s-master:~# ^C
root@k8s-master:~# kubectl create -f pvc.yaml 
persistentvolumeclaim/example-vanilla-block-pvc created
root@k8s-master:~# kubectl create -f pod.yaml 
pod/example-vanilla-block-pod created
root@k8s-master:~# kubectl get pvc -A
NAMESPACE   NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS               AGE
default     example-vanilla-block-pvc   Bound    pvc-fea2a434-aa3a-41ba-817a-c2cc482d8792   1Mi        RWO            example-vanilla-block-sc   8s
root@k8s-master:~# kubectl get pods
NAME                        READY   STATUS              RESTARTS   AGE
example-vanilla-block-pod   0/1     ContainerCreating   0          11s
root@k8s-master:~# kubectl get pods
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   1/1     Running   0          24s
root@k8s-master:~# 
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update CSI driver and syncer images in manifests
```
