### PR TITLE
Not run auth manager for file volumes if vSAN file services is not enabled

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 
+	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/sts"
 	"github.com/vmware/govmomi/vapi/rest"
@@ -355,4 +356,17 @@ func GetDatastoreInfoByURL(ctx context.Context, vc *VirtualCenter, clusterID, ds
 		}
 	}
 	return nil, fmt.Errorf("datastore corresponding to URL %v not found in cluster %v", dsURL, clusterID)
+}
+
+// isVsan67u3Release returns true if it is vSAN 67u3 Release of vCenter.
+func isVsan67u3Release(ctx context.Context, m *defaultVirtualCenterManager, host string) (bool, error) {
+	log := logger.GetLogger(ctx)
+	log.Debug("Checking if vCenter version is of vsan 67u3 release")
+	vc, err := m.GetVirtualCenter(ctx, host)
+	if err != nil || vc == nil {
+		log.Errorf("failed to get vcenter version. Err: %v", err)
+		return false, err
+	}
+	log.Debugf("vCenter version is :%q", vc.Client.Version)
+	return vc.Client.Version == cns.ReleaseVSAN67u3, nil
 }

--- a/pkg/common/cns-lib/vsphere/virtualcentermanager.go
+++ b/pkg/common/cns-lib/vsphere/virtualcentermanager.go
@@ -48,6 +48,10 @@ type VirtualCenterManager interface {
 	UnregisterVirtualCenter(ctx context.Context, host string) error
 	// UnregisterAllVirtualCenters disconnects and unregisters all virtual centers.
 	UnregisterAllVirtualCenters(ctx context.Context) error
+	// IsvSANFileServicesSupported checks if vSAN file services is supported or not.
+	IsvSANFileServicesSupported(ctx context.Context, host string) (bool, error)
+	// IsExtendVolumeSupported checks if extend volume is supported or not.
+	IsExtendVolumeSupported(ctx context.Context, host string) (bool, error)
 }
 
 var (
@@ -144,4 +148,26 @@ func (m *defaultVirtualCenterManager) UnregisterAllVirtualCenters(ctx context.Co
 		return true
 	})
 	return err
+}
+
+// IsvSANFileServicesSupported checks if vSAN file services is supported or not.
+func (m *defaultVirtualCenterManager) IsvSANFileServicesSupported(ctx context.Context, host string) (bool, error) {
+	log := logger.GetLogger(ctx)
+	is67u3Release, err := isVsan67u3Release(ctx, m, host)
+	if err != nil {
+		log.Errorf("Failed to identify the vCenter release with error: %+v", err)
+		return false, err
+	}
+	return !is67u3Release, nil
+}
+
+// IsExtendVolumeSupported checks if extend volume is supported or not.
+func (m *defaultVirtualCenterManager) IsExtendVolumeSupported(ctx context.Context, host string) (bool, error) {
+	log := logger.GetLogger(ctx)
+	is67u3Release, err := isVsan67u3Release(ctx, m, host)
+	if err != nil {
+		log.Errorf("Failed to identify the vCenter release with error: %+v", err)
+		return false, err
+	}
+	return !is67u3Release, nil
 }

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/fsnotify/fsnotify"
-	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/units"
 	"github.com/vmware/govmomi/vapi/tags"
@@ -65,23 +64,6 @@ type controller struct {
 
 // volumeMigrationService holds the pointer to VolumeMigration instance
 var volumeMigrationService migration.VolumeMigrationService
-
-var (
-	// VSAN67u3ControllerServiceCapability represents the capability of controller service
-	// for VSAN67u3 release
-	VSAN67u3ControllerServiceCapability = []csi.ControllerServiceCapability_RPC_Type{
-		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
-		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
-	}
-
-	// VSAN7ControllerServiceCapability represents the capability of controller service
-	// for VSAN 7.0 release
-	VSAN7ControllerServiceCapability = []csi.ControllerServiceCapability_RPC_Type{
-		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
-		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
-		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
-	}
-)
 
 // New creates a CNS controller
 func New() csitypes.CnsController {
@@ -167,8 +149,15 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		c.authMgr = authMgr
 		go common.ComputeDatastoreMapForBlockVolumes(authMgr.(*common.AuthManager),
 			config.Global.CSIAuthCheckIntervalInMin)
-		go common.ComputeDatastoreMapForFileVolumes(authMgr.(*common.AuthManager),
-			config.Global.CSIAuthCheckIntervalInMin)
+		isvSANFileServicesSupported, err := c.manager.VcenterManager.IsvSANFileServicesSupported(ctx, c.manager.VcenterConfig.Host)
+		if err != nil {
+			log.Errorf("failed to verify if vSAN file services is supported or not. Error:%+v", err)
+			return err
+		}
+		if isvSANFileServicesSupported {
+			go common.ComputeDatastoreMapForFileVolumes(authMgr.(*common.AuthManager),
+				config.Global.CSIAuthCheckIntervalInMin)
+		}
 	}
 
 	watcher, err := fsnotify.NewWatcher()
@@ -603,12 +592,12 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		}
 		if common.IsFileVolumeRequest(ctx, volumeCapabilities) {
 			volumeType = prometheus.PrometheusFileVolumeType
-			vsan67u3Release, err := isVsan67u3Release(ctx, c)
+			isvSANFileServicesSupported, err := c.manager.VcenterManager.IsvSANFileServicesSupported(ctx, c.manager.VcenterConfig.Host)
 			if err != nil {
-				log.Error("failed to get vcenter version to help identify if fileshare volume creation should be permitted or not. Error:%v", err)
+				log.Errorf("failed to verify if vSAN file services is supported or not. Error:%+v", err)
 				return nil, status.Error(codes.Internal, err.Error())
 			}
-			if vsan67u3Release {
+			if !isvSANFileServicesSupported {
 				msg := "fileshare volume creation is not supported on vSAN 67u3 release"
 				log.Error(msg)
 				return nil, status.Error(codes.FailedPrecondition, msg)
@@ -989,22 +978,6 @@ func (c *controller) GetCapacity(ctx context.Context, req *csi.GetCapacityReques
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// isVsan67u3Release returns true if controller is dealing with vSAN 67u3 Release of vCenter.
-func isVsan67u3Release(ctx context.Context, c *controller) (bool, error) {
-	log := logger.GetLogger(ctx)
-	log.Debug("Checking if vCenter version is of vsan 67u3 release")
-	if c.manager == nil || c.manager.VolumeManager == nil {
-		return false, errors.New("cannot retrieve vcenter version. controller manager is not initialized")
-	}
-	vc, err := c.manager.VcenterManager.GetVirtualCenter(ctx, c.manager.VcenterConfig.Host)
-	if err != nil || vc == nil {
-		log.Errorf("failed to get vcenter version. Err: %v", err)
-		return false, err
-	}
-	log.Debugf("vCenter version is :%q", vc.Client.Version)
-	return vc.Client.Version == cns.ReleaseVSAN67u3, nil
-}
-
 // initVolumeMigrationService is a helper method to initialize volumeMigrationService in controller
 func initVolumeMigrationService(ctx context.Context, c *controller) error {
 	log := logger.GetLogger(ctx)
@@ -1029,19 +1002,20 @@ func (c *controller) ControllerGetCapabilities(ctx context.Context, req *csi.Con
 	log := logger.GetLogger(ctx)
 	log.Infof("ControllerGetCapabilities: called with args %+v", *req)
 
-	var controllerCaps []csi.ControllerServiceCapability_RPC_Type
-
-	vsan67u3Release, err := isVsan67u3Release(ctx, c)
+	isExtendSupported, err := c.manager.VcenterManager.IsExtendVolumeSupported(ctx, c.manager.VcenterConfig.Host)
 	if err != nil {
-		log.Error("failed to get vcenter version to help identify controller service capabilities")
+		log.Errorf("failed to verify if extend volume is supported or not. Error:%+v", err)
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}
-	if vsan67u3Release {
-		controllerCaps = VSAN67u3ControllerServiceCapability
-	} else {
-		controllerCaps = VSAN7ControllerServiceCapability
+	controllerCaps := []csi.ControllerServiceCapability_RPC_Type{
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 	}
-
+	if isExtendSupported {
+		log.Debug("Adding extend volume capability to default capabilities")
+		controllerCaps = append(controllerCaps,
+			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME)
+	}
 	var caps []*csi.ControllerServiceCapability
 	for _, cap := range controllerCaps {
 		c := &csi.ControllerServiceCapability{


### PR DESCRIPTION
**What this PR does / why we need it**:
Make sure CSI driver doesn't compute datastores for file volumes when file services is not supported in vSphere67U3. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes  https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/723

**Special notes for your reviewer**:

**Release note**:
```release-note
Not run auth manager for file volumes if vSAN file services is not enabled
```

**Testing done:**

`make-unitest` passed.

CSI init logs on vSphere 67U3.
```
root@k8s-master:~# kubectl logs -f $POD_NAME -c vsphere-csi-controller -n kube-system
{"level":"info","time":"2021-03-16T23:03:00.784557973Z","caller":"logger/logger.go:37","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2021-03-16T23:03:00.802847093Z","caller":"vsphere-csi/main.go:54","msg":"Version : v2.1.0-rc.1-494-g1d18953-dirty","TraceId":"f57dd77c-de41-4068-b6ad-e2a19a30094b"}
{"level":"info","time":"2021-03-16T23:03:00.806356916Z","caller":"logger/logger.go:37","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2021-03-16T23:03:00.815452501Z","caller":"k8sorchestrator/k8sorchestrator.go:122","msg":"Initializing k8sOrchestratorInstance","TraceId":"cd38a958-4930-4b12-a7ea-f31935e120fd"}
{"level":"info","time":"2021-03-16T23:03:00.815976692Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"cd38a958-4930-4b12-a7ea-f31935e120fd"}
{"level":"info","time":"2021-03-16T23:03:00.818381328Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"cd38a958-4930-4b12-a7ea-f31935e120fd"}
{"level":"info","time":"2021-03-16T23:03:00.85773021Z","caller":"k8sorchestrator/k8sorchestrator.go:234","msg":"New internal feature states values stored successfully: map[csi-auth-check:true csi-migration:false]","TraceId":"cd38a958-4930-4b12-a7ea-f31935e120fd"}
{"level":"info","time":"2021-03-16T23:03:00.858369952Z","caller":"k8sorchestrator/k8sorchestrator.go:148","msg":"k8sOrchestratorInstance initialized","TraceId":"cd38a958-4930-4b12-a7ea-f31935e120fd"}
{"level":"info","time":"2021-03-16T23:03:00.859541149Z","caller":"config/config.go:302","msg":"No Net Permissions given in Config. Using default permissions.","TraceId":"cd38a958-4930-4b12-a7ea-f31935e120fd"}
{"level":"info","time":"2021-03-16T23:03:00.859860242Z","caller":"vanilla/controller.go:97","msg":"Initializing CNS controller","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.860116315Z","caller":"vsphere/utils.go:126","msg":"Defaulting timeout for vCenter Client to 5 minutes","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.860505916Z","caller":"vsphere/virtualcentermanager.go:69","msg":"Initializing defaultVirtualCenterManager...","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.86064699Z","caller":"vsphere/virtualcentermanager.go:71","msg":"Successfully initialized defaultVirtualCenterManager","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.861127044Z","caller":"vsphere/virtualcentermanager.go:115","msg":"Successfully registered VC \"10.184.78.154\"","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.861180619Z","caller":"volume/manager.go:111","msg":"Initializing new volume.defaultManager...","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.891174139Z","caller":"k8sorchestrator/k8sorchestrator.go:273","msg":"New feature states values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[csi-auth-check:true csi-migration:false]","TraceId":"0a837b7c-eec7-45a0-b5ac-81baa810311e"}
{"level":"info","time":"2021-03-16T23:03:00.947532009Z","caller":"vsphere/virtualcenter.go:159","msg":"New session ID for 'VSPHERE.LOCAL\\Administrator' = 52c133d7-de4f-3ef4-eeea-eb3e7d459ba4","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.947893127Z","caller":"node/manager.go:75","msg":"Initializing node.defaultManager...","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.948966155Z","caller":"node/manager.go:79","msg":"node.defaultManager initialized","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.949081508Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.949462386Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.952322029Z","caller":"vanilla/controller.go:160","msg":"CSIAuthCheck feature is enabled, loading AuthorizationService","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.952487501Z","caller":"common/authmanager.go:73","msg":"Initializing authorization service...","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.952548391Z","caller":"common/authmanager.go:83","msg":"authorization service initialized","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.954849022Z","caller":"vanilla/controller.go:210","msg":"Adding watch on path: \"/etc/cloud\"","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:00.954957176Z","caller":"service/service.go:106","msg":"configured: \"csi.vsphere.vmware.com\" with clusterFlavor: \"VANILLA\" and mode: \"controller\"","TraceId":"cd38a958-4930-4b12-a7ea-f31935e120fd"}
time="2021-03-16T23:03:00Z" level=info msg="identity service registered"
time="2021-03-16T23:03:00Z" level=info msg="controller service registered"
time="2021-03-16T23:03:00Z" level=info msg=serving endpoint="unix:///var/lib/csi/sockets/pluginproxy/csi.sock"
{"level":"info","time":"2021-03-16T23:03:00.956322502Z","caller":"common/authmanager.go:146","msg":"auth manager: ComputeDatastoreMapForBlockVolumes enter"}
{"level":"info","time":"2021-03-16T23:03:00.964305973Z","caller":"vanilla/controller.go:228","msg":"Starting the http server to expose Prometheus metrics..","TraceId":"2a415b6d-1c29-4cf1-b988-48903c6fc2a5"}
{"level":"info","time":"2021-03-16T23:03:01.016389151Z","caller":"node/manager.go:103","msg":"Successfully registered node: \"k8s-master\" with nodeUUID \"42184777-7f71-21a3-725f-2c12d0e18bda\"","TraceId":"aec3e78b-adc0-4c11-bb93-826526abfb26"}
{"level":"info","time":"2021-03-16T23:03:01.016753637Z","caller":"vsphere/virtualmachine.go:123","msg":"Initiating asynchronous datacenter listing with uuid 42184777-7f71-21a3-725f-2c12d0e18bda","TraceId":"aec3e78b-adc0-4c11-bb93-826526abfb26"}
{"level":"info","time":"2021-03-16T23:03:01.038144603Z","caller":"vanilla/controller.go:1021","msg":"ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"4c32f7b6-2343-4eb4-9865-5df16c1cd3c9"}
{"level":"info","time":"2021-03-16T23:03:01.038321262Z","caller":"vanilla/controller.go:1031","msg":"balu - controller caps for 67U3","TraceId":"4c32f7b6-2343-4eb4-9865-5df16c1cd3c9"}
{"level":"info","time":"2021-03-16T23:03:01.04915112Z","caller":"vanilla/controller.go:1021","msg":"ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"8202c8e0-92d2-4dc0-ae50-27ae726def9f"}
{"level":"info","time":"2021-03-16T23:03:01.050593687Z","caller":"vanilla/controller.go:1031","msg":"balu - controller caps for 67U3","TraceId":"8202c8e0-92d2-4dc0-ae50-27ae726def9f"}
{"level":"info","time":"2021-03-16T23:03:01.055766982Z","caller":"vsphere/datacenter.go:145","msg":"Publishing datacenter Datacenter [Datacenter: Datacenter:datacenter-2 @ /datacenter, VirtualCenterHost: 10.184.78.154]","TraceId":"aec3e78b-adc0-4c11-bb93-826526abfb26"}
{"level":"info","time":"2021-03-16T23:03:01.056301122Z","caller":"vsphere/virtualmachine.go:160","msg":"AsyncGetAllDatacenters with uuid 42184777-7f71-21a3-725f-2c12d0e18bda sent a dc Datacenter [Datacenter: Datacenter:datacenter-2 @ /datacenter, VirtualCenterHost: 10.184.78.154]","TraceId":"aec3e78b-adc0-4c11-bb93-826526abfb26"}
{"level":"info","time":"2021-03-16T23:03:01.060600936Z","caller":"vsphere/virtualmachine.go:174","msg":"Found VM VirtualMachine:vm-127 [VirtualCenterHost: 10.184.78.154, UUID: 42184777-7f71-21a3-725f-2c12d0e18bda, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /datacenter, VirtualCenterHost: 10.184.78.154]] given uuid 42184777-7f71-21a3-725f-2c12d0e18bda on DC Datacenter [Datacenter: Datacenter:datacenter-2 @ /datacenter, VirtualCenterHost: 10.184.78.154]","TraceId":"aec3e78b-adc0-4c11-bb93-826526abfb26"}
{"level":"info","time":"2021-03-16T23:03:01.060804988Z","caller":"vsphere/virtualmachine.go:185","msg":"Returning VM VirtualMachine:vm-127 [VirtualCenterHost: 10.184.78.154, UUID: 42184777-7f71-21a3-725f-2c12d0e18bda, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /datacenter, VirtualCenterHost: 10.184.78.154]] for UUID 42184777-7f71-21a3-725f-2c12d0e18bda","TraceId":"aec3e78b-adc0-4c11-bb93-826526abfb26"}
{"level":"info","time":"2021-03-16T23:03:01.060904268Z","caller":"node/manager.go:123","msg":"Successfully discovered node with nodeUUID 42184777-7f71-21a3-725f-2c12d0e18bda in vm VirtualMachine:vm-127 [VirtualCenterHost: 10.184.78.154, UUID: 42184777-7f71-21a3-725f-2c12d0e18bda, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /datacenter, VirtualCenterHost: 10.184.78.154]]","TraceId":"aec3e78b-adc0-4c11-bb93-826526abfb26"}
{"level":"info","time":"2021-03-16T23:03:01.061111271Z","caller":"node/manager.go:109","msg":"Successfully discovered node: \"k8s-master\" with nodeUUID \"42184777-7f71-21a3-725f-2c12d0e18bda\"","TraceId":"aec3e78b-adc0-4c11-bb93-826526abfb26"}
{"level":"info","time":"2021-03-16T23:03:01.061607827Z","caller":"node/manager.go:103","msg":"Successfully registered node: \"k8s-node1\" with nodeUUID \"4218edfd-67b7-ef58-3e39-83b98a672111\"","TraceId":"60bb5fd0-2a36-4ca3-973f-120d448cc548"}
{"level":"info","time":"2021-03-16T23:03:01.061672179Z","caller":"vsphere/virtualmachine.go:123","msg":"Initiating asynchronous datacenter listing with uuid 4218edfd-67b7-ef58-3e39-83b98a672111","TraceId":"60bb5fd0-2a36-4ca3-973f-120d448cc548"}
{"level":"info","time":"2021-03-16T23:03:01.123585667Z","caller":"vsphere/datacenter.go:145","msg":"Publishing datacenter Datacenter [Datacenter: Datacenter:datacenter-2 @ /datacenter, VirtualCenterHost: 10.184.78.154]","TraceId":"60bb5fd0-2a36-4ca3-973f-120d448cc548"}
{"level":"info","time":"2021-03-16T23:03:01.123661964Z","caller":"vsphere/virtualmachine.go:160","msg":"AsyncGetAllDatacenters with uuid 4218edfd-67b7-ef58-3e39-83b98a672111 sent a dc Datacenter [Datacenter: Datacenter:datacenter-2 @ /datacenter, VirtualCenterHost: 10.184.78.154]","TraceId":"60bb5fd0-2a36-4ca3-973f-120d448cc548"}
{"level":"info","time":"2021-03-16T23:03:01.135030466Z","caller":"vsphere/virtualmachine.go:174","msg":"Found VM VirtualMachine:vm-128 [VirtualCenterHost: 10.184.78.154, UUID: 4218edfd-67b7-ef58-3e39-83b98a672111, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /datacenter, VirtualCenterHost: 10.184.78.154]] given uuid 4218edfd-67b7-ef58-3e39-83b98a672111 on DC Datacenter [Datacenter: Datacenter:datacenter-2 @ /datacenter, VirtualCenterHost: 10.184.78.154]","TraceId":"60bb5fd0-2a36-4ca3-973f-120d448cc548"}
{"level":"info","time":"2021-03-16T23:03:01.135080028Z","caller":"vsphere/virtualmachine.go:185","msg":"Returning VM VirtualMachine:vm-128 [VirtualCenterHost: 10.184.78.154, UUID: 4218edfd-67b7-ef58-3e39-83b98a672111, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /datacenter, VirtualCenterHost: 10.184.78.154]] for UUID 4218edfd-67b7-ef58-3e39-83b98a672111","TraceId":"60bb5fd0-2a36-4ca3-973f-120d448cc548"}
{"level":"info","time":"2021-03-16T23:03:01.13509833Z","caller":"node/manager.go:123","msg":"Successfully discovered node with nodeUUID 4218edfd-67b7-ef58-3e39-83b98a672111 in vm VirtualMachine:vm-128 [VirtualCenterHost: 10.184.78.154, UUID: 4218edfd-67b7-ef58-3e39-83b98a672111, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-2 @ /datacenter, VirtualCenterHost: 10.184.78.154]]","TraceId":"60bb5fd0-2a36-4ca3-973f-120d448cc548"}
{"level":"info","time":"2021-03-16T23:03:01.135109138Z","caller":"node/manager.go:109","msg":"Successfully discovered node: \"k8s-node1\" with nodeUUID \"4218edfd-67b7-ef58-3e39-83b98a672111\"","TraceId":"60bb5fd0-2a36-4ca3-973f-120d448cc548"}
```

cc @chethanv28 @divyenpatel 