### PR TITLE
Exposed prometheus metrics for create, delete, attach and detach API s in vanilla CSI controller.

### DIFF
--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -54,6 +54,10 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
+          ports:
+            - containerPort: 2112
+              name: prometheus
+              protocol: TCP
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -67,6 +67,10 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
+          ports:
+            - containerPort: 2112
+              name: prometheus
+              protocol: TCP
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -65,6 +65,10 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
+          ports:
+            - containerPort: 2112
+              name: prometheus
+              protocol: TCP
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -68,6 +68,10 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
+          ports:
+            - containerPort: 2112
+              name: prometheus
+              protocol: TCP
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/pkg/csi/service/common/prometheus/metrics.go
+++ b/pkg/csi/service/common/prometheus/metrics.go
@@ -33,6 +33,10 @@ const (
 	PrometheusCreateVolumeOpType = "create-volume"
 	// PrometheusDeleteVolumeOpType represents the DeleteVolume operation.
 	PrometheusDeleteVolumeOpType = "delete-volume"
+	// PrometheusAttachVolumeOpType represents the AttachVolume operation.
+	PrometheusAttachVolumeOpType = "attach-volume"
+	// PrometheusDetachVolumeOpType represents the DetachVolume operation.
+	PrometheusDetachVolumeOpType = "detach-volume"
 
 	// PrometheusPassStatus represents a successful API run.
 	PrometheusPassStatus = "pass"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Exposed prometheus metrics for create, delete, attach and detach API s in vanilla CSI controller.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #629, #630

**Special notes for your reviewer**:
Tested by performing stress testing by creating 10 PVCs and 10 Pods in a loop. I captured the Grafana dashboard that is designed with promQL statements on the metrices exposed by CSI controller.

![image](https://user-images.githubusercontent.com/17838923/107583889-723dc900-6bb0-11eb-9148-43724cd84ca5.png)

Here's the corresponding metrics exposed by CSI controller container:
```
root@ubuntu:~/github-csi2/src/sigs.k8s.io/vsphere-csi-driver# kubectl --kubeconfig ~/wc.kubeconfig -n kube-system exec -it vsphere-csi-controller-84b7964b77-sgrwr -c vsphere-csi-controller -- curl localhost:2112/metrics | grep "csi"
# HELP csi_info CSI Info
# TYPE csi_info gauge
csi_info{version="v2.1.0-rc.1-398-g524a6fac-dirty"} 1
# HELP csi_volume_ops_histogram Histogram vector for CSI volume operations.
# TYPE csi_volume_ops_histogram histogram
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="1"} 0
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="2"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="3"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="4"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="5"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="7"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="10"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="12"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="15"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="18"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="20"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="25"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="30"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="60"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="120"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="180"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="300"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="fail",voltype="block",le="+Inf"} 1
csi_volume_ops_histogram_sum{optype="attach-volume",status="fail",voltype="block"} 1.905969451
csi_volume_ops_histogram_count{optype="attach-volume",status="fail",voltype="block"} 1
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="1"} 29
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="2"} 33
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="3"} 50
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="4"} 80
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="5"} 106
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="7"} 142
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="10"} 157
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="12"} 157
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="15"} 157
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="18"} 157
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="20"} 157
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="25"} 157
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="30"} 157
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="60"} 157
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="120"} 157
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="180"} 157
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="300"} 157
csi_volume_ops_histogram_bucket{optype="attach-volume",status="pass",voltype="block",le="+Inf"} 157
csi_volume_ops_histogram_sum{optype="attach-volume",status="pass",voltype="block"} 630.847950183
csi_volume_ops_histogram_count{optype="attach-volume",status="pass",voltype="block"} 157
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="1"} 0
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="2"} 0
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="3"} 1
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="4"} 2
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="5"} 2
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="7"} 2
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="10"} 9
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="12"} 17
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="15"} 72
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="18"} 118
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="20"} 120
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="25"} 120
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="30"} 120
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="60"} 120
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="120"} 120
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="180"} 120
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="300"} 120
csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="+Inf"} 120
csi_volume_ops_histogram_sum{optype="create-volume",status="pass",voltype="block"} 1704.8400606030004
csi_volume_ops_histogram_count{optype="create-volume",status="pass",voltype="block"} 120
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="1"} 0
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="2"} 12
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="3"} 21
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="4"} 23
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="5"} 24
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="7"} 48
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="10"} 61
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="12"} 86
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="15"} 99
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="18"} 106
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="20"} 115
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="25"} 118
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="30"} 120
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="60"} 120
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="120"} 120
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="180"} 120
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="300"} 120
csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="block",le="+Inf"} 120
csi_volume_ops_histogram_sum{optype="delete-volume",status="pass",voltype="block"} 1196.84715599
csi_volume_ops_histogram_count{optype="delete-volume",status="pass",voltype="block"} 120
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="1"} 0
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="2"} 26
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="3"} 59
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="4"} 90
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="5"} 121
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="7"} 151
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="10"} 152
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="12"} 152
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="15"} 152
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="18"} 152
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="20"} 152
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="25"} 152
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="30"} 152
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="60"} 152
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="120"} 152
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="180"} 152
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="300"} 152
csi_volume_ops_histogram_bucket{optype="detach-volume",status="pass",voltype="block",le="+Inf"} 152
csi_volume_ops_histogram_sum{optype="detach-volume",status="pass",voltype="block"} 555.300940925
csi_volume_ops_histogram_count{optype="detach-volume",status="pass",voltype="block"} 152
```
**Release note**:
```release-note
Exposed prometheus metrices for create, delete, attach and detach API s in vanilla CSI controller.
```
