### PR TITLE
Fix types in cnsregistervolume and cnsfileaccessconfig crd spec

### DIFF
--- a/pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml
@@ -47,7 +47,7 @@ spec:
           properties:
             done:
               description: Done indicates whether the ACL has been configured on file volume.
-              type: bool
+              type: boolean
             accessPoints:
               description: Access points per protocol supported by the volume.
               additionalProperties:

--- a/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml
@@ -55,9 +55,9 @@ spec:
           type: object
           description: CnsRegisterVolumeStatus defines the observed state of CnsRegisterVolume
           properties:
-            success:
+            registered:
               description: Indicates the volume is successfully imported.
-              type: bool
+              type: boolean
             error:
               description: The last error encountered during import operation, if any.
               type: string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CnsRegisterVolumeStatus is declared with the field `Registered`  
https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1/cnsregistervolume_types.go#L54
```
type CnsRegisterVolumeStatus struct {
  Registered bool `json:"registered"`
  Error string `json:"error,omitempty"`
}
```

Whereas, in the crd spec `registered` field does not exist. Instead it is called as `success` field:
https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml#L58
```
status:
  properties:
    success:
      type: bool
    error:
      type: string
```

We need to make this consistent

Also, the PR is changing the type for field `done` in cnsfileaccessconfig crd spec
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

```
Before
  Warning  CnsFileAccessConfigFailed     7m43s (x7 over 8m48s)  cns.vmware.com  Failed to update CnsFileAccessConfig instance with error: CnsFileAccessConfig.cns.vmware.com "fileaccessconfig2" is invalid: status.done: Invalid value: "boolean": status.done in body must be of type bool: "boolean"


After
  Normal   CnsFileAccessConfigSucceeded  6m47s                  cns.vmware.com  Successfully configured access points of VM: "test-cluster-e2e-script-gvtdoyn-workers-zkgpv-6545cf669f-7dd7f" on the volume: "example-vanilla-file-pvc"

```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix types in cnsregistervolume and cnsfileaccessconfig crd spec
```
