### PR TITLE
Exposed create and delete volume metrices from WCP CSI controller.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -815,6 +815,7 @@ github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJ
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware-tanzu/vm-operator-api v0.1.3 h1:4vxewu0jAN3fSoCBI6FhjmRGJ7ci0R2WNu/I6hacTYs=
 github.com/vmware-tanzu/vm-operator-api v0.1.3/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
+github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.24.1-0.20210127152625-854ba4efe87e h1:QPfnwPHD91grdm5OBiWkrRftSNrhpKODGsRC3/jM18U=
 github.com/vmware/govmomi v0.24.1-0.20210127152625-854ba4efe87e/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.17/vsphere-csi-controller.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.17/vsphere-csi-controller.yaml
@@ -203,6 +203,10 @@ spec:
           name: socket-dir
       - name: vsphere-csi-controller
         image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
+        ports:
+         - containerPort: 2112
+           name: prometheus
+           protocol: TCP
         lifecycle:
           preStop:
             exec:

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.18/vsphere-csi-controller.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.18/vsphere-csi-controller.yaml
@@ -203,6 +203,10 @@ spec:
           name: socket-dir
       - name: vsphere-csi-controller
         image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
+        ports:
+          - containerPort: 2112
+            name: prometheus
+            protocol: TCP
         lifecycle:
           preStop:
             exec:

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.19/vsphere-csi-controller.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.19/vsphere-csi-controller.yaml
@@ -204,6 +204,10 @@ spec:
           name: socket-dir
       - name: vsphere-csi-controller
         image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
+        ports:
+          - containerPort: 2112
+            name: prometheus
+            protocol: TCP
         lifecycle:
           preStop:
             exec:

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -18,8 +18,13 @@ package wcp
 
 import (
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/prometheus"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/fsnotify/fsnotify"
@@ -150,6 +155,19 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		log.Errorf("failed to watch on path: %q. err=%v", cfgDirPath, err)
 		return err
 	}
+	// Go module to keep the metrics http server running all the time.
+	go func() {
+		prometheus.CsiInfo.WithLabelValues(version).Set(1)
+		for {
+			log.Info("Starting the http server to expose Prometheus metrics..")
+			http.Handle("/metrics", promhttp.Handler())
+			err = http.ListenAndServe(":2112", nil)
+			if err != nil {
+				log.Warnf("Http server that exposes the Prometheus exited with err: %+v", err)
+			}
+			log.Info("Restarting http server to expose Prometheus metrics..")
+		}
+	}()
 	return nil
 }
 
@@ -402,49 +420,111 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 // in CreateVolumeRequest
 func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (
 	*csi.CreateVolumeResponse, error) {
-	ctx = logger.NewContextWithLogger(ctx)
-	log := logger.GetLogger(ctx)
-	log.Infof("CreateVolume: called with args %+v", *req)
 
-	// Validate create request
-	err := validateWCPCreateVolumeRequest(ctx, req)
-	if err != nil {
-		msg := fmt.Sprintf("Validation for CreateVolume Request: %+v has failed. Error: %+v", *req, err)
-		log.Error(msg)
-		return nil, err
-	}
+	start := time.Now()
+	volumeType := prometheus.PrometheusUnknownVolumeType
+	createVolumeInternal := func() (
+		*csi.CreateVolumeResponse, error) {
+		ctx = logger.NewContextWithLogger(ctx)
+		log := logger.GetLogger(ctx)
+		log.Infof("CreateVolume: called with args %+v", *req)
 
-	if common.IsFileVolumeRequest(ctx, req.GetVolumeCapabilities()) {
-		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.FileVolume) || !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIAuthCheck) {
-			msg := "File volume feature is disabled on the cluster"
-			log.Warn(msg)
-			return nil, status.Errorf(codes.Unimplemented, msg)
+		isBlockRequest := !common.IsFileVolumeRequest(ctx, req.GetVolumeCapabilities())
+		if isBlockRequest {
+			volumeType = prometheus.PrometheusBlockVolumeType
+		} else {
+			volumeType = prometheus.PrometheusFileVolumeType
 		}
-		return c.createFileVolume(ctx, req)
+		// Validate create request
+		err := validateWCPCreateVolumeRequest(ctx, req, isBlockRequest)
+		if err != nil {
+			msg := fmt.Sprintf("Validation for CreateVolume Request: %+v has failed. Error: %+v", *req, err)
+			log.Error(msg)
+			return nil, err
+		}
+
+		if !isBlockRequest {
+			if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.FileVolume) || !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIAuthCheck) {
+				msg := "File volume feature is disabled on the cluster"
+				log.Warn(msg)
+				return nil, status.Errorf(codes.Unimplemented, msg)
+			}
+			return c.createFileVolume(ctx, req)
+		}
+		return c.createBlockVolume(ctx, req)
 	}
-	return c.createBlockVolume(ctx, req)
+	resp, err := createVolumeInternal()
+	if err != nil {
+		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+	}
+	return resp, err
 }
 
 // DeleteVolume is deleting CNS Volume specified in DeleteVolumeRequest
 func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (
 	*csi.DeleteVolumeResponse, error) {
-	ctx = logger.NewContextWithLogger(ctx)
-	log := logger.GetLogger(ctx)
-	log.Infof("DeleteVolume: called with args: %+v", *req)
-	var err error
-	err = validateWCPDeleteVolumeRequest(ctx, req)
-	if err != nil {
-		msg := fmt.Sprintf("Validation for DeleteVolume Request: %+v has failed. Error: %+v", *req, err)
-		log.Error(msg)
-		return nil, err
+
+	start := time.Now()
+	volumeType := prometheus.PrometheusUnknownVolumeType
+
+	deleteVolumeInternal := func() (
+		*csi.DeleteVolumeResponse, error) {
+		ctx = logger.NewContextWithLogger(ctx)
+		log := logger.GetLogger(ctx)
+		log.Infof("DeleteVolume: called with args: %+v", *req)
+		var err error
+		err = validateWCPDeleteVolumeRequest(ctx, req)
+		if err != nil {
+			msg := fmt.Sprintf("Validation for DeleteVolume Request: %+v has failed. Error: %+v", *req, err)
+			log.Error(msg)
+			return nil, err
+		}
+		// Query CNS to get the volume type.
+		queryFilter := cnstypes.CnsQueryFilter{
+			VolumeIds: []cnstypes.CnsVolumeId{{Id: req.VolumeId}},
+		}
+		queryResult, err := c.manager.VolumeManager.QueryAllVolume(ctx, queryFilter, cnstypes.CnsQuerySelection{
+			Names: []string{
+				string(cnstypes.QuerySelectionNameTypeVolumeType),
+			},
+		})
+		if err != nil {
+			msg := fmt.Sprintf("QueryVolume failed for volumeID: %q. %+v", req.VolumeId, err.Error())
+			log.Error(msg)
+			return nil, status.Error(codes.Internal, msg)
+		}
+		if len(queryResult.Volumes) == 0 {
+			msg := fmt.Sprintf("volumeID %s not found in QueryVolume", req.VolumeId)
+			log.Error(msg)
+			return nil, status.Error(codes.Internal, msg)
+		}
+		if queryResult.Volumes[0].VolumeType == common.BlockVolumeType {
+			volumeType = prometheus.PrometheusBlockVolumeType
+		} else {
+			volumeType = prometheus.PrometheusFileVolumeType
+		}
+
+		err = common.DeleteVolumeUtil(ctx, c.manager.VolumeManager, req.VolumeId, true)
+		if err != nil {
+			msg := fmt.Sprintf("failed to delete volume: %q. Error: %+v", req.VolumeId, err)
+			log.Error(msg)
+			return nil, status.Errorf(codes.Internal, msg)
+		}
+		return &csi.DeleteVolumeResponse{}, nil
 	}
-	err = common.DeleteVolumeUtil(ctx, c.manager.VolumeManager, req.VolumeId, true)
+	resp, err := deleteVolumeInternal()
 	if err != nil {
-		msg := fmt.Sprintf("failed to delete volume: %q. Error: %+v", req.VolumeId, err)
-		log.Error(msg)
-		return nil, status.Errorf(codes.Internal, msg)
+		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
-	return &csi.DeleteVolumeResponse{}, nil
+	return resp, err
 }
 
 // ControllerPublishVolume attaches a volume to the Node VM.

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -72,8 +72,7 @@ func validateCreateFileReqParam(paramName, value string) bool {
 // CreateVolumeRequest for WCP CSI driver.
 // Function returns error if validation fails otherwise returns nil.
 // TODO: Need to remove AttributeHostLocal after external provisioner stops sending this parameter
-func validateWCPCreateVolumeRequest(ctx context.Context, req *csi.CreateVolumeRequest) error {
-	isBlockRequest := !common.IsFileVolumeRequest(ctx, req.GetVolumeCapabilities())
+func validateWCPCreateVolumeRequest(ctx context.Context, req *csi.CreateVolumeRequest, isBlockRequest bool) error {
 	// Get create params
 	params := req.GetParameters()
 	for paramName, value := range params {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Exposed create and delete volume metrices from WCP CSI controller.

Note that this PR is built on top of PR - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/605. This PR changes only 2 files - wcp/controller.go and wcp/controller_helper.go

Please review PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/605 before reviewing this PR.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #611 

**Special notes for your reviewer**:
Testing done:
1. Tested that the create and delete volume operation metrics are scraped by Prometheus and also verified that Grafana is showing the right data in the dashboard. Here's a screenshot of Grafana dashboard showing the success rates and latencies when an error condition was introduced.

![sv_create_delete2](https://user-images.githubusercontent.com/17838923/105678620-36152380-5ea2-11eb-8e43-1d4aff976b4d.jpg)


**Release note**:
```release-note
Exposed create and delete volume metrices from WCP CSI controller.
```
