### PR TITLE
fixing 2.1.0 yaml files in release-2.1 branch

### DIFF
--- a/manifests/v2.1.0/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.1.0/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.2.0
+          image: quay.io/k8scsi/csi-attacher:v3.0.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -70,7 +70,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.0.0
+          image: quay.io/k8scsi/livenessprobe:v2.1.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -96,7 +96,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: quay.io/k8scsi/csi-provisioner:v2.0.0
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/v2.1.0/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.1.0/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -20,7 +20,7 @@ spec:
       dnsPolicy: "Default"
       containers:
       - name: node-driver-registrar
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.0.1
         lifecycle:
           preStop:
             exec:
@@ -94,7 +94,7 @@ spec:
           periodSeconds: 5
           failureThreshold: 3
       - name: liveness-probe
-        image: quay.io/k8scsi/livenessprobe:v2.0.0
+        image: quay.io/k8scsi/livenessprobe:v2.1.0
         args:
         - --csi-address=/csi/csi.sock
         volumeMounts:

--- a/manifests/v2.1.0/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.1.0/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.2.0
+          image: quay.io/k8scsi/csi-attacher:v3.0.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -40,7 +40,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.5.0
+          image: quay.io/k8scsi/csi-resizer:v1.0.0
           args:
             - "--v=4"
             - "--csiTimeout=300s"
@@ -83,7 +83,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.0.0
+          image: quay.io/k8scsi/livenessprobe:v2.1.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -109,7 +109,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: quay.io/k8scsi/csi-provisioner:v2.0.0
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/v2.1.0/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.1.0/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -20,7 +20,7 @@ spec:
       dnsPolicy: "Default"
       containers:
       - name: node-driver-registrar
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.0.1
         lifecycle:
           preStop:
             exec:
@@ -94,7 +94,7 @@ spec:
           periodSeconds: 5
           failureThreshold: 3
       - name: liveness-probe
-        image: quay.io/k8scsi/livenessprobe:v2.0.0
+        image: quay.io/k8scsi/livenessprobe:v2.1.0
         args:
         - --csi-address=/csi/csi.sock
         volumeMounts:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
2.1.0 release of the driver is tested with following sidecar container images. 

Deployment yaml files in vsphere7.0u1 folder is correctly specifying them, but yaml files in vSphere 7.0 and vSphere 67u3 is not up to date.

-  csi-provisioner - v2.0.0
-  csi-attacher - v3.0.0
-  csi-resizer - v1.0.0
-  livenessprob - v2.1.0
-  csi-node-driver-registrar - v2.0.1


**Special notes for your reviewer**:
The only feature added in release 2.1.0 is to support vSphere CSI Migration from in-tree to CSI on vSphere 7.0u1, and feature is thoroughly tested using sidecar container images used in vSphere 7.0u1 folder.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fixing 2.1.0 yaml files in release-2.1 branch
```
