### PR TITLE
set max volumes per node

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -344,6 +344,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
+            - name: MAX_VOLUMES_PER_NODE
+              value: "0" # Maximum number of volumes that controller can publish to the node. If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
             - name: X_CSI_MODE
               value: "node"
             - name: X_CSI_SPEC_REQ_VALIDATION


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR allows setting a maximum number of volumes we can attach to the Node VM.
vSphere CSI Driver supports both block and file volume. With the current CSI design, it is difficult to limit the number of volume block volumes and the number of file volumes per node. In case when Kubernetes schedules a pod with block volume on the node which has reached its limit, attach keeps failing forever with the following error.

```
2021-04-30T20:22:01.862Z verbose vsanvcmgmtd[14719] [vSAN@6876 sub=FcdService opId=47e91fbf] CNS: key=1000 busNumber=0 numOfAttachedDevice=15
2021-04-30T20:22:01.862Z verbose vsanvcmgmtd[14719] [vSAN@6876 sub=FcdService opId=47e91fbf] CNS: key=1001 busNumber=1 numOfAttachedDevice=15
2021-04-30T20:22:01.862Z verbose vsanvcmgmtd[14719] [vSAN@6876 sub=FcdService opId=47e91fbf] CNS: key=1002 busNumber=2 numOfAttachedDevice=15
2021-04-30T20:22:01.862Z verbose vsanvcmgmtd[14719] [vSAN@6876 sub=FcdService opId=47e91fbf] CNS: key=1003 busNumber=3 numOfAttachedDevice=15
2021-04-30T20:22:01.862Z error vsanvcmgmtd[14719] [vSAN@6876 sub=FcdService opId=47e91fbf] CNS: Fail to add a SCSI controller, the number of SCSI controller reached limit
2021-04-30T20:22:01.862Z verbose vsanvcmgmtd[14719] [vSAN@6876 sub=FcdService opId=47e91fbf] CNS: Failed to add a new SCSI controller
2021-04-30T20:22:01.862Z info vsanvcmgmtd[14719] [vSAN@6876 sub=FcdService opId=47e91fbf] CNS: GetPVSCSIControlerWithFreeSlot return controllerKey=-99
2021-04-30T20:22:01.863Z error vsanvcmgmtd[14719] [vSAN@6876 sub=FcdService opId=47e91fbf] CNS: Failed to attach disk because missing SCSI controller
2021-04-30T20:22:01.863Z verbose vsanvcmgmtd[54433] [vSAN@6876 sub=FcdService opId=47e91fbe] CNS: key=1000 busNumber=0 numOfAttachedDevice=15

2021-04-30T20:22:01.863Z error vsanvcmgmtd[14719] [vSAN@6876 sub=FcdService opId=47e91fbf] CNS: Failed to attach disk to vm: vim.VirtualMachine:vm-244 with err: N3cns12CnsExceptionE(CNS: Failed to attach disk because missing SCSI controller)
--> [context]zKq7AVECAQAAAIoOEQEPdnNhbnZjbWdtdGQAAGcYNmxpYnZtYWNvcmUuc28AAJ+AKgCndSsAugwxAT+RDGxpYmNucy5zbwABcIwQARf7EQHlgRIBdhgMAVU2DADdECEAnmwhAPqmNQKHfwBsaWJwdGhyZWFkLnNvLjAAA781D2xpYmMuc28uNgA=[/context]
2021-04-30T20:22:01.863Z error vsanvcmgmtd[14719] [vSAN@6876 sub=Workflow opId=47e91fbf] CNS: Workflow current action has fault (vim.fault.CnsFault) {
-->    faultCause = (vmodl.MethodFault) null, 
-->    faultMessage = <unset>, 
-->    reason = "CNS: Failed to attach disk because missing SCSI controller"
-->    msg = ""
--> }
```

This PR allows customers to set ENV variable `MAX_VOLUMES_PER_NODE` in the node Daemonset to limit the number of volumes per node. Once this value is set, it will be applied to both block and file volumes. even though file volume does not have any SCSI controller/slots limits per node VM.

 

**Special notes for your reviewer**:
Deployed vSphere CSI Driver with the change made in this PR.

CSI Node Pod Logs

```
{"level":"info","time":"2021-05-11T17:59:48.035055089Z","caller":"service/node.go:648","msg":"NodeGetInfo: MAX_VOLUMES_PER_NODE is set to 5","TraceId":"e9880974-279a-4fca-94d0-5c3b19638c69"}

{"level":"info","time":"2021-05-11T17:59:48.096193948Z","caller":"service/node.go:679","msg":"NodeGetInfo response: node_id:\"k8s-master\" max_volumes_per_node:5 ","TraceId":"e9880974-279a-4fca-94d0-5c3b19638c69"}
```

CSI Node Object

```
# kubectl get csinodes k8s-node1 -o json
{
    "apiVersion": "storage.k8s.io/v1",
    "kind": "CSINode",
    "metadata": {
        "annotations": {
            "storage.alpha.kubernetes.io/migrated-plugins": "kubernetes.io/cinder"
        },
        "creationTimestamp": "2021-04-27T22:45:32Z",
        "name": "k8s-node1",
        "ownerReferences": [
            {
                "apiVersion": "v1",
                "kind": "Node",
                "name": "k8s-node1",
                "uid": "8c7d0fb4-1972-4d9e-a8d8-917b60a4be67"
            }
        ],
        "resourceVersion": "3101409",
        "uid": "2de113f0-4fe7-4c51-b2b7-c0b58aa3f532"
    },
    "spec": {
        "drivers": [
            {
                "allocatable": {
                    "count": 5
                },
                "name": "csi.vsphere.vmware.com",
                "nodeID": "k8s-node1",
                "topologyKeys": null
            }
        ]
    }
}
```

Created Stateful set with 25 replicas, on 4 worker node cluster with max allowed volumes per node is 5.

```
# kubectl get statefulset -o wide
NAME   READY   AGE   CONTAINERS   IMAGES
web    20/25   14m   nginx        k8s.gcr.io/nginx-slim:0.8
```

```
# kubectl get volumeattachment -o wide
NAME                                                                   ATTACHER                 PV                                         NODE        ATTACHED   AGE
csi-276315ae5fb6b395b4563c3b493b5210e1024ac56dc07483ee58371db3011224   csi.vsphere.vmware.com   pvc-d9c0ab98-9533-4d66-839a-cba9a03a2717   k8s-node3   true       10m
csi-27ea25ae13170e3e26d938f54764a01da6cc36ca3318de294db465231f5ed731   csi.vsphere.vmware.com   pvc-5703585f-0e88-42f6-965b-204d2e6ccc4b   k8s-node1   true       14m
csi-2a41ea9ea68aa79c8bbf0dc08d5591b15812ee74d417edfdb2744f9d3db10704   csi.vsphere.vmware.com   pvc-c92f6a63-1c3f-476c-b882-677e4782b40e   k8s-node3   true       8m24s
csi-2b23ccbb8eaf5dffcd7ac330d04766f1d857ccb712e131fe4d499e3881ae5397   csi.vsphere.vmware.com   pvc-2d14307b-b9c3-4262-abdf-ea94bbfbc4d6   k8s-node2   true       8m2s
csi-304d4ac4f8010acec876df8e876166c198f2172b7c8d099200e89ff00785226f   csi.vsphere.vmware.com   pvc-64770f27-c0e3-447d-9477-18fa1e7a824e   k8s-node2   true       13m
csi-3637e92ff4872c1df695cb905330f888beb226c15fda85b051e243f6a4654fb4   csi.vsphere.vmware.com   pvc-a8348b16-c229-4f2c-b2ab-a7618ac4ee72   k8s-node1   true       12m
csi-3dd0584beb0c5ee9d8ce3fa45a0315a68aaf090737ce528e832699fd75671731   csi.vsphere.vmware.com   pvc-dc2d2ff2-e447-492f-b037-c4dccb0e0064   k8s-node1   true       9m41s
csi-54c8a4266ebad32466880808c5909d28b190e7f2459975f235472d9cf5fc35be   csi.vsphere.vmware.com   pvc-341d8d55-d7e3-49cc-9080-23c8947e03ad   k8s-node4   true       7m7s
csi-64d1c5d3624c7f8393ee30eb72284dc2c91fb180482d06118dd576abbed0ed7d   csi.vsphere.vmware.com   pvc-83a287fe-f66a-42ef-95c4-7d866409025d   k8s-node1   true       8m58s
csi-67373d8c835e050dff28b8aae4a0b6407e2c2655c1d8be068e11d13b7700e4a5   csi.vsphere.vmware.com   pvc-9cf1bc34-261c-45a7-8a84-06a2d928315b   k8s-node4   true       10m
csi-6e5e19bcf126e542701264a05fb77ee5636cff620a4b7ffcf2811cc38793dec9   csi.vsphere.vmware.com   pvc-d26fbd25-5e65-4223-b2fd-d6d6739662e5   k8s-node2   true       10m
csi-71775abebf9043ef24b3f835f527e91aecf0a98488bbe3d5a67a663b0e952f85   csi.vsphere.vmware.com   pvc-32323721-d917-48db-a3b6-4172ef16e0f8   k8s-node3   true       7m35s
csi-782700a30a3b9cf372b1e6726fbc4ea44145477ae0ad982780217c14b3a426c9   csi.vsphere.vmware.com   pvc-6db1e644-480b-470c-9544-b8393c1ceb65   k8s-node4   true       12m
csi-7adb8ed11ff691843afcf37347101810122da28e54e24201a4dbd5bc07a7036b   csi.vsphere.vmware.com   pvc-219adae9-2db4-4c7a-a250-6988f210c3cd   k8s-node4   true       9m17s
csi-7f0af0719ef360e9874cb4d496f636782e845a81b3d9c83658bc190315c38b19   csi.vsphere.vmware.com   pvc-1cfb230e-ccdc-48ee-88b5-0e9d10d5054f   k8s-node3   true       11m
csi-9090a8998d2d44fcbdbff29c23cfbefc48b95f9a9ce2b3c73cb49cbb6425edb4   csi.vsphere.vmware.com   pvc-7bb0d8c9-fae5-4b9d-afd8-7db75f5fd67a   k8s-node2   true       12m
csi-915cfef12a84abc85f837e2d543f784d3327b9e1882778fbe8970e44e3cece2c   csi.vsphere.vmware.com   pvc-014ad984-2ae9-48c4-8607-4db940f75441   k8s-node4   true       14m
csi-a65aa04aeffa475d3f58f34bd7dc2bdd99990f58de19e034c9b9697c2ff1abb8   csi.vsphere.vmware.com   pvc-12c71ba4-4a60-49b8-b2b8-b58c2a20cbfb   k8s-node1   true       6m38s
csi-c0fd17cc2dc252adff516f149d2ce2346084123b62a616fb7e7658462ed33f97   csi.vsphere.vmware.com   pvc-e3625931-c02e-4888-814f-c69770393495   k8s-node2   true       6m8s
csi-ca5f24fdbad1f6a6b9702cb9f6889577435a773e14c9f6f643cd2a444cd509e1   csi.vsphere.vmware.com   pvc-edb8ae43-5602-440c-bde1-0dff9bf0698d   k8s-node3   true       13m
```

Kubernetes is not scheduling further pods on nodes as, Nodes maxed out allowed volume per node which is set to 5 for testing.

```
0/5 nodes are available: 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 4 node(s) exceed max volume count.
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
set max volumes per node
```
