### PR TITLE
Add roles/privileges check in file volume setup requirements

### DIFF
--- a/docs/book/features/file_volume.md
+++ b/docs/book/features/file_volume.md
@@ -11,6 +11,8 @@ Proceed to the requirements section below to enable this feature in your environ
 Check the [CSI vSphere compatibility matrix](../compatiblity_matrix.md) and the [supported features](../supported_features_matrix.md) section to verify if your environment conforms to all the required versions. Also check the [limits](../limits.md) section to understand if this feature can cater to your needs.
 In order to utilize this feature in your vSphere environment, you need to make sure of the following:
 
+- Verify if your vSphere user for CSI driver has the required roles and privileges to create file volumes. Refer to the roles and privileges section in the [CSI driver deployment pre-requisites](../driver-deployment/prerequisites.md) page for more information.
+
 - Enable and configure the file service in your vSAN cluster configuration. You must configure the necessary file service domains, IP pools, network etc in order to create file share volumes. Refer to [vSphere 7.0 vSAN File service](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vsan.doc/GUID-82565B82-C911-42F7-85B1-E9EF973EE90C.html) documentation to get started.
 
 - Establish a dedicated file share network connecting all the kubernetes nodes and make sure this network is routable to the vSAN File Share network.  Refer to [Network Access of vSAN File Share](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.storage.doc/GUID-EFC00FFF-E720-44F1-B229-4C13687E6B85.html) to understand the setup better.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Our documentation currently talks about applying the required roles and privileges for file volume creation in the driver deployment pre-requisites page only. File volume feature documentation requirements section does not refer to this yet. Customer looking to use this feature might overlook this requirement in the driver deployment pre-requisites page, hence this PR will make sure he/she doesn't miss it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add roles/privileges check in file volume setup requirements
```
