### PR TITLE
Compare FSS data on an update event in k8sorchestrator before updating the cache

### DIFF
--- a/pkg/internalapis/featurestates/featurestates.go
+++ b/pkg/internalapis/featurestates/featurestates.go
@@ -311,12 +311,12 @@ func configMapUpdated(oldObj, newObj interface{}) {
 
 	newfssConfigMap, ok := newObj.(*v1.ConfigMap)
 	if newfssConfigMap == nil || !ok {
-		log.Warnf("configMapUpdated: unrecognized old object %+v", newObj)
+		log.Warnf("configMapUpdated: unrecognized new object %+v", newObj)
 		return
 	}
 	oldfssConfigMap, ok := oldObj.(*v1.ConfigMap)
 	if oldfssConfigMap == nil || !ok {
-		log.Warnf("configMapUpdated: unrecognized new object %+v", newObj)
+		log.Warnf("configMapUpdated: unrecognized old object %+v", newObj)
 		return
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:  Currently the FSS informer in k8sorchestrator has a resync time of 30mins which means even if there isn't any update to the configmap, the configmapUpdate function will be called. This results in unnecessary logs being printed which can be avoided by comparing the FSS data to verify if there is a change before updating the cache. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Currently the controller and node logs are flooded with logs like:
```
{"level":"warn","time":"2021-04-17T22:43:05.549847352Z","caller":"k8sorchestrator/k8sorchestrator.go:468","msg":"Supervisor feature state values from \"csi-feature-states\" stored successfully: map[csi-auth-check:false csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true trigger-csi-fullsync:false volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"8323940a-f917-4b02-854d-d25fb8a654a5"}
{"level":"warn","time":"2021-04-17T23:13:05.49185222Z","caller":"k8sorchestrator/k8sorchestrator.go:468","msg":"Supervisor feature state values from \"csi-feature-states\" stored successfully: map[csi-auth-check:false csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true trigger-csi-fullsync:false volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"5196f8f3-bd69-4ff8-94f8-b75950a5599d"}
{"level":"warn","time":"2021-04-17T23:43:05.570750973Z","caller":"k8sorchestrator/k8sorchestrator.go:468","msg":"Supervisor feature state values from \"csi-feature-states\" stored successfully: map[csi-auth-check:false csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true trigger-csi-fullsync:false volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"4f3f69e9-347a-43ce-830a-08ddab6ab4e5"}
{"level":"warn","time":"2021-04-18T00:13:05.577111898Z","caller":"k8sorchestrator/k8sorchestrator.go:468","msg":"Supervisor feature state values from \"csi-feature-states\" stored successfully: map[csi-auth-check:false csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true trigger-csi-fullsync:false volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"199521c3-43e5-4c79-a287-118f4e7fafc7"}
```

Logs during controller init after this change is applied:
```
{"level":"info","time":"2021-04-20T23:59:11.244024584Z","caller":"k8sorchestrator/k8sorchestrator.go:145","msg":"Initializing k8sOrchestratorInstance","TraceId":"dd655c04-4aac-4b70-8656-2e1c02fa7d1b"}
{"level":"info","time":"2021-04-20T23:59:11.286149358Z","caller":"k8sorchestrator/k8sorchestrator.go:245","msg":"New internal feature states values stored successfully: map[csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"dd655c04-4aac-4b70-8656-2e1c02fa7d1b"}
{"level":"info","time":"2021-04-20T23:59:16.809993055Z","caller":"k8sorchestrator/k8sorchestrator.go:290","msg":"New supervisor feature states values stored successfully from svfeaturestates CR object: map[csi-auth-check:false csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true trigger-csi-fullsync:false volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"dd655c04-4aac-4b70-8656-2e1c02fa7d1b"}
{"level":"info","time":"2021-04-20T23:59:16.810176459Z","caller":"k8sorchestrator/k8sorchestrator.go:171","msg":"k8sOrchestratorInstance initialized","TraceId":"dd655c04-4aac-4b70-8656-2e1c02fa7d1b"}
{"level":"info","time":"2021-04-20T23:59:16.811620637Z","caller":"kubernetes/kubernetes.go:294","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"3d1e7011-a823-45e2-b922-a9c184ff09e7"}
{"level":"info","time":"2021-04-20T23:59:16.811875632Z","caller":"kubernetes/kubernetes.go:133","msg":"Connecting to supervisor cluster using the certs/token in Guest Cluster config","TraceId":"3d1e7011-a823-45e2-b922-a9c184ff09e7"}
{"level":"info","time":"2021-04-20T23:59:16.871863779Z","caller":"k8sorchestrator/k8sorchestrator.go:448","msg":"configMapAdded: Internal feature state values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"9ea7e93f-30a1-4bdb-ae5b-78e34b06a8a2"}
{"level":"info","time":"2021-04-21T00:04:17.332599067Z","caller":"kubernetes/dynamicInformers.go:74","msg":"Created new dynamic informer factory for \"test-gc-e2e-demo-ns\" namespace using the supervisor client","TraceId":"dd655c04-4aac-4b70-8656-2e1c02fa7d1b"}
{"level":"info","time":"2021-04-21T00:04:17.340268973Z","caller":"k8sorchestrator/k8sorchestrator.go:333","msg":"Informer to watch on cnscsisvfeaturestate CR starting..","TraceId":"dd655c04-4aac-4b70-8656-2e1c02fa7d1b"}
{"level":"info","time":"2021-04-21T00:04:17.378989702Z","caller":"k8sorchestrator/k8sorchestrator.go:550","msg":"fssCRAdded: New supervisor feature states values stored successfully from svfeaturestates CR object: map[csi-auth-check:false csi-sv-feature-states-replication:true file-volume:false online-volume-extend:true trigger-csi-fullsync:false volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"d082ee7e-3a91-4045-ac0f-19de237cca52"}
```
Did not notice repeated logs after every 30mins.
Tried manually updating the configmap and the event was triggered with proper logging.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Compare FSS data on an update event in k8sorchestrator before updating the cache
```
