### PR TITLE
Implementation of CnsFileVolumeClient functions.

### DIFF
--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -138,7 +138,7 @@ func GetVolumeMigrationService(ctx context.Context, volumeManager *cnsvolume.Man
 			}
 			go func() {
 				log.Debugf("Starting Informer for cnsvspherevolumemigrations")
-				informer, err := k8s.GetDynamicInformer(ctx, migrationv1alpha1.SchemeGroupVersion.Group, migrationv1alpha1.SchemeGroupVersion.Version, "cnsvspherevolumemigrations", "")
+				informer, err := k8s.GetDynamicInformer(ctx, migrationv1alpha1.SchemeGroupVersion.Group, migrationv1alpha1.SchemeGroupVersion.Version, "cnsvspherevolumemigrations")
 				if err != nil {
 					log.Errorf("failed to create dynamic informer for volume migration CRD. Err: %v", err)
 				}

--- a/pkg/internal/cnsoperator/cnsfilevolumeclient/cnsfilevolumeclient.go
+++ b/pkg/internal/cnsoperator/cnsfilevolumeclient/cnsfilevolumeclient.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnsfilevolumeclient
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/internal/cnsoperator/cnsfilevolumeclient/v1alpha1"
+	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
+)
+
+// FileVolumeClient exposes an interface to support
+// configuration of CNS file volume ACL's.
+type FileVolumeClient interface {
+	// AddClientVMToIPList adds the input clientVMName to the list of
+	// clientVMNames that expose the same external clientVMIP for a
+	// given file volume. fileVolumeName is used to uniquely
+	// identify CnsFileVolumeClient instances.
+	AddClientVMToIPList(ctx context.Context, fileVolumeName, clientVMName, clientVMIP string) error
+	// RemoveClientVMFromIPList removes the input clientVMName from
+	// the list of clientVMNames that expose the same external
+	// clientVMIP for a given file volume. fileVolumeName is used
+	// to uniquely identify CnsFileVolumeClient instances.
+	RemoveClientVMFromIPList(ctx context.Context, fileVolumeName, clientVMName, clientVMIP string) error
+}
+
+// fileVolumeClient maintains a client to the API
+// server for operations on CnsFileVolumeClient instance.
+// It also contains a per instance lock to handle
+// concurrent operations.
+type fileVolumeClient struct {
+	client client.Client
+	// Per volume lock for concurrent access to CnsFileVolumeClient instances.
+	// Keys are strings representing volume handles (or SV-PVC names).
+	// Values are individual sync.Mutex locks that need to be held
+	// to make updates to the CnsFileVolumeClient instance on the API server.
+	volumeLock *sync.Map
+}
+
+var (
+	fileVolumeClientInstanceLock sync.Mutex
+	fileVolumeClientInstance     *fileVolumeClient
+)
+
+// GetFileVolumeClientInstance returns a singleton of type FileVolumeClient.
+// Initializes the singleton if not already initialized.
+func GetFileVolumeClientInstance(ctx context.Context) (FileVolumeClient, error) {
+	fileVolumeClientInstanceLock.Lock()
+	defer fileVolumeClientInstanceLock.Unlock()
+	if fileVolumeClientInstance == nil {
+		log := logger.GetLogger(ctx)
+		config, err := k8s.GetKubeConfig(ctx)
+		if err != nil {
+			log.Errorf("failed to get kubeconfig. Err: %v", err)
+			return nil, err
+		}
+		k8sclient, err := k8s.NewClientForGroup(ctx, config, v1alpha1.GroupVersion.Group)
+		if err != nil {
+			log.Errorf("failed to create k8s client. Err: %v", err)
+			return nil, err
+		}
+		fileVolumeClientInstance = &fileVolumeClient{
+			client:     k8sclient,
+			volumeLock: &sync.Map{},
+		}
+	}
+
+	return fileVolumeClientInstance, nil
+}
+
+// AddClientVMToIPList adds the input clientVMName to the list of
+// clientVMNames that expose the same external IP address for a
+// given CnsFileVolumeClient instance.
+// Callers need to specify fileVolumeName as a combination of
+// "<SV-namespace>/<SV-PVC-name>". This combination is used to uniquely
+// identify CnsFileVolumeClient instances.
+// The instance is created if it doesn't exist.
+// Returns an error if the operation cannot be persisted on the API server.
+func (f *fileVolumeClient) AddClientVMToIPList(ctx context.Context, fileVolumeName, clientVMName, clientVMIP string) error {
+	log := logger.GetLogger(ctx)
+
+	log.Infof("Adding client VM %s to cnsfilevolumeclient %s list for IP address %s", clientVMName, fileVolumeName, clientVMIP)
+	actual, _ := f.volumeLock.LoadOrStore(fileVolumeName, &sync.Mutex{})
+	instanceLock, ok := actual.(*sync.Mutex)
+	if !ok {
+		return fmt.Errorf("failed to cast lock for cnsfilevolumeclient instance: %s", fileVolumeName)
+	}
+	instanceLock.Lock()
+	defer instanceLock.Unlock()
+
+	instance := &v1alpha1.CnsFileVolumeClient{}
+	instanceNamespace, instanceName, err := cache.SplitMetaNamespaceKey(fileVolumeName)
+	if err != nil {
+		log.Errorf("failed to split key %s with error: %+v", fileVolumeName, err)
+		return err
+	}
+	instanceKey := types.NamespacedName{
+		Namespace: instanceNamespace,
+		Name:      instanceName,
+	}
+	err = f.client.Get(ctx, instanceKey, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Create the instance as it does not exist on the API server.
+			instance = &v1alpha1.CnsFileVolumeClient{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: instanceNamespace,
+				},
+				Spec: v1alpha1.CnsFileVolumeClientSpec{
+					ExternalIPtoClientVms: map[string][]string{
+						clientVMIP: {
+							clientVMName,
+						},
+					},
+				},
+			}
+			log.Debugf("Creating cnsfilevolumeclient instance %s with spec: %+v", fileVolumeName, instance)
+			err = f.client.Create(ctx, instance)
+			if err != nil {
+				log.Errorf("failed to create cnsfilevolumeclient instance %s with error: %+v", fileVolumeName, err)
+				return err
+			}
+			return nil
+		}
+		log.Errorf("failed to get cnsfilevolumeclient instance %s with error: %+v", fileVolumeName, err)
+		return err
+	}
+
+	// Verify if input clientVM exists in existing ExternalIPtoClientVms list for input IP address
+	log.Debugf("Verifying if VM %s exists in ExternalIPtoClientVms list for IP address: %s. Current list: %+v", clientVMName, clientVMIP, instance.Spec.ExternalIPtoClientVms[clientVMIP])
+	oldClientVMList := instance.Spec.ExternalIPtoClientVms[clientVMIP]
+	for _, oldClientVM := range oldClientVMList {
+		if oldClientVM == clientVMName {
+			log.Debugf("Found VM %s in list. Returning.", clientVMName)
+			return nil
+		}
+	}
+	newClientVMList := append(oldClientVMList, clientVMName)
+	instance.Spec.ExternalIPtoClientVms[clientVMIP] = newClientVMList
+	log.Debugf("Updating cnsfilevolumeclient instance %s with spec: %+v", fileVolumeName, instance)
+	err = f.client.Update(ctx, instance)
+	if err != nil {
+		log.Errorf("failed to update cnsfilevolumeclient instance %s/%s with error: %+v", fileVolumeName, err)
+	}
+	return err
+}
+
+// RemoveClientVMFromIPList removes the input clientVMName from
+// the list of clientVMNames that expose the same external IP
+// address for a given CnsFileVolumeClient instance.
+// Callers need to specify fileVolumeName as a combination of
+// "<SV-namespace>/<SV-PVC-name>". This combination is used to uniquely
+// identify CnsFileVolumeClient instances.
+// If the given VM was the last client for this file volume, the instance is deleted from
+// the API server.
+// Returns an error if the operation cannot be persisted on the API server.
+func (f *fileVolumeClient) RemoveClientVMFromIPList(ctx context.Context, fileVolumeName, clientVMName, clientVMIP string) error {
+	log := logger.GetLogger(ctx)
+	log.Infof("Removing clientVM %s from cnsfilevolumeclient %s list for IP address %s", clientVMName, fileVolumeName, clientVMIP)
+	actual, _ := f.volumeLock.LoadOrStore(fileVolumeName, &sync.Mutex{})
+	instanceLock, ok := actual.(*sync.Mutex)
+	if !ok {
+		return fmt.Errorf("failed to cast lock for cnsfilevolumeclient instance: %s", fileVolumeName)
+	}
+	instanceLock.Lock()
+	defer instanceLock.Unlock()
+	instance := &v1alpha1.CnsFileVolumeClient{}
+	instanceNamespace, instanceName, err := cache.SplitMetaNamespaceKey(fileVolumeName)
+	if err != nil {
+		log.Errorf("failed to split key %s with error: %+v", fileVolumeName, err)
+		return err
+	}
+	instanceKey := types.NamespacedName{
+		Namespace: instanceNamespace,
+		Name:      instanceName,
+	}
+	err = f.client.Get(ctx, instanceKey, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Infof("cnsfilevolumeclient instance %s does not exist on API server", fileVolumeName)
+			return nil
+		}
+		log.Errorf("failed to get cnsfilevolumeclient instance %s with error: %+v", fileVolumeName, err)
+		return err
+	}
+
+	log.Debugf("Verifying if clientVM %s exists in ExternalIPtoClientVms list for IP address: %s. Current list: %+v", clientVMName, clientVMIP, instance.Spec.ExternalIPtoClientVms[clientVMIP])
+	for index, existingClientVM := range instance.Spec.ExternalIPtoClientVms[clientVMIP] {
+		if clientVMName == existingClientVM {
+			log.Debugf("Removing clientVM %s from ExternalIPtoClientVms list", clientVMName)
+			instance.Spec.ExternalIPtoClientVms[clientVMIP] = append(instance.Spec.ExternalIPtoClientVms[clientVMIP][:index], instance.Spec.ExternalIPtoClientVms[clientVMIP][index+1:]...)
+			if len(instance.Spec.ExternalIPtoClientVms[clientVMIP]) == 0 {
+				log.Debugf("Deleting entry for IP %s from spec.ExternalIPtoClientVms", clientVMIP)
+				delete(instance.Spec.ExternalIPtoClientVms, clientVMIP)
+			}
+			if len(instance.Spec.ExternalIPtoClientVms) == 0 {
+				log.Debugf("Deleting cnsfilevolumeclient instance %s from API server", fileVolumeName)
+				err = f.client.Delete(ctx, instance)
+				if err != nil {
+					log.Errorf("failed to delete cnsfilevolumeclient instance %s with error: %+v", fileVolumeName, err)
+					return err
+				}
+				f.volumeLock.Delete(fileVolumeName)
+				return nil
+			}
+			log.Debugf("Updating cnsfilevolumeclient instance %s with spec: %+v", fileVolumeName, instance)
+			err = f.client.Update(ctx, instance)
+			if err != nil {
+				log.Errorf("failed to update cnsfilevolumeclient instance %s with error: %+v", fileVolumeName, err)
+			}
+			return err
+		}
+	}
+	log.Debugf("Could not find VM %s in list. Returning.", clientVMName)
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR introduces functions to Init, Create, Delete and Modify CnsFileVolumeClient instances on the SV API server. 
Currently, there are no callers of these functions. CnsFileAccessConfig controller, which will be introduced in a later commit, will be the caller of these functions. 

Testing:

1. Simulate Creation of CnsFileVolumeClients instance:
```
root@423ef545fe0f53da5694445f08bc583b [ ~ ]# kubectl get cnsfilevolumeclient -A
NAMESPACE             NAME               AGE
test-gc-e2e-demo-ns   test-file-volume   33s
root@423ef545fe0f53da5694445f08bc583b [ ~ ]# kubectl describe cnsfilevolumeclient -A
Name:         test-file-volume
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileVolumeClient
Metadata:
  Creation Timestamp:  2020-12-21T19:20:21Z
  Generation:          1
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:externalIPtoClientVms:
          .:
          f:127.0.0.1:
    Manager:         vsphere-syncer
    Operation:       Update
    Time:            2020-12-21T19:20:21Z
  Resource Version:  285937
  Self Link:         /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsfilevolumeclients/test-file-volume
  UID:               30a8f77f-1066-4f05-ab11-3cc4b00a6b58
Spec:
  External I Pto Client Vms:
    127.0.0.1:
      test-client-vm
Events:  <none>
```
```
2020-12-21T19:20:21.002Z        INFO    cnsfilevolumeclient/cnsfilevolumeclient.go:93   Adding client VM test-client-vm to cnsfilevolumeclient test-gc-e2e-demo-ns/test-file-volume list for IP address 127.0.0.1       {"TraceId": "41935729-5c93-4ddb-b70e-efb9c4257350"}
2020-12-21T19:20:21.002Z        DEBUG   cnsfilevolumeclient/cnsfilevolumeclient.go:126  Creating cnsfilevolumeclient instance test-gc-e2e-demo-ns/test-file-volume with spec: &{TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:test-file-volume GenerateName: Namespace:test-gc-e2e-demo-ns SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[]} Spec:{ExternalIPtoClientVms:map[127.0.0.1:[test-client-vm]]}}   {"TraceId": "41935729-5c93-4ddb-b70e-efb9c4257350"}

```

2. Simulate deletion of CnsFileVolumeClients instance:
```
root@423ef545fe0f53da5694445f08bc583b [ ~ ]# kubectl get cnsfilevolumeclient -A
No resources found
```
```
2020-12-21T19:21:21.174Z        INFO    cnsfilevolumeclient/cnsfilevolumeclient.go:176  Removing clientVM test-client-vm from cnsfilevolumeclient test-gc-e2e-demo-ns/test-file-volume list for IP address 127.0.0.1    {"TraceId": "afce58f5-71d0-4841-a6ef-bf58566cdd32"}
2020-12-21T19:21:21.178Z        DEBUG   cnsfilevolumeclient/cnsfilevolumeclient.go:204  Verifying if clientVM test-client-vm exists in ExternalIPtoClientVms list for IP address: 127.0.0.1. Current list: [test-client-vm]     {"TraceId": "afce58f5-71d0-4841-a6ef-bf58566cdd32"}
2020-12-21T19:21:21.178Z        DEBUG   cnsfilevolumeclient/cnsfilevolumeclient.go:207  Removing clientVM test-client-vm from list      {"TraceId": "afce58f5-71d0-4841-a6ef-bf58566cdd32"}
2020-12-21T19:21:21.178Z        DEBUG   cnsfilevolumeclient/cnsfilevolumeclient.go:210  Deleting entry for IP 127.0.0.1 from spec.ExternalIPtoClientVms {"TraceId": "afce58f5-71d0-4841-a6ef-bf58566cdd32"}
2020-12-21T19:21:21.178Z        DEBUG   cnsfilevolumeclient/cnsfilevolumeclient.go:214  Deleting cnsfilevolumeclient instance test-gc-e2e-demo-ns/test-file-volume from API server      {"TraceId": "afce58f5-71d0-4841-a6ef-bf58566cdd32"}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Implementation of CnsFileVolumeClient functions
```
