### PR TITLE
Amend volume resize known issues documentation. Also add missing env var in topology aware setup instructions

### DIFF
--- a/docs/book/driver-deployment/deploying_csi_with_zones.md
+++ b/docs/book/driver-deployment/deploying_csi_with_zones.md
@@ -172,10 +172,15 @@ Install the vSphere CPI and the CSI driver using the zone and region entries.
      - name: vsphere-csi-node
      .
      .
-     volumeMounts:
-     - name: vsphere-config-volume
-       mountPath: /etc/cloud
-       readOnly: true
+       env:
+       - name: VSPHERE_CSI_CONFIG
+         value: "/etc/cloud/csi-vsphere.conf"
+     .
+     .
+       volumeMounts:
+       - name: vsphere-config-volume
+         mountPath: /etc/cloud
+         readOnly: true
      .
      .
      volumes:

--- a/docs/book/features/volume_topology.md
+++ b/docs/book/features/volume_topology.md
@@ -9,7 +9,7 @@
 
 Prerequisite : Enable topology in the Kubernetes Cluster. Follow steps mentioned in [Deployment with Topology](../driver-deployment/deploying_csi_with_zones.md).
 
-## Deploy workloads using topology with `immediate` volume binding mode <a id="deploy_workload_using_topology"></a>
+## Deploy workloads using topology with `immediate` volume binding mode <a id="deploy_workload_using_topology_immediate"></a>
 
 When topology is enabled in the cluster, you can deploy a Kubernetes workload to a specific region or zone defined in the topology.
 

--- a/docs/book/releases/v2.0.0.md
+++ b/docs/book/releases/v2.0.0.md
@@ -76,10 +76,10 @@
    - Issue: https://github.com/kubernetes/kubernetes/issues/88683
    - Impact: User may create a new PVC to statically bind to the undeleted PV. In this case, the volume on the storage system is resized but the filesystem is not resized accordingly. User may try to write to the volume whose filesystem is out of capacity.
    - Workaround: User can log into the container to manually resize the filesystem.
-2. Volume cannot be resized in a Statefulset or other workload API such as Deployment.
-   - Issue: https://github.com/kubernetes/enhancements/pull/660
-   - Impact: User cannot resize volume in a workload API such as StatefulSet.
-   - Workaround: None
+2. Volume associated with a Statefulset cannot be resized
+    - Issue: https://github.com/kubernetes/enhancements/pull/660
+    - Impact: User cannot resize volume in a StatefulSet.
+    - Workaround: If the statefulset is not managed by an operator, there is a slightly risky workaround which the user can use on their own discretion depending upon their use case. Please refer to https://serverfault.com/questions/955293/how-to-increase-disk-size-in-a-stateful-set for more details.
 3. Recover from volume expansion failure.
    - Impact: If volume expansion fails because storage system does not support it, there is no way to recover.
    - Issue: https://github.com/kubernetes/enhancements/pull/1516

--- a/docs/book/releases/v2.0.1.md
+++ b/docs/book/releases/v2.0.1.md
@@ -55,10 +55,10 @@
    - Issue: https://github.com/kubernetes/kubernetes/issues/88683
    - Impact: User may create a new PVC to statically bind to the undeleted PV. In this case, the volume on the storage system is resized but the filesystem is not resized accordingly. User may try to write to the volume whose filesystem is out of capacity.
    - Workaround: User can log into the container to manually resize the filesystem.
-2. Volume cannot be resized in a Statefulset or other workload API such as Deployment.
+2. Volume associated with a Statefulset cannot be resized
    - Issue: https://github.com/kubernetes/enhancements/pull/660
-   - Impact: User cannot resize volume in a workload API such as StatefulSet.
-   - Workaround: None
+   - Impact: User cannot resize volume in a StatefulSet.
+   - Workaround: If the statefulset is not managed by an operator, there is a slightly risky workaround which the user can use on their own discretion depending upon their use case. Please refer to https://serverfault.com/questions/955293/how-to-increase-disk-size-in-a-stateful-set for more details.
 3. Recover from volume expansion failure.
    - Impact: If volume expansion fails because storage system does not support it, there is no way to recover.
    - Issue: https://github.com/kubernetes/enhancements/pull/1516

--- a/docs/book/releases/v2.1.0.md
+++ b/docs/book/releases/v2.1.0.md
@@ -55,10 +55,10 @@
    - Issue: https://github.com/kubernetes/kubernetes/issues/88683
    - Impact: User may create a new PVC to statically bind to the undeleted PV. In this case, the volume on the storage system is resized but the filesystem is not resized accordingly. User may try to write to the volume whose filesystem is out of capacity.
    - Workaround: User can log into the container to manually resize the filesystem.
-2. Volume cannot be resized in a Statefulset or other workload API such as Deployment.
+2. Volume associated with a Statefulset cannot be resized
    - Issue: https://github.com/kubernetes/enhancements/pull/660
-   - Impact: User cannot resize volume in a workload API such as StatefulSet.
-   - Workaround: None
+   - Impact: User cannot resize volume in a StatefulSet.
+   - Workaround: If the statefulset is not managed by an operator, there is a slightly risky workaround which the user can use on their own discretion depending upon their use case. Please refer to https://serverfault.com/questions/955293/how-to-increase-disk-size-in-a-stateful-set for more details.
 3. Recover from volume expansion failure.
    - Impact: If volume expansion fails because storage system does not support it, there is no way to recover.
    - Issue: https://github.com/kubernetes/enhancements/pull/1516


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Our current documentation states that volume resize is not supported in workload APIs like deployments. This PR amends that known issue and makes it clear that volume resize is not supported in Statefulsets only. A possible workaround is also mentioned for customers to use at their own discretion. This PR also adds documentation about an env var needed in vsphere-csi-node container in node daemonsets to aide in setting up a topology aware cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Amend volume resize known issues documentation. Also add missing env var in topology aware setup instructions
```
