### PR TITLE
upgrading photon to 4.0

### DIFF
--- a/images/driver-base/Dockerfile
+++ b/images/driver-base/Dockerfile
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM photon:3.0
+FROM photon:4.0
 LABEL "maintainers"="Divyen Patel <divyenp@vmware.com>, Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>, Xing Yang <yangxi@vmware.com>"
 
-RUN tdnf -y upgrade
-
-RUN tdnf clean all
+RUN tdnf -y upgrade && tdnf clean all

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -52,6 +52,7 @@ LABEL "maintainers"="Divyen Patel <divyenp@vmware.com>, Sandeep Pissay Srinivasa
 # nfs-utils  : The nfs-utils package contains simple nfs client service.
 # util-linux : Utilities for handling file systems, consoles, partitions.
 # e2fsprogs  : The E2fsprogs package contains the utilities for handling the ext file system.
+# xfsprogs   : The xfsprogs package contains administration and debugging tools for the XFS file system
 
 RUN tdnf -y install \
   nfs-utils \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
upgrading photon to 4.0

**Special notes for your reviewer**:
Here is the temporary image created to validate volume lifecycle operations (Create, attach, mount, unmount, detach and delete) with photon 4.0 as the base image.

- docker.io/vcsidev/vsphere-csi:divyen-866
- docker.io/vcsidev/syncer:divyen-866

No issue observed during testing.


Output of building base driver image with Photon 4.0

```
divyenp@divyenp-a02 driver-base % ls
Dockerfile	Makefile
divyenp@divyenp-a02 driver-base % make

% make
docker build -t gcr.io/cloud-provider-vsphere/extra/csi-driver-base:v2.1.0-rc.1-653-g5521e92a .
[+] Building 12.1s (7/7) FINISHED                                                                                                                                                                   
 => [internal] load build definition from Dockerfile                                                                                                                                           0.0s
 => => transferring dockerfile: 828B                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/library/photon:4.0                                                                                                                                  2.2s
 => [auth] library/photon:pull token for registry-1.docker.io                                                                                                                                  0.0s
 => [1/2] FROM docker.io/library/photon:4.0@sha256:6b6060b812ba9c11c5abcaf6f9188131ba11f62313e516948391012d4820e237                                                                            3.6s
 => => resolve docker.io/library/photon:4.0@sha256:6b6060b812ba9c11c5abcaf6f9188131ba11f62313e516948391012d4820e237                                                                            0.0s
 => => sha256:6b6060b812ba9c11c5abcaf6f9188131ba11f62313e516948391012d4820e237 547B / 547B                                                                                                     0.0s
 => => sha256:7e5a6104e8c62dfbf46a182e8fdaf7020154b78df3d843ad47f090a87435065a 529B / 529B                                                                                                     0.0s
 => => sha256:efe302ef660dc9d74b383db396141b3915a5a847fd2577444a7b6dde1cd5d536 1.81kB / 1.81kB                                                                                                 0.0s
 => => sha256:8c546dbfb0605cb8268489289c1ddce53a335acb640097fc2ac45484b66aa543 15.78MB / 15.78MB                                                                                               2.7s
 => => extracting sha256:8c546dbfb0605cb8268489289c1ddce53a335acb640097fc2ac45484b66aa543                                                                                                      0.5s
 => [2/2] RUN tdnf -y upgrade && tdnf clean all                                                                                                                                                6.2s
 => exporting to image                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                        0.0s
 => => writing image sha256:8f6cfaf54ce3ea5138433be3d5454d3155aaaa46c4101ae685bd50eaae220b5b                                                                                                   0.0s
 => => naming to gcr.io/cloud-provider-vsphere/extra/csi-driver-base:v2.1.0-rc.1-653-g5521e92a                                                                                                 0.0s
docker tag gcr.io/cloud-provider-vsphere/extra/csi-driver-base:v2.1.0-rc.1-653-g5521e92a gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest                                                 
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
upgrading photon to 4.0
```
