### PR TITLE
Fix issue that fullsync returns with error 'Duplicated entity for each entity type in one cluster is found'

### DIFF
--- a/docs/book/releases/v2.1.0.md
+++ b/docs/book/releases/v2.1.0.md
@@ -53,6 +53,10 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
 7. When a Pod is rescheduled to a new node, there may be some lock contention which causes a delay in the volume getting detached from the old node and attached to the new node.
    - Impact: Rescheduled Pods remain in `Pending` state for an varying amount of time.
    - Workaround: Upgrade CSI driver to `v2.1.1`.
+8. When pod using a PVC is rescheduled to other node when metadatasyncer is down, fullsync might fail with error `Duplicated entity for each entity type in one cluster is found`.
+   - Impact: CNS may hold stale volume metadata.
+   - Workaround:
+      - Upgrade CSI driver with this fix.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.1.1.md
+++ b/docs/book/releases/v2.1.1.md
@@ -54,6 +54,10 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
    - Impact: In-tree vSphere volumes will not get migrated successfully
    - Workaround:
       - Upgrade CSI driver with this fix.
+7. When pod using a PVC is rescheduled to other node when metadatasyncer is down, fullsync might fail with error `Duplicated entity for each entity type in one cluster is found`.
+   - Impact: CNS may hold stale volume metadata.
+   - Workaround:
+      - Upgrade CSI driver with this fix.
 
 ### Kubernetes issues
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For Block volume, CNS only allow one instances for one EntityMetadata type in UpdateVolumeMetadataSpec.
Consider the following cases:
1. User create a pvc and a pod "pod1" to use this pvc. Metadata syncer will update the volume metadata in CNS that pod1 is using this pvc.
2. metadata syncer stopped for some reason and unable to push the metadata update down to CNS.
3. User delete the pod "pod1".
4. User create a new pod "pod2" to use this pvc.
5. fullsync detect that in CNS, pod1 is using the pvc, but from Kubernetes view, pod2 is using the pvc. So when invoke the CNS UpdateVolumeMetadata call, it will have two pod EntityMetadata, which will cause CNS fail with error  'Duplicated entity for each entity type in one cluster is found'
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #598

**Special notes for your reviewer**:
Steps to repro this issue:
1. create a pvc "example-vanilla-block-pvc ", wait for pvc bound to pv
2. create a pod "example-vanilla-block-pod" to use this pvc
3. stop vsan-health on VC
4. when vsan-health is stopped, delete the pod, which stop the metadata syncer to delete the pod metadata entry
5. create a new pod "example-vanilla-block-pod-1 " to use the same pvc 
6. start vsan-health on VC
7. when fullsync is triggered, check the syncer log, fullsync failed with error "Duplicated entity for each entity type in one cluster is found."
```
2021-02-19T22:55:12.965Z        INFO    syncer/fullsync.go:417  FullSync: update is required for volume: "ea003513-2a8f-4c90-b550-a520dfd84a73" {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
2021-02-19T22:55:12.965Z        DEBUG   syncer/fullsync.go:455  FullSync: Volume with id "ea003513-2a8f-4c90-b550-a520dfd84a73" added to volume update list     {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
2021-02-19T22:55:12.966Z        DEBUG   syncer/util.go:25       FullSync: Getting all PVs in Bound, Available or Released state {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
2021-02-19T22:55:12.966Z        DEBUG   syncer/util.go:34       FullSync: pv pvc-c0d1d059-481e-46c0-a4d8-451cdf84dc5a is in state Bound {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
2021-02-19T22:55:12.966Z        INFO    syncer/fullsync.go:228  FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion.      {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
2021-02-19T22:55:12.966Z        DEBUG   syncer/util.go:25       FullSync: Getting all PVs in Bound, Available or Released state {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
2021-02-19T22:55:12.966Z        DEBUG   syncer/util.go:34       FullSync: pv pvc-c0d1d059-481e-46c0-a4d8-451cdf84dc5a is in state Bound {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
2021-02-19T22:55:12.967Z        DEBUG   syncer/fullsync.go:275  FullSync: Calling UpdateVolumeMetadata for volume ea003513-2a8f-4c90-b550-a520dfd84a73 with updateSpec: (types.CnsVolumeMetadataUpdateSpec) {
 DynamicData: (types.DynamicData) {
 },
 VolumeId: (types.CnsVolumeId) {
  DynamicData: (types.DynamicData) {
  },
  Id: (string) (len=36) "ea003513-2a8f-4c90-b550-a520dfd84a73"
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=16) "vSAN-FVT-Cluster",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA",
   ClusterDistribution: (string) ""
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) (len=4 cap=4) {
   (*types.CnsKubernetesEntityMetadata)(0xc000756f00)({
    CnsEntityMetadata: (types.CnsEntityMetadata) {
     DynamicData: (types.DynamicData) {
     },
     EntityName: (string) (len=40) "pvc-c0d1d059-481e-46c0-a4d8-451cdf84dc5a",
     Labels: ([]types.KeyValue) <nil>,
     Delete: (bool) false,
     ClusterID: (string) (len=16) "vSAN-FVT-Cluster"
    },
    EntityType: (string) (len=17) "PERSISTENT_VOLUME",
    Namespace: (string) "",
    ReferredEntity: ([]types.CnsKubernetesEntityReference) <nil>
   }),
   (*types.CnsKubernetesEntityMetadata)(0xc000756f80)({
    CnsEntityMetadata: (types.CnsEntityMetadata) {
     DynamicData: (types.DynamicData) {
     },
    EntityName: (string) (len=25) "example-vanilla-block-pvc",
     Labels: ([]types.KeyValue) <nil>,
     Delete: (bool) false,
     ClusterID: (string) (len=16) "vSAN-FVT-Cluster"
    },
    EntityType: (string) (len=23) "PERSISTENT_VOLUME_CLAIM",
    Namespace: (string) (len=7) "default",
    ReferredEntity: ([]types.CnsKubernetesEntityReference) (len=1 cap=1) {
     (types.CnsKubernetesEntityReference) {
      EntityType: (string) (len=17) "PERSISTENT_VOLUME",
      EntityName: (string) (len=40) "pvc-c0d1d059-481e-46c0-a4d8-451cdf84dc5a",
      Namespace: (string) "",
      ClusterID: (string) (len=16) "vSAN-FVT-Cluster"
     }
    }
   }),
   (*types.CnsKubernetesEntityMetadata)(0xc000757000)({
    CnsEntityMetadata: (types.CnsEntityMetadata) {
     DynamicData: (types.DynamicData) {
     },
     EntityName: (string) (len=27) "example-vanilla-block-pod-1",
     Labels: ([]types.KeyValue) <nil>,
     Delete: (bool) false,
     ClusterID: (string) (len=16) "vSAN-FVT-Cluster"
    },
    EntityType: (string) (len=3) "POD",
    Namespace: (string) (len=7) "default",
    ReferredEntity: ([]types.CnsKubernetesEntityReference) (len=1 cap=1) {
     (types.CnsKubernetesEntityReference) {
      EntityType: (string) (len=23) "PERSISTENT_VOLUME_CLAIM",
      EntityName: (string) (len=25) "example-vanilla-block-pvc",
      Namespace: (string) (len=7) "default",
      ClusterID: (string) (len=16) "vSAN-FVT-Cluster"
     }
    }
   }),
   (*types.CnsKubernetesEntityMetadata)(0xc000757480)({
    CnsEntityMetadata: (types.CnsEntityMetadata) {
     DynamicData: (types.DynamicData) {
     },
     EntityName: (string) (len=25) "example-vanilla-block-pod",
     Labels: ([]types.KeyValue) <nil>,
     Delete: (bool) true,
     ClusterID: (string) (len=16) "vSAN-FVT-Cluster"
    },
     EntityType: (string) (len=3) "POD",
    Namespace: (string) (len=7) "default",
    ReferredEntity: ([]types.CnsKubernetesEntityReference) (len=1 cap=1) {
     (types.CnsKubernetesEntityReference) {
      EntityType: (string) (len=23) "PERSISTENT_VOLUME_CLAIM",
      EntityName: (string) (len=25) "example-vanilla-block-pvc",
      Namespace: (string) (len=7) "default",
      ClusterID: (string) (len=16) "vSAN-FVT-Cluster"
     }
    }
   })
  },
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=16) "vSAN-FVT-Cluster",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA",
    ClusterDistribution: (string) ""
   }
  }
 }
}
        {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
2021-02-19T22:55:12.974Z        DEBUG   volume/manager.go:544   Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator      {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
2021-02-19T22:55:13.006Z        ERROR   volume/manager.go:557   CNS UpdateVolume failed from vCenter "10.193.31.70" with err: ServerFaultCode: Duplicated entity for each entity type in one cluster is found.  {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume.(*defaultManager).UpdateVolumeMetadata
        /build/pkg/common/cns-lib/volume/manager.go:557
sigs.k8s.io/vsphere-csi-driver/pkg/syncer.fullSyncUpdateVolumes
        /build/pkg/syncer/fullsync.go:276
2021-02-19T22:55:13.007Z        WARN    syncer/fullsync.go:277  FullSync:UpdateVolumeMetadata failed with err ServerFaultCode: Duplicated entity for each entity type in one cluster is found.  {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
sigs.k8s.io/vsphere-csi-driver/pkg/syncer.fullSyncUpdateVolumes
        /build/pkg/syncer/fullsync.go:277
2021-02-19T22:55:13.007Z        DEBUG   syncer/fullsync.go:125  FullSync: cnsDeletionMap at end of cycle: map[] {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
2021-02-19T22:55:13.007Z        DEBUG   syncer/fullsync.go:126  FullSync: cnsCreationMap at end of cycle: map[] {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
2021-02-19T22:55:13.007Z        INFO    syncer/fullsync.go:127  FullSync: end   {"TraceId": "09dcc17f-e665-49e2-b6f8-5ba3634da1f1"}
```

With the fix in this PR, fullsync succeed. See log 
[tmp-1.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/6040450/tmp-1.txt)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix issue that fullsync returns with error 'Duplicated entity for each entity type in one cluster is found'
```
