### PR TITLE
Filter datastores for file volume creation in WCP

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -131,10 +131,15 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 	if err != nil {
 		return nil, err
 	}
-	var targetDatastoreUrlsForFile []string
 
+	var targetDatastoreUrlsForFile []string
 	if strings.TrimSpace(cfg.VirtualCenter[host].TargetvSANFileShareDatastoreURLs) != "" {
 		targetDatastoreUrlsForFile = strings.Split(cfg.VirtualCenter[host].TargetvSANFileShareDatastoreURLs, ",")
+	}
+
+	var targetvSANClustersForFile []string
+	if strings.TrimSpace(cfg.VirtualCenter[host].TargetvSANFileShareClusters) != "" {
+		targetvSANClustersForFile = strings.Split(cfg.VirtualCenter[host].TargetvSANFileShareClusters, ",")
 	}
 
 	var vcClientTimeout int
@@ -161,6 +166,7 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 		Password:                         cfg.VirtualCenter[host].Password,
 		Insecure:                         cfg.VirtualCenter[host].InsecureFlag,
 		TargetvSANFileShareDatastoreURLs: targetDatastoreUrlsForFile,
+		TargetvSANFileShareClusters:      targetvSANClustersForFile,
 		VCClientTimeout:                  vcClientTimeout,
 	}
 

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -112,6 +112,8 @@ type VirtualCenterConfig struct {
 	DatacenterPaths []string
 	// TargetDatastoreUrlsForFile represents URLs of file service enabled vSAN datastores in the virtual center.
 	TargetvSANFileShareDatastoreURLs []string
+	// TargetvSANFileShareClusters represents file service enabled vSAN clusters on which file volumes can be created.
+	TargetvSANFileShareClusters []string
 	// VCClientTimeout is the time limit in minutes for requests made by vCenter client
 	VCClientTimeout int
 }

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -113,6 +113,8 @@ type VirtualCenterConfig struct {
 	Datacenters string `gcfg:"datacenters"`
 	// Target datastore urls for provisioning file volumes.
 	TargetvSANFileShareDatastoreURLs string `gcfg:"targetvSANFileShareDatastoreURLs"`
+	// TargetvSANFileShareClusters represents file service enabled vSAN clusters on which file volumes can be created.
+	TargetvSANFileShareClusters string `gcfg:"targetvSANFileShareClusters"`
 }
 
 // GCConfig contains information used by guest cluster to access a supervisor

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -154,7 +154,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			return err
 		}
 		if isvSANFileServicesSupported {
-			go common.ComputeDatastoreMapForFileVolumes(authMgr.(*common.AuthManager),
+			go common.ComputeFSEnabledClustersToDsMap(authMgr.(*common.AuthManager),
 				config.Global.CSIAuthCheckIntervalInMin)
 		}
 	}
@@ -570,12 +570,13 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 	}
 	var volumeID string
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIAuthCheck) {
-		dsURLToInfoMap := c.authMgr.GetDatastoreMapForFileVolumes(ctx)
-		log.Debugf("Filtered Datastores: %+v", dsURLToInfoMap)
+		fsEnabledClusterToDsInfoMap := c.authMgr.GetFsEnabledClusterToDsMap(ctx)
+
 		var filteredDatastores []*cnsvsphere.DatastoreInfo
-		for _, datastore := range dsURLToInfoMap {
-			filteredDatastores = append(filteredDatastores, datastore)
+		for _, datastores := range fsEnabledClusterToDsInfoMap {
+			filteredDatastores = append(filteredDatastores, datastores...)
 		}
+
 		if len(filteredDatastores) == 0 {
 			msg := "no datastores found to create file volume"
 			log.Error(msg)

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -240,14 +240,14 @@ func (f *FakeAuthManager) GetDatastoreMapForBlockVolumes(ctx context.Context) ma
 	return datastoreMapForBlockVolumes
 }
 
-func (f *FakeAuthManager) GetDatastoreMapForFileVolumes(ctx context.Context) map[string]*cnsvsphere.DatastoreInfo {
-	datastoreMapForFileVolumes := make(map[string]*cnsvsphere.DatastoreInfo)
-	fmt.Print("FakeAuthManager: GetDatastoreMapForFileVolumes")
+func (f *FakeAuthManager) GetFsEnabledClusterToDsMap(ctx context.Context) map[string][]*cnsvsphere.DatastoreInfo {
+	fsEnabledClusterToDsMap := make(map[string][]*cnsvsphere.DatastoreInfo)
+	fmt.Print("FakeAuthManager: GetClusterToFsEnabledDsMap")
 	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
-		datastoreMapForFileVolumes, _ := common.GenerateDatastoreMapForFileVolumes(ctx, f.vcenter)
-		return datastoreMapForFileVolumes
+		fsEnabledClusterToDsMap, _ := common.GenerateFSEnabledClustersToDsMap(ctx, f.vcenter)
+		return fsEnabledClusterToDsMap
 	}
-	return datastoreMapForFileVolumes
+	return fsEnabledClusterToDsMap
 }
 
 func (f *FakeAuthManager) ResetvCenterInstance(ctx context.Context, vCenter *cnsvsphere.VirtualCenter) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. This PR is adding a new field `targetvSANFileShareClusters` to vSphere config secret. This field is optional and will be used only in WCP to filter datastores for file volume creation.  This field will be set by `wcpsvc` in the CSI secret when file volume feature is enabled on WCP.
The reason we're introducing this and not rely on existing `targetvSANFileShareDatastoreURLs` field is because `wcpsvc` doesn't want to add the logic fetch vSAN fileshare datastores in their layer. So the existing `targetvSANFileShareDatastoreURLs` field will be empty there.

2. This also adds a logic to periodically update the map of vSAN file service enabled cluster IDs to corresponding datastores, which will be used in file volume creation workflow.
For file volume creation in WCP, we currently take into account all clusters with Host.Config.Storage privilege and file services enabled. With introduction of this change, we will add another filter that only vSAN FS datastores corresponding to cluster IDs in the list will be used for file volume placement.

Since `targetvSANFileShareClusters` is not supposed to be used with vanilla set-up, file volume creation in vanilla will continue to use the same logic. It's just refactored a bit to use the map of cluster ID to datastore info objects.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

**WCP**: 
Enabled `csi-auth-check` and `file-volume` feature flags. The field `targetvSANFileShareClusters` was set in CSI secret by `wcpsvc`.
```
[Global]
insecure-flag = "true"
cluster-id = "domain-c9"
cnsregistervolumes-cleanup-intervalinmin = 720
cluster-distribution = "SupervisorCluster"
[VirtualCenter "sc-rdops-vm12-dhcp-124-153.eng.vmware.com"]
user = "workload_storage_management-1637b8a1-d93d-42af-bc4f-77318241a294@vsphere.local"
password = "%^E1dmI&vgzwU_m|F~b^"
datacenters = "datacenter-4"
port = "443"
targetvSANFileShareClusters = "domain-c9"         <<<<<<------------
```

With `csi-auth-check` enabled, the datastore maps generated periodically for file volumes are getting updated. Container init logs:
```
.
.
2021-04-09T00:53:51.327Z	DEBUG	common/authmanager.go:141	auth manager: refreshDatastoreMapsForFileVolumes is triggered	{"TraceId": "a5854276-495a-4089-9f71-4b90632d357b"}
2021-04-09T00:53:51.756Z	DEBUG	common/authmanager.go:390	Computing the map for vSAN FS enabled clusters to datastore URLS.	{"TraceId": "a5854276-495a-4089-9f71-4b90632d357b"}
2021-04-09T00:53:51.756Z	DEBUG	common/authmanager.go:433	Computing the clusters with vSAN file services enabled and Host.Config.Storage privileges	{"TraceId": "a5854276-495a-4089-9f71-4b90632d357b"}
2021-04-09T00:53:51.799Z	DEBUG	common/authmanager.go:473	auth manager: HasUserPrivilegeOnEntities returns [{{} ClusterComputeResource:domain-c21 [{{} Host.Config.Storage true}]} {{} ClusterComputeResource:domain-c9 [{{} Host.Config.Storage true}]}] when checking privileges [Host.Config.Storage] on entities [ClusterComputeResource:domain-c21 ClusterComputeResource:domain-c9] for user workload_storage_management-1637b8a1-d93d-42af-bc4f-77318241a294@vsphere.local	{"TraceId": "a5854276-495a-4089-9f71-4b90632d357b"}
2021-04-09T00:53:51.801Z	DEBUG	common/authmanager.go:489	Clusters with priv: Host.Config.Storage are : [ClusterComputeResource:domain-c21 @ /folder-WCP_DC/WCP_DC/host/edge-cluster ClusterComputeResource:domain-c9 @ /folder-WCP_DC/WCP_DC/host/compute-cluster]	{"TraceId": "a5854276-495a-4089-9f71-4b90632d357b"}
2021-04-09T00:53:51.861Z	DEBUG	common/authmanager.go:502	cluster: ClusterComputeResource:domain-c21 @ /folder-WCP_DC/WCP_DC/host/edge-cluster is a non-vSAN cluster. Skipping this cluster	{"TraceId": "a5854276-495a-4089-9f71-4b90632d357b"}
2021-04-09T00:53:51.892Z	DEBUG	common/authmanager.go:510	cluster: ClusterComputeResource:domain-c9 @ /folder-WCP_DC/WCP_DC/host/compute-cluster has vSAN file services enabled: true	{"TraceId": "a5854276-495a-4089-9f71-4b90632d357b"}
2021-04-09T00:53:51.925Z	DEBUG	common/authmanager.go:249	Adding vSAN datastore "ds:///vmfs/volumes/vsan:52ef5283816de19b-2ab5954ae5fb72d5/" to the list for FS enabled cluster "domain-c9"	{"TraceId": "a5854276-495a-4089-9f71-4b90632d357b"}
2021-04-09T00:53:51.931Z	DEBUG	common/authmanager.go:255	clusterToDsInfoListMap is map[domain-c9:[Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/vsan:52ef5283816de19b-2ab5954ae5fb72d5/]]	{"TraceId": "a5854276-495a-4089-9f71-4b90632d357b"}
2021-04-09T00:53:51.931Z	DEBUG	common/authmanager.go:148	auth manager: newFsEnabledClusterToDsMap is updated to map[domain-c9:[Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/vsan:52ef5283816de19b-2ab5954ae5fb72d5/]]	{"TraceId": "a5854276-495a-4089-9f71-4b90632d357b"}
.
.
```

When pvc was created with `ReadWriteMany` access mode, file volume did get created
Controller logs - The debug log captures that it's filtering the eligible datastores corresponding to the cluster ID in `targetvSANFileShareClusters`.

```
2021-04-09T00:55:47.465Z	INFO	wcp/controller.go:461	CreateVolume: called with args {Name:pvc-76d2346c-37d9-4b8a-b41d-efc119312e50 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<> access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[storagePolicyID:ed1eb546-d70d-447b-a04b-16e693d8d7aa] ..
2021-04-09T00:55:47.476Z	DEBUG	wcp/controller.go:418	Adding datastore "ds:///vmfs/volumes/vsan:52ef5283816de19b-2ab5954ae5fb72d5/" to filtered datastores	{"TraceId": "f41e771e-871a-4dce-9433-988d8b321396"}
.
.
.
2021-04-09T00:55:59.114Z	INFO	volume/manager.go:307	CreateVolume: Volume created successfully. VolumeName: "pvc-76d2346c-37d9-4b8a-b41d-efc119312e50", opId: "7e27edeb", volumeID: "file:3468d791-0c64-4b89-a750-ee511574cfed"	{"TraceId": "f41e771e-871a-4dce-9433-988d8b321396"}
2021-04-09T00:55:59.116Z	DEBUG	volume/manager.go:308	CreateVolume volumeId "file:3468d791-0c64-4b89-a750-ee511574cfed" is placed on datastore "ds:///vmfs/volumes/vsan:52ef5283816de19b-2ab5954ae5fb72d5/"
```

**Vanilla**:
 Enabled `csi-auth-check` and `file-volume` feature flags. The datastore maps are updated periodically for file volumes. Container init logs:
 ```
 2021-04-09T01:24:07.749Z	INFO	common/authmanager.go:167	auth manager: ComputeFSEnabledClustersToDsMap enter
2021-04-09T01:24:07.749Z	DEBUG	common/authmanager.go:141	auth manager: refreshDatastoreMapsForFileVolumes is triggered	{"TraceId": "68c42a94-707e-4e84-a4eb-94d947f723f9"}
2021-04-09T01:24:07.814Z	DEBUG	common/authmanager.go:390	Computing the map for vSAN FS enabled clusters to datastore URLS.	{"TraceId": "68c42a94-707e-4e84-a4eb-94d947f723f9"}
2021-04-09T01:24:07.814Z	DEBUG	common/authmanager.go:433	Computing the clusters with vSAN file services enabled and Host.Config.Storage privileges	{"TraceId": "68c42a94-707e-4e84-a4eb-94d947f723f9"}
2021-04-09T01:24:07.842Z	DEBUG	common/authmanager.go:473	auth manager: HasUserPrivilegeOnEntities returns [{{} ClusterComputeResource:domain-c53 [{{} Host.Config.Storage true}]}] when checking privileges [Host.Config.Storage] on entities [ClusterComputeResource:domain-c53] for user Administrator@vsphere.local	{"TraceId": "68c42a94-707e-4e84-a4eb-94d947f723f9"}
2021-04-09T01:24:07.842Z	DEBUG	common/authmanager.go:489	Clusters with priv: Host.Config.Storage are : [ClusterComputeResource:domain-c53 @ /test-vpx-1616553346-30311-hostpool/host/vSAN-FVT-Cluster1616553475.519551]	{"TraceId": "68c42a94-707e-4e84-a4eb-94d947f723f9"}
2021-04-09T01:24:07.930Z	DEBUG	common/authmanager.go:510	cluster: ClusterComputeResource:domain-c53 @ /test-vpx-1616553346-30311-hostpool/host/vSAN-FVT-Cluster1616553475.519551 has vSAN file services enabled: true	{"TraceId": "68c42a94-707e-4e84-a4eb-94d947f723f9"}
2021-04-09T01:24:07.946Z	DEBUG	common/authmanager.go:249	Adding vSAN datastore "ds:///vmfs/volumes/vsan:5275b948f0481b91-81f8515679f6c850/" to the list for FS enabled cluster "domain-c53"	{"TraceId": "68c42a94-707e-4e84-a4eb-94d947f723f9"}
2021-04-09T01:24:07.947Z	DEBUG	common/authmanager.go:255	clusterToDsInfoListMap is map[domain-c53:[Datastore: Datastore:datastore-59, datastore URL: ds:///vmfs/volumes/vsan:5275b948f0481b91-81f8515679f6c850/]]	{"TraceId": "68c42a94-707e-4e84-a4eb-94d947f723f9"}
2021-04-09T01:24:07.947Z	DEBUG	common/authmanager.go:148	auth manager: newFsEnabledClusterToDsMap is updated to map[domain-c53:[Datastore: Datastore:datastore-59, datastore URL: ds:///vmfs/volumes/vsan:5275b948f0481b91-81f8515679f6c850/]]	{"TraceId": "68c42a94-707e-4e84-a4eb-94d947f723f9"}
```

When pvc was created with `ReadWriteMany` access mode, file volume did get created
Controller logs:

```
2021-04-09T01:31:03.464Z	INFO	vanilla/controller.go:625	CreateVolume: called with args {Name:pvc-5c12922a-0929-4379-aa49-2bbd2f907c29 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "5c6cf200-7279-427f-a8a7-0f0ef662f6a6"}
2021-04-09T01:31:03.464Z	DEBUG	vsphere/utils.go:385	Checking if vCenter version is of vsan 67u3 release	{"TraceId": "5c6cf200-7279-427f-a8a7-0f0ef662f6a6"}
.
.
2021-04-09T01:31:15.303Z	INFO	volume/manager.go:307	CreateVolume: Volume created successfully. VolumeName: "pvc-5c12922a-0929-4379-aa49-2bbd2f907c29", opId: "2a17ebb7", volumeID: "file:92880b13-ba85-480d-a086-5d1c653a888b"	{"TraceId": "5c6cf200-7279-427f-a8a7-0f0ef662f6a6"}
2021-04-09T01:31:15.303Z	DEBUG	volume/manager.go:308	CreateVolume volumeId "file:92880b13-ba85-480d-a086-5d1c653a888b" is placed on datastore "ds:///vmfs/volumes/vsan:5275b948f0481b91-81f8515679f6c850/"	{"TraceId": "5c6cf200-7279-427f-a8a7-0f0ef662f6a6"}
```



 
 


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Filter datastores for file volume creation in WCP
```
