### PR TITLE
Update v1.0.3-rc.2 images in driver deployment yaml files

### DIFF
--- a/manifests/deploy/vsphere-csi-controller-ss.yaml
+++ b/manifests/deploy/vsphere-csi-controller-ss.yaml
@@ -39,7 +39,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.3-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.3-rc.2
           args:
             - "--v=4"
           imagePullPolicy: "Always"
@@ -79,7 +79,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.3-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.3-rc.2
           args:
             - "--v=2"
           imagePullPolicy: "Always"

--- a/manifests/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/deploy/vsphere-csi-node-ds.yaml
@@ -40,7 +40,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.3-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.3-rc.2
           imagePullPolicy: "Always"
           env:
             - name: NODE_NAME


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is updating the rc images names for driver and syncer in the manifests folder

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
```
# cat chethan/driver.yaml | grep image:
          image: quay.io/k8scsi/csi-attacher:v1.1.1
          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.3-rc.2
          image: quay.io/k8scsi/livenessprobe:v1.1.0
          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.3-rc.2
          image: quay.io/k8scsi/csi-provisioner:v1.2.2
root@k8s-master:~# cat chethan/node-ds.yaml | grep image:
          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.3-rc.2
          image: quay.io/k8scsi/livenessprobe:v1.1.0
(reverse-i-search)`': ^C
root@k8s-master:~# ^C
root@k8s-master:~# kubectl get pods -n kube-system
NAME                                 READY   STATUS    RESTARTS   AGE
coredns-57c7bff75f-vcxxf             1/1     Running   0          6d5h
coredns-57c7bff75f-xj5gr             1/1     Running   0          6d5h
etcd-k8s-master                      1/1     Running   0          6d5h
kube-apiserver-k8s-master            1/1     Running   1          3d3h
kube-controller-manager-k8s-master   1/1     Running   2          3d3h
kube-flannel-ds-8rt7t                1/1     Running   0          6d5h
kube-flannel-ds-b79h7                1/1     Running   0          6d5h
kube-proxy-mtnk4                     1/1     Running   0          6d5h
kube-proxy-xd7mj                     1/1     Running   0          6d5h
kube-scheduler-k8s-master            1/1     Running   2          6d5h
vsphere-csi-node-ft46h               3/3     Running   0          8m42s
vsphere-csi-node-tt8gp               3/3     Running   0          8m42s
root@k8s-master:~# kubectl create -f pvc.yaml 
Error from server (AlreadyExists): error when creating "pvc.yaml": persistentvolumeclaims "example-vanilla-block-pvc" already exists
root@k8s-master:~# kubectl delete -f pvc.yaml 
persistentvolumeclaim "example-vanilla-block-pvc" deleted
root@k8s-master:~# cat chethan/driver.yaml | grep image:
          image: quay.io/k8scsi/csi-attacher:v1.1.1
          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.3-rc.2
          image: quay.io/k8scsi/livenessprobe:v1.1.0
          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.3-rc.2
          image: quay.io/k8scsi/csi-provisioner:v1.2.2
root@k8s-master:~# kubectl get pods -n kube-system
NAME                                 READY   STATUS    RESTARTS   AGE
coredns-57c7bff75f-vcxxf             1/1     Running   0          6d5h
coredns-57c7bff75f-xj5gr             1/1     Running   0          6d5h
etcd-k8s-master                      1/1     Running   0          6d5h
kube-apiserver-k8s-master            1/1     Running   1          3d3h
kube-controller-manager-k8s-master   1/1     Running   2          3d3h
kube-flannel-ds-8rt7t                1/1     Running   0          6d5h
kube-flannel-ds-b79h7                1/1     Running   0          6d5h
kube-proxy-mtnk4                     1/1     Running   0          6d5h
kube-proxy-xd7mj                     1/1     Running   0          6d5h
kube-scheduler-k8s-master            1/1     Running   2          6d5h
vsphere-csi-controller-0             5/5     Running   0          11s
vsphere-csi-node-ft46h               3/3     Running   0          9m1s
vsphere-csi-node-tt8gp               3/3     Running   0          9m1s
root@k8s-master:~# kubectl create -f pvc.yaml 
persistentvolumeclaim/example-vanilla-block-pvc created
root@k8s-master:~# kubectl logs vsphere-csi-controller-0 -c vsphere-csi-controller -n kube-system -f
I1215 00:16:32.196755       1 config.go:261] GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
I1215 00:16:32.197772       1 config.go:206] Initializing vc server 10.92.184.51
I1215 00:16:32.197821       1 controller.go:73] Initializing CNS controller
I1215 00:16:32.198164       1 virtualcentermanager.go:63] Initializing defaultVirtualCenterManager...
I1215 00:16:32.198210       1 virtualcentermanager.go:65] Successfully initialized defaultVirtualCenterManager
I1215 00:16:32.198352       1 virtualcentermanager.go:107] Successfully registered VC "10.92.184.51"
I1215 00:16:32.198557       1 manager.go:80] Initializing volume.volumeManager...
I1215 00:16:32.198584       1 manager.go:84] volume.volumeManager initialized
I1215 00:16:32.309331       1 virtualcenter.go:145] New session ID for 'VSPHERE.LOCAL\Administrator' = 525a5267-4ec6-8db8-7428-cabc3fcdae56
I1215 00:16:32.309442       1 kubernetes.go:56] k8s client using in-cluster config
I1215 00:16:32.313692       1 manager.go:74] Initializing node.nodeManager...
I1215 00:16:32.313713       1 manager.go:78] node.nodeManager initialized
I1215 00:16:32.313721       1 kubernetes.go:56] k8s client using in-cluster config
I1215 00:16:32.314369       1 reflector.go:123] Starting reflector *v1.VolumeAttachment (0s) from pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflector.go:94
I1215 00:16:32.314466       1 reflector.go:161] Listing and watching *v1.VolumeAttachment from pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflector.go:94
I1215 00:16:32.314751       1 service.go:88] configured: csi.vsphere.vmware.com with map[mode:controller]
time="2020-12-15T00:16:32Z" level=info msg="identity service registered"
time="2020-12-15T00:16:32Z" level=info msg="controller service registered"
time="2020-12-15T00:16:32Z" level=info msg=serving endpoint="unix:///csi/csi.sock"
I1215 00:16:32.315298       1 reflector.go:123] Starting reflector *v1.Node (0s) from pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflector.go:94
I1215 00:16:32.315312       1 reflector.go:161] Listing and watching *v1.Node from pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflector.go:94
I1215 00:16:32.320604       1 reflector.go:123] Starting reflector *v1.PersistentVolume (0s) from pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflector.go:94
I1215 00:16:32.320624       1 reflector.go:161] Listing and watching *v1.PersistentVolume from pkg/mod/k8s.io/client-go@v11.0.0+incompatible/tools/cache/reflector.go:94
I1215 00:16:32.346939       1 manager.go:101] Successfully registered node: "k8s-node1" with nodeUUID "420a12a4-f6c2-d64f-4581-1cc2338db2cc"
I1215 00:16:32.347091       1 virtualmachine.go:126] Initiating asynchronous datacenter listing with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:32.362021       1 datacenter.go:148] Publishing datacenter Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]
I1215 00:16:32.362273       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:32.362293       1 virtualmachine.go:163] AsyncGetAllDatacenters with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc sent a dc Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]
I1215 00:16:32.367217       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:32.367240       1 virtualmachine.go:158] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:32.367246       1 virtualmachine.go:158] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:32.367252       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:32.367258       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:32.367263       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:32.370464       1 virtualmachine.go:178] Found VM VirtualMachine:vm-68 [VirtualCenterHost: 10.92.184.51, UUID: 420a12a4-f6c2-d64f-4581-1cc2338db2cc, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]] given uuid 420a12a4-f6c2-d64f-4581-1cc2338db2cc on DC Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51], canceling context
I1215 00:16:32.370563       1 virtualmachine.go:190] Returning VM VirtualMachine:vm-68 [VirtualCenterHost: 10.92.184.51, UUID: 420a12a4-f6c2-d64f-4581-1cc2338db2cc, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]] for UUID 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:32.370693       1 manager.go:120] Successfully discovered node with nodeUUID 420a12a4-f6c2-d64f-4581-1cc2338db2cc in vm VirtualMachine:vm-68 [VirtualCenterHost: 10.92.184.51, UUID: 420a12a4-f6c2-d64f-4581-1cc2338db2cc, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]]
I1215 00:16:32.370703       1 manager.go:107] Successfully discovered node: "k8s-node1" with nodeUUID "420a12a4-f6c2-d64f-4581-1cc2338db2cc"
I1215 00:16:32.370723       1 manager.go:101] Successfully registered node: "k8s-master" with nodeUUID "420af25e-3dab-7091-e799-63762474e20a"
I1215 00:16:32.370729       1 virtualmachine.go:126] Initiating asynchronous datacenter listing with uuid 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:32.386769       1 datacenter.go:148] Publishing datacenter Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]
I1215 00:16:32.390350       1 virtualmachine.go:158] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:32.390445       1 virtualmachine.go:163] AsyncGetAllDatacenters with uuid 420af25e-3dab-7091-e799-63762474e20a sent a dc Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]
I1215 00:16:32.395264       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:32.395290       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:32.395296       1 virtualmachine.go:158] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:32.395302       1 virtualmachine.go:158] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:32.395320       1 virtualmachine.go:158] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:32.395331       1 virtualmachine.go:142] AsyncGetAllDatacenters finished with uuid 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:32.395448       1 virtualmachine.go:178] Found VM VirtualMachine:vm-67 [VirtualCenterHost: 10.92.184.51, UUID: 420af25e-3dab-7091-e799-63762474e20a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]] given uuid 420af25e-3dab-7091-e799-63762474e20a on DC Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51], canceling context
I1215 00:16:32.395484       1 virtualmachine.go:190] Returning VM VirtualMachine:vm-67 [VirtualCenterHost: 10.92.184.51, UUID: 420af25e-3dab-7091-e799-63762474e20a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]] for UUID 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:32.395498       1 manager.go:120] Successfully discovered node with nodeUUID 420af25e-3dab-7091-e799-63762474e20a in vm VirtualMachine:vm-67 [VirtualCenterHost: 10.92.184.51, UUID: 420af25e-3dab-7091-e799-63762474e20a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]]
I1215 00:16:32.395507       1 manager.go:107] Successfully discovered node: "k8s-master" with nodeUUID "420af25e-3dab-7091-e799-63762474e20a"
I1215 00:16:32.900448       1 controller.go:413] ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I1215 00:16:34.437659       1 controller.go:413] ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I1215 00:16:34.553578       1 controller.go:266] DeleteVolume: called with args: {VolumeId:379ebeca-74af-4835-a7ad-c92abdc1c6be Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I1215 00:16:34.553897       1 vsphereutil.go:157] vSphere Cloud Provider deleting volume: 379ebeca-74af-4835-a7ad-c92abdc1c6be
I1215 00:16:41.150669       1 manager.go:362] DeleteVolume: volumeID: "379ebeca-74af-4835-a7ad-c92abdc1c6be", opId: "98cddc7d"
I1215 00:16:41.151129       1 manager.go:380] DeleteVolume: Volume deleted successfully. volumeID: "379ebeca-74af-4835-a7ad-c92abdc1c6be", opId: "98cddc7d"
I1215 00:16:41.151254       1 vsphereutil.go:163] Successfully deleted disk for volumeid: 379ebeca-74af-4835-a7ad-c92abdc1c6be
I1215 00:16:42.171782       1 controller.go:132] CreateVolume: called with args {Name:pvc-1820f4dc-c8ff-4ae4-8a1c-2f137e333db0 CapacityRange:required_bytes:1048576  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[datastoreurl:ds:///vmfs/volumes/vsan:52aaba491a549736-283b4af41887ccc6/] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I1215 00:16:42.173769       1 manager.go:219] Renewing VM VirtualMachine:vm-68 [VirtualCenterHost: 10.92.184.51, UUID: 420a12a4-f6c2-d64f-4581-1cc2338db2cc, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]] with new connection: nodeUUID 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:42.177950       1 manager.go:229] Updated VM VirtualMachine:vm-68 [VirtualCenterHost: 10.92.184.51, UUID: 420a12a4-f6c2-d64f-4581-1cc2338db2cc, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2, VirtualCenterHost: 10.92.184.51]] for node with nodeUUID 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:42.178139       1 manager.go:216] Renewing VM VirtualMachine:vm-67 [VirtualCenterHost: 10.92.184.51, UUID: 420af25e-3dab-7091-e799-63762474e20a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /vcqaDC, VirtualCenterHost: 10.92.184.51]], no new connection needed: nodeUUID 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:42.178170       1 manager.go:229] Updated VM VirtualMachine:vm-67 [VirtualCenterHost: 10.92.184.51, UUID: 420af25e-3dab-7091-e799-63762474e20a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2, VirtualCenterHost: 10.92.184.51]] for node with nodeUUID 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:42.178388       1 nodes.go:242] Getting accessible datastores for node VirtualMachine:vm-68
I1215 00:16:42.198080       1 nodes.go:242] Getting accessible datastores for node VirtualMachine:vm-67
I1215 00:16:42.208524       1 nodes.go:234] sharedDatastores : [Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/377bda63-308e0767/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/5fcf3c27-240641e7-e0da-020058a040f9/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/5fcf3c29-f728e27f-836c-020058a040f9/ Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/ab9c5c10-48c6f4de-0000-000000000000/ Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/de5fe353-634bc27f/ Datastore: Datastore:datastore-58, datastore URL: ds:///vmfs/volumes/vsan:52aaba491a549736-283b4af41887ccc6/]
I1215 00:16:42.241018       1 vsphereutil.go:117] vSphere CNS driver creating volume pvc-1820f4dc-c8ff-4ae4-8a1c-2f137e333db0 with create spec (*types.CnsVolumeCreateSpec)(0xc0006df340)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-1820f4dc-c8ff-4ae4-8a1c-2f137e333db0",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=1 cap=1) {
  (types.ManagedObjectReference) Datastore:datastore-58
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=15) "demo-cluster-id",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc0008b1e40)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 1
  },
  BackingDiskId: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) <nil>
})
I1215 00:16:42.247282       1 manager.go:133] Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator
I1215 00:16:42.584329       1 controller.go:266] DeleteVolume: called with args: {VolumeId:379ebeca-74af-4835-a7ad-c92abdc1c6be Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I1215 00:16:42.584753       1 vsphereutil.go:157] vSphere Cloud Provider deleting volume: 379ebeca-74af-4835-a7ad-c92abdc1c6be
I1215 00:16:42.687647       1 manager.go:349] VolumeID: "379ebeca-74af-4835-a7ad-c92abdc1c6be", not found. Returning success for this operation since the volume is not present
I1215 00:16:42.687712       1 vsphereutil.go:163] Successfully deleted disk for volumeid: 379ebeca-74af-4835-a7ad-c92abdc1c6be
I1215 00:16:46.089805       1 manager.go:166] CreateVolume: VolumeName: "pvc-1820f4dc-c8ff-4ae4-8a1c-2f137e333db0", opId: "98cddc7f"
I1215 00:16:46.089854       1 manager.go:188] CreateVolume: Volume created successfully. VolumeName: "pvc-1820f4dc-c8ff-4ae4-8a1c-2f137e333db0", opId: "98cddc7f", volumeID: "53402e96-35c9-4b51-ae8d-d4b0919133de"
I1215 00:16:46.336357       1 controller.go:132] CreateVolume: called with args {Name:pvc-1820f4dc-c8ff-4ae4-8a1c-2f137e333db0 CapacityRange:required_bytes:1048576  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[datastoreurl:ds:///vmfs/volumes/vsan:52aaba491a549736-283b4af41887ccc6/] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I1215 00:16:46.375049       1 manager.go:219] Renewing VM VirtualMachine:vm-68 [VirtualCenterHost: 10.92.184.51, UUID: 420a12a4-f6c2-d64f-4581-1cc2338db2cc, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2, VirtualCenterHost: 10.92.184.51]] with new connection: nodeUUID 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:46.408535       1 manager.go:229] Updated VM VirtualMachine:vm-68 [VirtualCenterHost: 10.92.184.51, UUID: 420a12a4-f6c2-d64f-4581-1cc2338db2cc, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2, VirtualCenterHost: 10.92.184.51]] for node with nodeUUID 420a12a4-f6c2-d64f-4581-1cc2338db2cc
I1215 00:16:46.415348       1 manager.go:216] Renewing VM VirtualMachine:vm-67 [VirtualCenterHost: 10.92.184.51, UUID: 420af25e-3dab-7091-e799-63762474e20a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2, VirtualCenterHost: 10.92.184.51]], no new connection needed: nodeUUID 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:46.415588       1 manager.go:229] Updated VM VirtualMachine:vm-67 [VirtualCenterHost: 10.92.184.51, UUID: 420af25e-3dab-7091-e799-63762474e20a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2, VirtualCenterHost: 10.92.184.51]] for node with nodeUUID 420af25e-3dab-7091-e799-63762474e20a
I1215 00:16:46.415628       1 nodes.go:242] Getting accessible datastores for node VirtualMachine:vm-68
I1215 00:16:46.456859       1 nodes.go:242] Getting accessible datastores for node VirtualMachine:vm-67
I1215 00:16:46.481331       1 nodes.go:234] sharedDatastores : [Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/377bda63-308e0767/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/5fcf3c27-240641e7-e0da-020058a040f9/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/5fcf3c29-f728e27f-836c-020058a040f9/ Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/ab9c5c10-48c6f4de-0000-000000000000/ Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/de5fe353-634bc27f/ Datastore: Datastore:datastore-58, datastore URL: ds:///vmfs/volumes/vsan:52aaba491a549736-283b4af41887ccc6/]
I1215 00:16:46.527280       1 vsphereutil.go:117] vSphere CNS driver creating volume pvc-1820f4dc-c8ff-4ae4-8a1c-2f137e333db0 with create spec (*types.CnsVolumeCreateSpec)(0xc00029cd10)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-1820f4dc-c8ff-4ae4-8a1c-2f137e333db0",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=1 cap=1) {
  (types.ManagedObjectReference) Datastore:datastore-58
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=15) "demo-cluster-id",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc0009118e0)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 1
  },
  BackingDiskId: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) <nil>
})
I1215 00:16:46.537115       1 manager.go:133] Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator
I1215 00:16:46.539659       1 manager.go:145] CreateVolume task still pending for VolumeName: "pvc-1820f4dc-c8ff-4ae4-8a1c-2f137e333db0", with taskInfo: &{DynamicData:{} Key:task-5315 Task:Task:task-5315 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:success Cancelled:false Cancelable:false Error:<nil> Result:{DynamicData:{} VolumeResults:[0xc000467d10]} Progress:0 Reason:0xc000559430 QueueTime:2020-12-15 00:16:42.292749 +0000 UTC StartTime:2020-12-15 00:16:42.300384 +0000 UTC CompleteTime:2020-12-15 00:16:46.082894 +0000 UTC EventChainId:17288 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:98cddc7f}
I1215 00:16:46.540060       1 manager.go:166] CreateVolume: VolumeName: "pvc-1820f4dc-c8ff-4ae4-8a1c-2f137e333db0", opId: "98cddc7f"
I1215 00:16:46.540156       1 manager.go:188] CreateVolume: Volume created successfully. VolumeName: "pvc-1820f4dc-c8ff-4ae4-8a1c-2f137e333db0", opId: "98cddc7f", volumeID: "53402e96-35c9-4b51-ae8d-d4b0919133de"



root@k8s-master:~# kubectl create -f pod.yaml 
pod/example-vanilla-block-pod created
root@k8s-master:~# kubectl get pods
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   1/1     Running   0          32s
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update CSI driver and syncer images in manifests
```
