### PR TITLE
Cherrypicking fix for recreating static file volume with same name to release-2.1

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -196,13 +196,29 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 			log.Errorf("CNS CreateVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 			return nil, err
 		}
-		var taskDetails createVolumeTaskDetails
-		// Store the task details and task object expiration time in volumeTaskMap
-		taskDetails.Lock()
-		taskDetails.task = task
-		taskDetails.expirationTime = time.Now().Add(time.Hour * time.Duration(defaultOpsExpirationTimeInHours))
-		volumeTaskMap[volNameFromInputSpec] = &taskDetails
-		taskDetails.Unlock()
+		var isStaticallyProvisionedBlockVolume bool
+		var isStaticallyProvisionedFileVolume bool
+		if spec.VolumeType == string(cnstypes.CnsVolumeTypeBlock) {
+			blockBackingDetails, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+			if ok && (blockBackingDetails.BackingDiskId != "" || blockBackingDetails.BackingDiskUrlPath != "") {
+				isStaticallyProvisionedBlockVolume = true
+			}
+		}
+		if spec.VolumeType == string(cnstypes.CnsVolumeTypeFile) {
+			fileBackingDetails, ok := spec.BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails)
+			if ok && fileBackingDetails.BackingFileId != "" {
+				isStaticallyProvisionedFileVolume = true
+			}
+		}
+		// Add the task details to volumeTaskMap only for dynamically provisioned volumes.
+		// For static volume provisioning we need not store the taskDetails as it doesn't result in orphaned volumes
+		if !isStaticallyProvisionedBlockVolume && !isStaticallyProvisionedFileVolume {
+			var taskDetails createVolumeTaskDetails
+			// Store the task details and task object expiration time in volumeTaskMap
+			taskDetails.task = task
+			taskDetails.expirationTime = time.Now().Add(time.Hour * time.Duration(defaultOpsExpirationTimeInHours))
+			volumeTaskMap[volNameFromInputSpec] = &taskDetails
+		}
 	}
 	// Get the taskInfo
 	taskInfo, err = cns.GetTaskInfo(ctx, task)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is cherrypicking fix for recreating static file volume with same name from master branch.
This fix making sure taskInfo details cache stores PV names only for dynamically provisioned volumes.
We do not need the cache for static volumes since they are not provisioned using external provisioner.
This is handled using backingDiskId and backingFileId details in create spec

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherrypicking fix for recreating static file volume with same name to release-2.1
```
