### PR TITLE
Fix fetch certificate file step in validation-webhook creation script

### DIFF
--- a/manifests/dev/vsphere-7.0u1/vanilla/create-validation-webhook.sh
+++ b/manifests/dev/vsphere-7.0u1/vanilla/create-validation-webhook.sh
@@ -41,7 +41,7 @@ done
 
 [ -z "${namespace}" ] && namespace=vmware-system-csi
 
-CA_BUNDLE=$(kubectl get configmap -n vmware-system-csi extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')
+CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')
 
 # clean-up previously created service and validatingwebhookconfiguration. Ignore errors if not present.
 

--- a/manifests/dev/vsphere-7.0u2/vanilla/create-validation-webhook.sh
+++ b/manifests/dev/vsphere-7.0u2/vanilla/create-validation-webhook.sh
@@ -41,7 +41,7 @@ done
 
 [ -z "${namespace}" ] && namespace=vmware-system-csi
 
-CA_BUNDLE=$(kubectl get configmap -n vmware-system-csi extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')
+CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')
 
 # clean-up previously created service and validatingwebhookconfiguration. Ignore errors if not present.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing the validation-webhook creation steps to fetch ca file from extension-apiserver-authentication configmap in kube-system namespace. It is incorrectly fetching from non-existent configmap in vmware-system-csi namespace and thus validation webhook is not initialized correctly.

As a result of incorrect steps we are observing the below errors while creating a simple storage class

```
kubectl create -f example-sc.yaml 
Error from server (InternalError): error when creating "example-sc1.yaml": Internal error occurred: failed calling webhook "validation.csi.vsphere.vmware.com": Post "https://vsphere-webhook-svc.vmware-system-csi.svc:443/validate?timeout=10s": x509: certificate signed by unknown authority
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Before: 
```
bash create-validation-webhook.sh 
Error from server (NotFound): configmaps "extension-apiserver-authentication" not found
service "vsphere-webhook-svc" deleted
validatingwebhookconfiguration.admissionregistration.k8s.io "validation.csi.vsphere.vmware.com" deleted
serviceaccount "vsphere-csi-webhook" deleted
deployment.apps "vsphere-csi-webhook" deleted
service/vsphere-webhook-svc created
validatingwebhookconfiguration.admissionregistration.k8s.io/validation.csi.vsphere.vmware.com created
serviceaccount/vsphere-csi-webhook created
role.rbac.authorization.k8s.io/vsphere-csi-webhook-role unchanged
rolebinding.rbac.authorization.k8s.io/vsphere-csi-webhook-role-binding unchanged
deployment.apps/vsphere-csi-webhook created
```

After:
```
bash create-validation-webhook.sh 
service "vsphere-webhook-svc" deleted
validatingwebhookconfiguration.admissionregistration.k8s.io "validation.csi.vsphere.vmware.com" deleted
serviceaccount "vsphere-csi-webhook" deleted
deployment.apps "vsphere-csi-webhook" deleted
service/vsphere-webhook-svc created
validatingwebhookconfiguration.admissionregistration.k8s.io/validation.csi.vsphere.vmware.com created
serviceaccount/vsphere-csi-webhook created
role.rbac.authorization.k8s.io/vsphere-csi-webhook-role unchanged
rolebinding.rbac.authorization.k8s.io/vsphere-csi-webhook-role-binding unchanged
deployment.apps/vsphere-csi-webhook created
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix fetch certificate file step in validation-webhook creation script
```
