### PR TITLE
Disable root squash and perform hard mount for file volumes in TKGS

### DIFF
--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -1031,6 +1031,9 @@ func publishFileVol(
 	if params.ro {
 		mntFlags = append(mntFlags, "ro")
 	}
+	if cnstypes.CnsClusterFlavor(os.Getenv(csitypes.EnvClusterFlavor)) == cnstypes.CnsClusterFlavorGuest {
+		mntFlags = append(mntFlags, "hard")
+	}
 	// Retrieve the file share access point from publish context
 	mntSrc, ok := req.GetPublishContext()[common.Nfsv4AccessPoint]
 	if !ok {

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -434,6 +434,7 @@ func (r *ReconcileCnsFileAccessConfig) configureVolumeACLs(ctx context.Context, 
 	vSanFileShareNetPermissions = append(vSanFileShareNetPermissions, vsanfstypes.VsanFileShareNetPermission{
 		Ips:         tkgVMIP,
 		Permissions: vsanFileShareAccessType,
+		AllowRoot:   true,
 	})
 
 	cnsNFSAccessControlSpecList := make([]cnstypes.CnsNFSAccessControlSpec, 0)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses the following for RWM support on TKGS: 
* File shares must be configured with root squash disabled
* Perform hard mount of NFS file shares

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Before:
![Screen Shot 2021-02-24 at 3 23 51 PM](https://user-images.githubusercontent.com/14131348/109079886-77bd0800-76b4-11eb-9fbb-31dcb69e4a16.png)


After disabling root squash:
![Screen Shot 2021-02-24 at 3 23 31 PM](https://user-images.githubusercontent.com/14131348/109079900-7ee41600-76b4-11eb-8da2-6ba1b770a171.png)

Created file volumes and pods to verify the following:

```
kubectl logs vsphere-csi-node-h7j76 -c vsphere-csi-node -n vmware-system-csi | grep hard
2021-02-24T22:34:33.045Z	DEBUG	service/node.go:1041	PublishFileVolume: Attempting to mount "nsxt1.vmware.com:/vsanfs/52d92f2e-3cbd-9751-23d1-bb401570b522" to "/var/lib/kubelet/pods/fa9ad530-94ac-4a2d-85a1-5d6fa6849acd/volumes/kubernetes.io~csi/pvc-85132e6f-eaf2-4414-a868-b01f6337237b/mount" with fstype "nfs4" and mountflags [hard]	{"TraceId": "79b32425-a00c-4ea2-84fd-8962a4913123"}
time="2021-02-24T22:34:33Z" level=info msg="mount command" args="-t nfs4 -o hard nsxt1.vmware.com:/vsanfs/52d92f2e-3cbd-9751-23d1-bb401570b522 /var/lib/kubelet/pods/fa9ad530-94ac-4a2d-85a1-5d6fa6849acd/volumes/kubernetes.io~csi/pvc-85132e6f-eaf2-4414-a868-b01f6337237b/mount" cmd=mount
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Set allow root to true for ACL configuration and perform hard mount for file volumes in TKGS
```
