### PR TITLE
fix run-e2e-test.sh

### DIFF
--- a/hack/run-e2e-test.sh
+++ b/hack/run-e2e-test.sh
@@ -50,7 +50,7 @@ else
     read -ra OPTS <<< "-v $GINKGO_OPTS"
 fi
 
-ginkgo "${OPTS[@]}" --focus="$FOCUS" tests/e2e
+ginkgo -mod=mod "${OPTS[@]}" --focus="$FOCUS" tests/e2e
 
 # Checking for test status
 TEST_PASS=$?


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is testing to see what make test-e2e is failing on the pipeline.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
use vendored go.mod to build e2e
```
