### PR TITLE
adding default fstype ext4 for upgraded csi-provisioner

### DIFF
--- a/manifests/v2.1.0/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.1.0/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -102,6 +102,7 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--default-fstype=ext4"
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"

--- a/manifests/v2.1.0/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.1.0/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -115,6 +115,7 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--default-fstype=ext4"
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"

--- a/manifests/v2.1.0/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.1.0/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -132,6 +132,7 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--default-fstype=ext4"
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
             #- "--strict-topology"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We missed to add default-fstype ext4 @RaunakShah added with this PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/471 in `v2.1.0` yaml files.

**Special notes for your reviewer**:
This change is required if user does not supply fstype in the storageclass and fsgroup is used.
Referance: 
- https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/370
- https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/370#issuecomment-714723454


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
adding default fstype ext4 for upgraded csi-provisioner
```

cc: @yastij 
