### PR TITLE
publish nfsv4 datastore is not supported

### DIFF
--- a/docs/book/compatiblity_matrix.md
+++ b/docs/book/compatiblity_matrix.md
@@ -21,3 +21,4 @@ Note:
 
 - vSphere CSI driver is not supported on Windows based vCenter.
 - vSphere CSI driver is not supported on vSAN stretch cluster.
+- vSphere CSI driver does not support provisioning block or raw block volumes on the NFSv4 Datastore.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
publish nfsv4 datastore is not supported.

**Which issue this PR fixes**
fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/714


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
declare nfsv4 datastore is not supported
```
