### PR TITLE
Move node annotation listener initialization to InitStoragePoolService function

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -321,18 +321,6 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			}
 		}()
 	}
-	// Trigger NodeAnnotationListener in StoragePool
-	go func() {
-		ctx, log = logger.GetNewContextWithLogger()
-		if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
-			scWatch := storagepool.GetStoragePoolService().GetScWatch()
-			spCntlr := storagepool.GetStoragePoolService().GetSPController()
-			err = storagepool.InitNodeAnnotationListener(ctx, metadataSyncer.k8sInformerManager, scWatch, spCntlr)
-			if err != nil {
-				log.Errorf("InitNodeAnnotationListener failed. err: %v", err)
-			}
-		}
-	}()
 
 	<-stopCh
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a nil pointer dereference bug which is caused intermittently due to initialization of node annotation listener with nil SpController. This happens due to initialization of node annotation listener and SpController happens on two separate thread and could lead to a scenario where node annotation listener get initialized first with uninitialized SpController (nil pointer). To fix this I moved initialization of node annotation listener on the same thread after SpController initialization.

**Special notes for your reviewer**:
Manual Testing: changed `vmware-system-esxi-node-moid` annotation to trigger node annotation listener. Previously if triggered it could lead to nil pointer dereference panic. Now observing that node listener is trigger which reconciles SP
```
2021-01-08T09:41:28.715Z        INFO    storagepool/nodeannotationlistener.go:70        Change in node annotation for wdc-rdops-vm10-dhcp-0-41.eng.vmware.com from host-2002 to host-22. Starting ReconcileAllStoragePools...   {"TraceId": "18c42544-5873-4bbf-adeb-499c0144770a"}
2021-01-08T09:41:28.808Z        INFO    storagepool/util.go:92  Datastore vsanDatastore properties: {vsanDatastore ds:///vmfs/volumes/vsan:52d3432700456a2d-0db0bd3f804494c0/ cns.vmware.com/vsan 52d3432700456a2d-0db0bd3f804494c0 false true 0xc000bdbb40 0xc000bdbb80}       {"TraceId": "18c42544-5873-4bbf-adeb-499c0144770a"}
2021-01-08T09:41:28.844Z        INFO    storagepool/util.go:154 Accessible nodes in MM for datastore datastore-67: map[wdc-rdops-vm10-dhcp-0-41.eng.vmware.com:false wdc-rdops-vm10-dhcp-19-238.eng.vmware.com:false wdc-rdops-vm10-dhcp-2-90.eng.vmware.com:false wdc-rdops-vm10-dhcp-24-12.eng.vmware.com:false]      {"TraceId": "18c42544-5873-4bbf-adeb-499c0144770a"}
2021-01-08T09:41:28.970Z        INFO    storagepool/intended_state.go:296       Updating StoragePool instance for storagepool-vsandatastore     {"TraceId": "18c42544-5873-4bbf-adeb-499c0144770a"}
2021-01-08T09:41:29.035Z        INFO    storagepool/intended_state.go:266       Host wdc-rdops-vm10-dhcp-19-238.eng.vmware.com has capacity &{Capacity:193256751104 CapacityReserved:69717721088 CapacityUsed:72812110806 HostMoID:host-43}     {"TraceId": "18c42544-5873-4bbf-adeb-499c0144770a"}
2021-01-08T09:41:29.051Z        INFO    storagepool/intended_state.go:266       Host wdc-rdops-vm10-dhcp-0-41.eng.vmware.com has capacity &{Capacity:193256751104 CapacityReserved:69726109696 CapacityUsed:72661115862 HostMoID:host-22}       {"TraceId": "18c42544-5873-4bbf-adeb-499c0144770a"}
2021-01-08T09:41:29.071Z        INFO    storagepool/intended_state.go:266       Host wdc-rdops-vm10-dhcp-2-90.eng.vmware.com has capacity &{Capacity:193256751104 CapacityReserved:35043409920 CapacityUsed:39672914902 HostMoID:host-37}       {"TraceId": "18c42544-5873-4bbf-adeb-499c0144770a"}
2021-01-08T09:41:29.099Z        INFO    storagepool/intended_state.go:266       Host wdc-rdops-vm10-dhcp-24-12.eng.vmware.com has capacity &{Capacity:193256751104 CapacityReserved:35051798528 CapacityUsed:39484171222 HostMoID:host-19}      {"TraceId": "18c42544-5873-4bbf-adeb-499c0144770a"}
2021-01-08T09:41:29.100Z        INFO    storagepool/intended_state.go:207       creating vsan sna sp "wdc-rdops-vm10-dhcp-2-90.eng.vmware.com"  {"TraceId": "18c42544-5873-4bbf-adeb-499c0144770a"}
2021-01-08T09:41:29.115Z        INFO    storagepool/intended_state.go:296       Updating StoragePool instance for storagepool-vsandatastore-wdc-rdops-vm10-dhcp-2-90.eng.vmware.com     {"TraceId": "18c42544-5873-4bbf-adeb-499c0144770a"}
....
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Move node annotation listener initialization to InitStoragePoolService function
```
