### PR TITLE
Ignore supervisor FSS configmap updates in nodes

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -429,6 +429,10 @@ func configMapAdded(obj interface{}) {
 
 	if fssConfigMap.Name == k8sOrchestratorInstance.supervisorFSS.configMapName &&
 		fssConfigMap.Namespace == k8sOrchestratorInstance.supervisorFSS.configMapNamespace {
+		if serviceMode == "node" {
+			log.Debug("Ignoring supervisor FSS configmap add event in the nodes")
+			return
+		}
 		if getSvFssCRAvailability() {
 			log.Debugf("Ignoring supervisor FSS configmap add event as %q CR is present", featurestates.CRDSingular)
 			return
@@ -459,6 +463,10 @@ func configMapUpdated(oldObj, newObj interface{}) {
 
 	if fssConfigMap.Name == k8sOrchestratorInstance.supervisorFSS.configMapName &&
 		fssConfigMap.Namespace == k8sOrchestratorInstance.supervisorFSS.configMapNamespace {
+		if serviceMode == "node" {
+			log.Debug("Ignoring supervisor FSS configmap update event in the nodes")
+			return
+		}
 		if getSvFssCRAvailability() {
 			log.Debugf("Ignoring supervisor FSS configmap update event as %q CR is present", featurestates.CRDSingular)
 			return
@@ -488,6 +496,10 @@ func configMapDeleted(obj interface{}) {
 	// Check if it is either internal or supervisor FSS configmap
 	if fssConfigMap.Name == k8sOrchestratorInstance.supervisorFSS.configMapName &&
 		fssConfigMap.Namespace == k8sOrchestratorInstance.supervisorFSS.configMapNamespace {
+		if serviceMode == "node" {
+			log.Debug("Ignoring supervisor FSS configmap delete event in the nodes")
+			return
+		}
 		if getSvFssCRAvailability() {
 			log.Debugf("Ignoring supervisor FSS configmap delete event as %q CR is present", featurestates.CRDSingular)
 			return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: In https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/783 PR, we made the change which ensures nodes only read the internal configmap in TKG cluster to decide if a feature is enabled or not. This PR will make sure changes/updates to the GCM replicated supervisor configmap will be ignored in the nodes and not cached. Without this PR, if the GCM replicated supervisor configmap is deleted, the node pods start crashing.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: Tested this code and nodes stopped crashing. As it is a debug log, I did not get any new logs in my output to share.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Ignore supervisor FSS configmap updates in nodes
```
