### PR TITLE
doc changes for v2.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD034 -->
 # Container Storage Interface (CSI) driver for vSphere
 
 This repository provides tools and scripts for building and testing the vSphere CSI provider. This driver is in a stable `GA` state and is suitable for production use. It currently requires vSphere 6.7 U3 or higher in order to operate.
@@ -19,27 +20,32 @@ Please use appropriate deployment yaml files available here - <https://github.co
 Note:
 
 * `v1.0.2`, deployment yamls files are compatible with `v1.0.1`.
-* It is recommended to use `v2.0.1` if you're on `vSphere 6.7 Update3`
+* It is recommended to use `v2.0.1` or `v2.1.0` if you're on `vSphere 6.7 Update3`. `v2.0.0` release is not backward compatible to vSphere 67u3 release.
+
+### v2.1.0
+
+* Refer https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.1.0 for features listing and notable changes.
+* Deployment YAML files - https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/release-2.1/manifests/v2.1.0
 
 ### v2.0.1
 
-* gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.1
-* gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.0.1
+* Refer https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.0.1 for feature listing and notable changes.
+* Deployment YAML files - https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/v2.0.1
 
 ### v2.0.0
 
-* gcr.io/cloud-provider-vsphere/csi/release/driver:v2.0.0
-* gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.0.0
+* Refer https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.0.0 for feature listing and notable changes.
+* Deployment YAML files - https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/v2.0.0
 
 ### v1.0.2
 
-* gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2
-* gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.2
+* Refer https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v1.0.2 for feature listing and notable changes.
+* Deployment YAML files - https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/v1.0.2
 
 ### v1.0.1
 
-* gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.1
-* gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.1
+* Refer https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v1.0.1 for feature listing and notable changes.
+* Deployment YAML files - https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/v1.0.1
 
 ## Contributing
 

--- a/docs/book/features/vsphere_csi_migration.md
+++ b/docs/book/features/vsphere_csi_migration.md
@@ -8,7 +8,7 @@
 
 ## Introduction <a id="introduction"></a>
 
-**Note:** vSphere CSI Driver images for this feature is not yet released. When images will be available for public consumption we will update this document.
+**Note:** Feature to migrate in-tree vSphere volumes to CSI is released as **beta** with [v2.1.0](https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.1.0).
 
 vSphere CSI driver and CNS bring in a lot of features that are not available in the in-tree vSphere volume plugin.
 
@@ -79,7 +79,7 @@ To try out vSphere CSI migration in beta for vSphere plugin, perform the followi
 
 1. Upgrade vSphere to 7.0u1.
 2. Upgrade kubernetes to 1.19 release.
-3. Install vSphere CSI Driver. Use deployment manifests and RBAC files published at https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/v2.1.0/vsphere-7.0u1/vanilla
+3. Install vSphere CSI Driver (version v2.1.0). Use deployment manifests and RBAC files published at https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/release-2.1/manifests/v2.1.0/vsphere-7.0u1/vanilla
    - Make sure to enable csi-migration feature gate in the deployment yaml file.
 
            apiVersion: v1
@@ -112,7 +112,7 @@ To try out vSphere CSI migration in beta for vSphere plugin, perform the followi
    - Installation steps:
      1. Create Private key, Certificate Signing Request and webhook secret containing Kubernetes signed Certificate and Private Key. Script is available to preform this task and it is located at `vsphere-csi-driver/manifests/v2.1.0/vsphere-7.0u1/vanilla/deploy/` on the repository.
 
-            $ cd vsphere-csi-driver/manifests/v2.1.0/vsphere-7.0u1/vanilla/deploy/
+            $ curl -O https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/release-2.1/manifests/v2.1.0/vsphere-7.0u1/vanilla/deploy/generate-signed-webhook-certs.sh
             $ ./generate-signed-webhook-certs.sh 
               creating certs in tmpdir /var/folders/vy/_6dvxx7j5db9sq9n38qjymwr002gzv/T/tmp.mclIK6Jn 
               Generating RSA private key, 2048 bit long modulus
@@ -129,7 +129,8 @@ To try out vSphere CSI migration in beta for vSphere plugin, perform the followi
 
      2. Create ValidatingWebhookConfiguration, WebHook Deployment Pod, Service Accounts, Cluster Role,  Role Bindings, Service to bind with webhook pod.
 
-            $ cd vsphere-csi-driver/manifests/v2.1.0/vsphere-7.0u1/vanilla/deploy/
+            $ curl -O https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/release-2.1/manifests/v2.1.0/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
+            $ curl -O https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/release-2.1/manifests/v2.1.0/vsphere-7.0u1/vanilla/deploy/create-validation-webhook.sh
             $ ./create-validation-webhook.sh
             service/vsphere-webhook-svc created
             validatingwebhookconfiguration.admissionregistration.k8s.io/validation.csi.vsphere.vmware.com created

--- a/docs/book/supported_features_matrix.md
+++ b/docs/book/supported_features_matrix.md
@@ -20,6 +20,7 @@ _Notes_:
 
 * vSphere CSI driver is not supported on Windows based vCenter.
 * vSphere CSI driver is not supported on vSAN stretch cluster.
+* Feature to migrate in-tree vSphere volumes to CSI is released as **beta** with [v2.1.0](https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.1.0). This feature requires vSphere 7.0u1.
 * vSphere CSI driver and Cloud Native Storage in vSphere does not currently support Storage DRS feature in vSphere.
 * Native K8s is any distribution that uses vanilla upstream Kubernetes binaries and pods (e.g. VMware TKG, TKGI, etc)
 * If the CSI version `2.0` driver is installed on K8s running on vSphere 6.7U3, the older CSI `1.0` driver features continue to work but the new CSI `2.0` features are not supported.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.1.0 is released.
This PR is changing the documentation for v2.1.0 release.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
doc changes for v2.1.0 release
```
