### PR TITLE
Add fake attach implementation in WCP controller

### DIFF
--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/deploy/vsphere-csi-controller-deployment.yaml
@@ -183,6 +183,7 @@ data:
   "volume-health": "true"
   "online-volume-extend": "false"
   "file-volume": "false"
+  "fake-attach": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/deploy/vsphere-csi-controller-deployment.yaml
@@ -183,6 +183,7 @@ data:
   "volume-health": "true"
   "online-volume-extend": "false"
   "file-volume": "false"
+  "fake-attach": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
@@ -184,6 +184,7 @@ data:
   "volume-health": "true"
   "online-volume-extend": "true"
   "file-volume": "false"
+  "fake-attach": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -22,11 +22,14 @@ import (
 	"strconv"
 	"sync"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
 var mapVolumePathToID map[string]map[string]string
@@ -60,6 +63,33 @@ func (c *FakeK8SOrchestrator) IsFSSEnabled(ctx context.Context, featureName stri
 		return featureState
 	}
 	return false
+}
+
+// IsFakeAttachAllowed checks if the passed volume can be fake attached and mark it as fake attached.
+func (c *FakeK8SOrchestrator) IsFakeAttachAllowed(ctx context.Context, volumeID string, volumeManager cnsvolume.Manager) (bool, error) {
+	// TODO - This can be implemented if we add WCP controller tests for attach volume
+	log := logger.GetLogger(ctx)
+	msg := "IsFakeAttachAllowed for FakeK8SOrchestrator is not yet implemented."
+	log.Error(msg)
+	return false, status.Error(codes.Unimplemented, msg)
+}
+
+// MarkFakeAttached marks the volume as fake attached.
+func (c *FakeK8SOrchestrator) MarkFakeAttached(ctx context.Context, volumeID string) error {
+	// TODO - This can be implemented if we add WCP controller tests for attach volume
+	log := logger.GetLogger(ctx)
+	msg := "MarkFakeAttached for FakeK8SOrchestrator is not yet implemented."
+	log.Error(msg)
+	return status.Error(codes.Unimplemented, msg)
+}
+
+// ClearFakeAttached checks if the volume was fake attached, and unmark it as not fake attached.
+func (c *FakeK8SOrchestrator) ClearFakeAttached(ctx context.Context, volumeID string) error {
+	// TODO - This can be implemented if we add WCP controller tests for attach volume
+	log := logger.GetLogger(ctx)
+	msg := "ClearFakeAttached for FakeK8SOrchestrator is not yet implemented."
+	log.Error(msg)
+	return status.Error(codes.Unimplemented, msg)
 }
 
 // GetFakeVolumeMigrationService returns the mocked VolumeMigrationService

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
@@ -36,6 +37,12 @@ var ContainerOrchestratorUtility COCommonInterface
 type COCommonInterface interface {
 	// Check if feature state switch is enabled for the given feature indicated by featureName
 	IsFSSEnabled(ctx context.Context, featureName string) bool
+	// Check if the passed volume can be fake attached
+	IsFakeAttachAllowed(ctx context.Context, volumeID string, volumeManager cnsvolume.Manager) (bool, error)
+	// Mark the volume as fake attached
+	MarkFakeAttached(ctx context.Context, volumeID string) error
+	// Check if the volume was fake attached, and unmark it as not fake attached.
+	ClearFakeAttached(ctx context.Context, volumeID string) error
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_helper.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_helper.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sorchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+)
+
+// getPVCAnnotations fetches annotations from PVC bound to passed volumeID and returns
+// annotation key-value pairs as a map
+func (c *K8sOrchestrator) getPVCAnnotations(ctx context.Context, volumeID string) (map[string]string, error) {
+	log := logger.GetLogger(ctx)
+	log.Debugf("Getting annotations on pvc corresponding to volume: %s", volumeID)
+	if pvc := c.volumeIDToPvcMap.get(volumeID); pvc != "" {
+		parts := strings.Split(pvc, "/")
+		pvcNamespace := parts[0]
+		pvcName := parts[1]
+
+		pvcObj, err := c.informerManager.GetPVCLister().PersistentVolumeClaims(pvcNamespace).Get(pvcName)
+		if err != nil {
+			log.Errorf("failed to get pvc: %s in namespace: %s. err=%v", pvcName, pvcNamespace, err)
+			return nil, err
+		}
+
+		return pvcObj.Annotations, nil
+	}
+
+	errMsg := fmt.Sprintf("could not find pvc for volumeID: %s", volumeID)
+	log.Debugf(errMsg)
+	return nil, errors.New(errMsg)
+}
+
+// updatePVCAnnotations updates annotations passed as key-value pairs
+// on PVC bound to passed volumeID
+func (c *K8sOrchestrator) updatePVCAnnotations(ctx context.Context, volumeID string, annotations map[string]string) error {
+	log := logger.GetLogger(ctx)
+	if pvc := c.volumeIDToPvcMap.get(volumeID); pvc != "" {
+		parts := strings.Split(pvc, "/")
+		pvcNamespace := parts[0]
+		pvcName := parts[1]
+
+		pvcObj, err := c.informerManager.GetPVCLister().PersistentVolumeClaims(pvcNamespace).Get(pvcName)
+		if err != nil {
+			log.Errorf("failed to get pvc: %s in namespace: %s. err=%v", pvcName, pvcNamespace, err)
+			return err
+		}
+
+		for key, val := range annotations {
+			// If value is not set, remove the annotation
+			if val == "" {
+				delete(pvcObj.ObjectMeta.Annotations, key)
+				log.Debugf("Removing annotation %s on pvc %s/%s", key, pvcNamespace, pvcName)
+			} else {
+				metav1.SetMetaDataAnnotation(&pvcObj.ObjectMeta, key, val)
+				log.Debugf("Updating annotation %s on pvc %s/%s to value: %s", key, pvcNamespace, pvcName, val)
+			}
+		}
+		_, err = c.k8sClient.CoreV1().PersistentVolumeClaims(pvcNamespace).Update(ctx, pvcObj, metav1.UpdateOptions{})
+		if err != nil {
+			log.Errorf("failed to update pvc annotations %s/%s with err:%+v", pvcNamespace, pvcName, err)
+			return err
+		}
+		return nil
+	}
+
+	errMsg := fmt.Sprintf("could not find pvc for volumeID: %s", volumeID)
+	log.Debugf(errMsg)
+	return errors.New(errMsg)
+}
+
+// isFileVolume checks if the Persistent Volume has ReadWriteMany or ReadOnlyMany support
+func isFileVolume(pv *v1.PersistentVolume) bool {
+	if len(pv.Spec.AccessModes) == 0 {
+		return false
+	}
+	for _, accessMode := range pv.Spec.AccessModes {
+		if accessMode == v1.ReadWriteMany || accessMode == v1.ReadOnlyMany {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -90,6 +90,9 @@ const (
 	// AttributeFirstClassDiskUUID is the SCSI Disk Identifier
 	AttributeFirstClassDiskUUID = "diskUUID"
 
+	// AttributeFakeAttached is the flag that indicates if a volume is fake attached
+	AttributeFakeAttached = "fake-attach"
+
 	// BlockVolumeType is the VolumeType for CNS Volume
 	BlockVolumeType = "BLOCK"
 
@@ -183,6 +186,22 @@ const (
 
 	// HostConfigStoragePriv is the privilege for file volumes
 	HostConfigStoragePriv = "Host.Config.Storage"
+
+	// AnnVolumeHealth is the key for HealthStatus annotation on volume claim
+	AnnVolumeHealth = "volumehealth.storage.kubernetes.io/health"
+
+	// AnnFakeAttached is the key for fake attach annotation on volume claim
+	AnnFakeAttached = "csi.vmware.com/fake-attached"
+
+	// VolHealthStatusAccessible is volume health status for accessible volume
+	VolHealthStatusAccessible = "accessible"
+
+	// VolHealthStatusInaccessible is volume health status for inaccessible volume
+	VolHealthStatusInaccessible = "inaccessible"
+
+	// AnnIgnoreInaccessiblePV is annotation key on volume claim to indicate
+	// if inaccessible PV can be fake attached
+	AnnIgnoreInaccessiblePV = "pv.attach.kubernetes.io/ignore-if-inaccessible"
 )
 
 // Supported container orchestrators
@@ -208,4 +227,6 @@ const (
 	VSANDirectDiskDecommission = "vsan-direct-disk-decommission"
 	// FileVolume is feature flag name for file volume support in WCP
 	FileVolume = "file-volume"
+	// FakeAttach is the feature flag for fake attach support in WCP
+	FakeAttach = "fake-attach"
 )

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/akutz/gofsutil"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	pbmtypes "github.com/vmware/govmomi/pbm/types"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
 
@@ -322,4 +323,20 @@ func GetK8sCloudOperatorServicePort(ctx context.Context) int {
 		}
 	}
 	return k8sCloudOperatorServicePort
+}
+
+// ConvertVolumeHealthStatus convert the volume health status into accessible/inaccessible status
+func ConvertVolumeHealthStatus(volHealthStatus string) (string, error) {
+	switch volHealthStatus {
+	case string(pbmtypes.PbmHealthStatusForEntityRed):
+		return VolHealthStatusInaccessible, nil
+	case string(pbmtypes.PbmHealthStatusForEntityGreen):
+		return VolHealthStatusAccessible, nil
+	case string(pbmtypes.PbmHealthStatusForEntityYellow):
+		return VolHealthStatusAccessible, nil
+	case string(pbmtypes.PbmHealthStatusForEntityUnknown):
+		return string(pbmtypes.PbmHealthStatusForEntityUnknown), nil
+	default:
+		return "", fmt.Errorf("cannot convert invalid volume health status %s", volHealthStatus)
+	}
 }

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -59,12 +59,6 @@ const (
 	volumeHealthRetryIntervalMax = 5 * time.Minute
 	// default number of threads concurrently running for volume health reconciler
 	volumeHealthWorkers = 10
-
-	// description of volume health status for accessible volume
-	volHealthStatusAccessible = "accessible"
-
-	// description of volume health status for inaccessible volume
-	volHealthStatusInAccessible = "inaccessible"
 )
 
 var (

--- a/pkg/syncer/volume_health.go
+++ b/pkg/syncer/volume_health.go
@@ -18,7 +18,6 @@ package syncer
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
@@ -27,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
@@ -85,7 +85,7 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 
 			// only update PVC health annotation if the HealthStatus of volume is not "unknown"
 			if vol.HealthStatus != string(pbmtypes.PbmHealthStatusForEntityUnknown) {
-				volHealthStatus, err := convertVolumeHealthStatus(vol.HealthStatus)
+				volHealthStatus, err := common.ConvertVolumeHealthStatus(vol.HealthStatus)
 				if err != nil {
 					log.Errorf("csiGetVolumeHealthStatus: invalid health status %q for volume %q", vol.HealthStatus, vol.VolumeId.Id)
 				}
@@ -132,20 +132,4 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 		}
 	}
 	log.Infof("GetVolumeHealthStatus: end")
-}
-
-// convertVolumeHealthStatus convert the volume health status into accessible/inaccessible status
-func convertVolumeHealthStatus(volHealthStatus string) (string, error) {
-	switch volHealthStatus {
-	case string(pbmtypes.PbmHealthStatusForEntityRed):
-		return volHealthStatusInAccessible, nil
-	case string(pbmtypes.PbmHealthStatusForEntityGreen):
-		return volHealthStatusAccessible, nil
-	case string(pbmtypes.PbmHealthStatusForEntityYellow):
-		return volHealthStatusAccessible, nil
-	case string(pbmtypes.PbmHealthStatusForEntityUnknown):
-		return string(pbmtypes.PbmHealthStatusForEntityUnknown), nil
-	default:
-		return "", fmt.Errorf("cannot convert invalid volume health status %s", volHealthStatus)
-	}
 }

--- a/pkg/syncer/volume_health_reconciler.go
+++ b/pkg/syncer/volume_health_reconciler.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
@@ -411,7 +412,7 @@ func (rc *volumeHealthReconciler) updateTKGPVC(ctx context.Context, svcPVC *v1.P
 	if svcPVC != nil {
 		svcAnnValue, svcAnnFound = svcPVC.ObjectMeta.Annotations[annVolumeHealth]
 	} else {
-		svcAnnValue = volHealthStatusInAccessible
+		svcAnnValue = common.VolHealthStatusInaccessible
 	}
 
 	if !tkgAnnFound && svcAnnFound || tkgAnnFound && svcAnnFound && tkgAnnValue != svcAnnValue || svcPVC == nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds fake attach functionality for inaccessible volumes in WCP controller, such that that for certain specially annotated PVCs, if PV is inaccessible from a host, ControllerPublishVolume will not fail and will add `fake-attach: true` in PublishContext which will be reflected in corresponding VolumeAttachment object.
It will also add annotation `csi.vmware.com/fake-attached: yes` to the PVC, which will be cleared during ControllerUnpublishVolume(detach) call.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Testing done:

***Attach***
1. Create a PVC with annotation `pv.attach.kubernetes.io/ignore-if-inaccessible` set to yes.
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.attach.kubernetes.io/ignore-if-inaccessible: yes                 <<<<------
    pv.kubernetes.io/bind-completed: yes
    pv.kubernetes.io/bound-by-controller: yes
    volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
    volumehealth.storage.kubernetes.io/health: inaccessible
.
.
.
  storageClassName: custom-storage-profile
  volumeMode: Filesystem
  volumeName: pvc-d1da2467-a6d7-4cfc-a288-aae8ab839760
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound
```

2. If the PV bound to this PVC is not accessible, the attach operation will not fail while creating a pod.
``` 
root@42368ae67ff68b6ddca6c6b4fd0bcb40 [ ~/manifests ]# kubectl apply -f pod.yaml -n my-podvm-ns
pod/block-pod created
```

WCP controller logs:
```
2020-12-16T01:05:06.697Z	INFO	wcp/controller.go:462	ControllerPublishVolume: called with args {VolumeId:a3dcb4f3-ff52-408d-a75c-30bd9c558751 NodeId:sc1-10-182-128-55.eng.vmware.com VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[storage.kubernetes.io/csiProvisionerIdentity:1607625493909-8081-csi.vsphere.vmware.com type:vSphere CNS Block Volume] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "f6492031-a66c-4e02-8d43-80a100145394"}
.
.
2020-12-16T01:05:15.372Z	INFO	volume/manager.go:336	AttachVolume: volumeID: "a3dcb4f3-ff52-408d-a75c-30bd9c558751", vm: "VirtualMachine:vm-139 [VirtualCenterHost: sc1-10-182-134-166.eng.vmware.com, UUID: 50366703-89b2-795f-7d92-89d16a294b06, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-182-134-166.eng.vmware.com]]", opId: "61dbaae8"
.
.
2020-12-16T01:05:15.377Z	ERROR	volume/manager.go:365	failed to attach cns volume: "a3dcb4f3-ff52-408d-a75c-30bd9c558751" to node vm: "VirtualMachine:vm-139 [VirtualCenterHost: sc1-10-182-134-166.eng.vmware.com, UUID: 50366703-89b2-795f-7d92-89d16a294b06.........................LocalizedMessage: (string) (len=105) \"Datastore 'agohil-nfs' is not accessible. No connected and accessible host is attached to this datastore.\"\n})\n". opId: "61dbaae8"
.
.
2020-12-16T01:05:15.380Z	INFO	wcp/controller.go:517	Volume attachment failed. Checking if it can be fake attached	{"TraceId": "f6492031-a66c-4e02-8d43-80a100145394"}
2020-12-16T01:05:15.380Z	DEBUG	k8sorchestrator/k8sorchestrator.go:478	Getting volume annotations for volume: a3dcb4f3-ff52-408d-a75c-30bd9c558751
2020-12-16T01:05:15.414Z	INFO	wcp/controller_helper.go:458	Found pv.attach.kubernetes.io/ignore-if-inaccessible annotation for volume a3dcb4f3-ff52-408d-a75c-30bd9c558751
2020-12-16T01:05:15.415Z	DEBUG	wcp/controller_helper.go:460	Checking volume health on CNS volume: a3dcb4f3-ff52-408d-a75c-30bd9c558751
2020-12-16T01:05:15.558Z	INFO	wcp/controller_helper.go:473	CNS volume health is: inaccessible
2020-12-16T01:05:15.558Z	INFO	wcp/controller.go:526	Volume a3dcb4f3-ff52-408d-a75c-30bd9c558751 is fake attached	{"TraceId": "f6492031-a66c-4e02-8d43-80a100145394"}
```

 3. The VolumeAttachment object will have a field `fake-attach: true` in AttachmentMetadata.
 ```
root@42368ae67ff68b6ddca6c6b4fd0bcb40 [ ~/manifests ]# kubectl describe volumeattachment csi-37e64a571c8b13c0a33fc9c8de761cc364bb16a2418689fa2f36face95424bc5
Name:         csi-37e64a571c8b13c0a33fc9c8de761cc364bb16a2418689fa2f36face95424bc5
Namespace:
Labels:       <none>
Annotations:  csi.alpha.kubernetes.io/node-id: sc1-10-182-128-55.eng.vmware.com
API Version:  storage.k8s.io/v1
Kind:         VolumeAttachment
.
.
Spec:
  Attacher:   csi.vsphere.vmware.com
  Node Name:  sc1-10-182-128-55.eng.vmware.com
  Source:
    Persistent Volume Name:  pvc-d1da2467-a6d7-4cfc-a288-aae8ab839760
Status:
  Attached:  true
  Attachment Metadata:
    Fake Attached:  true                        <<<<<<<<<<<<--------------------
    Type:           vSphere CNS Block Volume
Events:             <none>
```

4. The PVC will have annotation `csi.vmware.com/fake-attached: yes`
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    csi.vmware.com/fake-attached: yes                  <<<<<<<<----------
    pv.attach.kubernetes.io/ignore-if-inaccessible: yes                 
    pv.kubernetes.io/bind-completed: yes
    pv.kubernetes.io/bound-by-controller: yes
    volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
    volumehealth.storage.kubernetes.io/health: inaccessible
.
.
.
  storageClassName: custom-storage-profile
  volumeMode: Filesystem
  volumeName: pvc-d1da2467-a6d7-4cfc-a288-aae8ab839760
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound
```

***Detach***
When the pod is terminated and CSI receives a detach call, it will clear the annotation `csi.vmware.com/fake-attached` on corresponding PVC.

Controller logs:
```
2020-12-17T20:59:50.250Z	INFO	wcp/controller.go:552	ControllerUnpublishVolume: called with args {VolumeId:a1c6048c-6d5e-4734-a9f1-ada1b134024f NodeId:sc1-10-182-183-180.eng.vmware.com Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "e4e3b609-83ea-4bdc-9a94-66e8bbe1b62c"}
2020-12-17T20:59:50.251Z	DEBUG	k8sorchestrator/k8sorchestrator.go:475	Getting volume annotations for volume: a1c6048c-6d5e-4734-a9f1-ada1b134024f	{"TraceId": "e4e3b609-83ea-4bdc-9a94-66e8bbe1b62c"}
2020-12-17T20:59:50.295Z	DEBUG	k8sorchestrator/k8sorchestrator.go:512	Removing annotation csi.vmware.com/fake-attached on pvc playground-ns/block-pvc {"TraceId": "e4e3b609-83ea-4bdc-9a94-66e8bbe1b62c"}
```

***Pod behavior***
When the volume gets fake attached, the Spherelet agent in WCP fake mounts the volume by mounting a read-only empty tmpfs volume, and the pod goes into running state.
The application running in pod should be able to gracefully handle IO failures on fake attached volume. If the application doesn't handle this, the pod will terminate. 


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add fake attach implementation in WCP controller
```
