### PR TITLE
removing privileged securityContext from node-driver-registrar

### DIFF
--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -35,8 +35,6 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi

--- a/manifests/dev/vsphere-7.0/guestcluster/1.15/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0/guestcluster/1.15/pvcsi.yaml
@@ -279,8 +279,6 @@ spec:
             value: /csi/csi.sock
           - name: DRIVER_REG_SOCK_PATH
             value: /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: plugin-dir
             mountPath: /csi

--- a/manifests/dev/vsphere-7.0/guestcluster/1.16/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0/guestcluster/1.16/pvcsi.yaml
@@ -300,8 +300,6 @@ spec:
             value: /csi/csi.sock
           - name: DRIVER_REG_SOCK_PATH
             value: /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: plugin-dir
             mountPath: /csi

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -35,8 +35,6 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi

--- a/manifests/dev/vsphere-7.0u1/guestcluster/1.15/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u1/guestcluster/1.15/pvcsi.yaml
@@ -273,8 +273,6 @@ spec:
             value: /csi/csi.sock
           - name: DRIVER_REG_SOCK_PATH
             value: /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: plugin-dir
             mountPath: /csi

--- a/manifests/dev/vsphere-7.0u1/guestcluster/1.16/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u1/guestcluster/1.16/pvcsi.yaml
@@ -294,8 +294,6 @@ spec:
             value: /csi/csi.sock
           - name: DRIVER_REG_SOCK_PATH
             value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: plugin-dir
             mountPath: /csi

--- a/manifests/dev/vsphere-7.0u1/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u1/guestcluster/1.17/pvcsi.yaml
@@ -295,8 +295,6 @@ spec:
             value: /csi/csi.sock
           - name: DRIVER_REG_SOCK_PATH
             value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: plugin-dir
             mountPath: /csi

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -31,8 +31,6 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -300,8 +300,6 @@ spec:
             value: /csi/csi.sock
           - name: DRIVER_REG_SOCK_PATH
             value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: plugin-dir
             mountPath: /csi

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -300,8 +300,6 @@ spec:
             value: /csi/csi.sock
           - name: DRIVER_REG_SOCK_PATH
             value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: plugin-dir
             mountPath: /csi

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -300,8 +300,6 @@ spec:
             value: /csi/csi.sock
           - name: DRIVER_REG_SOCK_PATH
             value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: plugin-dir
             mountPath: /csi

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-node-ds.yaml
@@ -32,8 +32,6 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is removing privileged securityContext from node-driver-registrar.


**Which issue this PR fixes**
fixes #645

**Special notes for your reviewer**:
Testing done.

Verified node-driver-registrar container is running fine without any issue when securityContext privilege is removed. on the vanilla k8s setup. Following is the log.

```
I0223 19:21:32.155492 1 main.go:113] Version: v2.1.0-0-g80d42f24
I0223 19:21:32.160951 1 main.go:137] Attempting to open a gRPC connection with: "/csi/csi.sock"
I0223 19:21:32.161200 1 connection.go:153] Connecting to unix:///csi/csi.sock
W0223 19:21:42.162228 1 connection.go:172] Still connecting to unix:///csi/csi.sock
W0223 19:21:52.163700 1 connection.go:172] Still connecting to unix:///csi/csi.sock
W0223 19:22:02.161897 1 connection.go:172] Still connecting to unix:///csi/csi.sock
W0223 19:22:12.161720 1 connection.go:172] Still connecting to unix:///csi/csi.sock
W0223 19:22:22.161820 1 connection.go:172] Still connecting to unix:///csi/csi.sock
I0223 19:22:26.661136 1 main.go:144] Calling CSI driver to discover driver name
I0223 19:22:26.661162 1 connection.go:182] GRPC call: /csi.v1.Identity/GetPluginInfo
I0223 19:22:26.661167 1 connection.go:183] GRPC request: {}
I0223 19:22:26.669520 1 connection.go:185] GRPC response: {"name":"csi.vsphere.vmware.com","vendor_version":"v2.1.0-rc.1-420-g54076e1"}
I0223 19:22:26.669863 1 connection.go:186] GRPC error: <nil>
I0223 19:22:26.670150 1 main.go:154] CSI driver name: "csi.vsphere.vmware.com"
I0223 19:22:26.670486 1 node_register.go:52] Starting Registration Server at: /registration/csi.vsphere.vmware.com-reg.sock
I0223 19:22:26.670990 1 node_register.go:61] Registration Server started at: /registration/csi.vsphere.vmware.com-reg.sock
I0223 19:22:26.671488 1 node_register.go:86] Starting healthz server at HTTP endpoint: :9809
I0223 19:22:27.191236 1 main.go:80] Received GetInfo call: &InfoRequest{}
I0223 19:22:27.504316 1 main.go:90] Received NotifyRegistrationStatus call: &RegistrationStatus{PluginRegistered:true,Error:,}
I0223 19:22:37.426648 1 node_register.go:93] health check succeeded
I0223 19:22:47.420930 1 node_register.go:93] health check succeeded
I0223 19:22:57.421622 1 node_register.go:93] health check succeeded
I0223 19:23:07.422565 1 node_register.go:93] health check succeeded
```

TKGs is also working fine as expected

```
# kubectl logs vsphere-csi-node-69rmb  --namespace=vmware-system-csi -c node-driver-registrar
I0223 22:52:50.424344       1 main.go:110] Version: v1.1.0_vmware.1
I0223 22:52:50.424718       1 main.go:120] Attempting to open a gRPC connection with: "/csi/csi.sock"
I0223 22:52:50.425410       1 connection.go:151] Connecting to unix:///csi/csi.sock
I0223 22:52:52.503767       1 main.go:127] Calling CSI driver to discover driver name
I0223 22:52:52.504293       1 connection.go:180] GRPC call: /csi.v1.Identity/GetPluginInfo
I0223 22:52:52.504621       1 connection.go:181] GRPC request: {}
I0223 22:52:52.581068       1 connection.go:183] GRPC response: {"name":"csi.vsphere.vmware.com"}
I0223 22:52:52.582548       1 connection.go:184] GRPC error: <nil>
I0223 22:52:52.582562       1 main.go:137] CSI driver name: "csi.vsphere.vmware.com"
I0223 22:52:52.582939       1 node_register.go:54] Starting Registration Server at: /registration/csi.vsphere.vmware.com-reg.sock
I0223 22:52:52.583407       1 node_register.go:61] Registration Server started at: /registration/csi.vsphere.vmware.com-reg.sock
I0223 22:52:54.950540       1 main.go:77] Received GetInfo call: &InfoRequest{}
I0223 22:52:58.210521       1 main.go:87] Received NotifyRegistrationStatus call: &RegistrationStatus{PluginRegistered:true,Error:,}
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
removing privileged securityContext from node-driver-registrar
```
