### PR TITLE
fix csi controller pod tolerations

### DIFF
--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -20,10 +20,19 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
-        - operator: "Exists"
+        - key: node-role.kubernetes.io/master
+          operator: Exists
           effect: NoSchedule
-        - operator: "Exists"
-          effect: NoExecute
+        # uncomment below toleration if you need an aggressive pod eviction in case when
+        # node becomes not-ready or unreachable. Default is 300 seconds if not specified.
+        #- key: node.kubernetes.io/not-ready
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
+        #- key: node.kubernetes.io/unreachable
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher

--- a/manifests/dev/vsphere-7.0/supervisorcluster/k8s-1.15/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0/supervisorcluster/k8s-1.15/deploy/vsphere-csi-controller-deployment.yaml
@@ -23,10 +23,6 @@ spec:
         - operator: "Exists"
           key: "node-role.kubernetes.io/master"
           effect: "NoSchedule"
-        - operator: "Equal"
-          key: "kubeadmNode"
-          effect: "NoSchedule"
-          value: "master"
       hostNetwork: true
       containers:
         - name: csi-provisioner

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -20,10 +20,19 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
-        - operator: "Exists"
+        - key: node-role.kubernetes.io/master
+          operator: Exists
           effect: NoSchedule
-        - operator: "Exists"
-          effect: NoExecute
+        # uncomment below toleration if you need an aggressive pod eviction in case when
+        # node becomes not-ready or unreachable. Default is 300 seconds if not specified.
+        #- key: node.kubernetes.io/not-ready
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
+        #- key: node.kubernetes.io/unreachable
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher

--- a/manifests/dev/vsphere-7.0u1/supervisorcluster/k8s-1.15/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/supervisorcluster/k8s-1.15/deploy/vsphere-csi-controller-deployment.yaml
@@ -23,10 +23,6 @@ spec:
         - operator: "Exists"
           key: "node-role.kubernetes.io/master"
           effect: "NoSchedule"
-        - operator: "Equal"
-          key: "kubeadmNode"
-          effect: "NoSchedule"
-          value: "master"
       hostNetwork: true
       containers:
         - name: csi-provisioner

--- a/manifests/dev/vsphere-7.0u1/supervisorcluster/k8s-1.16/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/supervisorcluster/k8s-1.16/deploy/vsphere-csi-controller-deployment.yaml
@@ -23,10 +23,6 @@ spec:
         - operator: "Exists"
           key: "node-role.kubernetes.io/master"
           effect: "NoSchedule"
-        - operator: "Equal"
-          key: "kubeadmNode"
-          effect: "NoSchedule"
-          value: "master"
       hostNetwork: true
       containers:
         - name: csi-provisioner

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/validatingwebhook.yaml
@@ -85,10 +85,19 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
-        - operator: "Exists"
+        - key: node-role.kubernetes.io/master
+          operator: Exists
           effect: NoSchedule
-        - operator: "Exists"
-          effect: NoExecute
+        # uncomment below toleration if you need an aggressive pod eviction in case when
+        # node becomes not-ready or unreachable. Default is 300 seconds if not specified.
+        #- key: node.kubernetes.io/not-ready
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
+        #- key: node.kubernetes.io/unreachable
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -18,10 +18,19 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
-        - operator: "Exists"
+        - key: node-role.kubernetes.io/master
+          operator: Exists
           effect: NoSchedule
-        - operator: "Exists"
-          effect: NoExecute
+        # uncomment below toleration if you need an aggressive pod eviction in case when
+        # node becomes not-ready or unreachable. Default is 300 seconds if not specified.
+        #- key: node.kubernetes.io/not-ready
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
+        #- key: node.kubernetes.io/unreachable
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.17/deploy/vsphere-csi-controller-deployment.yaml
@@ -23,10 +23,6 @@ spec:
         - operator: "Exists"
           key: "node-role.kubernetes.io/master"
           effect: "NoSchedule"
-        - operator: "Equal"
-          key: "kubeadmNode"
-          effect: "NoSchedule"
-          value: "master"
       hostNetwork: true
       containers:
         - name: csi-provisioner

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.18/deploy/vsphere-csi-controller-deployment.yaml
@@ -23,10 +23,6 @@ spec:
         - operator: "Exists"
           key: "node-role.kubernetes.io/master"
           effect: "NoSchedule"
-        - operator: "Equal"
-          key: "kubeadmNode"
-          effect: "NoSchedule"
-          value: "master"
       hostNetwork: true
       containers:
         - name: csi-provisioner

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/k8s-1.19/deploy/vsphere-csi-controller-deployment.yaml
@@ -23,10 +23,6 @@ spec:
         - operator: "Exists"
           key: "node-role.kubernetes.io/master"
           effect: "NoSchedule"
-        - operator: "Equal"
-          key: "kubeadmNode"
-          effect: "NoSchedule"
-          value: "master"
       hostNetwork: true
       containers:
         - name: csi-provisioner

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/validatingwebhook.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/validatingwebhook.yaml
@@ -85,10 +85,19 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
-        - operator: "Exists"
+        - key: node-role.kubernetes.io/master
+          operator: Exists
           effect: NoSchedule
-        - operator: "Exists"
-          effect: NoExecute
+        # uncomment below toleration if you need an aggressive pod eviction in case when
+        # node becomes not-ready or unreachable. Default is 300 seconds if not specified.
+        #- key: node.kubernetes.io/not-ready
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
+        #- key: node.kubernetes.io/unreachable
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -18,10 +18,19 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
-        - operator: "Exists"
+        - key: node-role.kubernetes.io/master
+          operator: Exists
           effect: NoSchedule
-        - operator: "Exists"
-          effect: NoExecute
+        # uncomment below toleration if you need an aggressive pod eviction in case when
+        # node becomes not-ready or unreachable. Default is 300 seconds if not specified.
+        #- key: node.kubernetes.io/not-ready
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
+        #- key: node.kubernetes.io/unreachable
+        #  operator: Exists
+        #  effect: NoExecute
+        #  tolerationSeconds: 30
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In the current deployment YAML, vSphere CSI controller pod can tolerate any taint with `NoSchedule` and `NoExecute`.
https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml#L18-L24
```yaml
      nodeSelector:
        node-role.kubernetes.io/master: ""
      tolerations:
        - operator: "Exists"
          effect: NoSchedule
        - operator: "Exists"
          effect: NoExecute
```

With the above tolerations, when the master node on which CSI controller pod is running shutdown or becomes unavailable due to link outage, the CSI controller pod does not get evicted and re-scheduled on another available master node.


**Which issue this PR fixes**
This PR is fixing the issue mentioned above by correcting toleration as below in all flavors of YAML files.

```yaml
      nodeSelector:
        node-role.kubernetes.io/master: ""
      tolerations:
        - key: node-role.kubernetes.io/master
          operator: Exists
          effect: NoSchedule
```

For vanilla flavor, I have put a comment in the YAML as below

```yaml
      tolerations:
        - key: node-role.kubernetes.io/master
          operator: Exists
          effect: NoSchedule
        # uncomment below toleration if you need an aggressive pod eviction in case when
        # node becomes not-ready or unreachable. Default is 300 seconds if not specified.
        #- key: node.kubernetes.io/not-ready
        #  operator: Exists
        #  effect: NoExecute
        #  tolerationSeconds: 30
        #- key: node.kubernetes.io/unreachable
        #  operator: Exists
        #  effect: NoExecute
        #  tolerationSeconds: 30
```

**Special notes for your reviewer**:
Deployed multi-master setup and verified CSI controller pod gets evicted and re-created on the available master node after the node is shutdown and `node.kubernetes.io/unreachable:NoExecute` and `node.kubernetes.io/unreachable:NoSchedule` taints applied by Kubernetes on the powered down node.
                    

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix csi controller pod tolerations
```
