### PR TITLE
Update pvcsi yamls

### DIFF
--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -41,6 +41,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
@@ -354,7 +357,7 @@ spec:
         - name: sys-devices-dir
           mountPath: /sys/devices
       - name: liveness-probe
-        image: vmware.io/csi-livenessprobe/csi-livenessprobe:<image_tag>
+        image: vmware.io/csi-livenessprobe:<image_tag>
         args:
         - --csi-address=/csi/csi.sock
         imagePullPolicy: "IfNotPresent"

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -41,6 +41,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
@@ -354,7 +357,7 @@ spec:
         - name: sys-devices-dir
           mountPath: /sys/devices
       - name: liveness-probe
-        image: vmware.io/csi-livenessprobe/csi-livenessprobe:<image_tag>
+        image: vmware.io/csi-livenessprobe:<image_tag>
         args:
         - --csi-address=/csi/csi.sock
         imagePullPolicy: "IfNotPresent"

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -41,6 +41,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
@@ -354,7 +357,7 @@ spec:
         - name: sys-devices-dir
           mountPath: /sys/devices
       - name: liveness-probe
-        image: vmware.io/csi-livenessprobe/csi-livenessprobe:<image_tag>
+        image: vmware.io/csi-livenessprobe:<image_tag>
         args:
         - --csi-address=/csi/csi.sock
         imagePullPolicy: "IfNotPresent"

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.20/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.20/pvcsi.yaml
@@ -41,6 +41,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
@@ -354,7 +357,7 @@ spec:
         - name: sys-devices-dir
           mountPath: /sys/devices
       - name: liveness-probe
-        image: vmware.io/csi-livenessprobe/csi-livenessprobe:<image_tag>
+        image: vmware.io/csi-livenessprobe:<image_tag>
         args:
         - --csi-address=/csi/csi.sock
         imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is a follow up to https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/700

Changes image name of liveness probe. 
Add `patch` permissions to `volumeattachment/status` for external-attacher. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Attach volumeattachment status patch permissions and modify liveness probe tag for node daemonset
```
