### PR TITLE
GC test fix in gc_block_volume_expansion.go

### DIFF
--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -58,6 +58,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		pvcDeleted        bool
 		cmd               []string
 		svcClient         clientset.Interface
+		svNamespace       string
 	)
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
@@ -77,7 +78,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 
 		//Set resource quota
 		ginkgo.By("Set Resource quota for GC")
-		svcClient, svNamespace := getSvcClientAndNamespace()
+		svcClient, svNamespace = getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, rqLimit)
 
 		// Create Storage class and PVC
@@ -119,7 +120,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		}
 		err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		svcClient, svNamespace := getSvcClientAndNamespace()
+		svcClient, svNamespace = getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
 	})
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Fixes panic in,
[It] verify offline block volume expansion triggered when SVC CSI pod is down succeeds once SVC CSI pod comes up

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

