### PR TITLE
fixed detach volume error handling

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -433,29 +433,29 @@ func (m *defaultManager) DetachVolume(ctx context.Context, vm *cnsvsphere.Virtua
 		// Call the CNS DetachVolume
 		task, err := m.virtualCenter.CnsClient.DetachVolume(ctx, cnsDetachSpecList)
 		if err != nil {
+			if cnsvsphere.IsManagedObjectNotFound(err, cnsDetachSpec.Vm) {
+				// Detach failed with managed object not found, marking detach as successful, as Node VM is deleted and not present in the vCenter inventory
+				log.Infof("Node VM: %v not found on the vCenter. Marking Detach for volume:%q successful. err: %v", vm, volumeID, err)
+				return nil
+			}
 			if cnsvsphere.IsNotFoundError(err) {
 				// Detach failed with NotFound error, check if the volume is already detached
 				log.Infof("VolumeID: %q, not found. Checking whether the volume is already detached", volumeID)
 				diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
 				if err != nil {
-					log.Errorf("DetachVolume: CNS Detach has failed with err: %q. Unable to check if volume: %q is already detached from vm: %+v",
+					log.Errorf("DetachVolume: CNS Detach has failed with err: %+v. Unable to check if volume: %q is already detached from vm: %+v",
 						err, volumeID, vm)
 					return err
-				} else if diskUUID == "" {
-					log.Infof("DetachVolume: volumeID: %q not found on vm: %+v. Assuming volume is already detached",
-						volumeID, vm)
-					return nil
-				} else {
-					msg := fmt.Sprintf("failed to detach cns volume:%q from node vm: %+v. err: %v", volumeID, vm, err)
-					log.Error(msg)
-					return errors.New(msg)
 				}
-			} else {
-				log.Errorf("CNS DetachVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
-				return err
+				if diskUUID == "" {
+					log.Infof("DetachVolume: volumeID: %q not found on vm: %+v. Assuming volume is already detached", volumeID, vm)
+					return nil
+				}
 			}
+			msg := fmt.Sprintf("failed to detach cns volume:%q from node vm: %+v. err: %v", volumeID, vm, err)
+			log.Error(msg)
+			return errors.New(msg)
 		}
-
 		// Get the taskInfo
 		taskInfo, err := cns.GetTaskInfo(ctx, task)
 		if err != nil || taskInfo == nil {
@@ -476,21 +476,23 @@ func (m *defaultManager) DetachVolume(ctx context.Context, vm *cnsvsphere.Virtua
 		}
 		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
 		if volumeOperationRes.Fault != nil {
-			// Volume is already attached to VM
-			diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
-			if err != nil {
-				log.Errorf("DetachVolume: CNS Detach has failed with fault: %q. Unable to check if volume: %q is already detached from vm: %+v",
-					spew.Sdump(volumeOperationRes.Fault), volumeID, vm)
-				return err
-			} else if diskUUID == "" {
-				log.Infof("DetachVolume: volumeID: %q not found on vm: %+v. Assuming volume is already detached",
-					volumeID, vm)
-				return nil
-			} else {
-				msg := fmt.Sprintf("failed to detach cns volume:%q from node vm: %+v. fault: %q, opId: %q", volumeID, vm, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
-				log.Error(msg)
-				return errors.New(msg)
+			_, isNotFoundFault := volumeOperationRes.Fault.Fault.(*vim25types.NotFound)
+			if isNotFoundFault {
+				// check if volume is already detached from the VM
+				diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
+				if err != nil {
+					log.Errorf("DetachVolume: CNS Detach has failed with fault: %+v. Unable to check if volume: %q is already detached from vm: %+v",
+						spew.Sdump(volumeOperationRes.Fault), volumeID, vm)
+					return err
+				}
+				if diskUUID == "" {
+					log.Infof("DetachVolume: volumeID: %q not found on vm: %+v. Assuming volume is already detached", volumeID, vm)
+					return nil
+				}
 			}
+			msg := fmt.Sprintf("failed to detach cns volume:%q from node vm: %+v. fault: %+v, opId: %q", volumeID, vm, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			log.Error(msg)
+			return errors.New(msg)
 		}
 		log.Infof("DetachVolume: Volume detached successfully. volumeID: %q, vm: %q, opId: %q", volumeID, taskInfo.ActivationId, vm.String())
 		return nil

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -55,7 +55,7 @@ func IsDiskAttached(ctx context.Context, vm *cnsvsphere.VirtualMachine, volumeID
 				if virtualDisk.VDiskId != nil && virtualDisk.VDiskId.Id == volumeID {
 					virtualDevice := device.GetVirtualDevice()
 					if backing, ok := virtualDevice.Backing.(*vimtypes.VirtualDiskFlatVer2BackingInfo); ok {
-						log.Debugf("Found diskUUID %s for volume %s on vm %+v", backing.Uuid, volumeID, vm)
+						log.Infof("Found diskUUID %s for volume %s on vm %+v", backing.Uuid, volumeID, vm)
 						return backing.Uuid, nil
 					}
 				}

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -63,13 +63,18 @@ func IsAlreadyExists(err error) (bool, string) {
 	return isAlreadyExistsError, objectName
 }
 
-// IsManagedObjectNotFound checks if err is the ManagedObjectNotFound fault, if yes then returns true else return false
-func IsManagedObjectNotFound(err error) bool {
-	isNotFoundError := false
+// IsManagedObjectNotFound checks if err is the ManagedObjectNotFound fault,
+// if yes then checks ManagedObjectNotFound thrown for the the intended object, if yes return true else return false
+func IsManagedObjectNotFound(err error, moRef types.ManagedObjectReference) bool {
 	if soap.IsSoapFault(err) {
-		_, isNotFoundError = soap.ToSoapFault(err).VimFault().(types.ManagedObjectNotFound)
+		fault, isNotFoundError := soap.ToSoapFault(err).VimFault().(types.ManagedObjectNotFound)
+		if isNotFoundError {
+			if fault.Obj.Type == moRef.Type && fault.Obj.Value == moRef.Value {
+				return true
+			}
+		}
 	}
-	return isNotFoundError
+	return false
 }
 
 // GetCnsKubernetesEntityMetaData creates a CnsKubernetesEntityMetadataObject object from given parameters

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -375,7 +375,7 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context, request re
 			cnsVolumeID, nodeVM, request.Name, request.Namespace)
 		detachErr := volumes.GetManager(ctx, vcenter).DetachVolume(ctx, nodeVM, cnsVolumeID)
 		if detachErr != nil {
-			if cnsvsphere.IsManagedObjectNotFound(detachErr) {
+			if cnsvsphere.IsManagedObjectNotFound(detachErr, nodeVM.VirtualMachine.Reference()) {
 				msg := fmt.Sprintf("Found a managed object not found fault for vm: %+v", nodeVM)
 				removeFinalizerFromCRDInstance(ctx, instance, request)
 				err = updateCnsNodeVMAttachment(ctx, r.client, instance)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is created with the exact same code used in the https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/837
I have kept https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/837 for testing team to resolve the CICD Pipeline issue. In this PR I am rebasing my branch with the latest code on the master.

https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/837 is already reviewed and approved by @SandeepPissay  @chethanv28 and @RaunakShah 

This PR is fixing detach volume error handling to cover following cases.

1. During detach if it is observed that Node VM from vCenrer inventory is deleted, detach will be marked as successful.
2. During detach if NotFound fault is returned, we need to check VM devices to ensure volume is not attached to the Node VM. For all other fault fail detach volume operation.


**Special notes for your reviewer**:
Testing Done - Yes

Verified following cases
1. Detach passes when node VM is deleted.
2. Detach fails when FCD is attached to node VM, but fcd is not registered as CNS volume.
3. Detach passes when FCD is not attached to node VM, but fcd is not registered as CNS volume.
4.  Detach passe when FCD is attached to node VM, and FCD is registered as CNS volume.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fixed detach volume error handling
```
