### PR TITLE
[release-2.2 cherry-pick] Prevent GetVsanDatastores from throwing an error if a DC does not have datastores

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -385,6 +385,10 @@ func (vc *VirtualCenter) GetVsanDatastores(ctx context.Context) (map[string]*Dat
 		finder.SetDatacenter(dc.Datacenter)
 		datastoresList, err := finder.DatastoreList(ctx, "*")
 		if err != nil {
+			if _, ok := err.(*find.NotFoundError); ok {
+				log.Debugf("No datastores found on %q datacenter", dc.Name())
+				continue
+			}
 			log.Errorf("failed to get all the datastores. err: %+v", err)
 			return nil, err
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Cherry pick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/690 from master to release branch 2.2

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Prevent GetVsanDatastores from throwing an error if a DC does not have datastores 
```
