### PR TITLE
Watch ca file rotation in supervisor cluster and re-establish VC connection

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -43,6 +43,9 @@ const (
 	DefaultCloudConfigPath = "/etc/cloud/csi-vsphere.conf"
 	// DefaultGCConfigPath is the default path of GC config file
 	DefaultGCConfigPath = "/etc/cloud/pvcsi-config/cns-csi.conf"
+	// SupervisorCAFilePath is the file path of certificate in Supervisor Clusters
+	// This is needed to establish VC connection
+	SupervisorCAFilePath = "/etc/vmware/wcp/tls/vmca.pem"
 	// EnvVSphereCSIConfig contains the path to the CSI vSphere Config
 	EnvVSphereCSIConfig = "VSPHERE_CSI_CONFIG"
 	// EnvGCConfig contains the path to the CSI GC Config

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -208,12 +208,29 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				log.Debugf("fsnotify event: %q", event.String())
 				if event.Op&fsnotify.Remove == fsnotify.Remove {
 					for {
-						reloadConfigErr := ReloadConfiguration(metadataSyncer)
+						reloadConfigErr := ReloadConfiguration(metadataSyncer, false)
 						if reloadConfigErr == nil {
 							log.Infof("Successfully reloaded configuration from: %q", cfgPath)
 							break
 						}
 						log.Errorf("failed to reload configuration will retry again in 5 seconds. err: %+v", reloadConfigErr)
+						time.Sleep(5 * time.Second)
+					}
+				}
+				// Handling create event for reconnecting to VC when ca file is rotated
+				// In Supervisor cluster, ca file gets rotated at the path /etc/vmware/wcp/tls/vmca.pem
+				// WCP is handling ca file rotation by creating a /etc/vmware/wcp/tls/vmca.pem.tmp file with new contents
+				// and then renaming the file back to /etc/vmware/wcp/tls/vmca.pem.
+				// For such operations, fsnotify handles the event as a CREATE event
+				// The conditions below also ensures that the event is for the expected ca file path
+				if event.Op&fsnotify.Create == fsnotify.Create && event.Name == cnsconfig.SupervisorCAFilePath {
+					for {
+						reconnectVCErr := ReloadConfiguration(metadataSyncer, true)
+						if reconnectVCErr == nil {
+							log.Infof("Successfully re-established connection with VC from: %q", cnsconfig.SupervisorCAFilePath)
+							break
+						}
+						log.Errorf("failed to re-establish VC connection. Will retry again in 5 seconds. err: %+v", reconnectVCErr)
 						time.Sleep(5 * time.Second)
 					}
 				}
@@ -232,6 +249,15 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 	if err != nil {
 		log.Errorf("failed to watch on path: %q. err=%v", cfgDirPath, err)
 		return err
+	}
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		caFileDirPath := filepath.Dir(cnsconfig.SupervisorCAFilePath)
+		log.Infof("Adding watch on path: %q", caFileDirPath)
+		err = watcher.Add(caFileDirPath)
+		if err != nil {
+			log.Errorf("failed to watch on path: %q. err=%v", caFileDirPath, err)
+			return err
+		}
 	}
 
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
@@ -427,7 +453,11 @@ func updateTriggerCsiFullSyncInstance(ctx context.Context,
 }
 
 // ReloadConfiguration reloads configuration from the secret, and update controller's cached configs
-func ReloadConfiguration(metadataSyncer *metadataSyncInformer) error {
+// The function takes metadatasyncerInformer and reconnectToVCFromNewConfig as parameters.
+// If reconnectToVCFromNewConfig is set to true, the function re-establishes connection with VC,
+// else based on the configuration data changed during reload, the function resets config, reloads VC connection
+// when credentials are changed and returns appropriate error
+func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFromNewConfig bool) error {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Info("Reloading Configuration")
 	cfg, err := common.GetConfig(ctx)
@@ -463,7 +493,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer) error {
 			var vcenter *cnsvsphere.VirtualCenter
 			if metadataSyncer.configInfo.Cfg.Global.VCenterIP != newVCConfig.Host ||
 				metadataSyncer.configInfo.Cfg.Global.User != newVCConfig.Username ||
-				metadataSyncer.configInfo.Cfg.Global.Password != newVCConfig.Password {
+				metadataSyncer.configInfo.Cfg.Global.Password != newVCConfig.Password || reconnectToVCFromNewConfig {
 
 				// Verify if new configuration has valid credentials by connecting to vCenter.
 				// Proceed only if the connection succeeds, else return error.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding watch on certificate file mentioned in the vsphere-config-secret when insecure-flag is set to false. In such cases, we need to handle the certificate rotation in Supervisor cluster by using fsnotify (create event) functionality. When such ca file rotation event is observed, the driver needs to re-establish the VC connection using the new certificate. This PR is adding the support for such ca file rotation use cases. In Supervisor cluster, a tmp file named vmca.pem.tmp is created during ca file rotation to store the new content. Later on, it is renamed to vmca.pem. It is basically a `mv` command which does the renaming and fsnotify handles this as a `CREATE` event.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Deployed the CSI image built from PR and performed CA file rotation to observe re-establishing of VC connection.
```
2021-05-15T23:15:10.098Z	DEBUG	wcp/controller.go:160	Successfully handled Create event: (fsnotify.Event) "/etc/vmware/wcp/tls/vmca.pem": CREATE.  =====>>>>> CUSTOM LOG ADDED to print the event handling by fsnotify
 for "/etc/vmware/wcp/tls/vmca.pem"	{"TraceId": "f73d6d98-d33b-41b9-a315-686528e81e5e"}
2021-05-15T23:15:10.100Z	DEBUG	config/config.go:354	GetCnsconfig called with cfgPath: /etc/vmware/wcp/vsphere-cloud-provider.conf	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.106Z	DEBUG	config/config.go:261	Initializing vc server sc1-10-182-182-244.eng.vmware.com	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.107Z	INFO	config/config.go:300	No Net Permissions given in Config. Using default permissions.	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.108Z	INFO	vsphere/utils.go:152	Defaulting timeout for vCenter Client to 5 minutes	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.108Z	DEBUG	wcp/controller.go:290	Reconnecting to VC "sc1-10-182-182-244.eng.vmware.com"	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.109Z	DEBUG	vsphere/virtualcenter.go:148	Setting vCenter soap client timeout to 5m0s	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.203Z	INFO	vsphere/virtualcenter.go:174	New session ID for 'VSPHERE.LOCAL\workload_storage_management-a2b1a918-1da4-44af-af4f-a10e0a8819f3' = 52d8d219-7dc1-7372-3241-d0d4b28f13ea	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.204Z	INFO	wcp/controller.go:303	Obtaining new vCenterInstance	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.204Z	INFO	vsphere/virtualcenter.go:491	Initializing new vCenterInstance.	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.204Z	INFO	vsphere/pbm.go:75	PbmClient wasn't connected, ignoring	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.219Z	INFO	vsphere/cns.go:59	CnsClient wasn't connected, ignoring	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.219Z	INFO	vsphere/virtualcentermanager.go:140	Successfully unregistered VC sc1-10-182-182-244.eng.vmware.com	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.220Z	INFO	vsphere/virtualcentermanager.go:118	Successfully registered VC "sc1-10-182-182-244.eng.vmware.com"	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.220Z	DEBUG	vsphere/virtualcenter.go:148	Setting vCenter soap client timeout to 5m0s	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.270Z	INFO	vsphere/virtualcenter.go:174	New session ID for 'VSPHERE.LOCAL\workload_storage_management-a2b1a918-1da4-44af-af4f-a10e0a8819f3' = 523bdb60-1de3-e99d-747a-b13792414340	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.270Z	INFO	vsphere/virtualcenter.go:524	vCenterInstance initialized	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.270Z	INFO	volume/manager.go:165	Done resetting volume.defaultManager	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.270Z	INFO	volume/manager.go:113	Retrieving existing volume.defaultManager...	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.271Z	DEBUG	wcp/controller.go:321	Updated manager.CnsConfig	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.271Z	INFO	wcp/controller.go:323	Successfully re-established connection with the VirtualCenter: %qsc1-10-182-182-244.eng.vmware.com	{"TraceId": "50a35c72-69ed-4a2e-b2a9-f1326171a602"}
2021-05-15T23:15:10.271Z	INFO	wcp/controller.go:164	Successfully re-established connection with VC from: "/etc/vmware/wcp/tls/vmca.pem"	{"TraceId": "f73d6d98-d33b-41b9-a315-686528e81e5e"}
2021-05-15T23:15:10.271Z	DEBUG	wcp/controller.go:178	fsnotify event processed	{"TraceId": "f73d6d98-d33b-41b9-a315-686528e81e5e"}
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Watch ca file rotation in supervisor cluster
```
