### PR TITLE
Add default fstype to pvcsi and cns-csi manifests

### DIFF
--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.17/pvcsi.yaml
@@ -239,6 +239,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
+            - "--default-fstype=ext4"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.18/pvcsi.yaml
@@ -239,6 +239,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
+            - "--default-fstype=ext4"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.19/pvcsi.yaml
@@ -239,6 +239,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
+            - "--default-fstype=ext4"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS

--- a/manifests/dev/vsphere-7.0u2/guestcluster/1.20/pvcsi.yaml
+++ b/manifests/dev/vsphere-7.0u2/guestcluster/1.20/pvcsi.yaml
@@ -239,6 +239,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
+            - "--default-fstype=ext4"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.17/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.17/cns-csi.yaml
@@ -157,6 +157,7 @@ spec:
         - "--enable-leader-election"
         - "--leader-election-type=leases"
         - "--enable-hostlocal-placement=true"
+        - "--default-fstype=ext4"
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.18/cns-csi.yaml
@@ -159,6 +159,7 @@ spec:
             - "--enable-hostlocal-placement=true"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.19/cns-csi.yaml
@@ -168,6 +168,7 @@ spec:
             - "--enable-hostlocal-placement=true"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.20/cns-csi.yaml
@@ -165,6 +165,7 @@ spec:
             - "--enable-hostlocal-placement=true"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds `default-fstype` parameter to pvcsi and cnscsi manifests. pvcsi and cnscsi now use external-provisioner v2.1.0 for which this is a required parameter. We have made the changes to vanilla CSI in this PR - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/589

Relevant issue - https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/370

**Testing**

Before this change:

1. Create a sts and specify securityContext in the spec:
```
root@4227554b532c10e4099d2b8f094177a3 [ ~ ]# kubectl get pod
NAME         READY   STATUS    RESTARTS   AGE
test-pod-0   1/1     Running   0          69s
```

2. exec into pod and try to create files as a user at the mount point:
```
root@4227554b532c10e4099d2b8f094177a3 [ ~ ]# kubectl exec test-pod-0 -it sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
/ $ cd /usr/sw/adb/
/usr/sw/adb $ ls
/usr/sw/adb $ mkdir file
mkdir: can't create directory 'file': Permission denied
/usr/sw/adb $ touch test
touch: test: Permission denied
```

After this change:

```
root@4227554b532c10e4099d2b8f094177a3 [ ~ ]# kubectl exec test-pod-0 -it sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
/ $ cd usr/sw/adb/
/usr/sw/adb $ touch test
/usr/sw/adb $ mkdir file
/usr/sw/adb $ ls -al
total 6
drwxrwsr-x    3 root     10001         1024 Apr  8 19:32 .
drwxr-xr-x    6 root     root          4096 Apr  8 19:31 ..
drwxr-sr-x    2 10002    10001         1024 Apr  8 19:32 file
-rw-r--r--    1 10002    10001            0 Apr  8 19:32 test
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add default fstype to pvcsi and cnscsi manifests
```
