### PR TITLE
Update docs for vSAN stretch cluster supportability

### DIFF
--- a/docs/book/compatiblity_matrix.md
+++ b/docs/book/compatiblity_matrix.md
@@ -11,4 +11,7 @@ Refer to [upgrade support matrix](upgrade_support_matrix.md) to learn about upgr
 
 Refer to [feature matrix](supported_features_matrix.md) to learn about features added to the vSphere CSI 2.0 driver.
 
-Note: vSphere CSI driver is not supported on Windows based vCenter.
+Note:
+
+* vSphere CSI driver is not supported on Windows based vCenter.
+* vSphere CSI driver is not supported on vSAN stretch cluster.

--- a/docs/book/supported_features_matrix.md
+++ b/docs/book/supported_features_matrix.md
@@ -19,6 +19,7 @@
 _Notes_:
 
 * vSphere CSI driver is not supported on Windows based vCenter.
+* vSphere CSI driver is not supported on vSAN stretch cluster.
 * vSphere CSI driver and Cloud Native Storage in vSphere does not currently support Storage DRS feature in vSphere.
 * Native K8s is any distribution that uses vanilla upstream Kubernetes binaries and pods (e.g. VMware TKG, TKGI, etc)
 * If the CSI version `2.0` driver is installed on K8s running on vSphere 6.7U3, the older CSI `1.0` driver features continue to work but the new CSI `2.0` features are not supported.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is updating the vSphere CSI docs to add a note about CSI driver not supported on vSAN stretch cluster.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update supportability statement for vSAN stretch cluster in CSI driver docs
```
