### PR TITLE
Sync CSI yamls for Supervisor cluster from internal repos

### DIFF
--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.15/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.15/cns-csi.yaml
@@ -15,17 +15,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces"]
+    resources: ["nodes", "persistentvolumeclaims", "pods", "resourcequotas"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update", "create", "delete", "patch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims/status"]
-    verbs: ["update", "patch"]
+    verbs: ["get", "list", "watch", "update", "create", "delete"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch", "patch"]
@@ -37,34 +31,19 @@ rules:
     verbs: ["list", "watch", "create", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments/status"]
-    verbs: ["patch"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsvolumemetadatas", "cnsfileaccessconfigs"]
     verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["cns.vmware.com"]
-    resources: ["cnscsisvfeaturestates"]
-    verbs: ["create", "get", "list", "update", "watch"]
-  - apiGroups: ["cns.vmware.com"]
-    resources: ["cnsregistervolumes"]
-    verbs: ["get", "list", "watch", "update", "delete"]
-  - apiGroups: ["cns.vmware.com"]
-    resources: ["triggercsifullsyncs"]
-    verbs: ["create", "get", "update", "watch", "list"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["storagepools"]
     verbs: ["get", "watch", "list", "delete", "update", "create", "patch"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["get", "create", "update"]
+    verbs: ["get", "create"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
-  - apiGroups: ["vmoperator.vmware.com"]
-    resources: ["virtualmachines"]
-    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -150,17 +129,16 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v1.2.1_vmware.11
           args:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--feature-gates=Topology=true"
             - "--strict-topology"
-            - "--leader-election"
+            - "--enable-leader-election"
+            - "--leader-election-type=leases"
             - "--enable-hostlocal-placement=true"
-            - "--kube-api-qps=100"
-            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -175,12 +153,13 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.1.0_vmware.1
+          image: localhost:5000/vmware/csi-attacher/csi-attacher:v1.1.1
           args:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--leader-election-type=leases"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -192,31 +171,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
-        - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.1.0_vmware.1
-          imagePullPolicy: IfNotPresent
-          args:
-            - --v=4
-            - --timeout=300s
-            - --csi-address=$(ADDRESS)
-            - --leader-election
-            - --kube-api-qps=100
-            - --kube-api-burst=100
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
-          resources: {}
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
-          volumeMounts:
-            - mountPath: /csi
-              name: socket-dir
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
-          ports:
-           - containerPort: 2112
-             name: prometheus
-             protocol: TCP
           lifecycle:
             preStop:
               exec:
@@ -245,10 +201,8 @@ spec:
               readOnly: true
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
-            - mountPath: /etc/vmware/wcp/tls/
-              name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.2.0_vmware.1
+          image: localhost:5000/vmware/csi-livenessprobe/csi-livenessprobe:v1.1.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -270,8 +224,6 @@ spec:
               value: "6443"
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
-            - name: VOLUME_HEALTH_INTERVAL_MINUTES
-              value: "5"
             - name: POD_POLL_INTERVAL_SECONDS
               value: "2"
             - name: POD_LISTENER_SERVICE_PORT
@@ -281,16 +233,10 @@ spec:
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
           imagePullPolicy: "IfNotPresent"
-          ports:
-          - containerPort: 2113
-            name: prometheus
-            protocol: TCP
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /etc/vmware/wcp/tls/
-              name: host-vmca
       volumes:
         - name: vsphere-config-volume
           secret:
@@ -299,10 +245,14 @@ spec:
           hostPath:
             path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
             type: DirectoryOrCreate
-        - name: host-vmca
-          hostPath:
-            path: /etc/vmware/wcp/tls/
-            type: Directory
+---
+apiVersion: v1
+data:
+  "vsan-direct-disk-decommission": "false"
+kind: ConfigMap
+metadata:
+  name: csi-feature-states
+  namespace: vmware-system-csi
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
@@ -316,9 +266,8 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "vsan-direct-disk-decommission": "false"
   "trigger-csi-fullsync": "false"
-  "csi-sv-feature-states-replication": "true"
+  "csi-sv-feature-states-replication": "false"
   "fake-attach": "true"
 kind: ConfigMap
 metadata:
@@ -344,4 +293,3 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: LoadBalancer

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.16/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.16/cns-csi.yaml
@@ -15,7 +15,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces"]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
@@ -37,22 +37,13 @@ rules:
     verbs: ["list", "watch", "create", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments/status"]
-    verbs: ["patch"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsnodevmattachments", "cnsvolumemetadatas", "cnsfileaccessconfigs"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["cns.vmware.com"]
-    resources: ["cnscsisvfeaturestates"]
-    verbs: ["create", "get", "list", "update", "watch"]
-  - apiGroups: ["cns.vmware.com"]
     resources: ["cnsregistervolumes"]
     verbs: ["get", "list", "watch", "update", "delete"]
-  - apiGroups: ["cns.vmware.com"]
-    resources: ["triggercsifullsyncs"]
-    verbs: ["create", "get", "update", "watch", "list"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["storagepools"]
     verbs: ["get", "watch", "list", "delete", "update", "create", "patch"]
@@ -150,17 +141,16 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v1.2.1_vmware.11
           args:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--feature-gates=Topology=true"
             - "--strict-topology"
-            - "--leader-election"
+            - "--enable-leader-election"
+            - "--leader-election-type=leases"
             - "--enable-hostlocal-placement=true"
-            - "--kube-api-qps=100"
-            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -175,12 +165,13 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.1.0_vmware.1
+          image: localhost:5000/vmware/csi-attacher/csi-attacher:v1.1.1
           args:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--leader-election-type=leases"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -193,7 +184,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.1.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.0.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -213,10 +204,6 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
-          ports:
-           - containerPort: 2112
-             name: prometheus
-             protocol: TCP
           lifecycle:
             preStop:
               exec:
@@ -245,10 +232,8 @@ spec:
               readOnly: true
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
-            - mountPath: /etc/vmware/wcp/tls/
-              name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.2.0_vmware.1
+          image: localhost:5000/vmware/csi-livenessprobe/csi-livenessprobe:v1.1.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -281,16 +266,10 @@ spec:
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
           imagePullPolicy: "IfNotPresent"
-          ports:
-          - containerPort: 2113
-            name: prometheus
-            protocol: TCP
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /etc/vmware/wcp/tls/
-              name: host-vmca
       volumes:
         - name: vsphere-config-volume
           secret:
@@ -299,10 +278,26 @@ spec:
           hostPath:
             path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
             type: DirectoryOrCreate
-        - name: host-vmca
-          hostPath:
-            path: /etc/vmware/wcp/tls/
-            type: Directory
+---
+apiVersion: v1
+data:
+  "volume-extend": "true"
+  "volume-health": "true"
+  "trigger-csi-fullsync": "false"
+  "csi-sv-feature-states-replication": "false"
+  "fake-attach": "true"
+kind: ConfigMap
+metadata:
+  name: csi-feature-states
+  namespace: vmware-system-csi
+---
+apiVersion: v1
+data:
+  "vsan-direct-disk-decommission": "false"
+kind: ConfigMap
+metadata:
+  name: csi-feature-states
+  namespace: vmware-system-csi
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
@@ -311,19 +306,6 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
----
-apiVersion: v1
-data:
-  "volume-extend": "true"
-  "volume-health": "true"
-  "vsan-direct-disk-decommission": "false"
-  "trigger-csi-fullsync": "false"
-  "csi-sv-feature-states-replication": "true"
-  "fake-attach": "true"
-kind: ConfigMap
-metadata:
-  name: csi-feature-states
-  namespace: vmware-system-csi
 ---
 apiVersion: v1
 kind: Service
@@ -344,4 +326,3 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
-  type: LoadBalancer

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.18/cns-csi.yaml
@@ -51,6 +51,9 @@ rules:
     resources: ["cnsregistervolumes"]
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
+    resources: ["triggercsifullsyncs"]
+    verbs: ["create", "get", "update", "watch", "list"]
+  - apiGroups: ["cns.vmware.com"]
     resources: ["storagepools"]
     verbs: ["get", "watch", "list", "delete", "update", "create", "patch"]
   - apiGroups: ["apiextensions.k8s.io"]
@@ -158,7 +161,6 @@ spec:
             - "--enable-hostlocal-placement=true"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
-            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -211,6 +213,10 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
+          ports:
+           - containerPort: 2112
+             name: prometheus
+             protocol: TCP
           lifecycle:
             preStop:
               exec:
@@ -229,7 +235,7 @@ spec:
             - name: POD_LISTENER_SERVICE_PORT
               value: "29000"
             - name: VSPHERE_CSI_CONFIG
-              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf"
+              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
           imagePullPolicy: "IfNotPresent"
@@ -239,6 +245,8 @@ spec:
               readOnly: true
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
+            - mountPath: /etc/vmware/wcp/tls/
+              name: host-vmca
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.2.0_vmware.1
           args:
@@ -269,14 +277,20 @@ spec:
             - name: POD_LISTENER_SERVICE_PORT
               value: "29000"
             - name: VSPHERE_CSI_CONFIG
-              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf"
+              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
           imagePullPolicy: "IfNotPresent"
+          ports:
+           - containerPort: 2113
+             name: prometheus
+             protocol: TCP
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
+            - mountPath: /etc/vmware/wcp/tls/
+              name: host-vmca
       volumes:
         - name: vsphere-config-volume
           secret:
@@ -285,6 +299,10 @@ spec:
           hostPath:
             path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
             type: DirectoryOrCreate
+        - name: host-vmca
+          hostPath:
+            path: /etc/vmware/wcp/tls/
+            type: Directory
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
@@ -300,7 +318,7 @@ data:
   "volume-health": "true"
   "vsan-direct-disk-decommission": "false"
   "trigger-csi-fullsync": "false"
-  "csi-sv-feature-states-replication": "false"
+  "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"
 kind: ConfigMap
 metadata:
@@ -326,3 +344,4 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
+  type: LoadBalancer

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.19/cns-csi.yaml
@@ -54,6 +54,9 @@ rules:
     resources: ["cnsregistervolumes"]
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
+    resources: ["triggercsifullsyncs"]
+    verbs: ["create", "get", "update", "watch", "list"]
+  - apiGroups: ["cns.vmware.com"]
     resources: ["storagepools"]
     verbs: ["get", "watch", "list", "delete", "update", "create", "patch"]
   - apiGroups: ["apiextensions.k8s.io"]
@@ -167,7 +170,6 @@ spec:
             - "--enable-hostlocal-placement=true"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
-            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -221,6 +223,10 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
+          ports:
+           - containerPort: 2112
+             name: prometheus
+             protocol: TCP
           lifecycle:
             preStop:
               exec:
@@ -239,7 +245,7 @@ spec:
             - name: POD_LISTENER_SERVICE_PORT
               value: "29000"
             - name: VSPHERE_CSI_CONFIG
-              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf"
+              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
@@ -253,6 +259,8 @@ spec:
               readOnly: true
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
+            - mountPath: /etc/vmware/wcp/tls/
+              name: host-vmca
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.2.0_vmware.1
           args:
@@ -283,7 +291,7 @@ spec:
             - name: POD_LISTENER_SERVICE_PORT
               value: "29000"
             - name: VSPHERE_CSI_CONFIG
-              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf"
+              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
@@ -291,10 +299,16 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
           imagePullPolicy: "IfNotPresent"
+          ports:
+           - containerPort: 2113
+             name: prometheus
+             protocol: TCP
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
+            - mountPath: /etc/vmware/wcp/tls/
+              name: host-vmca
       volumes:
         - name: vsphere-config-volume
           secret:
@@ -303,6 +317,10 @@ spec:
           hostPath:
             path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
             type: DirectoryOrCreate
+        - name: host-vmca
+          hostPath:
+            path: /etc/vmware/wcp/tls/
+            type: Directory
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
@@ -321,7 +339,7 @@ data:
   "csi-auth-check": "false"
   "vsan-direct-disk-decommission": "false"
   "trigger-csi-fullsync": "false"
-  "csi-sv-feature-states-replication": "false"
+  "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"
 kind: ConfigMap
 metadata:
@@ -347,3 +365,4 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
+  type: LoadBalancer

--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.20/cns-csi.yaml
@@ -54,6 +54,9 @@ rules:
     resources: ["cnsregistervolumes"]
     verbs: ["get", "list", "watch", "update", "delete"]
   - apiGroups: ["cns.vmware.com"]
+    resources: ["triggercsifullsyncs"]
+    verbs: ["create", "get", "update", "watch", "list"]
+  - apiGroups: ["cns.vmware.com"]
     resources: ["storagepools"]
     verbs: ["get", "watch", "list", "delete", "update", "create", "patch"]
   - apiGroups: ["apiextensions.k8s.io"]
@@ -167,7 +170,6 @@ spec:
             - "--enable-hostlocal-placement=true"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
-            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -205,7 +207,7 @@ spec:
           args:
             - --v=4
             - --timeout=300s
-            - --handle-volume-inuse-error=false
+            - --handle-volume-inuse-error=false  # Set this to true if used in vSphere 7.0U1
             - --csi-address=$(ADDRESS)
             - --leader-election
             - --kube-api-qps=100
@@ -221,6 +223,10 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
+          ports:
+           - containerPort: 2112
+             name: prometheus
+             protocol: TCP
           lifecycle:
             preStop:
               exec:
@@ -239,7 +245,7 @@ spec:
             - name: POD_LISTENER_SERVICE_PORT
               value: "29000"
             - name: VSPHERE_CSI_CONFIG
-              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf"
+              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
@@ -253,6 +259,8 @@ spec:
               readOnly: true
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
+            - mountPath: /etc/vmware/wcp/tls/
+              name: host-vmca
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.2.0_vmware.1
           args:
@@ -283,7 +291,7 @@ spec:
             - name: POD_LISTENER_SERVICE_PORT
               value: "29000"
             - name: VSPHERE_CSI_CONFIG
-              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf"
+              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
@@ -291,10 +299,16 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
           imagePullPolicy: "IfNotPresent"
+          ports:
+           - containerPort: 2113
+             name: prometheus
+             protocol: TCP
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
+            - mountPath: /etc/vmware/wcp/tls/
+              name: host-vmca
       volumes:
         - name: vsphere-config-volume
           secret:
@@ -303,6 +317,10 @@ spec:
           hostPath:
             path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
             type: DirectoryOrCreate
+        - name: host-vmca
+          hostPath:
+            path: /etc/vmware/wcp/tls/
+            type: Directory
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
@@ -321,7 +339,7 @@ data:
   "csi-auth-check": "false"
   "vsan-direct-disk-decommission": "false"
   "trigger-csi-fullsync": "false"
-  "csi-sv-feature-states-replication": "false"
+  "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"
 kind: ConfigMap
 metadata:
@@ -347,3 +365,4 @@ spec:
       protocol: TCP
   selector:
     app: vsphere-csi-controller
+  type: LoadBalancer


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is publishing latest CSI yamls for Supervisor cluster. It is just a sync from the internal repos. The CSI yamls will now be consumed from github for Supervisor Cluster deployments

For 1.17, 1.18, 1.19 and 1.20 - the PR is syncing recently added changes in internal repo.
Please review this PR @lipingxue @divyenpatel 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Built a custom supervisor cluster ova and deployed a testbed to verify if csi driver is installed correctly:
```

kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-54f67d5cf7-dmm45   6/6     Running   0         7h33m
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Sync CSI yamls for Supervisor cluster
```
