### PR TITLE
Fix typo in vSphere 7.0 Vanilla CSI YAML 

### DIFF
--- a/manifests/dev/vsphere-7.0/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/vsphere-csi-driver.yaml
@@ -271,7 +271,7 @@ spec:
             secretName: vsphere-config-secret
         - name: socket-dir
           emptyDir: {}
---
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: There is minor error in the syntax for vSphere 7.0 CSI YAML in the dev folder, this PR fixes that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: 
Tested deploying the YAML:
```
csidriver.storage.k8s.io/csi.vsphere.vmware.com configured
serviceaccount/vsphere-csi-controller created
clusterrole.rbac.authorization.k8s.io/vsphere-csi-controller-role configured
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-controller-binding configured
serviceaccount/vsphere-csi-node created
role.rbac.authorization.k8s.io/vsphere-csi-node-role created
rolebinding.rbac.authorization.k8s.io/vsphere-csi-node-binding created
configmap/internal-feature-states.csi.vsphere.vmware.com created
deployment.apps/vsphere-csi-controller created
daemonset.apps/vsphere-csi-node created
service/vsphere-csi-controller created
```

Pods are up and running:
```
root@k8s-master-337:~# kc get pods
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-6b8648f5d9-jgp6d   6/6     Running   0          91s
vsphere-csi-node-2tdgp                    3/3     Running   0          91s
vsphere-csi-node-lg5w9                    3/3     Running   0          91s
vsphere-csi-node-r4c2d                    3/3     Running   0          91s
vsphere-csi-node-z5v75                    3/3     Running   0          91s
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix typo in vSphere 7.0 Vanilla CSI YAML 
```
