### PR TITLE
Refactor isFileServiceEnabled workflow to avoid multiple calls to List Datacenters

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -399,18 +399,12 @@ func (vc *VirtualCenter) GetHostsByCluster(ctx context.Context, clusterMorefValu
 
 // GetVsanDatastores returns all the datastore URL to DatastoreInfo map for all the
 // vSAN datastores in the VC.
-func (vc *VirtualCenter) GetVsanDatastores(ctx context.Context) (map[string]*DatastoreInfo, error) {
+func (vc *VirtualCenter) GetVsanDatastores(ctx context.Context, datacenters []*Datacenter) (map[string]*DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
 	if err := vc.Connect(ctx); err != nil {
 		log.Errorf("failed to connect to vCenter. err: %v", err)
 		return nil, err
 	}
-	datacenters, err := vc.ListDatacenters(ctx)
-	if err != nil {
-		log.Errorf("failed to find datacenters from VC: %+v, Error: %+v", vc.Config.Host, err)
-		return nil, err
-	}
-
 	vsanDsURLInfoMap := make(map[string]*DatastoreInfo)
 	for _, dc := range datacenters {
 		finder := find.NewFinder(dc.Datacenter.Client(), false)

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -97,7 +97,7 @@ func CreateBlockVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluste
 		// Datacenters are returned.
 		datacenters, err := vc.GetDatacenters(ctx)
 		if err != nil {
-			log.Errorf("failed to find datacenters from VC: %+v, Error: %+v", vc.Config.Host, err)
+			log.Errorf("failed to find datacenters from VC: %q, Error: %+v", vc.Config.Host, err)
 			return nil, err
 		}
 		isSharedDatastoreURL := false
@@ -284,8 +284,13 @@ func CreateFileVolumeUtilOld(ctx context.Context, clusterFlavor cnstypes.CnsClus
 	var datastores []vim25types.ManagedObjectReference
 	if spec.ScParams.DatastoreURL == "" {
 		if len(manager.VcenterConfig.TargetvSANFileShareDatastoreURLs) == 0 {
+			datacenters, err := vc.ListDatacenters(ctx)
+			if err != nil {
+				log.Errorf("failed to find datacenters from VC: %q, Error: %+v", vc.Config.Host, err)
+				return "", err
+			}
 			// get all vSAN datastores from VC
-			vsanDsURLToInfoMap, err := vc.GetVsanDatastores(ctx)
+			vsanDsURLToInfoMap, err := vc.GetVsanDatastores(ctx, datacenters)
 			if err != nil {
 				log.Errorf("failed to get vSAN datastores with error %+v", err)
 				return "", err
@@ -294,7 +299,7 @@ func CreateFileVolumeUtilOld(ctx context.Context, clusterFlavor cnstypes.CnsClus
 			for dsURL := range vsanDsURLToInfoMap {
 				allvsanDatastoreUrls = append(allvsanDatastoreUrls, dsURL)
 			}
-			fsEnabledMap, err := IsFileServiceEnabled(ctx, allvsanDatastoreUrls, vc)
+			fsEnabledMap, err := IsFileServiceEnabled(ctx, allvsanDatastoreUrls, vc, datacenters)
 			if err != nil {
 				log.Errorf("failed to get if file service is enabled on vsan datastores with error %+v", err)
 				return "", err

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -106,8 +106,14 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	isAuthCheckFSSEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIAuthCheck)
 	// Check if vSAN FS is enabled for TargetvSANFileShareDatastoreURLs only if CSIAuthCheck FSS is not enabled
 	if !isAuthCheckFSSEnabled && len(c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs) > 0 {
+		datacenters, err := vc.ListDatacenters(ctx)
+		if err != nil {
+			msg := fmt.Sprintf("failed to find datacenters from VC: %q, Error: %+v", vc.Config.Host, err)
+			log.Error(msg)
+			return errors.New(msg)
+		}
 		// Check if file service is enabled on datastore present in targetvSANFileShareDatastoreURLs.
-		dsToFileServiceEnabledMap, err := common.IsFileServiceEnabled(ctx, c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs, vc)
+		dsToFileServiceEnabledMap, err := common.IsFileServiceEnabled(ctx, c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs, vc, datacenters)
 		if err != nil {
 			msg := fmt.Sprintf("file service enablement check failed for datastore specified in TargetvSANFileShareDatastoreURLs. err=%v", err)
 			log.Error(msg)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This is PR is refactoring the methods in `isFileServiceEnabled` workflow to prevent multiple invocations of ListDatacenter method.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Ran e2e pipelines for testing

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Refactor isFileServiceEnabled workflow to avoid multiple calls to List Datacenters
```
