### PR TITLE
Update image tags during builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ deps:
 ##                                VERSIONS                                    ##
 ################################################################################
 # Ensure the version is injected into the binaries via a linker flag.
-export VERSION ?= $(shell git describe --always --dirty)
+export VERSION ?= $(shell git describe --tags '$(git rev-list --tags --max-count=1)')
 
 .PHONY: version
 version:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -41,7 +41,7 @@ PUSH=
 LATEST=
 CSI_IMAGE_NAME=
 SYNCER_IMAGE_NAME=
-VERSION=$(git describe --dirty --always 2>/dev/null)
+VERSION=$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>/dev/null)
 GCR_KEY_FILE="${GCR_KEY_FILE:-}"
 GOPROXY="${GOPROXY:-https://proxy.golang.org}"
 BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update image tags for make images

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Before:
```
make images
hack/release.sh
building gcr.io/cloud-provider-vsphere/csi/ci/driver:v2.1.0-rc.1-540-gc80077f-dirty
```

Now:
```
 make images
hack/release.sh
building gcr.io/cloud-provider-vsphere/csi/ci/driver:v2.2.0-rc.3
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update image tags to consume most recent tags during builds
```
