### PR TITLE
Add new field /status/capacity/allocatableSpace in Storage Pool CRD

### DIFF
--- a/pkg/apis/storagepool/cns/v1alpha1/storagepool_types.go
+++ b/pkg/apis/storagepool/cns/v1alpha1/storagepool_types.go
@@ -55,6 +55,9 @@ type PoolCapacity struct {
 	// Free Space of the storage pool
 	// +optional
 	FreeSpace *resource.Quantity `json:"freeSpace,omitempty"`
+	// allocatable capacity of storage pool
+	// +optional
+	AllocatableSpace *resource.Quantity `json:"allocatableSpace,omitempty"`
 }
 
 // StoragePoolError describes an error encountered on the pool

--- a/pkg/apis/storagepool/config/cns.vmware.com_storagepools.yaml
+++ b/pkg/apis/storagepool/config/cns.vmware.com_storagepools.yaml
@@ -57,6 +57,13 @@ spec:
             capacity:
               description: Total Capacity of the storage pool
               properties:
+                allocatableSpace:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: allocatable capacity of storage pool
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
                 freeSpace:
                   anyOf:
                   - type: integer


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a new field under status/capacity called allocatableSpace, which indicates the amount of space which can be allocated to a persistent volume. When creating a persistent volume some of the free space is consumed in overhead. We get allocatableSpace by subtracting overhead space from freeSpace. In vSAN-SNA overhead is upperbound by 4% of volume requested capacity and In vSAN Direct it is upperbound by 4MiB space. Thus maximum allocatable space in vSAN-SNA is 96% of free-capacity and in vSAN Direct its 4MiB less than free capacity.

**Special notes for your reviewer**:
**Tests**: Steps:

1. Replaced the existing syncer image with the image containing this code. Observe that a new field called allocatableSpace has been added. 
```
# tracking storagepool corressponding to a vsan-direct and a vsan-sna datastore
# Before image replacement
$ kubectl get storagepool -oyaml | grep -v "f:" | grep -A 2 "name\|capacity"
    name: storagepool-vsandatastore-wdc-rdops-vm05-dhcp-95-140.eng.vmware.com
    resourceVersion: "1629145"
    selfLink: /apis/cns.vmware.com/v1alpha1/storagepools/storagepool-vsandatastore-wdc-rdops-vm05-dhcp-95-140.eng.vmware.com
--
    capacity:
      freeSpace: 141222383454
      total: 214731587584

    name: storagepool-vsandirect-10.92.95.140-mpx.vmhba0-c0-t2-l0
    resourceVersion: "1628706"
    selfLink: /apis/cns.vmware.com/v1alpha1/storagepools/storagepool-vsandirect-10.92.95.140-mpx.vmhba0-c0-t2-l0
--
    capacity:
      freeSpace: 83852525568
      total: 85630910464
```

```
# After image replacement
$ kubectl get storagepool -oyaml | grep -v "f:" | grep -A 3 "name\|capacity" 
    name: storagepool-vsandatastore-wdc-rdops-vm05-dhcp-95-140.eng.vmware.com
    resourceVersion: "1633667"
    selfLink: /apis/cns.vmware.com/v1alpha1/storagepools/storagepool-vsandatastore-wdc-rdops-vm05-dhcp-95-140.eng.vmware.com
    uid: 33e7d97f-f397-4bc1-b9c6-5c5de63daa01
--
    capacity:
      allocatableSpace: 134848712384 # = 128601.75 MiB
      freeSpace: 140467408734
      total: 214731587584
--
    name: storagepool-vsandirect-10.92.95.140-mpx.vmhba0-c0-t2-l0
    resourceVersion: "1633678"
    selfLink: /apis/cns.vmware.com/v1alpha1/storagepools/storagepool-vsandirect-10.92.95.140-mpx.vmhba0-c0-t2-l0
    uid: 40b3f77f-13ce-4e8b-969b-0a969ff4038f
--
    capacity:
      allocatableSpace: 83848331264 #  = 79964 MiB
      freeSpace: 83852525568
      total: 85630910464
```
2. Verify that space mentioned in allocatableApace is indeed allocatable by creating PVCs to be placed on respective StoragePool and requesting space = allocatableSpace.
```
$ k get pv,pvc -A
NAME                                                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                      STORAGECLASS               REASON   AGE
persistentvolume/pvc-329a7a58-89f6-4ba7-8672-d6631eda31f2   128601Mi   RWO            Delete           Bound    psp-ns/vsan-sna-pvc-0      sample-vsan-sna-thick               3m
persistentvolume/pvc-87349853-c31d-48f5-80ef-b6b01838c107   79964Mi    RWO            Delete           Bound    psp-ns/vsan-direct-pvc-0   sample-vsan-direct-thick            3m

NAMESPACE   NAME                                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS               AGE
psp-ns      persistentvolumeclaim/vsan-direct-pvc-0   Bound    pvc-87349853-c31d-48f5-80ef-b6b01838c107   79964Mi    RWO            sample-vsan-direct-thick   3m
psp-ns      persistentvolumeclaim/vsan-sna-pvc-0      Bound    pvc-329a7a58-89f6-4ba7-8672-d6631eda31f2   128601Mi   RWO            sample-vsan-sna-thick      3m

$ kubectl get storagepool -oyaml | grep -v "f:" | grep -A 3 "name\|capacity" 
  name: storagepool-vsandatastore-wdc-rdops-vm05-dhcp-95-140.eng.vmware.com
  resourceVersion: "1648716"
  selfLink: /apis/cns.vmware.com/v1alpha1/storagepools/storagepool-vsandatastore-wdc-rdops-vm05-dhcp-95-140.eng.vmware.com
  uid: 33e7d97f-f397-4bc1-b9c6-5c5de63daa01
--
  capacity:
    allocatableSpace: 2714043523 # 2588.31 MiB
    freeSpace: 2827128670
    total: 214731587584
--
  name: storagepool-vsandirect-10.92.95.140-mpx.vmhba0-c0-t2-l0
  resourceVersion: "1655587"
  selfLink: /apis/cns.vmware.com/v1alpha1/storagepools/storagepool-vsandirect-10.92.95.140-mpx.vmhba0-c0-t2-l0
  uid: 40b3f77f-13ce-4e8b-969b-0a969ff4038f
--
  capacity:
    allocatableSpace: 0
    freeSpace: 3145728
    total: 85630910464
```
3. See that if we try to provision volume above allocatable space it fails with NotEnoughResources error.
```
# yaml spec of PVC
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: vsan-direct-pvc-1
  labels:
    supervisor: "true"
  annotations:
    volume.beta.kubernetes.io/storage-class: sample-vsan-direct-thick
spec:
  storageClassName: sample-vsan-direct-thick
  accessModes:
    - ReadWriteOnce
  volumeMode: Filesystem
  resources:
    requests:
      storage: 79965Mi

# vsan direct SP capacities
$ kubectl get storagepool  -oyaml | grep -v "f:" | grep -A 3 "name\|capacity"
    name: storagepool-vsandirect-10.92.66.4-mpx.vmhba0-c0-t2-l0
--
    capacity:
      allocatableSpace: 83848331264 # = 79964 MiB
      freeSpace: 83852525568
      total: 85630910464
--
    name: storagepool-vsandirect-10.92.71.22-mpx.vmhba0-c0-t2-l0
--
    capacity:
      allocatableSpace: 83848331264  # = 79964 MiB
      freeSpace: 83852525568
      total: 85630910464
--
    name: storagepool-vsandirect-10.92.76.255-mpx.vmhba0-c0-t2-l0
--
    capacity:
      allocatableSpace: 83848331264  # = 79964 MiB
      freeSpace: 83852525568
      total: 85630910464
--
    name: storagepool-vsandirect-10.92.95.140-mpx.vmhba0-c0-t2-l0
--
    capacity:
      allocatableSpace: 0
      freeSpace: 3145728
      total: 85630910464
 
$ kubectl describe pvc vsan-direct-pvc-1 -n psp-ns
Name:          vsan-direct-pvc-1
Namespace:     psp-ns
StorageClass:  sample-vsan-direct-thick
Status:        Pending
Volume:
Annotations:   failure-domain.beta.vmware.com/storagepool: FAILED_PLACEMENT-NotEnoughResources  <======
               volume.beta.kubernetes.io/storage-class: sample-vsan-direct-thick
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/selected-node: wdc-rdops-vm05-dhcp-66-4.eng.vmware.com
Capacity:
Events:
  Type     Reason                Age                   From                                                                                          Message
  ----     ------                ----                  ----                                                                                          -------
  Normal   WaitForFirstConsumer  3m (x10 over 5m14s)   persistentvolume-controller                                                                   waiting for first consumer to be created before binding
  Normal   Provisioning          52s (x8 over 2m58s)   csi.vsphere.vmware.com_421dd767a260c173f811f6c39e21081b_5626e59e-47fd-481a-a7b7-9a9f4bf8eeff  External provisioner is provisioning volume for claim "psp-ns/vsan-direct-pvc-1"
  Warning  ProvisioningFailed    52s (x8 over 2m58s)   csi.vsphere.vmware.com_421dd767a260c173f811f6c39e21081b_5626e59e-47fd-481a-a7b7-9a9f4bf8eeff  failed to provision volume with StorageClass "sample-vsan-direct-thick": rpc error: code = Unknown desc = fail to find a StoragePool passing all criteria
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add new field /status/capacity/allocatableSpace in Storage Pool CRD
```
