### PR TITLE
Add registerDisk & retrieveVStorageObject methods to support CSI migration on vsphere 67p04 and 7.0

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -48,6 +48,21 @@ func IsNotFoundError(err error) bool {
 	return isNotFoundError
 }
 
+// IsAlreadyExists checks if err is the AlreadyExists fault, if no then returns false
+// If the error is AlreadyExists fault, the method return true along with the
+// name of the managed object
+func IsAlreadyExists(err error) (bool, string) {
+	isAlreadyExistsError := false
+	objectName := ""
+	if soap.IsSoapFault(err) {
+		_, isAlreadyExistsError = soap.ToSoapFault(err).VimFault().(types.AlreadyExists)
+		if isAlreadyExistsError {
+			objectName = soap.ToSoapFault(err).VimFault().(types.AlreadyExists).Name
+		}
+	}
+	return isAlreadyExistsError, objectName
+}
+
 // IsManagedObjectNotFound checks if err is the ManagedObjectNotFound fault, if yes then returns true else return false
 func IsManagedObjectNotFound(err error) bool {
 	isNotFoundError := false

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vmware/govmomi/cns"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vsan"
+	"github.com/vmware/govmomi/vslm"
 
 	"sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
@@ -65,6 +66,8 @@ type VirtualCenter struct {
 	CnsClient *cns.Client
 	// VsanClient represents the VSAN client instance.
 	VsanClient *vsan.Client
+	// VslmClient represents the Vslm client instance.
+	VslmClient *vslm.Client
 }
 
 var (
@@ -278,6 +281,13 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 	if vc.CnsClient != nil {
 		if vc.CnsClient, err = NewCnsClient(ctx, vc.Client.Client); err != nil {
 			log.Errorf("failed to create CNS client on vCenter host %v with err: %v", vc.Config.Host, err)
+			return err
+		}
+	}
+	// Recreate VslmClient If created using timed out VC Client
+	if vc.VslmClient != nil {
+		if vc.VslmClient, err = NewVslmClient(ctx, vc.Client.Client); err != nil {
+			log.Errorf("failed to create Vslm client on vCenter host %v with err: %v", vc.Config.Host, err)
 			return err
 		}
 	}

--- a/pkg/common/cns-lib/vsphere/vslm.go
+++ b/pkg/common/cns-lib/vsphere/vslm.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vslm"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+)
+
+// NewVslmClient creates a new Vslm client
+func NewVslmClient(ctx context.Context, c *vim25.Client) (*vslm.Client, error) {
+	log := logger.GetLogger(ctx)
+	vslmClient, err := vslm.NewClient(ctx, c)
+	if err != nil {
+		log.Errorf("failed to create a new client for Vslm. err: %v", err)
+		return nil, err
+	}
+	return vslmClient, nil
+}
+
+// ConnectVslm creates a Vslm client for the virtual center.
+func (vc *VirtualCenter) ConnectVslm(ctx context.Context) error {
+	log := logger.GetLogger(ctx)
+	var err = vc.Connect(ctx)
+	if err != nil {
+		log.Errorf("failed to connect to Virtual Center host %q with err: %v", vc.Config.Host, err)
+		return err
+	}
+	if vc.VslmClient == nil {
+		if vc.VslmClient, err = NewVslmClient(ctx, vc.Client.Client); err != nil {
+			log.Errorf("failed to create Vslm client on vCenter host %q with err: %v", vc.Config.Host, err)
+			return err
+		}
+	}
+	return nil
+}
+
+// DisconnectVslm destroys the Vslm client for the virtual center.
+func (vc *VirtualCenter) DisconnectVslm(ctx context.Context) {
+	log := logger.GetLogger(ctx)
+	if vc.VslmClient == nil {
+		log.Info("VslmClient wasn't connected, ignoring")
+	} else {
+		vc.VslmClient = nil
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding implementation for RegisterDisk method in volume manager of vsphere CSI driver to promote virtual disks as FCD using Vslm endpoint. This is needed to support CSI migration feature in vSphere 67P04 release.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Wrote a small test program to verify the register disk method:
```
Successfully registered virtual disk with path 'https://10.186.43.166/folder/5f064860-20c3-afde-7154-02009d37541e/vm-3.vmdk?dcPath=datacenter&dsName=vsanDatastore' as FCD
```

```
client_test.go:69: Failed to register volume. Error: ServerFaultCode: The specified key, name, or identifier '5825f1ab-4f7b-44ea-ac84-ba2d67120b8d' already exists. 
 client_test.go:70: ServerFaultCode: The specified key, name, or identifier '5825f1ab-4f7b-44ea-ac84-ba2d67120b8d' already exists.
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add registerDisk method to promote virtual disks as FCD needed for CSI migration support in vsphere 67p04
```
