### PR TITLE
Add priority class for pvcsi deployment and daemon sets

### DIFF
--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -124,6 +124,7 @@ spec:
         - operator: "Exists"
           key: node-role.kubernetes.io/master
           effect: NoSchedule
+      priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:
         - name: csi-attacher
           image: vmware.io/csi-attacher:<image_tag>
@@ -298,6 +299,7 @@ spec:
         role: vsphere-csi
     spec:
       serviceAccountName: vsphere-csi-node
+      priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -124,6 +124,7 @@ spec:
         - operator: "Exists"
           key: node-role.kubernetes.io/master
           effect: NoSchedule
+      priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:
         - name: csi-attacher
           image: vmware.io/csi-attacher:<image_tag>
@@ -298,6 +299,7 @@ spec:
         role: vsphere-csi
     spec:
       serviceAccountName: vsphere-csi-node
+      priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -124,6 +124,7 @@ spec:
         - operator: "Exists"
           key: node-role.kubernetes.io/master
           effect: NoSchedule
+      priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:
         - name: csi-attacher
           image: vmware.io/csi-attacher:<image_tag>
@@ -298,6 +299,7 @@ spec:
         role: vsphere-csi
     spec:
       serviceAccountName: vsphere-csi-node
+      priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.20/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.20/pvcsi.yaml
@@ -124,6 +124,7 @@ spec:
         - operator: "Exists"
           key: node-role.kubernetes.io/master
           effect: NoSchedule
+      priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:
         - name: csi-attacher
           image: vmware.io/csi-attacher:<image_tag>
@@ -298,6 +299,7 @@ spec:
         role: vsphere-csi
     spec:
       serviceAccountName: vsphere-csi-node
+      priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding priority class for pvcsi deployment and daemon sets to prevent pvcsi pods from getting evicted.
Right now csi pods doesn't have priority set and are at risk of being evicted if there's no enough resource to schedule a high priority pod

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Deployed pvcsi with the yaml changes:
```
 kubectl get deployment -n vmware-system-csi -o yaml | grep critical
        priorityClassName: system-node-critical
root@4220e9054fb816412506e4042d0f7a22 [ ~ ]# kubectl get daemonset -n vmware-system-csi -o yaml | grep critical
        priorityClassName: system-node-critical
root@4220e9054fb816412506e4042d0f7a22 [ ~ ]# kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-5d8f794fd7-7qzhj   6/6     Running   1          27m
vsphere-csi-node-2n9mr                    3/3     Running   0          25m
vsphere-csi-node-9wj7d                    3/3     Running   0          24m
vsphere-csi-node-c2mcm                    3/3     Running   0          25m
vsphere-csi-node-l964j                    3/3     Running   0          25m
vsphere-csi-node-pbrfk                    3/3     Running   0          25m
vsphere-csi-node-tq5hp                    3/3     Running   0          25m
vsphere-csi-node-vqnt5                    3/3     Running   0          25m
vsphere-csi-node-vxdcf                    3/3     Running   0          25m
root@4220e9054fb816412506e4042d0f7a22 [ ~ ]#
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add priority class for pvcsi deployment and daemon sets
```
