### PR TITLE
Cherrypick fix of fullsync bug that CNS returns `Duplicated entity for each entity` to release-2.2 branch

### DIFF
--- a/docs/book/releases/v2.1.0.md
+++ b/docs/book/releases/v2.1.0.md
@@ -53,6 +53,10 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
 7. When a Pod is rescheduled to a new node, there may be some lock contention which causes a delay in the volume getting detached from the old node and attached to the new node.
    - Impact: Rescheduled Pods remain in `Pending` state for an varying amount of time.
    - Workaround: Upgrade CSI driver to `v2.1.1`.
+8. When pod using a PVC is rescheduled to other node when metadatasyncer is down, fullsync might fail with error `Duplicated entity for each entity type in one cluster is found`.
+   - Impact: CNS may hold stale volume metadata.
+   - Workaround:
+      - Upgrade CSI driver with this fix.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.1.1.md
+++ b/docs/book/releases/v2.1.1.md
@@ -54,6 +54,10 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
    - Impact: In-tree vSphere volumes will not get migrated successfully
    - Workaround:
       - Upgrade CSI driver with this fix.
+7. When pod using a PVC is rescheduled to other node when metadatasyncer is down, fullsync might fail with error `Duplicated entity for each entity type in one cluster is found`.
+   - Impact: CNS may hold stale volume metadata.
+   - Workaround:
+      - Upgrade CSI driver with this fix.
 
 ### Kubernetes issues
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherrypick fix of fullsync bug that CNS returns `Duplicated entity for each entity` to release-2.2 branch
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/671

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
