### PR TITLE
Fix static provisioning of PV in metadatasyncer

### DIFF
--- a/docs/book/features/block_volume.md
+++ b/docs/book/features/block_volume.md
@@ -248,8 +248,6 @@ and a `PersistentVolumeClaim`.
 Because the PV and the storage device already exists, there is no need to specify a storage class name in the PVC spec.
 There are many ways to create static PV and PVC binding. Example: Label matching, Volume Size matching etc
 
-Static Volume Provisioning is supported only in Vanilla Kubernetes clusters but not in Supervisor clusters
-
 **NOTE:** For Block volumes, vSphere Cloud Native Storage (CNS) only allows one PV in the Kubernetes cluster to refer to a storage disk. Creating multiple PV's using the same Block Volume Handle is not supported.
 
 ### Use Cases of Static Provisioning<a id="static_volume_provisioning_use_case"></a>
@@ -280,6 +278,8 @@ the same zone.
 
 This section describes the step by step instructions to provision a PersistentVolume statically on a `Vanilla Kubernetes`
 cluster. Make sure to mention `pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com` in the PV annotation.
+
+**Note:** You shouldn't specify the key `storage.kubernetes.io/csiProvisionerIdentity` in `csi.volumeAttributes` in PV spec(it indicates dynamically provisioned PVs).
 
 - Define a PVC and a PV as shown below
 

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -59,6 +59,8 @@ const (
 	volumeHealthRetryIntervalMax = 5 * time.Minute
 	// default number of threads concurrently running for volume health reconciler
 	volumeHealthWorkers = 10
+	// key for dynamically provisioned PV in volume attributes of PV spec
+	attribCSIProvisionerID = "storage.kubernetes.io/csiProvisionerIdentity"
 )
 
 var (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Metadatasyncer currently checks if a PV is statically provisioned by checking if the storage class has been provided in the spec, which is a bug. Static PVs can have storage class mentioned in the spec.
As a result, if we create a static PV with storage class specified, metadatasyncer currently invokes `CnsVolumeMetadataUpdateSpec` and CNS fails the call saying it's not a CNS volume.

This PR changes the logic for checking static PV by relying on a field called `storage.kubernetes.io/csiProvisionerIdentity` in `VolumeAttributes` of PV spec, which is added by external-provisioner for dynamically provisioned PVs.

Note the field in `VolumeAttributes` for a dynamically provisioned PV:
```
root@k8s-master-505:~# kubectl describe pv pvc-fe95277f-152d-44e7-9cd7-d5592ffa20e6
Name:            pvc-fe95277f-152d-44e7-9cd7-d5592ffa20e6
.
.
.
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      d5dc2772-4870-438c-b443-f66ede2ca04a
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1608327720916-8081-csi.vsphere.vmware.com  <<<<--------
                           type=vSphere CNS Block Volume
Events:                <none>
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Testing done:

Create a static PV with storage class name specified:
```
root@k8s-master-6:~# cat static-pv.yaml 
apiVersion: v1
kind: PersistentVolume
metadata:
  name: static-pv1
  annotations:
    pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
spec:
  capacity:
    storage: 100Mi
  accessModes:
    - ReadWriteOnce
  persistentVolumeReclaimPolicy: Retain
  storageClassName: sc1
  claimRef:
    namespace: default
    name: static-pvc1
  csi:
    driver: csi.vsphere.vmware.com
    volumeAttributes:
      type: "vSphere CNS Block Volume"
    volumeHandle: 0fba4cc2-1afc-4598-ad29-ae78ca1d86c0
```

Currently, the static PV creation invokes `CnsVolumeMetadataUpdateSpec` from metadatasyncer for a k8s and CNS sync.
```
{"log":"2020-12-15T12:51:01.097Z\u0009INFO\u0009volume/manager.go:560\u0009UpdateVolumeMetadata: volumeID: \"0fba4cc2-1afc-4598-ad29-ae78ca1d86c0\", opId: \"6d0bc714\"\u0009{\"TraceId\": \"35515d84-a97f-4b0c-ac04-aa91d9aef2bb\"}\n","stream":"stderr","time":"2020-12-15T12:51:01.097986229Z"}
{"log":"2020-12-15T12:51:01.099Z\u0009ERROR\u0009volume/manager.go:575\u0009failed to update volume. updateSpec: \"(*types.CnsVolumeMetadataUpdateSpec)(0xc0008310e0)({\\n DynamicData: (types.DynamicData) {\\n },\\n VolumeId: (types.CnsVolumeId) {\\n  DynamicData: (types.DynamicData) {\\n  },\\n  Id: (string) (len=36) \\\"0fba4cc2-1afc-4598-ad29-ae78ca1d86c0\\\"\\n },\\n Metadata: (types.CnsVolumeMetadata) {\\n  DynamicData: (types.DynamicData) {\\n  },\\n  ContainerCluster: (types.CnsContainerCluster) {\\n   DynamicData: (types.DynamicData) {\\n   },\\n   ClusterType: (string) (len=10) \\\"KUBERNETES\\\",\\n   ClusterId: (string) (len=16) \\\"vSAN-FVT-Cluster\\\",\\n   VSphereUser: (string) (len=27) \\\"VSPHERE.LOCAL\\\\\\\\Administrator\\\",\\n   ClusterFlavor: (string) (len=7) \\\"VANILLA\\\",\\n   ClusterDistribution: (string) \\\"\\\"\\n  },\\n  EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=1 cap=1) {\\n   (*types.CnsKubernetesEntityMetadata)(0xc00057dd80)({\\n    CnsEntityMetadata: (types.CnsEntityMetadata) {\\n     DynamicData: (types.DynamicData) {\\n     },\\n     EntityName: (string) (len=17) \\\"static-pv1-raunak\\\",\\n     Labels: ([]types.KeyValue) \u003cnil\u003e,\\n     Delete: (bool) false,\\n     ClusterID: (string) (len=16) \\\"vSAN-FVT-Cluster\\\"\\n    },\\n    EntityType: (string) (len=17) \\\"PERSISTENT_VOLUME\\\",\\n    Namespace: (string) \\\"\\\",\\n    ReferredEntity: ([]types.CnsKubernetesEntityReference) \u003cnil\u003e\\n   })\\n  },\\n  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {\\n   (types.CnsContainerCluster) {\\n    DynamicData: (types.DynamicData) {\\n    },\\n    ClusterType: (string) (len=10) \\\"KUBERNETES\\\",\\n    ClusterId: (string) (len=16) \\\"vSAN-FVT-Cluster\\\",\\n    VSphereUser: (string) (len=27) \\\"Administrator@vsphere.local\\\",\\n    ClusterFlavor: (string) (len=7) \\\"VANILLA\\\",\\n    ClusterDistribution: (string) \\\"\\\"\\n   }\\n  }\\n }\\n})\\n\", fault: \"(*types.LocalizedMethodFault)(0xc0007c8300)({\\n DynamicData: (types.DynamicData) {\\n },\\n Fault: (types.CnsFault) {\\n  BaseMethodFault: (types.BaseMethodFault) \u003cnil\u003e,\\n  Reason: (string) (len=79) \\\"CNS: The input volume 0fba4cc2-1afc-4598-ad29-ae78ca1d86c0 is not a CNS volume.\\\"\\n },\\n LocalizedMessage: (string) (len=95) \\\"CnsFault error: CNS: The input volume 0fba4cc2-1afc-4598-ad29-ae78ca1d86c0 is not a CNS volume.\\\"\\n})\\n\", opID: \"6d0bc714\"\u0009{\"TraceId\": \"35515d84-a97f-4b0c-ac04-aa91d9aef2bb\"}\n","stream":"stderr","time":"2020-12-15T12:51:01.099535686Z"}
```


After this change, metadatasyncer instead invokes `CreateVolume`, which registers the FCD as a CNS volume.

```
2021-01-04T19:40:24.628Z	DEBUG	syncer/metadatasyncer.go:581	PVUpdated: PV Updated from &PersistentVolume{ObjectMeta:{static-pv1   
.
.
2021-01-04T19:40:24.629Z	DEBUG	syncer/metadatasyncer.go:896	PVUpdated: observed static volume provisioning for the PV: "static-pv1" with volumeType: "BLOCK"	{"TraceId": "e0a682be-4267-410e-b77e-6074fc72d645"}
2021-01-04T19:40:24.654Z	INFO	syncer/metadatasyncer.go:908	PVUpdated: Verified volume: "723000bc-c19b-4884-9422-ac7edfef1ea0" is not marked as container volume in CNS. Calling CreateVolume with BackingID to mark volume as Container Volume.	{"TraceId": "e0a682be-4267-410e-b77e-6074fc72d645"}
2021-01-04T19:40:24.660Z	DEBUG	syncer/metadatasyncer.go:932	PVUpdated: vSphere CSI Driver is creating volume "static-pv1" with create spec (*types.CnsVolumeCreateSpec)(0xc000844000)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=10) "static-pv1",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) <nil>,
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=16) "vSAN-FVT-Cluster",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA",
   ClusterDistribution: (string) ""
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=1 cap=1) {
   (*types.CnsKubernetesEntityMetadata)(0xc0005e1580)({
    CnsEntityMetadata: (types.CnsEntityMetadata) {
     DynamicData: (types.DynamicData) {
     },
     EntityName: (string) (len=10) "static-pv1",
     Labels: ([]types.KeyValue) <nil>,
     Delete: (bool) false,
     ClusterID: (string) (len=16) "vSAN-FVT-Cluster"
    },
    EntityType: (string) (len=17) "PERSISTENT_VOLUME",
    Namespace: (string) "",
    ReferredEntity: ([]types.CnsKubernetesEntityReference) <nil>
   })
  },
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=16) "vSAN-FVT-Cluster",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA",
    ClusterDistribution: (string) ""
   }
  }
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc0005e7a70)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 0
  },
  BackingDiskId: (string) (len=36) "723000bc-c19b-4884-9422-ac7edfef1ea0",
  BackingDiskUrlPath: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) <nil>,
 CreateSpec: (types.BaseCnsBaseCreateSpec) <nil>
})
	{"TraceId": "e0a682be-4267-410e-b77e-6074fc72d645"}
2021-01-04T19:40:24.682Z	DEBUG	volume/manager.go:180	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator	{"TraceId": "e0a682be-4267-410e-b77e-6074fc72d645"}
2021-01-04T19:40:29.439Z	INFO	volume/manager.go:239	CreateVolume: VolumeName: "static-pv1", opId: "73bd0e03"	{"TraceId": "e0a682be-4267-410e-b77e-6074fc72d645"}
2021-01-04T19:40:29.441Z	INFO	volume/manager.go:298	CreateVolume: Volume created successfully. VolumeName: "static-pv1", opId: "73bd0e03", volumeID: "723000bc-c19b-4884-9422-ac7edfef1ea0"	{"TraceId": "e0a682be-4267-410e-b77e-6074fc72d645"}
2021-01-04T19:40:29.441Z	DEBUG	volume/manager.go:299	CreateVolume volumeId "723000bc-c19b-4884-9422-ac7edfef1ea0" is placed on datastore ""	{"TraceId": "e0a682be-4267-410e-b77e-6074fc72d645"}
2021-01-04T19:40:29.442Z	INFO	syncer/metadatasyncer.go:937	PVUpdated: vSphere CSI Driver has successfully marked volume: "723000bc-c19b-4884-9422-ac7edfef1ea0" as the container volume.	{"TraceId": "e0a682be-4267-410e-b77e-6074fc72d645"}
```
 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix static provisioning of PV in metadatasyncer
```
