### PR TITLE
Exposed CNS operation metrics.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c // indirect
-	honnef.co/go/tools v0.1.1 // indirect
+	honnef.co/go/tools v0.1.2 // indirect
 	k8s.io/api v0.18.5
 	k8s.io/apiextensions-apiserver v0.18.5
 	k8s.io/apimachinery v0.18.5

--- a/go.sum
+++ b/go.sum
@@ -1192,6 +1192,8 @@ honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YV
 honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=
 honnef.co/go/tools v0.1.1 h1:EVDuO03OCZwpV2t/tLLxPmPiomagMoBOgfPt0FM+4IY=
 honnef.co/go/tools v0.1.1/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
+honnef.co/go/tools v0.1.2 h1:SMdYLJl312RXuxXziCCHhRsp/tvct9cGKey0yv95tZM=
+honnef.co/go/tools v0.1.2/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 k8s.io/api v0.18.5 h1:fKbCxr+U3fu7k6jB+QeYPD/c6xKYeSJ2KVWmyUypuWM=
 k8s.io/api v0.18.5/go.mod h1:tN+e/2nbdGKOAH55NMV8oGrMG+3uRlA9GaRfvnCCSNk=
 k8s.io/apiextensions-apiserver v0.18.5 h1:pvbXjB/BRXZiO+/Erp5Pxr+lnhDCv5uxNxHh3FLGZ/g=

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/prometheus"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 
 	"github.com/davecgh/go-spew/spew"
@@ -161,659 +162,792 @@ func (m *defaultManager) ResetManager(ctx context.Context, vcenter *cnsvsphere.V
 
 // CreateVolume creates a new volume given its spec.
 func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVolumeCreateSpec) (*CnsVolumeInfo, error) {
-	log := logger.GetLogger(ctx)
-	err := validateManager(ctx, m)
-	if err != nil {
-		return nil, err
-	}
-	// Set up the VC connection
-	err = m.virtualCenter.ConnectCns(ctx)
-	if err != nil {
-		log.Errorf("ConnectCns failed with err: %+v", err)
-		return nil, err
-	}
-	// If the VSphereUser in the CreateSpec is different from session user, update the CreateSpec
-	s, err := m.virtualCenter.Client.SessionManager.UserSession(ctx)
-	if err != nil {
-		log.Errorf("failed to get usersession with err: %v", err)
-		return nil, err
-	}
-	if s.UserName != spec.Metadata.ContainerCluster.VSphereUser {
-		log.Debugf("Update VSphereUser from %s to %s", spec.Metadata.ContainerCluster.VSphereUser, s.UserName)
-		spec.Metadata.ContainerCluster.VSphereUser = s.UserName
-	}
-
-	// Construct the CNS VolumeCreateSpec list
-	var cnsCreateSpecList []cnstypes.CnsVolumeCreateSpec
-	var task *object.Task
-	var taskInfo *vim25types.TaskInfo
-	// store the volume name passed in by input spec, this name may exceed 80 characters
-	volNameFromInputSpec := spec.Name
-	// Call the CNS CreateVolume
-	taskDetailsInMap, ok := volumeTaskMap[volNameFromInputSpec]
-	if ok {
-		task = taskDetailsInMap.task
-		log.Infof("CreateVolume task still pending for VolumeName: %q, with taskInfo: %+v", volNameFromInputSpec, task)
-	} else {
-		// truncate the volume name to make sure the name is within 80 characters before calling CNS
-		if len(spec.Name) > maxLengthOfVolumeNameInCNS {
-			volNameAfterTruncate := spec.Name[0 : maxLengthOfVolumeNameInCNS-1]
-			spec.Name = volNameAfterTruncate
-			log.Infof("Create Volume with name %s is too long, truncate the name to %s", volNameFromInputSpec, spec.Name)
-			log.Debugf("CNS Create Volume is called with %v", spew.Sdump(*spec))
-		}
-		cnsCreateSpecList = append(cnsCreateSpecList, *spec)
-		task, err = m.virtualCenter.CnsClient.CreateVolume(ctx, cnsCreateSpecList)
+	internalCreateVolume := func() (*CnsVolumeInfo, error) {
+		log := logger.GetLogger(ctx)
+		err := validateManager(ctx, m)
 		if err != nil {
-			log.Errorf("CNS CreateVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 			return nil, err
 		}
-		var isStaticallyProvisionedBlockVolume bool
-		var isStaticallyProvisionedFileVolume bool
-		if spec.VolumeType == string(cnstypes.CnsVolumeTypeBlock) {
-			blockBackingDetails, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
-			if ok && (blockBackingDetails.BackingDiskId != "" || blockBackingDetails.BackingDiskUrlPath != "") {
-				isStaticallyProvisionedBlockVolume = true
-			}
+		// Set up the VC connection
+		err = m.virtualCenter.ConnectCns(ctx)
+		if err != nil {
+			log.Errorf("ConnectCns failed with err: %+v", err)
+			return nil, err
 		}
-		if spec.VolumeType == string(cnstypes.CnsVolumeTypeFile) {
-			fileBackingDetails, ok := spec.BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails)
-			if ok && fileBackingDetails.BackingFileId != "" {
-				isStaticallyProvisionedFileVolume = true
-			}
+		// If the VSphereUser in the CreateSpec is different from session user, update the CreateSpec
+		s, err := m.virtualCenter.Client.SessionManager.UserSession(ctx)
+		if err != nil {
+			log.Errorf("failed to get usersession with err: %v", err)
+			return nil, err
 		}
-		// Add the task details to volumeTaskMap only for dynamically provisioned volumes.
-		// For static volume provisioning we need not store the taskDetails as it doesn't result in orphaned volumes
-		if !isStaticallyProvisionedBlockVolume && !isStaticallyProvisionedFileVolume {
-			var taskDetails createVolumeTaskDetails
-			// Store the task details and task object expiration time in volumeTaskMap
-			taskDetails.task = task
-			taskDetails.expirationTime = time.Now().Add(time.Hour * time.Duration(defaultOpsExpirationTimeInHours))
-			volumeTaskMap[volNameFromInputSpec] = &taskDetails
+		if s.UserName != spec.Metadata.ContainerCluster.VSphereUser {
+			log.Debugf("Update VSphereUser from %s to %s", spec.Metadata.ContainerCluster.VSphereUser, s.UserName)
+			spec.Metadata.ContainerCluster.VSphereUser = s.UserName
 		}
-	}
-	// Get the taskInfo
-	taskInfo, err = cns.GetTaskInfo(ctx, task)
-	if err != nil || taskInfo == nil {
-		log.Errorf("failed to get taskInfo for CreateVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return nil, err
-	}
-	log.Infof("CreateVolume: VolumeName: %q, opId: %q", volNameFromInputSpec, taskInfo.ActivationId)
-	// Get the taskResult
-	taskResult, err := cns.GetTaskResult(ctx, taskInfo)
 
-	if err != nil {
-		log.Errorf("unable to find the task result for CreateVolume task from vCenter %q. taskID: %q, opId: %q createResults: %+v",
-			m.virtualCenter.Config.Host, taskInfo.Task.Value, taskInfo.ActivationId, taskResult)
-		return nil, err
-	}
-
-	if taskResult == nil {
-		log.Errorf("taskResult is empty for CreateVolume task: %q", taskInfo.ActivationId)
-		return nil, errors.New("taskResult is empty")
-	}
-	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
-	if volumeOperationRes.Fault != nil {
-		fault, ok := volumeOperationRes.Fault.Fault.(cnstypes.CnsAlreadyRegisteredFault)
-		if ok {
-			log.Infof("CreateVolume: Volume is already registered with CNS. VolumeName: %q, volumeID: %q, opId: %q", spec.Name, fault.VolumeId.Id, taskInfo.ActivationId)
-			return &CnsVolumeInfo{
-				DatastoreURL: "",
-				VolumeID:     fault.VolumeId,
-			}, nil
-		}
-		// Remove the taskInfo object associated with the volume name when the current task fails.
-		//  This is needed to ensure the sub-sequent create volume call from the external provisioner invokes Create Volume
+		// Construct the CNS VolumeCreateSpec list
+		var cnsCreateSpecList []cnstypes.CnsVolumeCreateSpec
+		var task *object.Task
+		var taskInfo *vim25types.TaskInfo
+		// store the volume name passed in by input spec, this name may exceed 80 characters
+		volNameFromInputSpec := spec.Name
+		// Call the CNS CreateVolume
 		taskDetailsInMap, ok := volumeTaskMap[volNameFromInputSpec]
 		if ok {
-			taskDetailsInMap.Lock()
-			log.Debugf("Deleted task for %s from volumeTaskMap because the task has failed", volNameFromInputSpec)
-			delete(volumeTaskMap, volNameFromInputSpec)
-			taskDetailsInMap.Unlock()
-		}
-		msg := fmt.Sprintf("failed to create cns volume %s. createSpec: %q, fault: %q, opId: %q", volNameFromInputSpec, spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
-		log.Error(msg)
-		return nil, errors.New(msg)
-	}
-	var datastoreURL string
-	volumeCreateResult := interface{}(taskResult).(*cnstypes.CnsVolumeCreateResult)
-	if volumeCreateResult.PlacementResults != nil {
-		var datastoreMoRef vim25types.ManagedObjectReference
-		for _, placementResult := range volumeCreateResult.PlacementResults {
-			// For the datastore which the volume is provisioned, placementFaults will not be set
-			if len(placementResult.PlacementFaults) == 0 {
-				datastoreMoRef = placementResult.Datastore
-				break
+			task = taskDetailsInMap.task
+			log.Infof("CreateVolume task still pending for VolumeName: %q, with taskInfo: %+v", volNameFromInputSpec, task)
+		} else {
+			// truncate the volume name to make sure the name is within 80 characters before calling CNS
+			if len(spec.Name) > maxLengthOfVolumeNameInCNS {
+				volNameAfterTruncate := spec.Name[0 : maxLengthOfVolumeNameInCNS-1]
+				spec.Name = volNameAfterTruncate
+				log.Infof("Create Volume with name %s is too long, truncate the name to %s", volNameFromInputSpec, spec.Name)
+				log.Debugf("CNS Create Volume is called with %v", spew.Sdump(*spec))
+			}
+			cnsCreateSpecList = append(cnsCreateSpecList, *spec)
+			task, err = m.virtualCenter.CnsClient.CreateVolume(ctx, cnsCreateSpecList)
+			if err != nil {
+				log.Errorf("CNS CreateVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+				return nil, err
+			}
+			var isStaticallyProvisionedBlockVolume bool
+			var isStaticallyProvisionedFileVolume bool
+			if spec.VolumeType == string(cnstypes.CnsVolumeTypeBlock) {
+				blockBackingDetails, ok := spec.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails)
+				if ok && (blockBackingDetails.BackingDiskId != "" || blockBackingDetails.BackingDiskUrlPath != "") {
+					isStaticallyProvisionedBlockVolume = true
+				}
+			}
+			if spec.VolumeType == string(cnstypes.CnsVolumeTypeFile) {
+				fileBackingDetails, ok := spec.BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails)
+				if ok && fileBackingDetails.BackingFileId != "" {
+					isStaticallyProvisionedFileVolume = true
+				}
+			}
+			// Add the task details to volumeTaskMap only for dynamically provisioned volumes.
+			// For static volume provisioning we need not store the taskDetails as it doesn't result in orphaned volumes
+			if !isStaticallyProvisionedBlockVolume && !isStaticallyProvisionedFileVolume {
+				var taskDetails createVolumeTaskDetails
+				// Store the task details and task object expiration time in volumeTaskMap
+				taskDetails.task = task
+				taskDetails.expirationTime = time.Now().Add(time.Hour * time.Duration(defaultOpsExpirationTimeInHours))
+				volumeTaskMap[volNameFromInputSpec] = &taskDetails
 			}
 		}
-		var dsMo mo.Datastore
-		pc := property.DefaultCollector(m.virtualCenter.Client.Client)
-		err := pc.RetrieveOne(ctx, datastoreMoRef, []string{"summary"}, &dsMo)
+		// Get the taskInfo
+		taskInfo, err = cns.GetTaskInfo(ctx, task)
+		if err != nil || taskInfo == nil {
+			log.Errorf("failed to get taskInfo for CreateVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return nil, err
+		}
+		log.Infof("CreateVolume: VolumeName: %q, opId: %q", volNameFromInputSpec, taskInfo.ActivationId)
+		// Get the taskResult
+		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+
 		if err != nil {
-			msg := fmt.Sprintf("failed to retrieve datastore summary property: %v", err)
+			log.Errorf("unable to find the task result for CreateVolume task from vCenter %q. taskID: %q, opId: %q createResults: %+v",
+				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskInfo.ActivationId, taskResult)
+			return nil, err
+		}
+
+		if taskResult == nil {
+			log.Errorf("taskResult is empty for CreateVolume task: %q", taskInfo.ActivationId)
+			return nil, errors.New("taskResult is empty")
+		}
+		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
+		if volumeOperationRes.Fault != nil {
+			fault, ok := volumeOperationRes.Fault.Fault.(cnstypes.CnsAlreadyRegisteredFault)
+			if ok {
+				log.Infof("CreateVolume: Volume is already registered with CNS. VolumeName: %q, volumeID: %q, opId: %q", spec.Name, fault.VolumeId.Id, taskInfo.ActivationId)
+				return &CnsVolumeInfo{
+					DatastoreURL: "",
+					VolumeID:     fault.VolumeId,
+				}, nil
+			}
+			// Remove the taskInfo object associated with the volume name when the current task fails.
+			//  This is needed to ensure the sub-sequent create volume call from the external provisioner invokes Create Volume
+			taskDetailsInMap, ok := volumeTaskMap[volNameFromInputSpec]
+			if ok {
+				taskDetailsInMap.Lock()
+				log.Debugf("Deleted task for %s from volumeTaskMap because the task has failed", volNameFromInputSpec)
+				delete(volumeTaskMap, volNameFromInputSpec)
+				taskDetailsInMap.Unlock()
+			}
+			msg := fmt.Sprintf("failed to create cns volume %s. createSpec: %q, fault: %q, opId: %q", volNameFromInputSpec, spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 			log.Error(msg)
 			return nil, errors.New(msg)
 		}
-		datastoreURL = dsMo.Summary.Url
+		var datastoreURL string
+		volumeCreateResult := interface{}(taskResult).(*cnstypes.CnsVolumeCreateResult)
+		if volumeCreateResult.PlacementResults != nil {
+			var datastoreMoRef vim25types.ManagedObjectReference
+			for _, placementResult := range volumeCreateResult.PlacementResults {
+				// For the datastore which the volume is provisioned, placementFaults will not be set
+				if len(placementResult.PlacementFaults) == 0 {
+					datastoreMoRef = placementResult.Datastore
+					break
+				}
+			}
+			var dsMo mo.Datastore
+			pc := property.DefaultCollector(m.virtualCenter.Client.Client)
+			err := pc.RetrieveOne(ctx, datastoreMoRef, []string{"summary"}, &dsMo)
+			if err != nil {
+				msg := fmt.Sprintf("failed to retrieve datastore summary property: %v", err)
+				log.Error(msg)
+				return nil, errors.New(msg)
+			}
+			datastoreURL = dsMo.Summary.Url
+		}
+
+		log.Infof("CreateVolume: Volume created successfully. VolumeName: %q, opId: %q, volumeID: %q", volNameFromInputSpec, taskInfo.ActivationId, volumeOperationRes.VolumeId.Id)
+		log.Debugf("CreateVolume volumeId %q is placed on datastore %q", volumeOperationRes.VolumeId.Id, datastoreURL)
+		return &CnsVolumeInfo{
+			DatastoreURL: datastoreURL,
+			VolumeID:     volumeOperationRes.VolumeId,
+		}, nil
+	}
+	start := time.Now()
+	resp, err := internalCreateVolume()
+	if err != nil {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsCreateVolumeOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsCreateVolumeOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
 
-	log.Infof("CreateVolume: Volume created successfully. VolumeName: %q, opId: %q, volumeID: %q", volNameFromInputSpec, taskInfo.ActivationId, volumeOperationRes.VolumeId.Id)
-	log.Debugf("CreateVolume volumeId %q is placed on datastore %q", volumeOperationRes.VolumeId.Id, datastoreURL)
-	return &CnsVolumeInfo{
-		DatastoreURL: datastoreURL,
-		VolumeID:     volumeOperationRes.VolumeId,
-	}, nil
+	return resp, err
 }
 
 // AttachVolume attaches a volume to a virtual machine given the spec.
 func (m *defaultManager) AttachVolume(ctx context.Context, vm *cnsvsphere.VirtualMachine, volumeID string) (string, error) {
-	log := logger.GetLogger(ctx)
-	err := validateManager(ctx, m)
-	if err != nil {
-		return "", err
-	}
-	// Set up the VC connection
-	err = m.virtualCenter.ConnectCns(ctx)
-	if err != nil {
-		log.Errorf("ConnectCns failed with err: %+v", err)
-		return "", err
-	}
-	// Construct the CNS AttachSpec list
-	var cnsAttachSpecList []cnstypes.CnsVolumeAttachDetachSpec
-	cnsAttachSpec := cnstypes.CnsVolumeAttachDetachSpec{
-		VolumeId: cnstypes.CnsVolumeId{
-			Id: volumeID,
-		},
-		Vm: vm.Reference(),
-	}
-	cnsAttachSpecList = append(cnsAttachSpecList, cnsAttachSpec)
-	// Call the CNS AttachVolume
-	task, err := m.virtualCenter.CnsClient.AttachVolume(ctx, cnsAttachSpecList)
-	if err != nil {
-		log.Errorf("CNS AttachVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return "", err
-	}
-	// Get the taskInfo
-	taskInfo, err := cns.GetTaskInfo(ctx, task)
-	if err != nil || taskInfo == nil {
-		log.Errorf("failed to get taskInfo for AttachVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return "", err
-	}
-	log.Infof("AttachVolume: volumeID: %q, vm: %q, opId: %q", volumeID, vm.String(), taskInfo.ActivationId)
-	// Get the taskResult
-	taskResult, err := cns.GetTaskResult(ctx, taskInfo)
-	if err != nil {
-		log.Errorf("unable to find the task result for AttachVolume task from vCenter %q with taskID %s and attachResults %v",
-			m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
-		return "", err
-	}
-
-	if taskResult == nil {
-		log.Errorf("taskResult is empty for AttachVolume task: %q, opId: %q", taskInfo.Task.Value, taskInfo.ActivationId)
-		return "", errors.New("taskResult is empty")
-	}
-
-	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
-	if volumeOperationRes.Fault != nil {
-		_, isResourceInUseFault := volumeOperationRes.Fault.Fault.(*vim25types.ResourceInUse)
-		if isResourceInUseFault {
-			log.Infof("observed ResourceInUse fault while attaching volume: %q with vm: %q", volumeID, vm.String())
-			// check if volume is already attached to the requested node
-			diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
-			if err != nil {
-				return "", err
-			}
-			if diskUUID != "" {
-				return diskUUID, nil
-			}
+	internalAttachVolume := func() (string, error) {
+		log := logger.GetLogger(ctx)
+		err := validateManager(ctx, m)
+		if err != nil {
+			return "", err
 		}
-		msg := fmt.Sprintf("failed to attach cns volume: %q to node vm: %q. fault: %q. opId: %q", volumeID, vm.String(), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
-		log.Error(msg)
-		return "", errors.New(msg)
+		// Set up the VC connection
+		err = m.virtualCenter.ConnectCns(ctx)
+		if err != nil {
+			log.Errorf("ConnectCns failed with err: %+v", err)
+			return "", err
+		}
+		// Construct the CNS AttachSpec list
+		var cnsAttachSpecList []cnstypes.CnsVolumeAttachDetachSpec
+		cnsAttachSpec := cnstypes.CnsVolumeAttachDetachSpec{
+			VolumeId: cnstypes.CnsVolumeId{
+				Id: volumeID,
+			},
+			Vm: vm.Reference(),
+		}
+		cnsAttachSpecList = append(cnsAttachSpecList, cnsAttachSpec)
+		// Call the CNS AttachVolume
+		task, err := m.virtualCenter.CnsClient.AttachVolume(ctx, cnsAttachSpecList)
+		if err != nil {
+			log.Errorf("CNS AttachVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return "", err
+		}
+		// Get the taskInfo
+		taskInfo, err := cns.GetTaskInfo(ctx, task)
+		if err != nil || taskInfo == nil {
+			log.Errorf("failed to get taskInfo for AttachVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return "", err
+		}
+		log.Infof("AttachVolume: volumeID: %q, vm: %q, opId: %q", volumeID, vm.String(), taskInfo.ActivationId)
+		// Get the taskResult
+		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+		if err != nil {
+			log.Errorf("unable to find the task result for AttachVolume task from vCenter %q with taskID %s and attachResults %v",
+				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
+			return "", err
+		}
+
+		if taskResult == nil {
+			log.Errorf("taskResult is empty for AttachVolume task: %q, opId: %q", taskInfo.Task.Value, taskInfo.ActivationId)
+			return "", errors.New("taskResult is empty")
+		}
+
+		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
+		if volumeOperationRes.Fault != nil {
+			_, isResourceInUseFault := volumeOperationRes.Fault.Fault.(*vim25types.ResourceInUse)
+			if isResourceInUseFault {
+				log.Infof("observed ResourceInUse fault while attaching volume: %q with vm: %q", volumeID, vm.String())
+				// check if volume is already attached to the requested node
+				diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
+				if err != nil {
+					return "", err
+				}
+				if diskUUID != "" {
+					return diskUUID, nil
+				}
+			}
+			msg := fmt.Sprintf("failed to attach cns volume: %q to node vm: %q. fault: %q. opId: %q", volumeID, vm.String(), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			log.Error(msg)
+			return "", errors.New(msg)
+		}
+		diskUUID := interface{}(taskResult).(*cnstypes.CnsVolumeAttachResult).DiskUUID
+		log.Infof("AttachVolume: Volume attached successfully. volumeID: %q, opId: %q, vm: %q, diskUUID: %q", volumeID, taskInfo.ActivationId, vm.String(), diskUUID)
+		return diskUUID, nil
 	}
-	diskUUID := interface{}(taskResult).(*cnstypes.CnsVolumeAttachResult).DiskUUID
-	log.Infof("AttachVolume: Volume attached successfully. volumeID: %q, opId: %q, vm: %q, diskUUID: %q", volumeID, taskInfo.ActivationId, vm.String(), diskUUID)
-	return diskUUID, nil
+	start := time.Now()
+	resp, err := internalAttachVolume()
+	if err != nil {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsAttachVolumeOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsAttachVolumeOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+	}
+	return resp, err
 }
 
 // DetachVolume detaches a volume from the virtual machine given the spec.
 func (m *defaultManager) DetachVolume(ctx context.Context, vm *cnsvsphere.VirtualMachine, volumeID string) error {
-	log := logger.GetLogger(ctx)
-	err := validateManager(ctx, m)
-	if err != nil {
-		return err
-	}
-	// Set up the VC connection
-	err = m.virtualCenter.ConnectCns(ctx)
-	if err != nil {
-		log.Errorf("ConnectCns failed with err: %+v", err)
-		return err
-	}
-	// Construct the CNS DetachSpec list
-	var cnsDetachSpecList []cnstypes.CnsVolumeAttachDetachSpec
-	cnsDetachSpec := cnstypes.CnsVolumeAttachDetachSpec{
-		VolumeId: cnstypes.CnsVolumeId{
-			Id: volumeID,
-		},
-		Vm: vm.Reference(),
-	}
-	cnsDetachSpecList = append(cnsDetachSpecList, cnsDetachSpec)
-	// Call the CNS DetachVolume
-	task, err := m.virtualCenter.CnsClient.DetachVolume(ctx, cnsDetachSpecList)
-	if err != nil {
-		if cnsvsphere.IsNotFoundError(err) {
-			// Detach failed with NotFound error, check if the volume is already detached
-			log.Infof("VolumeID: %q, not found. Checking whether the volume is already detached", volumeID)
+	internalDetachVolume := func() error {
+		log := logger.GetLogger(ctx)
+		err := validateManager(ctx, m)
+		if err != nil {
+			return err
+		}
+		// Set up the VC connection
+		err = m.virtualCenter.ConnectCns(ctx)
+		if err != nil {
+			log.Errorf("ConnectCns failed with err: %+v", err)
+			return err
+		}
+		// Construct the CNS DetachSpec list
+		var cnsDetachSpecList []cnstypes.CnsVolumeAttachDetachSpec
+		cnsDetachSpec := cnstypes.CnsVolumeAttachDetachSpec{
+			VolumeId: cnstypes.CnsVolumeId{
+				Id: volumeID,
+			},
+			Vm: vm.Reference(),
+		}
+		cnsDetachSpecList = append(cnsDetachSpecList, cnsDetachSpec)
+		// Call the CNS DetachVolume
+		task, err := m.virtualCenter.CnsClient.DetachVolume(ctx, cnsDetachSpecList)
+		if err != nil {
+			if cnsvsphere.IsNotFoundError(err) {
+				// Detach failed with NotFound error, check if the volume is already detached
+				log.Infof("VolumeID: %q, not found. Checking whether the volume is already detached", volumeID)
+				diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
+				if err != nil {
+					log.Errorf("DetachVolume: CNS Detach has failed with err: %q. Unable to check if volume: %q is already detached from vm: %+v",
+						err, volumeID, vm)
+					return err
+				} else if diskUUID == "" {
+					log.Infof("DetachVolume: volumeID: %q not found on vm: %+v. Assuming volume is already detached",
+						volumeID, vm)
+					return nil
+				} else {
+					msg := fmt.Sprintf("failed to detach cns volume:%q from node vm: %+v. err: %v", volumeID, vm, err)
+					log.Error(msg)
+					return errors.New(msg)
+				}
+			} else {
+				log.Errorf("CNS DetachVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+				return err
+			}
+		}
+
+		// Get the taskInfo
+		taskInfo, err := cns.GetTaskInfo(ctx, task)
+		if err != nil || taskInfo == nil {
+			log.Errorf("failed to get taskInfo for DetachVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return err
+		}
+		log.Infof("DetachVolume: volumeID: %q, vm: %q, opId: %q", volumeID, vm.String(), taskInfo.ActivationId)
+		// Get the task results for the given task
+		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+		if err != nil {
+			log.Errorf("unable to find the task result for DetachVolume task from vCenter %q with taskID %s and detachResults %v",
+				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
+			return err
+		}
+		if taskResult == nil {
+			log.Errorf("taskResult is empty for DetachVolume task: %q, opId: %q", taskInfo.Task.Value, taskInfo.ActivationId)
+			return errors.New("taskResult is empty")
+		}
+		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
+		if volumeOperationRes.Fault != nil {
+			// Volume is already attached to VM
 			diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
 			if err != nil {
-				log.Errorf("DetachVolume: CNS Detach has failed with err: %q. Unable to check if volume: %q is already detached from vm: %+v",
-					err, volumeID, vm)
+				log.Errorf("DetachVolume: CNS Detach has failed with fault: %q. Unable to check if volume: %q is already detached from vm: %+v",
+					spew.Sdump(volumeOperationRes.Fault), volumeID, vm)
 				return err
 			} else if diskUUID == "" {
 				log.Infof("DetachVolume: volumeID: %q not found on vm: %+v. Assuming volume is already detached",
 					volumeID, vm)
 				return nil
 			} else {
-				msg := fmt.Sprintf("failed to detach cns volume:%q from node vm: %+v. err: %v", volumeID, vm, err)
+				msg := fmt.Sprintf("failed to detach cns volume:%q from node vm: %+v. fault: %q, opId: %q", volumeID, vm, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 				log.Error(msg)
 				return errors.New(msg)
 			}
-		} else {
-			log.Errorf("CNS DetachVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-			return err
 		}
+		log.Infof("DetachVolume: Volume detached successfully. volumeID: %q, vm: %q, opId: %q", volumeID, taskInfo.ActivationId, vm.String())
+		return nil
 	}
-
-	// Get the taskInfo
-	taskInfo, err := cns.GetTaskInfo(ctx, task)
-	if err != nil || taskInfo == nil {
-		log.Errorf("failed to get taskInfo for DetachVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return err
-	}
-	log.Infof("DetachVolume: volumeID: %q, vm: %q, opId: %q", volumeID, vm.String(), taskInfo.ActivationId)
-	// Get the task results for the given task
-	taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+	start := time.Now()
+	err := internalDetachVolume()
 	if err != nil {
-		log.Errorf("unable to find the task result for DetachVolume task from vCenter %q with taskID %s and detachResults %v",
-			m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
-		return err
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsDetachVolumeOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsDetachVolumeOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
-	if taskResult == nil {
-		log.Errorf("taskResult is empty for DetachVolume task: %q, opId: %q", taskInfo.Task.Value, taskInfo.ActivationId)
-		return errors.New("taskResult is empty")
-	}
-	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
-	if volumeOperationRes.Fault != nil {
-		// Volume is already attached to VM
-		diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
-		if err != nil {
-			log.Errorf("DetachVolume: CNS Detach has failed with fault: %q. Unable to check if volume: %q is already detached from vm: %+v",
-				spew.Sdump(volumeOperationRes.Fault), volumeID, vm)
-			return err
-		} else if diskUUID == "" {
-			log.Infof("DetachVolume: volumeID: %q not found on vm: %+v. Assuming volume is already detached",
-				volumeID, vm)
-			return nil
-		} else {
-			msg := fmt.Sprintf("failed to detach cns volume:%q from node vm: %+v. fault: %q, opId: %q", volumeID, vm, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
-			log.Error(msg)
-			return errors.New(msg)
-		}
-	}
-	log.Infof("DetachVolume: Volume detached successfully. volumeID: %q, vm: %q, opId: %q", volumeID, taskInfo.ActivationId, vm.String())
-	return nil
+	return err
 }
 
 // DeleteVolume deletes a volume given its spec.
 func (m *defaultManager) DeleteVolume(ctx context.Context, volumeID string, deleteDisk bool) error {
-	log := logger.GetLogger(ctx)
-	err := validateManager(ctx, m)
-	if err != nil {
-		return err
-	}
-	// Set up the VC connection
-	err = m.virtualCenter.ConnectCns(ctx)
-	if err != nil {
-		log.Errorf("ConnectCns failed with err: %+v", err)
-		return err
-	}
-	// Construct the CNS VolumeId list
-	var cnsVolumeIDList []cnstypes.CnsVolumeId
-	cnsVolumeID := cnstypes.CnsVolumeId{
-		Id: volumeID,
-	}
-	// Call the CNS DeleteVolume
-	cnsVolumeIDList = append(cnsVolumeIDList, cnsVolumeID)
-	task, err := m.virtualCenter.CnsClient.DeleteVolume(ctx, cnsVolumeIDList, deleteDisk)
-	if err != nil {
-		if cnsvsphere.IsNotFoundError(err) {
-			log.Infof("VolumeID: %q, not found. Returning success for this operation since the volume is not present", volumeID)
-			return nil
+	internalDeleteVolume := func() error {
+		log := logger.GetLogger(ctx)
+		err := validateManager(ctx, m)
+		if err != nil {
+			return err
 		}
-		log.Errorf("CNS DeleteVolume failed from the  vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return err
+		// Set up the VC connection
+		err = m.virtualCenter.ConnectCns(ctx)
+		if err != nil {
+			log.Errorf("ConnectCns failed with err: %+v", err)
+			return err
+		}
+		// Construct the CNS VolumeId list
+		var cnsVolumeIDList []cnstypes.CnsVolumeId
+		cnsVolumeID := cnstypes.CnsVolumeId{
+			Id: volumeID,
+		}
+		// Call the CNS DeleteVolume
+		cnsVolumeIDList = append(cnsVolumeIDList, cnsVolumeID)
+		task, err := m.virtualCenter.CnsClient.DeleteVolume(ctx, cnsVolumeIDList, deleteDisk)
+		if err != nil {
+			if cnsvsphere.IsNotFoundError(err) {
+				log.Infof("VolumeID: %q, not found. Returning success for this operation since the volume is not present", volumeID)
+				return nil
+			}
+			log.Errorf("CNS DeleteVolume failed from the  vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return err
+		}
+		// Get the taskInfo
+		taskInfo, err := cns.GetTaskInfo(ctx, task)
+		if err != nil || taskInfo == nil {
+			log.Errorf("failed to get taskInfo for DeleteVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return err
+		}
+		log.Infof("DeleteVolume: volumeID: %q, opId: %q", volumeID, taskInfo.ActivationId)
+		// Get the task results for the given task
+		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+		if err != nil {
+			log.Errorf("unable to find the task result for DeleteVolume task from vCenter %q with taskID %s and deleteResults %v",
+				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
+			return err
+		}
+		if taskResult == nil {
+			log.Errorf("taskResult is empty for DeleteVolume task: %q, opID: %q", taskInfo.Task.Value, taskInfo.ActivationId)
+			return errors.New("taskResult is empty")
+		}
+		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
+		if volumeOperationRes.Fault != nil {
+			msg := fmt.Sprintf("failed to delete volume: %q, fault: %q, opID: %q", volumeID, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			log.Error(msg)
+			return errors.New(msg)
+		}
+		log.Infof("DeleteVolume: Volume deleted successfully. volumeID: %q, opId: %q", volumeID, taskInfo.ActivationId)
+		return nil
 	}
-	// Get the taskInfo
-	taskInfo, err := cns.GetTaskInfo(ctx, task)
-	if err != nil || taskInfo == nil {
-		log.Errorf("failed to get taskInfo for DeleteVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return err
-	}
-	log.Infof("DeleteVolume: volumeID: %q, opId: %q", volumeID, taskInfo.ActivationId)
-	// Get the task results for the given task
-	taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+	start := time.Now()
+	err := internalDeleteVolume()
 	if err != nil {
-		log.Errorf("unable to find the task result for DeleteVolume task from vCenter %q with taskID %s and deleteResults %v",
-			m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
-		return err
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsDeleteVolumeOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsDeleteVolumeOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
-	if taskResult == nil {
-		log.Errorf("taskResult is empty for DeleteVolume task: %q, opID: %q", taskInfo.Task.Value, taskInfo.ActivationId)
-		return errors.New("taskResult is empty")
-	}
-	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
-	if volumeOperationRes.Fault != nil {
-		msg := fmt.Sprintf("failed to delete volume: %q, fault: %q, opID: %q", volumeID, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
-		log.Error(msg)
-		return errors.New(msg)
-	}
-	log.Infof("DeleteVolume: Volume deleted successfully. volumeID: %q, opId: %q", volumeID, taskInfo.ActivationId)
-	return nil
+	return err
 }
 
 // UpdateVolume updates a volume given its spec.
 func (m *defaultManager) UpdateVolumeMetadata(ctx context.Context, spec *cnstypes.CnsVolumeMetadataUpdateSpec) error {
-	log := logger.GetLogger(ctx)
-	err := validateManager(ctx, m)
+	internalUpdateVolumeMetadata := func() error {
+		log := logger.GetLogger(ctx)
+		err := validateManager(ctx, m)
+		if err != nil {
+			return err
+		}
+		// Set up the VC connection
+		err = m.virtualCenter.ConnectCns(ctx)
+		if err != nil {
+			log.Errorf("ConnectCns failed with err: %+v", err)
+			return err
+		}
+		// If the VSphereUser in the VolumeMetadataUpdateSpec is different from session user, update the VolumeMetadataUpdateSpec
+		s, err := m.virtualCenter.Client.SessionManager.UserSession(ctx)
+		if err != nil {
+			log.Errorf("failed to get usersession with err: %v", err)
+			return err
+		}
+		if s.UserName != spec.Metadata.ContainerCluster.VSphereUser {
+			log.Debugf("Update VSphereUser from %s to %s", spec.Metadata.ContainerCluster.VSphereUser, s.UserName)
+			spec.Metadata.ContainerCluster.VSphereUser = s.UserName
+		}
+		var cnsUpdateSpecList []cnstypes.CnsVolumeMetadataUpdateSpec
+		cnsUpdateSpec := cnstypes.CnsVolumeMetadataUpdateSpec{
+			VolumeId: cnstypes.CnsVolumeId{
+				Id: spec.VolumeId.Id,
+			},
+			Metadata: spec.Metadata,
+		}
+		cnsUpdateSpecList = append(cnsUpdateSpecList, cnsUpdateSpec)
+		task, err := m.virtualCenter.CnsClient.UpdateVolumeMetadata(ctx, cnsUpdateSpecList)
+		if err != nil {
+			log.Errorf("CNS UpdateVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return err
+		}
+		// Get the taskInfo
+		taskInfo, err := cns.GetTaskInfo(ctx, task)
+		if err != nil || taskInfo == nil {
+			log.Errorf("failed to get taskInfo for UpdateVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return err
+		}
+		log.Infof("UpdateVolumeMetadata: volumeID: %q, opId: %q", spec.VolumeId.Id, taskInfo.ActivationId)
+		// Get the task results for the given task
+		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+		if err != nil {
+			log.Errorf("unable to find the task result for UpdateVolume task from vCenter %q with taskID %q, opId: %q and updateResults %+v",
+				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskInfo.ActivationId, taskResult)
+			return err
+		}
+		if taskResult == nil {
+			log.Errorf("taskResult is empty for UpdateVolume task: %q, opId: %q", taskInfo.Task.Value, taskInfo.ActivationId)
+			return errors.New("taskResult is empty")
+		}
+		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
+		if volumeOperationRes.Fault != nil {
+			msg := fmt.Sprintf("failed to update volume. updateSpec: %q, fault: %q, opID: %q", spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			log.Error(msg)
+			return errors.New(msg)
+		}
+		log.Infof("UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: %q, opId: %q", spec.VolumeId.Id, taskInfo.ActivationId)
+		return nil
+	}
+	start := time.Now()
+	err := internalUpdateVolumeMetadata()
 	if err != nil {
-		return err
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsUpdateVolumeMetadataOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsUpdateVolumeMetadataOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
-	// Set up the VC connection
-	err = m.virtualCenter.ConnectCns(ctx)
-	if err != nil {
-		log.Errorf("ConnectCns failed with err: %+v", err)
-		return err
-	}
-	// If the VSphereUser in the VolumeMetadataUpdateSpec is different from session user, update the VolumeMetadataUpdateSpec
-	s, err := m.virtualCenter.Client.SessionManager.UserSession(ctx)
-	if err != nil {
-		log.Errorf("failed to get usersession with err: %v", err)
-		return err
-	}
-	if s.UserName != spec.Metadata.ContainerCluster.VSphereUser {
-		log.Debugf("Update VSphereUser from %s to %s", spec.Metadata.ContainerCluster.VSphereUser, s.UserName)
-		spec.Metadata.ContainerCluster.VSphereUser = s.UserName
-	}
-	var cnsUpdateSpecList []cnstypes.CnsVolumeMetadataUpdateSpec
-	cnsUpdateSpec := cnstypes.CnsVolumeMetadataUpdateSpec{
-		VolumeId: cnstypes.CnsVolumeId{
-			Id: spec.VolumeId.Id,
-		},
-		Metadata: spec.Metadata,
-	}
-	cnsUpdateSpecList = append(cnsUpdateSpecList, cnsUpdateSpec)
-	task, err := m.virtualCenter.CnsClient.UpdateVolumeMetadata(ctx, cnsUpdateSpecList)
-	if err != nil {
-		log.Errorf("CNS UpdateVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return err
-	}
-	// Get the taskInfo
-	taskInfo, err := cns.GetTaskInfo(ctx, task)
-	if err != nil || taskInfo == nil {
-		log.Errorf("failed to get taskInfo for UpdateVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return err
-	}
-	log.Infof("UpdateVolumeMetadata: volumeID: %q, opId: %q", spec.VolumeId.Id, taskInfo.ActivationId)
-	// Get the task results for the given task
-	taskResult, err := cns.GetTaskResult(ctx, taskInfo)
-	if err != nil {
-		log.Errorf("unable to find the task result for UpdateVolume task from vCenter %q with taskID %q, opId: %q and updateResults %+v",
-			m.virtualCenter.Config.Host, taskInfo.Task.Value, taskInfo.ActivationId, taskResult)
-		return err
-	}
-	if taskResult == nil {
-		log.Errorf("taskResult is empty for UpdateVolume task: %q, opId: %q", taskInfo.Task.Value, taskInfo.ActivationId)
-		return errors.New("taskResult is empty")
-	}
-	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
-	if volumeOperationRes.Fault != nil {
-		msg := fmt.Sprintf("failed to update volume. updateSpec: %q, fault: %q, opID: %q", spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
-		log.Error(msg)
-		return errors.New(msg)
-	}
-	log.Infof("UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: %q, opId: %q", spec.VolumeId.Id, taskInfo.ActivationId)
-	return nil
+	return err
 }
 
 // ExpandVolume expands a volume given its spec.
 func (m *defaultManager) ExpandVolume(ctx context.Context, volumeID string, size int64) error {
-	log := logger.GetLogger(ctx)
-	err := validateManager(ctx, m)
-	if err != nil {
-		log.Errorf("validateManager failed with err: %+v", err)
-		return err
-	}
-	// Set up the VC connection
-	err = m.virtualCenter.ConnectCns(ctx)
-	if err != nil {
-		log.Errorf("ConnectCns failed with err: %+v", err)
-		return err
-	}
-	// Construct the CNS ExtendSpec list
-	var cnsExtendSpecList []cnstypes.CnsVolumeExtendSpec
-	cnsExtendSpec := cnstypes.CnsVolumeExtendSpec{
-		VolumeId: cnstypes.CnsVolumeId{
-			Id: volumeID,
-		},
-		CapacityInMb: size,
-	}
-	cnsExtendSpecList = append(cnsExtendSpecList, cnsExtendSpec)
-	// Call the CNS ExtendVolume
-	log.Infof("Calling CnsClient.ExtendVolume: VolumeID [%q] Size [%d] cnsExtendSpecList [%#v]", volumeID, size, cnsExtendSpecList)
-	task, err := m.virtualCenter.CnsClient.ExtendVolume(ctx, cnsExtendSpecList)
-	if err != nil {
-		if cnsvsphere.IsNotFoundError(err) {
-			log.Errorf("VolumeID: %q, not found. Cannot expand volume.", volumeID)
-			return errors.New("volume not found")
+	internalExpandVolume := func() error {
+		log := logger.GetLogger(ctx)
+		err := validateManager(ctx, m)
+		if err != nil {
+			log.Errorf("validateManager failed with err: %+v", err)
+			return err
 		}
-		log.Errorf("CNS ExtendVolume failed from the vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return err
+		// Set up the VC connection
+		err = m.virtualCenter.ConnectCns(ctx)
+		if err != nil {
+			log.Errorf("ConnectCns failed with err: %+v", err)
+			return err
+		}
+		// Construct the CNS ExtendSpec list
+		var cnsExtendSpecList []cnstypes.CnsVolumeExtendSpec
+		cnsExtendSpec := cnstypes.CnsVolumeExtendSpec{
+			VolumeId: cnstypes.CnsVolumeId{
+				Id: volumeID,
+			},
+			CapacityInMb: size,
+		}
+		cnsExtendSpecList = append(cnsExtendSpecList, cnsExtendSpec)
+		// Call the CNS ExtendVolume
+		log.Infof("Calling CnsClient.ExtendVolume: VolumeID [%q] Size [%d] cnsExtendSpecList [%#v]", volumeID, size, cnsExtendSpecList)
+		task, err := m.virtualCenter.CnsClient.ExtendVolume(ctx, cnsExtendSpecList)
+		if err != nil {
+			if cnsvsphere.IsNotFoundError(err) {
+				log.Errorf("VolumeID: %q, not found. Cannot expand volume.", volumeID)
+				return errors.New("volume not found")
+			}
+			log.Errorf("CNS ExtendVolume failed from the vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return err
+		}
+		// Get the taskInfo
+		taskInfo, err := cns.GetTaskInfo(ctx, task)
+		if err != nil || taskInfo == nil {
+			log.Errorf("failed to get taskInfo for ExtendVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return err
+		}
+		log.Infof("ExpandVolume: volumeID: %q, opId: %q", volumeID, taskInfo.ActivationId)
+		// Get the task results for the given task
+		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+		if err != nil {
+			log.Errorf("Unable to find the task result for ExtendVolume task from vCenter %q with taskID %s and extend volume Results %v",
+				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
+			return err
+		}
+		if taskResult == nil {
+			log.Errorf("TaskResult is empty for ExtendVolume task: %q, opID: %q", taskInfo.Task.Value, taskInfo.ActivationId)
+			return errors.New("taskResult is empty")
+		}
+		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
+		if volumeOperationRes.Fault != nil {
+			msg := fmt.Sprintf("failed to extend volume: %q, fault: %q, opID: %q", volumeID, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			log.Error(msg)
+			return errors.New(msg)
+		}
+		log.Infof("ExpandVolume: Volume expanded successfully. volumeID: %q, opId: %q", volumeID, taskInfo.ActivationId)
+		return nil
 	}
-	// Get the taskInfo
-	taskInfo, err := cns.GetTaskInfo(ctx, task)
-	if err != nil || taskInfo == nil {
-		log.Errorf("failed to get taskInfo for ExtendVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return err
-	}
-	log.Infof("ExpandVolume: volumeID: %q, opId: %q", volumeID, taskInfo.ActivationId)
-	// Get the task results for the given task
-	taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+	start := time.Now()
+	err := internalExpandVolume()
 	if err != nil {
-		log.Errorf("Unable to find the task result for ExtendVolume task from vCenter %q with taskID %s and extend volume Results %v",
-			m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
-		return err
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsExpandVolumeOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsExpandVolumeOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
-	if taskResult == nil {
-		log.Errorf("TaskResult is empty for ExtendVolume task: %q, opID: %q", taskInfo.Task.Value, taskInfo.ActivationId)
-		return errors.New("taskResult is empty")
-	}
-	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
-	if volumeOperationRes.Fault != nil {
-		msg := fmt.Sprintf("failed to extend volume: %q, fault: %q, opID: %q", volumeID, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
-		log.Error(msg)
-		return errors.New(msg)
-	}
-	log.Infof("ExpandVolume: Volume expanded successfully. volumeID: %q, opId: %q", volumeID, taskInfo.ActivationId)
-	return nil
+	return err
 }
 
 // QueryVolume returns volumes matching the given filter.
 func (m *defaultManager) QueryVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
-	log := logger.GetLogger(ctx)
-	err := validateManager(ctx, m)
-	if err != nil {
-		return nil, err
+	internalQueryVolume := func() (*cnstypes.CnsQueryResult, error) {
+		log := logger.GetLogger(ctx)
+		err := validateManager(ctx, m)
+		if err != nil {
+			return nil, err
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Set up the VC connection
+		err = m.virtualCenter.ConnectCns(ctx)
+		if err != nil {
+			log.Errorf("ConnectCns failed with err: %+v", err)
+			return nil, err
+		}
+		//Call the CNS QueryVolume
+		res, err := m.virtualCenter.CnsClient.QueryVolume(ctx, queryFilter)
+		if err != nil {
+			log.Errorf("CNS QueryVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return nil, err
+		}
+		res = updateQueryResult(ctx, m, res)
+		return res, err
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	// Set up the VC connection
-	err = m.virtualCenter.ConnectCns(ctx)
+	start := time.Now()
+	resp, err := internalQueryVolume()
 	if err != nil {
-		log.Errorf("ConnectCns failed with err: %+v", err)
-		return nil, err
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsQueryVolumeOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsQueryVolumeOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
-	//Call the CNS QueryVolume
-	res, err := m.virtualCenter.CnsClient.QueryVolume(ctx, queryFilter)
-	if err != nil {
-		log.Errorf("CNS QueryVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return nil, err
-	}
-	res = updateQueryResult(ctx, m, res)
-	return res, err
+	return resp, err
 }
 
 // QueryAllVolume returns all volumes matching the given filter and selection.
 func (m *defaultManager) QueryAllVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter, querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
-	log := logger.GetLogger(ctx)
-	err := validateManager(ctx, m)
-	if err != nil {
-		return nil, err
+	internalQueryAllVolume := func() (*cnstypes.CnsQueryResult, error) {
+		log := logger.GetLogger(ctx)
+		err := validateManager(ctx, m)
+		if err != nil {
+			return nil, err
+		}
+		// Set up the VC connection
+		err = m.virtualCenter.ConnectCns(ctx)
+		if err != nil {
+			log.Errorf("ConnectCns failed with err: %+v", err)
+			return nil, err
+		}
+		//Call the CNS QueryAllVolume
+		res, err := m.virtualCenter.CnsClient.QueryAllVolume(ctx, queryFilter, querySelection)
+		if err != nil {
+			log.Errorf("CNS QueryAllVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return nil, err
+		}
+		res = updateQueryResult(ctx, m, res)
+		return res, err
 	}
-	// Set up the VC connection
-	err = m.virtualCenter.ConnectCns(ctx)
+	start := time.Now()
+	resp, err := internalQueryAllVolume()
 	if err != nil {
-		log.Errorf("ConnectCns failed with err: %+v", err)
-		return nil, err
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsQueryAllVolumeOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsQueryAllVolumeOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
-	//Call the CNS QueryAllVolume
-	res, err := m.virtualCenter.CnsClient.QueryAllVolume(ctx, queryFilter, querySelection)
-	if err != nil {
-		log.Errorf("CNS QueryAllVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return nil, err
-	}
-	res = updateQueryResult(ctx, m, res)
-	return res, err
+	return resp, err
 }
 
 // QueryVolumeInfo calls the CNS QueryVolumeInfo API and return a task, from which CnsQueryVolumeInfoResult is extracted
 func (m *defaultManager) QueryVolumeInfo(ctx context.Context, volumeIDList []cnstypes.CnsVolumeId) (*cnstypes.CnsQueryVolumeInfoResult, error) {
-	log := logger.GetLogger(ctx)
-	err := validateManager(ctx, m)
-	if err != nil {
-		return nil, err
-	}
-	// Set up the VC connection
-	err = m.virtualCenter.ConnectCns(ctx)
-	if err != nil {
-		log.Errorf("ConnectCns failed with err: %+v", err)
-		return nil, err
-	}
-	//Call the CNS QueryVolumeInfo
-	queryVolumeInfoTask, err := m.virtualCenter.CnsClient.QueryVolumeInfo(ctx, volumeIDList)
-	if err != nil {
-		log.Errorf("CNS QueryAllVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return nil, err
-	}
+	internalQueryVolumeInfo := func() (*cnstypes.CnsQueryVolumeInfoResult, error) {
+		log := logger.GetLogger(ctx)
+		err := validateManager(ctx, m)
+		if err != nil {
+			return nil, err
+		}
+		// Set up the VC connection
+		err = m.virtualCenter.ConnectCns(ctx)
+		if err != nil {
+			log.Errorf("ConnectCns failed with err: %+v", err)
+			return nil, err
+		}
+		//Call the CNS QueryVolumeInfo
+		queryVolumeInfoTask, err := m.virtualCenter.CnsClient.QueryVolumeInfo(ctx, volumeIDList)
+		if err != nil {
+			log.Errorf("CNS QueryAllVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return nil, err
+		}
 
-	// Get the taskInfo
-	taskInfo, err := cns.GetTaskInfo(ctx, queryVolumeInfoTask)
-	if err != nil || taskInfo == nil {
-		log.Errorf("failed to get taskInfo for QueryVolumeInfo task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return nil, err
+		// Get the taskInfo
+		taskInfo, err := cns.GetTaskInfo(ctx, queryVolumeInfoTask)
+		if err != nil || taskInfo == nil {
+			log.Errorf("failed to get taskInfo for QueryVolumeInfo task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return nil, err
+		}
+		log.Infof("QueryVolumeInfo: volumeIDList: %v, opId: %q", volumeIDList, taskInfo.ActivationId)
+		// Get the task results for the given task
+		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+		if err != nil {
+			log.Errorf("unable to find the task result for QueryVolumeInfo task from vCenter %q with taskID %s and taskResult %v",
+				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
+			return nil, err
+		}
+		if taskResult == nil {
+			log.Errorf("taskResult is empty for DeleteVolume task: %q, opID: %q", taskInfo.Task.Value, taskInfo.ActivationId)
+			return nil, errors.New("taskResult is empty")
+		}
+		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
+		if volumeOperationRes.Fault != nil {
+			msg := fmt.Sprintf("failed to Query volumes: %v, fault: %q, opID: %q", volumeIDList, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			log.Error(msg)
+			return nil, errors.New(msg)
+		}
+		volumeInfoResult := interface{}(taskResult).(*cnstypes.CnsQueryVolumeInfoResult)
+		log.Infof("QueryVolumeInfo successfully returned volumeInfo volumeIDList %v:, opId: %q", volumeIDList, taskInfo.ActivationId)
+		return volumeInfoResult, nil
 	}
-	log.Infof("QueryVolumeInfo: volumeIDList: %v, opId: %q", volumeIDList, taskInfo.ActivationId)
-	// Get the task results for the given task
-	taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+	start := time.Now()
+	resp, err := internalQueryVolumeInfo()
 	if err != nil {
-		log.Errorf("unable to find the task result for QueryVolumeInfo task from vCenter %q with taskID %s and taskResult %v",
-			m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
-		return nil, err
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsQueryVolumeInfoOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsQueryVolumeInfoOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
-	if taskResult == nil {
-		log.Errorf("taskResult is empty for DeleteVolume task: %q, opID: %q", taskInfo.Task.Value, taskInfo.ActivationId)
-		return nil, errors.New("taskResult is empty")
-	}
-	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
-	if volumeOperationRes.Fault != nil {
-		msg := fmt.Sprintf("failed to Query volumes: %v, fault: %q, opID: %q", volumeIDList, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
-		log.Error(msg)
-		return nil, errors.New(msg)
-	}
-	volumeInfoResult := interface{}(taskResult).(*cnstypes.CnsQueryVolumeInfoResult)
-	log.Infof("QueryVolumeInfo successfully returned volumeInfo volumeIDList %v:, opId: %q", volumeIDList, taskInfo.ActivationId)
-	return volumeInfoResult, nil
+	return resp, err
 }
 
 func (m *defaultManager) RelocateVolume(ctx context.Context, relocateSpecList ...cnstypes.BaseCnsVolumeRelocateSpec) (*object.Task, error) {
-	log := logger.GetLogger(ctx)
-	err := validateManager(ctx, m)
-	if err != nil {
-		log.Errorf("validateManager failed with err: %+v", err)
-		return nil, err
-	}
+	internalRelocateVolume := func() (*object.Task, error) {
+		log := logger.GetLogger(ctx)
+		err := validateManager(ctx, m)
+		if err != nil {
+			log.Errorf("validateManager failed with err: %+v", err)
+			return nil, err
+		}
 
-	// Set up the VC connection
-	err = m.virtualCenter.ConnectCns(ctx)
-	if err != nil {
-		log.Errorf("ConnectCns failed with err: %+v", err)
-		return nil, err
+		// Set up the VC connection
+		err = m.virtualCenter.ConnectCns(ctx)
+		if err != nil {
+			log.Errorf("ConnectCns failed with err: %+v", err)
+			return nil, err
+		}
+		res, err := m.virtualCenter.CnsClient.RelocateVolume(ctx, relocateSpecList...)
+		if err != nil {
+			log.Errorf("CNS RelocateVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return nil, err
+		}
+		return res, err
 	}
-	res, err := m.virtualCenter.CnsClient.RelocateVolume(ctx, relocateSpecList...)
+	start := time.Now()
+	resp, err := internalRelocateVolume()
 	if err != nil {
-		log.Errorf("CNS RelocateVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return nil, err
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsRelocateVolumeOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsRelocateVolumeOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
-	return res, err
+	return resp, err
 }
 
 // ConfigureVolumeACLs configures net permissions for a given CnsVolumeACLConfigureSpec
 func (m *defaultManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error {
-	log := logger.GetLogger(ctx)
-	err := validateManager(ctx, m)
-	if err != nil {
-		return err
-	}
-	// Set up the VC connection
-	err = m.virtualCenter.ConnectCns(ctx)
-	if err != nil {
-		log.Errorf("ConnectCns failed with err: %+v", err)
-		return err
-	}
+	internalConfigureVolumeACLs := func() error {
+		log := logger.GetLogger(ctx)
+		err := validateManager(ctx, m)
+		if err != nil {
+			return err
+		}
+		// Set up the VC connection
+		err = m.virtualCenter.ConnectCns(ctx)
+		if err != nil {
+			log.Errorf("ConnectCns failed with err: %+v", err)
+			return err
+		}
 
-	var task *object.Task
-	var taskInfo *vim25types.TaskInfo
+		var task *object.Task
+		var taskInfo *vim25types.TaskInfo
 
-	task, err = m.virtualCenter.CnsClient.ConfigureVolumeACLs(ctx, spec)
+		task, err = m.virtualCenter.CnsClient.ConfigureVolumeACLs(ctx, spec)
+		if err != nil {
+			log.Errorf("CNS ConfigureVolumeACLs failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return err
+		}
+
+		// Get the taskInfo
+		taskInfo, err = cns.GetTaskInfo(ctx, task)
+		if err != nil {
+			log.Errorf("failed to get taskInfo for ConfigureVolumeACLs task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			return err
+		}
+		// Get the taskResult
+		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
+		if err != nil {
+			log.Errorf("unable to find the task result for ConfigureVolumeACLs task from vCenter %q. taskID: %q, opId: %q ConfigureVolumeACL results: %+v . Error: %v",
+				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskInfo.ActivationId, taskResult, err)
+			return err
+		}
+
+		if taskResult == nil {
+			log.Errorf("taskResult is empty for ConfigureVolumeACLs task: %q. ConfigureVolumeACLsSpec: %q", taskInfo.ActivationId, spew.Sdump(spec))
+			return errors.New("taskResult is empty")
+		}
+		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
+		if volumeOperationRes.Fault != nil {
+			msg := fmt.Sprintf("failed to apply ConfigureVolumeACLs. Volume ID: %s. ConfigureVolumeACLsSpec: %q, fault: %q, opId: %q", spec.VolumeId.Id, spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			log.Error(msg)
+			return errors.New(msg)
+		}
+
+		log.Infof("ConfigureVolumeACLs: Volume ACLs configured successfully. VolumeName: %q, opId: %q, volumeID: %q", spec.VolumeId.Id, taskInfo.ActivationId, volumeOperationRes.VolumeId.Id)
+		return nil
+	}
+	start := time.Now()
+	err := internalConfigureVolumeACLs()
 	if err != nil {
-		log.Errorf("CNS ConfigureVolumeACLs failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return err
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsConfigureVolumeACLOpType,
+			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+	} else {
+		prometheus.CnsControlOpsHistVec.WithLabelValues(prometheus.PrometheusCnsConfigureVolumeACLOpType,
+			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
-
-	// Get the taskInfo
-	taskInfo, err = cns.GetTaskInfo(ctx, task)
-	if err != nil {
-		log.Errorf("failed to get taskInfo for ConfigureVolumeACLs task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-		return err
-	}
-	// Get the taskResult
-	taskResult, err := cns.GetTaskResult(ctx, taskInfo)
-	if err != nil {
-		log.Errorf("unable to find the task result for ConfigureVolumeACLs task from vCenter %q. taskID: %q, opId: %q ConfigureVolumeACL results: %+v . Error: %v",
-			m.virtualCenter.Config.Host, taskInfo.Task.Value, taskInfo.ActivationId, taskResult, err)
-		return err
-	}
-
-	if taskResult == nil {
-		log.Errorf("taskResult is empty for ConfigureVolumeACLs task: %q. ConfigureVolumeACLsSpec: %q", taskInfo.ActivationId, spew.Sdump(spec))
-		return errors.New("taskResult is empty")
-	}
-	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
-	if volumeOperationRes.Fault != nil {
-		msg := fmt.Sprintf("failed to apply ConfigureVolumeACLs. Volume ID: %s. ConfigureVolumeACLsSpec: %q, fault: %q, opId: %q", spec.VolumeId.Id, spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
-		log.Error(msg)
-		return errors.New(msg)
-	}
-
-	log.Infof("ConfigureVolumeACLs: Volume ACLs configured successfully. VolumeName: %q, opId: %q, volumeID: %q", spec.VolumeId.Id, taskInfo.ActivationId, volumeOperationRes.VolumeId.Id)
-	return nil
+	return err
 }

--- a/pkg/csi/service/common/prometheus/metrics.go
+++ b/pkg/csi/service/common/prometheus/metrics.go
@@ -29,6 +29,8 @@ const (
 	// PrometheusUnknownVolumeType is used in situation when the volume type could not be found.
 	PrometheusUnknownVolumeType = "unknown"
 
+	// CSI operation types
+
 	// PrometheusCreateVolumeOpType represents the CreateVolume operation.
 	PrometheusCreateVolumeOpType = "create-volume"
 	// PrometheusDeleteVolumeOpType represents the DeleteVolume operation.
@@ -37,6 +39,31 @@ const (
 	PrometheusAttachVolumeOpType = "attach-volume"
 	// PrometheusDetachVolumeOpType represents the DetachVolume operation.
 	PrometheusDetachVolumeOpType = "detach-volume"
+
+	// CNS operation types
+
+	// PrometheusCnsCreateVolumeOpType represents the CreateVolume operation.
+	PrometheusCnsCreateVolumeOpType = "create-volume"
+	// PrometheusCnsDeleteVolumeOpType represents the DeleteVolume operation.
+	PrometheusCnsDeleteVolumeOpType = "delete-volume"
+	// PrometheusCnsAttachVolumeOpType represents the AttachVolume operation.
+	PrometheusCnsAttachVolumeOpType = "attach-volume"
+	// PrometheusCnsDetachVolumeOpType represents the DetachVolume operation.
+	PrometheusCnsDetachVolumeOpType = "detach-volume"
+	// PrometheusCnsUpdateVolumeMetadataOpType represents the UpdateVolumeMetadata operation.
+	PrometheusCnsUpdateVolumeMetadataOpType = "update-volume-metadata"
+	// PrometheusCnsExpandVolumeOpType represents the ExpandVolume operation.
+	PrometheusCnsExpandVolumeOpType = "expand-volume"
+	// PrometheusCnsQueryVolumeOpType represents the QueryVolume operation.
+	PrometheusCnsQueryVolumeOpType = "query-volume"
+	// PrometheusCnsQueryAllVolumeOpType represents the QueryAllVolume operation.
+	PrometheusCnsQueryAllVolumeOpType = "query-all-volume"
+	// PrometheusCnsQueryVolumeInfoOpType represents the QueryVolumeInfo operation.
+	PrometheusCnsQueryVolumeInfoOpType = "query-volume-info"
+	// PrometheusCnsRelocateVolumeOpType represents the RelocateVolume operation.
+	PrometheusCnsRelocateVolumeOpType = "relocate-volume"
+	// PrometheusCnsConfigureVolumeACLOpType represents the ConfigureVolumeAcl operation.
+	PrometheusCnsConfigureVolumeACLOpType = "configure-volume-acl"
 
 	// PrometheusPassStatus represents a successful API run.
 	PrometheusPassStatus = "pass"
@@ -51,9 +78,9 @@ var (
 		Help: "CSI Info",
 	}, []string{"version"})
 
-	// VolumeControlOpsHistVec is a histogram vector metric to observe various control
+	// CsiControlOpsHistVec is a histogram vector metric to observe various control
 	// operations in CSI.
-	VolumeControlOpsHistVec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	CsiControlOpsHistVec = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "csi_volume_ops_histogram",
 		Help: "Histogram vector for CSI volume operations.",
 		// Creating more buckets for operations that takes few seconds and less buckets
@@ -65,4 +92,19 @@ var (
 		// Possible optype - "create-volume", "delete-volume", "attach-volume", "detach-volume", "expand-volume"
 		// Possible status - "pass", "fail"
 		[]string{"voltype", "optype", "status"})
+
+	// CnsControlOpsHistVec is a histogram vector metric to observe various control
+	// operations on CNS. Note that this captures the time taken by CNS into a bucket
+	// as seen by the client(CSI in this case).
+	CnsControlOpsHistVec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "cns_volume_ops_histogram",
+		Help: "Histogram vector for CNS operations.",
+		// Creating more buckets for operations that takes few seconds and less buckets
+		// for those that are taking a long time. A CNS operation taking a long time is
+		// unexpected and we don't have to be accurate(just approximation is fine).
+		Buckets: []float64{1, 2, 3, 4, 5, 7, 10, 12, 15, 18, 20, 25, 30, 60, 120, 180, 300},
+	},
+		// Possible optype - "create-volume", "delete-volume", "attach-volume", "detach-volume", "expand-volume", etc
+		// Possible status - "pass", "fail"
+		[]string{"optype", "status"})
 )

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -601,10 +601,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	}
 	resp, err := createVolumeInternal()
 	if err != nil {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
 			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
 	} else {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
 			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
@@ -695,10 +695,10 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	}
 	resp, err := deleteVolumeInternal()
 	if err != nil {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
 			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
 	} else {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
 			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
@@ -808,10 +808,10 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	}
 	resp, err := controllerPublishVolumeInternal()
 	if err != nil {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
 			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
 	} else {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
 			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
@@ -904,10 +904,10 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	}
 	resp, err := controllerUnpublishVolumeInternal()
 	if err != nil {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
 			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
 	} else {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
 			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
 	return resp, err

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -455,10 +455,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	}
 	resp, err := createVolumeInternal()
 	if err != nil {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
 			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
 	} else {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
 			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
@@ -518,10 +518,10 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	}
 	resp, err := deleteVolumeInternal()
 	if err != nil {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
 			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
 	} else {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
 			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
 	return resp, err

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -299,10 +299,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	}
 	resp, err := createVolumeInternal()
 	if err != nil {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
 			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
 	} else {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
 			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
@@ -359,10 +359,10 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	}
 	resp, err := deleteVolumeInternal()
 	if err != nil {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
 			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
 	} else {
-		prometheus.VolumeControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
 			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
 	return resp, err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR exposes the CNS operation metrics useful to track the overall operation success rates and latencies.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #655

**Special notes for your reviewer**:

1. Created a bunch of PVCs and Pods, and validated that the CNS operation metrics are exposed by the http server:
```
root@ubuntu:~/test/prometheus/vanilla/example-apps# kubectl --kubeconfig ~/wc.kubeconfig -n kube-system exec -it vsphere-csi-controller-5685d5f955-9tbsn -c vsphere-csi-controller -- curl localhost:2112/metrics |
 grep "cns"
# HELP cns_volume_ops_histogram Histogram vector for CNS operations.
# TYPE cns_volume_ops_histogram histogram
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="1"} 10
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="2"} 11
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="3"} 21
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="4"} 36
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="5"} 43
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="7"} 56
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="10"} 62
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="12"} 62
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="15"} 62
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="18"} 63
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="20"} 63
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="25"} 63
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="30"} 63
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="60"} 63
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="120"} 63
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="180"} 63
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="300"} 63
cns_volume_ops_histogram_bucket{optype="attach-volume",status="pass",le="+Inf"} 63
cns_volume_ops_histogram_sum{optype="attach-volume",status="pass"} 254.98948107299995
cns_volume_ops_histogram_count{optype="attach-volume",status="pass"} 63
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="1"} 0
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="2"} 0
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="3"} 0
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="4"} 0
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="5"} 0
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="7"} 0
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="10"} 0
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="12"} 4
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="15"} 6
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="18"} 25
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="20"} 30
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="25"} 43
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="30"} 50
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="60"} 50
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="120"} 50
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="180"} 50
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="300"} 50
cns_volume_ops_histogram_bucket{optype="create-volume",status="pass",le="+Inf"} 50
cns_volume_ops_histogram_sum{optype="create-volume",status="pass"} 955.5294136770002
cns_volume_ops_histogram_count{optype="create-volume",status="pass"} 50
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="1"} 0
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="2"} 5
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="3"} 9
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="4"} 11
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="5"} 12
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="7"} 18
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="10"} 24
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="12"} 30
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="15"} 36
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="18"} 40
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="20"} 47
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="25"} 48
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="30"} 50
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="60"} 50
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="120"} 50
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="180"} 50
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="300"} 50
cns_volume_ops_histogram_bucket{optype="delete-volume",status="pass",le="+Inf"} 50
cns_volume_ops_histogram_sum{optype="delete-volume",status="pass"} 545.1364178590001
cns_volume_ops_histogram_count{optype="delete-volume",status="pass"} 50
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="1"} 0
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="2"} 18
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="3"} 30
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="4"} 40
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="5"} 53
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="7"} 64
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="10"} 65
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="12"} 65
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="15"} 65
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="18"} 65
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="20"} 65
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="25"} 65
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="30"} 65
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="60"} 65
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="120"} 65
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="180"} 65
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="300"} 65
cns_volume_ops_histogram_bucket{optype="detach-volume",status="pass",le="+Inf"} 65
cns_volume_ops_histogram_sum{optype="detach-volume",status="pass"} 219.06225204099997
cns_volume_ops_histogram_count{optype="detach-volume",status="pass"} 65
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="1"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="2"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="3"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="4"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="5"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="7"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="10"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="12"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="15"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="18"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="20"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="25"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="30"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="60"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="120"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="180"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="300"} 50
cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="+Inf"} 50
cns_volume_ops_histogram_sum{optype="query-all-volume",status="pass"} 7.591715432999999
cns_volume_ops_histogram_count{optype="query-all-volume",status="pass"} 50
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="1"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="2"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="3"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="4"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="5"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="7"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="10"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="12"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="15"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="18"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="20"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="25"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="30"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="60"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="120"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="180"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="300"} 65
cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="+Inf"} 65
cns_volume_ops_histogram_sum{optype="query-volume",status="pass"} 23.161040144999994
cns_volume_ops_histogram_count{optype="query-volume",status="pass"} 65
```

2. Created a CNS dashboard for the exposed metrics:

![image](https://user-images.githubusercontent.com/17838923/108142676-13c68e00-707b-11eb-8413-ac9082c6daa8.png)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
