### PR TITLE
watch on cnscsisvfeaturestates deletion and add back cnscsisvfeaturestates CR in the namespace

### DIFF
--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.17/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.17/cns-csi.yaml
@@ -43,7 +43,7 @@ rules:
   verbs: ["get", "list", "watch", "update"]
 - apiGroups: ["cns.vmware.com"]
   resources: ["cnscsisvfeaturestates"]
-  verbs: ["create", "get", "list", "update"]
+  verbs: ["create", "get", "list", "update", "watch"]
 - apiGroups: ["cns.vmware.com"]
   resources: ["cnsregistervolumes"]
   verbs: ["get", "list", "watch", "update", "delete"]

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.18/cns-csi.yaml
@@ -46,7 +46,7 @@ rules:
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnscsisvfeaturestates"]
-    verbs: ["create", "get", "list", "update"]
+    verbs: ["create", "get", "list", "update", "watch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsregistervolumes"]
     verbs: ["get", "list", "watch", "update", "delete"]

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.19/cns-csi.yaml
@@ -46,7 +46,7 @@ rules:
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnscsisvfeaturestates"]
-    verbs: ["create", "get", "list", "update"]
+    verbs: ["create", "get", "list", "update", "watch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfilevolumeclients"]
     verbs: ["get", "update", "create", "delete"]

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.20/cns-csi.yaml
@@ -46,7 +46,7 @@ rules:
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnscsisvfeaturestates"]
-    verbs: ["create", "get", "list", "update"]
+    verbs: ["create", "get", "list", "update", "watch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsfilevolumeclients"]
     verbs: ["get", "update", "create", "delete"]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding a watch on the cnscsisvfeaturestates CRs

When `cnscsisvfeaturestates` is deleted from the workload namespace, but workload namespace is not being deleted, `cnscsisvfeaturestates` will be recreated in the namespace. This change helps against accidental removal of cnscsisvfeaturestates CR from workload namespace.

Without this change if `cnscsisvfeaturestates` is deleted from the workload namespace, it will not be re-created until the supervisor controller pod --> syncer container restarts or until we modify `csi-feature-states` config-map.

**Special notes for your reviewer**:
Testing done:  https://gist.github.com/divyenpatel/4fd381d7979d0cf04eb6ece24a3834fd

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
watch on cnscsisvfeaturestates deletion and add back cnscsisvfeaturestates CR in the namespace
```
