### PR TITLE
correcting args for csi-provisioner and csi-resizer and rbac rules

### DIFF
--- a/manifests/v2.1.0/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.1.0/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -101,11 +101,10 @@ spec:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"
-            - "--enable-leader-election"
-            - "--leader-election-type=leases"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/v2.1.0/vsphere-67u3/vanilla/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/v2.1.0/vsphere-67u3/vanilla/rbac/vsphere-csi-controller-rbac.yaml
@@ -27,6 +27,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/v2.1.0/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.1.0/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -43,7 +43,7 @@ spec:
           image: quay.io/k8scsi/csi-resizer:v1.0.0
           args:
             - "--v=4"
-            - "--csiTimeout=300s"
+            - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
           env:
@@ -114,11 +114,10 @@ spec:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"
-            - "--enable-leader-election"
-            - "--leader-election-type=leases"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/v2.1.0/vsphere-7.0/vanilla/rbac/vsphere-csi-controller-rbac.yaml
+++ b/manifests/v2.1.0/vsphere-7.0/vanilla/rbac/vsphere-csi-controller-rbac.yaml
@@ -30,6 +30,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This is follow up change on top of https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/586


**Special notes for your reviewer**:
Verified deploying driver using updated yaml files and verified create, attach, detach and delete workflow.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
correcting args for csi-provisioner and csi-resizer and rbac rules
```

cc: @yastij 
