### PR TITLE
Remove duplicate configmaps in 1.15 and 1.16 csi yamls for SVC

### DIFF
--- a/manifests/supervisorcluster/1.15/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.15/cns-csi.yaml
@@ -263,18 +263,6 @@ spec:
   podInfoOnMount: false
 ---
 apiVersion: v1
-data:
-  "volume-extend": "true"
-  "volume-health": "true"
-  "trigger-csi-fullsync": "false"
-  "csi-sv-feature-states-replication": "false"
-  "fake-attach": "true"
-kind: ConfigMap
-metadata:
-  name: csi-feature-states
-  namespace: vmware-system-csi
----
-apiVersion: v1
 kind: Service
 metadata:
   name: vsphere-csi-controller

--- a/manifests/supervisorcluster/1.16/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.16/cns-csi.yaml
@@ -281,18 +281,6 @@ spec:
 ---
 apiVersion: v1
 data:
-  "volume-extend": "true"
-  "volume-health": "true"
-  "trigger-csi-fullsync": "false"
-  "csi-sv-feature-states-replication": "false"
-  "fake-attach": "true"
-kind: ConfigMap
-metadata:
-  name: csi-feature-states
-  namespace: vmware-system-csi
----
-apiVersion: v1
-data:
   "vsan-direct-disk-decommission": "false"
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is removing duplicate configmaps in supervisor cluster csi yamls. This got added during the final yaml sync.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove duplicate configmaps in 1.15 and 1.16 csi yamls for SVC
```
