### PR TITLE
Fix the condition check for updateing the existing CRD

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -362,13 +362,17 @@ func createCustomResourceDefinition(ctx context.Context, newCrd *apiextensionsv1
 
 	crdName := newCrd.ObjectMeta.Name
 	crd, err := apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx, newCrd, metav1.CreateOptions{})
-		if err != nil {
-			log.Errorf("Failed to create %q CRD with err: %+v", crdName, err)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx, newCrd, metav1.CreateOptions{})
+			if err != nil {
+				log.Errorf("Failed to create %q CRD with err: %+v", crdName, err)
+				return err
+			}
+			log.Infof("%q CRD created successfully", crdName)
+		} else {
 			return err
 		}
-		log.Infof("%q CRD created successfully", crdName)
 	} else {
 		// Update the existing CRD with new CRD
 		crd.Spec = newCrd.Spec


### PR DESCRIPTION
Updating the exsiting CRD should happend if the CRD found.
In the previous, it happens when getting CRD returns an err, and the err is not NotFound.
That seems not correct.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The previous code will update the CRD even when getting the old CRD returns an error, which may hide error messages.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
