### PR TITLE
Support for CnsQueryAsyncVolume

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.3
-	github.com/vmware/govmomi v0.24.1
+	github.com/vmware/govmomi v0.25.1-0.20210423021950-c00437518152
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,7 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -795,8 +796,8 @@ github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1
 github.com/vmware-tanzu/vm-operator-api v0.1.3 h1:4vxewu0jAN3fSoCBI6FhjmRGJ7ci0R2WNu/I6hacTYs=
 github.com/vmware-tanzu/vm-operator-api v0.1.3/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/vmware/govmomi v0.24.1 h1:ecVvrxF28/5g738gLTiYgc62fpGfIPRKheQ1Dj1p35w=
-github.com/vmware/govmomi v0.24.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.25.1-0.20210423021950-c00437518152 h1:Rh0+/tLmUpiI2fpE2mmLx0VLm+cskmiDLc28axxU5Cc=
+github.com/vmware/govmomi v0.25.1-0.20210423021950-c00437518152/go.mod h1:bi7jKMEW2kgT/dO5LrVPsVjS3apHGz0sDmY3ADSxHRQ=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=

--- a/manifests/supervisorcluster/1.17/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.17/cns-csi.yaml
@@ -320,6 +320,7 @@ data:
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"
+  "async-query-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.18/cns-csi.yaml
@@ -320,6 +320,7 @@ data:
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"
+  "async-query-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.19/cns-csi.yaml
@@ -341,6 +341,7 @@ data:
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"
+  "async-query-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -341,6 +341,7 @@ data:
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"
+  "async-query-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -341,6 +341,7 @@ data:
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"
+  "async-query-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -100,6 +100,7 @@ data:
   "csi-auth-check": "true"
   "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"
+  "async-query-volume": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+)
+
+// QueryVolumeUtil helps to invoke query volume API based on the feature state set for using query async volume.
+// If useQueryVolumeAsync is set to true, the function invokes CNS QueryVolumeAsync, otherwise it invokes synchronous QueryVolume API
+// The function also take volume manager instance, query filters, query selection as params
+// Returns queryResult when query volume succeeds, otherwise returns appropriate errors
+func QueryVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cnstypes.CnsQueryFilter, querySelection cnstypes.CnsQuerySelection, useQueryVolumeAsync bool) (*cnstypes.CnsQueryResult, error) {
+	log := logger.GetLogger(ctx)
+	var queryAsyncNotSupported bool
+	var queryResult *cnstypes.CnsQueryResult
+	var err error
+	if useQueryVolumeAsync {
+		// AsyncQueryVolume feature switch is disabled
+		queryResult, err = m.QueryVolumeAsync(ctx, queryFilter, querySelection)
+		if err != nil {
+			if err.Error() == cnsvsphere.ErrNotSupported.Error() {
+				log.Warn("QueryVolumeAsync is not supported. Invoking QueryVolume API")
+				queryAsyncNotSupported = true
+			} else { // Return for any other failures
+				msg := fmt.Sprintf("QueryVolumeAsync failed for queryFilter: %v. Err=%+v", queryFilter, err.Error())
+				log.Error(msg)
+				return nil, status.Error(codes.Internal, msg)
+			}
+		}
+	}
+	if !useQueryVolumeAsync || queryAsyncNotSupported {
+		queryResult, err = m.QueryAllVolume(ctx, queryFilter, querySelection)
+		if err != nil {
+			msg := fmt.Sprintf("QueryVolume failed for queryFilter: %+v. Err=%+v", queryFilter, err.Error())
+			log.Error(msg)
+			return nil, status.Error(codes.Internal, msg)
+		}
+	}
+	return queryResult, nil
+}

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -234,6 +234,8 @@ const (
 	CSIMigration = "csi-migration"
 	// CSIAuthCheck is feature flag for auth check
 	CSIAuthCheck = "csi-auth-check"
+	// AsyncQueryVolume is feature flag for using async query volume API
+	AsyncQueryVolume = "async-query-volume"
 	// CSISVFeatureStateReplication is feature flag for SV feature state replication feature
 	CSISVFeatureStateReplication = "csi-sv-feature-states-replication"
 	// VSANDirectDiskDecommission is feature flag for vsanD disk decommission

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
@@ -476,12 +477,12 @@ func DeleteVolumeUtil(ctx context.Context, volManager cnsvolume.Manager, volumeI
 }
 
 // ExpandVolumeUtil is the helper function to extend CNS volume for given volumeId
-func ExpandVolumeUtil(ctx context.Context, manager *Manager, volumeID string, capacityInMb int64) error {
+func ExpandVolumeUtil(ctx context.Context, manager *Manager, volumeID string, capacityInMb int64, useAsyncQueryVolume bool) error {
 	var err error
 	log := logger.GetLogger(ctx)
 	log.Debugf("vSphere CSI driver expanding volume %q to new size %d Mb.", volumeID, capacityInMb)
 
-	expansionRequired, err := isExpansionRequired(ctx, volumeID, capacityInMb, manager)
+	expansionRequired, err := isExpansionRequired(ctx, volumeID, capacityInMb, manager, useAsyncQueryVolume)
 	if err != nil {
 		return err
 	}
@@ -552,23 +553,25 @@ func getDatastore(ctx context.Context, vc *vsphere.VirtualCenter, datastoreURL s
 }
 
 // isExpansionRequired verifies if the requested size to expand a volume is greater than the current size
-func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int64, manager *Manager) (bool, error) {
+func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int64, manager *Manager, useAsyncQueryVolume bool) (bool, error) {
 	log := logger.GetLogger(ctx)
 	volumeIds := []cnstypes.CnsVolumeId{{Id: volumeID}}
 	queryFilter := cnstypes.CnsQueryFilter{
 		VolumeIds: volumeIds,
 	}
+	// Select only the backing object details.
 	querySelection := cnstypes.CnsQuerySelection{
 		Names: []string{
 			string(cnstypes.QuerySelectionNameTypeBackingObjectDetails),
 		},
 	}
 	// Query only the backing object details.
-	queryResult, err := manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
+	queryResult, err := utils.QueryVolumeUtil(ctx, manager.VolumeManager, queryFilter, querySelection, useAsyncQueryVolume)
 	if err != nil {
-		log.Errorf("failed to call QueryVolume for volumeID: %q: %v", volumeID, err)
+		log.Errorf("QueryVolume failed with err=%+v", err.Error())
 		return false, err
 	}
+
 	var currentSize int64
 	if len(queryResult.Volumes) > 0 {
 		currentSize = queryResult.Volumes[0].BackingObjectDetails.(cnstypes.BaseCnsBackingObjectDetails).GetCnsBackingObjectDetails().CapacityInMb

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -40,6 +40,7 @@ import (
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/common/prometheus"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
@@ -764,9 +765,9 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 				},
 			}
 			// Select only the backing object details.
-			queryResult, err := c.manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
+			queryResult, err := utils.QueryVolumeUtil(ctx, c.manager.VolumeManager, queryFilter, querySelection, commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 			if err != nil {
-				msg := fmt.Sprintf("QueryVolume failed for volumeID: %q. %+v", req.VolumeId, err.Error())
+				msg := fmt.Sprintf("QueryVolume failed with err=%+v", err.Error())
 				log.Error(msg)
 				return nil, status.Error(codes.Internal, msg)
 			}
@@ -879,12 +880,13 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 				},
 			}
 			// Select only the volume type.
-			queryResult, err := c.manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
+			queryResult, err := utils.QueryVolumeUtil(ctx, c.manager.VolumeManager, queryFilter, querySelection, commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 			if err != nil {
-				msg := fmt.Sprintf("QueryVolume failed for volumeID: %q. %+v", req.VolumeId, err.Error())
+				msg := fmt.Sprintf("QueryVolume failed with err=%+v", err.Error())
 				log.Error(msg)
 				return nil, status.Error(codes.Internal, msg)
 			}
+
 			if len(queryResult.Volumes) == 0 {
 				msg := fmt.Sprintf("volumeID %q not found in QueryVolume", req.VolumeId)
 				log.Error(msg)
@@ -995,7 +997,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 	volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
 
-	err = common.ExpandVolumeUtil(ctx, c.manager, volumeID, volSizeMB)
+	err = common.ExpandVolumeUtil(ctx, c.manager, volumeID, volSizeMB, commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 	if err != nil {
 		msg := fmt.Sprintf("failed to expand volume: %q to size: %d with error: %+v", volumeID, volSizeMB, err)
 		log.Error(msg)

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -806,7 +806,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 		volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
 
-		err = common.ExpandVolumeUtil(ctx, c.manager, volumeID, volSizeMB)
+		err = common.ExpandVolumeUtil(ctx, c.manager, volumeID, volSizeMB, commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 		if err != nil {
 			msg := fmt.Sprintf("failed to expand volume: %+q to size: %d err %+v", volumeID, volSizeMB, err)
 			log.Error(msg)

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -28,6 +28,7 @@ import (
 
 	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
@@ -94,14 +95,13 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) erro
 			metadataSyncer.configInfo.Cfg.Global.ClusterID,
 		},
 	}
-	querySelection := cnstypes.CnsQuerySelection{}
-	queryAllResult, err := metadataSyncer.volumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
+	queryResult, err := utils.QueryVolumeUtil(ctx, metadataSyncer.volumeManager, queryFilter, cnstypes.CnsQuerySelection{}, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 	if err != nil {
-		log.Errorf("FullSync: failed to queryAllVolume with err %+v", err)
+		log.Errorf("PVCUpdated: QueryVolume failed with err=%+v", err.Error())
 		return err
 	}
 
-	volumeToCnsEntityMetadataMap, volumeToK8sEntityMetadataMap, volumeClusterDistributionMap, err := fullSyncConstructVolumeMaps(ctx, k8sPVs, queryAllResult.Volumes, pvToPVCMap, pvcToPodMap, metadataSyncer, migrationFeatureStateForFullSync)
+	volumeToCnsEntityMetadataMap, volumeToK8sEntityMetadataMap, volumeClusterDistributionMap, err := fullSyncConstructVolumeMaps(ctx, k8sPVs, queryResult.Volumes, pvToPVCMap, pvcToPodMap, metadataSyncer, migrationFeatureStateForFullSync)
 	if err != nil {
 		log.Errorf("FullSync: fullSyncGetEntityMetadata failed with err %+v", err)
 		return err
@@ -117,7 +117,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) erro
 	// Get specs for create and update volume calls
 	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor, metadataSyncer.configInfo.Cfg.Global.ClusterDistribution)
 	createSpecArray, updateSpecArray := fullSyncGetVolumeSpecs(ctx, vcenter.Client.Version, k8sPVs, volumeToCnsEntityMetadataMap, volumeToK8sEntityMetadataMap, volumeClusterDistributionMap, containerCluster, metadataSyncer, migrationFeatureStateForFullSync)
-	volToBeDeleted, err := getVolumesToBeDeleted(ctx, queryAllResult.Volumes, k8sPVMap, metadataSyncer, migrationFeatureStateForFullSync)
+	volToBeDeleted, err := getVolumesToBeDeleted(ctx, queryResult.Volumes, k8sPVMap, metadataSyncer, migrationFeatureStateForFullSync)
 	if err != nil {
 		log.Errorf("FullSync: failed to get list of volumes to be deleted with err %+v", err)
 		return err
@@ -239,7 +239,7 @@ func fullSyncDeleteVolumes(ctx context.Context, volumeIDDeleteArray []cnstypes.C
 		log.Info("FullSync: fullSyncDeleteVolumes could not find any volume which is not present in k8s and needs to be checked for volume deletion.")
 		return
 	}
-	allQueryResults, err := fullSyncGetQueryResults(ctx, queryVolumeIds, "", metadataSyncer.volumeManager)
+	allQueryResults, err := fullSyncGetQueryResults(ctx, queryVolumeIds, "", metadataSyncer.volumeManager, metadataSyncer)
 	if err != nil {
 		log.Errorf("FullSync: fullSyncGetQueryResults failed to query volume metadata from vc. Err: %v", err)
 		return
@@ -367,7 +367,7 @@ func fullSyncConstructVolumeMaps(ctx context.Context, pvList []*v1.PersistentVol
 		log.Warn("could not find any volume which is present in both k8s and in CNS")
 		return volumeToCnsEntityMetadataMap, volumeToK8sEntityMetadataMap, volumeClusterDistributionMap, nil
 	}
-	allQueryResults, err := fullSyncGetQueryResults(ctx, queryVolumeIds, metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.volumeManager)
+	allQueryResults, err := fullSyncGetQueryResults(ctx, queryVolumeIds, metadataSyncer.configInfo.Cfg.Global.ClusterID, metadataSyncer.volumeManager, metadataSyncer)
 	if err != nil {
 		log.Errorf("FullSync: fullSyncGetQueryResults failed to query volume metadata from vc. Err: %v", err)
 		return nil, nil, nil, err

--- a/pkg/syncer/volume_health.go
+++ b/pkg/syncer/volume_health.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
@@ -46,10 +47,9 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 			string(cnstypes.QuerySelectionNameTypeHealthStatus),
 		},
 	}
-
-	queryAllResult, err := metadataSyncer.volumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
+	queryResult, err := utils.QueryVolumeUtil(ctx, metadataSyncer.volumeManager, queryFilter, querySelection, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 	if err != nil {
-		log.Errorf("csiGetVolumeHealthStatus: failed to queryAllVolume with err %+v", err)
+		log.Error("csiGetVolumeHealthStatus: QueryVolume failed with err=%+v", err.Error())
 		return
 	}
 
@@ -77,7 +77,7 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 		}
 	}
 
-	for _, vol := range queryAllResult.Volumes {
+	for _, vol := range queryResult.Volumes {
 		log.Debugf("Volume %q Health Status %q", vol.VolumeId.Id, vol.HealthStatus)
 
 		if pvc, ok := volumeHandleToPvcMap[vol.VolumeId.Id]; ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding definition for QueryVolumeAsync API which helps in retrieving volume information. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Enabled feature on vsphere cfg:
```
cat /etc/vmware/vsphereFeatures/vsphereFeatures.cfg | grep "QUERY"
CNS_ASYNC_QUERY                            = enabled
```

Enabled feature in CSI fss configmap
```
kubectl describe configmap -n vmware-system-csi
Name:         internal-feature-states.csi.vsphere.vmware.com
Namespace:    vmware-system-csi
...
...
async-query-volume:
----
true
```

Created pvc and pods to verify in logs if CNSQueryAsync is invoked & succeeds:
```
kubectl create -f pvc.yaml 
persistentvolumeclaim/example-vanilla-block-pvc created
#######################################
root@k8s-master-611:~# kubectl create -f pod.yaml 
pod/example-vanilla-block-pod created
#######################################
root@k8s-master-611:~# kubectl get pods -n vmware-system-csi
NAME                                     READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-c86867749-qbjsg   6/6     Running   0          10m
vsphere-csi-node-6wnhc                   3/3     Running   5          10m
vsphere-csi-node-bxkfs                   3/3     Running   5          10m
vsphere-csi-node-tzfq9                   3/3     Running   0          10m
vsphere-csi-node-z4l84                   3/3     Running   5          10m
#######################################
root@k8s-master-611:~# kubectl get pods -A
NAMESPACE           NAME                                     READY   STATUS    RESTARTS   AGE
default             example-vanilla-block-pod                1/1     Running   0          98s
#######################################
root@k8s-master-611:~# kubectl logs vsphere-csi-controller-c86867749-qbjsg -c vsphere-syncer -n vmware-system-csi | grep Query
2021-05-14T15:04:52.344Z	INFO	volume/manager.go:1078	QueryVolumeAsync successfully returned CnsQueryResult, opId: "4df75b4a"
2021-05-14T15:04:52.345Z	DEBUG	volume/manager.go:1079	QueryVolumeAsync returned CnsQueryResult: (types.CnsQueryResult) {
2021-05-14T15:04:52.345Z	DEBUG	syncer/util.go:137	FullSync: fullSyncGetQueryResults is called with volumeIds [{{} 3369ead5-998b-436a-9aac-8e7a34dd919f}] for clusterID vSAN-FVT-Cluster1620768125.2877822
2021-05-14T15:04:52.345Z	DEBUG	syncer/util.go:151	Query volumes with offset: 0 and limit: 500
2021-05-14T15:04:52.367Z	INFO	volume/manager.go:1078	QueryVolumeAsync successfully returned CnsQueryResult, opId: "4df75b4c"
2021-05-14T15:04:52.368Z	DEBUG	volume/manager.go:1079	QueryVolumeAsync returned CnsQueryResult: (types.CnsQueryResult) {
2021-05-14T15:06:52.352Z	INFO	volume/manager.go:1078	QueryVolumeAsync successfully returned CnsQueryResult, opId: "4df75b8c"
2021-05-14T15:06:52.353Z	DEBUG	volume/manager.go:1079	QueryVolumeAsync returned CnsQueryResult: (types.CnsQueryResult) {
2021-05-14T15:08:24.637Z	INFO	volume/manager.go:1078	QueryVolumeAsync successfully returned CnsQueryResult, opId: "4df75be9"	{"TraceId": "00df6683-03a5-4971-b8dd-d9bf0054213f"}
2021-05-14T15:08:24.637Z	DEBUG	volume/manager.go:1079	QueryVolumeAsync returned CnsQueryResult: (types.CnsQueryResult) {
2021-05-14T15:08:52.336Z	INFO	volume/manager.go:1078	QueryVolumeAsync successfully returned CnsQueryResult, opId: "4df75bfe"
2021-05-14T15:08:52.336Z	DEBUG	volume/manager.go:1079	QueryVolumeAsync returned CnsQueryResult: (types.CnsQueryResult) {
2021-05-14T15:08:52.337Z	DEBUG	syncer/util.go:137	FullSync: fullSyncGetQueryResults is called with volumeIds [{{} 8b6cf8b6-6104-4b7f-84f4-1c09cdfed310}] for clusterID vSAN-FVT-Cluster1620768125.2877822
2021-05-14T15:08:52.337Z	DEBUG	syncer/util.go:151	Query volumes with offset: 0 and limit: 500
2021-05-14T15:08:52.357Z	INFO	volume/manager.go:1078	QueryVolumeAsync successfully returned CnsQueryResult, opId: "4df75c00"
2021-05-14T15:08:52.357Z	DEBUG	volume/manager.go:1079	QueryVolumeAsync returned CnsQueryResult: (types.CnsQueryResult) {
2021-05-14T15:10:52.356Z	INFO	volume/manager.go:1078	QueryVolumeAsync successfully returned CnsQueryResult, opId: "4df75cc8"
2021-05-14T15:10:52.356Z	DEBUG	volume/manager.go:1079	QueryVolumeAsync returned CnsQueryResult: (types.CnsQueryResult) {
2021-05-14T15:10:52.357Z	DEBUG	syncer/util.go:137	FullSync: fullSyncGetQueryResults is called with volumeIds [{{} 8b6cf8b6-6104-4b7f-84f4-1c09cdfed310}] for clusterID vSAN-FVT-Cluster1620768125.2877822
2021-05-14T15:10:52.357Z	DEBUG	syncer/util.go:151	Query volumes with offset: 0 and limit: 500
2021-05-14T15:10:52.381Z	INFO	volume/manager.go:1078	QueryVolumeAsync successfully returned CnsQueryResult, opId: "4df75cca"
2021-05-14T15:10:52.381Z	DEBUG	volume/manager.go:1079	QueryVolumeAsync returned CnsQueryResult: (types.CnsQueryResult) {
2021-05-14T15:12:52.339Z	INFO	volume/manager.go:1078	QueryVolumeAsync successfully returned CnsQueryResult, opId: "4df75d49"
2021-05-14T15:12:52.339Z	DEBUG	volume/manager.go:1079	QueryVolumeAsync returned CnsQueryResult: (types.CnsQueryResult) {
2021-05-14T15:13:00.891Z	INFO	volume/manager.go:1078	QueryVolumeAsync successfully returned CnsQueryResult, opId: "4df75d5c"	{"TraceId": "4b482d32-7448-4ac3-937d-5bb2a249b3c9"}
2021-05-14T15:13:00.891Z	DEBUG	volume/manager.go:1079	QueryVolumeAsync returned CnsQueryResult: (types.CnsQueryResult) {
2021-05-14T15:14:52.360Z	INFO	volume/manager.go:1078	QueryVolumeAsync successfully returned CnsQueryResult, opId: "4df75e35"
2021-05-14T15:14:52.361Z	DEBUG	volume/manager.go:1079	QueryVolumeAsync returned CnsQueryResult: (types.CnsQueryResult) {
2021-05-14T15:14:52.365Z	DEBUG	syncer/util.go:137	FullSync: fullSyncGetQueryResults is called with volumeIds [{{} 27ce4b95-300b-4192-a658-0dae253d4d7b}] for clusterID vSAN-FVT-Cluster1620768125.2877822
2021-05-14T15:14:52.365Z	DEBUG	syncer/util.go:151	Query volumes with offset: 0 and limit: 500
2021-05-14T15:14:52.389Z	INFO	volume/manager.go:1078	QueryVolumeAsync successfully returned CnsQueryResult, opId: "4df75e37"
2021-05-14T15:14:52.389Z	DEBUG	volume/manager.go:1079	QueryVolumeAsync returned CnsQueryResult: (types.CnsQueryResult) {
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support for CnsQueryAsyncVolume API
```
