### PR TITLE
Enable CSI auth check in vSphere 67U3 and 7.0 manifests

### DIFF
--- a/manifests/dev/vsphere-67u3/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/vsphere-csi-driver.yaml
@@ -85,7 +85,7 @@ roleRef:
 apiVersion: v1
 data:
   "csi-migration": "false"
-  "csi-auth-check": "false"
+  "csi-auth-check": "true"
   "online-volume-extend": "false"
   "trigger-csi-fullsync" : "false"
 kind: ConfigMap

--- a/manifests/dev/vsphere-7.0/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/vsphere-csi-driver.yaml
@@ -88,7 +88,7 @@ roleRef:
 apiVersion: v1
 data:
   "csi-migration": "false"
-  "csi-auth-check": "false"
+  "csi-auth-check": "true"
   "online-volume-extend": "false"
   "trigger-csi-fullsync" : "false"
 kind: ConfigMap


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable CSI auth check in vSphere 67U3 and 7.0
This PR is already tested as part of https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/724

**Release note**:
```release-note
Enable CSI auth check in vSphere 67U3 and 7.0
```

@divyenpatel  @chethanv28 
