### PR TITLE
Fix nil pointer dereference in volume health reconciler

### DIFF
--- a/pkg/syncer/volume_health_reconciler.go
+++ b/pkg/syncer/volume_health_reconciler.go
@@ -346,7 +346,7 @@ func (rc *volumeHealthReconciler) syncPVC(key string) error {
 	}
 	if tkgPVList == nil {
 		// If no PV is found, the SV PVC may not be referenced within this TKG. Do not requeue this request.
-		log.Debugf("Tanzu Kubernetes Grid PV not found for Supervisor PVC %s/%s. Igonoring ...", svcPVC.Namespace, svcPVC.Name)
+		log.Debugf("Tanzu Kubernetes Grid PV not found for Supervisor PVC %s/%s. Igonoring ...", namespace, name)
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR fixes a nil pointer dereference in volume health reconciler. If SVPVC is nil, there's an attempt to print SVPVC.Name and SVPVC.Namespace

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix nil pointer dereference in volume health reconciler
```
