### PR TITLE
Replacing the usage of CNS Query with QueryAll(with selection) to avoid SPBM workflows.

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -553,7 +553,13 @@ func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int
 	queryFilter := cnstypes.CnsQueryFilter{
 		VolumeIds: volumeIds,
 	}
-	queryResult, err := manager.VolumeManager.QueryVolume(ctx, queryFilter)
+	querySelection := cnstypes.CnsQuerySelection{
+		Names: []string{
+			string(cnstypes.QuerySelectionNameTypeBackingObjectDetails),
+		},
+	}
+	// Query only the backing object details.
+	queryResult, err := manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
 	if err != nil {
 		log.Errorf("failed to call QueryVolume for volumeID: %q: %v", volumeID, err)
 		return false, err

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -751,7 +751,13 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 			queryFilter := cnstypes.CnsQueryFilter{
 				VolumeIds: []cnstypes.CnsVolumeId{{Id: req.VolumeId}},
 			}
-			queryResult, err := c.manager.VolumeManager.QueryVolume(ctx, queryFilter)
+			querySelection := cnstypes.CnsQuerySelection{
+				Names: []string{
+					string(cnstypes.QuerySelectionNameTypeBackingObjectDetails),
+				},
+			}
+			// Select only the backing object details.
+			queryResult, err := c.manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
 			if err != nil {
 				msg := fmt.Sprintf("QueryVolume failed for volumeID: %q. %+v", req.VolumeId, err.Error())
 				log.Error(msg)
@@ -860,7 +866,13 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			queryFilter := cnstypes.CnsQueryFilter{
 				VolumeIds: []cnstypes.CnsVolumeId{{Id: req.VolumeId}},
 			}
-			queryResult, err := c.manager.VolumeManager.QueryVolume(ctx, queryFilter)
+			querySelection := cnstypes.CnsQuerySelection{
+				Names: []string{
+					string(cnstypes.QuerySelectionNameTypeVolumeType),
+				},
+			}
+			// Select only the volume type.
+			queryResult, err := c.manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
 			if err != nil {
 				msg := fmt.Sprintf("QueryVolume failed for volumeID: %q. %+v", req.VolumeId, err.Error())
 				log.Error(msg)

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -837,7 +837,8 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim, pv *v1.Pe
 			queryFilter := cnstypes.CnsQueryFilter{
 				VolumeIds: []cnstypes.CnsVolumeId{{Id: volumeHandle}},
 			}
-			queryResult, err := metadataSyncer.volumeManager.QueryVolume(ctx, queryFilter)
+			// Query with empty selection. CNS returns only the volume ID from it's cache.
+			queryResult, err := metadataSyncer.volumeManager.QueryAllVolume(ctx, queryFilter, cnstypes.CnsQuerySelection{})
 			if err != nil {
 				log.Warnf("PVCUpdated: Failed to query volume metadata for volume %q with error %+v", volumeHandle, err)
 				return false, err
@@ -979,7 +980,8 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 		}
 		volumeOperationsLock.Lock()
 		defer volumeOperationsLock.Unlock()
-		queryResult, err := metadataSyncer.volumeManager.QueryVolume(ctx, queryFilter)
+		// QueryAll with no selection will return only the volume ID.
+		queryResult, err := metadataSyncer.volumeManager.QueryAllVolume(ctx, queryFilter, cnstypes.CnsQuerySelection{})
 		if err != nil {
 			log.Errorf("PVUpdated: QueryVolume failed. error: %+v", err)
 			return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This is needed to reduce the number of Query API calls in CNS. There are many common places in CSI where we do not have to invoke Query. Instead we can invoke QeuryAll with selection to avoid SPBM workflows. This PR fixes the common places that can use QueryAll instead of Query API.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #757

**Special notes for your reviewer**:
Tested that the code change is working fine on vSphere 7.0U2 deployment. I logged(temporary code change which is removed in the PR) the QueryAll result in the code to validate that CNS is returning the selected properties.

ControllerPublish for file showing that the NFS access points are correctly returned:
```

2021-03-23T19:57:47.785Z        INFO    vanilla/controller.go:766       publish: Query Result: &{DynamicData:{} Volumes:[{DynamicData:{} VolumeId:{DynamicData:{} Id:file:adea8404-b5db-430f-952e-f0ae42d4a67c} DatastoreUrl: Name: VolumeType: StoragePolicyId: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser: ClusterFlavor: ClusterDistribution:} EntityMetadata:[] ContainerClusterArray:[]} BackingObjectDetails:0xc0009f36c0 ComplianceStatus: DatastoreAccessibilityStatus: HealthStatus:}] Cursor:{DynamicData:{} Offset:1 Limit:0 TotalRecords:1}}     {"TraceId": "779081a7-5f2b-4f01-bcbd-a795e98a865a"}
2021-03-23T19:57:47.787Z        INFO    vanilla/controller.go:831       ControllerPublishVolume successful with publish context: map[Nfsv4AccessPoint:h10-92-61-72.vsanfs-sh.prv:/vsanfs/5234b5b8-6b47-d127-83fb-e158641e176a type:vSphere CNS File Volume]     {"TraceId": "779081a7-5f2b-4f01-bcbd-a795e98a865a"}
```

ControllerUnpublish for file showing that the volume type is correctly returned by CNS QueryAll:
```
2021-03-23T20:00:10.015Z        INFO    vanilla/controller.go:882       unpublish: Query Result: &{DynamicData:{} Volumes:[{DynamicData:{} VolumeId:{DynamicData:{} Id:file:adea8404-b5db-430f-952e-f0ae42d4a67c} DatastoreUrl: Name: VolumeType:FILE StoragePolicyId: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser: ClusterFlavor: ClusterDistribution:} EntityMetadata:[] ContainerClusterArray:[]} BackingObjectDetails:<nil> ComplianceStatus: DatastoreAccessibilityStatus: HealthStatus:}] Cursor:{DynamicData:{} Offset:1 Limit:0 TotalRecords:1}}      {"TraceId": "518a58e6-11be-443e-a396-46156ce8df8b"}
2021-03-23T20:00:10.016Z        INFO    vanilla/controller.go:890       Skipping ControllerUnpublish for file volume "file:adea8404-b5db-430f-952e-f0ae42d4a67c"        {"TraceId": "518a58e6-11be-443e-a396-46156ce8df8b"}
```

ControllerUnpublish for block showing that the volume type is correctly returned by CNS QueryAll:
```
2021-03-23T19:30:31.628Z        INFO    vanilla/controller.go:882       unpublish: Query Result: &{DynamicData:{} Volumes:[{DynamicData:{} VolumeId:{DynamicData:{} Id:c561e7f5-c67f-4303-8be7-4ad9ec4109a9} DatastoreUrl: Name: VolumeType:BLOCK StoragePolicyId: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser: ClusterFlavor: ClusterDistribution:} EntityMetadata:[] ContainerClusterArray:[]} BackingObjectDetails:<nil> ComplianceStatus: DatastoreAccessibilityStatus: HealthStatus:}] Cursor:{DynamicData:{} Offset:1 Limit:0 TotalRecords:1}}  {"TraceId": "a0eeb234-fee1-4f89-8d12-3ebad80fface"}
```

csiPVCUpdated in syncer correctly getting the volumeId in QueryAll:
```
2021-03-23T19:22:14.958Z        INFO    syncer/metadatasyncer.go:846    csiPVCUpdated: Query Result: &{DynamicData:{} Volumes:[{DynamicData:{} VolumeId:{DynamicData:{} Id:c561e7f5-c67f-4303-8be7-4ad9ec4109a9} DatastoreUrl: Name: VolumeType: StoragePolicyId: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser: ClusterFlavor: ClusterDistribution:} EntityMetadata:[] ContainerClusterArray:[]} BackingObjectDetails:<nil> ComplianceStatus: DatastoreAccessibilityStatus: HealthStatus:}] Cursor:{DynamicData:{} Offset:1 Limit:0 TotalRecords:1}}   {"TraceId": "45b07826-468b-4c86-b2c3-266cb503b8f4"}
```

isExpansionRequired method in expand volume showing that the backing object detail is correct returned by QueryAll:
```
2021-03-23T19:53:32.320Z        INFO    common/vsphereutil.go:567       isExpansionRequired: Query Result: &{DynamicData:{} Volumes:[{DynamicData:{} VolumeId:{DynamicData:{} Id:a3c74c54-aa95-4b3d-bb10-c7d8fb2965ea} DatastoreUrl: Name: VolumeType: StoragePolicyId: Metadata:{DynamicData:{} ContainerCluster:{DynamicData:{} ClusterType: ClusterId: VSphereUser: ClusterFlavor: ClusterDistribution:} EntityMetadata:[] ContainerClusterArray:[]} BackingObjectDetails:0xc0004677a0 ComplianceStatus: DatastoreAccessibilityStatus: HealthStatus:}] Cursor:{DynamicData:{} Offset:1 Limit:0 TotalRecords:1}}, backingObj: &{DynamicData:{} CapacityInMb:2048}     {"TraceId": "eecc75b6-0d6e-40c9-a41b-1637f5fdc1f4"}
```

Validated that the PR works fine for block volumes in vSphere 6.7 U3. I observed the same ControllerUnpublish  and csiPVCUpdated logs in controller and syncer containers respectively.

Successfully ran the E2E tests. Some failures were observed that are not related to this PR.


**Release note**:
```release-note
Replacing the usage of CNS Query with QueryAll(with selection) to avo…
```
