### PR TITLE
Skip non-exisistent policies when refreshing storage class cache

### DIFF
--- a/pkg/common/cns-lib/vsphere/pbm.go
+++ b/pkg/common/cns-lib/vsphere/pbm.go
@@ -129,11 +129,8 @@ func (vc *VirtualCenter) PbmRetrieveContent(ctx context.Context, policyIds []str
 		})
 	}
 	profiles, err := vc.PbmClient.RetrieveContent(ctx, pbmPolicyIds)
-	if err != nil {
-		return nil, err
-	}
 
-	return simplifyProfileStructs(ctx, profiles), nil
+	return simplifyProfileStructs(ctx, profiles), err
 }
 
 func simplifyProfileStructs(ctx context.Context, profiles []pbmtypes.BasePbmProfile) []SpbmPolicyContent {


### PR DESCRIPTION
**What this PR does / why we need it**:
StorageClass present in a cluster that is pointing to a non-existent stale SPBM policy ID causes an issue in the StoragePool controller. The StorageClass watch within the StoragePool controller tries to keep an in-memory cache of the list of SPBM policy IDs found, whether they are `HostLocal` policies and the policy's compatibility with Datastores. This requires
1. fetching the policy contents from SPBM and 
2. checking compatibility from SPBM.

While (2) was already immune to invalid profileIDs (1) was not. This was causing the cache sync to fail. Eventually, the compatible datastores for a vsan-sna StoragePool was not getting populated correctly.

This PR fixes the issue by making (1) also immune to invalid profileIDs. If there are invalid profileIDs reported by SPBM when trying to fetch their profile contents, the watch now skips over those and once again fetches the profile contents for the valid ones to populate in the cache. The effect of fixing this part of the logic is that, much later when the vsan-sna StoragePools are created, they get the right compatible StorageClasses populated.

**Testing**
Created two StorageClass'es with fake SPBM profile IDs in the cluster. This triggered the StorageClass watch to sync the cache. The logs show that the fix works by skipping over the fake profile IDs.
```
2021-01-05T11:43:57.432Z        INFO    storagepool/storageclasswatch.go:188    StorageClassWatch cache refresh due to sample-vsan-direct-thick {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
2021-01-05T11:43:57.522Z        ERROR   storagepool/storageclasswatch.go:361    Invalid profile error: Profile not found. Id: 78e3edde-f963-4b03-a056-2f6027c62ab0-junk2, 78e3edde-f963-4b03-a056-2f6027c62ab0-junk,    {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
2021-01-05T11:43:57.522Z        DEBUG   storagepool/storageclasswatch.go:372    isInvalidProfileErr [78e3edde-f963-4b03-a056-2f6027c62ab0-junk2 78e3edde-f963-4b03-a056-2f6027c62ab0-junk]      {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
2021-01-05T11:43:57.523Z        INFO    storagepool/storageclasswatch.go:330    Removing invalid profileIds [78e3edde-f963-4b03-a056-2f6027c62ab0-junk2 78e3edde-f963-4b03-a056-2f6027c62ab0-junk] from cache: [3aabfb96-19ce-4e2c-8659-60b46c945d8a 8b6297f0-f60c-48e1-ba93-c6bbf9882a0b 78e3edde-f963-4b03-a056-2f6027c62ab0 78e3edde-f963-4b03-a056-2f6027c62ab0-junk 78e3edde-f963-4b03-a056-2f6027c62ab0-junk2]        {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
2021-01-05T11:43:57.543Z        DEBUG   storagepool/storageclasswatch.go:343    Successfully retrieved content of policies [3aabfb96-19ce-4e2c-8659-60b46c945d8a 8b6297f0-f60c-48e1-ba93-c6bbf9882a0b 78e3edde-f963-4b03-a056-2f6027c62ab0]{"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
2021-01-05T11:43:57.544Z        INFO    storagepool/storageclasswatch.go:248    sc sample-vsan-sna-thick is hostLocal: true     {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
2021-01-05T11:43:57.544Z        INFO    storagepool/storageclasswatch.go:248    sc sample-vsan-direct-thick is hostLocal: false {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
2021-01-05T11:43:57.544Z        INFO    storagepool/storageclasswatch.go:248    sc vsandirect is hostLocal: false       {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
...
2021-01-05T11:43:57.862Z        ERROR   storagepool/storageclasswatch.go:361    Invalid profile error: Failed to fetch content for the provided profiles.       {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
2021-01-05T11:43:57.862Z        INFO    storagepool/storageclasswatch.go:405    Skipping non-existent policy 78e3edde-f963-4b03-a056-2f6027c62ab0-junk that failed in check PBM compatibility [Datastore:datastore-68] with error ServerFaultCode: Failed to fetch content for the provided profiles.       {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
2021-01-05T11:43:57.903Z        ERROR   storagepool/storageclasswatch.go:361    Invalid profile error: Failed to fetch content for the provided profiles.       {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
2021-01-05T11:43:57.903Z        INFO    storagepool/storageclasswatch.go:405    Skipping non-existent policy 78e3edde-f963-4b03-a056-2f6027c62ab0-junk2 that failed in check PBM compatibility [Datastore:datastore-68] with error ServerFaultCode: Failed to fetch content for the provided profiles.      {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
...
2021-01-05T11:43:58.247Z        INFO    storagepool/intended_state.go:207       creating vsan sna sp "wdc-10-206-105-46.eng.vmware.com" {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
2021-01-05T11:43:58.252Z        INFO    storagepool/intended_state.go:284       Creating StoragePool instance for storagepool-vsandatastore-wdc-10-206-105-46.eng.vmware.com    {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
2021-01-05T11:43:58.284Z        DEBUG   storagepool/intended_state.go:291       Successfully created StoragePool &{map[apiVersion:cns.vmware.com/v1alpha1 kind:StoragePool metadata:map[creationTimestamp:2021-01-05T11:43:58Z generation:1 labels:map[cns.vmware.com/StoragePoolType:vsan-sna] managedFields:[map[apiVersion:cns.vmware.com/v1alpha1 fieldsType:FieldsV1 fieldsV1:map[f:metadata:map[f:labels:map[.:map[] f:cns.vmware.com/StoragePoolType:map[]]] f:spec:map[.:map[] f:driver:map[] f:parameters:map[.:map[] f:datastoreUrl:map[]]] f:status:map[.:map[] f:accessibleNodes:map[] f:capacity:map[.:map[] f:freeSpace:map[] f:total:map[]] f:compatibleStorageClasses:map[]]] manager:vsphere-syncer operation:Update time:2021-01-05T11:43:58Z]] name:storagepool-vsandatastore-wdc-10-206-105-46.eng.vmware.com resourceVersion:815902 selfLink:/apis/cns.vmware.com/v1alpha1/storagepools/storagepool-vsandatastore-wdc-10-206-105-46.eng.vmware.com uid:0e2d1b01-6868-46a8-86db-ad0ae459247d] spec:map[driver:csi.vsphere.vmware.com parameters:map[datastoreUrl:ds:///vmfs/volumes/vsan:52e366c2ccb66ace-77bde6736fe7176f/]] status:map[accessibleNodes:[wdc-10-206-105-46.eng.vmware.com] capacity:map[freeSpace:120415280170 total:193256751104] compatibleStorageClasses:[sample-vsan-sna-thick]]]} {"TraceId": "4e81492e-7963-4db1-9395-ac5fa3acf99e"}
```

Also, the vsan-sna StoragePools now have the `compatibleStorageClasses` field populated correctly.
```
root@422be1dec9f4e27ebc9659b7107023d2 [ ~ ]# kubectl get storagepool storagepool-vsandatastore-wdc-10-206-100-56.eng.vmware.com -oyaml
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePool
metadata:
  creationTimestamp: "2021-01-05T11:43:58Z"
  generation: 1
  labels:
    cns.vmware.com/StoragePoolType: vsan-sna
  managedFields:
    <snip>
    manager: vsphere-syncer
    operation: Update
    time: "2021-01-05T11:43:58Z"
  name: storagepool-vsandatastore-wdc-10-206-100-56.eng.vmware.com
  resourceVersion: "815905"
  selfLink: /apis/cns.vmware.com/v1alpha1/storagepools/storagepool-vsandatastore-wdc-10-206-100-56.eng.vmware.com
  uid: 31796086-8c7c-488e-b1b8-7e78dd46a35c
spec:
  driver: csi.vsphere.vmware.com
  parameters:
    datastoreUrl: ds:///vmfs/volumes/vsan:52e366c2ccb66ace-77bde6736fe7176f/
status:
  accessibleNodes:
  - wdc-10-206-100-56.eng.vmware.com
  capacity:
    freeSpace: 120608218154
    total: 193256751104
  compatibleStorageClasses:
  - sample-vsan-sna-thick
```