### PR TITLE
Revert "Assign full permissions for file volumes created in WCP"

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -293,15 +293,16 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 			vcConfig.InsecureFlag = cfg.Global.InsecureFlag
 		}
 	}
-
+	clusterFlavor, err := GetClusterFlavor(ctx)
+	if err != nil {
+		return err
+	}
 	if cfg.NetPermissions == nil {
 		// If no net permissions are given, assume default
 		log.Info("No Net Permissions given in Config. Using default permissions.")
-		// TODO:
-		// For now, adding full permissions for READ/WRITE for all file volumes on all flavors
-		// Later when ACLs are implemented for file volumes in WCP, give full permissions
-		// only for Vanilla and no permissions for WCP.
-		cfg.NetPermissions = map[string]*NetPermissionConfig{"#": GetDefaultNetPermission()}
+		if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
+			cfg.NetPermissions = map[string]*NetPermissionConfig{"#": GetDefaultNetPermission()}
+		}
 	} else {
 		for key, netPerm := range cfg.NetPermissions {
 			if netPerm.Permissions == "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This reverts commit 9e08b95cf2fd9407b52f89b20a31626856723fad - https://github.com/kubernetes-sigs/vsphere-csi-driver/commit/9e08b95cf2fd9407b52f89b20a31626856723fad

full permissions were given to TKG file share PVC's since we didnt have ACL config code changes yet. This PR reverts that change. 

Testing:
Thanks to @chethanv28 for the below tests.

Permissions for file volume created in TKG Before this change:
![RWM Volumes](https://user-images.githubusercontent.com/5894281/108774511-9ab0b600-7514-11eb-8bc3-d7b11196c6f0.png)


Permissions after this change
![Screen Shot 2021-02-22 at 12 27 01 PM](https://user-images.githubusercontent.com/5894281/108774548-a43a1e00-7514-11eb-90a7-0460035f55bd.png)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
No permissions for file volumes created in WCP 
```
