### PR TITLE
[Cherry-pick] Logout VC client if we encounter error while connecting

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -211,6 +211,14 @@ func (vc *VirtualCenter) Connect(ctx context.Context) error {
 	err := vc.connect(ctx, false)
 	if err != nil {
 		log.Errorf("Cannot connect to vCenter with err: %v", err)
+		// Logging out of the current session to make sure we
+		// retry creating a new client in the next attempt
+		defer func() {
+			logoutErr := vc.Client.Logout(ctx)
+			if logoutErr != nil {
+				log.Errorf("Could not logout of VC session. Error: %v", logoutErr)
+			}
+		}()
 	}
 	return err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Cherry-pick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/711 to 2.2 branch

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: All test cases have been run in the master branch commit

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Logout VC client if we encounter error while connecting
```
