### PR TITLE
Enable online resize in dev 7.0U2 manifests

### DIFF
--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -400,7 +400,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "online-volume-extend": "false"
+  "online-volume-extend": "true"
   "file-volume": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -400,7 +400,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "online-volume-extend": "false"
+  "online-volume-extend": "true"
   "file-volume": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -400,7 +400,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "online-volume-extend": "false"
+  "online-volume-extend": "true"
   "file-volume": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/deploy/vsphere-csi-controller-deployment.yaml
@@ -185,6 +185,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "false"
   "file-volume": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/deploy/vsphere-csi-controller-deployment.yaml
@@ -185,6 +185,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "false"
   "file-volume": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
@@ -186,7 +186,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "online-volume-extend": "false"
+  "online-volume-extend": "true"
   "file-volume": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -158,7 +158,7 @@ apiVersion: v1
 data:
   "csi-migration": "false"
   "csi-auth-check": "false"
-  "online-volume-extend": "false"
+  "online-volume-extend": "true"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Enable online resize of block volumes on Vanilla, Supervisor (K8s 1.19 version only) and TKGS clusters (K8s 1.17, 1.18, 1.19 versions)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enable online resize in dev 7.0U2 manifests
```
