### PR TITLE
Unit tests for storagepool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,9 @@ require (
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.1.0 // indirect
+	github.com/prometheus/common v0.6.0
 	github.com/rexray/gocsi v1.2.1
+	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -895,6 +895,7 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/syncer/storagepool/intended_state.go
+++ b/pkg/syncer/storagepool/intended_state.go
@@ -37,6 +37,9 @@ import (
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
 
+var findAccessibleNodesInCluster = findAccessibleNodes
+var getDSProperties = getDatastoreProperties
+
 const (
 	changeThresholdB = 1 * 1024 * 1024 * 1024
 )
@@ -104,14 +107,14 @@ func newIntendedState(ctx context.Context, ds *cnsvsphere.DatastoreInfo,
 	spName := makeStoragePoolName(ds.Info.Name)
 
 	// get datastore properties like capacity, freeSpace, dsURL, dsType, accessible, inMM, containerID
-	dsProps := getDatastoreProperties(ctx, ds)
+	dsProps := getDSProperties(ctx, ds)
 	if dsProps == nil || dsProps.capacity == nil || dsProps.freeSpace == nil {
 		err := fmt.Errorf("error fetching datastore properties for %v", ds.Reference().Value)
 		log.Error(err)
 		return nil, err
 	}
 
-	nodesMap, err := findAccessibleNodes(ctx, ds.Datastore.Datastore, clusterID, vcClient.Client)
+	nodesMap, err := findAccessibleNodesInCluster(ctx, ds.Datastore.Datastore, clusterID, vc.Client.Client)
 	if err != nil {
 		log.Errorf("Error finding accessible nodes of datastore %v. Err: %+v", ds, err)
 		return nil, err

--- a/pkg/syncer/storagepool/listener.go
+++ b/pkg/syncer/storagepool/listener.go
@@ -32,6 +32,8 @@ import (
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
 
+var getCandidateDatastores = cnsvsphere.GetCandidateDatastoresInCluster
+
 var (
 	// reconcileAllMutex should be acquired to run ReconcileAllStoragePools so that only one thread runs at a time.
 	reconcileAllMutex sync.Mutex
@@ -210,7 +212,7 @@ func ReconcileAllStoragePools(ctx context.Context, scWatchCntlr *StorageClassWat
 		return err
 	}
 	// Get datastores from VC
-	sharedDatastores, vsanDirectDatastores, err := cnsvsphere.GetCandidateDatastoresInCluster(ctx, &vc, spCtl.clusterID)
+	sharedDatastores, vsanDirectDatastores, err := getCandidateDatastores(ctx, &vc, spCtl.clusterID)
 	if err != nil {
 		log.Errorf("Failed to find datastores from VC. Err: %+v", err)
 		return err

--- a/pkg/syncer/storagepool/storagepool_suite_test.go
+++ b/pkg/syncer/storagepool/storagepool_suite_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepool
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
+	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
+)
+
+func TestStoragepool(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Storagepool Suite")
+}
+
+var (
+	ctx       context.Context
+	informer  metadataSyncInformer
+	k8sClient *testclient.Clientset
+)
+
+var _ = BeforeSuite(func() {
+	ctx = context.Background()
+
+	config, _ := configFromEnvOrSim()
+
+	config.Global.ClusterID = "test-cid"
+
+	vcenterconfig, err := cnsvsphere.GetVirtualCenterConfig(ctx, config)
+	Expect(err).To(BeNil())
+
+	vcManager := cnsvsphere.GetVirtualCenterManager(ctx)
+	vcenter, err := vcManager.RegisterVirtualCenter(ctx, vcenterconfig)
+	Expect(err).To(BeNil())
+
+	vcenter.ConnectCns(ctx)
+
+	getCandidateDatastores = getFakeDatastores
+
+	// initialise storagepool service
+	err = setUpInitStoragePoolService(ctx, vcenter, config.Global.ClusterID)
+	Expect(err).To(BeNil())
+
+	// initialise fake k8s client
+	k8sClient = testclient.NewSimpleClientset()
+
+	informer.k8sInformerManager = k8s.NewInformer(k8sClient)
+
+})
+
+var _ = AfterSuite(func() {
+
+	// set function names back to the original ones after the tests have finished executing
+	getCandidateDatastores = cnsvsphere.GetCandidateDatastoresInCluster
+	findAccessibleNodesInCluster = findAccessibleNodes
+	getDSProperties = getDatastoreProperties
+
+})

--- a/pkg/syncer/storagepool/storagepool_test.go
+++ b/pkg/syncer/storagepool/storagepool_test.go
@@ -1,0 +1,377 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepool
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/storagepool/cns/v1alpha1"
+)
+
+var (
+	nodeAnnotation string = "vmware-system-esxi-node-moid"
+)
+
+var _ = Describe("Storagepool", func() {
+
+	AfterEach(func() {
+
+		// get SP with name expectedSpName
+		expectedSpName := "storagepool-localds-0"
+		spClient, spResource, err := getSPClient(ctx)
+		Expect(err).To(BeNil())
+
+		// Delete the SP so that the env is clean for the next test
+		ctx := context.Background()
+		spClient.Resource(*spResource).Delete(ctx, expectedSpName, metav1.DeleteOptions{})
+	})
+
+	Describe("when an SP doesn't exist", func() {
+		It("should create SP", func() {
+			findAccessibleNodesInCluster = findFakeAccessibleNodes
+			ReconcileAllStoragePools(ctx, scWatchCntlrTest, spControllerTest)
+
+			spClient, spResource, err := getSPClient(ctx)
+			Expect(err).To(BeNil())
+
+			expectedSpName := "storagepool-localds-0"
+			// SP with name expectedSpName must be created
+			ctx := context.Background()
+			_, err = spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+
+			Expect(err).To(BeNil())
+
+		})
+	})
+
+	Describe("when datastore values get updated", func() {
+		It("SP values should get updated", func() {
+			findAccessibleNodesInCluster = findFakeAccessibleNodes
+			ReconcileAllStoragePools(ctx, scWatchCntlrTest, spControllerTest)
+
+			spClient, spResource, err := getSPClient(ctx)
+			Expect(err).To(BeNil())
+
+			expectedSpName := "storagepool-localds-0"
+			// get SP with name expectedSpName
+			ctx := context.Background()
+			_, err = spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+
+			// make sure SP was created initially
+			Expect(err).To(BeNil())
+
+			// use fake datastore properties to get updated DS values
+			getDSProperties = getFakeDatastorePropertiesDSInMM
+			ReconcileAllStoragePools(ctx, scWatchCntlrTest, spControllerTest)
+
+			// get SP with name expectedSpName
+			sp, _ := spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+
+			spCapacity, _, _ := unstructured.NestedMap(sp.Object, "status", "capacity")
+
+			expectedFreeSpace, _ := strconv.ParseInt(freeSpaceStr, 10, 64)
+			expectedTotalSpace, _ := strconv.ParseInt(capacityStr, 10, 64)
+
+			// free and total space must be updated as per DS values
+			Expect(spCapacity["freeSpace"]).To(Equal(expectedFreeSpace))
+			Expect(spCapacity["total"]).To(Equal(expectedTotalSpace))
+
+		})
+	})
+
+	Describe("when an invalid SP exists", func() {
+		It("should delete that SP", func() {
+
+			invalidSp := getStotagepoolInstance()
+
+			spClient, spResource, err := getSPClient(ctx)
+			Expect(err).To(BeNil())
+
+			// create invalid SP
+			ctx := context.Background()
+			_, err = spClient.Resource(*spResource).Create(ctx, invalidSp, metav1.CreateOptions{})
+			// verify if the SP got created successfully
+			Expect(err).To(BeNil())
+
+			// Make sure SP with name fakeSPName actually got created
+			expectedSpName := fakeSPName
+			// get SP with name expectedSpName
+			_, err = spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+
+			findAccessibleNodesInCluster = findFakeAccessibleNodes
+			ReconcileAllStoragePools(ctx, scWatchCntlrTest, spControllerTest)
+
+			// get SP with name expectedSpName
+			_, err = spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+
+			// error must not be nil as the SP got deleted
+			Expect(err).NotTo(BeNil())
+
+		})
+	})
+
+	Describe("when all hosts are in MM", func() {
+		It("should contain the correct error message", func() {
+
+			findAccessibleNodesInCluster = findFakeMMNodes
+			getDSProperties = getDatastoreProperties
+			ReconcileAllStoragePools(ctx, scWatchCntlrTest, spControllerTest)
+
+			expectedSpName := "storagepool-localds-0"
+			spClient, spResource, err := getSPClient(ctx)
+			Expect(err).To(BeNil())
+
+			// get SP with name expectedSpName
+			ctx := context.Background()
+			sp, err := spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+
+			spError, _, err := unstructured.NestedString(sp.Object, "status", "error", "message")
+			Expect(err).To(BeNil())
+			Expect(spError).To(Equal(v1alpha1.SpErrors[v1alpha1.ErrStateAllHostsInMM].Message))
+
+		})
+	})
+
+	Describe("when all hosts are inaccessible", func() {
+		It("should contain the correct error message", func() {
+
+			findAccessibleNodesInCluster = findFakeInAccessibleNodes
+			ReconcileAllStoragePools(ctx, scWatchCntlrTest, spControllerTest)
+
+			expectedSpName := "storagepool-localds-0"
+			spClient, spResource, err := getSPClient(ctx)
+			Expect(err).To(BeNil())
+
+			// get SP with name expectedSpName
+			ctx := context.Background()
+			sp, err := spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+
+			Expect(err).To(BeNil())
+			spError, _, err := unstructured.NestedString(sp.Object, "status", "error", "message")
+			Expect(err).To(BeNil())
+			Expect(spError).To(Equal(v1alpha1.SpErrors[v1alpha1.ErrStateNoAccessibleHosts].Message))
+
+		})
+	})
+
+	Describe("when all hosts are in valid state", func() {
+		It("should contain not error", func() {
+
+			findAccessibleNodesInCluster = findFakeAccessibleNodes
+			getDSProperties = getDatastoreProperties
+			ReconcileAllStoragePools(ctx, scWatchCntlrTest, spControllerTest)
+
+			expectedSpName := "storagepool-localds-0"
+			spClient, spResource, err := getSPClient(ctx)
+			Expect(err).To(BeNil())
+
+			// get SP with name expectedSpName
+			ctx := context.Background()
+			sp, err := spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+
+			spError, _, err := unstructured.NestedString(sp.Object, "status", "error", "message")
+			Expect(err).To(BeNil())
+			Expect(spError).To(Equal(""))
+
+		})
+	})
+
+	Describe("when datastores are in MM", func() {
+		It("should contain the correct error message", func() {
+
+			findAccessibleNodesInCluster = findFakeAccessibleNodes
+			getDSProperties = getFakeDatastorePropertiesDSInMM
+			ReconcileAllStoragePools(ctx, scWatchCntlrTest, spControllerTest)
+
+			expectedSpName := "storagepool-localds-0"
+			spClient, spResource, err := getSPClient(ctx)
+			Expect(err).To(BeNil())
+
+			// get SP with name expectedSpName
+			ctx := context.Background()
+			sp, err := spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+
+			spError, _, err := unstructured.NestedString(sp.Object, "status", "error", "message")
+			Expect(err).To(BeNil())
+
+			Expect(spError).To(Equal(v1alpha1.SpErrors[v1alpha1.ErrStateDatastoreInMM].Message))
+
+		})
+	})
+
+	Describe("when datastores are inaccessible", func() {
+		It("should contain the correct error message", func() {
+
+			findAccessibleNodesInCluster = findFakeAccessibleNodes
+			getDSProperties = getFakeDatastorePropertiesDSInaccessible
+			ReconcileAllStoragePools(ctx, scWatchCntlrTest, spControllerTest)
+
+			expectedSpName := "storagepool-localds-0"
+			spClient, spResource, err := getSPClient(ctx)
+			Expect(err).To(BeNil())
+
+			// get SP with name expectedSpName
+
+			ctx := context.Background()
+			sp, err := spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+
+			spError, _, err := unstructured.NestedString(sp.Object, "status", "error", "message")
+			Expect(err).To(BeNil())
+
+			Expect(spError).To(Equal(v1alpha1.SpErrors[v1alpha1.ErrStateDatastoreNotAccessible].Message))
+
+		})
+	})
+
+	Describe("when node is updated", func() {
+		It("SP reconcilation occurs and SP is created", func() {
+			findAccessibleNodesInCluster = findFakeAccessibleNodes
+
+			go InitNodeAnnotationListener(ctx, informer.k8sInformerManager, scWatchCntlrTest, spControllerTest)
+
+			time.Sleep(1000 * time.Millisecond)
+
+			// Create a new node
+			nodeAnn := make(map[string]string)
+			nodeAnn[nodeAnnotation] = "host-123"
+			nodeName := "wdc-node-2"
+			node := getNodeSpec(nodeName, nodeAnn)
+			ctx := context.Background()
+			k8sClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+
+			nodeAnn[nodeAnnotation] = "host-456"
+			patchNode(nodeName, nodeAnn, k8sClient)
+
+			time.Sleep(1000 * time.Millisecond)
+
+			spClient, spResource, err := getSPClient(ctx)
+			Expect(err).To(BeNil())
+
+			expectedSpName := "storagepool-localds-0"
+			// get SP that is expected to be created
+			_, err = spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+
+		})
+	})
+
+	Describe("when node is updated", func() {
+		It("SP reconcilation occurs and SP values are updated", func() {
+			findAccessibleNodesInCluster = findFakeAccessibleNodes
+			// reconcile manually to make sure an inital SP is created
+			ReconcileAllStoragePools(ctx, scWatchCntlrTest, spControllerTest)
+
+			// Trigger NodeAnnotationListener
+			go InitNodeAnnotationListener(ctx, informer.k8sInformerManager, scWatchCntlrTest, spControllerTest)
+
+			// get fake datastore values that should be reflected in the SP created above
+			getDSProperties = getFakeDatastorePropertiesDSInMM
+
+			time.Sleep(1000 * time.Millisecond)
+
+			nodeAnn := make(map[string]string)
+			nodeAnn[nodeAnnotation] = "host-560"
+
+			nodeName := "wdc-node-2"
+			node := getNodeSpec(nodeName, nodeAnn)
+			ctx := context.Background()
+			k8sClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+
+			// change node annotation to trigger reconcilation
+			nodeAnn[nodeAnnotation] = "host-987"
+			patchNode(nodeName, nodeAnn, k8sClient)
+
+			time.Sleep(1000 * time.Millisecond)
+
+			spClient, spResource, err := getSPClient(ctx)
+			Expect(err).To(BeNil())
+
+			expectedSpName := "storagepool-localds-0"
+			// Fetch SP that is expected to be created
+			sp, err := spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+
+			spCapacity, _, err := unstructured.NestedMap(sp.Object, "status", "capacity")
+			Expect(err).To(BeNil())
+
+			expectedFreeSpace, _ := strconv.ParseInt(freeSpaceStr, 10, 64)
+			expectedTotalSpace, _ := strconv.ParseInt(capacityStr, 10, 64)
+
+			// free and total space must be updated as per DS values
+			Expect(spCapacity["freeSpace"]).To(Equal(expectedFreeSpace))
+			Expect(spCapacity["total"]).To(Equal(expectedTotalSpace))
+
+		})
+	})
+
+	Describe("when node is not updated", func() {
+		It("SP should not be updated either", func() {
+			findAccessibleNodesInCluster = findFakeAccessibleNodes
+			getDSProperties = getDatastoreProperties
+			// reconcile manually to make sure an inital SP is created
+			ReconcileAllStoragePools(ctx, scWatchCntlrTest, spControllerTest)
+
+			go InitNodeAnnotationListener(ctx, informer.k8sInformerManager, scWatchCntlrTest, spControllerTest)
+
+			// get fake datastore values but they will not be reflected in the SP created above as the reconcilation is not expected to happen
+			getDSProperties = getFakeDatastorePropertiesDSInMM
+
+			time.Sleep(1000 * time.Millisecond)
+
+			// create a new node
+			nodeAnn := make(map[string]string)
+			nodeAnn[nodeAnnotation] = "host-539"
+			nodeName := "wdc-node-3"
+			node := getNodeSpec(nodeName, nodeAnn)
+			ctx := context.Background()
+			k8sClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+
+			spClient, spResource, err := getSPClient(ctx)
+			Expect(err).To(BeNil())
+
+			expectedSpName := "storagepool-localds-0"
+			// get SP that is expected to be created
+			sp, err := spClient.Resource(*spResource).Get(ctx, expectedSpName, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+
+			spCapacity, _, err := unstructured.NestedMap(sp.Object, "status", "capacity")
+			Expect(err).To(BeNil())
+
+			expectedFreeSpace, _ := strconv.ParseInt(freeSpaceStr, 10, 64)
+			expectedTotalSpace, _ := strconv.ParseInt(capacityStr, 10, 64)
+
+			// free and total space must not be updated to fake DS values
+			Expect(spCapacity["freeSpace"]).NotTo(Equal(expectedFreeSpace))
+			Expect(spCapacity["total"]).NotTo(Equal(expectedTotalSpace))
+
+		})
+	})
+
+})

--- a/pkg/syncer/storagepool/test_util.go
+++ b/pkg/syncer/storagepool/test_util.go
@@ -1,0 +1,345 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storagepool
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	cnssim "github.com/vmware/govmomi/cns/simulator"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	pbmsim "github.com/vmware/govmomi/pbm/simulator"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+
+	v1 "k8s.io/api/core/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/homedir"
+	spconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	spv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/storagepool/cns/v1alpha1"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
+)
+
+var (
+	sharedDatastoreManagedObject *mo.Datastore
+	spControllerTest             *SpController
+	scWatchCntlrTest             *StorageClassWatch
+	freeSpaceStr                 = "12345678900"
+	capacityStr                  = "98765432100"
+	fakeSPName                   = "storagepool-samplesp"
+)
+
+type metadataSyncInformer struct {
+	k8sInformerManager *k8s.InformerManager
+}
+
+// setUpInitStoragePoolService Initialises storagepool service
+func setUpInitStoragePoolService(ctx context.Context, vc *cnsvsphere.VirtualCenter, clusterID string) error {
+	log := logger.GetLogger(ctx)
+	log.Infof("Initializing Storage Pool Service for unit tests")
+
+	cfg, err := spconfig.GetConfig()
+	if err != nil {
+		log.Errorf("Failed to get kubernetes config. Err: %+v", err)
+		return err
+	}
+
+	kubecfgPath := ""
+	if flag.Lookup("kubeconfig") != nil {
+		kubecfgPath = flag.Lookup("kubeconfig").Value.(flag.Getter).Get().(string)
+		if kubecfgPath == "" {
+			if home := homedir.HomeDir(); home != "" {
+				flag.Set("kubeconfig", filepath.Join(home, ".kube", "config"))
+			}
+		}
+	}
+
+	// Create StoragePool CRD
+	crdKind := reflect.TypeOf(spv1alpha1.StoragePool{}).Name()
+	crdSingular := "storagepool"
+	crdPlural := "storagepools"
+	crdName := crdPlural + "." + spv1alpha1.SchemeGroupVersion.Group
+	err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, crdName, crdSingular, crdPlural,
+		crdKind, spv1alpha1.SchemeGroupVersion.Group, spv1alpha1.SchemeGroupVersion.Version, apiextensionsv1beta1.ClusterScoped)
+	if err != nil {
+		log.Errorf("Failed to create %q CRD. Err: %+v", crdKind, err)
+		return err
+	}
+
+	err = vc.ConnectPbm(ctx)
+	if err != nil {
+		log.Errorf("Failed to connect to SPBM service. Err: %+v", err)
+		return err
+	}
+
+	// Start the services
+	spControllerTest, err = newSPController(vc, clusterID)
+	if err != nil {
+		log.Errorf("Failed starting StoragePool controller. Err: %+v", err)
+		return err
+	}
+
+	scWatchCntlrTest, err = startStorageClassWatch(ctx, spControllerTest, cfg)
+	if err != nil {
+		log.Errorf("Failed starting the Storageclass watch. Err: %+v", err)
+		return err
+	}
+
+	defaultStoragePoolServiceLock.Lock()
+	defer defaultStoragePoolServiceLock.Unlock()
+	defaultStoragePoolService.spController = spControllerTest
+	defaultStoragePoolService.scWatchCntlr = scWatchCntlrTest
+	defaultStoragePoolService.clusterID = clusterID
+
+	startPropertyCollectorListener(ctx)
+
+	log.Infof("Done initializing Storage Pool Service for unit tests")
+	return nil
+}
+
+func configFromSim() (*config.Config, func()) {
+	return configFromSimWithTLS(new(tls.Config), true)
+}
+
+// configFromSimWithTLS starts a vcsim instance and returns config for use against the vcsim instance.
+// The vcsim instance is configured with a tls.Config. The returned client
+// config can be configured to allow/decline insecure connections.
+func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.Config, func()) {
+	cfg := &config.Config{}
+	model := simulator.VPX()
+	defer model.Remove()
+
+	err := model.Create()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	model.Service.TLS = tlsConfig
+	s := model.Service.NewServer()
+
+	// CNS Service simulator
+	model.Service.RegisterSDK(cnssim.New())
+
+	// PBM Service simulator
+	model.Service.RegisterSDK(pbmsim.New())
+	cfg.Global.InsecureFlag = insecureAllowed
+
+	cfg.Global.VCenterIP = s.URL.Hostname()
+	cfg.Global.VCenterPort = s.URL.Port()
+	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.Password, _ = s.URL.User.Password()
+	cfg.Global.Datacenters = "DC0"
+
+	cfg.VirtualCenter = make(map[string]*config.VirtualCenterConfig)
+	cfg.VirtualCenter[s.URL.Hostname()] = &config.VirtualCenterConfig{
+		User:         cfg.Global.User,
+		Password:     cfg.Global.Password,
+		VCenterPort:  cfg.Global.VCenterPort,
+		InsecureFlag: cfg.Global.InsecureFlag,
+		Datacenters:  cfg.Global.Datacenters,
+	}
+
+	return cfg, func() {
+		s.Close()
+		model.Remove()
+	}
+}
+
+func configFromEnvOrSim() (*config.Config, func()) {
+	cfg := &config.Config{}
+	if err := config.FromEnv(context.TODO(), cfg); err != nil {
+		return configFromSim()
+	}
+	return cfg, func() {}
+}
+
+func getFakeDatastores(ctx context.Context, vc *cnsvsphere.VirtualCenter, clusterID string) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+
+	var sharedDatastoreURL string
+	if v := os.Getenv("VSPHERE_DATASTORE_URL"); v != "" {
+		sharedDatastoreURL = v
+	} else {
+		sharedDatastoreURL = simulator.Map.Any("Datastore").(*simulator.Datastore).Info.GetDatastoreInfo().Url
+	}
+
+	var datacenterName string
+	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
+		datacenterName = v
+	} else {
+		datacenterName = simulator.Map.Any("Datacenter").(*simulator.Datacenter).Name
+	}
+
+	finder := find.NewFinder(vc.Client.Client, false)
+	dc, _ := finder.Datacenter(ctx, datacenterName)
+	finder.SetDatacenter(dc)
+	datastores, err := finder.DatastoreList(ctx, "*")
+	if err != nil {
+		return nil, nil, err
+	}
+	var dsList []types.ManagedObjectReference
+	for _, ds := range datastores {
+		dsList = append(dsList, ds.Reference())
+	}
+	var dsMoList []mo.Datastore
+	pc := property.DefaultCollector(dc.Client())
+	properties := []string{"info"}
+	err = pc.Retrieve(ctx, dsList, properties, &dsMoList)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, dsMo := range dsMoList {
+		if dsMo.Info.GetDatastoreInfo().Url == sharedDatastoreURL {
+			sharedDatastoreManagedObject = &dsMo
+		}
+	}
+	if sharedDatastoreManagedObject == nil {
+		return nil, nil, fmt.Errorf("Failed to get shared datastores")
+	}
+	return []*cnsvsphere.DatastoreInfo{
+		{
+			Datastore: &cnsvsphere.Datastore{
+				Datastore:  object.NewDatastore(dc.Client(), sharedDatastoreManagedObject.Reference()),
+				Datacenter: nil},
+			Info: sharedDatastoreManagedObject.Info.GetDatastoreInfo(),
+		},
+	}, nil, nil
+}
+
+// returns an accessible node where the ESX host is not in MM
+func findFakeAccessibleNodes(_ context.Context, _ *object.Datastore,
+	_ string, _ *vim25.Client) (map[string]bool, error) {
+	nodes := map[string]bool{"wdc-node-1": false}
+	return nodes, nil
+}
+
+// returns an accessible node where the ESX host is n MM
+func findFakeMMNodes(_ context.Context, _ *object.Datastore,
+	_ string, _ *vim25.Client) (map[string]bool, error) {
+	nodes := map[string]bool{"wdc-node-1": true}
+	return nodes, nil
+}
+
+// returns zero accessible nodes
+func findFakeInAccessibleNodes(_ context.Context, _ *object.Datastore,
+	_ string, _ *vim25.Client) (map[string]bool, error) {
+	nodes := map[string]bool{}
+	return nodes, nil
+}
+
+func getStotagepoolInstance() *unstructured.Unstructured {
+
+	accessibleNodes := []string{"wdc-node-1"}
+	compatibleStorageClasses := []string{"sample-ftt0"}
+	sp := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cns.vmware.com/v1alpha1",
+			"kind":       "StoragePool",
+			"metadata": map[string]interface{}{
+				"name": fakeSPName,
+			},
+			"spec": map[string]interface{}{
+				"driver": "csi.vsphere.vmware.com",
+				"parameters": map[string]interface{}{
+					"datastoreUrl": "ds:///vmfs/volumes/vsan:5230620c19c89030-1df1c2b3107af012/",
+				},
+			},
+			"status": map[string]interface{}{
+				"accessibleNodes":          accessibleNodes,
+				"compatibleStorageClasses": compatibleStorageClasses,
+				"capacity": map[string]interface{}{
+					"total":     "880392798208",
+					"freeSpace": "723378944087",
+				},
+			},
+		},
+	}
+
+	return sp
+}
+
+func getNodeSpec(testNodeName string, annotations map[string]string) *v1.Node {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testNodeName,
+			Annotations: annotations,
+		},
+	}
+	return node
+}
+
+func patchNode(testNodeName string, annotations map[string]string, k8sClient *testclient.Clientset) {
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": annotations,
+		},
+	}
+
+	patchBytes, _ := json.Marshal(patch)
+	ctx := context.Background()
+	k8sClient.CoreV1().Nodes().Patch(ctx, testNodeName, k8stypes.MergePatchType, patchBytes, metav1.PatchOptions{})
+}
+
+// datastore properties where datastore is in MM
+func getFakeDatastorePropertiesDSInMM(ctx context.Context, d *cnsvsphere.DatastoreInfo) *dsProps {
+	c := resource.MustParse(capacityStr)
+	f := resource.MustParse(freeSpaceStr)
+	prop := &dsProps{
+		capacity:   &c,
+		freeSpace:  &f,
+		dsURL:      "/tmp/govcsim-DC0-LocalDS_0",
+		dsType:     "cns.vmware.com/OTHER",
+		accessible: true,
+		inMM:       true,
+	}
+	return prop
+}
+
+// datastore properties where DS is not accessible
+func getFakeDatastorePropertiesDSInaccessible(ctx context.Context, d *cnsvsphere.DatastoreInfo) *dsProps {
+	c := resource.MustParse(capacityStr)
+	f := resource.MustParse(freeSpaceStr)
+	prop := &dsProps{
+		capacity:   &c,
+		freeSpace:  &f,
+		dsURL:      "/tmp/govcsim-DC0-LocalDS_0",
+		dsType:     "cns.vmware.com/OTHER",
+		accessible: false,
+		inMM:       false,
+	}
+	return prop
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Adding unit tests for storagepool. 


**Testing**:
```Unit tests pass successfully:
Ran 11 of 11 Specs in 5.407 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/syncer/storagepool	6.116s
```

Also successfully built the syncer image and was able to create new storagepools.

