### PR TITLE
using single instance of tagmanager for getting shared datastores in the topology

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualmachine.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine.go
@@ -244,20 +244,9 @@ func (vm *VirtualMachine) GetAncestors(ctx context.Context) ([]mo.ManagedEntity,
 }
 
 // GetZoneRegion returns zone and region of the node vm
-func (vm *VirtualMachine) GetZoneRegion(ctx context.Context, zoneCategoryName string, regionCategoryName string) (zone string, region string, err error) {
+func (vm *VirtualMachine) GetZoneRegion(ctx context.Context, zoneCategoryName string, regionCategoryName string, tagManager *tags.Manager) (zone string, region string, err error) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("GetZoneRegion: called with zoneCategoryName: %s, regionCategoryName: %s", zoneCategoryName, regionCategoryName)
-	tagManager, err := vm.GetTagManager(ctx)
-	if err != nil || tagManager == nil {
-		log.Errorf("failed to get tagManager. Error: %v", err)
-		return "", "", err
-	}
-	defer func() {
-		err = tagManager.Logout(ctx)
-		if err != nil {
-			log.Errorf("failed to logout tagManager. err: %v", err)
-		}
-	}()
 	var objects []mo.ManagedEntity
 	objects, err = vm.GetAncestors(ctx)
 	if err != nil {
@@ -305,21 +294,10 @@ func (vm *VirtualMachine) GetZoneRegion(ctx context.Context, zoneCategoryName st
 
 // IsInZoneRegion checks if virtual machine belongs to specified zone and region
 // This function returns true if virtual machine belongs to specified zone/region, else returns false.
-func (vm *VirtualMachine) IsInZoneRegion(ctx context.Context, zoneCategoryName string, regionCategoryName string, zoneValue string, regionValue string) (bool, error) {
+func (vm *VirtualMachine) IsInZoneRegion(ctx context.Context, zoneCategoryName string, regionCategoryName string, zoneValue string, regionValue string, tagManager *tags.Manager) (bool, error) {
 	log := logger.GetLogger(ctx)
 	log.Infof("IsInZoneRegion: called with zoneCategoryName: %s, regionCategoryName: %s, zoneValue: %s, regionValue: %s", zoneCategoryName, regionCategoryName, zoneValue, regionValue)
-	tagManager, err := vm.GetTagManager(ctx)
-	if err != nil || tagManager == nil {
-		log.Errorf("failed to get tagManager. Error: %v", err)
-		return false, err
-	}
-	defer func() {
-		err = tagManager.Logout(ctx)
-		if err != nil {
-			log.Errorf("failed to logout tagManager. err: %v", err)
-		}
-	}()
-	vmZone, vmRegion, err := vm.GetZoneRegion(ctx, zoneCategoryName, regionCategoryName)
+	vmZone, vmRegion, err := vm.GetZoneRegion(ctx, zoneCategoryName, regionCategoryName, tagManager)
 	if err != nil {
 		log.Errorf("failed to get accessibleTopology for vm: %v, err: %v", vm.Reference(), err)
 		return false, err

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -701,7 +701,18 @@ func (s *service) NodeGetInfo(
 				return nil, status.Errorf(codes.Internal, err.Error())
 			}
 		}
-		zone, region, err := nodeVM.GetZoneRegion(ctx, cfg.Labels.Zone, cfg.Labels.Region)
+		tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
+		if err != nil {
+			log.Errorf("failed to create tagManager. Err: %v", err)
+			return nil, status.Errorf(codes.Internal, err.Error())
+		}
+		defer func() {
+			err := tagManager.Logout(ctx)
+			if err != nil {
+				log.Errorf("failed to logout tagManager. err: %v", err)
+			}
+		}()
+		zone, region, err := nodeVM.GetZoneRegion(ctx, cfg.Labels.Zone, cfg.Labels.Region, tagManager)
 		if err != nil {
 			log.Errorf("failed to get accessibleTopology for vm: %v, err: %v", nodeVM.Reference(), err)
 			return nil, status.Errorf(codes.Internal, err.Error())

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/units"
+	"github.com/vmware/govmomi/vapi/tags"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -51,7 +52,7 @@ import (
 type NodeManagerInterface interface {
 	Initialize(ctx context.Context) error
 	GetSharedDatastoresInK8SCluster(ctx context.Context) ([]*cnsvsphere.DatastoreInfo, error)
-	GetSharedDatastoresInTopology(ctx context.Context, topologyRequirement *csi.TopologyRequirement, zoneKey string, regionKey string) ([]*cnsvsphere.DatastoreInfo, map[string][]map[string]string, error)
+	GetSharedDatastoresInTopology(ctx context.Context, topologyRequirement *csi.TopologyRequirement, tagManager *tags.Manager, zoneKey string, regionKey string) ([]*cnsvsphere.DatastoreInfo, map[string][]map[string]string, error)
 	GetNodeByName(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
 	GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachine, error)
 }
@@ -379,7 +380,25 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			log.Errorf(errMsg)
 			return nil, status.Error(codes.NotFound, errMsg)
 		}
-		sharedDatastores, datastoreTopologyMap, err = c.nodeMgr.GetSharedDatastoresInTopology(ctx, topologyRequirement, c.manager.CnsConfig.Labels.Zone, c.manager.CnsConfig.Labels.Region)
+		vcenter, err := c.manager.VcenterManager.GetVirtualCenter(ctx, c.manager.VcenterConfig.Host)
+		if err != nil {
+			errMsg := fmt.Sprintf("Failed to get vCenter. Err: %v", err)
+			log.Errorf(errMsg)
+			return nil, status.Error(codes.NotFound, errMsg)
+		}
+		tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
+		if err != nil {
+			errMsg := fmt.Sprintf("Failed to get tagManager. Err: %v", err)
+			log.Errorf(errMsg)
+			return nil, status.Error(codes.NotFound, errMsg)
+		}
+		defer func() {
+			err := tagManager.Logout(ctx)
+			if err != nil {
+				log.Errorf("failed to logout tagManager. err: %v", err)
+			}
+		}()
+		sharedDatastores, datastoreTopologyMap, err = c.nodeMgr.GetSharedDatastoresInTopology(ctx, topologyRequirement, tagManager, c.manager.CnsConfig.Labels.Zone, c.manager.CnsConfig.Labels.Region)
 		if err != nil || len(sharedDatastores) == 0 {
 			msg := fmt.Sprintf("failed to get shared datastores in topology: %+v. Error: %+v", topologyRequirement, err)
 			log.Error(msg)

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -36,6 +36,7 @@ import (
 	pbmsim "github.com/vmware/govmomi/pbm/simulator"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -225,7 +226,7 @@ func (f *FakeNodeManager) GetAllNodes(ctx context.Context) ([]*cnsvsphere.Virtua
 	return nil, nil
 }
 
-func (f *FakeNodeManager) GetSharedDatastoresInTopology(ctx context.Context, topologyRequirement *csi.TopologyRequirement, zoneKey string, regionKey string) ([]*cnsvsphere.DatastoreInfo, map[string][]map[string]string, error) {
+func (f *FakeNodeManager) GetSharedDatastoresInTopology(ctx context.Context, topologyRequirement *csi.TopologyRequirement, tagManager *tags.Manager, zoneKey string, regionKey string) ([]*cnsvsphere.DatastoreInfo, map[string][]map[string]string, error) {
 	return nil, nil, nil
 }
 

--- a/pkg/csi/service/vanilla/nodes.go
+++ b/pkg/csi/service/vanilla/nodes.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/vmware/govmomi/vapi/tags"
+
 	cnsnode "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/node"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
@@ -133,7 +135,7 @@ func (nodes *Nodes) GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachi
 //      ds:///vmfs/volumes/vsan:524fae1aaca129a5-1ee55a87f26ae626/:
 //         [map[failure-domain.beta.kubernetes.io/region:k8s-region-us failure-domain.beta.kubernetes.io/zone:k8s-zone-us-west]
 //         map[failure-domain.beta.kubernetes.io/region:k8s-region-us failure-domain.beta.kubernetes.io/zone:k8s-zone-us-east]]]]
-func (nodes *Nodes) GetSharedDatastoresInTopology(ctx context.Context, topologyRequirement *csi.TopologyRequirement, zoneCategoryName string, regionCategoryName string) ([]*cnsvsphere.DatastoreInfo, map[string][]map[string]string, error) {
+func (nodes *Nodes) GetSharedDatastoresInTopology(ctx context.Context, topologyRequirement *csi.TopologyRequirement, tagManager *tags.Manager, zoneCategoryName string, regionCategoryName string) ([]*cnsvsphere.DatastoreInfo, map[string][]map[string]string, error) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("GetSharedDatastoresInTopology: called with topologyRequirement: %+v, zoneCategoryName: %s, regionCategoryName: %s", topologyRequirement, zoneCategoryName, regionCategoryName)
 	allNodes, err := nodes.cnsNodeManager.GetAllNodes(ctx)
@@ -152,7 +154,7 @@ func (nodes *Nodes) GetSharedDatastoresInTopology(ctx context.Context, topologyR
 		log.Debugf("getNodesInZoneRegion: called with zoneValue: %s, regionValue: %s", zoneValue, regionValue)
 		var nodeVMsInZoneAndRegion []*cnsvsphere.VirtualMachine
 		for _, nodeVM := range allNodes {
-			isNodeInZoneRegion, err := nodeVM.IsInZoneRegion(ctx, zoneCategoryName, regionCategoryName, zoneValue, regionValue)
+			isNodeInZoneRegion, err := nodeVM.IsInZoneRegion(ctx, zoneCategoryName, regionCategoryName, zoneValue, regionValue, tagManager)
 			if err != nil {
 				log.Errorf("Error checking if node VM: %v belongs to zone [%s] and region [%s]. err: %+v", nodeVM, zoneValue, regionValue, err)
 				return nil, err


### PR DESCRIPTION
using a single instance of tag manager for getting shared datastores in the topology

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
GetTagManager() calls add big delay to the CreateVolume latency. This PR is getting rid of creating of tagManager in GetZoneRegion() and IsInZoneRegion().
This will help long CreatePVC latency with volume topology.

PR will also help to fix `Failed to login for the rest client` issue observed in https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/597 When we create many instances of tagManager, it is observed that restclient login fails with `rest/com/vmware/cis/session: context deadline exceeded`.

 


**Which issue this PR fixes** 
Fixes: https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/597

**Special notes for your reviewer**:
Validated PR by creating 30 volumes using podManagementPolicy: Parallel in stateful, all of them created successfully.

SC used for validation

```
apiVersion: storage.k8s.io/v1
metadata:
  name: example-vanilla-block-sc
provisioner: csi.vsphere.vmware.com
allowedTopologies:
  - matchLabelExpressions:
      - key: failure-domain.beta.kubernetes.io/zone
        values:
          - zone-a
          - zone-b
      - key: failure-domain.beta.kubernetes.io/region
        values:
          - region-1
```


```
www-web-0    Bound    pvc-c7e1b24e-d9fa-4fac-ac95-9552c03abd42   1Gi        RWO            example-vanilla-block-sc   2m3s
www-web-1    Bound    pvc-6311ba4c-8fdd-41fa-9439-4cc990ca0c66   1Gi        RWO            example-vanilla-block-sc   2m3s
www-web-10   Bound    pvc-d0b58c94-ffea-404a-8729-034ba09b2dcf   1Gi        RWO            example-vanilla-block-sc   2m1s
www-web-11   Bound    pvc-23f3f549-598e-4506-8679-cbc6341d3332   1Gi        RWO            example-vanilla-block-sc   2m1s
www-web-12   Bound    pvc-693b675b-77be-4a82-981c-d491c8601e3a   1Gi        RWO            example-vanilla-block-sc   2m1s
www-web-13   Bound    pvc-d6580719-d033-4eee-a42e-aaa7bc0e867d   1Gi        RWO            example-vanilla-block-sc   2m1s
www-web-14   Bound    pvc-a1f5671a-08a6-4649-a68c-e573d0d7cabb   1Gi        RWO            example-vanilla-block-sc   2m1s
www-web-15   Bound    pvc-6790451a-a97f-4982-a4d9-3d2fce5af588   1Gi        RWO            example-vanilla-block-sc   2m
www-web-16   Bound    pvc-57894908-0b48-4f1b-816c-003740d23614   1Gi        RWO            example-vanilla-block-sc   2m
www-web-17   Bound    pvc-543eef9c-ee57-48c0-a68f-2574f6f94535   1Gi        RWO            example-vanilla-block-sc   2m
www-web-18   Bound    pvc-d7f2b6a8-1d67-4118-ae83-7e51bb802806   1Gi        RWO            example-vanilla-block-sc   2m
www-web-19   Bound    pvc-d9ca19ea-6276-49ca-a62b-732172fd8ab2   1Gi        RWO            example-vanilla-block-sc   119s
www-web-2    Bound    pvc-5c5eee0c-afac-4559-830b-58215bfb1f7e   1Gi        RWO            example-vanilla-block-sc   2m3s
www-web-20   Bound    pvc-94225252-5e5c-4d14-802a-16d839b4d11a   1Gi        RWO            example-vanilla-block-sc   119s
www-web-21   Bound    pvc-93594e29-5c60-435f-af64-ed6b6a279423   1Gi        RWO            example-vanilla-block-sc   119s
www-web-22   Bound    pvc-e299cbab-a9b7-4849-ab92-9758e8205b12   1Gi        RWO            example-vanilla-block-sc   119s
www-web-23   Bound    pvc-c18a8723-8401-439f-85fc-f05b4d7aa2f5   1Gi        RWO            example-vanilla-block-sc   119s
www-web-24   Bound    pvc-02ba1c25-aca6-4968-b228-db81c1fdceae   1Gi        RWO            example-vanilla-block-sc   119s
www-web-25   Bound    pvc-4c517107-40fc-4b48-a684-b9058f738a8f   1Gi        RWO            example-vanilla-block-sc   119s
www-web-26   Bound    pvc-34de3cb3-0e5f-4d41-9578-67c7436770e3   1Gi        RWO            example-vanilla-block-sc   118s
www-web-27   Bound    pvc-7f4a1d22-697c-4163-a80c-62fb6b4888cb   1Gi        RWO            example-vanilla-block-sc   118s
www-web-28   Bound    pvc-339e763f-9bf2-4ef4-bc33-038fa1b3391a   1Gi        RWO            example-vanilla-block-sc   118s
www-web-29   Bound    pvc-325db329-977d-4bf4-a8fc-f91051787ee3   1Gi        RWO            example-vanilla-block-sc   118s
www-web-3    Bound    pvc-4d8f76d4-5f6e-4cfa-b1e5-4b7a015013c0   1Gi        RWO            example-vanilla-block-sc   2m3s
www-web-4    Bound    pvc-e5af23b0-0fbc-4e29-ab4a-00786494f88a   1Gi        RWO            example-vanilla-block-sc   2m3s
www-web-5    Bound    pvc-2b4ab239-b9b3-4e24-8a83-12e3ff4997b6   1Gi        RWO            example-vanilla-block-sc   2m2s
www-web-6    Bound    pvc-26f19881-284d-480c-9d8b-3f5602dac530   1Gi        RWO            example-vanilla-block-sc   2m2s
www-web-7    Bound    pvc-b64c2a22-8df6-4bbf-a5b2-d5ee012b0c91   1Gi        RWO            example-vanilla-block-sc   2m2s
www-web-8    Bound    pvc-bc8c9c8a-5a6b-4929-a18c-5ddc7a959c3d   1Gi        RWO            example-vanilla-block-sc   2m2s
www-web-9    Bound    pvc-cce108dd-e69f-499a-8ee8-616f4080aad8   1Gi        RWO            example-vanilla-block-sc   2m1s
```

```
# kubectl get nodes -L failure-domain.beta.kubernetes.io/zone -L failure-domain.beta.kubernetes.io/region
NAME         STATUS   ROLES    AGE    VERSION   ZONE     REGION
k8s-master   Ready    master   10h    v1.19.8   zone-b   region-1
k8s-node1    Ready    <none>   128m   v1.19.8   zone-b   region-1
k8s-node2    Ready    <none>   126m   v1.19.8   zone-a   region-1
k8s-node3    Ready    <none>   125m   v1.19.8   zone-a   region-1
k8s-node4    Ready    <none>   125m   v1.19.8   zone-a   region-1
```

```
root@k8s-master:~# kubectl get pods -o wide
NAME     READY   STATUS    RESTARTS   AGE   IP            NODE        NOMINATED NODE   READINESS GATES
web-0    1/1     Running   0          31m   10.244.1.5    k8s-node1   <none>           <none>
web-1    1/1     Running   0          31m   10.244.1.4    k8s-node1   <none>           <none>
web-10   1/1     Running   0          31m   10.244.1.14   k8s-node1   <none>           <none>
web-11   1/1     Running   0          31m   10.244.1.18   k8s-node1   <none>           <none>
web-12   1/1     Running   0          31m   10.244.1.7    k8s-node1   <none>           <none>
web-13   1/1     Running   0          31m   10.244.1.19   k8s-node1   <none>           <none>
web-14   1/1     Running   0          31m   10.244.1.12   k8s-node1   <none>           <none>
web-15   1/1     Running   0          31m   10.244.2.7    k8s-node2   <none>           <none>
web-16   1/1     Running   0          31m   10.244.4.8    k8s-node4   <none>           <none>
web-17   1/1     Running   0          31m   10.244.1.10   k8s-node1   <none>           <none>
web-18   1/1     Running   0          31m   10.244.1.11   k8s-node1   <none>           <none>
web-19   1/1     Running   0          31m   10.244.4.7    k8s-node4   <none>           <none>
web-2    1/1     Running   0          31m   10.244.2.6    k8s-node2   <none>           <none>
web-20   1/1     Running   0          31m   10.244.2.9    k8s-node2   <none>           <none>
web-21   1/1     Running   0          31m   10.244.1.15   k8s-node1   <none>           <none>
web-22   1/1     Running   0          31m   10.244.4.9    k8s-node4   <none>           <none>
web-23   1/1     Running   0          31m   10.244.3.6    k8s-node3   <none>           <none>
web-24   1/1     Running   0          31m   10.244.1.16   k8s-node1   <none>           <none>
web-25   1/1     Running   0          31m   10.244.1.13   k8s-node1   <none>           <none>
web-26   1/1     Running   0          31m   10.244.3.5    k8s-node3   <none>           <none>
web-27   1/1     Running   0          31m   10.244.3.8    k8s-node3   <none>           <none>
web-28   1/1     Running   0          31m   10.244.1.20   k8s-node1   <none>           <none>
web-29   1/1     Running   0          31m   10.244.2.10   k8s-node2   <none>           <none>
web-3    1/1     Running   0          31m   10.244.3.7    k8s-node3   <none>           <none>
web-4    1/1     Running   0          31m   10.244.1.6    k8s-node1   <none>           <none>
web-5    1/1     Running   0          31m   10.244.2.8    k8s-node2   <none>           <none>
web-6    1/1     Running   0          31m   10.244.1.8    k8s-node1   <none>           <none>
web-7    1/1     Running   0          31m   10.244.4.6    k8s-node4   <none>           <none>
web-8    1/1     Running   0          31m   10.244.1.9    k8s-node1   <none>           <none>
web-9    1/1     Running   0          31m   10.244.1.17   k8s-node1   <none>           <none>
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
using single instance of tagmanager for getting shared datastores in the topology
```
