### PR TITLE
Replacing the usage of CNS Query with QueryAll(with selection) to avoid SPBM workflows

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -553,7 +553,13 @@ func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int
 	queryFilter := cnstypes.CnsQueryFilter{
 		VolumeIds: volumeIds,
 	}
-	queryResult, err := manager.VolumeManager.QueryVolume(ctx, queryFilter)
+	querySelection := cnstypes.CnsQuerySelection{
+		Names: []string{
+			string(cnstypes.QuerySelectionNameTypeBackingObjectDetails),
+		},
+	}
+	// Query only the backing object details.
+	queryResult, err := manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
 	if err != nil {
 		log.Errorf("failed to call QueryVolume for volumeID: %q: %v", volumeID, err)
 		return false, err

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -751,7 +751,13 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 			queryFilter := cnstypes.CnsQueryFilter{
 				VolumeIds: []cnstypes.CnsVolumeId{{Id: req.VolumeId}},
 			}
-			queryResult, err := c.manager.VolumeManager.QueryVolume(ctx, queryFilter)
+			querySelection := cnstypes.CnsQuerySelection{
+				Names: []string{
+					string(cnstypes.QuerySelectionNameTypeBackingObjectDetails),
+				},
+			}
+			// Select only the backing object details.
+			queryResult, err := c.manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
 			if err != nil {
 				msg := fmt.Sprintf("QueryVolume failed for volumeID: %q. %+v", req.VolumeId, err.Error())
 				log.Error(msg)
@@ -860,7 +866,13 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			queryFilter := cnstypes.CnsQueryFilter{
 				VolumeIds: []cnstypes.CnsVolumeId{{Id: req.VolumeId}},
 			}
-			queryResult, err := c.manager.VolumeManager.QueryVolume(ctx, queryFilter)
+			querySelection := cnstypes.CnsQuerySelection{
+				Names: []string{
+					string(cnstypes.QuerySelectionNameTypeVolumeType),
+				},
+			}
+			// Select only the volume type.
+			queryResult, err := c.manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
 			if err != nil {
 				msg := fmt.Sprintf("QueryVolume failed for volumeID: %q. %+v", req.VolumeId, err.Error())
 				log.Error(msg)

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -755,7 +755,8 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim, pv *v1.Pe
 			queryFilter := cnstypes.CnsQueryFilter{
 				VolumeIds: []cnstypes.CnsVolumeId{{Id: volumeHandle}},
 			}
-			queryResult, err := metadataSyncer.volumeManager.QueryVolume(ctx, queryFilter)
+			// Query with empty selection. CNS returns only the volume ID from it's cache.
+			queryResult, err := metadataSyncer.volumeManager.QueryAllVolume(ctx, queryFilter, cnstypes.CnsQuerySelection{})
 			if err != nil {
 				log.Warnf("PVCUpdated: Failed to query volume metadata for volume %q with error %+v", volumeHandle, err)
 				return false, err
@@ -897,7 +898,8 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 		}
 		volumeOperationsLock.Lock()
 		defer volumeOperationsLock.Unlock()
-		queryResult, err := metadataSyncer.volumeManager.QueryVolume(ctx, queryFilter)
+		// QueryAll with no selection will return only the volume ID.
+		queryResult, err := metadataSyncer.volumeManager.QueryAllVolume(ctx, queryFilter, cnstypes.CnsQuerySelection{})
 		if err != nil {
 			log.Errorf("PVUpdated: QueryVolume failed. error: %+v", err)
 			return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry-picking PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/758 into 2.2 release.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #757 

**Special notes for your reviewer**:

**Release note**:
```release-note
Replacing the usage of CNS Query with QueryAll(with selection) to avoid SPBM workflows
```
