### PR TITLE
GC VolumeExpansion Testcase Fix

### DIFF
--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -1378,7 +1378,8 @@ func invokeTestForVolumeExpansion(f *framework.Framework, client clientset.Inter
 
 	if guestCluster {
 		ginkgo.By("Checking for PVC resize completion on SVC PVC")
-		gomega.Expect(verifyResizeCompletedInSupervisor(svcPVCName)).To(gomega.BeTrue())
+		_, err = waitForFSResizeInSvc(svcPVCName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
 	// Delete POD
@@ -1577,7 +1578,8 @@ func invokeTestForVolumeExpansionWithFilesystem(f *framework.Framework, client c
 
 	if guestCluster {
 		ginkgo.By("Checking for PVC resize completion on SVC PVC")
-		gomega.Expect(verifyResizeCompletedInSupervisor(svcPVCName)).To(gomega.BeTrue())
+		_, err = waitForFSResizeInSvc(svcPVCName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
 	// Delete POD
@@ -1995,7 +1997,8 @@ func invokeTestForExpandVolumeMultipleTimes(f *framework.Framework, client clien
 
 	if guestCluster {
 		ginkgo.By("Checking for PVC resize completion on SVC PVC")
-		gomega.Expect(verifyResizeCompletedInSupervisor(svcPVCName)).To(gomega.BeTrue())
+		_, err = waitForFSResizeInSvc(svcPVCName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
 	ginkgo.By(fmt.Sprintf("File system resize finished successfully to %d", fsSize))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the intermittent failure of the test case 
Verify volume expansion with initial filesystem before expansion

Also, I have added a fix for the below testcase to make it more robust 
Verify volume expansion can happen multiple times
Verify volume expansion with no filesystem before expansion

Logs
https://gist.github.com/marunachalam/6987ce789648c4d60a73e3b80e80563e