### PR TITLE
upgrading ci golang image

### DIFF
--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -17,7 +17,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.13
+ARG GOLANG_IMAGE=golang:1.15
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
upgrading GOLANG_IMAGE in images/ci/Dockerfile to `golang:1.15` to be consistent with GOLANG_IMAGE in other dockerfiles.


make build-ci-image output

```
% make build-ci-image
/Library/Developer/CommandLineTools/usr/bin/make -C images/ci build
docker build -t gcr.io/cloud-provider-vsphere/csi-ci:v2.1.0-rc.1-645-gbd5e6a55 -f Dockerfile ../..
[+] Building 224.4s (30/30) FINISHED                                                                                                                                                                                                              
 => [internal] load build definition from Dockerfile                                                                                                                                                                                         0.0s
 => => transferring dockerfile: 7.55kB                                                                                                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                            0.0s
 => => transferring context: 2B                                                                                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/golang:1.15                                                                                                                                                                               1.2s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                                            1.2s
 => => transferring context: 36.97MB                                                                                                                                                                                                         1.2s
 => CACHED [build-cache 1/8] FROM docker.io/library/golang:1.15@sha256:b77e77539fea94e3f90f54fb19c6b20e8de4d80ea980a3bdfbcfadf89c9ff540                                                                                                      0.0s
 => CACHED [build-cache 2/8] WORKDIR /build                                                                                                                                                                                                  0.0s
 => [stage-2  2/13] RUN apt-get update &&     apt-get install -y --no-install-recommends       ca-certificates       curl       git       jq       mercurial       python3       python3-pip       unzip       zip &&     rm -rf /var/cach  15.3s
 => CACHED [mod-cache 3/6] COPY go.mod go.sum ./                                                                                                                                                                                             0.0s
 => [mod-cache 4/6] COPY pkg ./pkg/                                                                                                                                                                                                          0.2s
 => [mod-cache 5/6] COPY cmd ./cmd/                                                                                                                                                                                                          0.0s
 => [mod-cache 6/6] RUN go mod download && go mod verify                                                                                                                                                                                   109.9s
 => [stage-2  3/13] RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-265.0.0-linux-x86_64.tar.gz |     tar xzC / &&     /google-cloud-sdk/bin/gcloud components update                             60.1s
 => [stage-2  4/13] RUN apt-get update &&     apt-get install -y --no-install-recommends       apt-transport-https       ca-certificates       curl       gnupg2       software-properties-common       lsb-release &&     rm -rf /var/cac  33.1s 
 => [stage-2  5/13] RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "${ID}")/gpg | apt-key add - &&     add-apt-repository       "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "  1.8s 
 => [stage-2  6/13] RUN apt-get update &&     apt-get install -y --no-install-recommends docker-ce=18.06.* &&     rm -rf /var/cache/apt/* /var/lib/apt/lists/* &&     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker      30.3s 
 => [build-cache 3/8] COPY --from=mod-cache /go/pkg/mod /go/pkg/mod/                                                                                                                                                                        19.8s 
 => [stage-2  7/13] RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' |     tee --append /etc/default/docker                                                                                                                 0.5s 
 => [build-cache 4/8] COPY go.mod go.sum hack/make/ldflags.txt ./                                                                                                                                                                            0.0s 
 => [build-cache 5/8] COPY pkg ./pkg/                                                                                                                                                                                                        0.0s 
 => [build-cache 6/8] COPY cmd ./cmd/                                                                                                                                                                                                        0.0s 
 => [build-cache 7/8] RUN LDFLAGS=$(cat ldflags.txt) &&     go build -ldflags "${LDFLAGS}" ./cmd/vsphere-csi                                                                                                                                59.3s 
 => [stage-2  8/13] RUN mkdir /docker-graph                                                                                                                                                                                                  0.3s 
 => [stage-2  9/13] COPY --from=mod-cache   /go/pkg/mod           /go/pkg/mod/                                                                                                                                                              25.3s
 => [build-cache 8/8] RUN LDFLAGS=$(cat ldflags.txt) &&     go build -ldflags "${LDFLAGS}" ./cmd/syncer                                                                                                                                      5.6s
 => [stage-2 10/13] COPY --from=build-cache /root/.cache/go-build /root/.cache/go-build/                                                                                                                                                     1.0s
 => [stage-2 11/13] RUN  mkdir -p /home/prow/go/pkg && ln -s /go/pkg/mod /home/prow/go/pkg/mod                                                                                                                                               0.3s
 => [stage-2 12/13] WORKDIR /go/src/sigs.k8s.io/vsphere-csi-driver/                                                                                                                                                                          0.0s
 => [stage-2 13/13] COPY . ./                                                                                                                                                                                                                0.3s
 => exporting to image                                                                                                                                                                                                                      14.3s
 => => exporting layers                                                                                                                                                                                                                     14.3s
 => => writing image sha256:a8205dbc7850af46d0580fbb838597ef9633f296dcc67235cb817b6ab04256ec                                                                                                                                                 0.0s
 => => naming to gcr.io/cloud-provider-vsphere/csi-ci:v2.1.0-rc.1-645-gbd5e6a55                                                                                                                                                              0.0s
docker tag gcr.io/cloud-provider-vsphere/csi-ci:v2.1.0-rc.1-645-gbd5e6a55 gcr.io/cloud-provider-vsphere/csi-ci:latest
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
upgrading ci golang image to golang:1.15
```
