### PR TITLE
Removed QueryAllVolume in DeleteVolume workflow.

### DIFF
--- a/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -54,10 +54,6 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
-          ports:
-            - containerPort: 2112
-              name: prometheus
-              protocol: TCP
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -82,6 +78,9 @@ spec:
           ports:
             - name: healthz
               containerPort: 9808
+              protocol: TCP
+            - name: prometheus
+              containerPort: 2112
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -67,10 +67,6 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
-          ports:
-            - containerPort: 2112
-              name: prometheus
-              protocol: TCP
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -95,6 +91,9 @@ spec:
           ports:
             - name: healthz
               containerPort: 9808
+              protocol: TCP
+            - name: prometheus
+              containerPort: 2112
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -65,10 +65,6 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
-          ports:
-            - containerPort: 2112
-              name: prometheus
-              protocol: TCP
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -97,6 +93,9 @@ spec:
           ports:
             - name: healthz
               containerPort: 9808
+              protocol: TCP
+            - name: prometheus
+              containerPort: 2112
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/dev/vsphere-7.0u2/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -68,10 +68,6 @@ spec:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
-          ports:
-            - containerPort: 2112
-              name: prometheus
-              protocol: TCP
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -100,6 +96,9 @@ spec:
           ports:
             - name: healthz
               containerPort: 9808
+              protocol: TCP
+            - name: prometheus
+              containerPort: 2112
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -668,32 +668,8 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 				log.Error(msg)
 				return nil, status.Errorf(codes.Internal, msg)
 			}
-		} else {
-			// Query CNS to get the volume type.
-			queryFilter := cnstypes.CnsQueryFilter{
-				VolumeIds: []cnstypes.CnsVolumeId{{Id: req.VolumeId}},
-			}
-			queryResult, err := c.manager.VolumeManager.QueryAllVolume(ctx, queryFilter, cnstypes.CnsQuerySelection{
-				Names: []string{
-					string(cnstypes.QuerySelectionNameTypeVolumeType),
-				},
-			})
-			if err != nil {
-				msg := fmt.Sprintf("QueryVolume failed for volumeID: %q. %+v", req.VolumeId, err.Error())
-				log.Error(msg)
-				return nil, status.Error(codes.Internal, msg)
-			}
-			if len(queryResult.Volumes) == 0 {
-				msg := fmt.Sprintf("volumeID %s not found in QueryVolume", req.VolumeId)
-				log.Error(msg)
-				return nil, status.Error(codes.Internal, msg)
-			}
-			if queryResult.Volumes[0].VolumeType == common.BlockVolumeType {
-				volumeType = prometheus.PrometheusBlockVolumeType
-			} else {
-				volumeType = prometheus.PrometheusFileVolumeType
-			}
 		}
+		// TODO: Add code to determine the volume type and set volumeType for Prometheus metric accordingly.
 		err = common.DeleteVolumeUtil(ctx, c.manager.VolumeManager, req.VolumeId, true)
 		if err != nil {
 			msg := fmt.Sprintf("failed to delete volume: %q. Error: %+v", req.VolumeId, err)

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -483,31 +483,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 			log.Error(msg)
 			return nil, err
 		}
-		// Query CNS to get the volume type.
-		queryFilter := cnstypes.CnsQueryFilter{
-			VolumeIds: []cnstypes.CnsVolumeId{{Id: req.VolumeId}},
-		}
-		queryResult, err := c.manager.VolumeManager.QueryAllVolume(ctx, queryFilter, cnstypes.CnsQuerySelection{
-			Names: []string{
-				string(cnstypes.QuerySelectionNameTypeVolumeType),
-			},
-		})
-		if err != nil {
-			msg := fmt.Sprintf("QueryVolume failed for volumeID: %q. %+v", req.VolumeId, err.Error())
-			log.Error(msg)
-			return nil, status.Error(codes.Internal, msg)
-		}
-		if len(queryResult.Volumes) == 0 {
-			msg := fmt.Sprintf("volumeID %s not found in QueryVolume", req.VolumeId)
-			log.Error(msg)
-			return nil, status.Error(codes.Internal, msg)
-		}
-		if queryResult.Volumes[0].VolumeType == common.BlockVolumeType {
-			volumeType = prometheus.PrometheusBlockVolumeType
-		} else {
-			volumeType = prometheus.PrometheusFileVolumeType
-		}
-
+		// TODO: Add code to determine the volume type and set volumeType for Prometheus metric accordingly.
 		err = common.DeleteVolumeUtil(ctx, c.manager.VolumeManager, req.VolumeId, true)
 		if err != nil {
 			msg := fmt.Sprintf("failed to delete volume: %q. Error: %+v", req.VolumeId, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Summary:
1. DeleteVolume workflow is changed to not invoke QueryAll API. The prometheus metrics will be pushed with volumeType as 'unknown'. The plan is to address this in the future PR where we will get the volumeType from a CR(possibly introduced as part of orphan volume handling).
2. Consolidated the ports exposed by CSI controller under a single place.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #676

**Special notes for your reviewer**:
1. Tested that the DeleteVolume workflow is working as expected.
2. Validated that the prometheus metrics are exposed as expected.
3. Tested that I can repro the problem without this PR. 

Here's the DeleteVolume logs without the fix:
```
{"level":"error","time":"2021-02-27T00:18:22.410076468Z","caller":"vanilla/controller.go:669","msg":"volumeID 5b5d0501-1b94-43cb-ae05-b03f135119bb not found in QueryVolume","TraceId":"af96f87a-78d9-4aad-8f89-4a3798b9b98a","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.(*controller).DeleteVolume.func1\n\t/build/pkg/csi/service/vanilla/controller.go:669\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla.(*controller).DeleteVolume\n\t/build/pkg/csi/service/vanilla/controller.go:696\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_DeleteVolume_Handler.func1\n\t/go/pkg/mod/github.com/container-storage-interface/spec@v1.2.0/lib/go/csi/csi.pb.go:5164\ngithub.com/rexray/gocsi/middleware/serialvolume.(*interceptor).deleteVolume\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/middleware/serialvolume/serial_volume_locker.go:183\ngithub.com/rexray/gocsi/middleware/serialvolume.(*interceptor).handle\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/middleware/serialvolume/serial_volume_locker.go:92\ngithub.com/rexray/gocsi/utils.ChainUnaryServer.func2.1.1\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/utils/utils_middleware.go:99\ngithub.com/rexray/gocsi/middleware/specvalidator.(*interceptor).handleServer.func1\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/middleware/specvalidator/spec_validator.go:178\ngithub.com/rexray/gocsi/middleware/specvalidator.(*interceptor).handle\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/middleware/specvalidator/spec_validator.go:218\ngithub.com/rexray/gocsi/middleware/specvalidator.(*interceptor).handleServer\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/middleware/specvalidator/spec_validator.go:177\ngithub.com/rexray/gocsi/utils.ChainUnaryServer.func2.1.1\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/utils/utils_middleware.go:99\ngithub.com/rexray/gocsi.(*StoragePlugin).injectContext\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/middleware.go:231\ngithub.com/rexray/gocsi/utils.ChainUnaryServer.func2.1.1\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/utils/utils_middleware.go:99\ngithub.com/rexray/gocsi/utils.ChainUnaryServer.func2\n\t/go/pkg/mod/github.com/rexray/gocsi@v1.2.1/utils/utils_middleware.go:106\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_DeleteVolume_Handler\n\t/go/pkg/mod/github.com/container-storage-interface/spec@v1.2.0/lib/go/csi/csi.pb.go:5166\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1024\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1313\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.1\n\t/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:722"}
```

With this PR, the problem is fixed. Here's the delete workflow logs:
```
{"level":"info","time":"2021-02-27T00:20:32.880349876Z","caller":"vanilla/controller.go:642","msg":"DeleteVolume: called with args: {VolumeId:5b5d0501-1b94-43cb-ae05-b03f135119bb Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"476b6d29-008c-430d-83a3-1a5af50e0dac"}
{"level":"info","time":"2021-02-27T00:20:33.119949835Z","caller":"volume/manager.go:529","msg":"VolumeID: \"5b5d0501-1b94-43cb-ae05-b03f135119bb\", not found. Returning success for this operation since the volume is not present","TraceId":"476b6d29-008c-430d-83a3-1a5af50e0dac"}
```


**Release note**:
```release-note
Ignore CNS QueryAllVolume returning no result in DeleteVolume workflow.
```

Validated that the vsphere_csi metrics exposed for DeleteVolume has volumeType as "unknown":
```
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="1"} 0
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="2"} 0
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="3"} 0
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="4"} 0
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="5"} 0
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="7"} 0
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="10"} 0
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="12"} 1
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="15"} 1
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="18"} 2
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="20"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="25"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="30"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="60"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="120"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="180"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="300"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="create-volume",status="pass",voltype="block",le="+Inf"} 10
vsphere_csi_volume_ops_histogram_sum{optype="create-volume",status="pass",voltype="block"} 181.831416217
vsphere_csi_volume_ops_histogram_count{optype="create-volume",status="pass",voltype="block"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="1"} 0
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="2"} 1
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="3"} 2
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="4"} 2
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="5"} 2
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="7"} 2
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="10"} 2
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="12"} 3
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="15"} 4
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="18"} 5
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="20"} 5
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="25"} 9
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="30"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="60"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="120"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="180"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="300"} 10
vsphere_csi_volume_ops_histogram_bucket{optype="delete-volume",status="pass",voltype="unknown",le="+Inf"} 10
vsphere_csi_volume_ops_histogram_sum{optype="delete-volume",status="pass",voltype="unknown"} 161.352650547
vsphere_csi_volume_ops_histogram_count{optype="delete-volume",status="pass",voltype="unknown"} 10
```