### PR TITLE
fixed nil pointer access in volume health reconciler

### DIFF
--- a/pkg/syncer/volume_health_reconciler.go
+++ b/pkg/syncer/volume_health_reconciler.go
@@ -354,6 +354,10 @@ func (rc *volumeHealthReconciler) syncPVC(key string) error {
 
 	for _, tkgPV := range tkgPVList {
 		// Update Tanzu Kubernetes Grid PVC volume health annotation
+		if tkgPV.Spec.ClaimRef == nil {
+			log.Debugf("skipping tkgPV: %v with nil ClaimRef", tkgPV.Name)
+			continue
+		}
 		err = rc.updateTKGPVC(ctx, svcPVC, tkgPV)
 		if err != nil {
 			log.Errorf("updating Tanzu Kubernetes Grid PVC for PV %s failed: %v", tkgPV.Name, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
volume health reconciler has crashed the syncer container when TKG PVs with no claim ref is observed.
skipping PVs with nil `claimref` gives protection against syncer container crash.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fixed nil pointer access in volume health reconciler
```
