### PR TITLE
upgrading csi sidecar containers

### DIFF
--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -36,7 +36,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.2.0
+          image: quay.io/k8scsi/csi-attacher:v3.1.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -86,7 +86,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.0.0
+          image: quay.io/k8scsi/livenessprobe:v2.2.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -118,16 +118,16 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: quay.io/k8scsi/csi-provisioner:v2.1.0
           args:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--default-fstype=ext4"
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"
-            - "--enable-leader-election"
-            - "--leader-election-type=leases"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: "Default"
       containers:
       - name: node-driver-registrar
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
         lifecycle:
           preStop:
             exec:
@@ -102,7 +102,7 @@ spec:
           periodSeconds: 5
           failureThreshold: 3
       - name: liveness-probe
-        image: quay.io/k8scsi/livenessprobe:v2.0.0
+        image: quay.io/k8scsi/livenessprobe:v2.2.0
         args:
         - --csi-address=/csi/csi.sock
         volumeMounts:

--- a/manifests/dev/vsphere-67u3/vanilla/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/rbac/vsphere-csi-controller-rbac.yaml
@@ -27,6 +27,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -36,7 +36,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.2.0
+          image: quay.io/k8scsi/csi-attacher:v3.1.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -49,10 +49,10 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.5.0
+          image: quay.io/k8scsi/csi-resizer:v1.1.0
           args:
             - "--v=4"
-            - "--csiTimeout=300s"
+            - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
           env:
@@ -99,7 +99,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.0.0
+          image: quay.io/k8scsi/livenessprobe:v2.2.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -131,16 +131,16 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: quay.io/k8scsi/csi-provisioner:v2.1.0
           args:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--default-fstype=ext4"
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"
-            - "--enable-leader-election"
-            - "--leader-election-type=leases"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: "Default"
       containers:
       - name: node-driver-registrar
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
         lifecycle:
           preStop:
             exec:
@@ -102,7 +102,7 @@ spec:
           periodSeconds: 5
           failureThreshold: 3
       - name: liveness-probe
-        image: quay.io/k8scsi/livenessprobe:v2.0.0
+        image: quay.io/k8scsi/livenessprobe:v2.2.0
         args:
         - --csi-address=/csi/csi.sock
         volumeMounts:

--- a/manifests/dev/vsphere-7.0/vanilla/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/rbac/vsphere-csi-controller-rbac.yaml
@@ -30,6 +30,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v3.0.0
+          image: quay.io/k8scsi/csi-attacher:v3.1.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -47,7 +47,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v1.0.0
+          image: quay.io/k8scsi/csi-resizer:v1.1.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -101,7 +101,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.1.0
+          image: quay.io/k8scsi/livenessprobe:v2.2.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -135,7 +135,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v2.0.0
+          image: quay.io/k8scsi/csi-provisioner:v2.1.0
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -20,7 +20,7 @@ spec:
       dnsPolicy: "Default"
       containers:
       - name: node-driver-registrar
-        image: quay.io/k8scsi/csi-node-driver-registrar:v2.0.1
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
         args:
         - "--v=5"
         - "--csi-address=$(ADDRESS)"
@@ -104,7 +104,7 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 5
       - name: liveness-probe
-        image: quay.io/k8scsi/livenessprobe:v2.1.0
+        image: quay.io/k8scsi/livenessprobe:v2.2.0
         args:
           - "--v=4"
           - "--csi-address=/csi/csi.sock"

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v3.0.0
+          image: quay.io/k8scsi/csi-attacher:v3.1.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -47,7 +47,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v1.0.0
+          image: quay.io/k8scsi/csi-resizer:v1.1.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -104,7 +104,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.1.0
+          image: quay.io/k8scsi/livenessprobe:v2.2.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -138,7 +138,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v2.0.0
+          image: quay.io/k8scsi/csi-provisioner:v2.1.0
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: "Default"
       containers:
       - name: node-driver-registrar
-        image: quay.io/k8scsi/csi-node-driver-registrar:v2.0.1
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
         args:
         - "--v=5"
         - "--csi-address=$(ADDRESS)"
@@ -109,7 +109,7 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 5
       - name: liveness-probe
-        image: quay.io/k8scsi/livenessprobe:v2.1.0
+        image: quay.io/k8scsi/livenessprobe:v2.2.0
         args:
           - "--v=4"
           - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is upgrading sidecar container images. We need to upgrade sidecar container images to help fix several issues observed in the older sidecar container images.

PR is upgrading sidecar container images to the following latest versions.

- quay.io/k8scsi/livenessprobe:v2.2.0
- quay.io/k8scsi/csi-attacher:v3.1.0
- quay.io/k8scsi/csi-provisioner:v2.1.0
- quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
- quay.io/k8scsi/csi-resizer:v1.1.0



**Special notes for your reviewer**:
Testing done - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/582#issuecomment-763169305


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
upgrading csi sidecar containers
```
