### PR TITLE
Bump up govmomi to v0.24.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.3
-	github.com/vmware/govmomi v0.23.2-0.20201031083551-1cfa19267614
+	github.com/vmware/govmomi v0.24.1-0.20210127152625-854ba4efe87e
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -815,9 +815,8 @@ github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJ
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware-tanzu/vm-operator-api v0.1.3 h1:4vxewu0jAN3fSoCBI6FhjmRGJ7ci0R2WNu/I6hacTYs=
 github.com/vmware-tanzu/vm-operator-api v0.1.3/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
-github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/vmware/govmomi v0.23.2-0.20201031083551-1cfa19267614 h1:Pw/uggJO55NA442TyCmY9BQmaw66xJsf9pvUr1ijPqM=
-github.com/vmware/govmomi v0.23.2-0.20201031083551-1cfa19267614/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.24.1-0.20210127152625-854ba4efe87e h1:QPfnwPHD91grdm5OBiWkrRftSNrhpKODGsRC3/jM18U=
+github.com/vmware/govmomi v0.24.1-0.20210127152625-854ba4efe87e/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -640,7 +640,7 @@ func (vs *vSphere) getHostUUID(ctx context.Context, hostInfo string) string {
 func (c *VsanClient) VsanQueryObjectIdentities(ctx context.Context, cluster vimtypes.ManagedObjectReference) (*vsantypes.VsanObjectIdentityAndHealth, error) {
 	req := vsantypes.VsanQueryObjectIdentities{
 		This:    VsanQueryObjectIdentitiesInstance,
-		Cluster: cluster,
+		Cluster: &cluster,
 	}
 
 	res, err := vsanmethods.VsanQueryObjectIdentities(ctx, c.serviceClient, &req)
@@ -648,7 +648,7 @@ func (c *VsanClient) VsanQueryObjectIdentities(ctx context.Context, cluster vimt
 	if err != nil {
 		return nil, err
 	}
-	return &res.Returnval, nil
+	return res.Returnval, nil
 }
 
 //QueryVsanObjects takes vsan uuid as input and returns the vSANObj related information like lsom_objects and disk_objects
@@ -683,11 +683,11 @@ func (c *VsanClient) QueryVsanObjects(ctx context.Context, uuids []string, vs *v
 			Value: value,
 		}
 	)
-	req := vsantypes.QueryVsanObjects{
+	req := types.QueryVsanObjects{
 		This:  QueryVsanObjectsInstance,
 		Uuids: uuids,
 	}
-	res, err := vsanmethods.QueryVsanObjects(ctx, c.serviceClient, &req)
+	res, err := methods.QueryVsanObjects(ctx, c.serviceClient, &req)
 	if err != nil {
 		framework.Logf("QueryVsanObjects Failed with err %v", err)
 		return "", err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is bumping up govmomi version to use latest version: v0.24.1. This is needed mainly to utilize configure ACL APIs required for file volume support in vSphere with K8s

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Ran e2e tests manually since the e2e pipeline is currently failing:
https://gist.github.com/chethanv28/736c656f62cb117bfa991596d512a0e3
The above tests include Stateful set testing, lable updates, different disk size volume provisioning, data persistence.
This covers create/delete, attach/detach, update volume metadata and other core APIs


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump up govmomi to v0.24.1
```
