### PR TITLE
SV FSS Replication - Fix logging, Update RBAC for 1.20, and honor workloadnamespace label removal

### DIFF
--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.20/cns-csi.yaml
@@ -15,7 +15,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas"]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
@@ -44,6 +44,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsvolumemetadatas", "cnsfileaccessconfigs"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnscsisvfeaturestates"]
+    verbs: ["create", "get", "list", "update"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfilevolumeclients"]
     verbs: ["get", "update", "create", "delete"]
@@ -318,6 +321,7 @@ data:
   "csi-auth-check": "false"
   "vsan-direct-disk-decommission": "false"
   "trigger-csi-fullsync": "false"
+  "csi-sv-feature-states-replication": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing the following things
1. Fixed logging namespace name when a namespace is deleted.
Without the fix, we see following log message when workload namespace is deleted.
>{"level":"info","time":"2021-04-13T23:02:44.685986342Z","caller":"featurestates/featurestates.go:396","msg":"Namespace: \"\" is deleted","TraceId":"9e851a7f-7218-4405-90ec-96e382a168f8"}
2. Adding RBAC rules and new feature switch `"csi-sv-feature-states-replication": "false"` in the 1.20 cns-csi.yaml file
3. Fixing bug to stop updating CRs in the workload namespace after `vSphereClusterID` label is removed from the namespace. 

**Special notes for your reviewer**:
Testing is done. - https://gist.github.com/divyenpatel/c9cf2f6dcb85582e69cd33a151db98cd

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
SV FSS Replication - Fix logging, Update RBAC for 1.20, and honor workloadnamespace label removal
```
