### PR TITLE
fix block mode volume stuck in termination (issue #338)

### DIFF
--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -1365,7 +1365,7 @@ func getDevFromMount(target string) (*Device, error) {
 		if m.Path == target {
 			// something is mounted to target, get underlying disk
 			d := m.Device
-			if m.Device == "udev" {
+			if m.Device == "udev" || m.Device == "devtmpfs" {
 				d = m.Source
 			}
 			dev, err := getDevice(d)

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -1347,6 +1347,17 @@ func getDevFromMount(target string) (*Device, error) {
 	// Type:devtmpfs
 	// Opts:[rw relatime]}
 
+	// example for RAW block device on devtmpfs
+	// Host Information:
+	//   OS: Red Hat Enterprise Linux CoreOS release 4.5
+	//   Platform: OpenShift 4.5.7
+	//
+	// Device:devtmpfs
+	// Path:/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-4e248bb9-f82a-4001-a031-74fc03c9f630/108db26e-3946-469a-9a9c-dd9d6a600956
+	// Source:/dev/sdb
+	// Type:devtmpfs
+	// Opts:[rw nosuid]}
+
 	// example for Mounted block device
 	// Device:/dev/sdb
 	// Path:/var/lib/kubelet/pods/c46d6473-0810-11ea-94c1-005056825b1f/volumes/kubernetes.io~csi/pvc-9e3d1d08-080f-11ea-be93-005056825b1f/mount


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The current version of the vSphere CSI driver seems unable to execute the NodeUnpublishVolume function for block volumes when running a recent version of OpenShift (I was testing with 4.5.19). The logfiles showed the following error:

`msg="/csi.v1.Node/NodeUnpublishVolume: REP 0477: rpc error: code = Internal desc = error getting block device for volume: 351c47f9-6b5d-42fb-ac77-50dea17a1333, err: lstat devtmpfs: no such file or directory"`

After digging a bit deeper, I found that the driver code seems to handle it correctly only for mounts with type udev. RHEL Core OS uses devtmpfs for these mounts, and therefore the special treatment for block volumes does not kick in.

The result of this behavior is that pods which consume PVs of volumeMode Block remain in Terminating state until the publish mountpoint is removed manually, or the worker node is rebooted.

A detailed description of the problem can be found in #338.

**Which issue this PR fixes**
* fixes #338 

**Special notes for your reviewer**:
I'm a first time contributor to this project, please let me know if there is anything missing.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
* fixes #338 - Pod with block mode volume stuck in Termination
```
