### PR TITLE
Remove subResource field in cnsfilevolumeclient and cnsfileaccessconfig crd

### DIFF
--- a/pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml
@@ -10,8 +10,6 @@ spec:
     plural: cnsfileaccessconfigs
     singular: cnsfileaccessconfig
   scope: Namespaced
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       description: CnsFileAccessConfig is the Schema for the cnsfileaccessconfig API

--- a/pkg/internal/cnsoperator/config/cnsfilevolumeclient_crd.yaml
+++ b/pkg/internal/cnsoperator/config/cnsfilevolumeclient_crd.yaml
@@ -15,8 +15,6 @@ spec:
     plural: cnsfilevolumeclients
     singular: cnsfilevolumeclient
   scope: Namespaced
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       description: CnsFileVolumeClient is the Schema for the cnsfilevolumeclients


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is removing `subResources` field in cnsfilevolumeclient & cnsfileaccessconfig CRD yamls.
With status added as subResource, it is preventing operations like modify/update/add on status field.
Hence this PR is removing `Subresources` for testing

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
```
kubectl describe cnsfileaccessconfigs.cns.vmware.com -A
Name:         fileaccessconfig2
Namespace:    test-gc-e2e-demo-ns-gvtdoyn
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileAccessConfig
Metadata:
  Creation Timestamp:  2020-12-16T02:58:22Z
  Generation:          1
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:pvcName:
        f:vmName:
        f:volumeName:
      f:status:
        .:
        f:error:
    Manager:         kubectl
    Operation:       Update
    Time:            2020-12-16T02:58:22Z
  Resource Version:  16606863
  Self Link:         /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns-gvtdoyn/cnsfileaccessconfigs/fileaccessconfig2
  UID:               d25387ad-508f-487c-b43a-13f17a53969c
Spec:
  Pvc Name:     example-vanilla-file-pvc-balu
  Vm Name:      test-cluster-e2e-script-gvtdoyn-workers-zkgpv-6545cf669f-7dd7f
  Volume Name:  test
Status:
  Error:  error
Events:   <none>


root@422532e72d1290ac98e64ed26d2ef627 [ ~ ]# kubectl edit cnsfileaccessconfigs.cns.vmware.com fileaccessconfig2 -n test-gc-e2e-demo-ns-gvtdoyn
cnsfileaccessconfig.cns.vmware.com/fileaccessconfig2 edited


Edited `error` to `errors` and added `accessPoints`
root@422532e72d1290ac98e64ed26d2ef627 [ ~ ]# kubectl describe cnsfileaccessconfigs.cns.vmware.com -A
Name:         fileaccessconfig2
Namespace:    test-gc-e2e-demo-ns-gvtdoyn
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileAccessConfig
Metadata:
  Creation Timestamp:  2020-12-16T02:58:22Z
  Generation:          3
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:pvcName:
        f:vmName:
        f:volumeName:
      f:status:
        .:
        f:accessPoints:
          .:
          f:1:
        f:error:
    Manager:         kubectl
    Operation:       Update
    Time:            2020-12-16T02:59:44Z
  Resource Version:  16607619
  Self Link:         /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns-gvtdoyn/cnsfileaccessconfigs/fileaccessconfig2
  UID:               d25387ad-508f-487c-b43a-13f17a53969c
Spec:
  Pvc Name:     example-vanilla-file-pvc
  Vm Name:      test-cluster-e2e-script-gvtdoyn-workers-zkgpv-6545cf669f-7dd7f
  Volume Name:  test
Status:
  Access Points:
    nfsV4.1:    temp
  Error:  errors
Events:   <none>
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove status as subresource from cnsfilevolumeclient and cnsfileaccessconfig crd
```
