### PR TITLE
Do not populate volumemanager for TKG as part of CnsOperator Init

### DIFF
--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -69,11 +69,15 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 	log.Infof("Initializing CNS Operator")
 	cnsOperator := &cnsOperator{}
 	cnsOperator.configInfo = configInfo
-	vCenter, err := types.GetVirtualCenterInstance(ctx, cnsOperator.configInfo, false)
-	if err != nil {
-		return err
+
+	var volumeManager volumes.Manager
+	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload || clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
+		vCenter, err := types.GetVirtualCenterInstance(ctx, cnsOperator.configInfo, false)
+		if err != nil {
+			return err
+		}
+		volumeManager = volumes.GetManager(ctx, vCenter)
 	}
-	volumeManager := volumes.GetManager(ctx, vCenter)
 
 	// Get a config to talk to the apiserver
 	restConfig, err := config.GetConfig()


### PR DESCRIPTION
**What this PR does / why we need it**:
The syncer container is failing to come up for TKG cluster because of following error
```
{"level":"info","time":"2021-03-18T21:08:31.89442173Z","caller":"syncer/metadatasyncer.go:124","msg":"Initializing MetadataSyncer"}
{"level":"info","time":"2021-03-18T21:08:31.895841273Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config"}
{"level":"info","time":"2021-03-18T21:08:31.898849471Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2021-03-18T21:08:31.91091174Z","caller":"manager/init.go:69","msg":"Initializing CNS Operator","TraceId":"d77debe0-f931-4b6a-99c7-f0fb9bae1f76"}
{"level":"info","time":"2021-03-18T21:08:31.911230159Z","caller":"types/commontypes.go:69","msg":"Initializing new vCenterInstance.","TraceId":"d77debe0-f931-4b6a-99c7-f0fb9bae1f76"}
{"level":"error","time":"2021-03-18T21:08:31.911837123Z","caller":"types/commontypes.go:74","msg":"failed to get VirtualCenterConfig. Err: Unable get vCenter Hosts from VSphereConfig","TraceId":"d77debe0-f931-4b6a-99c7-f0fb9bae1f76","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/types.GetVirtualCenterInstance\n\t/build/mts/release/sb-44968070/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/syncer/types/commontypes.go:74\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer/cnsoperator/manager.InitCnsOperator\n\t/build/mts/release/sb-44968070/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/syncer/cnsoperator/manager/init.go:72\nmain.initSyncerComponents.func1.2\n\t/build/mts/release/sb-44968070/cayman_vsphere_csi_driver/vsphere_csi_driver/src/cmd/syncer/main.go:171"}
{"level":"error","time":"2021-03-18T21:08:31.912239118Z","caller":"syncer/main.go:172","msg":"Error initializing Cns Operator. Error: Unable get vCenter Hosts from VSphereConfig","stacktrace":"main.initSyncerComponents.func1.2\n\t/build/mts/release/sb-44968070/cayman_vsphere_csi_driver/vsphere_csi_driver/src/cmd/syncer/main.go:172"}
```

The reason this is happening is because InitCnsOperator is trying to populate the volume manager which is not required for TKG.  

What this PR does is to add checks so that it doesn't populate volume manager for TKG and does it for only vanilla and SV.

**Release note**:
```release-note
Do not populate volumemanager for TKG as part of CnsOperator Init
```

**Testing Done:**

Syncer Init logs with `trigger-csi-fullsync` feature flag disabled.
```
root@4218d1b3b7b60decf43ec818f1012daa [ ~ ]# kubectl  logs -n vmware-system-csi              vsphere-csi-controller-7598dbfcb8-kdwzs -c vsphere-syncer -f
{"level":"info","time":"2021-03-18T21:56:25.266992267Z","caller":"logger/logger.go:37","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2021-03-18T21:56:25.26852011Z","caller":"syncer/main.go:72","msg":"Version : v2.1.0-rc.1-510-g19dbdc7-dirty","TraceId":"7d73bbe0-58b5-4385-9c3c-b0819f497bef"}
{"level":"info","time":"2021-03-18T21:56:25.269679569Z","caller":"syncer/main.go:89","msg":"Starting container with operation mode: METADATA_SYNC","TraceId":"7d73bbe0-58b5-4385-9c3c-b0819f497bef"}
{"level":"info","time":"2021-03-18T21:56:25.272559568Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"7d73bbe0-58b5-4385-9c3c-b0819f497bef"}
{"level":"info","time":"2021-03-18T21:56:25.276135876Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"7d73bbe0-58b5-4385-9c3c-b0819f497bef"}
I0318 21:56:25.277771       1 leaderelection.go:242] attempting to acquire leader lease  vmware-system-csi/vsphere-syncer...
{"level":"info","time":"2021-03-18T21:56:25.278730327Z","caller":"syncer/main.go:115","msg":"Starting the http server to expose Prometheus metrics..","TraceId":"7d73bbe0-58b5-4385-9c3c-b0819f497bef"}
I0318 21:56:44.747777       1 leaderelection.go:252] successfully acquired lease vmware-system-csi/vsphere-syncer
{"level":"info","time":"2021-03-18T21:56:44.753882798Z","caller":"k8sorchestrator/k8sorchestrator.go:122","msg":"Initializing k8sOrchestratorInstance","TraceId":"40cb688b-6866-463a-b86f-60396ce5c9bc"}
{"level":"info","time":"2021-03-18T21:56:44.757831849Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"40cb688b-6866-463a-b86f-60396ce5c9bc"}
{"level":"info","time":"2021-03-18T21:56:44.761743201Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"40cb688b-6866-463a-b86f-60396ce5c9bc"}
{"level":"info","time":"2021-03-18T21:56:44.804743952Z","caller":"k8sorchestrator/k8sorchestrator.go:216","msg":"New supervisor feature states values stored successfully: map[csi-auth-check:false file-volume:false online-volume-extend:true volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"40cb688b-6866-463a-b86f-60396ce5c9bc"}
{"level":"info","time":"2021-03-18T21:56:44.836936127Z","caller":"k8sorchestrator/k8sorchestrator.go:234","msg":"New internal feature states values stored successfully: map[file-volume:false online-volume-extend:true trigger-csi-fullsync:false volume-extend:true volume-health:true]","TraceId":"40cb688b-6866-463a-b86f-60396ce5c9bc"}
{"level":"info","time":"2021-03-18T21:56:44.841796686Z","caller":"k8sorchestrator/k8sorchestrator.go:148","msg":"k8sOrchestratorInstance initialized","TraceId":"40cb688b-6866-463a-b86f-60396ce5c9bc"}
{"level":"info","time":"2021-03-18T21:56:44.854776197Z","caller":"k8sorchestrator/k8sorchestrator.go:490","msg":"trigger-csi-fullsync feature state set to false in internal-feature-states.csi.vsphere.vmware.com ConfigMap","TraceId":"40cb688b-6866-463a-b86f-60396ce5c9bc"}
{"level":"info","time":"2021-03-18T21:56:44.859166611Z","caller":"syncer/metadatasyncer.go:124","msg":"Initializing MetadataSyncer"}
{"level":"info","time":"2021-03-18T21:56:44.866810502Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config"}
{"level":"info","time":"2021-03-18T21:56:44.865853312Z","caller":"manager/init.go:69","msg":"Initializing CNS Operator","TraceId":"4fdc7e29-06a8-4468-89ca-e7ff9a177bd3"}
{"level":"info","time":"2021-03-18T21:56:44.874537996Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2021-03-18T21:56:44.879891734Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2021-03-18T21:56:44.884159819Z","caller":"k8sorchestrator/k8sorchestrator.go:269","msg":"New feature states values from \"csi-feature-states\" stored successfully: map[csi-auth-check:false file-volume:false online-volume-extend:true volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"05ee2a21-fe73-4f43-8221-c59a05d9e713"}
{"level":"info","time":"2021-03-18T21:56:44.886383732Z","caller":"k8sorchestrator/k8sorchestrator.go:273","msg":"New feature states values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[file-volume:false online-volume-extend:true trigger-csi-fullsync:false volume-extend:true volume-health:true]","TraceId":"499b07ea-9d52-44bd-a62f-bb20a9a27f1c"}
{"level":"info","time":"2021-03-18T21:56:45.075901695Z","caller":"kubernetes/kubernetes.go:143","msg":"Connecting to supervisor cluster using the certs/token in Guest Cluster config"}
{"level":"info","time":"2021-03-18T21:56:45.078669422Z","caller":"syncer/metadatasyncer.go:208","msg":"Adding watch on path: \"/etc/cloud/pvcsi-config\""}
{"level":"info","time":"2021-03-18T21:56:45.079261481Z","caller":"syncer/metadatasyncer.go:216","msg":"Adding watch on path: \"/etc/cloud/pvcsi-provider\""}
{"level":"info","time":"2021-03-18T21:56:45.180588826Z","caller":"syncer/metadatasyncer.go:259","msg":"Initialized metadata syncer"}
{"level":"info","time":"2021-03-18T21:56:45.180892738Z","caller":"syncer/metadatasyncer.go:89","msg":"FullSync: fullSync interval is set to 30 minutes"}
{"level":"info","time":"2021-03-18T21:56:45.184110689Z","caller":"k8sorchestrator/k8sorchestrator.go:490","msg":"trigger-csi-fullsync feature state set to false in internal-feature-states.csi.vsphere.vmware.com ConfigMap"}
{"level":"info","time":"2021-03-18T21:56:45.185303134Z","caller":"syncer/metadatasyncer.go:308","msg":"\"trigger-csi-fullsync\" feature flag is not enabled. Using the traditional way to directly invoke full sync"}
{"level":"info","time":"2021-03-18T21:56:45.186309735Z","caller":"syncer/metadatasyncer.go:313","msg":"fullSync is triggered"}
{"level":"info","time":"2021-03-18T21:56:45.191789742Z","caller":"syncer/metadatasyncer.go:1242","msg":"supervisorNamespace test-gc-e2e-demo-ns","TraceId":"8855980a-f690-40c2-b752-dbd730b7715a"}
{"level":"info","time":"2021-03-18T21:56:45.193601974Z","caller":"syncer/metadatasyncer.go:1243","msg":"initVolumeHealthReconciler is triggered","TraceId":"8855980a-f690-40c2-b752-dbd730b7715a"}
{"level":"info","time":"2021-03-18T21:56:45.193230637Z","caller":"syncer/metadatasyncer.go:1268","msg":"initResizeReconciler is triggered","TraceId":"6195f74e-c839-4b40-a734-abd014daed09"}
{"level":"info","time":"2021-03-18T21:56:45.193376739Z","caller":"syncer/pvcsi_fullsync.go:37","msg":"FullSync: Start","TraceId":"6195f74e-c839-4b40-a734-abd014daed09"}
{"level":"info","time":"2021-03-18T21:56:45.226040513Z","caller":"syncer/pvcsi_fullsync.go:95","msg":"FullSync: Creating CnsVolumeMetadata fac0a95a-04ac-4750-b0ed-c13b8349f160-4f8f9acd-4d5d-4d0c-a014-807372874806 on the supervisor cluster for entity type \"PERSISTENT_VOLUME\"","TraceId":"6195f74e-c839-4b40-a734-abd014daed09"}
{"level":"info","time":"2021-03-18T21:56:45.299052091Z","caller":"syncer/resize_reconciler.go:159","msg":"Resize reconciler: Start","TraceId":"6195f74e-c839-4b40-a734-abd014daed09"}
{"level":"info","time":"2021-03-18T21:56:45.325478673Z","caller":"syncer/util.go:183","msg":"getPVCKey: PVC key test-gc-e2e-demo-ns/example-vanilla-block-pvc","TraceId":"228b1fd3-15f7-4c95-8091-4fb318f6725f"}
{"level":"info","time":"2021-03-18T21:56:45.325582707Z","caller":"syncer/volume_health_reconciler.go:245","msg":"addPVC: add test-gc-e2e-demo-ns/example-vanilla-block-pvc to claim queue","TraceId":"228b1fd3-15f7-4c95-8091-4fb318f6725f"}
{"level":"info","time":"2021-03-18T21:56:45.3302479Z","caller":"syncer/util.go:183","msg":"getPVCKey: PVC key test-gc-e2e-demo-ns/fac0a95a-04ac-4750-b0ed-c13b8349f160-4e1173de-0b7e-4ab1-b3ae-9c0948a16187","TraceId":"01640c09-e0e5-4c51-8d39-d97d624d09a7"}
{"level":"info","time":"2021-03-18T21:56:45.330535625Z","caller":"syncer/volume_health_reconciler.go:245","msg":"addPVC: add test-gc-e2e-demo-ns/fac0a95a-04ac-4750-b0ed-c13b8349f160-4e1173de-0b7e-4ab1-b3ae-9c0948a16187 to claim queue","TraceId":"01640c09-e0e5-4c51-8d39-d97d624d09a7"}
{"level":"info","time":"2021-03-18T21:56:45.338546022Z","caller":"syncer/pvcsi_fullsync.go:95","msg":"FullSync: Creating CnsVolumeMetadata fac0a95a-04ac-4750-b0ed-c13b8349f160-4e1173de-0b7e-4ab1-b3ae-9c0948a16187 on the supervisor cluster for entity type \"PERSISTENT_VOLUME_CLAIM\"","TraceId":"6195f74e-c839-4b40-a734-abd014daed09"}
{"level":"info","time":"2021-03-18T21:56:45.380766702Z","caller":"manager/init.go:173","msg":"Registering Components for Cns Operator","TraceId":"4fdc7e29-06a8-4468-89ca-e7ff9a177bd3"}
{"level":"info","time":"2021-03-18T21:56:45.384188868Z","caller":"k8sorchestrator/k8sorchestrator.go:490","msg":"trigger-csi-fullsync feature state set to false in internal-feature-states.csi.vsphere.vmware.com ConfigMap","TraceId":"a0065b3c-ef36-4ebe-859f-e10144fe7bc7"}
{"level":"info","time":"2021-03-18T21:56:45.384679366Z","caller":"triggercsifullsync/triggercsifullsync_controller.go:82","msg":"Not initializing the TriggerCsiFullSync Controller as TriggerCsiFullSync feature is disabled on the cluster","TraceId":"a0065b3c-ef36-4ebe-859f-e10144fe7bc7"}
{"level":"info","time":"2021-03-18T21:56:45.388332975Z","caller":"manager/init.go:187","msg":"Starting Cns Operator","TraceId":"4fdc7e29-06a8-4468-89ca-e7ff9a177bd3"}
{"level":"info","time":"2021-03-18T21:56:45.40874791Z","caller":"syncer/pvcsi_fullsync.go:95","msg":"FullSync: Creating CnsVolumeMetadata fac0a95a-04ac-4750-b0ed-c13b8349f160-644595a0-5a81-471a-88b5-0a4851085283 on the supervisor cluster for entity type \"POD\"","TraceId":"6195f74e-c839-4b40-a734-abd014daed09"}
{"level":"info","time":"2021-03-18T21:56:45.413350157Z","caller":"syncer/volume_health_reconciler.go:284","msg":"Starting volume health reconciler","TraceId":"8855980a-f690-40c2-b752-dbd730b7715a"}
{"level":"info","time":"2021-03-18T21:56:45.413851733Z","caller":"syncer/volume_health_reconciler.go:332","msg":"syncPVC: Found Supervisor Cluster PVC: test-gc-e2e-demo-ns/example-vanilla-block-pvc","TraceId":"19191461-c405-46e4-a594-62c9831ca1f4"}
{"level":"info","time":"2021-03-18T21:56:45.415605106Z","caller":"syncer/volume_health_reconciler.go:332","msg":"syncPVC: Found Supervisor Cluster PVC: test-gc-e2e-demo-ns/fac0a95a-04ac-4750-b0ed-c13b8349f160-4e1173de-0b7e-4ab1-b3ae-9c0948a16187","TraceId":"0d641737-997c-404c-b6d7-a94fe943db8f"}
{"level":"info","time":"2021-03-18T21:56:45.437348796Z","caller":"syncer/volume_health_reconciler.go:419","msg":"updateTKGPVC: Detected volume health annotation change. Need to update Tanzu Kubernetes Grid PVC default/example-vanilla-block-gc-pvc. Existing TKG PVC annotation: . New annotation: accessible","TraceId":"0d641737-997c-404c-b6d7-a94fe943db8f"}
{"level":"info","time":"2021-03-18T21:56:45.509543205Z","caller":"syncer/volume_health_reconciler.go:428","msg":"updateTKGPVC: Updated Tanzu Kubernetes Grid PVC default/example-vanilla-block-gc-pvc, set annotation accessible at time Thu Mar 18 21:56:45 UTC 2021","TraceId":"0d641737-997c-404c-b6d7-a94fe943db8f"}
{"level":"info","time":"2021-03-18T21:56:45.509922155Z","caller":"syncer/volume_health_reconciler.go:362","msg":"Updated Tanzu Kubernetes Grid PVC for PV pvc-4e1173de-0b7e-4ab1-b3ae-9c0948a16187","TraceId":"0d641737-997c-404c-b6d7-a94fe943db8f"}
{"level":"info","time":"2021-03-18T21:56:45.544277927Z","caller":"syncer/pvcsi_fullsync.go:124","msg":"FullSync: End","TraceId":"6195f74e-c839-4b40-a734-abd014daed09"}
```

Since the default is `trigger-csi-fullsync` feature flag disabled, we can have this PR checked in if everything looks good.

cc @chethanv28 @divyenpatel 