### PR TITLE
Identify datastore name from full datastore path

### DIFF
--- a/docs/book/releases/v2.1.0.md
+++ b/docs/book/releases/v2.1.0.md
@@ -44,6 +44,10 @@
    - Workaround:
       - No workaround. User should not attempt to delete PV which is bound to PVC. User should only delete a PV if they know that the underlying volume in the storage system is gone.
       - If user has accidentally left orphan volumes on the datastore by not following the guideline, and if user has captured the volume handles or First Class Disk IDs of deleted PVs, storage admin can help delete those volumes using `govc disk.rm <volume-handle/FCD ID>` command.
+6. When in-tree vSphere plugin is configured to use default datastore in this format default-datastore: `</datacenter-name>/datastore/<default-datastore-name>`, migration of the volume will fail as mentioned here: https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/628. If default datastore is configured in this format `<default-datastore-name>` then we do not see this issue
+   - Impact: In-tree vSphere volumes will not get migrated successfully
+   - Workaround:
+      - Upgrade CSI driver with this fix.
 
 ### Kubernetes issues
 

--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -325,10 +325,11 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volu
 		log.Errorf(msg)
 		return "", errors.New(msg)
 	}
-	datastoreName := re.FindAllString(volumeSpec.VolumePath, -1)[0]
-	vmdkPath := strings.TrimSpace(strings.Trim(volumeSpec.VolumePath, datastoreName))
-	datastoreName = strings.Trim(strings.Trim(datastoreName, "["), "]")
-
+	datastoreFullPath := re.FindAllString(volumeSpec.VolumePath, -1)[0]
+	vmdkPath := strings.TrimSpace(strings.Trim(volumeSpec.VolumePath, datastoreFullPath))
+	datastoreFullPath = strings.Trim(strings.Trim(datastoreFullPath, "["), "]")
+	datastorePathSplit := strings.Split(datastoreFullPath, "/")
+	datastoreName := datastorePathSplit[len(datastorePathSplit)-1]
 	var datacenters string
 	var user string
 	var host string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is enhancing the way datastore name is identified from datastore path for volume migration service.
The current implementation works fine for datastore info found in volume path in this format = [<datastore-name>]. However there are other formats [/datacenter-name/datastore/datastore-name], and we need to extract the last section of the datastore info. 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #628 

**Special notes for your reviewer**:
https://play.golang.org/p/n5qimFHvgjV

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Identify datastore name from full datastore path
```
