### PR TITLE
Add k8s 1.21 yaml for Supervisor cluster

### DIFF
--- a/manifests/dev/vsphere-7.0u2/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/dev/vsphere-7.0u2/supervisorcluster/1.21/cns-csi.yaml
@@ -1,0 +1,368 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vmware-system-csi
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsnodevmattachments", "cnsvolumemetadatas", "cnsfileaccessconfigs"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnscsisvfeaturestates"]
+    verbs: ["create", "get", "list", "update", "watch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsfilevolumeclients"]
+    verbs: ["get", "update", "create", "delete"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsregistervolumes"]
+    verbs: ["get", "list", "watch", "update", "delete"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["triggercsifullsyncs"]
+    verbs: ["create", "get", "update", "watch", "list"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["storagepools"]
+    verbs: ["get", "watch", "list", "delete", "update", "create", "patch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["vmoperator.vmware.com"]
+    resources: ["virtualmachines"]
+    verbs: ["get", "list"]
+  - apiGroups: ["vmware.com"]
+    resources: ["virtualnetworks"]
+    verbs: ["get"]
+  - apiGroups: ["netoperator.vmware.com"]
+    resources: ["networkinterfaces"]
+    verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: vmware-system-csi
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csiRole
+  namespace: vmware-system-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: wcp-privileged-psp
+subjects:
+  # For the vmware-system-csi nodes.
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts:vmware-system-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: vmware-system-csi
+  name: vsphere-csi-secret-reader
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vsphere-csi-provisioner-secret-binding
+  namespace: vmware-system-csi
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: vmware-system-csi
+roleRef:
+  kind: Role
+  name: vsphere-csi-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vsphere-csi-controller
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-controller
+        role: vsphere-csi
+    spec:
+      serviceAccount: vsphere-csi-controller
+      nodeSelector:
+        node-role.kubernetes.io/master: ''
+      tolerations:
+        - operator: "Exists"
+          key: "node-role.kubernetes.io/master"
+          effect: "NoSchedule"
+        - operator: "Equal"
+          key: "kubeadmNode"
+          effect: "NoSchedule"
+          value: "master"
+      hostNetwork: true
+      containers:
+        - name: csi-provisioner
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--feature-gates=Topology=true"
+            - "--strict-topology"
+            - "--leader-election"
+            - "--enable-hostlocal-placement=true"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_PORT
+              value: "29000"
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-attacher
+          image: localhost:5000/vmware.io/csi-attacher:v3.1.0_vmware.1
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-resizer
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.1.0_vmware.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=4
+            - --timeout=300s
+            - --handle-volume-inuse-error=false  # Set this to true if used in vSphere 7.0U1
+            - --csi-address=$(ADDRESS)
+            - --leader-election
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: vsphere-csi-controller
+          image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
+          ports:
+           - containerPort: 2112
+             name: prometheus
+             protocol: TCP
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: CLUSTER_FLAVOR
+              value: "WORKLOAD"
+            - name: X_CSI_MODE
+              value: "controller"
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+            - name: POD_LISTENER_SERVICE_PORT
+              value: "29000"
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "50"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "50"
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - mountPath: /etc/vmware/wcp
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+            - mountPath: /etc/vmware/wcp/tls/
+              name: host-vmca
+        - name: liveness-probe
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.2.0_vmware.1
+          args:
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+        - name: vsphere-syncer
+          image: localhost:5000/vmware/syncer:<syncer_ver>
+          args:
+            - "--leader-election"
+          env:
+            - name: CLUSTER_FLAVOR
+              value: "WORKLOAD"
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+            - name: FULL_SYNC_INTERVAL_MINUTES
+              value: "30"
+            - name: VOLUME_HEALTH_INTERVAL_MINUTES
+              value: "5"
+            - name: POD_POLL_INTERVAL_SECONDS
+              value: "2"
+            - name: POD_LISTENER_SERVICE_PORT
+              value: "29000"
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "50"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "50"
+          imagePullPolicy: "IfNotPresent"
+          ports:
+           - containerPort: 2113
+             name: prometheus
+             protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/vmware/wcp
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /etc/vmware/wcp/tls/
+              name: host-vmca
+      volumes:
+        - name: vsphere-config-volume
+          secret:
+            secretName: vsphere-config-secret
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
+            type: DirectoryOrCreate
+        - name: host-vmca
+          hostPath:
+            path: /etc/vmware/wcp/tls/
+            type: Directory
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: csi.vsphere.vmware.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+---
+apiVersion: v1
+data:
+  "volume-extend": "true"
+  "volume-health": "true"
+  "online-volume-extend": "true"
+  "file-volume": "false"
+  "csi-auth-check": "false"
+  "vsan-direct-disk-decommission": "false"
+  "trigger-csi-fullsync": "false"
+  "csi-sv-feature-states-replication": "true"
+  "fake-attach": "true"
+kind: ConfigMap
+metadata:
+  name: csi-feature-states
+  namespace: vmware-system-csi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller
+  type: LoadBalancer


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding k8s 1.21 CSI yamls for Supervisor cluster. Currently it's the same yaml as of 1.20. If an edit is required for any issue, we can fix that in subsequent PR.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
These yamls would allow the upstream internal build jobs to consume CSI yaml for k8s 1.21 and proceed with the testing.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add k8s 1.21 yaml for Supervisor cluster
```
