### PR TITLE
Handle virtualmachine not found errors during pvcsi detach operation

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -24,13 +24,10 @@ import (
 	"strings"
 	"time"
 
-	"sigs.k8s.io/vsphere-csi-driver/pkg/common/prometheus"
-
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fsnotify/fsnotify"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -41,13 +38,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator"
 	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/prometheus"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
@@ -716,6 +716,10 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 	}
 	var err error
 	if err := c.vmOperatorClient.Get(ctx, vmKey, virtualMachine); err != nil {
+		if errors.IsNotFound(err) {
+			log.Infof("VirtualMachine %s/%s not found. Assuming volume %s was detached.", c.supervisorNamespace, req.NodeId, req.VolumeId)
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
 		msg := fmt.Sprintf("failed to get VirtualMachines for node: %q. Error: %+v", req.NodeId, err)
 		log.Error(msg)
 		return nil, status.Errorf(codes.Internal, msg)
@@ -736,6 +740,10 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 			break
 		}
 		if err := c.vmOperatorClient.Get(ctx, vmKey, virtualMachine); err != nil {
+			if errors.IsNotFound(err) {
+				log.Infof("VirtualMachine %s/%s not found. Assuming volume %s was detached.", c.supervisorNamespace, req.NodeId, req.VolumeId)
+				return &csi.ControllerUnpublishVolumeResponse{}, nil
+			}
 			msg := fmt.Sprintf("failed to get VirtualMachines for node: %q. Error: %+v", req.NodeId, err)
 			log.Error(msg)
 			return nil, status.Errorf(codes.Internal, msg)
@@ -783,18 +791,24 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 			log.Debugf("Observed vm name: %q, expecting vm name: %q, volumeID: %q. Continuing...", vm.Name, virtualMachine.Name, req.VolumeId)
 			continue
 		}
-		isVolumeDetached = true
-		for _, volume := range vm.Status.Volumes {
-			if volume.Name == req.VolumeId {
-				log.Debugf("Volume %q still exists in VirtualMachine %q status", volume.Name, virtualMachine.Name)
-				isVolumeDetached = false
-				if volume.Attached && volume.Error != "" {
-					msg := fmt.Sprintf("failed to detach volume %q from VirtualMachine %q with Error: %v", volume.Name, virtualMachine.Name, volume.Error)
-					log.Error(msg)
-					return nil, status.Errorf(codes.Internal, msg)
+		switch event.Type {
+		case watch.Added, watch.Modified:
+			isVolumeDetached = true
+			for _, volume := range vm.Status.Volumes {
+				if volume.Name == req.VolumeId {
+					log.Debugf("Volume %q still exists in VirtualMachine %q status", volume.Name, virtualMachine.Name)
+					isVolumeDetached = false
+					if volume.Attached && volume.Error != "" {
+						msg := fmt.Sprintf("failed to detach volume %q from VirtualMachine %q with Error: %v", volume.Name, virtualMachine.Name, volume.Error)
+						log.Error(msg)
+						return nil, status.Errorf(codes.Internal, msg)
+					}
+					break
 				}
-				break
 			}
+		case watch.Deleted:
+			log.Infof("VirtualMachine %s/%s deleted. Assuming volume %s was detached.", c.supervisorNamespace, req.NodeId, req.VolumeId)
+			isVolumeDetached = true
 		}
 	}
 	log.Infof("ControllerUnpublishVolume: Volume detached successfully %q", req.VolumeId)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR allows pvcsi ControllerUnpublishVolume to succeed if the `VirtualMachine` object is not found in the user namespace. 
Currently since we do not catch this, ControllerUnpublishVolume fails continuously. As a result, during TKGS upgrades, some pods get stuck in the ContainerCreating state because the volumes cannot be detached from the older node. 

**Testing**

Before this change:
During upgrades of TKGS cluster, pods that are drained from older nodes failed to detach with the following error:

```
{"level":"error","time":"2021-04-06T02:49:04.592248879Z","caller":"wcpguest/controller.go:714","msg":"failed to get VirtualMachines for node: \"test-cluster-workers-9tqhp-569d57f4fb-xmqjl\". Error: virtualmachines.vmoperator.vmware.com \"test-cluster-workers-9tqhp-569d57f4fb-xmqjl\" not found","TraceId":"9e1555c3-399b-4d6e-88a7-d1d3c4960e72
```

This resulted in Pods being stuck in ContainerCreating state on the newer node since the older VolumeAttachment object was not deleted. 

After this change:

pvCSI Detach calls succeeds with following logs:

```
{"level":"info","time":"2021-04-06T20:35:28.355861377Z","caller":"wcpguest/controller.go:720","msg":"VirtualMachine test-gc-e2e-demo-ns/test-cluster-raunak-workers-nbjqn-6f9b76887f-l89wz not found. Assuming volume b2b15c1c-ce9f-4773-b348-c023cc065fac-f826115e-fcbd-44f8-9e19-b6c180dec7df was detached.","TraceId":"3d9d43b6-a578-4950-801e-64605334d344"}
{"level":"info","time":"2021-04-06T20:35:28.357643076Z","caller":"wcpguest/controller.go:720","msg":"VirtualMachine test-gc-e2e-demo-ns/test-cluster-raunak-workers-nbjqn-6f9b76887f-l89wz not found. Assuming volume b2b15c1c-ce9f-4773-b348-c023cc065fac-3c22dce4-107b-470d-afc2-5f1328997ed7 was detached.","TraceId":"fbf8a345-50c3-4dd2-ab78-da34dc4de312"}
```
Pods are scheduled on new nodes and new VolumeAttachments are created successfully. 



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Handle virtualmachine not found errors during pvcsi detach operation
```
