### PR TITLE
Vanilla onlineresize 2nd set

### DIFF
--- a/tests/e2e/docs/vanilla_cluster_setup.md
+++ b/tests/e2e/docs/vanilla_cluster_setup.md
@@ -49,6 +49,9 @@ list of datastore URLs where you want to deploy file share volumes. Retrieve thi
     export SHARED_VSPHERE_DATASTORE_URL="ds:///vmfs/volumes/5cf05d97-4aac6e02-2940-02003e89d50e/"
     export NONSHARED_VSPHERE_DATASTORE_URL="ds:///vmfs/volumes/5cf05d98-b2c43515-d903-02003e89d50e/"
     export DESTINATION_VSPHERE_DATASTORE_URL="ds:///vmfs/volumes/5ad05d98-c2d43415-a903-12003e89d50e/" # Any local datastore url
+    export SHARED_VVOL_DATASTORE_URL="ds:///vmfs/volumes/vvol:5c5ddeccfb2f476c-ac17f22d228af0f1/" #shared VVOL datastore url
+    export SHARED_NFS_DATASTORE_URL="ds:///vmfs/volumes/fb4efbd8-6e969410/" #shared NFS datastore url
+    export SHARED_VMFS_DATASTORE_URL="ds:///vmfs/volumes/6009698f-424076e2-c60d-02008c6fa7e4/" #shared VMFS datastore url
     export STORAGE_POLICY_FOR_SHARED_DATASTORES="vSAN Default Storage Policy"
     export STORAGE_POLICY_FOR_NONSHARED_DATASTORES="non-shared-ds-policy"
     # Make sure env var FULL_SYNC_WAIT_TIME should be at least double of the manifest variable FULL_SYNC_INTERVAL_MINUTES in csi-driver-deploy.yaml

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -53,6 +53,9 @@ const (
 	envRegionZoneWithNoSharedDS                = "TOPOLOGY_WITH_NO_SHARED_DATASTORE"
 	envRegionZoneWithSharedDS                  = "TOPOLOGY_WITH_SHARED_DATASTORE"
 	envSharedDatastoreURL                      = "SHARED_VSPHERE_DATASTORE_URL"
+	envSharedVVOLDatastoreURL                  = "SHARED_VVOL_DATASTORE_URL"
+	envSharedNFSDatastoreURL                   = "SHARED_NFS_DATASTORE_URL"
+	envSharedVMFSDatastoreURL                  = "SHARED_VMFS_DATASTORE_URL"
 	envStoragePolicyNameForNonSharedDatastores = "STORAGE_POLICY_FOR_NONSHARED_DATASTORES"
 	envStoragePolicyNameForSharedDatastores    = "STORAGE_POLICY_FOR_SHARED_DATASTORES"
 	envStoragePolicyNameFromInaccessibleZone   = "STORAGE_POLICY_FROM_INACCESSIBLE_ZONE"
@@ -177,4 +180,13 @@ func setClusterFlavor(clusterFlavor cnstypes.CnsClusterFlavor) {
 	default:
 		vanillaCluster = true
 	}
+}
+
+// isValueSet check whether the environment variable is set or not
+func isValueSet(varName string) bool {
+	varValue := os.Getenv(varName)
+	if varValue == "" {
+		return false
+	}
+	return true
 }

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -2183,3 +2183,21 @@ func getDefaultDatastore(ctx context.Context) *object.Datastore {
 	gomega.Expect(defaultDatastore).NotTo(gomega.BeNil())
 	return defaultDatastore
 }
+
+//invokeVsanHealthService this method starts/stops VSAN health service based on the operation that we pass in the parameter
+func invokeVsanHealthService(operation string, vcAddress string) {
+	ginkgo.By(fmt.Sprintf("%s Starting vsan-health on the vCenter host", operation))
+	err := invokeVCenterServiceControl(operation, vsanhealthServiceName, vcAddress)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to %s", vsanHealthServiceWaitTime, operation))
+	time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
+}
+
+//invokeSPSService this method starts/stops SPS service based on the operation that we pass in the parameter
+func invokeSPSService(operation string, vcAddress string) {
+	ginkgo.By(fmt.Sprintf("%s SPS on the vCenter host", operation))
+	err := invokeVCenterServiceControl(operation, spsServiceName, vcAddress)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow SPS to %s", sleepTimeOut, operation))
+	time.Sleep(time.Duration(sleepTimeOut) * time.Second)
+}

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -344,7 +344,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	})
 
 	/*
-		Verify online volume expansion does nor support shrinking volume
+		Verify online volume expansion does not support shrinking volume
 
 		1. Create StorageClass with allowVolumeExpansion set to true.
 		2. Create PVC which uses the StorageClass created in step 1.
@@ -467,11 +467,12 @@ func increaseVolumeMultipleTimes(f *framework.Framework, client clientset.Interf
 	framework.Logf("PVC name : " + pvclaim.Name)
 	pv := getPvFromClaim(client, namespace, pvclaim.Name)
 	pvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
-	waitForPvResize(pv, client, pvcSize, totalResizeWaitPeriod)
+	err := waitForPvResize(pv, client, pvcSize, totalResizeWaitPeriod)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	ginkgo.By("Checking for conditions on pvc")
 	framework.Logf("PVC Name :", pvclaim.Name)
-	pvclaim, err := waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, totalResizeWaitPeriod)
+	pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, totalResizeWaitPeriod)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
@@ -510,6 +511,7 @@ func verifyPVCSizeAfterResize(f *framework.Framework, client clientset.Interface
 	defer cancel()
 
 	pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	ginkgo.By("Verifying PVC size requested in volume expansion is honored")
 	currentPvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
 	size := currentPvcSize.DeepCopy()


### PR DESCRIPTION
**Added Vanilla Online Volume resize test cases (Second set)**

```
1. Verify online volume expansion when VSAN-health is down
2. Verify online volume expansion when SPS is down
3. Verify online volume expansion by updating PVC with different size
4. Verify online volume expansion on shared VVOL datastore
5. Verify online volume expansion on shared NFS datastore
6. Verify online volume expansion on shared VMFS datastore

https://gist.github.com/kavyashree-r/89cbae6f76a07d764a81b16414f8fbc7
```