### PR TITLE
add retry logic and refactor ReloadConfiguration for wcp and gc

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -17,23 +17,24 @@ limitations under the License.
 package wcp
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/common/prometheus"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/fsnotify/fsnotify"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/units"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/prometheus"
 
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
@@ -137,7 +138,15 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 				}
 				log.Debugf("fsnotify event: %q", event.String())
 				if event.Op&fsnotify.Remove == fsnotify.Remove {
-					c.ReloadConfiguration()
+					for {
+						reloadConfigErr := c.ReloadConfiguration()
+						if reloadConfigErr == nil {
+							log.Infof("Successfully reloaded configuration from: %q", cfgPath)
+							break
+						}
+						log.Errorf("failed to reload configuration. will retry again in 5 seconds. err: %+v", reloadConfigErr)
+						time.Sleep(5 * time.Second)
+					}
 				}
 			case err, ok := <-watcher.Errors:
 				if !ok {
@@ -173,54 +182,67 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 
 // ReloadConfiguration reloads configuration from the secret, and update controller's config cache
 // and VolumeManager's VC Config cache.
-func (c *controller) ReloadConfiguration() {
+func (c *controller) ReloadConfiguration() error {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Info("Reloading Configuration")
 	cfg, err := common.GetConfig(ctx)
 	if err != nil {
 		log.Errorf("failed to read config. Error: %+v", err)
-		return
+		return err
 	}
 	newVCConfig, err := cnsvsphere.GetVirtualCenterConfig(ctx, cfg)
 	if err != nil {
 		log.Errorf("failed to get VirtualCenterConfig. err=%v", err)
-		return
+		return err
 	}
 	if newVCConfig != nil {
 		var vcenter *cnsvsphere.VirtualCenter
 		if c.manager.VcenterConfig.Host != newVCConfig.Host ||
 			c.manager.VcenterConfig.Username != newVCConfig.Username ||
 			c.manager.VcenterConfig.Password != newVCConfig.Password {
-			log.Debugf("Unregistering virtual center: %q from virtualCenterManager", c.manager.VcenterConfig.Host)
-			err = c.manager.VcenterManager.UnregisterAllVirtualCenters(ctx)
-			if err != nil {
-				log.Errorf("failed to unregister vcenter with virtualCenterManager.")
-				return
+
+			// Verify if new configuration has valid credentials by connecting to vCenter.
+			// Proceed only if the connection succeeds, else return error.
+			newVC := &cnsvsphere.VirtualCenter{Config: newVCConfig}
+			if err = newVC.Connect(ctx); err != nil {
+				msg := fmt.Sprintf("failed to connect to VirtualCenter host: %q, Err: %+v", newVCConfig.Host, err)
+				log.Error(msg)
+				return errors.New(msg)
 			}
-			log.Debugf("Registering virtual center: %q with virtualCenterManager", newVCConfig.Host)
-			vcenter, err = c.manager.VcenterManager.RegisterVirtualCenter(ctx, newVCConfig)
+
+			// Reset virtual center singleton instance by passing reload flag as true
+			log.Info("Obtaining new vCenterInstance")
+			vcenter, err = cnsvsphere.GetVirtualCenterInstance(ctx, &cnsconfig.ConfigurationInfo{Cfg: cfg}, true)
 			if err != nil {
-				log.Errorf("failed to register VC with virtualCenterManager. err=%v", err)
-				return
+				msg := fmt.Sprintf("failed to get VirtualCenter. err=%v", err)
+				log.Error(msg)
+				return errors.New(msg)
 			}
-			c.manager.VcenterManager = cnsvsphere.GetVirtualCenterManager(ctx)
 		} else {
-			vcenter, err = c.manager.VcenterManager.GetVirtualCenter(ctx, newVCConfig.Host)
+			// If it's not a VC host or VC credentials update, same singleton instance can be used
+			// and it's Config field can be updated
+			vcenter, err = cnsvsphere.GetVirtualCenterInstance(ctx, &cnsconfig.ConfigurationInfo{Cfg: cfg}, false)
 			if err != nil {
-				log.Errorf("failed to get VirtualCenter. err=%v", err)
-				return
+				msg := fmt.Sprintf("failed to get VirtualCenter. err=%v", err)
+				log.Error(msg)
+				return errors.New(msg)
 			}
 			vcenter.Config = newVCConfig
 		}
 		c.manager.VolumeManager.ResetManager(ctx, vcenter)
-		c.manager.VolumeManager = cnsvolume.GetManager(ctx, vcenter)
 		c.manager.VcenterConfig = newVCConfig
+		c.manager.VolumeManager = cnsvolume.GetManager(ctx, vcenter)
+		if c.authMgr != nil {
+			c.authMgr.ResetvCenterInstance(ctx, vcenter)
+			log.Debugf("Updated vCenter in auth manager")
+		}
 	}
 	if cfg != nil {
-		log.Debugf("updating manager.CnsConfig")
 		c.manager.CnsConfig = cfg
+		log.Debugf("Updated manager.CnsConfig")
 	}
 	log.Info("Successfully reloaded configuration")
+	return nil
 }
 
 // createBlockVolume creates a block volume based on the CreateVolumeRequest.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This is the follow-up PR for WCP and GC to keep the same retry and reload config logic as we applied on vanilla in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/740 

**Which issue this PR fixes** 
In Supervisor, If we fail to un-register, register, and get vCenter in ReloadConfiguration, we do not update Venter credentials and we never get a call back to update vCenter credentials.

In GC, if we fail to re-create clients using a new config, we are missing config updates.

**Special notes for your reviewer**:
Performed vCenter Password Rotation on Supervisor Cluster and captured logs.
Also created PVC,PV and Pod in TKG after password rotation. No issue observed.

SV Controller Logs
```
{"level":"info","time":"2021-04-06T18:24:04.723835513Z","caller":"wcp/controller.go:187","msg":"Reloading Configuration","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:04.743889884Z","caller":"config/config.go:300","msg":"No Net Permissions given in Config. Using default permissions.","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:04.744841357Z","caller":"vsphere/utils.go:142","msg":"Defaulting timeout for vCenter Client to 5 minutes","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:05.036478411Z","caller":"vsphere/virtualcenter.go:172","msg":"New session ID for 'VSPHERE.LOCAL\\workload_storage_management-c45340fc-f535-45f3-86d6-43aa09fd5920' = 525dfc06-2b34-c586-c60e-820ad56c34dc","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:05.03723765Z","caller":"wcp/controller.go:214","msg":"Obtaining new vCenterInstance","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:05.037414012Z","caller":"vsphere/virtualcenter.go:495","msg":"Initializing new vCenterInstance.","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:05.03875786Z","caller":"vsphere/pbm.go:75","msg":"PbmClient wasn't connected, ignoring","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:05.097892023Z","caller":"vsphere/cns.go:59","msg":"CnsClient wasn't connected, ignoring","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:05.098132287Z","caller":"vsphere/virtualcentermanager.go:140","msg":"Successfully unregistered VC sc2-10-186-198-247.eng.vmware.com","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:05.09837274Z","caller":"vsphere/virtualcentermanager.go:118","msg":"Successfully registered VC \"sc2-10-186-198-247.eng.vmware.com\"","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:05.20425091Z","caller":"vsphere/virtualcenter.go:172","msg":"New session ID for 'VSPHERE.LOCAL\\workload_storage_management-c45340fc-f535-45f3-86d6-43aa09fd5920' = 52a04dde-ae88-4d2d-8911-86c0f7dbd49e","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:05.204357872Z","caller":"vsphere/virtualcenter.go:528","msg":"vCenterInstance initialized","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:05.204430667Z","caller":"volume/manager.go:165","msg":"Done resetting volume.defaultManager","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:05.204504255Z","caller":"volume/manager.go:113","msg":"Retrieving existing volume.defaultManager...","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}
{"level":"info","time":"2021-04-06T18:24:05.204562016Z","caller":"wcp/controller.go:244","msg":"Successfully reloaded configuration","TraceId":"2a1c8c58-1292-423d-b791-d027dbd08172"}

```

SV Syncer logs
```
{"level":"info","time":"2021-04-06T18:24:04.6914837Z","caller":"syncer/metadatasyncer.go:431","msg":"Reloading Configuration","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:04.703038111Z","caller":"config/config.go:300","msg":"No Net Permissions given in Config. Using default permissions.","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:04.703282849Z","caller":"vsphere/utils.go:142","msg":"Defaulting timeout for vCenter Client to 5 minutes","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:04.96470285Z","caller":"vsphere/virtualcenter.go:172","msg":"New session ID for 'VSPHERE.LOCAL\\workload_storage_management-c45340fc-f535-45f3-86d6-43aa09fd5920' = 52f0fba1-1646-efae-18ca-3d580b51c7ea","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:04.969946554Z","caller":"syncer/metadatasyncer.go:477","msg":"Obtaining new vCenterInstance using new credentials","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:04.970310261Z","caller":"vsphere/virtualcenter.go:495","msg":"Initializing new vCenterInstance.","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:05.039404966Z","caller":"vsphere/virtualcentermanager.go:140","msg":"Successfully unregistered VC sc2-10-186-198-247.eng.vmware.com","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:05.04114045Z","caller":"vsphere/virtualcentermanager.go:118","msg":"Successfully registered VC \"sc2-10-186-198-247.eng.vmware.com\"","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:05.185709133Z","caller":"vsphere/virtualcenter.go:172","msg":"New session ID for 'VSPHERE.LOCAL\\workload_storage_management-c45340fc-f535-45f3-86d6-43aa09fd5920' = 5221a92a-50f2-b526-6ffd-6fff26075682","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:05.190856723Z","caller":"vsphere/virtualcenter.go:528","msg":"vCenterInstance initialized","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:05.190978446Z","caller":"volume/manager.go:165","msg":"Done resetting volume.defaultManager","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:05.191061583Z","caller":"volume/manager.go:113","msg":"Retrieving existing volume.defaultManager...","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:05.257419372Z","caller":"storagepool/service.go:178","msg":"Resetting VC connection in StoragePool service","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
{"level":"info","time":"2021-04-06T18:24:05.257758429Z","caller":"syncer/metadatasyncer.go:504","msg":"updated metadataSyncer.configInfo","TraceId":"00b75cb0-d644-4ee7-aa04-b328af2ce624"}
```



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add retry logic and refactor ReloadConfiguration for wcp and gc
```
