### PR TITLE
Fixed this message during build - package cnsctl is not in GOROOT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ CNSCTL_BIN := $(BIN_OUT)/$(CNSCTL_BIN_NAME).$(GOOS)_$(GOARCH)
 build-cnsctl: $(CNSCTL_BIN)
 ifndef CNSCTL_BIN_SRCS
 CNSCTL_BIN_SRCS := $(CNSCTL_BIN_NAME)/main.go go.mod go.sum
-CNSCTL_BIN_SRCS += $(addsuffix /*.go,$(shell go list -f '{{ join .Deps "\n" }}' $(CNSCTL_BIN_NAME) | grep $(MOD_NAME) | sed 's~$(MOD_NAME)~.~'))
+CNSCTL_BIN_SRCS += $(addsuffix /*.go,$(shell go list -f '{{ join .Deps "\n" }}' ./$(CNSCTL_BIN_NAME) | grep $(MOD_NAME) | sed 's~$(MOD_NAME)~.~'))
 export CNSCTL_BIN_SRCS
 endif
 $(CNSCTL_BIN): $(CNSCTL_BIN_SRCS)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixed this message during build - package cnsctl is not in GOROOT

**Special notes for your reviewer**:

Build logs before this fix:
```
root@ubuntu:~/github-csi2/src/sigs.k8s.io/vsphere-csi-driver# make build
Makefile:37: This project uses Go modules and should not be cloned into the GOPATH
package cnsctl is not in GOROOT (/usr/lib/go-1.15/src/cnsctl)
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.Version=v2.1.0-rc.1-404-g012f441b"' -o /root/github-csi2/src/sigs.k8s.io/vsphere-csi-driver/.build/bin/vsphere-csi.linux_amd64 cmd/vsphere-csi/main.go
/root/github-csi//bin/controller-gen crd:trivialVersions=true paths=./pkg/apis/storagepool/... output:crd:dir=pkg/apis/storagepool/config
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/pkg/syncer.Version=v2.1.0-rc.1-404-g012f441b"' -o /root/github-csi2/src/sigs.k8s.io/vsphere-csi-driver/.build/bin/syncer.linux_amd64 cmd/syncer/main.go
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "main.Version=v2.1.0-rc.1-404-g012f441b"' -o /root/github-csi2/src/sigs.k8s.io/vsphere-csi-driver/.build/bin/cnsctl.linux_amd64 cnsctl/main.go
```

Build logs with this PR:
```
root@ubuntu:~/github-csi2/src/sigs.k8s.io/vsphere-csi-driver# make build
Makefile:37: This project uses Go modules and should not be cloned into the GOPATH
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.Version=v2.1.0-rc.1-404-g012f441b-dirty"' -o /root/github-csi2/src/sigs.k8s.io/vsphere-csi-driver/.build/bin/vsphere-csi.linux_amd64 cmd/vsphere-csi/main.go
/root/github-csi//bin/controller-gen crd:trivialVersions=true paths=./pkg/apis/storagepool/... output:crd:dir=pkg/apis/storagepool/config
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/pkg/syncer.Version=v2.1.0-rc.1-404-g012f441b-dirty"' -o /root/github-csi2/src/sigs.k8s.io/vsphere-csi-driver/.build/bin/syncer.linux_amd64 cmd/syncer/main.go
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "main.Version=v2.1.0-rc.1-404-g012f441b-dirty"' -o /root/github-csi2/src/sigs.k8s.io/vsphere-csi-driver/.build/bin/cnsctl.linux_amd64 cnsctl/main.go
```
As we can see, we no longer get the message - package cnsctl is not in GOROOT (/usr/lib/go-1.15/src/cnsctl)

Note: I do not plan to run E2E tests since this PR is not really changing the code.


**Release note**:
```release-note
Fixed this message during build - package cnsctl is not in GOROOT
```
