### PR TITLE
Fix typo in the error message formatting

### DIFF
--- a/pkg/syncer/cnsoperator/controller/triggercsifullsync/triggercsifullsync_controller.go
+++ b/pkg/syncer/cnsoperator/controller/triggercsifullsync/triggercsifullsync_controller.go
@@ -244,7 +244,7 @@ func (r *ReconcileTriggerCsiFullSync) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, nil
 	}
 	if fullSyncErr != nil {
-		msg := fmt.Sprintf("Full sync failed for triggerSyncID: %d with error: %+v", triggerSyncID, err)
+		msg := fmt.Sprintf("Full sync failed for triggerSyncID: %d with error: %+v", triggerSyncID, fullSyncErr)
 		log.Error(msg)
 		setInstanceError(ctx, r, instance, msg, startTime)
 	} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing a minor typo in error message formatting
Here is the wrong error message:
```
Full sync failed for triggerSyncID: 3 with error: <nil>
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix typo in the error message formatting in trigger full sync controller
```
