### PR TITLE
vCenter version check to enable online volume expansion feature

### DIFF
--- a/manifests/dev/vsphere-67u3/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/vsphere-csi-driver.yaml
@@ -89,7 +89,11 @@ apiVersion: v1
 data:
   "csi-migration": "false"
   "csi-auth-check": "true"
-  "online-volume-extend": "false"
+  # Internal FSS for online volume expansion is enabled in v2.2.0 version of the driver.
+  # The vSphere version needs to be at least 7.0U2 for this feature to work.
+  # If the vSphere version is lower then the online volume expansion will fail
+  # with appropriate error message during runtime.
+  "online-volume-extend": "true"
   "trigger-csi-fullsync" : "false"
 kind: ConfigMap
 metadata:

--- a/manifests/dev/vsphere-7.0/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/vsphere-csi-driver.yaml
@@ -92,7 +92,7 @@ apiVersion: v1
 data:
   "csi-migration": "false"
   "csi-auth-check": "true"
-  "online-volume-extend": "false"
+  "online-volume-extend": "true"
   "trigger-csi-fullsync" : "false"
 kind: ConfigMap
 metadata:
@@ -156,6 +156,9 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--leader-election"
+            # Uncomment the line below to increase performance of online
+            # resize in vSphere versions 7.0U2 or above
+            # - "--handle-volume-inuse-error=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/dev/vsphere-7.0u1/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/dev/vsphere-7.0u1/vanilla/vsphere-csi-driver.yaml
@@ -95,7 +95,7 @@ apiVersion: v1
 data:
   "csi-migration": "false"
   "csi-auth-check": "true"
-  "online-volume-extend": "false"
+  "online-volume-extend": "true"
   "trigger-csi-fullsync" : "false"
 kind: ConfigMap
 metadata:
@@ -159,6 +159,9 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--leader-election"
+            # Uncomment the line below to increase performance of online
+            # resize in vSphere versions 7.0U2 or above
+            # - "--handle-volume-inuse-error=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -189,7 +189,7 @@ func IsOnlineExpansion(ctx context.Context, volumeID string, nodes []*cnsvsphere
 		log.Error(msg)
 		return status.Errorf(codes.Internal, msg)
 	} else if diskUUID != "" {
-		msg := fmt.Sprintf("failed to expand volume: %q. Volume is attached to node. Only offline volume expansion is supported", volumeID)
+		msg := fmt.Sprintf("failed to expand volume: %q. Volume is attached to node. Online volume expansion is not supported in this version", volumeID)
 		log.Error(msg)
 		return status.Errorf(codes.FailedPrecondition, msg)
 	}

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -946,8 +946,15 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		log.Error(msg)
 		return nil, status.Errorf(codes.Unimplemented, msg)
 	}
+
+	isOnlineExpansionSupported, err := c.manager.VcenterManager.IsOnlineExtendVolumeSupported(ctx, c.manager.VcenterConfig.Host)
+	if err != nil {
+		msg := fmt.Sprintf("failed to check if online expansion is supported due to error: %v", err)
+		log.Error(msg)
+		return nil, status.Errorf(codes.Internal, msg)
+	}
 	isOnlineExpansionEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend)
-	err := validateVanillaControllerExpandVolumeRequest(ctx, req, isOnlineExpansionEnabled)
+	err = validateVanillaControllerExpandVolumeRequest(ctx, req, isOnlineExpansionEnabled, isOnlineExpansionSupported)
 	if err != nil {
 		msg := fmt.Sprintf("validation for ExpandVolume Request: %+v has failed. Error: %v", *req, err)
 		log.Error(msg)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: We need a vCenter version check to enable online volume expand feature in the controller so that we can enable the online-volume-extend FSS for all vSphere versions in vanilla manifests for 2.2. Currently the FSS is being used to regulate this feature for certain vCenter versions which is not according to the design we had in plan for FSS checks.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: 
Testing done -

On vSphere 7.0U1/ESX 7.0U1:
```
root@k8s-master-544:~# kc logs vsphere-csi-controller-7c5bb6b7df-jbzlr -c vsphere-csi-controller | grep "8984952e-e71c-4ee2-a8c9-85f757f9925c"
2021-03-22T20:24:14.093Z	INFO	vanilla/controller.go:915	ControllerExpandVolume: called with args {VolumeId:1f9136c3-08f8-4f54-b519-1d154828c564 CapacityRange:required_bytes:2147483648  Secrets:map[] VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
2021-03-22T20:24:14.094Z	INFO	vsphere/virtualcentermanager.go:185	Online volume expansion is not supported on vCenter version "vSAN 7.0U1"	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
2021-03-22T20:24:14.094Z	DEBUG	node/manager.go:235	Renewing VM VirtualMachine:vm-50 [VirtualCenterHost: 10.168.120.82, UUID: 421c5d26-a788-feec-c053-31cacb3cadff, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.168.120.82]] with new connection: nodeUUID 421c5d26-a788-feec-c053-31cacb3cadff	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
2021-03-22T20:24:14.098Z	DEBUG	node/manager.go:245	Updated VM VirtualMachine:vm-50 [VirtualCenterHost: 10.168.120.82, UUID: 421c5d26-a788-feec-c053-31cacb3cadff, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.168.120.82]] for node with nodeUUID 421c5d26-a788-feec-c053-31cacb3cadff	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
2021-03-22T20:24:14.098Z	DEBUG	node/manager.go:232	Renewing VM VirtualMachine:vm-47 [VirtualCenterHost: 10.168.120.82, UUID: 421ccc91-d352-f482-064f-24591b7e4e1a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.168.120.82]], no new connection needed: nodeUUID 421ccc91-d352-f482-064f-24591b7e4e1a	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
2021-03-22T20:24:14.098Z	DEBUG	node/manager.go:245	Updated VM VirtualMachine:vm-47 [VirtualCenterHost: 10.168.120.82, UUID: 421ccc91-d352-f482-064f-24591b7e4e1a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.168.120.82]] for node with nodeUUID 421ccc91-d352-f482-064f-24591b7e4e1a	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
2021-03-22T20:24:14.098Z	DEBUG	node/manager.go:232	Renewing VM VirtualMachine:vm-48 [VirtualCenterHost: 10.168.120.82, UUID: 421cbb05-5e91-a23b-1893-b5e7f3d69b71, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.168.120.82]], no new connection needed: nodeUUID 421cbb05-5e91-a23b-1893-b5e7f3d69b71	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
2021-03-22T20:24:14.099Z	DEBUG	node/manager.go:245	Updated VM VirtualMachine:vm-48 [VirtualCenterHost: 10.168.120.82, UUID: 421cbb05-5e91-a23b-1893-b5e7f3d69b71, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.168.120.82]] for node with nodeUUID 421cbb05-5e91-a23b-1893-b5e7f3d69b71	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
2021-03-22T20:24:14.099Z	DEBUG	node/manager.go:232	Renewing VM VirtualMachine:vm-49 [VirtualCenterHost: 10.168.120.82, UUID: 421c9dba-55d5-3170-82e7-d464f29f21a8, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.168.120.82]], no new connection needed: nodeUUID 421c9dba-55d5-3170-82e7-d464f29f21a8	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
2021-03-22T20:24:14.099Z	DEBUG	node/manager.go:245	Updated VM VirtualMachine:vm-49 [VirtualCenterHost: 10.168.120.82, UUID: 421c9dba-55d5-3170-82e7-d464f29f21a8, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.168.120.82]] for node with nodeUUID 421c9dba-55d5-3170-82e7-d464f29f21a8	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
2021-03-22T20:24:14.104Z	DEBUG	volume/util.go:58	Found diskUUID 6000C293-ad8c-494a-0edf-c98fb7036963 for volume 1f9136c3-08f8-4f54-b519-1d154828c564 on vm VirtualMachine:vm-50 [VirtualCenterHost: 10.168.120.82, UUID: 421c5d26-a788-feec-c053-31cacb3cadff, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.168.120.82]]	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
2021-03-22T20:24:14.104Z	ERROR	common/common_controller_helper.go:193	failed to expand volume: "1f9136c3-08f8-4f54-b519-1d154828c564". Volume is attached to node. Online volume expansion is not supported in this version	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
2021-03-22T20:24:14.105Z	ERROR	vanilla/controller.go:936	validation for ExpandVolume Request: {VolumeId:1f9136c3-08f8-4f54-b519-1d154828c564 CapacityRange:required_bytes:2147483648  Secrets:map[] VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} has failed. Error: rpc error: code = FailedPrecondition desc = failed to expand volume: "1f9136c3-08f8-4f54-b519-1d154828c564". Volume is attached to node. 
Online volume expansion is not supported in this version	{"TraceId": "8984952e-e71c-4ee2-a8c9-85f757f9925c"}
```

In vSphere 7.0U2:
```
{"level":"info","time":"2021-03-22T21:12:46.348266273Z","caller":"vanilla/controller.go:915","msg":"ControllerExpandVolume: called with args {VolumeId:6a23200c-7b6b-4db0-ae0f-057818b0c95a CapacityRange:required_bytes:2147483648  Secrets:map[] VolumeCapability:mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"02d3b8be-e26f-4721-a93d-91e2dae0244c"}
{"level":"info","time":"2021-03-22T21:12:47.446074202Z","caller":"common/vsphereutil.go:484","msg":"Requested size 2048 Mb is greater than current size for volumeID: \"6a23200c-7b6b-4db0-ae0f-057818b0c95a\". Need volume expansion.","TraceId":"02d3b8be-e26f-4721-a93d-91e2dae0244c"}
{"level":"info","time":"2021-03-22T21:12:47.450373698Z","caller":"volume/manager.go:675","msg":"Calling CnsClient.ExtendVolume: VolumeID [\"6a23200c-7b6b-4db0-ae0f-057818b0c95a\"] Size [2048] cnsExtendSpecList [[]types.CnsVolumeExtendSpec{types.CnsVolumeExtendSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:\"6a23200c-7b6b-4db0-ae0f-057818b0c95a\"}, CapacityInMb:2048}}]","TraceId":"02d3b8be-e26f-4721-a93d-91e2dae0244c"}
{"level":"info","time":"2021-03-22T21:12:52.96421619Z","caller":"volume/manager.go:691","msg":"ExpandVolume: volumeID: \"6a23200c-7b6b-4db0-ae0f-057818b0c95a\", opId: \"07beb374\"","TraceId":"02d3b8be-e26f-4721-a93d-91e2dae0244c"}
{"level":"info","time":"2021-03-22T21:12:52.964493142Z","caller":"volume/manager.go:709","msg":"ExpandVolume: Volume expanded successfully. volumeID: \"6a23200c-7b6b-4db0-ae0f-057818b0c95a\", opId: \"07beb374\"","TraceId":"02d3b8be-e26f-4721-a93d-91e2dae0244c"}
{"level":"info","time":"2021-03-22T21:12:52.964586099Z","caller":"common/vsphereutil.go:490","msg":"Successfully expanded volume for volumeid \"6a23200c-7b6b-4db0-ae0f-057818b0c95a\" to new size 2048 Mb.","TraceId":"02d3b8be-e26f-4721-a93d-91e2dae0244c"}
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add vCenter version check to enable online volume expansion feature
```
