### PR TITLE
FSS replication changes for GC

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -77,7 +77,7 @@ func main() {
 		log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
 	}
 	commonco.SetInitParams(ctx, clusterFlavor, &syncer.COInitParams, *supervisorFSSName, *supervisorFSSNamespace,
-		*internalFSSName, *internalFSSNamespace)
+		*internalFSSName, *internalFSSNamespace, "")
 	admissionhandler.COInitParams = &syncer.COInitParams
 
 	if *operationMode == operationModeWebHookServer {

--- a/cmd/vsphere-csi/main.go
+++ b/cmd/vsphere-csi/main.go
@@ -58,8 +58,9 @@ func main() {
 	if err != nil {
 		log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
 	}
+	serviceMode := os.Getenv("X_CSI_MODE")
 	commonco.SetInitParams(ctx, clusterFlavor, &service.COInitParams, *supervisorFSSName, *supervisorFSSNamespace,
-		*internalFSSName, *internalFSSNamespace)
+		*internalFSSName, *internalFSSNamespace, serviceMode)
 
 	gocsi.Run(
 		context.Background(),

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -422,6 +422,7 @@ data:
   "online-volume-extend": "true"
   "file-volume": "false"
   "trigger-csi-fullsync": "false"
+  "csi-sv-feature-states-replication": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -422,6 +422,7 @@ data:
   "online-volume-extend": "true"
   "file-volume": "false"
   "trigger-csi-fullsync": "false"
+  "csi-sv-feature-states-replication": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.20/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.20/pvcsi.yaml
@@ -421,6 +421,7 @@ data:
   "volume-health": "true"
   "online-volume-extend": "true"
   "file-volume": "false"
+  "csi-sv-feature-states-replication": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -138,7 +138,8 @@ func GetVolumeMigrationService(ctx context.Context, volumeManager *cnsvolume.Man
 			}
 			go func() {
 				log.Debugf("Starting Informer for cnsvspherevolumemigrations")
-				informer, err := k8s.GetDynamicInformer(ctx, migrationv1alpha1.SchemeGroupVersion.Group, migrationv1alpha1.SchemeGroupVersion.Version, "cnsvspherevolumemigrations")
+				informer, err := k8s.GetDynamicInformer(ctx, migrationv1alpha1.SchemeGroupVersion.Group, migrationv1alpha1.SchemeGroupVersion.Version,
+					"cnsvspherevolumemigrations", metav1.NamespaceNone, true)
 				if err != nil {
 					log.Errorf("failed to create dynamic informer for volume migration CRD. Err: %v", err)
 				}

--- a/pkg/csi/service/common/commonco/utils.go
+++ b/pkg/csi/service/common/commonco/utils.go
@@ -29,7 +29,7 @@ import (
 
 // SetInitParams initializes the parameters required to create a container agnostic orchestrator instance
 func SetInitParams(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, initParams *interface{},
-	supervisorFSSName, supervisorFSSNamespace, internalFSSName, internalFSSNamespace string) {
+	supervisorFSSName, supervisorFSSNamespace, internalFSSName, internalFSSNamespace, serviceMode string) {
 	log := logger.GetLogger(ctx)
 	// Set default values for FSS, if not given and initiate CO-agnostic init params
 	switch clusterFlavor {
@@ -47,6 +47,7 @@ func SetInitParams(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
 				Name:      supervisorFSSName,
 				Namespace: supervisorFSSNamespace,
 			},
+			ServiceMode: serviceMode,
 		}
 	case cnstypes.CnsClusterFlavorVanilla:
 		if strings.TrimSpace(internalFSSName) == "" {
@@ -62,6 +63,7 @@ func SetInitParams(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
 				Name:      internalFSSName,
 				Namespace: internalFSSNamespace,
 			},
+			ServiceMode: serviceMode,
 		}
 	case cnstypes.CnsClusterFlavorGuest:
 		if strings.TrimSpace(supervisorFSSName) == "" {
@@ -89,6 +91,7 @@ func SetInitParams(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
 				Name:      supervisorFSSName,
 				Namespace: supervisorFSSNamespace,
 			},
+			ServiceMode: serviceMode,
 		}
 	default:
 		log.Fatalf("Unrecognised cluster flavor %q. Container orchestrator init params not initialized.", clusterFlavor)

--- a/pkg/kubernetes/dynamicInformers.go
+++ b/pkg/kubernetes/dynamicInformers.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	restclient "k8s.io/client-go/rest"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+)
+
+var (
+	dynamicInformerFactoryMap           = make(map[string]dynamicinformer.DynamicSharedInformerFactory)
+	dynamicInformerInitLock             = &sync.Mutex{}
+	supervisorDynamicInformerFactoryMap = make(map[string]dynamicinformer.DynamicSharedInformerFactory)
+	supervisorDynamicInformerInitLock   = &sync.Mutex{}
+)
+
+// newDynamicInformerFactory creates a dynamic informer factory for a given namespace if it doesn't exist already
+func newDynamicInformerFactory(ctx context.Context, cfg *restclient.Config, namespace string, isInCluster bool) (dynamicinformer.DynamicSharedInformerFactory, error) {
+	log := logger.GetLogger(ctx)
+	var (
+		dynamicInformerFactory dynamicinformer.DynamicSharedInformerFactory
+		exists                 bool
+	)
+	// Check if dynamic informer factory exists for the given namespace
+	if isInCluster {
+		// Acquire lock
+		dynamicInformerInitLock.Lock()
+		defer dynamicInformerInitLock.Unlock()
+
+		dynamicInformerFactory, exists = dynamicInformerFactoryMap[namespace]
+	} else {
+		// Acquire lock
+		supervisorDynamicInformerInitLock.Lock()
+		defer supervisorDynamicInformerInitLock.Unlock()
+
+		dynamicInformerFactory, exists = supervisorDynamicInformerFactoryMap[namespace]
+	}
+	if !exists {
+		// Grab a dynamic interface to create informer
+		dc, err := dynamic.NewForConfig(cfg)
+		if err != nil {
+			log.Errorf("could not generate dynamic client for config. InCluster: %t Error :%v", isInCluster, err)
+			return nil, err
+		}
+		dynamicInformerFactory = dynamicinformer.NewFilteredDynamicSharedInformerFactory(dc, 0, namespace, nil)
+		if isInCluster {
+			dynamicInformerFactoryMap[namespace] = dynamicInformerFactory
+			log.Infof("Created new dynamic informer factory for %q namespace", namespace)
+		} else {
+			supervisorDynamicInformerFactoryMap[namespace] = dynamicInformerFactory
+			log.Infof("Created new dynamic informer factory for %q namespace using the supervisor client", namespace)
+		}
+	}
+	return dynamicInformerFactory, nil
+}
+
+// GetDynamicInformer returns informer for specified CRD group, version, name and namespace
+// isInCluster should be set to true if the resource is present in the same cluster,
+// otherwise set false if the resource is present in the supervisor cluster in TKG flavor
+func GetDynamicInformer(ctx context.Context, crdGroup, crdVersion, crdName, namespace string, isInCluster bool) (informers.GenericInformer, error) {
+	log := logger.GetLogger(ctx)
+	var (
+		cfg *restclient.Config
+		err error
+	)
+
+	if isInCluster {
+		cfg, err = GetKubeConfig(ctx)
+		if err != nil {
+			log.Errorf("failed to read config. Error: %+v", err)
+			return nil, err
+		}
+	} else {
+		cnsConfig, err := common.GetConfig(ctx)
+		if err != nil {
+			log.Errorf("failed to read config. Error: %+v", err)
+			return nil, err
+		}
+		// Get rest client config for supervisor
+		cfg = GetRestClientConfigForSupervisor(ctx, cnsConfig.GC.Endpoint, cnsConfig.GC.Port)
+	}
+
+	// Fetching dynamic informer factory for given namespace
+	dynamicInformerFactory, err := newDynamicInformerFactory(ctx, cfg, namespace, isInCluster)
+	if err != nil {
+		log.Errorf("could not retrieve dynamic informer factory for %q namespace. Error: %+v", namespace, err)
+		return nil, err
+	}
+
+	// Return informer from shared dynamic informer factory for input resource
+	gvr := schema.GroupVersionResource{Group: crdGroup, Version: crdVersion, Resource: crdName}
+	return dynamicInformerFactory.ForResource(gvr), nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This is a follow up PR to https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/764 to take care of the GC side changes. FSS checks on GC will first check for the availability of the cnscsisvfeaturestate CR to retrieve SV FSS values, if not present we fallback to check the GCM replicated configmap. We have also introduced new code to check the service mode in node containers and check only the internal configmap for feature states.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: 
**Old SV/New TKGS Init logs:**

TKGS logs -
```
{"level":"info","time":"2021-04-14T23:11:50.90992539Z","caller":"k8sorchestrator/k8sorchestrator.go:140","msg":"Initializing k8sOrchestratorInstance","TraceId":"0042e433-7f97-4458-b33d-18df02224ea3"}
{"level":"info","time":"2021-04-14T23:11:50.937343584Z","caller":"k8sorchestrator/k8sorchestrator.go:237","msg":"New internal feature states values stored successfully: map[csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"0042e433-7f97-4458-b33d-18df02224ea3"}
{"level":"info","time":"2021-04-14T23:11:52.598801558Z","caller":"k8sorchestrator/k8sorchestrator.go:270","msg":"cnscsisvfeaturestate CR not found in supervisor namespace. Defaulting to the \"csi-feature-states\" FSS configmap in \"vmware-system-csi\" namespace. Error: no matches for kind \"CnsCsiSvFeatureStates\" in version \"cns.vmware.com/v1alpha1\"","TraceId":"0042e433-7f97-4458-b33d-18df02224ea3"}
{"level":"info","time":"2021-04-14T23:11:52.608057596Z","caller":"k8sorchestrator/k8sorchestrator.go:342","msg":"New supervisor feature states values stored successfully: map[online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"0042e433-7f97-4458-b33d-18df02224ea3"}
{"level":"info","time":"2021-04-14T23:11:52.608626378Z","caller":"k8sorchestrator/k8sorchestrator.go:166","msg":"k8sOrchestratorInstance initialized","TraceId":"0042e433-7f97-4458-b33d-18df02224ea3"}
{"level":"info","time":"2021-04-14T23:11:52.620539085Z","caller":"k8sorchestrator/k8sorchestrator.go:427","msg":"Supervisor feature state values from \"csi-feature-states\" stored successfully: map[online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"c91ad796-7bf7-4f8d-a5d5-ae35ddd4b240"}
{"level":"info","time":"2021-04-14T23:11:52.621019989Z","caller":"k8sorchestrator/k8sorchestrator.go:432","msg":"Internal feature state values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"f6ee31b5-e88d-4049-856b-49c7e3a7986c"}
```

**Old SV/New TKGS with SV being upgraded:**
SV logs -
```
{"level":"info","time":"2021-04-14T23:32:49.984507343Z","caller":"k8sorchestrator/k8sorchestrator.go:140","msg":"Initializing k8sOrchestratorInstance","TraceId":"cf1525a9-9df3-440e-b236-5066e5b60ac5"}
{"level":"info","time":"2021-04-14T23:32:50.231178763Z","caller":"k8sorchestrator/k8sorchestrator.go:342","msg":"New supervisor feature states values stored successfully: map[csi-sv-feature-states-replication:true online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"cf1525a9-9df3-440e-b236-5066e5b60ac5"}
{"level":"info","time":"2021-04-14T23:32:50.232430603Z","caller":"k8sorchestrator/k8sorchestrator.go:166","msg":"k8sOrchestratorInstance initialized","TraceId":"cf1525a9-9df3-440e-b236-5066e5b60ac5"}
{"level":"info","time":"2021-04-14T23:32:50.265382023Z","caller":"k8sorchestrator/k8sorchestrator.go:427","msg":"Supervisor feature state values from \"csi-feature-states\" stored successfully: map[csi-sv-feature-states-replication:true online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"4d7e5127-d743-4686-b20e-4586118a5685"}
```

TKGS logs - 
```
{"level":"info","time":"2021-04-14T23:36:53.147965596Z","caller":"kubernetes/dynamicInformers.go:76","msg":"Created new dynamic informer factory for \"test-gc-e2e-demo-ns\" namespace using the supervisor client","TraceId":"0042e433-7f97-4458-b33d-18df02224ea3"}
{"level":"info","time":"2021-04-14T23:36:53.149511921Z","caller":"k8sorchestrator/k8sorchestrator.go:323","msg":"Informer to watch on cnscsisvfeaturestate CR starting..","TraceId":"0042e433-7f97-4458-b33d-18df02224ea3"}
{"level":"info","time":"2021-04-14T23:36:53.342905336Z","caller":"k8sorchestrator/k8sorchestrator.go:514","msg":"fssCRAdded: New supervisor feature states values stored successfully from svfeaturestates CR object: map[csi-sv-feature-states-replication:true online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"67f98210-8f5d-4703-9477-f7c42d9879ee"}
```

Update csi-feature-states ConfigMap with a new feature:
SV logs -
```
{"level":"warn","time":"2021-04-14T23:39:40.464090054Z","caller":"k8sorchestrator/k8sorchestrator.go:457","msg":"Supervisor feature state values from \"csi-feature-states\" stored successfully: map[csi-sv-feature-states-replication:true online-volume-extend:true test-feature:false volume-extend:true volume-health:true]","TraceId":"4b3b833f-985b-40f8-a7fb-c137f0be88be"}
```

TKGS logs - 
```
{"level":"warn","time":"2021-04-14T23:39:50.938111693Z","caller":"k8sorchestrator/k8sorchestrator.go:538","msg":"fssCRUpdated: New supervisor feature states values stored successfully from svfeaturestates CR object: map[csi-sv-feature-states-replication:true online-volume-extend:true test-feature:false volume-extend:true volume-health:true]","TraceId":"97f74ed8-96d1-432f-8bb5-101d13f4df71"}
```

**New SV/New TKG Init logs:**
SV logs -
```
{"level":"info","time":"2021-04-14T23:32:49.984507343Z","caller":"k8sorchestrator/k8sorchestrator.go:140","msg":"Initializing k8sOrchestratorInstance","TraceId":"cf1525a9-9df3-440e-b236-5066e5b60ac5"}
{"level":"info","time":"2021-04-14T23:32:50.231178763Z","caller":"k8sorchestrator/k8sorchestrator.go:342","msg":"New supervisor feature states values stored successfully: map[csi-sv-feature-states-replication:true online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"cf1525a9-9df3-440e-b236-5066e5b60ac5"}
{"level":"info","time":"2021-04-14T23:32:50.232430603Z","caller":"k8sorchestrator/k8sorchestrator.go:166","msg":"k8sOrchestratorInstance initialized","TraceId":"cf1525a9-9df3-440e-b236-5066e5b60ac5"}
{"level":"info","time":"2021-04-14T23:32:50.265382023Z","caller":"k8sorchestrator/k8sorchestrator.go:427","msg":"Supervisor feature state values from \"csi-feature-states\" stored successfully: map[csi-sv-feature-states-replication:true online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"4d7e5127-d743-4686-b20e-4586118a5685"}
```

TKGS logs - 
```
{"level":"info","time":"2021-04-14T23:45:49.597743189Z","caller":"k8sorchestrator/k8sorchestrator.go:140","msg":"Initializing k8sOrchestratorInstance","TraceId":"8e13cdfa-caa0-47f7-ac61-aad270081b83"}
{"level":"info","time":"2021-04-14T23:45:50.282415596Z","caller":"k8sorchestrator/k8sorchestrator.go:237","msg":"New internal feature states values stored successfully: map[csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"8e13cdfa-caa0-47f7-ac61-aad270081b83"}
{"level":"info","time":"2021-04-14T23:45:50.701201128Z","caller":"k8sorchestrator/k8sorchestrator.go:282","msg":"New supervisor feature states values stored successfully from svfeaturestates CR object: map[csi-sv-feature-states-replication:true online-volume-extend:true test-feature:false volume-extend:true volume-health:true]","TraceId":"8e13cdfa-caa0-47f7-ac61-aad270081b83"}
{"level":"info","time":"2021-04-14T23:45:50.701808706Z","caller":"k8sorchestrator/k8sorchestrator.go:166","msg":"k8sOrchestratorInstance initialized","TraceId":"8e13cdfa-caa0-47f7-ac61-aad270081b83"}
{"level":"info","time":"2021-04-14T23:45:50.79524794Z","caller":"k8sorchestrator/k8sorchestrator.go:432","msg":"Internal feature state values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"c3be68ec-0215-4f41-a0d1-af5781f1355e"}
```

**Also tested the following:**
Online resize feature is enabled and works as expected
Delete of GCM replicated configmap: No logs noticed. GC controller container did not crash.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
SV FSS replication changes for GC
```
