### PR TITLE
Update driver manifests to indicate api version for CSIDriver based on k8s version

### DIFF
--- a/manifests/dev/vsphere-67u3/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/dev/vsphere-67u3/vanilla/vsphere-csi-driver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1 # For k8s 1.17 or lower use storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: csi.vsphere.vmware.com

--- a/manifests/dev/vsphere-7.0/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/dev/vsphere-7.0/vanilla/vsphere-csi-driver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1 # For k8s 1.17 or lower use storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: csi.vsphere.vmware.com

--- a/manifests/v2.1.1/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.1.1/vsphere-67u3/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -127,7 +127,7 @@ metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
   namespace: kube-system
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1 # For k8s 1.17 or lower use storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: csi.vsphere.vmware.com

--- a/manifests/v2.1.1/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.1.1/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
@@ -140,7 +140,7 @@ metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
   namespace: kube-system
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1 # For k8s 1.17 or lower use storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: csi.vsphere.vmware.com


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is just preventing warnings that can be observed while deploying csi driver on k8s 1.18 or higher.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Before:
```
kubectl apply -f driver.yaml 
Warning: storage.k8s.io/v1beta1 CSIDriver is deprecated in v1.19+, unavailable in v1.22+; use storage.k8s.io/v1 CSIDriver
```

After:
```
kubectl apply -f driver.yaml 
deployment.apps/vsphere-csi-controller created
configmap/internal-feature-states.csi.vsphere.vmware.com created
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update driver manifests to indicate api version for CSIDriver
```
