### PR TITLE
Logout existing VC client if we encounter error while connecting to other components in VC

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -211,6 +211,14 @@ func (vc *VirtualCenter) Connect(ctx context.Context) error {
 	err := vc.connect(ctx, false)
 	if err != nil {
 		log.Errorf("Cannot connect to vCenter with err: %v", err)
+		// Logging out of the current session to make sure we
+		// retry creating a new client in the next attempt
+		defer func() {
+			logoutErr := vc.Client.Logout(ctx)
+			if logoutErr != nil {
+				log.Errorf("Could not logout of VC session. Error: %v", logoutErr)
+			}
+		}()
 	}
 	return err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: If we try to create a PVC while the VC is getting rebooted, all CSI operations post the reboot is complete start to fail with `ServerFaultCode: NotAuthenticated` error. This is because the VC connect function fails to retry if the code fails after the main VC client is created, this means the client connections to PBM, CNS and vSAN are stale. This fix will ensure that the VC client is logged out on all connection failures and creates a new connection in the next attempt.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: Testing done:
Tried creating a volume during a VC reboot and the volume creation succeeded as soon as VC and all its components (PBM, CNS and vSAN) are up. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Logout existing VC client if we encounter error while connecting to other components in VC
```
