### PR TITLE
Create CnsVolumeOperationRequest definiton on API server and define VolumeOperationRequest interface

### DIFF
--- a/manifests/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.18/cns-csi.yaml
@@ -321,6 +321,7 @@ data:
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"
   "async-query-volume": "false"
+  "csi-volume-manager-idempotency": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.19/cns-csi.yaml
@@ -342,6 +342,7 @@ data:
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"
   "async-query-volume": "false"
+  "csi-volume-manager-idempotency": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -342,6 +342,7 @@ data:
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"
   "async-query-volume": "false"
+  "csi-volume-manager-idempotency": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -342,6 +342,7 @@ data:
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"
   "async-query-volume": "false"
+  "csi-volume-manager-idempotency": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -101,6 +101,7 @@ data:
   "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"
   "async-query-volume": "false"
+  "csi-volume-manager-idempotency": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -246,4 +246,6 @@ const (
 	FakeAttach = "fake-attach"
 	// TriggerCSIFullSyync is feature flag to trigger full sync
 	TriggerCsiFullSync = "trigger-csi-fullsync"
+	// CSIVolumeManagerIdempotency is the feature flag for idempotency handling in CSI volume manager
+	CSIVolumeManagerIdempotency = "csi-volume-manager-idempotency"
 )

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest"
 )
 
 // NodeManagerInterface provides functionality to manage nodes.
@@ -212,6 +213,15 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &c.manager.VolumeManager, config, false)
 		if err != nil {
 			log.Errorf("failed to get migration service. Err: %v", err)
+			return err
+		}
+	}
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency) {
+		log.Infof("CSI Volume manager idempotency handling feature flag is enabled.")
+		// TODO: Assign VolumeOperationRequest object to a variable
+		_, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx)
+		if err != nil {
+			log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
 			return err
 		}
 	}

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest"
 )
 
 const (
@@ -127,6 +128,15 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		c.authMgr = authMgr
 		// TODO: Invoke similar method for block volumes
 		go common.ComputeFSEnabledClustersToDsMap(authMgr.(*common.AuthManager), config.Global.CSIAuthCheckIntervalInMin)
+	}
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency) {
+		log.Infof("CSI Volume manager idempotency handling feature flag is enabled.")
+		// TODO: Assign VolumeOperationRequest object to a variable
+		_, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx)
+		if err != nil {
+			log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
+			return err
+		}
 	}
 	go func() {
 		for {

--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnsvolumeoperationrequest
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+	cnsvolumeoperationrequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
+	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
+)
+
+// VolumeOperationRequest is an interface that supports handling idempotency
+// in CSI volume manager. This interface persists operation details invoked
+// on CNS and returns the persisted information to callers whenever it is requested.
+type VolumeOperationRequest interface {
+	// GetRequestDetails returns the details of the operation on the volume
+	// that is persisted by the VolumeOperationRequest interface.
+	// Returns an error if any error is encountered while attempting to
+	// read the previously persisted information.
+	// If no previous information has been persisted, it returns an empty object.
+	GetRequestDetails(ctx context.Context, name string) (*VolumeOperationRequestDetails, error)
+	// StoreRequestDetails persists the details of the operation taking
+	// place on the volume.
+	// Returns an error if any error is encountered. Clients must assume
+	// that the attempt to persist the information failed if an error is returned.
+	StoreRequestDetails(ctx context.Context, instance *VolumeOperationRequestDetails) error
+}
+
+// VolumeOperationRequestDetails stores details about a single operation
+// on the given volume. These details are persisted by
+// VolumeOperationRequestInterface and the persisted details will be
+// returned by the interface on request by the caller.
+type VolumeOperationRequestDetails struct {
+}
+
+// operationRequestStoreOnETCD implements the VolumeOperationsRequest interface.
+// This implementation persists the operation information on etcd via a client
+// to the API server. Reads are also done directly on etcd; there is no caching
+// layer involved.
+type operationRequestStoreOnETCD struct {
+	k8sclient client.Client
+}
+
+const (
+	// CRDName represent the name of cnsvolumeoperationrequest CRD
+	CRDName = "cnsvolumeoperationrequests.cns.vmware.com"
+	// CRDSingular represent the singular name of cnsvolumeoperationrequest CRD
+	CRDSingular = "cnsvolumeoperationrequest"
+	// CRDPlural represent the plural name of cnsvolumeoperationrequest CRD
+	CRDPlural = "cnsvolumeoperationrequests"
+)
+
+// InitVolumeOperationRequestInterface creates the CnsVolumeOperationRequest
+// definition on the API server and returns an implementation of
+// VolumeOperationRequest interface. Clients are unaware of the implementation
+// details to read and persist volume operation details.
+// This function is not thread safe. Multiple serial calls to this function will
+// return multiple new instances of the VolumeOperationRequest interface.
+// TODO: Make this thread-safe and a singleton.
+func InitVolumeOperationRequestInterface(ctx context.Context) (VolumeOperationRequest, error) {
+	log := logger.GetLogger(ctx)
+
+	// Create CnsVolumeOperationRequest definition on API server
+	log.Info("Creating cnsvolumeoperationrequest definition on API server")
+	err := k8s.CreateCustomResourceDefinitionFromSpec(ctx, CRDName, CRDSingular, CRDPlural,
+		reflect.TypeOf(cnsvolumeoperationrequestv1alpha1.CnsVolumeOperationRequest{}).Name(), cnsvolumeoperationrequestv1alpha1.SchemeGroupVersion.Group, cnsvolumeoperationrequestv1alpha1.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
+	if err != nil {
+		log.Errorf("failed to create cnsvolumeoperationrequest CRD with error: %v", err)
+	}
+
+	// Get in cluster config for client to API server
+	config, err := k8s.GetKubeConfig(ctx)
+	if err != nil {
+		log.Errorf("failed to get kubeconfig with error: %v", err)
+		return nil, err
+	}
+
+	// Create client to API server
+	k8sclient, err := k8s.NewClientForGroup(ctx, config, cnsvolumeoperationrequestv1alpha1.SchemeGroupVersion.Group)
+	if err != nil {
+		log.Errorf("failed to create k8sClient with error: %v", err)
+		return nil, err
+	}
+
+	// Initialize the operationRequestStoreOnETCD implementation of VolumeOperationRequest
+	// interface.
+	// NOTE: Currently there is only a single implementation of this interface.
+	// Future implementations will need modify this step.
+	operationRequestStore := &operationRequestStoreOnETCD{
+		k8sclient: k8sclient,
+	}
+
+	return operationRequestStore, nil
+}
+
+// GetRequestDetails returns the details of the operation on the volume
+// that is persisted by the VolumeOperationRequest interface, by querying
+// API server for a CnsVolumeOperationRequest instance with the given
+// name.
+// Returns an error if any error is encountered while attempting to
+// read the previously persisted information from the API server.
+// If no previous information has been persisted, it returns an empty object.
+func (or *operationRequestStoreOnETCD) GetRequestDetails(ctx context.Context, name string) (*VolumeOperationRequestDetails, error) {
+	log := logger.GetLogger(ctx)
+	// TODO: Implement GetRequestDetails for operationRequestStoreOnETCD
+	err := fmt.Errorf("GetRequestDetails not implemented for operationRequestStoreOnETCD")
+	log.Error(err)
+	return nil, err
+}
+
+// StoreRequestDetails persists the details of the operation taking
+// place on the volume by storing it on the API server.
+// Returns an error if any error is encountered. Clients must assume
+// that the attempt to persist the information failed if an error is returned.
+func (or *operationRequestStoreOnETCD) StoreRequestDetails(ctx context.Context, instance *VolumeOperationRequestDetails) error {
+	log := logger.GetLogger(ctx)
+	// TODO: Implement StoreRequestDetails for operationRequestStoreOnETCD
+	err := fmt.Errorf("StoreRequestDetails not implemented for operationRequestStoreOnETCD")
+	log.Error(err)
+	return err
+}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -53,6 +53,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 	internalapis "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis"
+	cnsvolumeoperationrequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
 )
 
 const (
@@ -167,6 +168,11 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 			return nil, err
 		}
 		err = internalapis.AddToScheme(scheme)
+		if err != nil {
+			log.Errorf("failed to add to scheme with err: %+v", err)
+			return nil, err
+		}
+		err = cnsvolumeoperationrequestv1alpha1.AddToScheme(scheme)
 		if err != nil {
 			log.Errorf("failed to add to scheme with err: %+v", err)
 			return nil, err
@@ -372,9 +378,9 @@ func createCustomResourceDefinition(ctx context.Context, newCrd *apiextensionsv1
 		return nil
 	}
 
-	err = waitForCustomResourceToBeEstablished(ctx, apiextensionsClientSet, crd.Name)
+	err = waitForCustomResourceToBeEstablished(ctx, apiextensionsClientSet, crdName)
 	if err != nil {
-		log.Errorf("CRD %q created but failed to establish. Err: %+v", crd.Name, err)
+		log.Errorf("CRD %q created but failed to establish. Err: %+v", crdName, err)
 	}
 	return err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR does the following:
- Creates the `CnsVolumeOperationRequest` definiton on API server during Vanilla and WCP controller Initialization 
- Defines the `VolumeOperationRequest` interface that will be leveraged by CSI volume manager to store and read volume operation information on the API server.
- Framework for one implementation of  VolumeOperationRequest interface - `operationRequestStoreOnETCD`.
- Introduce new fss flag for this idempotency handling feature set to false. 

Also fixes #862
**Testing**

Enable FSS in configmap:
```
# kubectl get configmap -n vmware-system-csi -o yaml
apiVersion: v1
items:
- apiVersion: v1
  data:
    csi-auth-check: "true"
    csi-migration: "false"
    csi-volume-manager-idempotency: "true"
...
```

Create new CSI Pod with this change:
```
# kubectl get pod -n vmware-system-csi
NAME                                     READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-7c76c85fc-ldvvl   6/6     Running   0          7m53s
vsphere-csi-node-86d2p                   3/3     Running   19         46h
```

Verify CRD is created:
```
# kubectl get crd | grep cns
cnsvolumeoperationrequests.cns.vmware.com   2021-05-13T22:07:31Z

```

CSI controller logs:
```
{"log":"2021-05-13T22:07:31.864Z\u0009INFO\u0009vanilla/controller.go:219\u0009CSI Volume manager idempotency handling feature flag is enabled.\u0009{\"TraceId\": \"1ca69580-e887-4666-b6a9-87721808bd83\"}\n","stream":"stderr","time":"2021-05-13T22:07:31.864926815Z"}
{"log":"2021-05-13T22:07:31.864Z\u0009INFO\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:98\u0009Creating cnsvolumeoperationrequest definition on API server\u0009{\"TraceId\": \"1ca69580-e887-4666-b6a9-87721808bd83\"}\n","stream":"stderr","time":"2021-05-13T22:07:31.865110257Z"}
...
{"log":"2021-05-13T22:07:31.950Z\u0009INFO\u0009kubernetes/kubernetes.go:367\u0009\"cnsvolumeoperationrequests.cns.vmware.com\" CRD created successfully\u0009{\"TraceId\": \"1ca69580-e887-4666-b6a9-87721808bd83\"}\n","stream":"stderr","time":"2021-05-13T22:07:31.974725004Z"}

```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #862

**Special notes for your reviewer**:

This change does NOT address:
- Implementation of `VolumeOperationRequest` interface.
- Use case where feature flag is enabled after CSI initialization.
- Changes to CSI Volume manager
- Define `VolumeOperationRequestDetails`: In-memory structure that will be used to communicate data between CSI Volume Manager and VolumeOperationRequest interface.
- 
All of these will be addressed in a follow up PR. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Create CnsVolumeOperationRequest definiton on API server and define VolumeOperationRequest interface
```
