### PR TITLE
fixed misspell reported by golangci-lint

### DIFF
--- a/pkg/syncer/k8scloudoperator/placement.go
+++ b/pkg/syncer/k8scloudoperator/placement.go
@@ -273,7 +273,7 @@ func GetSVMotionPlan(ctx context.Context, client kubernetes.Interface, storagePo
 	if len(accessibleNodes) != 1 {
 		log.Warnf("Unexpected number of accessible nodes found for storage pool %v. Expected 1 found %v", storagePoolName, len(accessibleNodes))
 		if len(accessibleNodes) == 0 {
-			return nil, fmt.Errorf("the given datastore/StoragePool is not accessible from any host. Maybe its unmounted or host is under maintainence mode")
+			return nil, fmt.Errorf("the given datastore/StoragePool is not accessible from any host. Maybe its unmounted or host is under maintenance mode")
 		}
 		// if datastore is accessible from multiple host, ignore the error.
 	}

--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -750,7 +750,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		restConfig, storageclass, profileID := staticProvisioningPreSetUpUtil(ctx)
 
 		defer func() {
-			log.Infof("Delete storage clas")
+			log.Infof("Delete storage class")
 			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()

--- a/tests/e2e/gc_block_resize_retain_policy.go
+++ b/tests/e2e/gc_block_resize_retain_policy.go
@@ -334,7 +334,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		4. verify GC1 PVC is removed but SVC PV, PVC and GC1 PV still exist
 		5. delete GC1 PV.  SVC PV, PVC still exist
 		6. Create a new GC GC2
-		7. create SC in GC1 similar to the SC created in step 1 but with recalim policy set to delete
+		7. create SC in GC1 similar to the SC created in step 1 but with reclaim policy set to delete
 		8. Create new PV in GC2 using the SVC PVC from step 5 and SC created in step 7
 		9. create new  PVC in GC2 using PV created in step 8
 		10. verify a new PVC API object is created

--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -490,7 +490,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		Steps:
 		1. Create a SC with allowVolumeExpansion set to 'true'
 		2. create a PVC of 2Gi using the SC created in step 1 and wait for binding with PV
-		3. resize GC PVC to 4Gi and 5Gi in two seperate threads
+		3. resize GC PVC to 4Gi and 5Gi in two separate threads
 		4. Verify GC PVC reaches 5Gi "FilesystemResizePending" state
 		5. Check using CNS query that size of the volume is 5Gi
 		6. Verify size of PVs in SVC and GC are 5Gi

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1046,7 +1046,7 @@ func getCnsNodeVMAttachmentByName(ctx context.Context, f *framework.Framework, e
 	return nil
 }
 
-//verifyIsAttachedInSupervisor verifies the crd instance is attached in supervisior
+//verifyIsAttachedInSupervisor verifies the crd instance is attached in supervisor
 func verifyIsAttachedInSupervisor(ctx context.Context, f *framework.Framework, expectedInstanceName string, crdVersion string, crdGroup string) {
 	instance := getCnsNodeVMAttachmentByName(ctx, f, expectedInstanceName, crdVersion, crdGroup)
 	if instance != nil {
@@ -1056,7 +1056,7 @@ func verifyIsAttachedInSupervisor(ctx context.Context, f *framework.Framework, e
 	gomega.Expect(instance).NotTo(gomega.BeNil())
 }
 
-//verifyIsDetachedInSupervisor verifies the crd instance is detached from supervisior
+//verifyIsDetachedInSupervisor verifies the crd instance is detached from supervisor
 func verifyIsDetachedInSupervisor(ctx context.Context, f *framework.Framework, expectedInstanceName string, crdVersion string, crdGroup string) {
 	instance := getCnsNodeVMAttachmentByName(ctx, f, expectedInstanceName, crdVersion, crdGroup)
 	if instance != nil {
@@ -1713,7 +1713,7 @@ func waitForAllHostsToBeUp(ctx context.Context, vs *vSphere) {
 }
 
 //psodHostWithPv methods finds the esx host where pv is residing and psods it.
-//It uses VsanObjIndentities and QueryVsanObjects apis to acheive it and returns the host ip
+//It uses VsanObjIndentities and QueryVsanObjects apis to achieve it and returns the host ip
 func psodHostWithPv(ctx context.Context, vs *vSphere, pvName string) string {
 	ginkgo.By("VsanObjIndentities")
 	framework.Logf("pvName %v", pvName)
@@ -1754,7 +1754,7 @@ func VsanObjIndentities(ctx context.Context, vs *vSphere, pvName string) string 
 		} else if supervisorCluster {
 			computeCluster = "wcp-app-platform-sanity-cluster"
 		}
-		framework.Logf("Default cluster is choosen for test")
+		framework.Logf("Default cluster is chosen for test")
 	}
 	clusterComputeResource, vsanHealthClient = getClusterComputeResource(ctx, vs)
 
@@ -2343,7 +2343,7 @@ func setClusterDistribution(ctx context.Context, client clientset.Interface, clu
 		_, err := client.CoreV1().Secrets(csiSystemNamespace).Update(ctx, currentSecret, metav1.UpdateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		//Adding a explict wait of one min for the Cluster-distribution to refect latest value
+		//Adding a explicit wait of one min for the Cluster-distribution to reflect latest value
 		time.Sleep(time.Duration(pollTimeoutShort))
 
 		framework.Logf("Cluster distribution value is now set to = %s", clusterDistribution)

--- a/tests/e2e/vcp_to_csi_create_delete.go
+++ b/tests/e2e/vcp_to_csi_create_delete.go
@@ -707,7 +707,7 @@ func waitForCnsVSphereVolumeMigrationCrdToBeDeleted(ctx context.Context, crd *mi
 	return waitErr
 }
 
-// verifyCnsVolumeMetadata verify the pv, pvc, pod infromation on given cns volume
+// verifyCnsVolumeMetadata verify the pv, pvc, pod information on given cns volume
 func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume, pod *v1.Pod) bool {
 	cnsQueryResult, err := e2eVSphere.queryCNSVolumeWithResult(volumeID)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -836,7 +836,7 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv 
 	return pvEntryFound == verifyPvEntry && pvcEntryFound == verifyPvcEntry && podEntryFound == verifyPodEntry
 }
 
-// waitAndVerifyCnsVolumeMetadata verify the pv, pvc, pod infromation on given cns volume
+// waitAndVerifyCnsVolumeMetadata verify the pv, pvc, pod information on given cns volume
 func waitAndVerifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume, pod *v1.Pod) error {
 	waitErr := wait.PollImmediate(poll*5, pollTimeout, func() (bool, error) {
 		matches := verifyCnsVolumeMetadata(volumeID, pvc, pv, pod)

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -588,7 +588,7 @@ func (vs *vSphere) getHostUUID(ctx context.Context, hostInfo string) string {
 		} else if supervisorCluster {
 			computeCluster = "wcp-app-platform-sanity-cluster"
 		}
-		framework.Logf("Default cluster is choosen for test")
+		framework.Logf("Default cluster is chosen for test")
 	}
 
 	err := json.Unmarshal([]byte(hostInfo), &result)
@@ -660,7 +660,7 @@ func (c *VsanClient) QueryVsanObjects(ctx context.Context, uuids []string, vs *v
 		} else if supervisorCluster {
 			computeCluster = "wcp-app-platform-sanity-cluster"
 		}
-		framework.Logf("Default cluster is choosen for test")
+		framework.Logf("Default cluster is chosen for test")
 	}
 	clusterComputeResource, _, err := getClusterName(ctx, vs)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/vsphere_file_volume_basic_mount.go
+++ b/tests/e2e/vsphere_file_volume_basic_mount.go
@@ -145,7 +145,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] Verify Two Pods can read write files
 		invokeTestForCreateFileVolumeAndMount(f, client, namespace, accessMode, filePath1, filePath2, true, false, true)
 	})
 	/*
-		Verify File Volume is created without specifing fstype in pv spec
+		Verify File Volume is created without specifying fstype in pv spec
 
 			1. Create StorageClass without specifying fsType
 			2. Create a PVC1 with "ReadWriteMany" using the SC from above
@@ -163,7 +163,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] Verify Two Pods can read write files
 		Cleanup:
 			1. Delete all the Pods, pvcs and storage class and verify the deletion
 	*/
-	ginkgo.It("[csi-file-vanilla] Verify File Volume is created without specifing fstype in pv spec", func() {
+	ginkgo.It("[csi-file-vanilla] Verify File Volume is created without specifying fstype in pv spec", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fixed misspell reported by golangci-lint

```
 % golangci-lint run --disable-all -E misspell
pkg/syncer/k8scloudoperator/placement.go:276:130: `maintainence` is a misspelling of `maintenance` (misspell)
                        return nil, fmt.Errorf("the given datastore/StoragePool is not accessible from any host. Maybe its unmounted or host is under maintainence mode")
                                                                                                                                                      ^
tests/e2e/csi_static_provisioning_basic.go:753:30: `clas` is a misspelling of `class` (misspell)
                        log.Infof("Delete storage clas")
                                                  ^
tests/e2e/gc_block_resize_retain_policy.go:337:68: `recalim` is a misspelling of `reclaim` (misspell)
                7. create SC in GC1 similar to the SC created in step 1 but with recalim policy set to delete
                                                                                 ^
tests/e2e/gc_block_volume_expansion.go:493:42: `seperate` is a misspelling of `separate` (misspell)
                3. resize GC PVC to 4Gi and 5Gi in two seperate threads
                                                       ^
tests/e2e/util.go:1049:73: `supervisior` is a misspelling of `supervisor` (misspell)
//verifyIsAttachedInSupervisor verifies the crd instance is attached in supervisior
                                                                        ^
tests/e2e/util.go:1059:75: `supervisior` is a misspelling of `supervisor` (misspell)
//verifyIsDetachedInSupervisor verifies the crd instance is detached from supervisior
                                                                          ^
tests/e2e/util.go:1716:59: `acheive` is a misspelling of `achieve` (misspell)
//It uses VsanObjIndentities and QueryVsanObjects apis to acheive it and returns the host ip
                                                          ^
tests/e2e/util.go:1757:38: `choosen` is a misspelling of `chosen` (misspell)
                framework.Logf("Default cluster is choosen for test")
                                                   ^
tests/e2e/util.go:2125:39: `addres` is a misspelling of `address` (misspell)
                        sshCmd = "gawk -i inplace '/--bind-addres/ { print; print \"    - --feature-gates=CSIMigration=true,CSIMigrationvSphere=true\"; next }1' " + kcmManifest
                                                           ^
tests/e2e/util.go:2346:14: `explict` is a misspelling of `explicit` (misspell)
                //Adding a explict wait of one min for the Cluster-distribution to refect latest value
                           ^
tests/e2e/vcp_to_csi_create_delete.go:710:52: `infromation` is a misspelling of `information` (misspell)
// verifyCnsVolumeMetadata verify the pv, pvc, pod infromation on given cns volume
                                                   ^
tests/e2e/vcp_to_csi_create_delete.go:839:59: `infromation` is a misspelling of `information` (misspell)
// waitAndVerifyCnsVolumeMetadata verify the pv, pvc, pod infromation on given cns volume
                                                          ^
tests/e2e/vsphere.go:591:38: `choosen` is a misspelling of `chosen` (misspell)
                framework.Logf("Default cluster is choosen for test")
                                                   ^
tests/e2e/vsphere.go:663:38: `choosen` is a misspelling of `chosen` (misspell)
                framework.Logf("Default cluster is choosen for test")
                                                   ^
tests/e2e/vsphere_file_volume_basic_mount.go:148:41: `specifing` is a misspelling of `specifying` (misspell)
                Verify File Volume is created without specifing fstype in pv spec
                                                      ^
tests/e2e/vsphere_file_volume_basic_mount.go:166:70: `specifing` is a misspelling of `specifying` (misspell)
        ginkgo.It("[csi-file-vanilla] Verify File Volume is created without specifing fstype in pv spec", func() {
```


**Special notes for your reviewer**:
No functional or logical change in the code.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fixed misspell reported by golangci-lint
```
