### PR TITLE
updating migration doc and adding installation steps for CPI

### DIFF
--- a/docs/book/driver-deployment/prerequisites.md
+++ b/docs/book/driver-deployment/prerequisites.md
@@ -131,37 +131,104 @@ The VMs can also be configured by using the `govc` command-line tool.
 
 ## vSphere Cloud Provider Interface (CPI) <a id="vsphere_cpi"></a>
 
-vSphere CSI driver needs the `ProviderID` field to be set for all nodes.
-
-This can be done by installing vSphere Cloud Provider Interface (CPI) on your k8s cluster.
-
-Before installing CPI, verify that all nodes are tainted with "node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule".
-
-```bash
-$ kubectl describe nodes | egrep "Taints:|Name:"
-Name:               k8s-master
-Taints:             node-role.kubernetes.io/master:NoSchedule
-Name:               k8s-node1
-Taints:             node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
-Name:               k8s-node2
-Taints:             node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
-Name:               k8s-node3
-Taints:             node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
-Name:               k8s-node4
-Taints:             node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
-```
-
-When the kubelet is started with an “external” cloud provider, this taint is set on a node to mark it as unusable. After a controller from the cloud-controller-manager initializes this node, the kubelet removes this taint.
-
 Follow the steps described under “Install the vSphere Cloud Provider Interface” in [https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md](https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md) to deploy CPI.
 
-Verify `ProviderID` is set for all nodes.
+Installation steps for vSphere CPI is briefly described here
 
-```bash
-$ kubectl describe nodes | grep "ProviderID"
-ProviderID: vsphere://<provider-id1>
-ProviderID: vsphere://<provider-id2>
-ProviderID: vsphere://<provider-id3>
-ProviderID: vsphere://<provider-id4>
-ProviderID: vsphere://<provider-id5>
-```
+1. Create a cloud-config configmap of vSphere configuration
+
+    Here is an example configuration file with dummy values:
+
+    ```bash
+    tee /etc/kubernetes/vsphere.conf >/dev/null <<EOF
+    [Global]
+    insecure-flag = "true"
+
+    [VirtualCenter "IP or FQDN"]
+    user = "username@vsphere.local"
+    password = "password"
+    port = "port"
+    datacenters = "<datacenter1-path>, <datacenter2-path>, ..."
+
+    EOF
+    ```
+
+    ```bash
+    cd /etc/kubernetes
+    kubectl create configmap cloud-config --from-file=vsphere.conf --namespace=kube-system
+    ```
+
+    ```bash
+    kubectl get configmap cloud-config --namespace=kube-system
+    NAME           DATA   AGE
+    cloud-config   1      82s
+    ```
+
+   Remove vsphere.conf file created at /etc/kubernetes/
+
+    ```bash
+    rm -rf /etc/kubernetes/vsphere.conf
+    ```
+
+2. Install CPI.
+
+   1. Taint nodes.
+  
+       Before installing CPI, verify all nodes (including master nodes) are tainted with "node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule".
+
+       To taint nodes use following command
+
+        ```bash
+        kubectl taint node <node-name> node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
+        ```
+
+        When the kubelet is started with an “external” cloud provider, this taint is set on a node to mark it as unusable. After a controller from the cloud-controller-manager initializes this node, the kubelet removes this taint.
+
+   2. Create a cloud-config configmap of vSphere configuration. Note: This is used for CPI. There is separate secret required for vSphere CSI driver.
+
+      - Here is an example configuration file with dummy values:
+
+          ```bash
+          tee /etc/kubernetes/vsphere.conf >/dev/null <<EOF
+          [Global]
+          insecure-flag = "true"
+
+          [VirtualCenter "IP or FQDN"]
+          user = "username@vsphere.local"
+          password = "password"
+          port = "port"
+          datacenters = "<datacenter1-path>, <datacenter2-path>, ..."
+
+          EOF
+          ```
+
+        Here in vsphere.conf file,
+
+          - `insecure-flag` - should be set to true to use self-signed certificate for login.
+          - `VirtualCenter` - section defines vCenter IP address / FQDN.
+          - `user` - vCenter username.
+          - `password` - password for vCenter user specified with user.
+          - `port` - vCenter Server Port.
+          - `datacenters` - list of all comma separated datacenter paths where kubernetes node VMs are present. When datacenter is located at the root, the name of datacenter is enough but when datacenter is placed in the folder, path needs to be specified as folder/datacenter-name. Please note since comma is used as a delimiter, the datacenter name itself must not contain a comma.
+
+   3. Create Roles, Roles Bindings, Service Account, Service and cloud-controller-manager Pod.
+
+      ```bash
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/manifests/controller-manager/cloud-controller-manager-roles.yaml
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+      kubectl apply -f https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
+      ```
+
+   4. Verify `ProviderID` is set for all nodes.
+
+      ```bash
+      $ kubectl describe nodes | grep "ProviderID"
+      ProviderID: vsphere://<provider-id1>
+      ProviderID: vsphere://<provider-id2>
+      ProviderID: vsphere://<provider-id3>
+      ProviderID: vsphere://<provider-id4>
+      ProviderID: vsphere://<provider-id5>
+      ```
+
+      vSphere CSI driver needs the `ProviderID` field to be set for all nodes.
+  

--- a/docs/book/features/vsphere_csi_migration.md
+++ b/docs/book/features/vsphere_csi_migration.md
@@ -79,7 +79,8 @@ To try out vSphere CSI migration in beta for vSphere plugin, perform the followi
 
 1. Upgrade vSphere to 7.0u1.
 2. Upgrade kubernetes to 1.19 release.
-3. Install vSphere CSI Driver (version v2.1.0). Use deployment manifests and RBAC files published at https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/release-2.1/manifests/v2.1.0/vsphere-7.0u1/vanilla
+3. Install vSphere Cloud Provider Interface (CPI). Please follow guideline mentioned at https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/prerequisites.html#vsphere_cpi
+4. Install vSphere CSI Driver (version v2.1.0). Use deployment manifests and RBAC files published at https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/release-2.1/manifests/v2.1.0/vsphere-7.0u1/vanilla
    - Make sure to enable csi-migration feature gate in the deployment yaml file.
 
            apiVersion: v1
@@ -90,7 +91,7 @@ To try out vSphere CSI migration in beta for vSphere plugin, perform the followi
              name: internal-feature-states.csi.vsphere.vmware.com
              namespace: kube-system
 
-4. Install admission webhook.
+5. Install admission webhook.
    - vSphere CSI driver does not support provisioning of volume by specifying migration specific parameters in the StorageClass.
      These parameters were added by vSphere CSI translation library, and should not be used in the storage class directly.
 
@@ -139,7 +140,7 @@ To try out vSphere CSI migration in beta for vSphere plugin, perform the followi
             clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-webhook-role-binding created
             deployment.apps/vsphere-csi-webhook created
 
-5. Enable feature flags `CSIMigration` and `CSIMigrationvSphere`
+6. Enable feature flags `CSIMigration` and `CSIMigrationvSphere`
 
    - `CSIMigrationvSphere` flag enables shims and translation logic to route volume operations from the vSphere in-tree plugin to vSphere CSI plugin. Supports falling back to in-tree vSphere plugin if a node does not have a vSphere CSI plugin installed and configured.
    - `CSIMigrationvSphere` requires `CSIMigration` feature flag to be enabled. This flag is enabling CSI migration on the Kubernetes Cluster.
@@ -182,8 +183,8 @@ To try out vSphere CSI migration in beta for vSphere plugin, perform the followi
 
    - Repeat this for all workload nodes in the Kubernetes Cluster.
 
-6. There is also an optional `CSIMigrationvSphereComplete` flag that can be enabled if all the nodes have CSI migration enabled. `CSIMigrationvSphereComplete` helps stop registering the vSphere in-tree plugin in kubelet and volume controllers and enables shims and translation logic to route volume operations from the vSphere in-tree plugin to vSphere CSI plugin. `CSIMigrationvSphereComplete` flag requires `CSIMigration` and `CSIMigrationvSphere` feature flags enabled and vSphere CSI plugin installed and configured on all nodes in the cluster.
-7. Verify vSphere in-tree PVCs and PVs are migrated to vSphere CSI driver, verify `pv.kubernetes.io/migrated-to: csi.vsphere.vmware.com` annotations are present on PVCs and PVs.
+7. There is also an optional `CSIMigrationvSphereComplete` flag that can be enabled if all the nodes have CSI migration enabled. `CSIMigrationvSphereComplete` helps stop registering the vSphere in-tree plugin in kubelet and volume controllers and enables shims and translation logic to route volume operations from the vSphere in-tree plugin to vSphere CSI plugin. `CSIMigrationvSphereComplete` flag requires `CSIMigration` and `CSIMigrationvSphere` feature flags enabled and vSphere CSI plugin installed and configured on all nodes in the cluster.
+8. Verify vSphere in-tree PVCs and PVs are migrated to vSphere CSI driver, verify `pv.kubernetes.io/migrated-to: csi.vsphere.vmware.com` annotations are present on PVCs and PVs.
 
      Annotations on PVCs
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is updating vSphere CSI Migration documentation and mentioning that vSphere CPI is also required to be installed.
This PR is also adding basic installation steps for deploying vSphere CPI.

**Special notes for your reviewer**:
Request for the update - https://kubernetes.slack.com/archives/CG04EL876/p1610599102000100?thread_ts=1608763744.021600&cid=CG04EL876

Preview links

- https://deploy-preview-592--kubernetes-sigs-vsphere-csi-driver.netlify.app/features/vsphere_csi_migration.html#how-to-enable-vsphere-csi-migration
- https://deploy-preview-592--kubernetes-sigs-vsphere-csi-driver.netlify.app/driver-deployment/prerequisites.html#vsphere_cpi



cc: @mrajashree @xing-yang 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
updating migration doc and adding installation steps for CPI
```
