### PR TITLE
Avoid volume deletion in syncer and remove caching of tasks for static provisioning

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -28,9 +28,11 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	csictx "github.com/rexray/gocsi/context"
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/vim25/soap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 	volumes "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
@@ -368,27 +370,43 @@ func pvDeleted(obj interface{}, metadataSyncer *MetadataSyncInformer) {
 		klog.V(3).Infof("PVDeleted: Not a Vsphere CSI Volume: %+v", pv)
 		return
 	}
-	var deleteDisk bool
-	if pv.Spec.ClaimRef != nil && (pv.Status.Phase == v1.VolumeAvailable || pv.Status.Phase == v1.VolumeReleased) && pv.Spec.PersistentVolumeReclaimPolicy == v1.PersistentVolumeReclaimDelete {
-		klog.V(3).Infof("PVDeleted: Volume deletion will be handled by Controller")
-		return
-	}
 
-	if pv.Spec.ClaimRef == nil || (pv.Spec.PersistentVolumeReclaimPolicy != v1.PersistentVolumeReclaimDelete) {
-		klog.V(4).Infof("PVDeleted: Setting DeleteDisk to false")
-		deleteDisk = false
-	} else {
-		// We set delete disk=true for the case where PV status is failed after deletion of pvc
-		// In this case, metadatasyncer will remove the volume
-		klog.V(4).Infof("PVDeleted: Setting DeleteDisk to true")
-		deleteDisk = true
-	}
 	volumeOperationsLock.Lock()
 	defer volumeOperationsLock.Unlock()
-	klog.V(4).Infof("PVDeleted: vSphere provisioner deleting volume %v with delete disk %v", pv, deleteDisk)
-	if err := volumes.GetManager(metadataSyncer.vcenter).DeleteVolume(pv.Spec.CSI.VolumeHandle, deleteDisk); err != nil {
-		klog.Errorf("PVDeleted: Failed to delete disk %s with error %+v", pv.Spec.CSI.VolumeHandle, err)
-		return
+	if pv.Spec.ClaimRef == nil && pv.Status.Phase != v1.VolumeBound {
+		// Check if PV is not bound to any persistence volume claim, it means we need to de-register the volume
+		// This is needed because the delete volume call will not be invoked in the CSI controller
+		klog.V(4).Infof("PVDeleted: Deleting volume %v with delete disk %v", pv, false)
+		if err := volumes.GetManager(metadataSyncer.vcenter).DeleteVolume(pv.Spec.CSI.VolumeHandle, false); err != nil {
+			klog.Errorf("PVDeleted: Failed to delete disk %s with error %+v", pv.Spec.CSI.VolumeHandle, err)
+			return
+		}
+	} else {
+		// For all other cases we need to remove the PV metadata for the deleted PV
+		klog.V(4).Infof("PVDeleted: Removing pv metadata for pv: %v", pv.Name)
+		var metadataList []cnstypes.BaseCnsEntityMetadata
+		pvMetadata := cnsvsphere.GetCnsKubernetesEntityMetaData(pv.Name, nil, true, string(cnstypes.CnsKubernetesEntityTypePV), pv.Namespace)
+		metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(pvMetadata))
+
+		updateSpec := &cnstypes.CnsVolumeMetadataUpdateSpec{
+			VolumeId: cnstypes.CnsVolumeId{
+				Id: pv.Spec.CSI.VolumeHandle,
+			},
+			Metadata: cnstypes.CnsVolumeMetadata{
+				ContainerCluster: cnsvsphere.GetContainerCluster(metadataSyncer.cfg.Global.ClusterID, metadataSyncer.cfg.VirtualCenter[metadataSyncer.vcenter.Config.Host].User),
+				EntityMetadata:   metadataList,
+			},
+		}
+		if err := volumes.GetManager(metadataSyncer.vcenter).UpdateVolumeMetadata(updateSpec); err != nil {
+			if soap.IsSoapFault(err) {
+				soapFault := soap.ToSoapFault(err)
+				if _, ok := soapFault.VimFault().(vimtypes.NotFound); ok {
+					klog.V(2).Infof("VolumeID: %q, not found for PV: %q. Volume could be already deleted by CSI controller", pv.Spec.CSI.VolumeHandle, pv.Name)
+					return
+				}
+			}
+			klog.Errorf("PVDeleted: UpdateVolumeMetadata failed with err %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is preventing volume deletion by syncer container for volumes with reclaim policy retain.
In scenarios where syncer receives PV delete event for reclaim policy delete we need to remove pv metadata from CNS.

The PR is also removing caching of tasks for statically provisioned volumes. This is needed because, the taskInfo cache is an in-memory map which is used by syncer and controller containers. Both syncer and controller have their own instance of taskInfo cache since they run as different containers. 
So, if we use taskInfo cache for statically provisioned volumes and add taskInfo entries while creating volumes(from syncer) and delete the associated PVC (from controller), we cannot recreate the static volume with the same name until cleanup happens(every 1 hour)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
```
I1211 08:12:24.923142       1 metadatasyncer.go:388] PVDeleted: vSphere provisioner removing volume metadata for the pv: &PersistentVolume{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:pvc-45c030d8-3225-4ef6-9e37-0f126515ab36,GenerateName:,Namespace:,SelfLink:/api/v1/persistentvolumes/pvc-45c030d8-3225-4ef6-9e37-0f126515ab36,UID:e55f764b-5fb0-4f41-9030-c9080b323f72,ResourceVersion:538165,Generation:0,CreationTimestamp:2020-12-11 08:09:41 +0000 UTC,DeletionTimestamp:2020-12-11 08:12:24 +0000 UTC,DeletionGracePeriodSeconds:*0,Labels:map[string]string{},Annotations:map[string]string{pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com,},OwnerReferences:[],Finalizers:[kubernetes.io/pv-protection],ClusterName:,Initializers:nil,ManagedFields:[{csi-provisioner Update v1 2020-12-11 08:09:41 +0000 UTC nil} {kube-controller-manager Update v1 2020-12-11 08:11:35 +0000 UTC nil}],},Spec:PersistentVolumeSpec{Capacity:ResourceList{storage: {{1048576 0} {<nil>} 1Mi BinarySI},},PersistentVolumeSource:PersistentVolumeSource{GCEPersistentDisk:nil,AWSElasticBlockStore:nil,HostPath:nil,Glusterfs:nil,NFS:nil,RBD:nil,ISCSI:nil,Cinder:nil,CephFS:nil,FC:nil,Flocker:nil,FlexVolume:nil,AzureFile:nil,VsphereVolume:nil,Quobyte:nil,AzureDisk:nil,PhotonPersistentDisk:nil,PortworxVolume:nil,ScaleIO:nil,Local:nil,StorageOS:nil,CSI:&CSIPersistentVolumeSource{Driver:csi.vsphere.vmware.com,VolumeHandle:8a107210-3adb-40e6-8d18-4fa14177f7e2,ReadOnly:false,FSType:ext4,VolumeAttributes:map[string]string{fstype: ,storage.kubernetes.io/csiProvisionerIdentity: 1607674023385-8081-csi.vsphere.vmware.com,type: vSphere CNS Block Volume,},ControllerPublishSecretRef:nil,NodeStageSecretRef:nil,NodePublishSecretRef:nil,},},AccessModes:[ReadWriteOnce],ClaimRef:&ObjectReference{Kind:PersistentVolumeClaim,Namespace:default,Name:example-vanilla-block-pvc,UID:45c030d8-3225-4ef6-9e37-0f126515ab36,APIVersion:v1,ResourceVersion:537754,FieldPath:,},PersistentVolumeReclaimPolicy:Delete,StorageClassName:example-vanilla-block-sc,MountOptions:[],VolumeMode:*Filesystem,NodeAffinity:nil,},Status:PersistentVolumeStatus{Phase:Released,Message:,Reason:,},}. Volume deletion will be handled by Controller
I1211 08:12:24.942122       1 manager.go:400] Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator
I1211 08:12:25.030761       1 manager.go:417] VolumeID: "8a107210-3adb-40e6-8d18-4fa14177f7e2", not found. Returning success for this operation since the volume is not present
I1211 08:12:25.030894       1 metadatasyncer.go:398] PVDeleted: Volume deletion will be handled by Controller
I1211 08:12:36.886787       1 reflector.go:370] pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflec
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Prevent volume deletion in syncer for volumes with reclaim policy delete
```
