### PR TITLE
Resolve inconsistencies in the vanilla YAMLs for different vSphere versions

### DIFF
--- a/manifests/v2.2.0/vsphere-67u3/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.2.0/vsphere-67u3/deploy/vsphere-csi-controller-deployment.yaml
@@ -54,13 +54,17 @@ spec:
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: X_CSI_MODE
               value: "controller"
             - name: VSPHERE_CSI_CONFIG
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -71,7 +75,7 @@ spec:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
           ports:
             - name: healthz
@@ -114,6 +118,10 @@ spec:
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/manifests/v2.2.0/vsphere-67u3/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.2.0/vsphere-67u3/deploy/vsphere-csi-node-ds.yaml
@@ -9,6 +9,8 @@ spec:
       app: vsphere-csi-node
   updateStrategy:
     type: "RollingUpdate"
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:
@@ -100,7 +102,7 @@ spec:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 5
           periodSeconds: 5
           failureThreshold: 3
       - name: liveness-probe

--- a/manifests/v2.2.0/vsphere-7.0/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.2.0/vsphere-7.0/deploy/vsphere-csi-controller-deployment.yaml
@@ -70,13 +70,17 @@ spec:
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: X_CSI_MODE
               value: "controller"
             - name: VSPHERE_CSI_CONFIG
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -87,7 +91,7 @@ spec:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
           ports:
             - name: healthz
@@ -130,6 +134,10 @@ spec:
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/manifests/v2.2.0/vsphere-7.0/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.2.0/vsphere-7.0/deploy/vsphere-csi-node-ds.yaml
@@ -9,6 +9,8 @@ spec:
       app: vsphere-csi-node
   updateStrategy:
     type: "RollingUpdate"
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:
@@ -100,7 +102,7 @@ spec:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 5
           periodSeconds: 5
           failureThreshold: 3
       - name: liveness-probe

--- a/manifests/v2.2.0/vsphere-7.0u1/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.2.0/vsphere-7.0u1/deploy/vsphere-csi-node-ds.yaml
@@ -100,7 +100,7 @@ spec:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 5
           periodSeconds: 5
           failureThreshold: 3
       - name: liveness-probe

--- a/manifests/v2.2.0/vsphere-7.0u1/rbac/vsphere-csi-node-rbac.yaml
+++ b/manifests/v2.2.0/vsphere-7.0u1/rbac/vsphere-csi-node-rbac.yaml
@@ -1,0 +1,29 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-node
+  namespace: kube-system
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-role
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-binding
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: vsphere-csi-node-role
+  apiGroup: rbac.authorization.k8s.io

--- a/manifests/v2.2.0/vsphere-7.0u2/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.2.0/vsphere-7.0u2/deploy/vsphere-csi-node-ds.yaml
@@ -105,7 +105,7 @@ spec:
             path: /healthz
             port: healthz
           initialDelaySeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 5
           periodSeconds: 5
           failureThreshold: 3
       - name: liveness-probe


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: We have noticed certain irregularities between the YAMLs for each vsphere version in vanilla folder. These are harmless changes and will not cause any changes in the workflow but we need to maintain consistency in our YAMLs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Resolve inconsistencies in the vanilla YAMLs for different vSphere versions
```
