### PR TITLE
Update RBAC and FSS info in manifests dev 7.0 and 6.7U3 folders

### DIFF
--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -41,6 +41,9 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
@@ -51,6 +54,10 @@ spec:
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
@@ -83,6 +90,8 @@ spec:
           image: gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest
           args:
             - "--leader-election"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -91,6 +100,10 @@ spec:
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume

--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -17,6 +17,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      serviceAccountName: vsphere-csi-node
       dnsPolicy: "Default"
       containers:
       - name: node-driver-registrar
@@ -43,6 +44,9 @@ spec:
           mountPath: /registration
       - name: vsphere-csi-node
         image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
+        args:
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME
@@ -62,6 +66,10 @@ spec:
           value: "true"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           privileged: true
           capabilities:

--- a/manifests/dev/vsphere-67u3/vanilla/rbac/vsphere-csi-node-rbac.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/rbac/vsphere-csi-node-rbac.yaml
@@ -1,0 +1,29 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-node
+  namespace: kube-system
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-role
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-binding
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: vsphere-csi-node-role
+  apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/vsphere-7.0/guestcluster/1.15/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0/guestcluster/1.15/pvcsi.yaml
@@ -9,6 +9,12 @@ metadata:
   name: vsphere-csi-controller
   namespace: {{ .PVCSINamespace }}
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-node
+  namespace: {{ .PVCSINamespace }}
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -43,14 +49,13 @@ metadata:
   name: vsphere-csi-node-role
   namespace: {{ .PVCSINamespace }}
 rules:
-  - apiGroups:
-    - "policy"
-    resources:
-    - podsecuritypolicies
-    verbs:
-    - use
-    resourceNames:
-    - vmware-system-privileged
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames: ["vmware-system-privileged"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -72,7 +77,7 @@ metadata:
   namespace: {{ .PVCSINamespace }}
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-node
     namespace: {{ .PVCSINamespace }}
 roleRef:
   kind: Role
@@ -122,6 +127,11 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: vmware.io/vsphere-csi:<image_tag>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -150,6 +160,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
             - mountPath: /etc/cloud/pvcsi-provider
               name: pvcsi-provider-volume
@@ -163,6 +175,10 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -173,6 +189,8 @@ spec:
               value: "GUEST_CLUSTER"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
           - mountPath: /etc/cloud/pvcsi-provider
             name: pvcsi-provider-volume
@@ -243,6 +261,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      serviceAccountName: vsphere-csi-node
       containers:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>
@@ -269,6 +288,11 @@ spec:
             mountPath: /registration
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
+        args:
+          - "--supervisor-fss-name=csi-feature-states"
+          - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "IfNotPresent"
         env:
         - name: NODE_NAME
@@ -285,6 +309,8 @@ spec:
           value: "GUEST_CLUSTER"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          value: {{ .PVCSINamespace }}
         securityContext:
           privileged: true
           capabilities:

--- a/manifests/dev/vsphere-7.0/guestcluster/1.16/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0/guestcluster/1.16/pvcsi.yaml
@@ -9,6 +9,12 @@ metadata:
   name: vsphere-csi-controller
   namespace: {{ .PVCSINamespace }}
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-node
+  namespace: {{ .PVCSINamespace }}
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -49,14 +55,13 @@ metadata:
   name: vsphere-csi-node-role
   namespace: {{ .PVCSINamespace }}
 rules:
-  - apiGroups:
-    - "policy"
-    resources:
-    - podsecuritypolicies
-    verbs:
-    - use
-    resourceNames:
-    - vmware-system-privileged
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames: ["vmware-system-privileged"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -78,7 +83,7 @@ metadata:
   namespace: {{ .PVCSINamespace }}
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: vsphere-csi-node
     namespace: {{ .PVCSINamespace }}
 roleRef:
   kind: Role
@@ -128,6 +133,11 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: vmware.io/vsphere-csi:<image_tag>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -158,6 +168,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
             - mountPath: /etc/cloud/pvcsi-provider
               name: pvcsi-provider-volume
@@ -171,6 +183,10 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -181,6 +197,8 @@ spec:
               value: "GUEST_CLUSTER"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
           volumeMounts:
           - mountPath: /etc/cloud/pvcsi-provider
             name: pvcsi-provider-volume
@@ -264,6 +282,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      serviceAccountName: vsphere-csi-node
       containers:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>
@@ -290,6 +309,11 @@ spec:
             mountPath: /registration
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
+        args:
+          - "--supervisor-fss-name=csi-feature-states"
+          - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "IfNotPresent"
         env:
         - name: NODE_NAME
@@ -306,6 +330,8 @@ spec:
           value: "GUEST_CLUSTER"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          value: {{ .PVCSINamespace }}
         securityContext:
           privileged: true
           capabilities:

--- a/manifests/dev/vsphere-7.0/supervisorcluster/k8s-1.15/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0/supervisorcluster/k8s-1.15/deploy/vsphere-csi-controller-deployment.yaml
@@ -73,6 +73,9 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: vsphere-csi-controller
           image: vmware/vsphere-csi:<vsphere_csi_ver>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
           lifecycle:
             preStop:
               exec:
@@ -98,6 +101,10 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp
@@ -119,6 +126,8 @@ spec:
           image: vmware/syncer:<syncer_ver>
           args:
             - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
@@ -136,6 +145,10 @@ spec:
               value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -54,6 +54,9 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
@@ -64,6 +67,10 @@ spec:
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
@@ -96,6 +103,8 @@ spec:
           image: gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest
           args:
             - "--leader-election"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -104,6 +113,10 @@ spec:
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -17,6 +17,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      serviceAccountName: vsphere-csi-node
       dnsPolicy: "Default"
       containers:
       - name: node-driver-registrar
@@ -43,6 +44,9 @@ spec:
           mountPath: /registration
       - name: vsphere-csi-node
         image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
+        args:
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
         imagePullPolicy: "Always"
         env:
         - name: NODE_NAME
@@ -62,6 +66,10 @@ spec:
           value: "true"
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           privileged: true
           capabilities:

--- a/manifests/dev/vsphere-7.0/vanilla/rbac/vsphere-csi-node-rbac.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/rbac/vsphere-csi-node-rbac.yaml
@@ -1,0 +1,29 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-node
+  namespace: kube-system
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-role
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-binding
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: vsphere-csi-node-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: The latest vSphere CSI images expect the controller and node service accounts to have `read, list, watch` privileges for configmaps to be able to read the FSS configmaps in CSI namespace. If these privileges are not available, we see repeated errors in these containers everytime `IsFSSEnabled` is called. Although 6.7U3 and 7.0 versions do not have these configmaps, we need to give these privileges to K8sOrchestrator so that it can default the FSS values to False by detecting that configmaps are missing.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: Follow-up PR to https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/487

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add RBAC and FSS info in manifests dev 7.0 and 6.7U3 folders
```
