### PR TITLE
Configure ACLs for file volumes

### DIFF
--- a/pkg/syncer/cnsoperator/util/util.go
+++ b/pkg/syncer/cnsoperator/util/util.go
@@ -54,6 +54,10 @@ const (
 	wcpNetworkConfigMap = "wcp-network-config"
 	// Key for network-provider field in 'wcp-network-config' configmap
 	networkProvider = "network_provider"
+	// NSXTNetworkProvider holds the network provider name for NSX-T based setups
+	NSXTNetworkProvider = "NSXT_CONTAINER_PLUGIN"
+	// VDSNetworkProvider holds the network provider name for VDS based setups
+	VDSNetworkProvider = "VSPHERE_NETWORK"
 )
 
 // GetVolumeID gets the volume ID from the PV that is bound to PVC by pvcName
@@ -150,9 +154,10 @@ func GetTKGVMIP(ctx context.Context, vmOperatorClient client.Client, dc dynamic.
 	return ip, nil
 }
 
-// GetNetworkProvider reads the network-config configmap in Supervisor cluster and
-// returns the network provider as NSX-T or VDS. Returns an error if network provider
-// is not present in the configmap.
+// GetNetworkProvider reads the network-config configmap in Supervisor cluster
+// Returns the network provider as NSXT_CONTAINER_PLUGIN for NSX-T OR
+// Returns the network provider as VSPHERE_NETWORK for VDS.
+// Returns an error if network provider is not present in the configmap.
 func GetNetworkProvider(ctx context.Context) (string, error) {
 	log := logger.GetLogger(ctx)
 	k8sclient, err := k8s.NewClient(ctx)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding implementation for invoking configure volume ACLs API for file volumes
The unit tests are failing due to bumping up of govmomi version. Will be addressing this is here: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/602

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
The configure volume ACLs API will be invoked from cnsfileaccessconfig controller when controller publish volume(File Volumes) is invoked from TKGS. 
**Special notes for your reviewer**:


From cnsfileaccessconfigcontroller, this method was invoked to configureACLs

```
2021-01-29T00:57:10.637Z	INFO	cnsfilevolumeclient/cnsfilevolumeclient.go:103	Fetching client VMs list from cnsfilevolumeclient test-gc-e2e-demo-ns/b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef for IP address 192.168.124.2	{"TraceId": "cba134f2-04e3-4564-af3a-7ac2ab98aea8"}


2021-01-29T00:57:10.751Z	INFO	cnsfilevolumeclient/cnsfilevolumeclient.go:125	Cnsfilevolumeclient instance test-gc-e2e-demo-ns/b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef not found: cnsfilevolumeclients.cns.vmware.com "b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef" not found. Returning empty list	{"TraceId": "cba134f2-04e3-4564-af3a-7ac2ab98aea8"}

2021-01-29T00:57:56.569Z	INFO	cnsfilevolumeclient/cnsfilevolumeclient.go:152	Adding client VM test-cluster-e2e-script-workers-hggkp-6bb876f4df-tx826 to cnsfilevolumeclient test-gc-e2e-demo-ns/b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef list for IP address 192.168.124.2	{"TraceId": "cba134f2-04e3-4564-af3a-7ac2ab98aea8"}
2021-01-29T00:57:56.599Z	DEBUG	cnsfilevolumeclient/cnsfilevolumeclient.go:188	Creating cnsfilevolumeclient instance test-gc-e2e-demo-ns/b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef with spec: &{TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef GenerateName: Namespace:test-gc-e2e-demo-ns SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[]} Spec:{ExternalIPtoClientVms:map[192.168.124.2:[test-cluster-e2e-script-workers-hggkp-6bb876f4df-tx826]]}}	{"TraceId": "cba134f2-04e3-4564-af3a-7ac2ab98aea8"}


2021-01-29T00:57:56.569Z	INFO	volume/manager.go:818	ConfigureVolumeACLs: Configured VolumeACLs successfully. VolumeName: "file:988c01dc-98af-45db-85df-b97882020f5e", opId: "ede725ed", volumeID: "file:988c01dc-98af-45db-85df-b97882020f5e"	{"TraceId": "cba134f2-04e3-4564-af3a-7ac2ab98aea8"}
2021-01-29T00:57:56.569Z	DEBUG	cnsfileaccessconfig/cnsfileaccessconfig_controller.go:397	Successfully configured ACLs for volume "file:988c01dc-98af-45db-85df-b97882020f5e"	{"TraceId": "cba134f2-04e3-4564-af3a-7ac2ab98aea8"}
2021-01-29T00:57:56.569Z	INFO	cnsfilevolumeclient/cnsfilevolumeclient.go:152	Adding client VM test-cluster-e2e-script-workers-hggkp-6bb876f4df-tx826 to cnsfilevolumeclient test-gc-e2e-demo-ns/b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef list for IP address 192.168.124.2	{"TraceId": "cba134f2-04e3-4564-af3a-7ac2ab98aea8"}
```


```
root@4230b5ef311c6c8686e63f62f5d303c4 [ ~ ]# kubectl get cnsfilevolumeclients -A
NAMESPACE             NAME                                                                        AGE
test-gc-e2e-demo-ns   b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef   31s
```

```
b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileVolumeClient
Metadata:
  Creation Timestamp:  2021-01-29T00:57:56Z
  Generation:          1
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:externalIPtoClientVms:
          .:
          f:192.168.124.2:
    Manager:         vsphere-syncer
    Operation:       Update
    Time:            2021-01-29T00:57:56Z
  Resource Version:  9660241
  Self Link:         /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsfilevolumeclients/b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef
  UID:               f00d75d7-b121-47ad-8ca5-16b410336713
Spec:
  External I Pto Client Vms:
    192.168.124.2:
      test-cluster-e2e-script-workers-hggkp-6bb876f4df-tx826
Events:  <none>
```

```
root@4230b5ef311c6c8686e63f62f5d303c4 [ ~ ]# kubectl describe cnsfileaccessconfigs.cns.vmware.com -n test-gc-e2e-demo-ns
Name:         test-cluster-e2e-script-workers-hggkp-6bb876f4df-tx826-b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsFileAccessConfig
Metadata:
  Creation Timestamp:  2021-01-29T00:35:12Z
  Finalizers:
    cns.vmware.com
  Generation:  3
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:pvcName:
        f:vmName:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2021-01-29T00:35:12Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"cns.vmware.com":
        f:ownerReferences:
          .:
          k:{"uid":"fd78e879-07d1-4646-b19b-172d88a6dd5e"}:
            .:
            f:apiVersion:
            f:blockOwnerDeletion:
            f:controller:
            f:kind:
            f:name:
            f:uid:
      f:status:
        f:accessPoints:
          .:
          f:NFSv3:
          f:NFSv4.1:
        f:done:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2021-01-29T00:57:56Z
  Owner References:
    API Version:           v1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  VirtualMachine
    Name:                  test-cluster-e2e-script-workers-hggkp-6bb876f4df-tx826
    UID:                   fd78e879-07d1-4646-b19b-172d88a6dd5e
  Resource Version:        9660245
  Self Link:               /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsfileaccessconfigs/test-cluster-e2e-script-workers-hggkp-6bb876f4df-tx826-b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef
  UID:                     4d3d8698-ec6e-46b3-abc6-bdc3e7ac061d
Spec:
  Pvc Name:  b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef
  Vm Name:   test-cluster-e2e-script-workers-hggkp-6bb876f4df-tx826
Status:
  Access Points:
    NFSv3:    h172-16-10-11.chethanvtest.testdomain:/5227db7d-e905-d906-93ec-467e8d0de846
    NFSv4.1:  h172-16-10-10.chethanvtest.testdomain:/vsanfs/5227db7d-e905-d906-93ec-467e8d0de846
  Done:       true
Events:
  Type     Reason                        Age                 From            Message
  ----     ------                        ----                ----            -------
  Warning  CnsFileAccessConfigFailed     27m (x11 over 44m)  cns.vmware.com  Failed to update CnsFileAccessConfig instance with error: Failed to get the list of clients VMs for IP "192.168.124.2". Error: cnsfilevolumeclients.cns.vmware.com "b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef" not found
  Normal   CnsFileAccessConfigSucceeded  22m                 cns.vmware.com  Successfully configured access points of VM: "test-cluster-e2e-script-workers-hggkp-6bb876f4df-tx826" on the volume: "b765ab11-d287-403f-b31b-16d057e5ee9f-53bd1da7-fa6b-4226-b1e4-d4a855d98aef"

```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Configure ACLs for file volumes
```
![Screen Shot 2021-01-28 at 5 15 25 PM](https://user-images.githubusercontent.com/14131348/106220384-3a865880-6190-11eb-9416-023810164914.png)

![Screen Shot 2021-01-28 at 5 43 35 PM](https://user-images.githubusercontent.com/14131348/106220442-60136200-6190-11eb-8739-410d7ff64029.png)
