### PR TITLE
add retries to deleteFCD() calls which follow PV delete call

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	adminPassword                              = "Admin!23"
+	busyBoxImageOnGcr                          = "gcr.io/google_containers/busybox:1.27"
 	configSecret                               = "vsphere-config-secret"
 	crdCNSNodeVMAttachment                     = "cnsnodevmattachments"
 	crdCNSVolumeMetadatas                      = "cnsvolumemetadatas"
@@ -39,6 +40,7 @@ const (
 	defaultPandoraSyncWaitTime                 = 90
 	defaultVCRebootWaitTime                    = 180
 	destinationDatastoreURL                    = "DESTINATION_VSPHERE_DATASTORE_URL"
+	disklibUnlinkErr                           = "DiskLib_Unlink"
 	diskSize                                   = "2Gi"
 	diskSizeInMb                               = int64(2048)
 	diskSizeInMinMb                            = int64(200)
@@ -60,6 +62,7 @@ const (
 	envSupervisorClusterNamespace              = "SVC_NAMESPACE"
 	envSupervisorClusterNamespaceToDelete      = "SVC_NAMESPACE_TO_DELETE"
 	envTopologyWithOnlyOneNode                 = "TOPOLOGY_WITH_ONLY_ONE_NODE"
+	envVmdkDiskURL                             = "DISK_URL_PATH"
 	envVolumeOperationsScale                   = "VOLUME_OPS_SCALE"
 	esxPassword                                = "ca$hc0w"
 	execCommand                                = "/bin/df -T /mnt/volume1 | /bin/awk 'FNR == 2 {print $2}' > /mnt/volume1/fstype && while true ; do sleep 2 ; done"
@@ -110,6 +113,8 @@ const (
 	totalResizeWaitPeriod                      = 10 * time.Minute
 	vSphereCSIControllerPodNamePrefix          = "vsphere-csi-controller"
 	vmUUIDLabel                                = "vmware-system-vm-uuid"
+	vsanDefaultStorageClassInSVC               = "vsan-default-storage-policy"
+	vsanDefaultStoragePolicyName               = "vSAN Default Storage Policy"
 	vsanHealthServiceWaitTime                  = 15
 	vsanhealthServiceName                      = "vsan-health"
 	vsphereCloudProviderConfiguration          = "vsphere-cloud-provider.conf"
@@ -118,10 +123,6 @@ const (
 	waitTimeForCNSNodeVMAttachmentReconciler   = 30 * time.Second
 	wcpServiceName                             = "wcp"
 	zoneKey                                    = "failure-domain.beta.kubernetes.io/zone"
-	envVmdkDiskURL                             = "DISK_URL_PATH"
-	vsanDefaultStorageClassInSVC               = "vsan-default-storage-policy"
-	vsanDefaultStoragePolicyName               = "vSAN Default Storage Policy"
-	busyBoxImageOnGcr                          = "gcr.io/google_containers/busybox:1.27"
 )
 
 // The following variables are required to know cluster type to run common e2e tests

--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -181,8 +181,12 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] full-sync-test", func() {
 		err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		ginkgo.By(fmt.Sprintf("Waiting for volume %s to be deleted", fcdID))
+		err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		ginkgo.By(fmt.Sprintf("Deleting FCD: %s", fcdID))
-		err = e2eVSphere.deleteFCD(ctx, fcdID, datastore.Reference())
+		err = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(), disklibUnlinkErr)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	})
@@ -348,7 +352,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] full-sync-test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Deleting FCD: %s", fcdID))
-		err = e2eVSphere.deleteFCD(ctx, fcdID, datastore.Reference())
+		err = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(), disklibUnlinkErr)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	})
@@ -622,8 +626,12 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] full-sync-test", func() {
 		err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		ginkgo.By(fmt.Sprintf("Waiting for volume %s to be deleted", fcdID))
+		err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		ginkgo.By(fmt.Sprintf("Deleting FCD: %s", fcdID))
-		err = e2eVSphere.deleteFCD(ctx, fcdID, datastore.Reference())
+		err = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(), disklibUnlinkErr)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	})
@@ -685,8 +693,12 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] full-sync-test", func() {
 		err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		ginkgo.By(fmt.Sprintf("Waiting for volume %s to be deleted", fcdID))
+		err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		ginkgo.By(fmt.Sprintf("Deleting FCD: %s", fcdID))
-		err = e2eVSphere.deleteFCD(ctx, fcdID, datastore.Reference())
+		err = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(), disklibUnlinkErr)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 

--- a/tests/e2e/labelupdates.go
+++ b/tests/e2e/labelupdates.go
@@ -436,7 +436,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] label-updates", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Deleting FCD: %s", fcdID))
-		err = e2eVSphere.deleteFCD(ctx, fcdID, datastore.Reference())
+		err = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(), disklibUnlinkErr)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Deleting the Storage Class")
@@ -570,7 +570,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] label-updates", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Deleting FCD: %s", fcdID))
-		err = e2eVSphere.deleteFCD(ctx, fcdID, datastore.Reference())
+		err = deleteFcdWithRetriesForSpecificErr(ctx, fcdID, datastore.Reference(), disklibUnlinkErr)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	})

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -2126,3 +2126,22 @@ func getPersistentVolumeClaimSpecForFileShare(namespace string, labels map[strin
 	pvc.Spec.AccessModes = []v1.PersistentVolumeAccessMode{accessMode}
 	return pvc
 }
+
+//deleteFcdWithRetriesForSpecificErr method to retry fcd deletion when a specific error is encountered
+func deleteFcdWithRetriesForSpecificErr(ctx context.Context, fcdID string, dsRef types.ManagedObjectReference, errToIgnore string) error {
+	var err error
+	waitErr := wait.PollImmediate(poll*15, pollTimeout, func() (bool, error) {
+		framework.Logf("Trying to delete FCD: %s", fcdID)
+		err = e2eVSphere.deleteFCD(ctx, fcdID, dsRef)
+		if err != nil {
+			if strings.Contains(err.Error(), errToIgnore) {
+				// In FCD, there is a background thread that makes calls to host to sync datastore every minute.
+				framework.Logf("Hit error '%s' while trying to delete FCD: %s, will retry after %v seconds ...", err.Error(), fcdID, poll*15)
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	return waitErr
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: deleteFCD() call after a PV delete call may fail, we have to retry the operation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

