### PR TITLE
Set cluster distribution in full sync for volumes created before upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.3
-	github.com/vmware/govmomi v0.24.1-0.20210127152625-854ba4efe87e
+	github.com/vmware/govmomi v0.24.1-0.20210211225628-8e9d4eb7d357
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -816,8 +816,8 @@ github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmF
 github.com/vmware-tanzu/vm-operator-api v0.1.3 h1:4vxewu0jAN3fSoCBI6FhjmRGJ7ci0R2WNu/I6hacTYs=
 github.com/vmware-tanzu/vm-operator-api v0.1.3/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/vmware/govmomi v0.24.1-0.20210127152625-854ba4efe87e h1:QPfnwPHD91grdm5OBiWkrRftSNrhpKODGsRC3/jM18U=
-github.com/vmware/govmomi v0.24.1-0.20210127152625-854ba4efe87e/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.24.1-0.20210211225628-8e9d4eb7d357 h1:8n/rCTYyci4UqVOReJg/TeUxoPVStntNQF3Y7dlxxEA=
+github.com/vmware/govmomi v0.24.1-0.20210211225628-8e9d4eb7d357/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fixes a bug where existing volumes that do not have cluster-distribution set are not updated after the cluster is upgraded. We previously required a PV/PVC label update for the cluster-distrubtion to be updated. This PR makes a change in full sync to add this functionality so that no user intervention is required set the cluster-distribution on existing volumes. 

For vSphere releases that do not support cluster-distribution parameter, this value will be unset on CNS. This PR includes logic to prevent CSI from updating the volume metadata based on cluster-distribution parameter in those vSphere releases. 

Govmomi PR to add vsphere 7.0u2 constant - https://github.com/vmware/govmomi/pull/2272

Volume metadata before upgrade shows that `ClusterDistribution` is not set
![Screen Shot 2021-02-08 at 12 15 01 PM](https://user-images.githubusercontent.com/5894281/107413924-37f7fd00-6ac6-11eb-9e6c-eabaa4d52fcc.png)


Volume metadata after CSI upgrade. Full sync adds `ClusterDistribution` in the first cycle 
![Screen Shot 2021-02-08 at 12 18 23 PM](https://user-images.githubusercontent.com/5894281/107413954-3dedde00-6ac6-11eb-9c38-6f484b389e17.png)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Set cluster distribution in full sync for volumes created before upgrading vSphere to 7.0 U2 release
```
