### PR TITLE
Set health annotation to Inaccessible when it is not set

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -351,6 +351,10 @@ func ConvertVolumeHealthStatus(volHealthStatus string) (string, error) {
 	case string(pbmtypes.PbmHealthStatusForEntityUnknown):
 		return string(pbmtypes.PbmHealthStatusForEntityUnknown), nil
 	default:
-		return "", fmt.Errorf("cannot convert invalid volume health status %s", volHealthStatus)
+		// NOTE: volHealthStatus is not set by SPBM in this case.
+		// This implies the volume does not exist any more.
+		// Set health annotation to "Inaccessible" so that
+		// the caller can make appropriate reactions based on this status
+		return VolHealthStatusInaccessible, nil
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If HealthStatus is not set by SPBM, it implies the volume does not exist any more.
Set health annotation to "Inaccessible" so that the caller can make appropriate reactions based on this status.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Set health annotation to Inaccessible if it is not set by SPBM as it implies volume does not exist.
```
