### PR TITLE
Enhance placement engine to honor node-affinity annotation 

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -58,10 +58,6 @@ const (
 	// For Example: FsType: "ext4"
 	AttributeFsType = "fstype"
 
-	// AttributeAffineToHost represents the ESX host moid to which this PV should be affinitized
-	// For Example: AffineToHost: "host-25"
-	AttributeAffineToHost = "affinetohost"
-
 	// AttributeStoragePool represents name of the StoragePool on which to place the PVC
 	// For example: StoragePool: "storagepool-vsandatastore"
 	AttributeStoragePool = "storagepool"

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -232,10 +232,6 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		param := strings.ToLower(paramName)
 		if param == common.AttributeStoragePolicyID {
 			storagePolicyID = req.Parameters[paramName]
-		} else if param == common.AttributeAffineToHost {
-			affineToHost = req.Parameters[common.AttributeAffineToHost]
-			// XXX: We don't set the accessibleNodes here as we expect the partners to specify the node selector in pod
-			// spec while creating it. This mode of placement will be deprecated soon as we progress towards storagePool
 		} else if param == common.AttributeStoragePool {
 			storagePool = req.Parameters[paramName]
 			if !isValidAccessibilityRequirement(topologyRequirement) {
@@ -262,8 +258,6 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 					return nil, status.Errorf(codes.Internal, msg)
 				}
 				log.Infof("Will select datastore %s as per the provided storage pool %s", selectedDatastoreURL, storagePool)
-				//Ignore affineToHost if received, as storagePool takes precedence for placement decision
-				affineToHost = ""
 			} else if storagePoolType == vsanSna {
 				// Query API server to get ESX Host Moid from the hostLocalNodeName
 				if len(accessibleNodes) != 1 {

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -51,7 +51,6 @@ import (
 func validateCreateBlockReqParam(paramName, value string) bool {
 	return paramName == common.AttributeStoragePolicyID ||
 		paramName == common.AttributeFsType ||
-		paramName == common.AttributeAffineToHost ||
 		paramName == common.AttributeStoragePool ||
 		(paramName == common.AttributeHostLocal && strings.EqualFold(value, "true"))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The placement engine should honor PVC with storage classes having Immediate volume binding mode if the node-affinity annotation is specified in the PVC. The following code changes add the necessary validation for the same.
Further, CSI driver is not required to handle affineToHost parameter in the `CreateVolume` request from external provisioner. Henceforth, all host-local related info is implied through `storagepool` parameter of the request.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This fixes the issue #577 

**Special notes for your reviewer**:

**_Testing:_**

**_Storage classes:_**
```
$ kubectl get sc
NAME                       PROVISIONER              RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
sample-hostlocal           csi.vsphere.vmware.com   Delete          Immediate              true                   5h47m
sample-vsan-direct-thick   csi.vsphere.vmware.com   Delete          WaitForFirstConsumer   true                   6h14m
sample-vsan-sna-thick      csi.vsphere.vmware.com   Delete          WaitForFirstConsumer   true                   6h14m
```

**_PVC spec with node affinity:_**
```
$ cat affineToHostPvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: affinetohost-pvc
  namespace: sample-domain-c9
  annotations:
    failure-domain.beta.vmware.com/node: sc2-10-186-82-158.eng.vmware.com
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 5Mi
  storageClassName: sample-hostlocal
```

_**Testcases:**_
1. Created a sample-hostlocal storage policy and storage class with Immediate volume binding and created the following PVC with node-affinity annotation:
**_Result:_** Verified that the volume is provisioned in the node `sc2-10-186-82-158.eng.vmware.com`

_Persistent Volume:_
```
Name:              pvc-8b6377b5-fece-44a0-ae3c-955d810f6a61
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      sample-hostlocal
Status:            Bound
Claim:             sample-domain-c9/affinetohost-pvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          5Mi
Node Affinity:
  Required Terms:
    Term 0:        kubernetes.io/hostname in [sc2-10-186-82-158.eng.vmware.com]
Message:
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      317100f8-4d16-4c55-b96d-c8e0c7209a70
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1609982977904-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```

2. Created another PVC similar to above and modifying the storage class to `sample-vsan-sna-thick`. As this storage class is having `WaitForFirstConsumer` volume binding mode, created a pod requesting for this PVC.
**_Result:_** Verified that volume is provisioned successfully as DRS picked the same node (_sc2-10-186-82-158.eng.vmware.com_) for pod placement.

3. Created another PVC using the same manifest as (2) and modified the node-affinity to another node (_sc2-10-186-88-23.eng.vmware.com_).
**_Result:_** This time, the DRS picked the node _sc2-10-186-82-158.eng.vmware.com_ and as a result, PV provisioning failed as expected.

_Persistent Volume Claim:_
```
Name:          affinetohost-pvc1
Namespace:     sample-domain-c9
StorageClass:  sample-vsan-sna-thick
Status:        Pending
Volume:
Labels:        <none>
Annotations:   failure-domain.beta.vmware.com/node: sc2-10-186-88-23.eng.vmware.com
               failure-domain.beta.vmware.com/storagepool: FAILED_PLACEMENT-InvalidConfiguration
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/selected-node: sc2-10-186-82-158.eng.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:
Access Modes:
VolumeMode:    Filesystem
Mounted By:    affinetohost-pod
Events:
  Type     Reason                Age                From                                                                                          Message
  ----     ------                ----               ----                                                                                          -------
  Normal   WaitForFirstConsumer  25s (x2 over 36s)  persistentvolume-controller                                                                   waiting for first consumer to be created before binding
  Warning  ProvisioningFailed    21s                csi.vsphere.vmware.com_4235ef7c2562b4f5beec19d274e6dbf8_ce6ddb0d-5087-11eb-82b7-005056b54d91  failed to provision volume with StorageClass "sample-vsan-sna-thick": rpc error: code = Unknown desc = invalid configuration - host specified in the nodeAffinity annotation is not provided in the topology requirement
  Normal   ExternalProvisioning  10s (x3 over 22s)  persistentvolume-controller                                                                   waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   Provisioning          8s (x5 over 22s)   csi.vsphere.vmware.com_4235ef7c2562b4f5beec19d274e6dbf8_ce6ddb0d-5087-11eb-82b7-005056b54d91  External provisioner is provisioning volume for claim "sample-domain-c9/affinetohost-pvc1"
  Warning  ProvisioningFailed    8s (x4 over 21s)   csi.vsphere.vmware.com_4235ef7c2562b4f5beec19d274e6dbf8_ce6ddb0d-5087-11eb-82b7-005056b54d91  failed to provision volume with StorageClass "sample-vsan-sna-thick": rpc error: code = Internal desc = Error in specified StoragePool FAILED_PLACEMENT-InvalidConfiguration. Error: failed to get StoragePool with name FAILED_PLACEMENT-InvalidConfiguration: storagepools.cns.vmware.com "FAILED_PLACEMENT-InvalidConfiguration" not found
```

4. PVC without Node annotation:

Spec:
```
$ cat affineToHostPvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: affinetohost-pvc
  namespace: sample-domain-c9
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 5Mi
  storageClassName: sample-hostlocal
```

Log indicating that the code flow got returned from placement engine:
```
2021-01-12T00:11:59.064Z        DEBUG   k8scloudoperator/k8scloudoperator.go:313        Aborting placement for PVC[affinetohost-pvc] as neither volume binding of the storage class is [WaitForFirstConsumer]nor nodeAffinity PVC annotation is specified
```
This volume got eventually placed in the node sc1-10-78-124-77.eng.vmware.com

_PV and PVC description:_

```
$ ks describe pvc affinetohost-pvc
Name:          affinetohost-pvc
Namespace:     sample-domain-c9
StorageClass:  sample-hostlocal
Status:        Bound
Volume:        pvc-db75c107-8953-4f40-9e7d-4c58a6ce21d8
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      5Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
Events:
  Type    Reason                Age                    From                                                                                          Message
  ----    ------                ----                   ----                                                                                          -------
  Normal  Provisioning          2m32s                  csi.vsphere.vmware.com_421cc544a0ddc1c3b87d94caa2785b58_f2a6f72d-5469-11eb-b05a-0050569c39ca  External provisioner is provisioning volume for claim "sample-domain-c9/affinetohost-pvc"
  Normal  ExternalProvisioning  2m31s (x2 over 2m32s)  persistentvolume-controller                                                                   waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator


$ ks describe pv
Name:            pvc-db75c107-8953-4f40-9e7d-4c58a6ce21d8
Labels:          <none>
Annotations:     pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    sample-hostlocal
Status:          Bound
Claim:           sample-domain-c9/affinetohost-pvc
Reclaim Policy:  Delete
Access Modes:    RWO
VolumeMode:      Filesystem
Capacity:        5Mi
Node Affinity:   <none>
Message:
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      9bef4db4-8c20-4c32-8a8b-f6951cc3662d
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1610409958425-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
