### PR TITLE
supervisor feature switch states replications on workload namespaces

### DIFF
--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.17/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.17/cns-csi.yaml
@@ -15,7 +15,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
 - apiGroups: [""]
-  resources: ["nodes", "pods", "configmaps", "resourcequotas"]
+  resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
@@ -41,6 +41,9 @@ rules:
 - apiGroups: ["cns.vmware.com"]
   resources: ["cnsnodevmattachments", "cnsvolumemetadatas"]
   verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["cns.vmware.com"]
+  resources: ["cnscsisvfeaturestates"]
+  verbs: ["create", "get", "list", "update"]
 - apiGroups: ["cns.vmware.com"]
   resources: ["cnsregistervolumes"]
   verbs: ["get", "list", "watch", "update", "delete"]
@@ -302,6 +305,7 @@ data:
   "volume-extend": "true"
   "volume-health": "true"
   "trigger-csi-fullsync": "false"
+  "csi-sv-feature-states-replication": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.18/cns-csi.yaml
@@ -15,7 +15,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas"]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
@@ -44,6 +44,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsvolumemetadatas", "cnsfileaccessconfigs"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnscsisvfeaturestates"]
+    verbs: ["create", "get", "list", "update"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsregistervolumes"]
     verbs: ["get", "list", "watch", "update", "delete"]
@@ -297,6 +300,7 @@ data:
   "volume-health": "true"
   "vsan-direct-disk-decommission": "false"
   "trigger-csi-fullsync": "false"
+  "csi-sv-feature-states-replication": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.19/cns-csi.yaml
@@ -15,7 +15,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas"]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
@@ -44,6 +44,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsvolumemetadatas", "cnsfileaccessconfigs"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnscsisvfeaturestates"]
+    verbs: ["create", "get", "list", "update"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfilevolumeclients"]
     verbs: ["get", "update", "create", "delete"]
@@ -318,6 +321,7 @@ data:
   "csi-auth-check": "false"
   "vsan-direct-disk-decommission": "false"
   "trigger-csi-fullsync": "false"
+  "csi-sv-feature-states-replication": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -234,6 +234,8 @@ const (
 	CSIMigration = "csi-migration"
 	// CSIAuthCheck is feature flag for auth check
 	CSIAuthCheck = "csi-auth-check"
+	// CSISVFeatureStateReplication is feature flag for SV feature state replication feature
+	CSISVFeatureStateReplication = "csi-sv-feature-states-replication"
 	// VSANDirectDiskDecommission is feature flag for vsanD disk decommission
 	VSANDirectDiskDecommission = "vsan-direct-disk-decommission"
 	// FileVolume is feature flag name for file volume support in WCP

--- a/pkg/internalapis/featurestates/featurestates.go
+++ b/pkg/internalapis/featurestates/featurestates.go
@@ -1,0 +1,431 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package featurestates
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"strconv"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis"
+	featurestatesv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/featurestates/v1alpha1"
+	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
+)
+
+const (
+	// CRDName represent the name of cnscsisvfeaturestate CRD
+	CRDName = "cnscsisvfeaturestates.cns.vmware.com"
+	// CRDGroupName represent the group of cnscsisvfeaturestate CRD
+	CRDGroupName = "cns.vmware.com"
+	// CRDSingular represent the singular name of cnscsisvfeaturestate CRD
+	CRDSingular = "cnscsisvfeaturestate"
+	// CRDPlural represent the plural name of cnscsisvfeaturestates CRD
+	CRDPlural = "cnscsisvfeaturestates"
+	// WorkLoadNamespaceLabelKey is the label key found on the workload namespace in the supervisor k8s cluster
+	WorkLoadNamespaceLabelKey = "vSphereClusterID"
+	// SVFeatureStateCRName to be used for CR in workload namespaces
+	SVFeatureStateCRName = "svfeaturestates"
+	// crUpdateRetryInterval is the interval at which pending CR update/create tasks are executed
+	crUpdateRetryInterval = 30 * time.Second
+)
+
+// pendingCRUpdates holds latest states of the namespaces to push CR update, latest feature states and the lock to operate
+// on namespaceUpdateMap and latestFeatureStates
+type pendingCRUpdates struct {
+	// lock to acquire before updating namespaceUpdateMap and latestFeatureStates
+	lock *sync.RWMutex
+	// holds namespace name and status to update CR in the namespace
+	// map value true, means update is pending, false means no update is required.
+	namespaceUpdateMap map[string]bool
+	// latest featureStates
+	latestFeatureStates []featurestatesv1alpha1.FeatureState
+}
+
+var (
+	supervisorFeatureStatConfigMapName       string
+	supervisorFeatureStateConfigMapNamespace string
+	pendingCRUpdatesObj                      *pendingCRUpdates
+	k8sClient                                clientset.Interface
+	controllerRuntimeClient                  client.Client
+)
+
+// StartSvFSSReplicationService Starts SvFSSReplicationService
+func StartSvFSSReplicationService(ctx context.Context, svFeatureStatConfigMapName string, svFeatureStateConfigMapNamespace string) error {
+	log := logger.GetLogger(ctx)
+	log.Info("Starting SvFSSReplicationService")
+
+	supervisorFeatureStatConfigMapName = svFeatureStatConfigMapName
+	supervisorFeatureStateConfigMapNamespace = svFeatureStateConfigMapNamespace
+	pendingCRUpdatesObj = &pendingCRUpdates{
+		lock:                &sync.RWMutex{},
+		namespaceUpdateMap:  make(map[string]bool),
+		latestFeatureStates: make([]featurestatesv1alpha1.FeatureState, 0),
+	}
+	var err error
+	// This is idempotent if CRD is pre-created then we continue with initialization of svFSSReplicationService
+	err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, CRDName, CRDSingular, CRDPlural,
+		reflect.TypeOf(featurestatesv1alpha1.CnsCsiSvFeatureStates{}).Name(), CRDGroupName, internalapis.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
+	if err != nil {
+		log.Errorf("failed to create CnsCsiSvFeatureStates CRD. Error: %v", err)
+		return err
+	}
+
+	// Create the kubernetes client
+	k8sClient, err = k8s.NewClient(ctx)
+	if err != nil {
+		log.Errorf("create k8s client failed. Err: %v", err)
+		return err
+	}
+	// get kube config
+	config, err := k8s.GetKubeConfig(ctx)
+	if err != nil {
+		log.Errorf("failed to get kubeconfig. Error: %v", err)
+		return err
+	}
+	// create controller runtime client
+	controllerRuntimeClient, err = k8s.NewClientForGroup(ctx, config, CRDGroupName)
+	if err != nil {
+		log.Errorf("failed to create controllerRuntimeClient. Err: %v", err)
+		return err
+	}
+
+	// Create k8s Informer and watch on configmaps and namespaces
+	informer := k8s.NewInformer(k8sClient)
+	// configmap informer to watch on SV featurestate config-map
+	informer.AddConfigMapListener(ctx, k8sClient, svFeatureStateConfigMapNamespace,
+		// Add
+		func(Obj interface{}) {
+			configMapAdded(Obj)
+		},
+		// Update
+		func(oldObj interface{}, newObj interface{}) {
+			configMapUpdated(oldObj, newObj)
+		},
+		// Delete
+		func(obj interface{}) {
+			configMapDeleted(obj)
+		})
+
+	// namespace informer to watch on namespaces
+	informer.AddNamespaceListener(
+		// Add
+		func(obj interface{}) {
+			namespaceAdded(obj)
+		},
+		// Update
+		func(oldObj interface{}, newObj interface{}) {
+			namespaceUpdated(oldObj, newObj)
+		},
+		// Delete
+		func(obj interface{}) {
+			namespaceDeleted(obj)
+		})
+	informer.Listen()
+	log.Infof("Informer on config-map and namespaces started")
+
+	// Start routine to process pending feature state updates
+	go pendingCRUpdatesObj.processPendingCRUpdates()
+	log.Infof("Started background routine to process pending feature state updates at regular interval")
+	log.Infof("SvFSSReplicationService is running")
+	var stopCh = make(chan bool)
+	<-stopCh
+	return nil
+}
+
+// processPendingCRUpdates helps process pending CR updates at regular interval
+func (pendingCRUpdatesObj *pendingCRUpdates) processPendingCRUpdates() {
+	ticker := time.NewTicker(crUpdateRetryInterval)
+	for range ticker.C {
+		func() {
+			pendingCRUpdatesObj.lock.Lock()
+			defer pendingCRUpdatesObj.lock.Unlock()
+
+			ctx, log := logger.GetNewContextWithLogger()
+			var err error
+			if len(pendingCRUpdatesObj.latestFeatureStates) == 0 {
+				log.Warn("empty feature states observed. feature state config-map might be deleted. Trying to obtain latest feature states.")
+				pendingCRUpdatesObj.latestFeatureStates, err = getFeatureStates(ctx)
+				if err != nil {
+					log.Errorf("failed to get feature states. error: %v", err)
+					return
+				}
+			}
+			for namespace, updateRequired := range pendingCRUpdatesObj.namespaceUpdateMap {
+				if !updateRequired {
+					log.Debugf("CR update is not required for the namespace: %q", namespace)
+					continue
+				}
+				log.Infof("Feature state update is required for namespace: %q", namespace)
+				// check if CR is present on the namespace
+				featurestateCR := &featurestatesv1alpha1.CnsCsiSvFeatureStates{}
+				err := controllerRuntimeClient.Get(ctx, client.ObjectKey{Name: SVFeatureStateCRName,
+					Namespace: namespace}, featurestateCR)
+				if err == nil {
+					// Attempt to Update CR
+					featurestateCR.Spec.FeatureStates = pendingCRUpdatesObj.latestFeatureStates
+					err = controllerRuntimeClient.Update(ctx, featurestateCR)
+					if err != nil {
+						log.Errorf("failed to update cnsCsiSvFeatureStates CR instance in the namespace: %q, Err: %v", namespace, err)
+						continue
+					}
+					pendingCRUpdatesObj.namespaceUpdateMap[namespace] = false
+					log.Infof("Updated cnsCsiSvFeatureStates CR instance in the namespace: %q", namespace)
+				} else {
+					if apierrors.IsNotFound(err) {
+						log.Infof("cnsCsiSvFeatureStates CR instance is not present in the namespace: %q. "+
+							"Creating CR with latest feature switch state, Err: %v", namespace, err)
+						// attempt to Create the CR
+						cnsCsiSvFeatureStates := &featurestatesv1alpha1.CnsCsiSvFeatureStates{
+							ObjectMeta: metav1.ObjectMeta{Name: SVFeatureStateCRName, Namespace: namespace},
+							Spec: featurestatesv1alpha1.CnsCsiSvFeatureStatesSpec{
+								FeatureStates: pendingCRUpdatesObj.latestFeatureStates,
+							},
+						}
+						err = controllerRuntimeClient.Create(ctx, cnsCsiSvFeatureStates)
+						if err != nil {
+							log.Errorf("failed to create cnsCsiSvFeatureStates CR instance in the "+
+								"namespace: %q. Continuing the FSS replication to other namespaces.., Err: %v", namespace, err)
+							continue
+						}
+						pendingCRUpdatesObj.namespaceUpdateMap[namespace] = false
+						log.Infof("Created cnsCsiSvFeatureStates CR instance in the namespace: %q", namespace)
+					} else {
+						log.Errorf("failed to check if cnsCsiSvFeatureStates CR is present in the namespace :%q, err: %v", namespace, err)
+					}
+				}
+			}
+		}()
+	}
+}
+
+// enqueueFeatureStateUpdatesForAllWorkloadNamespaces helps enqueue featurestates updates for all workload namespaces
+func (pendingCRUpdatesObj *pendingCRUpdates) enqueueFeatureStateUpdatesForAllWorkloadNamespaces(ctx context.Context, featurestates []featurestatesv1alpha1.FeatureState) {
+	pendingCRUpdatesObj.lock.Lock()
+	defer pendingCRUpdatesObj.lock.Unlock()
+
+	log := logger.GetLogger(ctx)
+	pendingCRUpdatesObj.latestFeatureStates = featurestates
+	for namespace := range pendingCRUpdatesObj.namespaceUpdateMap {
+		pendingCRUpdatesObj.namespaceUpdateMap[namespace] = true
+	}
+	log.Infof("Enqueued CR updates for all workload namespaces")
+}
+
+// enqueueFeatureStateUpdatesForWorkloadNamespace enqueues CR updates for specified workload namespaces
+func (pendingCRUpdatesObj *pendingCRUpdates) enqueueFeatureStateUpdatesForWorkloadNamespace(ctx context.Context, namespace string) {
+	pendingCRUpdatesObj.lock.Lock()
+	defer pendingCRUpdatesObj.lock.Unlock()
+
+	log := logger.GetLogger(ctx)
+	pendingCRUpdatesObj.namespaceUpdateMap[namespace] = true
+	log.Infof("Enqueued CR updates for workload namespace: %q", namespace)
+}
+
+// configMapAdded is called when configmap is created
+func configMapAdded(obj interface{}) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx)
+
+	fssConfigMap, ok := obj.(*v1.ConfigMap)
+	if fssConfigMap == nil || !ok {
+		log.Warnf("configMapAdded: unrecognized object %+v", obj)
+		return
+	}
+	if fssConfigMap.Name == supervisorFeatureStatConfigMapName &&
+		fssConfigMap.Namespace == supervisorFeatureStateConfigMapNamespace {
+		log.Infof("Observed fss add: fss: %+v", fssConfigMap.Data)
+		var err error
+		var featureStates []featurestatesv1alpha1.FeatureState
+		for feature, state := range fssConfigMap.Data {
+			var featureState featurestatesv1alpha1.FeatureState
+			featureState.Name = feature
+			featureState.Enabled, err = strconv.ParseBool(state)
+			if err != nil {
+				log.Errorf("failed to parse feature state value: %v for feature: %q", state, feature)
+				os.Exit(1)
+			}
+			featureStates = append(featureStates, featureState)
+		}
+		pendingCRUpdatesObj.enqueueFeatureStateUpdatesForAllWorkloadNamespaces(ctx, featureStates)
+	}
+}
+
+// configMapUpdated is called when configmap is updated
+func configMapUpdated(oldObj, newObj interface{}) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx)
+
+	newfssConfigMap, ok := newObj.(*v1.ConfigMap)
+	if newfssConfigMap == nil || !ok {
+		log.Warnf("configMapUpdated: unrecognized old object %+v", newObj)
+		return
+	}
+	oldfssConfigMap, ok := oldObj.(*v1.ConfigMap)
+	if oldfssConfigMap == nil || !ok {
+		log.Warnf("configMapUpdated: unrecognized new object %+v", newObj)
+		return
+	}
+
+	if newfssConfigMap.Name == supervisorFeatureStatConfigMapName &&
+		newfssConfigMap.Namespace == supervisorFeatureStateConfigMapNamespace {
+		if reflect.DeepEqual(newfssConfigMap.Data, oldfssConfigMap.Data) {
+			return
+		}
+		log.Infof("Observed fss update: oldfss: %+v newfss: %+v", oldfssConfigMap.Data, newfssConfigMap.Data)
+		var err error
+		var featureStates []featurestatesv1alpha1.FeatureState
+		for feature, state := range newfssConfigMap.Data {
+			var featureState featurestatesv1alpha1.FeatureState
+			featureState.Name = feature
+			featureState.Enabled, err = strconv.ParseBool(state)
+			if err != nil {
+				log.Errorf("failed to parse feature state value: %v for feature: %q", state, feature)
+				os.Exit(1)
+			}
+			featureStates = append(featureStates, featureState)
+		}
+		pendingCRUpdatesObj.enqueueFeatureStateUpdatesForAllWorkloadNamespaces(ctx, featureStates)
+	}
+}
+
+// configMapDeleted is called when config-map is deleted
+func configMapDeleted(obj interface{}) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx)
+
+	fssConfigMap, ok := obj.(*v1.ConfigMap)
+	if fssConfigMap == nil || !ok {
+		log.Warnf("configMapDeleted: unrecognized object %+v", obj)
+		return
+	}
+	if fssConfigMap.Name == supervisorFeatureStatConfigMapName &&
+		fssConfigMap.Namespace == supervisorFeatureStateConfigMapNamespace {
+		log.Errorf("supervisor feature switch state configmap %q from the namespace: %q is deleted", supervisorFeatureStatConfigMapName, supervisorFeatureStateConfigMapNamespace)
+		os.Exit(1)
+	}
+}
+
+// namespaceAdded adds is called when new namespace is added on the k8s cluster.
+func namespaceAdded(obj interface{}) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx)
+
+	namespace, ok := obj.(*v1.Namespace)
+	if namespace == nil || !ok {
+		log.Warnf("namespaceAdded: unrecognized object %+v", obj)
+		return
+	}
+	if _, ok = namespace.Labels[WorkLoadNamespaceLabelKey]; ok {
+		log.Infof("Observed new workload namespace: %v", namespace.Name)
+		pendingCRUpdatesObj.enqueueFeatureStateUpdatesForWorkloadNamespace(ctx, namespace.Name)
+	}
+}
+
+// namespaceUpdated is called when namespace is updated
+func namespaceUpdated(oldObj, newObj interface{}) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx)
+
+	oldNamespace, ok := oldObj.(*v1.Namespace)
+	if oldNamespace == nil || !ok {
+		log.Warnf("namespaceUpdated: unrecognized object %+v", oldObj)
+		return
+	}
+	newNamespace, ok := newObj.(*v1.Namespace)
+	if newNamespace == nil || !ok {
+		log.Warnf("namespaceUpdated: unrecognized object %+v", oldObj)
+		return
+	}
+
+	_, labelPresentInOldNamespace := oldNamespace.Labels[WorkLoadNamespaceLabelKey]
+	_, labelPresentInNewNamespace := newNamespace.Labels[WorkLoadNamespaceLabelKey]
+
+	if !labelPresentInOldNamespace && labelPresentInNewNamespace {
+		log.Infof("Observed new workload namespace: %v", newNamespace.Name)
+		pendingCRUpdatesObj.enqueueFeatureStateUpdatesForWorkloadNamespace(ctx, newNamespace.Name)
+	}
+}
+
+// namespaceDeleted is called when namespace is deleted
+func namespaceDeleted(obj interface{}) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = logger.NewContextWithLogger(ctx)
+	log := logger.GetLogger(ctx)
+
+	namespace, ok := obj.(*v1.Namespace)
+	if namespace == nil || !ok {
+		log.Warnf("namespaceDeleted: unrecognized object %+v", obj)
+		return
+	}
+	log.Infof("Namespace: %q is deleted", namespace.Namespace)
+
+	pendingCRUpdatesObj.lock.Lock()
+	defer pendingCRUpdatesObj.lock.Unlock()
+	delete(pendingCRUpdatesObj.namespaceUpdateMap, namespace.Name)
+}
+
+// getFeatureStates returns latest feature states from supervisor config-map
+// if failed to retrieve feature states, func returns error with empty array of FeatureState
+func getFeatureStates(ctx context.Context) ([]featurestatesv1alpha1.FeatureState, error) {
+	log := logger.GetLogger(ctx)
+	//  Retrieve SV FeatureStates configmap
+	fssConfigMap, err := k8sClient.CoreV1().ConfigMaps(supervisorFeatureStateConfigMapNamespace).Get(ctx, supervisorFeatureStatConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Errorf("supervisor feature switch state with name: %q not found in the namespace: %q", supervisorFeatureStatConfigMapName, supervisorFeatureStateConfigMapNamespace)
+			os.Exit(1)
+		}
+		log.Errorf("failed to retrieve SV feature switch state from namespace:%q with name: %q", supervisorFeatureStateConfigMapNamespace, supervisorFeatureStatConfigMapName)
+		return nil, err
+	}
+
+	log.Infof("Successfully retrieved SV feature switch state from namespace:%q with name: %q", supervisorFeatureStateConfigMapNamespace, supervisorFeatureStatConfigMapName)
+	var featureStates []featurestatesv1alpha1.FeatureState
+	for feature, state := range fssConfigMap.Data {
+		var featureState featurestatesv1alpha1.FeatureState
+		featureState.Name = feature
+		featureState.Enabled, err = strconv.ParseBool(state)
+		if err != nil {
+			log.Errorf("failed to parse feature state value: %v for feature: %q.", state, feature)
+			os.Exit(1)
+		}
+		featureStates = append(featureStates, featureState)
+	}
+	return featureStates, nil
+}

--- a/pkg/kubernetes/informers.go
+++ b/pkg/kubernetes/informers.go
@@ -99,6 +99,20 @@ func (im *InformerManager) AddPVListener(add func(obj interface{}), update func(
 	})
 }
 
+// AddNamespaceListener hooks up add, update, delete callbacks
+func (im *InformerManager) AddNamespaceListener(add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
+	if im.namespaceInformer == nil {
+		im.namespaceInformer = im.informerFactory.Core().V1().Namespaces().Informer()
+	}
+	im.namespaceSynced = im.namespaceInformer.HasSynced
+
+	im.namespaceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    add,
+		UpdateFunc: update,
+		DeleteFunc: remove,
+	})
+}
+
 // AddConfigMapListener hooks up add, update, delete callbacks
 func (im *InformerManager) AddConfigMapListener(ctx context.Context, client clientset.Interface, namespace string, add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.configMapInformer == nil {

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -69,6 +69,11 @@ type InformerManager struct {
 	// Function to determine if pvcInformer has been synced
 	pvcSynced cache.InformerSynced
 
+	// namespaceInformer informer
+	namespaceInformer cache.SharedInformer
+	// Function to determine if namespaceInformer has been synced
+	namespaceSynced cache.InformerSynced
+
 	// Pod informer
 	podInformer cache.SharedInformer
 	// Function to determine if podInformer has been synced


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Following changes are done in this PR

- Added a service to replicate supervisor feature switch states to workload namespaces.
- when service is started, it is creating or updating `cnscsisvfeaturestate` CR in all workload namespaces.
- any failure to create or update CR will be re-tried at regular intervals.
- service is watching on FSS config-map changes on the supervisor and updates all workload namespaces with the latest feature switch states. 
- service is watching on new workload namespaces added on the cluster and helps create `cnscsisvfeaturestate` CR with the latest feature switch states.
- service will crash when we observe that the fss config-map is deleted or not found or we fail to parse the config-map value.


**Special notes for your reviewer**:
Testing done

Verified CR is registered and created by `SvFSSReplicationService`.

```
# kubectl api-resources -o wide | grep cnscsisvfeaturestates
cnscsisvfeaturestates                                cns.vmware.com/v1alpha1                      true         CnsCsiSvFeatureStates             [delete deletecollection get list patch create update watch]
```

Verified CR is created in the workload namespace

```
# kubectl get cnscsisvfeaturestates --all-namespaces
NAMESPACE             NAME              AGE
test-gc-e2e-demo-ns   svfeaturestates   27s

# kubectl describe cnscsisvfeaturestates/svfeaturestates --namespace=test-gc-e2e-demo-ns
Name:         svfeaturestates
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsCsiSvFeatureStates
Metadata:
  Creation Timestamp:  2021-03-26T07:38:59Z
  Generation:          1
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:featureStates:
    Manager:         vsphere-syncer
    Operation:       Update
    Time:            2021-03-26T07:38:59Z
  Resource Version:  326666
  Self Link:         /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnscsisvfeaturestates/svfeaturestates
  UID:               36772301-12fc-44d8-8e9c-3606cb36bf73
Spec:
  Feature States:
    Enabled:  true
    Name:     volume-extend
    Enabled:  true
    Name:     volume-health
    Enabled:  false
    Name:     vsan-direct-disk-decommission
    Enabled:  false
    Name:     csi-auth-check
    Enabled:  true
    Name:     csi-sv-feature-states-replication
    Enabled:  false
    Name:     file-volume
    Enabled:  true
    Name:     online-volume-extend
Events:       <none>
```

Updated `csi-feature-states` config-map in the `vmware-system-csi` namespace and added new-feature: 'true' and verified new state is updated in CRs.

```
# kubectl describe cnscsisvfeaturestates/svfeaturestates --namespace=test-gc-e2e-demo-ns
Name:         svfeaturestates
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsCsiSvFeatureStates
Metadata:
  Creation Timestamp:  2021-03-26T07:38:59Z
  Generation:          26
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:featureStates:
    Manager:         vsphere-syncer
    Operation:       Update
    Time:            2021-03-26T07:38:59Z
  Resource Version:  630156
  Self Link:         /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnscsisvfeaturestates/svfeaturestates
  UID:               36772301-12fc-44d8-8e9c-3606cb36bf73
Spec:
  Feature States:
    Enabled:  true
    Name:     csi-sv-feature-states-replication
    Enabled:  false
    Name:     file-volume
    Enabled:  true
    Name:     new-feature
    Enabled:  true
    Name:     online-volume-extend
    Enabled:  true
    Name:     volume-extend
    Enabled:  true
    Name:     volume-health
    Enabled:  false
    Name:     vsan-direct-disk-decommission
    Enabled:  false
    Name:     csi-auth-check
Events:       <none>
```

Test logs with latest commit on this PR.

```
# kubectl logs vsphere-csi-controller-778f8c6469-829ft --namespace=vmware-system-csi -c vsphere-syncer | grep "featurestates/featurestates"
{"level":"info","time":"2021-04-01T17:23:02.602032018Z","caller":"featurestates/featurestates.go:79","msg":"Starting SvFSSReplicationService"}
{"level":"info","time":"2021-04-01T17:23:03.247089098Z","caller":"featurestates/featurestates.go:407","msg":"successfully retrieved SV feature switch state from namespace:\"vmware-system-csi\" with name: \"csi-feature-states\""}
{"level":"info","time":"2021-04-01T17:23:03.257189554Z","caller":"featurestates/featurestates.go:259","msg":"observed fss add: fss: map[csi-auth-check:false csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"6c2b76d1-dcf6-414c-b9ba-85fa495a1518"}
{"level":"info","time":"2021-04-01T17:23:03.28052837Z","caller":"featurestates/featurestates.go:345","msg":"observed new workload namespace: test-gc-e2e-demo-ns","TraceId":"d8c99350-f29d-48fd-9957-9e55f90937ca"}
{"level":"info","time":"2021-04-01T17:23:03.280665151Z","caller":"featurestates/featurestates.go:242","msg":"enqueued CR updates for workload namespace: \"test-gc-e2e-demo-ns\"","TraceId":"d8c99350-f29d-48fd-9957-9e55f90937ca"}
{"level":"info","time":"2021-04-01T17:23:03.362006548Z","caller":"featurestates/featurestates.go:154","msg":"informer on config-map and namespaces started"}
{"level":"info","time":"2021-04-01T17:23:03.362278406Z","caller":"featurestates/featurestates.go:158","msg":"started background routine to process pending feature state updates at regular interval"}
{"level":"info","time":"2021-04-01T17:23:03.362380642Z","caller":"featurestates/featurestates.go:159","msg":"SvFSSReplicationService is running"}
{"level":"info","time":"2021-04-01T17:23:33.363806664Z","caller":"featurestates/featurestates.go:179","msg":"feature state update is required for namespace: \"test-gc-e2e-demo-ns\"","TraceId":"27d590a9-f5ad-4e46-8478-cf3df3d5e9cf"}
{"level":"info","time":"2021-04-01T17:23:33.370967476Z","caller":"featurestates/featurestates.go:196","msg":"cnsCsiSvFeatureStates CR instance is not present in the namespace: \"test-gc-e2e-demo-ns\". Creating CR with latest feature switch state, Err: cnscsisvfeaturestates.cns.vmware.com \"svfeaturestates\" not found","TraceId":"27d590a9-f5ad-4e46-8478-cf3df3d5e9cf"}
{"level":"info","time":"2021-04-01T17:23:33.399092038Z","caller":"featurestates/featurestates.go:212","msg":"created cnsCsiSvFeatureStates CR instance in the namespace: \"test-gc-e2e-demo-ns\"","TraceId":"27d590a9-f5ad-4e46-8478-cf3df3d5e9cf"}
{"level":"info","time":"2021-04-01T17:24:45.684198506Z","caller":"featurestates/featurestates.go:298","msg":"observed fss update: oldfss: map[csi-auth-check:false csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true volume-extend:true volume-health:true vsan-direct-disk-decommission:false] newfss: map[csi-auth-check:false csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true test1:true test2:false volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"77f98051-f49f-4a37-a404-472a83a2aed1"}
{"level":"info","time":"2021-04-01T17:24:45.744059853Z","caller":"featurestates/featurestates.go:231","msg":"enqueued CR updates for workload namespace: \"test-gc-e2e-demo-ns\"","TraceId":"77f98051-f49f-4a37-a404-472a83a2aed1"}
{"level":"info","time":"2021-04-01T17:25:03.367747416Z","caller":"featurestates/featurestates.go:174","msg":"starting to process pending feature state updates","TraceId":"3c22daf6-1ac4-44d6-bc75-1a81e99d954e"}
{"level":"info","time":"2021-04-01T17:25:03.367821945Z","caller":"featurestates/featurestates.go:179","msg":"feature state update is required for namespace: \"test-gc-e2e-demo-ns\"","TraceId":"3c22daf6-1ac4-44d6-bc75-1a81e99d954e"}
{"level":"info","time":"2021-04-01T17:25:03.408830725Z","caller":"featurestates/featurestates.go:193","msg":"updated cnsCsiSvFeatureStates CR instance in the namespace: \"test-gc-e2e-demo-ns\"","TraceId":"3c22daf6-1ac4-44d6-bc75-1a81e99d954e"}
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
supervisor feature switch states replications on workload namespaces
```
