### PR TITLE
[Cherry-pick] Add empty datacenter issue to known issues for current 2.1.x releases 

### DIFF
--- a/docs/book/releases/v2.1.0.md
+++ b/docs/book/releases/v2.1.0.md
@@ -48,15 +48,16 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
       - If user has accidentally left orphan volumes on the datastore by not following the guideline, and if user has captured the volume handles or First Class Disk IDs of deleted PVs, storage admin can help delete those volumes using `govc disk.rm <volume-handle/FCD ID>` command.
 6. When in-tree vSphere plugin is configured to use default datastore in this format default-datastore: `</datacenter-name>/datastore/<default-datastore-name>`, migration of the volume will fail as mentioned here: https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/628. If default datastore is configured in this format `<default-datastore-name>` then we do not see this issue
    - Impact: In-tree vSphere volumes will not get migrated successfully
-   - Workaround:
-      - Upgrade CSI driver with this fix.
+   - Workaround: This is being fixed in an upcoming version.
 7. When a Pod is rescheduled to a new node, there may be some lock contention which causes a delay in the volume getting detached from the old node and attached to the new node.
    - Impact: Rescheduled Pods remain in `Pending` state for an varying amount of time.
    - Workaround: Upgrade CSI driver to `v2.1.1`.
 8. When pod using a PVC is rescheduled to other node when metadatasyncer is down, fullsync might fail with error `Duplicated entity for each entity type in one cluster is found`.
    - Impact: CNS may hold stale volume metadata.
-   - Workaround:
-      - Upgrade CSI driver with this fix.
+   - Workaround: This is being fixed in an upcoming version.
+9. If there are no datastores present in any one of the datacenters in your vSphere environment, CSI file volume provisioning fails with `failed to get all the datastores` error.
+   - Impact: File volume provisioning keeps failing.
+   - Workaround: Either remove the `ReadOnly` privilege on this datacenter for the user listed in the `vsphere-config-secret` secret or add a datastore to this datacenter. Refer to `vsphere-roles-and-privileges` section in the [prerequisites](../driver-deployment/prerequisites.md) page to change the permissions on this datacenter.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.1.1.md
+++ b/docs/book/releases/v2.1.1.md
@@ -52,12 +52,13 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
       - If user has accidentally left orphan volumes on the datastore by not following the guideline, and if user has captured the volume handles or First Class Disk IDs of deleted PVs, storage admin can help delete those volumes using `govc disk.rm <volume-handle/FCD ID>` command.
 6. When in-tree vSphere plugin is configured to use default datastore in this format default-datastore: `</datacenter-name>/datastore/<default-datastore-name>`, migration of the volume will fail as mentioned here: https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/628. If default datastore is configured in this format `<default-datastore-name>` then we do not see this issue
    - Impact: In-tree vSphere volumes will not get migrated successfully
-   - Workaround:
-      - Upgrade CSI driver with this fix.
+   - Workaround: This is being fixed in an upcoming version.
 7. When pod using a PVC is rescheduled to other node when metadatasyncer is down, fullsync might fail with error `Duplicated entity for each entity type in one cluster is found`.
    - Impact: CNS may hold stale volume metadata.
-   - Workaround:
-      - Upgrade CSI driver with this fix.
+   - Workaround: This is being fixed in an upcoming version.
+8. If there are no datastores present in any one of the datacenters in your vSphere environment, CSI file volume provisioning fails with `failed to get all the datastores` error.
+   - Impact: File volume provisioning keeps failing.
+   - Workaround: Either remove the `ReadOnly` privilege on this datacenter for the user listed in the `vsphere-config-secret` secret or add a datastore to this datacenter. Refer to `vsphere-roles-and-privileges` section in the [prerequisites](../driver-deployment/prerequisites.md) page to change the permissions on this datacenter.
 
 ### Kubernetes issues
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Cherry-pick PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/694

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add empty datacenter issue to known issues for current 2.1.x releases
```
