### PR TITLE
Add volume health timestamp in GC.

### DIFF
--- a/pkg/syncer/volume_health_reconciler.go
+++ b/pkg/syncer/volume_health_reconciler.go
@@ -419,12 +419,13 @@ func (rc *volumeHealthReconciler) updateTKGPVC(ctx context.Context, svcPVC *v1.P
 		log.Infof("updateTKGPVC: Detected volume health annotation change. Need to update Tanzu Kubernetes Grid PVC %s/%s. Existing TKG PVC annotation: %s. New annotation: %s", tkgPVCObj.Namespace, tkgPVCObj.Name, tkgAnnValue, svcAnnValue)
 		tkgPVCClone := tkgPVCObj.DeepCopy()
 		metav1.SetMetaDataAnnotation(&tkgPVCClone.ObjectMeta, annVolumeHealth, svcAnnValue)
+		metav1.SetMetaDataAnnotation(&tkgPVCClone.ObjectMeta, annVolumeHealthTS, time.Now().Format(time.UnixDate))
 		_, err := rc.tkgKubeClient.CoreV1().PersistentVolumeClaims(tkgPVCClone.Namespace).Update(ctx, tkgPVCClone, metav1.UpdateOptions{})
 		if err != nil {
 			log.Errorf("cannot update claim [%s/%s]: [%v]", tkgPVCClone.Namespace, tkgPVCClone.Name, err)
 			return err
 		}
-		log.Infof("updateTKGPVC: Updated Tanzu Kubernetes Grid PVC %s/%s", tkgPVCObj.Namespace, tkgPVCObj.Name)
+		log.Infof("updateTKGPVC: Updated Tanzu Kubernetes Grid PVC %s/%s, set annotation %s at time %s", tkgPVCObj.Namespace, tkgPVCObj.Name, svcAnnValue, time.Now().Format(time.UnixDate))
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is to add volume health timestamp annotation for PVC in WCP guest cluster.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Test Result.
1. create a PVC in guest cluster. wait for PVC and PV bound.
2. check the PVC in supervisor cluster, the volume health timestamp annotation has been set on PVC.
```
root@420d2943d85aa4fb095e340b57f19395 [ ~ ]# kubectl describe pvc -n test-gc-e2e-demo-ns   a5419804-27b1-464f-9605-1d2161d3f923-636c971a-7f60-4c6c-bed4-f00df1937915
Name:          a5419804-27b1-464f-9605-1d2161d3f923-636c971a-7f60-4c6c-bed4-f00df1937915
Namespace:     test-gc-e2e-demo-ns
StorageClass:  gc-storage-profile
Status:        Bound
Volume:        pvc-6aab3c65-6a6b-4589-a635-afde31145c0b
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Thu Mar 11 19:48:35 UTC 2021
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
Events:
  Type     Reason                 Age                    From                                                                                          Message
  ----     ------                 ----                   ----                                                                                          -------
  Warning  ProvisioningFailed     6m36s (x2 over 6m38s)  csi.vsphere.vmware.com_420d2943d85aa4fb095e340b57f19395_d3c5181a-75b7-4838-b30f-1569f0f6121c  failed to provision volume with StorageClass "gc-storage-profile": rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 127.0.0.1:29000: connect: connection refused"
  Normal   Provisioning           6m34s (x3 over 6m38s)  csi.vsphere.vmware.com_420d2943d85aa4fb095e340b57f19395_d3c5181a-75b7-4838-b30f-1569f0f6121c  External provisioner is provisioning volume for claim "test-gc-e2e-demo-ns/a5419804-27b1-464f-9605-1d2161d3f923-636c971a-7f60-4c6c-bed4-f00df1937915"
  Normal   ExternalProvisioning   6m27s (x4 over 6m54s)  persistentvolume-controller                                                                   waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   ProvisioningSucceeded  6m5s                   csi.vsphere.vmware.com_420d2943d85aa4fb095e340b57f19395_d3c5181a-75b7-4838-b30f-1569f0f6121c  Successfully provisioned volume pvc-6aab3c65-6a6b-4589-a635-afde31145c0b
```
3. check the PVC in guest cluster, the volume health timestamp annotation has been set on PVC too.
```
root@420d2943d85aa4fb095e340b57f19395 [ ~ ]# export KUBECONFIG=tkc
root@420d2943d85aa4fb095e340b57f19395 [ ~ ]# kubectl describe pvc example-vanilla-block-pvc
Name:          example-vanilla-block-pvc
Namespace:     default
StorageClass:  gc-storage-profile
Status:        Bound
Volume:        pvc-636c971a-7f60-4c6c-bed4-f00df1937915
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Thu Mar 11 19:48:59 UTC 2021
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
Events:
  Type     Reason                 Age                     From                                                                                                Message
  ----     ------                 ----                    ----                                                                                                -------
  Normal   Provisioning           8m11s                   csi.vsphere.vmware.com_vsphere-csi-controller-65bc688c9-tfb5l_838db2ee-3b44-4456-97d8-ca16ab79a287  External provisioner is provisioning volume for claim "default/example-vanilla-block-pvc"
  Warning  ProvisioningFailed     7m57s                   csi.vsphere.vmware.com_vsphere-csi-controller-65bc688c9-tfb5l_838db2ee-3b44-4456-97d8-ca16ab79a287  failed to provision volume with StorageClass "gc-storage-profile": rpc error: code = Canceled desc = context canceled
  Warning  ProvisioningFailed     5m53s                   csi.vsphere.vmware.com_vsphere-csi-controller-65bc688c9-tfb5l_a2ac843f-f0b1-4faf-bb7d-5930f7df9b80  failed to provision volume with StorageClass "gc-storage-profile": rpc error: code = Internal desc = failed to create volume on namespace: test-gc-e2e-demo-ns  in supervisor cluster. Error: persistentVolumeClaim a5419804-27b1-464f-9605-1d2161d3f923-636c971a-7f60-4c6c-bed4-f00df1937915 in namespace test-gc-e2e-demo-ns not in phase Bound within 240 seconds
  Normal   Provisioning           5m52s (x2 over 7m42s)   csi.vsphere.vmware.com_vsphere-csi-controller-65bc688c9-tfb5l_a2ac843f-f0b1-4faf-bb7d-5930f7df9b80  External provisioner is provisioning volume for claim "default/example-vanilla-block-pvc"
  Normal   ExternalProvisioning   5m14s (x13 over 8m11s)  persistentvolume-controller                                                                         waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   ProvisioningSucceeded  5m9s                    csi.vsphere.vmware.com_vsphere-csi-controller-65bc688c9-tfb5l_a2ac843f-f0b1-4faf-bb7d-5930f7df9b80  Successfully provisioned volume pvc-636c971a-7f60-4c6c-bed4-f00df1937915

```
4. check the PVCSI log,  see the following log.
```
kubectl logs  vsphere-csi-controller-65bc688c9-tfb5l -c vsphere-syncer -n vmware-system-csi | grep "updateTKGPVC"
{"level":"info","time":"2021-03-11T19:48:59.396816162Z","caller":"syncer/volume_health_reconciler.go:419","msg":"updateTKGPVC: Detected volume health annotation change. Need to update Tanzu Kubernetes Grid PVC default/example-vanilla-block-pvc. Existing TKG PVC annotation: . New annotation: accessible","TraceId":"3d559f18-9baf-4fe4-9f3e-1b7a12489640"}
{"level":"info","time":"2021-03-11T19:48:59.604682057Z","caller":"syncer/volume_health_reconciler.go:428","msg":"updateTKGPVC: Updated Tanzu Kubernetes Grid PVC default/example-vanilla-block-pvc, set annotation accessible at time Thu Mar 11 19:48:59 UTC 2021","TraceId":"3d559f18-9baf-4fe4-9f3e-1b7a12489640"}
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
add volume health timestamp annotation for PVC in WCP guest cluster.
```
