### PR TITLE
Assign clusterflavor to TriggerCsiFullSyncReconciler

### DIFF
--- a/pkg/syncer/cnsoperator/controller/triggercsifullsync/triggercsifullsync_controller.go
+++ b/pkg/syncer/cnsoperator/controller/triggercsifullsync/triggercsifullsync_controller.go
@@ -103,7 +103,8 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	configInfo *types.ConfigInfo, recorder record.EventRecorder) reconcile.Reconciler {
-	return &ReconcileTriggerCsiFullSync{client: mgr.GetClient(), scheme: mgr.GetScheme(), configInfo: configInfo, recorder: recorder}
+	return &ReconcileTriggerCsiFullSync{client: mgr.GetClient(), scheme: mgr.GetScheme(),
+		clusterFlavor: clusterFlavor, configInfo: configInfo, recorder: recorder}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler


### PR DESCRIPTION
**What this PR does / why we need it**:
TriggerCsiFullSync controller doesn't populate clusterflavor as part its reconciler object. Because of this it calls csifullsync instead of pvcsifullsync on GC. This is failing the syncer container because of this.

```
{"level":"info","time":"2021-03-22T17:42:53.884957381Z","caller":"triggercsifullsync/triggercsifullsync_controller.go:224","msg":"Reconciling trigger full sync with triggerSyncID: 5","TraceId":"8a84dbdf-2699-46c2-8b1e-e77876c079f8"}
{"level":"info","time":"2021-03-22T17:42:53.887746074Z","caller":"syncer/metadatasyncer.go:301","msg":"Incremented TriggerSyncID from 4 to 5 as part of periodic run to trigger full sync","TraceId":"1176f85e-e9b0-43e7-8a50-c93da1122458"}
{"level":"info","time":"2021-03-22T17:42:53.912997371Z","caller":"syncer/fullsync.go:40","msg":"FullSync: start","TraceId":"8a84dbdf-2699-46c2-8b1e-e77876c079f8"}
E0322 17:42:53.914888       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 709 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1d9caa0, 0x336d630)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.5/pkg/util/runtime/runtime.go:74 +0xa6
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.5/pkg/util/runtime/runtime.go:48 +0x89
panic(0x1d9caa0, 0x336d630)
	/usr/local/go/src/runtime/panic.go:969 +0x1b9
sigs.k8s.io/vsphere-csi-driver/pkg/syncer.CsiFullSync(0x24a6a60, 0xc0002871a0, 0xc0001be5a0, 0xc000b68510, 0xc0000cfb80)
	/build/pkg/syncer/fullsync.go:99 +0x85d
sigs.k8s.io/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/triggercsifullsync.(*ReconcileTriggerCsiFullSync).Reconcile(0xc0008795c0, 0x0, 0x0, 0xc000b27be0, 0xb, 0x6eab3546, 0xc000c0d710, 0xc000c0d688, 0xc000c0d680)
	/build/pkg/syncer/cnsoperator/controller/triggercsifullsync/triggercsifullsync_controller.go:240 +0x957
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000c0c000, 0x1ebe6a0, 0xc0006e9ac0, 0xc000b6a400)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.1/pkg/internal/controller/controller.go:233 +0x166
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000c0c000, 0x203000)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.1/pkg/internal/controller/controller.go:209 +0xb0
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc000c0c000)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.1/pkg/internal/controller/controller.go:188 +0x2b
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000912b90)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.5/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000912b90, 0x2463a80, 0xc000be7b30, 0xc000c0c301, 0xc000b1a300)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.5/pkg/util/wait/wait.go:156 +0xad
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000912b90, 0x3b9aca00, 0x0, 0x1, 0xc000b1a300)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.5/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.Until(0xc000912b90, 0x3b9aca00, 0xc000b1a300)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.5/pkg/util/wait/wait.go:90 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.1/pkg/internal/controller/controller.go:170 +0x3fa
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x1a56ffd]
```

This is happening because clusterflavor is not assigned to TriggerCsiFullSyncReconciler. Once clusterflavor is assigned to TriggerCsiFullSyncReconciler, it runs the correct pvcsi full sync on GC.

Fixes bug - https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/748

**Release note**:
```release-note
Assign clusterflavor to TriggerCsiFullSyncReconciler
```

**Testing done on GC:**

**Syncer Init logs**

```
I0322 18:13:38.045220       1 leaderelection.go:252] successfully acquired lease vmware-system-csi/vsphere-syncer
{"level":"info","time":"2021-03-22T18:13:38.046171819Z","caller":"k8sorchestrator/k8sorchestrator.go:122","msg":"Initializing k8sOrchestratorInstance","TraceId":"f1207526-a0a1-4074-8b30-68e447ba78e4"}
{"level":"info","time":"2021-03-22T18:13:38.046315585Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"f1207526-a0a1-4074-8b30-68e447ba78e4"}
{"level":"info","time":"2021-03-22T18:13:38.046773118Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"f1207526-a0a1-4074-8b30-68e447ba78e4"}
{"level":"info","time":"2021-03-22T18:13:38.095254295Z","caller":"k8sorchestrator/k8sorchestrator.go:216","msg":"New supervisor feature states values stored successfully: map[csi-auth-check:false file-volume:false online-volume-extend:true trigger-csi-fullsync:true volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"f1207526-a0a1-4074-8b30-68e447ba78e4"}
{"level":"info","time":"2021-03-22T18:13:38.110359219Z","caller":"k8sorchestrator/k8sorchestrator.go:234","msg":"New internal feature states values stored successfully: map[file-volume:false online-volume-extend:true trigger-csi-fullsync:true volume-extend:true volume-health:true]","TraceId":"f1207526-a0a1-4074-8b30-68e447ba78e4"}
{"level":"info","time":"2021-03-22T18:13:38.110450329Z","caller":"k8sorchestrator/k8sorchestrator.go:148","msg":"k8sOrchestratorInstance initialized","TraceId":"f1207526-a0a1-4074-8b30-68e447ba78e4"}
{"level":"info","time":"2021-03-22T18:13:38.112422357Z","caller":"manager/init.go:216","msg":"Triggerfullsync feature enabled","TraceId":"f1207526-a0a1-4074-8b30-68e447ba78e4"}
{"level":"info","time":"2021-03-22T18:13:38.123280307Z","caller":"k8sorchestrator/k8sorchestrator.go:273","msg":"New feature states values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[file-volume:false online-volume-extend:true trigger-csi-fullsync:true volume-extend:true volume-health:true]","TraceId":"c9f723ed-cc78-44b9-97ec-143e8287a309"}
{"level":"info","time":"2021-03-22T18:13:38.123683246Z","caller":"k8sorchestrator/k8sorchestrator.go:269","msg":"New feature states values from \"csi-feature-states\" stored successfully: map[csi-auth-check:false file-volume:false online-volume-extend:true trigger-csi-fullsync:true volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"0ab26025-23dc-4f2d-b4e4-e3b4375d9298"}
{"level":"info","time":"2021-03-22T18:13:38.129343586Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"f1207526-a0a1-4074-8b30-68e447ba78e4"}
{"level":"info","time":"2021-03-22T18:13:38.131278942Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"f1207526-a0a1-4074-8b30-68e447ba78e4"}
{"level":"info","time":"2021-03-22T18:13:38.174530818Z","caller":"kubernetes/kubernetes.go:381","msg":"\"triggercsifullsyncs.cns.vmware.com\" CRD updated successfully","TraceId":"f1207526-a0a1-4074-8b30-68e447ba78e4"}
{"level":"info","time":"2021-03-22T18:13:38.663717919Z","caller":"manager/init.go:253","msg":"Found \"csifullsync\" instance with InProgress set to true on syncer startup. Resetting InProgress field to false as no full sync is currently running","TraceId":"f1207526-a0a1-4074-8b30-68e447ba78e4"}
{"level":"info","time":"2021-03-22T18:13:38.718836202Z","caller":"syncer/metadatasyncer.go:124","msg":"Initializing MetadataSyncer"}
{"level":"info","time":"2021-03-22T18:13:38.720411953Z","caller":"manager/init.go:69","msg":"Initializing CNS Operator","TraceId":"eebb96f7-bd1c-45eb-9341-fdbe4233d558"}
{"level":"info","time":"2021-03-22T18:13:38.722219191Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config"}
{"level":"info","time":"2021-03-22T18:13:38.727573572Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2021-03-22T18:13:38.734722023Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2021-03-22T18:13:38.993975822Z","caller":"kubernetes/kubernetes.go:143","msg":"Connecting to supervisor cluster using the certs/token in Guest Cluster config"}
{"level":"info","time":"2021-03-22T18:13:39.000185253Z","caller":"syncer/metadatasyncer.go:208","msg":"Adding watch on path: \"/etc/cloud/pvcsi-config\""}
{"level":"info","time":"2021-03-22T18:13:39.003665923Z","caller":"syncer/metadatasyncer.go:216","msg":"Adding watch on path: \"/etc/cloud/pvcsi-provider\""}
{"level":"info","time":"2021-03-22T18:13:39.10460165Z","caller":"syncer/metadatasyncer.go:259","msg":"Initialized metadata syncer"}
{"level":"info","time":"2021-03-22T18:13:39.112087211Z","caller":"syncer/metadatasyncer.go:89","msg":"FullSync: fullSync interval is set to 30 minutes"}
{"level":"info","time":"2021-03-22T18:13:39.11583541Z","caller":"syncer/metadatasyncer.go:267","msg":"\"trigger-csi-fullsync\" feature flag is enabled. Using TriggerCsiFullSync API to trigger full sync"}
{"level":"info","time":"2021-03-22T18:13:39.193837561Z","caller":"manager/init.go:173","msg":"Registering Components for Cns Operator","TraceId":"eebb96f7-bd1c-45eb-9341-fdbe4233d558"}
{"level":"info","time":"2021-03-22T18:13:39.196997507Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"f6ec5bfb-f554-44a9-90b7-8803f7a60f5d"}
{"level":"info","time":"2021-03-22T18:13:39.197420247Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"f6ec5bfb-f554-44a9-90b7-8803f7a60f5d"}
{"level":"info","time":"2021-03-22T18:13:39.19970401Z","caller":"manager/init.go:187","msg":"Starting Cns Operator","TraceId":"eebb96f7-bd1c-45eb-9341-fdbe4233d558"}
{"level":"info","time":"2021-03-22T18:13:39.576827173Z","caller":"syncer/metadatasyncer.go:1268","msg":"initResizeReconciler is triggered","TraceId":"790cd620-bf68-48f6-9421-99ea554d2e49"}
{"level":"info","time":"2021-03-22T18:13:39.577294858Z","caller":"syncer/metadatasyncer.go:284","msg":"periodic fullSync is triggered","TraceId":"00db81c8-f62c-4a9f-a175-ac29dab8b567"}
{"level":"info","time":"2021-03-22T18:13:39.584032108Z","caller":"syncer/metadatasyncer.go:1242","msg":"supervisorNamespace test-gc-e2e-demo-ns","TraceId":"81b84601-ba67-40df-aabf-ccd692faa9a6"}
{"level":"info","time":"2021-03-22T18:13:39.584414953Z","caller":"syncer/metadatasyncer.go:1243","msg":"initVolumeHealthReconciler is triggered","TraceId":"81b84601-ba67-40df-aabf-ccd692faa9a6"}
{"level":"info","time":"2021-03-22T18:13:39.627574478Z","caller":"triggercsifullsync/triggercsifullsync_controller.go:225","msg":"Reconciling trigger full sync with triggerSyncID: 13","TraceId":"9de81bab-b521-4858-b60c-b1601d67eb70"}
{"level":"info","time":"2021-03-22T18:13:39.631742637Z","caller":"syncer/metadatasyncer.go:301","msg":"Incremented TriggerSyncID from 12 to 13 as part of periodic run to trigger full sync","TraceId":"81b84601-ba67-40df-aabf-ccd692faa9a6"}
{"level":"info","time":"2021-03-22T18:13:39.6557362Z","caller":"syncer/pvcsi_fullsync.go:37","msg":"FullSync: Start","TraceId":"9de81bab-b521-4858-b60c-b1601d67eb70"}
{"level":"info","time":"2021-03-22T18:13:39.681641275Z","caller":"syncer/resize_reconciler.go:159","msg":"Resize reconciler: Start","TraceId":"790cd620-bf68-48f6-9421-99ea554d2e49"}
{"level":"info","time":"2021-03-22T18:13:39.689343117Z","caller":"syncer/pvcsi_fullsync.go:124","msg":"FullSync: End","TraceId":"9de81bab-b521-4858-b60c-b1601d67eb70"}
{"level":"info","time":"2021-03-22T18:13:39.68976167Z","caller":"triggercsifullsync/triggercsifullsync_controller.go:253","msg":"Full sync successful with triggerSyncID: 13","TraceId":"9de81bab-b521-4858-b60c-b1601d67eb70"}
{"level":"info","time":"2021-03-22T18:13:39.724963564Z","caller":"syncer/util.go:183","msg":"getPVCKey: PVC key test-gc-e2e-demo-ns/example-vanilla-block-pvc","TraceId":"c77c8912-c768-44c3-b7a9-b07c76ea9e52"}
{"level":"info","time":"2021-03-22T18:13:39.725119631Z","caller":"syncer/volume_health_reconciler.go:245","msg":"addPVC: add test-gc-e2e-demo-ns/example-vanilla-block-pvc to claim queue","TraceId":"c77c8912-c768-44c3-b7a9-b07c76ea9e52"}
{"level":"info","time":"2021-03-22T18:13:39.809396658Z","caller":"syncer/volume_health_reconciler.go:284","msg":"Starting volume health reconciler","TraceId":"81b84601-ba67-40df-aabf-ccd692faa9a6"}
{"level":"info","time":"2021-03-22T18:13:39.818912009Z","caller":"syncer/volume_health_reconciler.go:332","msg":"syncPVC: Found Supervisor Cluster PVC: test-gc-e2e-demo-ns/example-vanilla-block-pvc","TraceId":"d6236d0d-df62-4e85-ac57-301b6f7739fd"}
```

```
root@421abc0fcc02aad9b51164be8d1e0749 [ ~ ]# kubectl describe triggercsifullsyncs.cns.vmware.com csifullsync
Name:         csifullsync
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         TriggerCsiFullSync
Metadata:
  Creation Timestamp:  2021-03-22T17:41:14Z
  Generation:          40
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:triggerSyncID:
      f:status:
        .:
        f:inProgress:
        f:lastRunEndTimeStamp:
        f:lastRunStartTimeStamp:
        f:lastSuccessfulEndTimeStamp:
        f:lastSuccessfulStartTimeStamp:
        f:lastTriggerSyncID:
    Manager:         vsphere-syncer
    Operation:       Update
    Time:            2021-03-22T18:13:39Z
  Resource Version:  6923037
  Self Link:         /apis/cns.vmware.com/v1alpha1/triggercsifullsyncs/csifullsync
  UID:               de683132-772b-4ab2-b88c-884025c97ff9
Spec:
  Trigger Sync ID:  13
Status:
  In Progress:                       false
  Last Run End Time Stamp:           2021-03-22T18:13:39Z
  Last Run Start Time Stamp:         2021-03-22T18:13:39Z
  Last Successful End Time Stamp:    2021-03-22T18:13:39Z
  Last Successful Start Time Stamp:  2021-03-22T18:13:39Z
  Last Trigger Sync ID:              13
Events:
  Type    Reason                       Age   From            Message
  ----    ------                       ----  ----            -------
  Normal  TriggerCsiFullSyncSucceeded  69s   cns.vmware.com  Full sync successful with triggerSyncID: 13
  ```
  
  **Testing done on WCP**
  
  **Syncer init logs**
  
  ```
  root@421a3891773378aaffdb54f7968bbfaa [ ~ ]# kubectl logs -f vsphere-csi-controller-7fd884577b-vc4kc -c vsphere-syncer -n vmware-system-csi
{"level":"info","time":"2021-03-22T19:41:13.33194819Z","caller":"logger/logger.go:37","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2021-03-22T19:41:13.332203367Z","caller":"syncer/main.go:72","msg":"Version : v2.1.0-rc.1-518-g26ddaa8-dirty","TraceId":"16982470-f385-43bb-8d4e-08fafb896afd"}
{"level":"info","time":"2021-03-22T19:41:13.332240805Z","caller":"commonco/utils.go:38","msg":"Defaulting feature states configmap name to \"csi-feature-states\"","TraceId":"16982470-f385-43bb-8d4e-08fafb896afd"}
{"level":"info","time":"2021-03-22T19:41:13.332268049Z","caller":"commonco/utils.go:42","msg":"Defaulting feature states configmap namespace to \"vmware-system-csi\"","TraceId":"16982470-f385-43bb-8d4e-08fafb896afd"}
{"level":"info","time":"2021-03-22T19:41:13.332293091Z","caller":"syncer/main.go:89","msg":"Starting container with operation mode: METADATA_SYNC","TraceId":"16982470-f385-43bb-8d4e-08fafb896afd"}
{"level":"info","time":"2021-03-22T19:41:13.333362906Z","caller":"config/config.go:300","msg":"No Net Permissions given in Config. Using default permissions.","TraceId":"16982470-f385-43bb-8d4e-08fafb896afd"}
{"level":"info","time":"2021-03-22T19:41:13.334471894Z","caller":"k8scloudoperator/k8scloudoperator.go:80","msg":"Trying to initialize the K8s Cloud Operator gRPC service","TraceId":"16982470-f385-43bb-8d4e-08fafb896afd"}
{"level":"info","time":"2021-03-22T19:41:13.337624012Z","caller":"common/util.go:319","msg":"Connecting to K8s Cloud Operator Service on port 29000","TraceId":"16982470-f385-43bb-8d4e-08fafb896afd"}
{"level":"info","time":"2021-03-22T19:41:13.343649268Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"16982470-f385-43bb-8d4e-08fafb896afd"}
{"level":"info","time":"2021-03-22T19:41:13.349086276Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"16982470-f385-43bb-8d4e-08fafb896afd"}
{"level":"info","time":"2021-03-22T19:41:13.355915323Z","caller":"syncer/main.go:115","msg":"Starting the http server to expose Prometheus metrics..","TraceId":"16982470-f385-43bb-8d4e-08fafb896afd"}
{"level":"info","time":"2021-03-22T19:41:13.334331119Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"16982470-f385-43bb-8d4e-08fafb896afd"}
{"level":"info","time":"2021-03-22T19:41:13.36593053Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"16982470-f385-43bb-8d4e-08fafb896afd"}
I0322 19:41:13.369905       1 leaderelection.go:242] attempting to acquire leader lease  vmware-system-csi/vsphere-syncer...
I0322 19:41:33.040585       1 leaderelection.go:252] successfully acquired lease vmware-system-csi/vsphere-syncer
{"level":"info","time":"2021-03-22T19:41:33.050079612Z","caller":"k8sorchestrator/k8sorchestrator.go:122","msg":"Initializing k8sOrchestratorInstance","TraceId":"0905c983-1c2a-4375-abe6-3f1622e2a414"}
{"level":"info","time":"2021-03-22T19:41:33.052861705Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"0905c983-1c2a-4375-abe6-3f1622e2a414"}
{"level":"info","time":"2021-03-22T19:41:33.054401829Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"0905c983-1c2a-4375-abe6-3f1622e2a414"}
{"level":"info","time":"2021-03-22T19:41:33.09153717Z","caller":"k8sorchestrator/k8sorchestrator.go:216","msg":"New supervisor feature states values stored successfully: map[csi-auth-check:false file-volume:false online-volume-extend:true trigger-csi-fullsync:true volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"0905c983-1c2a-4375-abe6-3f1622e2a414"}
{"level":"info","time":"2021-03-22T19:41:33.092129523Z","caller":"k8sorchestrator/k8sorchestrator.go:148","msg":"k8sOrchestratorInstance initialized","TraceId":"0905c983-1c2a-4375-abe6-3f1622e2a414"}
{"level":"info","time":"2021-03-22T19:41:33.092147322Z","caller":"manager/init.go:216","msg":"Triggerfullsync feature enabled","TraceId":"0905c983-1c2a-4375-abe6-3f1622e2a414"}
{"level":"info","time":"2021-03-22T19:41:33.108371919Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"0905c983-1c2a-4375-abe6-3f1622e2a414"}
{"level":"info","time":"2021-03-22T19:41:33.108634409Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"0905c983-1c2a-4375-abe6-3f1622e2a414"}
{"level":"info","time":"2021-03-22T19:41:33.188573007Z","caller":"k8sorchestrator/k8sorchestrator.go:269","msg":"New feature states values from \"csi-feature-states\" stored successfully: map[csi-auth-check:false file-volume:false online-volume-extend:true trigger-csi-fullsync:true volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"abf8d6a4-8fed-4b54-95c5-c045024b10db"}
{"level":"info","time":"2021-03-22T19:41:33.329068215Z","caller":"kubernetes/kubernetes.go:381","msg":"\"triggercsifullsyncs.cns.vmware.com\" CRD updated successfully","TraceId":"0905c983-1c2a-4375-abe6-3f1622e2a414"}
I0322 19:41:34.396392       1 request.go:621] Throttling request took 1.011048647s, request: GET:https://127.0.0.1:6443/apis/networking.k8s.io/v1beta1?timeout=32s
{"level":"info","time":"2021-03-22T19:41:35.231795848Z","caller":"manager/init.go:246","msg":"Created the a new instance of \"csifullsync\" TriggerCsiFullSync instance as it was not found.","TraceId":"0905c983-1c2a-4375-abe6-3f1622e2a414"}
{"level":"info","time":"2021-03-22T19:41:35.232436378Z","caller":"syncer/metadatasyncer.go:124","msg":"Initializing MetadataSyncer"}
{"level":"info","time":"2021-03-22T19:41:35.241444395Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config"}
{"level":"info","time":"2021-03-22T19:41:35.242892448Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50."}
{"level":"info","time":"2021-03-22T19:41:35.259251418Z","caller":"types/commontypes.go:69","msg":"Initializing new vCenterInstance."}
{"level":"info","time":"2021-03-22T19:41:35.260267773Z","caller":"vsphere/utils.go:127","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2021-03-22T19:41:35.260507545Z","caller":"vsphere/virtualcentermanager.go:68","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2021-03-22T19:41:35.262069272Z","caller":"vsphere/virtualcentermanager.go:70","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2021-03-22T19:41:35.262352871Z","caller":"vsphere/virtualcentermanager.go:114","msg":"Successfully registered VC \"sc2-10-186-103-147.eng.vmware.com\""}
{"level":"info","time":"2021-03-22T19:41:35.273266082Z","caller":"manager/init.go:69","msg":"Initializing CNS Operator","TraceId":"f2d13df8-838b-4ae8-88c8-b375aa8cb864"}
{"level":"info","time":"2021-03-22T19:41:35.274873143Z","caller":"storagepool/service.go:55","msg":"Initializing Storage Pool Service"}
{"level":"info","time":"2021-03-22T19:41:35.281450143Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config"}
{"level":"info","time":"2021-03-22T19:41:35.307131539Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50."}
{"level":"info","time":"2021-03-22T19:41:35.390564876Z","caller":"kubernetes/kubernetes.go:381","msg":"\"storagepools.cns.vmware.com\" CRD updated successfully"}
{"level":"info","time":"2021-03-22T19:41:35.414171422Z","caller":"vsphere/virtualcenter.go:159","msg":"New session ID for 'VSPHERE.LOCAL\\workload_storage_management-e82608de-19c4-4437-955e-f3ddd377c0c4' = 521c3929-656f-cef0-0c42-b75556e05ad3"}
{"level":"info","time":"2021-03-22T19:41:35.414285371Z","caller":"types/commontypes.go:102","msg":"vCenterInstance initialized"}
{"level":"info","time":"2021-03-22T19:41:35.414886921Z","caller":"volume/manager.go:111","msg":"Initializing new volume.defaultManager..."}
{"level":"info","time":"2021-03-22T19:41:35.414999894Z","caller":"syncer/metadatasyncer.go:208","msg":"Adding watch on path: \"/etc/vmware/wcp\""}
{"level":"info","time":"2021-03-22T19:41:35.415907547Z","caller":"volume/manager.go:108","msg":"Retrieving existing volume.defaultManager...","TraceId":"f2d13df8-838b-4ae8-88c8-b375aa8cb864"}
{"level":"info","time":"2021-03-22T19:41:35.418419692Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"f2d13df8-838b-4ae8-88c8-b375aa8cb864"}
{"level":"info","time":"2021-03-22T19:41:35.419548254Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"f2d13df8-838b-4ae8-88c8-b375aa8cb864"}
{"level":"info","time":"2021-03-22T19:41:35.495419582Z","caller":"kubernetes/kubernetes.go:381","msg":"\"cnsnodevmattachments.cns.vmware.com\" CRD updated successfully","TraceId":"f2d13df8-838b-4ae8-88c8-b375aa8cb864"}
{"level":"info","time":"2021-03-22T19:41:35.496816696Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"f2d13df8-838b-4ae8-88c8-b375aa8cb864"}
{"level":"info","time":"2021-03-22T19:41:35.498987826Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"f2d13df8-838b-4ae8-88c8-b375aa8cb864"}
{"level":"info","time":"2021-03-22T19:41:35.509788229Z","caller":"storagepool/service.go:151","msg":"Done initializing Storage Pool Service"}
{"level":"info","time":"2021-03-22T19:41:35.511527324Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config"}
{"level":"info","time":"2021-03-22T19:41:35.520181378Z","caller":"storagepool/service.go:129","msg":"VSANDirectDiskDecommission feature is disabled on the cluster"}
{"level":"info","time":"2021-03-22T19:41:35.526526441Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50."}
{"level":"info","time":"2021-03-22T19:41:35.539593969Z","caller":"storagepool/listener.go:103","msg":"Starting property collector..."}
{"level":"info","time":"2021-03-22T19:41:35.567779281Z","caller":"storagepool/nodeannotationlistener.go:50","msg":"NodeAnnotationListener initialized."}
{"level":"info","time":"2021-03-22T19:41:35.568890149Z","caller":"storagepool/storageclasswatch.go:188","msg":"StorageClassWatch cache refresh due to gc-storage-profile","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:35.605809683Z","caller":"kubernetes/kubernetes.go:381","msg":"\"cnsvolumemetadatas.cns.vmware.com\" CRD updated successfully","TraceId":"f2d13df8-838b-4ae8-88c8-b375aa8cb864"}
{"level":"info","time":"2021-03-22T19:41:35.608213979Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"f2d13df8-838b-4ae8-88c8-b375aa8cb864"}
{"level":"info","time":"2021-03-22T19:41:35.609554385Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"f2d13df8-838b-4ae8-88c8-b375aa8cb864"}
{"level":"info","time":"2021-03-22T19:41:35.614768432Z","caller":"storagepool/listener.go:108","msg":"Got 8 property collector update(s)","TraceId":"54a87db4-9775-4f9b-973d-bfa9ea82fd75"}
{"level":"info","time":"2021-03-22T19:41:35.614837808Z","caller":"storagepool/listener.go:193","msg":"Scheduled ReconcileAllStoragePools started","TraceId":"54a87db4-9775-4f9b-973d-bfa9ea82fd75"}
{"level":"info","time":"2021-03-22T19:41:35.672833999Z","caller":"storagepool/storageclasswatch.go:248","msg":"sc gc-storage-profile is hostLocal: false","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:35.694078648Z","caller":"kubernetes/kubernetes.go:381","msg":"\"cnsregistervolumes.cns.vmware.com\" CRD updated successfully","TraceId":"f2d13df8-838b-4ae8-88c8-b375aa8cb864"}
{"level":"info","time":"2021-03-22T19:41:35.702954066Z","caller":"manager/init.go:302","msg":"Adding watch on path: \"/etc/vmware/wcp\"","TraceId":"f2d13df8-838b-4ae8-88c8-b375aa8cb864"}
{"level":"info","time":"2021-03-22T19:41:35.728207144Z","caller":"manager/init.go:152","msg":"Triggering CnsRegisterVolume cleanup routine","TraceId":"be61e474-954f-4562-b09a-fe33601a7ef4"}
{"level":"info","time":"2021-03-22T19:41:35.733950362Z","caller":"manager/cleanupcnsregistervolumes.go:35","msg":"cleanUpCnsRegisterVolumeInstances: start","TraceId":"be61e474-954f-4562-b09a-fe33601a7ef4"}
{"level":"info","time":"2021-03-22T19:41:35.826869855Z","caller":"syncer/metadatasyncer.go:259","msg":"Initialized metadata syncer"}
{"level":"info","time":"2021-03-22T19:41:35.828317291Z","caller":"syncer/metadatasyncer.go:89","msg":"FullSync: fullSync interval is set to 2 minutes"}
{"level":"info","time":"2021-03-22T19:41:35.830067351Z","caller":"syncer/metadatasyncer.go:267","msg":"\"trigger-csi-fullsync\" feature flag is enabled. Using TriggerCsiFullSync API to trigger full sync"}
{"level":"info","time":"2021-03-22T19:41:35.997040581Z","caller":"storagepool/util.go:92","msg":"Datastore vsanDatastore properties: {vsanDatastore ds:///vmfs/volumes/vsan:52e87ab0f8de23c5-82d7bf5aaf317477/ cns.vmware.com/vsan 52e87ab0f8de23c5-82d7bf5aaf317477 false true 0xc000e65680 0xc000e656c0}","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.016706197Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.018879985Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.063813865Z","caller":"storagepool/util.go:154","msg":"Accessible nodes in MM for datastore datastore-42: map[sc2-10-186-103-104.eng.vmware.com:false sc2-10-186-105-192.eng.vmware.com:false sc2-10-186-97-173.eng.vmware.com:false]","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.122291893Z","caller":"storagepool/intended_state.go:327","msg":"Updating StoragePool instance for storagepool-vsandatastore","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.184555678Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.184886442Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.223311931Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.223883354Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.344082349Z","caller":"storagepool/intended_state.go:297","msg":"Host sc2-10-186-97-173.eng.vmware.com has capacity &{Capacity:307190824960 CapacityReserved:70002933760 CapacityUsed:172093970841 HostMoID:host-12}","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.589829041Z","caller":"storagepool/intended_state.go:297","msg":"Host sc2-10-186-103-104.eng.vmware.com has capacity &{Capacity:307190824960 CapacityReserved:70002933760 CapacityUsed:132587821465 HostMoID:host-15}","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.644563199Z","caller":"storagepool/intended_state.go:297","msg":"Host sc2-10-186-105-192.eng.vmware.com has capacity &{Capacity:307190824960 CapacityReserved:70002933760 CapacityUsed:135213455769 HostMoID:host-19}","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.644677532Z","caller":"storagepool/intended_state.go:218","msg":"creating vsan sna sp \"sc2-10-186-103-104.eng.vmware.com\"","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.658622744Z","caller":"storagepool/intended_state.go:327","msg":"Updating StoragePool instance for storagepool-vsandatastore-sc2-10-186-103-104.eng.vmware.com","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.767458904Z","caller":"storagepool/intended_state.go:218","msg":"creating vsan sna sp \"sc2-10-186-105-192.eng.vmware.com\"","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.827376795Z","caller":"storagepool/intended_state.go:327","msg":"Updating StoragePool instance for storagepool-vsandatastore-sc2-10-186-105-192.eng.vmware.com","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.858498864Z","caller":"storagepool/intended_state.go:218","msg":"creating vsan sna sp \"sc2-10-186-97-173.eng.vmware.com\"","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:36.911556897Z","caller":"storagepool/intended_state.go:327","msg":"Updating StoragePool instance for storagepool-vsandatastore-sc2-10-186-97-173.eng.vmware.com","TraceId":"c962a152-01cd-416b-82ec-52eedb46934d"}
{"level":"info","time":"2021-03-22T19:41:37.529898687Z","caller":"manager/init.go:173","msg":"Registering Components for Cns Operator","TraceId":"be61e474-954f-4562-b09a-fe33601a7ef4"}
{"level":"info","time":"2021-03-22T19:41:37.530543009Z","caller":"cnsfileaccessconfig/cnsfileaccessconfig_controller.go:92","msg":"Not initializing the CnsFileAccessConfig Controller as File volume feature is disabled on the cluster","TraceId":"be545b3b-411b-459b-98c3-de0605329a57"}
{"level":"info","time":"2021-03-22T19:41:37.530973887Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"919c96a6-cd2f-4503-a334-b42c30821639"}
{"level":"info","time":"2021-03-22T19:41:37.531792258Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"919c96a6-cd2f-4503-a334-b42c30821639"}
{"level":"info","time":"2021-03-22T19:41:37.542988823Z","caller":"node/manager.go:75","msg":"Initializing node.defaultManager...","TraceId":"7fb7327e-94a1-46b3-8d84-3478a7b9898e"}
{"level":"info","time":"2021-03-22T19:41:37.543114026Z","caller":"node/manager.go:79","msg":"node.defaultManager initialized","TraceId":"7fb7327e-94a1-46b3-8d84-3478a7b9898e"}
{"level":"info","time":"2021-03-22T19:41:37.558132462Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"6339381d-3d40-4dfd-8063-acc0bff674f6"}
{"level":"info","time":"2021-03-22T19:41:37.558891169Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"6339381d-3d40-4dfd-8063-acc0bff674f6"}
{"level":"info","time":"2021-03-22T19:41:37.580079957Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"bf3dff85-ee4f-4d71-9267-9a3b80195b02"}
{"level":"info","time":"2021-03-22T19:41:37.58160335Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"bf3dff85-ee4f-4d71-9267-9a3b80195b02"}
{"level":"info","time":"2021-03-22T19:41:37.584454675Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"835f43e0-c9c1-4fc5-97df-658df7e517bb"}
{"level":"info","time":"2021-03-22T19:41:37.584780317Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"835f43e0-c9c1-4fc5-97df-658df7e517bb"}
{"level":"info","time":"2021-03-22T19:41:37.587375582Z","caller":"manager/init.go:187","msg":"Starting Cns Operator","TraceId":"be61e474-954f-4562-b09a-fe33601a7ef4"}
{"level":"info","time":"2021-03-22T19:41:37.645570661Z","caller":"syncer/metadatasyncer.go:111","msg":"VolumeHealth: VolumeHealth interval is set to 5 minutes"}
{"level":"info","time":"2021-03-22T19:41:37.645883026Z","caller":"syncer/metadatasyncer.go:340","msg":"getVolumeHealthStatus is triggered","TraceId":"0ea202ce-f689-4b2b-9269-4346f5df11e4"}
{"level":"info","time":"2021-03-22T19:41:37.645914762Z","caller":"syncer/volume_health.go:35","msg":"csiGetVolumeHealthStatus: start","TraceId":"0ea202ce-f689-4b2b-9269-4346f5df11e4"}
{"level":"info","time":"2021-03-22T19:41:37.651632689Z","caller":"syncer/metadatasyncer.go:284","msg":"periodic fullSync is triggered","TraceId":"0270b891-c64e-4978-af50-12deb832711e"}
{"level":"info","time":"2021-03-22T19:41:37.822514022Z","caller":"manager/init.go:154","msg":"Completed CnsRegisterVolume cleanup","TraceId":"be61e474-954f-4562-b09a-fe33601a7ef4"}
{"level":"info","time":"2021-03-22T19:41:37.833905792Z","caller":"syncer/metadatasyncer.go:301","msg":"Incremented TriggerSyncID from 0 to 1 as part of periodic run to trigger full sync","TraceId":"0270b891-c64e-4978-af50-12deb832711e"}
{"level":"info","time":"2021-03-22T19:41:37.868071487Z","caller":"triggercsifullsync/triggercsifullsync_controller.go:225","msg":"Reconciling trigger full sync with triggerSyncID: 1","TraceId":"171a3878-beca-43af-b14a-c0cb9c081f60"}
{"level":"info","time":"2021-03-22T19:41:37.963491012Z","caller":"syncer/fullsync.go:40","msg":"FullSync: start","TraceId":"171a3878-beca-43af-b14a-c0cb9c081f60"}
{"level":"info","time":"2021-03-22T19:41:39.832861789Z","caller":"syncer/volume_health.go:133","msg":"GetVolumeHealthStatus: end","TraceId":"0ea202ce-f689-4b2b-9269-4346f5df11e4"}
{"level":"info","time":"2021-03-22T19:41:39.934609392Z","caller":"syncer/util.go:161","msg":"0 more volumes to be queried","TraceId":"171a3878-beca-43af-b14a-c0cb9c081f60"}
{"level":"info","time":"2021-03-22T19:41:39.93501938Z","caller":"syncer/util.go:163","msg":"Metadata retrieved for all requested volumes","TraceId":"171a3878-beca-43af-b14a-c0cb9c081f60"}
{"level":"info","time":"2021-03-22T19:41:39.940902339Z","caller":"syncer/fullsync.go:440","msg":"FullSync: update is not required for volume: \"b71d00d7-a1b4-45c9-8a82-106bfeeea252\"","TraceId":"171a3878-beca-43af-b14a-c0cb9c081f60"}
{"level":"info","time":"2021-03-22T19:41:39.941626493Z","caller":"syncer/fullsync.go:240","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion.","TraceId":"171a3878-beca-43af-b14a-c0cb9c081f60"}
{"level":"info","time":"2021-03-22T19:41:39.944754513Z","caller":"syncer/fullsync.go:138","msg":"FullSync: end","TraceId":"171a3878-beca-43af-b14a-c0cb9c081f60"}
{"level":"info","time":"2021-03-22T19:41:39.945572969Z","caller":"triggercsifullsync/triggercsifullsync_controller.go:253","msg":"Full sync successful with triggerSyncID: 1","TraceId":"171a3878-beca-43af-b14a-c0cb9c081f60"}

```

```
root@421a3891773378aaffdb54f7968bbfaa [ ~ ]# kubectl get triggercsifullsyncs.cns.vmware.com csifullsync -o json
{
    "apiVersion": "cns.vmware.com/v1alpha1",
    "kind": "TriggerCsiFullSync",
    "metadata": {
        "creationTimestamp": "2021-03-22T19:41:35Z",
        "generation": 4,
        "managedFields": [
            {
                "apiVersion": "cns.vmware.com/v1alpha1",
                "fieldsType": "FieldsV1",
                "fieldsV1": {
                    "f:spec": {
                        ".": {},
                        "f:triggerSyncID": {}
                    },
                    "f:status": {
                        ".": {},
                        "f:inProgress": {},
                        "f:lastRunEndTimeStamp": {},
                        "f:lastRunStartTimeStamp": {},
                        "f:lastSuccessfulEndTimeStamp": {},
                        "f:lastSuccessfulStartTimeStamp": {},
                        "f:lastTriggerSyncID": {}
                    }
                },
                "manager": "vsphere-syncer",
                "operation": "Update",
                "time": "2021-03-22T19:41:39Z"
            }
        ],
        "name": "csifullsync",
        "resourceVersion": "14819712",
        "selfLink": "/apis/cns.vmware.com/v1alpha1/triggercsifullsyncs/csifullsync",
        "uid": "120a2d69-8be3-496b-a9ff-164cd0bf37c5"
    },
    "spec": {
        "triggerSyncID": 1
    },
    "status": {
        "inProgress": false,
        "lastRunEndTimeStamp": "2021-03-22T19:41:39Z",
        "lastRunStartTimeStamp": "2021-03-22T19:41:37Z",
        "lastSuccessfulEndTimeStamp": "2021-03-22T19:41:39Z",
        "lastSuccessfulStartTimeStamp": "2021-03-22T19:41:37Z",
        "lastTriggerSyncID": 1
    }
}
```

  **Testing done on Vanilla**
  
  **Syncer init logs**
 
```
root@k8s-master:~# kubectl logs -f $POD_NAME -c vsphere-syncer -n kube-system
{"level":"info","time":"2021-03-22T20:02:29.707769555Z","caller":"logger/logger.go:37","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2021-03-22T20:02:29.708041345Z","caller":"syncer/main.go:72","msg":"Version : v2.1.0-rc.1-518-g26ddaa8-dirty","TraceId":"be29dffc-1175-4041-b052-5b891fea5257"}
{"level":"info","time":"2021-03-22T20:02:29.708128076Z","caller":"syncer/main.go:89","msg":"Starting container with operation mode: METADATA_SYNC","TraceId":"be29dffc-1175-4041-b052-5b891fea5257"}
{"level":"info","time":"2021-03-22T20:02:29.709143551Z","caller":"config/config.go:300","msg":"No Net Permissions given in Config. Using default permissions.","TraceId":"be29dffc-1175-4041-b052-5b891fea5257"}
{"level":"info","time":"2021-03-22T20:02:29.709292622Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"be29dffc-1175-4041-b052-5b891fea5257"}
{"level":"info","time":"2021-03-22T20:02:29.709605556Z","caller":"syncer/main.go:115","msg":"Starting the http server to expose Prometheus metrics..","TraceId":"be29dffc-1175-4041-b052-5b891fea5257"}
{"level":"info","time":"2021-03-22T20:02:29.709872492Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"be29dffc-1175-4041-b052-5b891fea5257"}
I0322 20:02:29.711711       1 leaderelection.go:242] attempting to acquire leader lease  kube-system/vsphere-syncer...
I0322 20:02:29.736006       1 leaderelection.go:252] successfully acquired lease kube-system/vsphere-syncer
{"level":"info","time":"2021-03-22T20:02:29.736232955Z","caller":"k8sorchestrator/k8sorchestrator.go:122","msg":"Initializing k8sOrchestratorInstance","TraceId":"7f9a5c1c-2271-4527-893f-c420a3daad0c"}
{"level":"info","time":"2021-03-22T20:02:29.736263838Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"7f9a5c1c-2271-4527-893f-c420a3daad0c"}
{"level":"info","time":"2021-03-22T20:02:29.736438607Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"7f9a5c1c-2271-4527-893f-c420a3daad0c"}
{"level":"info","time":"2021-03-22T20:02:29.766175937Z","caller":"k8sorchestrator/k8sorchestrator.go:234","msg":"New internal feature states values stored successfully: map[csi-auth-check:true csi-migration:false trigger-csi-fullsync:true]","TraceId":"7f9a5c1c-2271-4527-893f-c420a3daad0c"}
{"level":"info","time":"2021-03-22T20:02:29.766258033Z","caller":"k8sorchestrator/k8sorchestrator.go:148","msg":"k8sOrchestratorInstance initialized","TraceId":"7f9a5c1c-2271-4527-893f-c420a3daad0c"}
{"level":"info","time":"2021-03-22T20:02:29.766578135Z","caller":"manager/init.go:216","msg":"Triggerfullsync feature enabled","TraceId":"7f9a5c1c-2271-4527-893f-c420a3daad0c"}
{"level":"info","time":"2021-03-22T20:02:29.773246561Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"7f9a5c1c-2271-4527-893f-c420a3daad0c"}
{"level":"info","time":"2021-03-22T20:02:29.773653617Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"7f9a5c1c-2271-4527-893f-c420a3daad0c"}
{"level":"info","time":"2021-03-22T20:02:29.787239518Z","caller":"kubernetes/kubernetes.go:381","msg":"\"triggercsifullsyncs.cns.vmware.com\" CRD updated successfully","TraceId":"7f9a5c1c-2271-4527-893f-c420a3daad0c"}
{"level":"info","time":"2021-03-22T20:02:29.787537956Z","caller":"k8sorchestrator/k8sorchestrator.go:273","msg":"New feature states values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[csi-auth-check:true csi-migration:false trigger-csi-fullsync:true]","TraceId":"eb10671e-23dc-4e4a-a849-62371b013517"}
{"level":"info","time":"2021-03-22T20:02:30.126990639Z","caller":"manager/init.go:246","msg":"Created the a new instance of \"csifullsync\" TriggerCsiFullSync instance as it was not found.","TraceId":"7f9a5c1c-2271-4527-893f-c420a3daad0c"}
{"level":"info","time":"2021-03-22T20:02:30.128431184Z","caller":"manager/init.go:69","msg":"Initializing CNS Operator","TraceId":"027ec768-3c9f-4c6a-9376-853aae00384c"}
{"level":"info","time":"2021-03-22T20:02:30.12885754Z","caller":"types/commontypes.go:69","msg":"Initializing new vCenterInstance.","TraceId":"027ec768-3c9f-4c6a-9376-853aae00384c"}
{"level":"info","time":"2021-03-22T20:02:30.12897913Z","caller":"vsphere/utils.go:127","msg":"Defaulting timeout for vCenter Client to 5 minutes","TraceId":"027ec768-3c9f-4c6a-9376-853aae00384c"}
{"level":"info","time":"2021-03-22T20:02:30.129422887Z","caller":"vsphere/virtualcentermanager.go:68","msg":"Initializing defaultVirtualCenterManager...","TraceId":"027ec768-3c9f-4c6a-9376-853aae00384c"}
{"level":"info","time":"2021-03-22T20:02:30.129456843Z","caller":"vsphere/virtualcentermanager.go:70","msg":"Successfully initialized defaultVirtualCenterManager","TraceId":"027ec768-3c9f-4c6a-9376-853aae00384c"}
{"level":"info","time":"2021-03-22T20:02:30.129469041Z","caller":"vsphere/virtualcentermanager.go:114","msg":"Successfully registered VC \"10.184.78.154\"","TraceId":"027ec768-3c9f-4c6a-9376-853aae00384c"}
{"level":"info","time":"2021-03-22T20:02:30.13238286Z","caller":"syncer/metadatasyncer.go:124","msg":"Initializing MetadataSyncer"}
{"level":"info","time":"2021-03-22T20:02:30.136119786Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config"}
{"level":"info","time":"2021-03-22T20:02:30.145801277Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2021-03-22T20:02:30.189612143Z","caller":"vsphere/virtualcenter.go:159","msg":"New session ID for 'VSPHERE.LOCAL\\Administrator' = 52fe78c6-8f23-8f05-d8c0-94db12d8c691","TraceId":"027ec768-3c9f-4c6a-9376-853aae00384c"}
{"level":"info","time":"2021-03-22T20:02:30.190025981Z","caller":"types/commontypes.go:102","msg":"vCenterInstance initialized","TraceId":"027ec768-3c9f-4c6a-9376-853aae00384c"}
{"level":"info","time":"2021-03-22T20:02:30.19007428Z","caller":"volume/manager.go:111","msg":"Initializing new volume.defaultManager...","TraceId":"027ec768-3c9f-4c6a-9376-853aae00384c"}
{"level":"info","time":"2021-03-22T20:02:30.194963808Z","caller":"volume/manager.go:108","msg":"Retrieving existing volume.defaultManager..."}
{"level":"info","time":"2021-03-22T20:02:30.195158035Z","caller":"syncer/metadatasyncer.go:208","msg":"Adding watch on path: \"/etc/cloud\""}
{"level":"info","time":"2021-03-22T20:02:30.295643992Z","caller":"syncer/metadatasyncer.go:259","msg":"Initialized metadata syncer"}
{"level":"info","time":"2021-03-22T20:02:30.296101401Z","caller":"syncer/metadatasyncer.go:89","msg":"FullSync: fullSync interval is set to 30 minutes"}
{"level":"info","time":"2021-03-22T20:02:30.298342237Z","caller":"syncer/metadatasyncer.go:267","msg":"\"trigger-csi-fullsync\" feature flag is enabled. Using TriggerCsiFullSync API to trigger full sync"}
{"level":"info","time":"2021-03-22T20:02:30.4452304Z","caller":"manager/init.go:173","msg":"Registering Components for Cns Operator","TraceId":"027ec768-3c9f-4c6a-9376-853aae00384c"}
{"level":"info","time":"2021-03-22T20:02:30.44882495Z","caller":"kubernetes/kubernetes.go:91","msg":"k8s client using in-cluster config","TraceId":"69cd9da4-06da-4d42-be23-687374ac3884"}
{"level":"info","time":"2021-03-22T20:02:30.449126797Z","caller":"kubernetes/kubernetes.go:304","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"69cd9da4-06da-4d42-be23-687374ac3884"}
{"level":"info","time":"2021-03-22T20:02:30.450596924Z","caller":"manager/init.go:187","msg":"Starting Cns Operator","TraceId":"027ec768-3c9f-4c6a-9376-853aae00384c"}
{"level":"info","time":"2021-03-22T20:02:30.553121642Z","caller":"syncer/metadatasyncer.go:284","msg":"periodic fullSync is triggered","TraceId":"9f463999-c709-4c21-9a57-5b13a4af4ae4"}
{"level":"info","time":"2021-03-22T20:02:30.563435072Z","caller":"syncer/metadatasyncer.go:301","msg":"Incremented TriggerSyncID from 0 to 1 as part of periodic run to trigger full sync","TraceId":"9f463999-c709-4c21-9a57-5b13a4af4ae4"}
{"level":"info","time":"2021-03-22T20:02:30.564270932Z","caller":"triggercsifullsync/triggercsifullsync_controller.go:225","msg":"Reconciling trigger full sync with triggerSyncID: 1","TraceId":"f2c9b976-8c31-4ba4-836e-8a118aacd70b"}
{"level":"info","time":"2021-03-22T20:02:30.569526413Z","caller":"syncer/fullsync.go:40","msg":"FullSync: start","TraceId":"f2c9b976-8c31-4ba4-836e-8a118aacd70b"}
{"level":"warn","time":"2021-03-22T20:02:30.652497289Z","caller":"syncer/fullsync.go:368","msg":"could not find any volume which is present in both k8s and in CNS","TraceId":"f2c9b976-8c31-4ba4-836e-8a118aacd70b"}
{"level":"info","time":"2021-03-22T20:02:30.652761359Z","caller":"syncer/fullsync.go:240","msg":"FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion.","TraceId":"f2c9b976-8c31-4ba4-836e-8a118aacd70b"}
{"level":"info","time":"2021-03-22T20:02:30.653140866Z","caller":"syncer/fullsync.go:138","msg":"FullSync: end","TraceId":"f2c9b976-8c31-4ba4-836e-8a118aacd70b"}
{"level":"info","time":"2021-03-22T20:02:30.653400565Z","caller":"triggercsifullsync/triggercsifullsync_controller.go:253","msg":"Full sync successful with triggerSyncID: 1","TraceId":"f2c9b976-8c31-4ba4-836e-8a118aacd70b"}
```
@chethanv28 @divyenpatel 