### PR TITLE
Bump up attacher and provisioner sidecar containers

### DIFF
--- a/manifests/dev/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/dev/vanilla/vsphere-csi-driver.yaml
@@ -141,12 +141,14 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v3.1.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.0
           args:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -256,7 +258,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is bumping up attacher and provisioner side car containers to respective latest releases. The latest releases of these sidecars are compatible with CSI spec 1.4.0. This is needed in vSphere CSI driver deployment yamls, prior to bumping up CSI spec to 1.4 in vSphere CSI driver itself in `go.mod` 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
The bump up of attacher and provisioner also provides many bug fixes which can be found here: 
`https://github.com/kubernetes-csi/external-attacher/blob/release-3.2/CHANGELOG/CHANGELOG-3.2.md`
`https://github.com/kubernetes-csi/external-provisioner/blob/release-2.2/CHANGELOG/CHANGELOG-2.2.md`

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump up attacher and provisioner sidecar containers to latest releases
```
