### PR TITLE
Remove optional tag from cluster-distribution docs

### DIFF
--- a/docs/book/driver-deployment/installation.md
+++ b/docs/book/driver-deployment/installation.md
@@ -54,7 +54,7 @@ Here is an example vSphere configuration file for block volumes, with dummy valu
 $ cat /etc/kubernetes/csi-vsphere.conf
 [Global]
 cluster-id = "<cluster-id>"
-cluster-distribution = "<cluster-distribution>" # optional
+cluster-distribution = "<cluster-distribution>"
 ca-file = <ca file path> # optional, use with insecure-flag set to false
 thumbprint = "<cert thumbprint>" # optional, use with insecure-flag set to false without providing ca-file
 
@@ -70,7 +70,7 @@ Where the entries have the following meaning:
 
 - `cluster-id` - represents the unique cluster identifier. Each kubernetes cluster should have it's own unique cluster-id set in the configuration file. The cluster ID should not exceed 64 characters.
 
-- `cluster-distribution` - represents the distribution of the kubernetes cluster. This parameter will be made mandatory in a future release. Examples are `Openshift`, `Anthos` and `PKS`.
+- `cluster-distribution` - represents the distribution of the kubernetes cluster. This parameter is optional but will be made mandatory in a future release. Examples are `Openshift`, `Anthos` and `PKS`.
 
   - values with special character `\r` causes vSphere CSI controller to go into CrashLoopBackOff state.
 
@@ -103,7 +103,7 @@ For file volumes, there are some extra parameters added to the config to help sp
 $ cat /etc/kubernetes/csi-vsphere.conf
 [Global]
 cluster-id = "<cluster-id>"
-cluster-distribution = "<cluster-distribution>" # optional
+cluster-distribution = "<cluster-distribution>"
 ca-file = <ca file path> # optional, use with insecure-flag set to false
 
 [NetPermissions "A"]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Follow up PR to https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/739/files#r599727738


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove optional tag from cluster-distribution docs
```
