### PR TITLE
fix registering types to help initialize CNS operator

### DIFF
--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
-	apis "sigs.k8s.io/vsphere-csi-driver/pkg/apis/storagepool"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -174,7 +173,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 	log.Info("Registering Components for Cns Operator")
 
 	// Setup Scheme for all resources for external APIs
-	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := cnsoperatorv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Errorf("failed to set the scheme for Cns operator. Err: %+v", err)
 		return err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing registering types to help initialize CNS operator.
Without this fix, syncer container is crashing in WCP with the following error.

```
{"level":"error","time":"2021-05-03T18:36:48.530974478Z","caller":"manager/init.go:192","msg":"failed to start Cns operator. Err: no kind is registered for the type v1alpha1.CnsNodeVmAttachment in scheme \"pkg/runtime/scheme.go:100\"","TraceId":"450f5ffd-9fb6-4472-98af-e97a1872b799","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/cnsoperator/manager.InitCnsOperator\n\t/build/pkg/syncer/cnsoperator/manager/init.go:192\nmain.initSyncerComponents.func1.2\n\t/build/cmd/syncer/main.go:171"}
{"level":"error","time":"2021-05-03T18:36:48.531106868Z","caller":"syncer/main.go:172","msg":"Error initializing Cns Operator. Error: no kind is registered for the type v1alpha1.CnsNodeVmAttachment in scheme \"pkg/runtime/scheme.go:100\"","stacktrace":"main.initSyncerComponents.func1.2\n\t/build/cmd/syncer/main.go:172"}
```


**Special notes for your reviewer**:

Testing done: Yes

Logs from syncer container - supervisor

```
# cat vsphere-syncer.log | more
2021-05-03T20:38:24.700Z	INFO	logger/logger.go:37	Setting default log level to :"DEVELOPMENT"
2021-05-03T20:38:24.700Z	INFO	syncer/main.go:72	Version : v2.1.0-rc.1-625-g18aedb1	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b"}
2021-05-03T20:38:24.700Z	INFO	commonco/utils.go:38	Defaulting feature states configmap name to "csi-feature-states"	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b
"}
2021-05-03T20:38:24.700Z	INFO	commonco/utils.go:42	Defaulting feature states configmap namespace to "vmware-system-csi"	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b
"}
2021-05-03T20:38:24.700Z	DEBUG	commonco/utils.go:99	Container orchestrator init params: {SupervisorFeatureStatesConfigInfo:{Name:csi-feature-states Namespace:vmware-system-c
si} ServiceMode:}	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b"}
2021-05-03T20:38:24.700Z	INFO	syncer/main.go:89	Starting container with operation mode: METADATA_SYNC	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b"}
2021-05-03T20:38:24.700Z	DEBUG	config/config.go:354	GetCnsconfig called with cfgPath: /etc/vmware/wcp/vsphere-cloud-provider.conf	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c
97c1925b"}
2021-05-03T20:38:24.700Z	DEBUG	config/config.go:261	Initializing vc server sc1-10-78-185-113.eng.vmware.com	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b"}
2021-05-03T20:38:24.700Z	INFO	config/config.go:300	No Net Permissions given in Config. Using default permissions.	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b"}
2021-05-03T20:38:24.700Z	INFO	kubernetes/kubernetes.go:81	k8s client using in-cluster config	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b"}
2021-05-03T20:38:24.700Z	INFO	k8scloudoperator/k8scloudoperator.go:80	Trying to initialize the K8s Cloud Operator gRPC service	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c
97c1925b"}
2021-05-03T20:38:24.701Z	INFO	common/util.go:333	Connecting to K8s Cloud Operator Service on port 29000	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b"}
2021-05-03T20:38:24.701Z	INFO	kubernetes/kubernetes.go:294	Setting client QPS to 50.000000 and Burst to 50.	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b"}
2021-05-03T20:38:24.701Z	DEBUG	k8scloudoperator/k8scloudoperator.go:82	K8s Cloud Operator Service will be running on port 29000	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c
97c1925b"}
2021-05-03T20:38:24.702Z	INFO	kubernetes/kubernetes.go:81	k8s client using in-cluster config	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b"}
2021-05-03T20:38:24.702Z	INFO	kubernetes/kubernetes.go:294	Setting client QPS to 50.000000 and Burst to 50.	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b"}
2021-05-03T20:38:24.704Z	INFO	syncer/main.go:115	Starting the http server to expose Prometheus metrics..	{"TraceId": "613f13e9-43a1-4c7e-9a12-e35c97c1925b"}
I0503 20:38:24.705089       1 leaderelection.go:243] attempting to acquire leader lease vmware-system-csi/vsphere-syncer...
I0503 20:38:24.739585       1 leaderelection.go:253] successfully acquired lease vmware-system-csi/vsphere-syncer
2021-05-03T20:38:24.740Z	INFO	k8sorchestrator/k8sorchestrator.go:145	Initializing k8sOrchestratorInstance	{"TraceId": "073fcf04-5c7b-4c1b-8bfb-11e364614b03"}
2021-05-03T20:38:24.740Z	INFO	kubernetes/kubernetes.go:81	k8s client using in-cluster config	{"TraceId": "073fcf04-5c7b-4c1b-8bfb-11e364614b03"}
2021-05-03T20:38:24.740Z	INFO	kubernetes/kubernetes.go:294	Setting client QPS to 50.000000 and Burst to 50.	{"TraceId": "073fcf04-5c7b-4c1b-8bfb-11e364614b03"}
2021-05-03T20:38:24.774Z	INFO	k8sorchestrator/k8sorchestrator.go:352	New supervisor feature states values stored successfully: map[csi-auth-check:false csi-sv-feature-states-
replication:true fake-attach:true file-volume:false online-volume-extend:true trigger-csi-fullsync:false volume-extend:true volume-health:true vsan-direct-disk-decommission:false]	{
"TraceId": "073fcf04-5c7b-4c1b-8bfb-11e364614b03"}
2021-05-03T20:38:24.775Z	DEBUG	k8sorchestrator/k8sorchestrator.go:620	Initializing volume ID to PVC name map	{"TraceId": "073fcf04-5c7b-4c1b-8bfb-11e364614b03"}
2021-05-03T20:38:24.775Z	INFO	k8sorchestrator/k8sorchestrator.go:171	k8sOrchestratorInstance initialized	{"TraceId": "073fcf04-5c7b-4c1b-8bfb-11e364614b03"}
2021-05-03T20:38:24.775Z	INFO	syncer/metadatasyncer.go:127	Initializing MetadataSyncer
2021-05-03T20:38:24.775Z	INFO	kubernetes/kubernetes.go:81	k8s client using in-cluster config
2021-05-03T20:38:24.775Z	INFO	kubernetes/kubernetes.go:294	Setting client QPS to 50.000000 and Burst to 50.
2021-05-03T20:38:24.778Z	INFO	vsphere/virtualcenter.go:491	Initializing new vCenterInstance.
2021-05-03T20:38:24.778Z	INFO	vsphere/utils.go:147	Defaulting timeout for vCenter Client to 5 minutes
2021-05-03T20:38:24.778Z	INFO	vsphere/virtualcentermanager.go:72	Initializing defaultVirtualCenterManager...
2021-05-03T20:38:24.778Z	INFO	vsphere/virtualcentermanager.go:74	Successfully initialized defaultVirtualCenterManager
2021-05-03T20:38:24.778Z	INFO	vsphere/virtualcentermanager.go:118	Successfully registered VC "sc1-10-78-185-113.eng.vmware.com"
2021-05-03T20:38:24.779Z	DEBUG	vsphere/virtualcenter.go:148	Setting vCenter soap client timeout to 5m0s
2021-05-03T20:38:24.793Z	INFO	storagepool/service.go:55	Initializing Storage Pool Service
2021-05-03T20:38:24.794Z	INFO	kubernetes/kubernetes.go:81	k8s client using in-cluster config
2021-05-03T20:38:24.794Z	INFO	kubernetes/kubernetes.go:294	Setting client QPS to 50.000000 and Burst to 50.
2021-05-03T20:38:24.794Z	INFO	manager/init.go:69	Initializing CNS Operator	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125"}
2021-05-03T20:38:24.796Z	INFO	k8sorchestrator/k8sorchestrator.go:443	configMapAdded: Supervisor feature state values from "csi-feature-states" stored successfully: map[csi-au
th-check:false csi-sv-feature-states-replication:true fake-attach:true file-volume:false online-volume-extend:true trigger-csi-fullsync:false volume-extend:true volume-health:true vsan-
direct-disk-decommission:false]	{"TraceId": "cb0010bb-fdf2-46ce-a826-46ddebcd013a"}
W0503 20:38:24.826528       1 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomRes
ourceDefinition
W0503 20:38:24.838033       1 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomRes
ourceDefinition
2021-05-03T20:38:24.838Z	INFO	kubernetes/kubernetes.go:371	"storagepools.cns.vmware.com" CRD updated successfully
2021-05-03T20:38:24.910Z	INFO	vsphere/virtualcenter.go:174	New session ID for 'VSPHERE.LOCAL\workload_storage_management-abe47424-cc26-4cfa-ab54-2a7d4e9728cb' = 5238d437-3d
cb-fa9f-46ff-ca6ab85884f4
2021-05-03T20:38:24.910Z	INFO	vsphere/virtualcenter.go:524	vCenterInstance initialized
2021-05-03T20:38:24.910Z	INFO	volume/manager.go:116	Initializing new volume.defaultManager...
2021-05-03T20:38:24.911Z	INFO	volume/manager.go:113	Retrieving existing volume.defaultManager...	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125"}
2021-05-03T20:38:24.911Z	INFO	kubernetes/kubernetes.go:81	k8s client using in-cluster config	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125"}
2021-05-03T20:38:24.911Z	INFO	kubernetes/kubernetes.go:294	Setting client QPS to 50.000000 and Burst to 50.	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125"}
2021-05-03T20:38:24.912Z	INFO	featurestates/featurestates.go:83	Starting SvFSSReplicationService
2021-05-03T20:38:24.912Z	INFO	kubernetes/kubernetes.go:81	k8s client using in-cluster config
2021-05-03T20:38:24.912Z	INFO	kubernetes/kubernetes.go:294	Setting client QPS to 50.000000 and Burst to 50.
2021-05-03T20:38:24.912Z	INFO	syncer/metadatasyncer.go:229	Adding watch on path: "/etc/vmware/wcp"
2021-05-03T20:38:24.912Z	DEBUG	syncer/metadatasyncer.go:201	Waiting for event on fsnotify watcher
W0503 20:38:24.928701       1 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomRes
ourceDefinition
W0503 20:38:24.938795       1 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomRes
ourceDefinition
W0503 20:38:24.958639       1 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomRes
ourceDefinition
2021-05-03T20:38:24.959Z	INFO	kubernetes/kubernetes.go:371	"cnsnodevmattachments.cns.vmware.com" CRD updated successfully	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125
"}
2021-05-03T20:38:24.960Z	INFO	kubernetes/kubernetes.go:81	k8s client using in-cluster config	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125"}
2021-05-03T20:38:24.960Z	INFO	kubernetes/kubernetes.go:294	Setting client QPS to 50.000000 and Burst to 50.	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125"}
W0503 20:38:24.965737       1 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomRes
ourceDefinition
2021-05-03T20:38:24.967Z	INFO	kubernetes/kubernetes.go:371	"cnscsisvfeaturestates.cns.vmware.com" CRD updated successfully
2021-05-03T20:38:24.968Z	INFO	kubernetes/kubernetes.go:81	k8s client using in-cluster config
W0503 20:38:24.969728       1 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomRes
ourceDefinition
W0503 20:38:24.976121       1 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomRes
ourceDefinition
2021-05-03T20:38:24.976Z	INFO	kubernetes/kubernetes.go:371	"cnsvolumemetadatas.cns.vmware.com" CRD updated successfully	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125
"}
2021-05-03T20:38:24.977Z	INFO	kubernetes/kubernetes.go:81	k8s client using in-cluster config	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125"}
2021-05-03T20:38:24.978Z	INFO	kubernetes/kubernetes.go:294	Setting client QPS to 50.000000 and Burst to 50.	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125"}
2021-05-03T20:38:24.980Z	INFO	kubernetes/kubernetes.go:294	Setting client QPS to 50.000000 and Burst to 50.
W0503 20:38:24.987152       1 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomRes
ourceDefinition
2021-05-03T20:38:24.988Z	INFO	kubernetes/kubernetes.go:81	k8s client using in-cluster config
2021-05-03T20:38:24.989Z	INFO	kubernetes/kubernetes.go:294	Setting client QPS to 50.000000 and Burst to 50.
W0503 20:38:25.016082       1 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomRes
ourceDefinition
2021-05-03T20:38:25.016Z	INFO	kubernetes/kubernetes.go:371	"cnsregistervolumes.cns.vmware.com" CRD updated successfully	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125
"}
2021-05-03T20:38:25.016Z	INFO	manager/init.go:302	Adding watch on path: "/etc/vmware/wcp"	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125"}
2021-05-03T20:38:25.029Z	INFO	manager/init.go:152	Triggering CnsRegisterVolume cleanup routine	{"TraceId": "49649d5c-66a1-45a5-afd3-73f7d2f8bc45"}
2021-05-03T20:38:25.029Z	INFO	manager/cleanupcnsregistervolumes.go:35	cleanUpCnsRegisterVolumeInstances: start	{"TraceId": "49649d5c-66a1-45a5-afd3-73f7d2f8bc45"}
2021-05-03T20:38:25.046Z	INFO	storagepool/service.go:151	Done initializing Storage Pool Service
2021-05-03T20:38:25.022Z	DEBUG	manager/init.go:276	Waiting for event on fsnotify watcher	{"TraceId": "d4510d33-0480-4858-95f6-ba70347b2125"}
2021-05-03T20:38:25.058Z	INFO	kubernetes/kubernetes.go:81	k8s client using in-cluster config
2021-05-03T20:38:25.058Z	INFO	kubernetes/kubernetes.go:294	Setting client QPS to 50.000000 and Burst to 50.
2021-05-03T20:38:25.059Z	INFO	storagepool/nodeannotationlistener.go:50	NodeAnnotationListener initialized.
2021-05-03T20:38:25.059Z	INFO	storagepool/service.go:129	VSANDirectDiskDecommission feature is disabled on the cluster
2021-05-03T20:38:25.060Z	INFO	storagepool/listener.go:103	Starting property collector...
2021-05-03T20:38:25.105Z	INFO	storagepool/listener.go:108	Got 15 property collector update(s)	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object ClusterComputeResource:domain-c75 properties [{{} host assign {[HostSystem:host-40 HostSyst
em:host-37 HostSystem:host-31 HostSystem:host-28]}}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:171	Scheduled ReconcileAllStoragePools starting	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	INFO	storagepool/listener.go:193	Scheduled ReconcileAllStoragePools started	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object HostSystem:host-40 properties [{{} datastore assign {[Datastore:datastore-66 Datastore:data
store-68 Datastore:datastore-67 Datastore:datastore-81]}} {{} runtime.inMaintenanceMode assign false}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object HostSystem:host-37 properties [{{} datastore assign {[Datastore:datastore-69 Datastore:data
store-70 Datastore:datastore-67 Datastore:datastore-81]}} {{} runtime.inMaintenanceMode assign false}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object HostSystem:host-31 properties [{{} datastore assign {[Datastore:datastore-71 Datastore:data
store-72 Datastore:datastore-67 Datastore:datastore-81]}} {{} runtime.inMaintenanceMode assign false}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object HostSystem:host-28 properties [{{} datastore assign {[Datastore:datastore-74 Datastore:data
store-73 Datastore:datastore-67 Datastore:datastore-81]}} {{} runtime.inMaintenanceMode assign false}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object Datastore:datastore-81 properties [{{} summary assign {{} Datastore:datastore-81 vsanDatast
ore ds:///vmfs/volumes/vsan:525c58c145017a34-0d676eab2ecd51cb/ 2576879714304 2328888302644 33745911808 true 0xc000e5f4bc vsan normal}}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523
"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:123	Starting update for single StoragePool datastore-81	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/intended_state.go:355	Skipping update for datastore-81	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object Datastore:datastore-67 properties [{{} summary assign {{} Datastore:datastore-67 nfs0-1 ds:
///vmfs/volumes/97c3d9b1-6ea91a2b/ 316933144576 316164227072 5740941312 true 0xc000e5f7fc NFS normal}}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:123	Starting update for single StoragePool datastore-67	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/intended_state.go:355	Skipping update for datastore-67	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object Datastore:datastore-68 properties [{{} summary assign {{} Datastore:datastore-68 esxi-H1-lo
cal-datastore-1 ds:///vmfs/volumes/6090535f-191349f4-3401-02008cd709f8/ 16911433728 15134097408 0 true 0xc000e5fb24 VMFS normal}}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523
"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:123	Starting update for single StoragePool datastore-68	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/intended_state.go:355	Skipping update for datastore-68	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object Datastore:datastore-66 properties [{{} summary assign {{} Datastore:datastore-66 esxi-H1-lo
cal-datastore-0 ds:///vmfs/volumes/6090535e-764284e4-8a65-02008cd709f8/ 321854111744 320339968000 0 true 0xc000e5fe1c VMFS normal}}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523
"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:123	Starting update for single StoragePool datastore-66	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/intended_state.go:355	Skipping update for datastore-66	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object Datastore:datastore-70 properties [{{} summary assign {{} Datastore:datastore-70 esxi-H4-lo
cal-datastore-1 ds:///vmfs/volumes/6090536c-9c1e6b18-ccfd-02008c5f463f/ 16911433728 15134097408 0 true 0xc000e6a12c VMFS normal}}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523
"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:123	Starting update for single StoragePool datastore-70	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/intended_state.go:355	Skipping update for datastore-70	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object Datastore:datastore-69 properties [{{} summary assign {{} Datastore:datastore-69 esxi-H4-lo
cal-datastore-0 ds:///vmfs/volumes/6090536a-f9750eca-4a1b-02008c5f463f/ 321854111744 320339968000 0 true 0xc000e6a43c VMFS normal}}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523
"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:123	Starting update for single StoragePool datastore-69	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/intended_state.go:355	Skipping update for datastore-69	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object Datastore:datastore-72 properties [{{} summary assign {{} Datastore:datastore-72 esxi-H2-lo
cal-datastore-1 ds:///vmfs/volumes/60905365-cbf59f2c-2827-02008c21766f/ 16911433728 15134097408 0 true 0xc000e6a764 VMFS normal}}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523
"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:123	Starting update for single StoragePool datastore-72	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/intended_state.go:355	Skipping update for datastore-72	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object Datastore:datastore-71 properties [{{} summary assign {{} Datastore:datastore-71 esxi-H2-lo
cal-datastore-0 ds:///vmfs/volumes/60905362-28836974-77ae-02008c21766f/ 321854111744 320071532544 0 true 0xc000e6aa74 VMFS normal}}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523
"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:123	Starting update for single StoragePool datastore-71	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/intended_state.go:355	Skipping update for datastore-71	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object Datastore:datastore-73 properties [{{} summary assign {{} Datastore:datastore-73 esxi-H0-lo
cal-datastore-1 ds:///vmfs/volumes/6090535c-f9bfe4d4-64c4-02008c37b178/ 16911433728 15134097408 0 true 0xc000e6ae5a VMFS normal}}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523
"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:123	Starting update for single StoragePool datastore-73	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/intended_state.go:355	Skipping update for datastore-73	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:112	Got update for object Datastore:datastore-74 properties [{{} summary assign {{} Datastore:datastore-74 esxi-H0-lo
cal-datastore-0 ds:///vmfs/volumes/6090535b-71db5082-8bc6-02008c37b178/ 321854111744 320339968000 0 true 0xc000e6b16c VMFS normal}}]	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523
"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:123	Starting update for single StoragePool datastore-74	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/intended_state.go:355	Skipping update for datastore-74	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.105Z	DEBUG	storagepool/listener.go:137	Done processing 15 property collector update(s)	{"TraceId": "e28bb645-a259-43af-85be-1e8e01bd5523"}
2021-05-03T20:38:25.213Z	INFO	syncer/metadatasyncer.go:280	Initialized metadata syncer
```

Logs from syncer container - Guest Cluster

```
kubectl logs vsphere-csi-controller-5b9c9c7f87-fvpvw -c vsphere-syncer -n vmware-system-csi
{"level":"info","time":"2021-05-04T18:16:28.737156372Z","caller":"logger/logger.go:37","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2021-05-04T18:16:28.755163784Z","caller":"syncer/main.go:72","msg":"Version : v2.1.0-rc.1-625-g18aedb14","TraceId":"aa84a6dc-3449-4ca1-97c5-0aeacd0ff746"}
{"level":"info","time":"2021-05-04T18:16:28.759957541Z","caller":"syncer/main.go:89","msg":"Starting container with operation mode: METADATA_SYNC","TraceId":"aa84a6dc-3449-4ca1-97c5-0aeacd0ff746"}
{"level":"info","time":"2021-05-04T18:16:28.77300308Z","caller":"syncer/main.go:115","msg":"Starting the http server to expose Prometheus metrics..","TraceId":"aa84a6dc-3449-4ca1-97c5-0aeacd0ff746"}
{"level":"info","time":"2021-05-04T18:16:28.822628784Z","caller":"kubernetes/kubernetes.go:81","msg":"k8s client using in-cluster config","TraceId":"aa84a6dc-3449-4ca1-97c5-0aeacd0ff746"}
{"level":"info","time":"2021-05-04T18:16:28.830145428Z","caller":"kubernetes/kubernetes.go:294","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"aa84a6dc-3449-4ca1-97c5-0aeacd0ff746"}
I0504 18:16:28.861868       1 leaderelection.go:243] attempting to acquire leader lease vmware-system-csi/vsphere-syncer...
I0504 18:17:12.717427       1 leaderelection.go:253] successfully acquired lease vmware-system-csi/vsphere-syncer
{"level":"info","time":"2021-05-04T18:17:12.725480929Z","caller":"k8sorchestrator/k8sorchestrator.go:145","msg":"Initializing k8sOrchestratorInstance","TraceId":"af951d0a-c3fb-4c44-bdb1-9edeadc37fa9"}
{"level":"info","time":"2021-05-04T18:17:12.727835565Z","caller":"kubernetes/kubernetes.go:81","msg":"k8s client using in-cluster config","TraceId":"af951d0a-c3fb-4c44-bdb1-9edeadc37fa9"}
{"level":"info","time":"2021-05-04T18:17:12.741580467Z","caller":"kubernetes/kubernetes.go:294","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"af951d0a-c3fb-4c44-bdb1-9edeadc37fa9"}
{"level":"info","time":"2021-05-04T18:17:12.789932782Z","caller":"k8sorchestrator/k8sorchestrator.go:245","msg":"New internal feature states values stored successfully: map[csi-sv-feature-states-replication:false file-volume:false online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"af951d0a-c3fb-4c44-bdb1-9edeadc37fa9"}
{"level":"info","time":"2021-05-04T18:17:12.802009904Z","caller":"k8sorchestrator/k8sorchestrator.go:352","msg":"New supervisor feature states values stored successfully: map[csi-auth-check:false csi-sv-feature-states-replication:false file-volume:false online-volume-extend:true trigger-csi-fullsync:false volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"af951d0a-c3fb-4c44-bdb1-9edeadc37fa9"}
{"level":"info","time":"2021-05-04T18:17:12.8035023Z","caller":"k8sorchestrator/k8sorchestrator.go:171","msg":"k8sOrchestratorInstance initialized","TraceId":"af951d0a-c3fb-4c44-bdb1-9edeadc37fa9"}
{"level":"info","time":"2021-05-04T18:17:12.803959169Z","caller":"syncer/metadatasyncer.go:127","msg":"Initializing MetadataSyncer"}
{"level":"info","time":"2021-05-04T18:17:12.804398167Z","caller":"kubernetes/kubernetes.go:81","msg":"k8s client using in-cluster config"}
{"level":"info","time":"2021-05-04T18:17:12.811597336Z","caller":"kubernetes/kubernetes.go:294","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2021-05-04T18:17:12.814843728Z","caller":"manager/init.go:69","msg":"Initializing CNS Operator","TraceId":"24fb2bff-1923-4fa1-a26b-b4dcc128f687"}
{"level":"info","time":"2021-05-04T18:17:12.83663204Z","caller":"k8sorchestrator/k8sorchestrator.go:448","msg":"configMapAdded: Internal feature state values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[csi-sv-feature-states-replication:false file-volume:false online-volume-extend:true volume-extend:true volume-health:true]","TraceId":"e6026b11-5621-412b-b53e-1a75177999f2"}
{"level":"info","time":"2021-05-04T18:17:12.838122418Z","caller":"k8sorchestrator/k8sorchestrator.go:443","msg":"configMapAdded: Supervisor feature state values from \"csi-feature-states\" stored successfully: map[csi-auth-check:false csi-sv-feature-states-replication:false file-volume:false online-volume-extend:true trigger-csi-fullsync:false volume-extend:true volume-health:true vsan-direct-disk-decommission:false]","TraceId":"2ede7cde-c301-4cef-898a-2d8fb63813f4"}
{"level":"info","time":"2021-05-04T18:17:12.838507044Z","caller":"kubernetes/kubernetes.go:294","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2021-05-04T18:17:13.030240233Z","caller":"kubernetes/kubernetes.go:133","msg":"Connecting to supervisor cluster using the certs/token in Guest Cluster config"}
{"level":"info","time":"2021-05-04T18:17:13.033624103Z","caller":"syncer/metadatasyncer.go:229","msg":"Adding watch on path: \"/etc/cloud/pvcsi-config\""}
{"level":"info","time":"2021-05-04T18:17:13.034215654Z","caller":"syncer/metadatasyncer.go:237","msg":"Adding watch on path: \"/etc/cloud/pvcsi-provider\""}
{"level":"info","time":"2021-05-04T18:17:13.237624279Z","caller":"syncer/metadatasyncer.go:280","msg":"Initialized metadata syncer"}
{"level":"info","time":"2021-05-04T18:17:13.239011194Z","caller":"syncer/metadatasyncer.go:92","msg":"FullSync: fullSync interval is set to 2 minutes"}
{"level":"info","time":"2021-05-04T18:17:13.240051666Z","caller":"syncer/metadatasyncer.go:329","msg":"\"trigger-csi-fullsync\" feature flag is not enabled. Using the traditional way to directly invoke full sync"}
{"level":"info","time":"2021-05-04T18:17:13.243511759Z","caller":"syncer/metadatasyncer.go:334","msg":"fullSync is triggered","TraceId":"85e05e08-d939-4b63-87cb-bb5bd692b863"}
{"level":"info","time":"2021-05-04T18:17:13.243521507Z","caller":"syncer/metadatasyncer.go:1293","msg":"initResizeReconciler is triggered","TraceId":"85e05e08-d939-4b63-87cb-bb5bd692b863"}
{"level":"info","time":"2021-05-04T18:17:13.24367795Z","caller":"syncer/pvcsi_fullsync.go:37","msg":"FullSync: Start","TraceId":"85e05e08-d939-4b63-87cb-bb5bd692b863"}
{"level":"info","time":"2021-05-04T18:17:13.248843963Z","caller":"syncer/metadatasyncer.go:1267","msg":"supervisorNamespace test-gc-e2e-demo-ns","TraceId":"f4402b90-a038-463e-b16a-dfe314442dc1"}
{"level":"info","time":"2021-05-04T18:17:13.249509101Z","caller":"syncer/metadatasyncer.go:1268","msg":"initVolumeHealthReconciler is triggered","TraceId":"f4402b90-a038-463e-b16a-dfe314442dc1"}
{"level":"info","time":"2021-05-04T18:17:13.26796803Z","caller":"syncer/pvcsi_fullsync.go:124","msg":"FullSync: End","TraceId":"85e05e08-d939-4b63-87cb-bb5bd692b863"}
{"level":"info","time":"2021-05-04T18:17:13.347346245Z","caller":"manager/init.go:173","msg":"Registering Components for Cns Operator","TraceId":"24fb2bff-1923-4fa1-a26b-b4dcc128f687"}
{"level":"info","time":"2021-05-04T18:17:13.347925368Z","caller":"syncer/resize_reconciler.go:159","msg":"Resize reconciler: Start","TraceId":"85e05e08-d939-4b63-87cb-bb5bd692b863"}
{"level":"info","time":"2021-05-04T18:17:13.363717018Z","caller":"triggercsifullsync/triggercsifullsync_controller.go:82","msg":"Not initializing the TriggerCsiFullSync Controller as TriggerCsiFullSync feature is disabled on the cluster","TraceId":"ade86fe2-29b7-4cf4-bcc0-51fb7c66af0a"}
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix registering types to help initialize CNS operator
```
