### PR TITLE
Running a http server in syncer container to expose prometheus metrics.

### DIFF
--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -106,6 +106,10 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
+          ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
@@ -161,3 +165,23 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: kube-system
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -119,6 +119,10 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
+          ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
@@ -174,3 +178,23 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: kube-system
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -119,6 +119,10 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
+          ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
@@ -179,3 +183,22 @@ spec:
   attachRequired: true
   podInfoOnMount: false
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: kube-system
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -187,6 +187,10 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
@@ -411,3 +415,22 @@ metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
   namespace: {{ .PVCSINamespace }}
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: {{ .PVCSINamespace }}
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -187,6 +187,10 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
@@ -411,3 +415,22 @@ metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
   namespace: {{ .PVCSINamespace }}
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: {{ .PVCSINamespace }}
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -187,6 +187,10 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
@@ -411,3 +415,22 @@ metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
   namespace: {{ .PVCSINamespace }}
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: {{ .PVCSINamespace }}
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.17/vsphere-csi-controller.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.17/vsphere-csi-controller.yaml
@@ -269,6 +269,10 @@ spec:
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
         imagePullPolicy: "IfNotPresent"
+        ports:
+          - containerPort: 2113
+            name: prometheus
+            protocol: TCP
         volumeMounts:
         - mountPath: /etc/vmware/wcp
           name: vsphere-config-volume
@@ -299,3 +303,22 @@ metadata:
   name: csi-feature-states
   namespace: vmware-system-csi
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.18/vsphere-csi-controller.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.18/vsphere-csi-controller.yaml
@@ -269,6 +269,10 @@ spec:
         - name: LOGGER_LEVEL
           value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
         imagePullPolicy: "IfNotPresent"
+        ports:
+          - containerPort: 2113
+            name: prometheus
+            protocol: TCP
         volumeMounts:
         - mountPath: /etc/vmware/wcp
           name: vsphere-config-volume
@@ -299,3 +303,22 @@ metadata:
   name: csi-feature-states
   namespace: vmware-system-csi
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.19/vsphere-csi-controller.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.19/vsphere-csi-controller.yaml
@@ -278,6 +278,10 @@ spec:
         - name: INCLUSTER_CLIENT_BURST
           value: "50"
         imagePullPolicy: "IfNotPresent"
+        ports:
+          - containerPort: 2113
+            name: prometheus
+            protocol: TCP
         volumeMounts:
         - mountPath: /etc/vmware/wcp
           name: vsphere-config-volume
@@ -309,3 +313,22 @@ metadata:
   name: csi-feature-states
   namespace: vmware-system-csi
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -122,6 +122,10 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
+          ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
@@ -185,3 +189,22 @@ spec:
   attachRequired: true
   podInfoOnMount: false
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: kube-system
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/prometheus"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/prometheus"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 
 	"github.com/davecgh/go-spew/spew"

--- a/pkg/common/prometheus/metrics.go
+++ b/pkg/common/prometheus/metrics.go
@@ -74,14 +74,20 @@ const (
 var (
 	// CsiInfo is a gauge metric to observe the CSI version.
 	CsiInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "csi_info",
+		Name: "vsphere_csi_info",
 		Help: "CSI Info",
+	}, []string{"version"})
+
+	// SyncerInfo is a gauge metric to observe the CSI version.
+	SyncerInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "vsphere_syncer_info",
+		Help: "Syncer Info",
 	}, []string{"version"})
 
 	// CsiControlOpsHistVec is a histogram vector metric to observe various control
 	// operations in CSI.
 	CsiControlOpsHistVec = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "csi_volume_ops_histogram",
+		Name: "vsphere_csi_volume_ops_histogram",
 		Help: "Histogram vector for CSI volume operations.",
 		// Creating more buckets for operations that takes few seconds and less buckets
 		// for those that are taking a long time. A CSI operation taking a long time is
@@ -97,7 +103,7 @@ var (
 	// operations on CNS. Note that this captures the time taken by CNS into a bucket
 	// as seen by the client(CSI in this case).
 	CnsControlOpsHistVec = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "cns_volume_ops_histogram",
+		Name: "vsphere_cns_volume_ops_histogram",
 		Help: "Histogram vector for CNS operations.",
 		// Creating more buckets for operations that takes few seconds and less buckets
 		// for those that are taking a long time. A CNS operation taking a long time is

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/prometheus"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/prometheus"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/fsnotify/fsnotify"

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/prometheus"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/prometheus"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/fsnotify/fsnotify"

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/prometheus"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/prometheus"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Added code in syncer to start the http server to expose prometheus metrics.
2. Moved mtrics.go to a common package that can be used by CSI and syncer containers.
3. Added "vsphere_" prefix for all the metrics that will be exposed.
4. Exposing the http servers in both CSI controller and syncer via a Service. This is a pre-requisite for scraping metrics via Prometheus. This change in the deployment yaml is done for all flavors of CSI.

**Special notes for your reviewer**:
1. Verified that the syncer is exposing metrics for CNS operations.
```
root@ubuntu:~/test/prometheus# kubectl -n kube-system exec -it  vsphere-csi-controller-76fd7bb7f5-dxtkq -c vsphere-syncer -- curl localhost:2113/metrics | grep vsphere
# HELP vsphere_cns_volume_ops_histogram Histogram vector for CNS operations.
# TYPE vsphere_cns_volume_ops_histogram histogram
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="1"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="2"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="3"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="4"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="5"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="7"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="10"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="12"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="15"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="18"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="20"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="25"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="30"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="60"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="120"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="180"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="300"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-all-volume",status="pass",le="+Inf"} 3
vsphere_cns_volume_ops_histogram_sum{optype="query-all-volume",status="pass"} 0.348039594
vsphere_cns_volume_ops_histogram_count{optype="query-all-volume",status="pass"} 3
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="1"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="2"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="3"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="4"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="5"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="7"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="10"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="12"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="15"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="18"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="20"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="25"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="30"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="60"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="120"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="180"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="300"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="query-volume",status="pass",le="+Inf"} 53
vsphere_cns_volume_ops_histogram_sum{optype="query-volume",status="pass"} 11.396147360999999
vsphere_cns_volume_ops_histogram_count{optype="query-volume",status="pass"} 53
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="1"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="2"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="3"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="4"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="5"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="7"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="10"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="12"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="15"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="18"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="20"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="25"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="30"} 2
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="60"} 2
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="120"} 2
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="180"} 2
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="300"} 2
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="fail",le="+Inf"} 2
vsphere_cns_volume_ops_histogram_sum{optype="update-volume-metadata",status="fail"} 53.507682596
vsphere_cns_volume_ops_histogram_count{optype="update-volume-metadata",status="fail"} 2
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="1"} 0
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="2"} 40
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="3"} 171
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="4"} 180
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="5"} 183
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="7"} 200
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="10"} 202
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="12"} 204
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="15"} 206
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="18"} 207
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="20"} 207
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="25"} 207
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="30"} 207
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="60"} 207
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="120"} 207
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="180"} 207
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="300"} 207
vsphere_cns_volume_ops_histogram_bucket{optype="update-volume-metadata",status="pass",le="+Inf"} 207
vsphere_cns_volume_ops_histogram_sum{optype="update-volume-metadata",status="pass"} 582.7905217350002
vsphere_cns_volume_ops_histogram_count{optype="update-volume-metadata",status="pass"} 207
# HELP vsphere_syncer_info Syncer Info
# TYPE vsphere_syncer_info gauge
vsphere_syncer_info{version="v2.1.0-rc.1-417-gfb61db8e-dirty"} 1
```

2. Here's a Grafana dashboard showing the CNS operations in the syncer container:

![image](https://user-images.githubusercontent.com/17838923/108910489-cb5b2300-75da-11eb-99e5-18ac3a53400b.png)

3. I will trigger E2E pipeline for all flavors.

**Release note**:
```release-note
Running a http server in syncer container to expose prometheus metrics.
```
