### PR TITLE
e2e-test: Test for CSI-CNS Telemetry - Part2

### DIFF
--- a/tests/e2e/csi_cns_telemetry.go
+++ b/tests/e2e/csi_cns_telemetry.go
@@ -127,8 +127,8 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Cluster 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(len(queryResult1.Volumes) > 0).To(gomega.BeTrue())
 
-		framework.Logf("Cluster-distribution value on CNS is %s", queryResult1.Volumes[0].Metadata.ContainerCluster.ClusterDistribution)
-		gomega.Expect(queryResult1.Volumes[0].Metadata.ContainerCluster.ClusterDistribution).Should(gomega.Equal(vanillaClusterDistribution), "Wrong/empty cluster-distribution name present on CNS")
+		framework.Logf("Cluster-distribution value on CNS is %s", queryResult1.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution)
+		gomega.Expect(queryResult1.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution).Should(gomega.Equal(vanillaClusterDistribution), "Wrong/empty cluster-distribution name present on CNS")
 
 		ginkgo.By("Setting the cluster-distribution value to empty")
 		setClusterDistribution(ctx, client, "")
@@ -167,8 +167,8 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Cluster 
 		gomega.Expect(len(queryResult2.Volumes) > 0).To(gomega.BeTrue())
 
 		ginkgo.By("Verifying cluster-distribution value specified in secret is honored")
-		framework.Logf("Cluster-distribution value on CNS is %s", queryResult2.Volumes[0].Metadata.ContainerCluster.ClusterDistribution)
-		gomega.Expect(queryResult2.Volumes[0].Metadata.ContainerCluster.ClusterDistribution).Should(gomega.Equal(""), "Wrong/empty cluster-distribution name present on CNS")
+		framework.Logf("Cluster-distribution value on CNS is %s", queryResult2.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution)
+		gomega.Expect(queryResult2.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution).Should(gomega.Equal(""), "Wrong/empty cluster-distribution name present on CNS")
 
 		// For Old PVCs to reflect the latest Cluster-Distribution Value, wait for full sync
 		framework.Logf("Sleeping full-sync interval for all the volumes Metadata to reflect the cluster-distribution value to = Empty")
@@ -183,33 +183,33 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Cluster 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(len(queryResult3.Volumes) > 0).To(gomega.BeTrue())
 
-		framework.Logf("Cluster-distribution value on CNS is %s", queryResult3.Volumes[0].Metadata.ContainerCluster.ClusterDistribution)
-		gomega.Expect(queryResult3.Volumes[0].Metadata.ContainerCluster.ClusterDistribution).Should(gomega.Equal(""), "Wrong/empty cluster-distribution name present on CNS")
+		framework.Logf("Cluster-distribution value on CNS is %s", queryResult3.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution)
+		gomega.Expect(queryResult3.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution).Should(gomega.Equal(""), "Wrong/empty cluster-distribution name present on CNS")
 
 		ginkgo.By("Setting the cluster-distribution value with escape character and special characters")
-		setClusterDistribution(ctx, client, vanillaClusterDirtributionWithSpecialChar)
+		setClusterDistribution(ctx, client, vanillaClusterDistributionWithSpecialChar)
 
 		// For Old PVCs to reflect the latest Cluster-Distribution Value, wait for full sync
-		framework.Logf("Sleeping full-sync interval for all the volumes Metadata to reflect the cluster-distribution value to = %s", vanillaClusterDirtributionWithSpecialChar)
+		framework.Logf("Sleeping full-sync interval for all the volumes Metadata to reflect the cluster-distribution value to = %s", vanillaClusterDistributionWithSpecialChar)
 		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
 
 		//Add additional safe wait time for cluster-distribution to reflect on metadata
-		framework.Logf("Sleeping for additional safe one min for volumes Metadata to reflect the cluster-distribution value to = %s", vanillaClusterDirtributionWithSpecialChar)
+		framework.Logf("Sleeping for additional safe one min for volumes Metadata to reflect the cluster-distribution value to = %s", vanillaClusterDistributionWithSpecialChar)
 		time.Sleep(time.Duration(pollTimeoutShort))
 
 		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult on PVC2 with VolumeID: %s", volHandle2))
 		queryResult2, err = e2eVSphere.queryCNSVolumeWithResult(volHandle2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(len(queryResult2.Volumes) > 0).To(gomega.BeTrue())
-		framework.Logf("Cluster-distribution value on CNS is %s", queryResult2.Volumes[0].Metadata.ContainerCluster.ClusterDistribution)
+		framework.Logf("Cluster-distribution value on CNS is %s", queryResult2.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution)
 
 		queryResult3, err = e2eVSphere.queryCNSVolumeWithResult(volHandle1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(len(queryResult3.Volumes) > 0).To(gomega.BeTrue())
-		framework.Logf("Cluster-distribution value on CNS is %s", queryResult3.Volumes[0].Metadata.ContainerCluster.ClusterDistribution)
+		framework.Logf("Cluster-distribution value on CNS is %s", queryResult3.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution)
 
 		ginkgo.By("Verifying cluster-distribution value specified in secret is honored")
-		gomega.Expect(queryResult2.Volumes[0].Metadata.ContainerCluster.ClusterDistribution).Should(gomega.Equal(vanillaClusterDirtributionWithSpecialChar), "Wrong/empty cluster-distribution name present on CNS")
-		gomega.Expect(queryResult3.Volumes[0].Metadata.ContainerCluster.ClusterDistribution).Should(gomega.Equal(vanillaClusterDirtributionWithSpecialChar), "Wrong/empty cluster-distribution name present on CNS")
+		gomega.Expect(queryResult2.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution).Should(gomega.Equal(vanillaClusterDistributionWithSpecialChar), "Wrong/empty cluster-distribution name present on CNS")
+		gomega.Expect(queryResult3.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution).Should(gomega.Equal(vanillaClusterDistributionWithSpecialChar), "Wrong/empty cluster-distribution name present on CNS")
 	})
 })

--- a/tests/e2e/csi_cns_telemetry_statefulsets.go
+++ b/tests/e2e/csi_cns_telemetry_statefulsets.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+)
+
+/*
+	Test performs following operations
+
+	Steps
+	1. Create a storage class.
+	2. Create nginx service.
+	3. Create nginx statefulsets with 3 replicas.
+	4. Wait until all Pods are ready and PVCs are bounded with PV.
+	5. Expect PVC to pass and cluster distribution value set to latest update
+	6. Scaledown nginx statefulsets with 0 replicas.
+	7. Delete all PVCs from the tests namespace.
+	8. Delete the storage class.
+*/
+
+var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor] [csi-guest] CNS-CSI Cluster Distribution for StatefulSets", func() {
+	f := framework.NewDefaultFramework("csi-cns-telemetry")
+	var (
+		namespace         string
+		client            clientset.Interface
+		storagePolicyName string
+		scParameters      map[string]string
+	)
+	ginkgo.BeforeEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		namespace = getNamespaceToRunTests(f)
+		client = f.ClientSet
+		bootstrap()
+		sc, err := client.StorageV1().StorageClasses().Get(ctx, storageclassname, metav1.GetOptions{})
+		if err == nil && sc != nil {
+			gomega.Expect(client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+		}
+		scParameters = make(map[string]string)
+		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
+		if vanillaCluster {
+			//Reset the cluster distribution value to default value "CSI-Vanilla"
+			setClusterDistribution(ctx, client, vanillaClusterDistribution)
+		}
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		if supervisorCluster {
+			deleteResourceQuota(client, namespace)
+		}
+		ginkgo.By(fmt.Sprintf("Deleting all statefulsets in namespace: %v", namespace))
+		fss.DeleteAllStatefulSets(client, namespace)
+		ginkgo.By(fmt.Sprintf("Deleting service nginx in namespace: %v", namespace))
+		err := client.CoreV1().Services(namespace).Delete(ctx, servicename, *metav1.NewDeleteOptions(0))
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		if vanillaCluster {
+			//Reset the cluster distribution value to default value "CSI-Vanilla"
+			setClusterDistribution(ctx, client, vanillaClusterDistribution)
+		}
+	})
+
+	ginkgo.It("Statefulset service for cluster-distribution metadata check", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		var clusterDistributionValue string
+		defer cancel()
+		// decide which test setup is available to run
+		if vanillaCluster {
+			ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+			scParameters = nil
+			clusterDistributionValue = vanillaClusterDistribution
+		} else if supervisorCluster {
+			ginkgo.By("CNS_TEST: Running for WCP setup")
+			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+			scParameters[scParamStoragePolicyID] = profileID
+			// create resource quota
+			createResourceQuota(client, namespace, rqLimit, storageclassname)
+			clusterDistributionValue = svClusterDistribution
+
+		} else {
+			ginkgo.By("Set Resource quota for GC")
+			scParameters[svStorageClassName] = storagePolicyName
+			svcClient, svNamespace := getSvcClientAndNamespace()
+			setResourceQuota(svcClient, svNamespace, rqLimit)
+			clusterDistributionValue = tkgClusterDistribution
+		}
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(storageclassname, scParameters, nil, "", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		// Waiting for pods status to be Ready
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(), fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(), "Number of Pods in the statefulset should match with number of replicas")
+
+		// Get the list of Volumes attached to Pods before scale down
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					// Verify the attached volume match the one in CNS cache
+					volumeID := pv.Spec.CSI.VolumeHandle
+
+					if guestCluster {
+						volumeID = getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
+					}
+
+					// Verify the attached volume has cluster-distribution value set
+					ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult for PVC with VolumeID: %s", pv.Spec.CSI.VolumeHandle))
+					queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volumeID)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					gomega.Expect(len(queryResult.Volumes) > 0).To(gomega.BeTrue())
+
+					framework.Logf("Cluster-distribution value on CNS is %s", queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution)
+					gomega.Expect(queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution).Should(gomega.Equal(clusterDistributionValue), "Wrong/empty cluster-distribution name present on CNS")
+
+				}
+			}
+		}
+
+		replicas = 0
+		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas))
+		_, scaledownErr := fss.Scale(client, statefulset, replicas)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		ssPodsAfterScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas)).To(gomega.BeTrue(), "Number of Pods in the statefulset should match with number of replicas")
+	})
+})

--- a/tests/e2e/csi_cns_telemetry_vc_reboot.go
+++ b/tests/e2e/csi_cns_telemetry_vc_reboot.go
@@ -1,0 +1,374 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+)
+
+var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Cluster Distribution Operations during VC reboot", func() {
+	f := framework.NewDefaultFramework("csi-cns-telemetry")
+	var (
+		client           clientset.Interface
+		namespace        string
+		vcRebootWaitTime int
+	)
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		namespace = getNamespaceToRunTests(f)
+		bootstrap()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		if os.Getenv(envVCRebootWaitTime) != "" {
+			vcRebootWaitTime, err = strconv.Atoi(os.Getenv(envVCRebootWaitTime))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		} else {
+			vcRebootWaitTime = defaultVCRebootWaitTime
+		}
+
+		if vanillaCluster {
+			//Reset the cluster distribution value to default value "CSI-Vanilla"
+			setClusterDistribution(ctx, client, vanillaClusterDistribution)
+		}
+	})
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		if vanillaCluster {
+			//Reset the cluster distribution value to default value "CSI-Vanilla"
+			setClusterDistribution(ctx, client, vanillaClusterDistribution)
+		}
+	})
+
+	/*
+		Steps
+		1. Create StorageClass.
+		2. Create PVC which uses the StorageClass created in step 1.
+		3. Wait for PV to be provisioned.
+		4. Wait for PVC's status to become bound.
+		5. Create pod using PVC.
+		6. Wait for Disk to be attached to the node.
+		7. Reboot VC.
+		8. Update cluster-distribution value and create PVC while VC reboots.
+		9. Wait for the VC to reboot completely and PVC to be bound.
+		10. Create pod using the PVC.
+		12. Wait for Disk to be attached to the node.
+		13. Delete pod and Wait for Volume Disk to be detached from the Node.
+		14. Delete PVC, PV and Storage Class.
+	*/
+
+	ginkgo.It("[csi-block-vanilla] [csi-file-vanilla] verify volume operations while vc reboot", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		var storageclass *storagev1.StorageClass
+		var pvclaim *v1.PersistentVolumeClaim
+		var storageclass2 *storagev1.StorageClass
+		var pvclaim2 *v1.PersistentVolumeClaim
+		var fullSyncWaitTime int
+		var err error
+
+		// Read full-sync value
+		if os.Getenv(envFullSyncWaitTime) != "" {
+			fullSyncWaitTime, err = strconv.Atoi(os.Getenv(envFullSyncWaitTime))
+			framework.Logf("Full-Sync interval time value is = %v", fullSyncWaitTime)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By("Creating Storage Class and PVC")
+		// decide which test setup is available to run
+		if vanillaCluster {
+			ginkgo.By("CNS_TEST: Running for Vanilla setup")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, nil, "", nil, "", false, "")
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Waiting for claim to be in bound phase")
+		pvc, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvclaim}, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvc).NotTo(gomega.BeEmpty())
+		pv := getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)
+		volumeID := pv.Spec.CSI.VolumeHandle
+
+		ginkgo.By("Creating pod to attach PV to the node")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		var vmUUID string
+		var vmUUID2 string
+		nodeName := pod.Spec.NodeName
+
+		if vanillaCluster {
+			vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+		}
+
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID, nodeName))
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volumeID, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+
+		ginkgo.By("Rebooting VC")
+		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+		err = invokeVCenterReboot(vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Sleep for a short while for the VC to shutdown, before invoking PVC creation and cluster-distribution value
+		time.Sleep(pollTimeoutShort)
+
+		ginkgo.By("Set cluster-distribution value while the VC reboot in progress")
+
+		if vanillaCluster {
+			// Set Cluster-distribution while the VC reboot in progress
+			setClusterDistribution(ctx, client, vanillaClusterDistributionWithSpecialChar)
+		}
+
+		defer func() {
+			if vanillaCluster {
+				//Reset the cluster distribution value to default value "CSI-Vanilla"
+				setClusterDistribution(ctx, client, vanillaClusterDistribution)
+			}
+		}()
+
+		// decide which test setup is available to run
+		if vanillaCluster {
+			ginkgo.By("Creating another PVC for Vanilla setup")
+			storageclass2, pvclaim2, err = createPVCAndStorageClass(client, namespace, nil, nil, "", nil, "", false, "")
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass2.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By(fmt.Sprintf("Waiting for %v for host to come up fully", vcRebootWaitTime))
+		time.Sleep(time.Duration(vcRebootWaitTime) * time.Second)
+		ginkgo.By("Done with reboot")
+
+		//After reboot
+		bootstrap()
+
+		ginkgo.By("Waiting for PVC2 claim to be in bound phase")
+		pvc2, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvclaim2}, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvc2).NotTo(gomega.BeEmpty())
+		pv2 := getPvFromClaim(client, pvclaim2.Namespace, pvclaim2.Name)
+		volumeID2 := pv2.Spec.CSI.VolumeHandle
+
+		ginkgo.By("Creating pod to attach PV2 to the node")
+		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim2}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		nodeName2 := pod2.Spec.NodeName
+
+		if vanillaCluster {
+			vmUUID2 = getNodeUUID(client, pod2.Spec.NodeName)
+		}
+
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID2, nodeName2))
+		isDiskAttached2, err := e2eVSphere.isVolumeAttachedToVM(client, volumeID2, vmUUID2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached2).To(gomega.BeTrue(), "Volume is not attached to the node")
+
+		// Verify the attached volume has cluster-distribution value set
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult for PVC with VolumeID: %s", pv2.Spec.CSI.VolumeHandle))
+		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(pv2.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(len(queryResult.Volumes) > 0).To(gomega.BeTrue())
+
+		framework.Logf("Cluster-distribution value on CNS is %s", queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution)
+		gomega.Expect(queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution).Should(gomega.Equal(vanillaClusterDistributionWithSpecialChar), "Wrong/empty cluster-distribution name present on CNS")
+
+		ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
+		err = fpod.DeletePodWithWait(client, pod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod2.Name, namespace))
+		err = fpod.DeletePodWithWait(client, pod2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if vanillaCluster {
+			ginkgo.By("Verify volume is detached from the node")
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+
+			ginkgo.By("Verify volume is detached from the node")
+			isDiskDetached2, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv2.Spec.CSI.VolumeHandle, pod2.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached2).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv2.Spec.CSI.VolumeHandle, pod2.Spec.NodeName))
+
+		}
+	})
+
+	/*
+		Steps
+		1. Create StorageClass.
+		2. Create PVC which uses the StorageClass created in step 1.
+		3. Wait for PV to be provisioned.
+		4. Wait for PVC's status to become bound.
+		5. Create pod using PVC.
+		6. Wait for Disk to be attached to the node.
+		7. Reboot VC.
+		8. Update cluster-distribution value and create PVC after VC reboots.
+		9. Wait for PVC to be bound.
+		10. Create pod using the PVC.
+		12. Wait for Disk to be attached to the node.
+		13. Delete pod and Wait for Volume Disk to be detached from the Node.
+		14. Delete PVC, PV and Storage Class.
+	*/
+	ginkgo.It("[csi-block-vanilla] [csi-file-vanilla] verify volume operations after vc reboots", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		var storageclass *storagev1.StorageClass
+		var pvclaim *v1.PersistentVolumeClaim
+		var fullSyncWaitTime int
+		var err error
+
+		// Read full-sync value
+		if os.Getenv(envFullSyncWaitTime) != "" {
+			fullSyncWaitTime, err = strconv.Atoi(os.Getenv(envFullSyncWaitTime))
+			framework.Logf("Full-Sync interval time value is = %v", fullSyncWaitTime)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By("Rebooting VC")
+		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+		err = invokeVCenterReboot(vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By(fmt.Sprintf("Waiting for %v for host to come up fully", vcRebootWaitTime))
+		time.Sleep(time.Duration(vcRebootWaitTime) * time.Second)
+		ginkgo.By("Done with reboot")
+
+		//After reboot
+		bootstrap()
+
+		// Sleep for a short while for the VC to shutdown, before invoking PVC creation and cluster-distribution value
+		time.Sleep(pollTimeoutShort)
+
+		ginkgo.By("Set cluster-distribution value after the VC reboot in progress")
+		// Set Cluster-distribution while the VC reboot in progress
+		setClusterDistribution(ctx, client, vanillaClusterDistributionWithSpecialChar)
+
+		defer func() {
+			//Reset the cluster distribution value to default value "CSI-Vanilla"
+			setClusterDistribution(ctx, client, vanillaClusterDistribution)
+		}()
+
+		ginkgo.By("Creating Storage Class and PVC")
+		// decide which test setup is available to run
+		if vanillaCluster {
+			ginkgo.By("CNS_TEST: Running for Vanilla setup")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, nil, "", nil, "", false, "")
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Waiting for claim to be in bound phase")
+		pvc, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvclaim}, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvc).NotTo(gomega.BeEmpty())
+		pv := getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)
+		volumeID := pv.Spec.CSI.VolumeHandle
+
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod to attach PV to the node")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		var vmUUID string
+
+		nodeName := pod.Spec.NodeName
+
+		if vanillaCluster {
+			vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+		}
+
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID, nodeName))
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volumeID, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+
+		// Verify the attached volume has cluster-distribution value set
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult for PVC with VolumeID: %s", pv.Spec.CSI.VolumeHandle))
+		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(len(queryResult.Volumes) > 0).To(gomega.BeTrue())
+
+		framework.Logf("Cluster-distribution value on CNS is %s", queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution)
+		gomega.Expect(queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution).Should(gomega.Equal(vanillaClusterDistributionWithSpecialChar), "Wrong/empty cluster-distribution name present on CNS")
+
+		ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
+		err = fpod.DeletePodWithWait(client, pod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if vanillaCluster {
+			ginkgo.By("Verify volume is detached from the node")
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		}
+	})
+})

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -116,11 +116,13 @@ const (
 	startOperation                             = "start"
 	stopOperation                              = "stop"
 	supervisorClusterOperationsTimeout         = 3 * time.Minute
+	svClusterDistribution                      = "SupervisorCluster"
 	svOperationTimeout                         = 240 * time.Second
 	svStorageClassName                         = "SVStorageClass"
 	totalResizeWaitPeriod                      = 10 * time.Minute
+	tkgClusterDistribution                     = "TKGService"
 	vanillaClusterDistribution                 = "CSI-Vanilla"
-	vanillaClusterDirtributionWithSpecialChar  = "CSI-\tVanilla-#Test"
+	vanillaClusterDistributionWithSpecialChar  = "CSI-\tVanilla-#Test"
 	vSphereCSIControllerPodNamePrefix          = "vsphere-csi-controller"
 	vmUUIDLabel                                = "vmware-system-vm-uuid"
 	vsanDefaultStorageClassInSVC               = "vsan-default-storage-policy"


### PR DESCRIPTION
**e2e-test: Test for CSI-CNS Telemetry - Part2**:

**Special notes for your reviewer**:
Automation for CSI-CNS Telemetry - Part2
1. Verify cluster-distribution value for volumes created by StatefulSets
2. Verify cluster-distribution value while VC reboot in progress (also covers PVC creation while VC reboot in progress)
3. Verify cluster-distribution value after VC reboot competes
4. Fix the PR 2750309


Test logs:
1. StatefulSets test: https://gist.github.com/rpanduranga/60ac94ad09dc6dd4059e7de62699a70d

2 & 3. VC reboot https://gist.github.com/rpanduranga/0afd0877812eb0bac1ab2ead0918a9c4

4. Regression - https://gist.github.com/rpanduranga/d7d488f515ba3be42edb0d64e4a2804a


StatefulSets Tests for WCP-SV
https://gist.github.com/rpanduranga/ff3d8bfc99b6498c6cd1c898a6aa919d

StatefulSets Tests for WCP-GC
https://gist.github.com/rpanduranga/ea9ccddfeb7777027ad47f1e9e530768