### PR TITLE
Remove broken URLs and update installation documentation to make it generic across releases

### DIFF
--- a/docs/book/driver-deployment/deploying_csi_with_zones.md
+++ b/docs/book/driver-deployment/deploying_csi_with_zones.md
@@ -106,7 +106,7 @@ Install the vSphere CPI and the CSI driver using the zone and region entries.
 
 ##### Procedure
 
-1. Install the vSphere CPI.
+1. Create a config secret for vSphere CPI:
 
    In the value fields of the configmap cloud-config file, specify region and zone.
    Make sure to add the names of categories you defined in vSphere, such as k8s-region and k8s-zone.
@@ -132,13 +132,17 @@ Install the vSphere CPI and the CSI driver using the zone and region entries.
    ```bash
    cd /etc/kubernetes
    kubectl create configmap cloud-config --from-file=vsphere.conf --namespace=kube-system
+   ```
 
+2. Create Roles, Roles Bindings, Service Account, Service and cloud-controller-manager Pod
+
+   ```bash
    kubectl apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/manifests/controller-manager/cloud-controller-manager-roles.yaml
    kubectl apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
    kubectl apply -f https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
    ```
 
-2. Verify that your CCM installation is successful.
+3. Verify that your CCM installation is successful.
 
    After installation, labels `failure-domain.beta.kubernetes.io/region` and `failure-domain.beta.kubernetes.io/zone` are applied to all nodes.
 
@@ -153,7 +157,7 @@ Install the vSphere CPI and the CSI driver using the zone and region entries.
    k8s-node5    Ready    <none>   18m   v1.14.2   zone-c   region-1
    ```
 
-3. Install the CSI driver.
+4. Install the CSI driver.
 
    Make sure `external-provisioner` is deployed with the arguments `--feature-gates=Topology=true` and `--strict-topology`.
 
@@ -191,7 +195,7 @@ Install the vSphere CPI and the CSI driver using the zone and region entries.
      .
      ```
 
-4. Verify that your CSI driver installation is successful.
+5. Verify that your CSI driver installation is successful.
 
    ```bash
    kubectl get csinodes -o jsonpath='{range .items[*]}{.metadata.name} {.spec}{"\n"}{end}'

--- a/docs/book/driver-deployment/installation.md
+++ b/docs/book/driver-deployment/installation.md
@@ -12,7 +12,6 @@ The following steps need to be performed on the k8s node where the vSphere CSI d
   - [vSphere configuration file for block volumes](#vsphereconf_for_block)
   - [vSphere configuration file for file volumes](#vsphereconf_for_file)
 - [Create a kubernetes secret for vSphere credentials](#create_k8s_secret)
-- [Create Roles, ServiceAccount and ClusterRoleBinding for vSphere CSI Driver](#csi_service_account)
 - [Install vSphere CSI driver](#install)
 - [Verify that CSI has been successfully deployed](#verify)
 
@@ -178,33 +177,17 @@ For security purposes, it is advised to remove this configuration file.
 rm csi-vsphere.conf
 ```
 
-## Create Roles, ServiceAccount and ClusterRoleBinding for vSphere CSI Driver <a id="csi_service_account"></a>
-
-Create ClusterRole, ServiceAccounts and ClusterRoleBinding needed for installation of vSphere CSI Driver
-
-```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/v2.0.0/vsphere-7.0/vanilla/rbac/vsphere-csi-controller-rbac.yaml
-```
-
-Click [here](https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/v2.0.0/vsphere-7.0/vanilla/rbac) to view the roles assigned to vSphere CSI Driver.
-
 ## Install vSphere CSI driver <a id="install"></a>
 
-Our CSI Controller runs as a Kubernetes deployment, with a replica count of 1. For version `v2.0.0`, the `vsphere-csi-controller` Pod consists of 6 containers – the CSI controller, External Provisioner, External Attacher, External Resizer, Liveness probe and [vSphere Syncer](https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/pkg/syncer).
+Before you deploy the vSphere CSI driver, refer to the [Compatibility](../compatiblity_matrix.md) page to view the supported kubernetes versions for a particular vSphere CSI version and [feature support](../supported_features_matrix.md) page to see what features are supported on that version.
 
-```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/v2.0.0/vsphere-7.0/vanilla/deploy/vsphere-csi-controller-deployment.yaml
-```
+- Choose the manifests pertaining to the latest version of vSphere CSI driver from the [Github](https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/) repository. For example, if you want to deploy vSphere CSI v2.1.1 on a vSphere 7.0u1 environment, you will choose [this](https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/v2.1.1/vsphere-7.0u1/vanilla) folder.
+  
+  NOTE: Refer [vSphere CSI Driver - Deployment with Topology](deploying_csi_with_zones.md) to deploy your kubernetes cluster with topology aware provisioning feature.
 
-There is also a CSI node Daemonset to be deployed, that will run on every node.
+- Create the roles, cluster roles and service accounts needed for installation of vSphere CSI Driver by deploying the YAML files available in the `rbac` folder of the vSphere CSI driver version you have chosen.
 
-```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/v2.0.0/vsphere-7.0/vanilla/deploy/vsphere-csi-node-ds.yaml
-```
-
-Click [here](https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests/v2.0.0/vsphere-7.0/vanilla/deploy) to view the deployment manifest for vSphere CSI driver.
-
-NOTE: Visit [vSphere CSI Driver - Deployment with Topology](deploying_csi_with_zones.md) to deploy your kubernetes cluster with topology aware provisioning feature.
+- Deploy the CSI controller and node daemonset using the YAML files available in the `deploy` folder of the same version.
 
 ## Verify that CSI has been successfully deployed <a id="verify"></a>
 

--- a/docs/book/driver-deployment/prerequisites.md
+++ b/docs/book/driver-deployment/prerequisites.md
@@ -185,7 +185,7 @@ cloud-config   1      82s
 
 Remove vsphere.conf file created at /etc/kubernetes/
 
-Step-3: Create Roles, Roles Bindings, Service Account, Service and cloud-controller-manager Pod.
+Step-3: Create Roles, Roles Bindings, Service Account, Service and cloud-controller-manager Pod
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/manifests/controller-manager/cloud-controller-manager-roles.yaml


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: The URLs mentioned in the installation page result in 404 error. Making the documentation generic so that we do not have to update this content after every release. Also updated CPI manifest URLs as the previous ones are deprecated.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: Easy view links:
https://deploy-preview-777--kubernetes-sigs-vsphere-csi-driver.netlify.app/driver-deployment/prerequisites.html#vsphere_cpi
https://deploy-preview-777--kubernetes-sigs-vsphere-csi-driver.netlify.app/driver-deployment/installation.html#install
https://deploy-preview-777--kubernetes-sigs-vsphere-csi-driver.netlify.app/driver-deployment/deploying_csi_with_zones.html#enable_zones_for_vsphere_cpi_and_csi


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove broken URLs and update installation documentation to make it generic across releases
```
