### PR TITLE
Simple cleanups for service.go

### DIFF
--- a/pkg/csi/service/logger/logger.go
+++ b/pkg/csi/service/logger/logger.go
@@ -14,11 +14,11 @@ type LogLevel string
 const (
 	// ProductionLogLevel is the level for the production log.
 	ProductionLogLevel LogLevel = "PRODUCTION"
-	// DevelopmentLogLevel is the level for development log
+	// DevelopmentLogLevel is the level for development log.
 	DevelopmentLogLevel LogLevel = "DEVELOPMENT"
-	// EnvLoggerLevel is the level for the environment log
+	// EnvLoggerLevel is the environment variable name for log level.
 	EnvLoggerLevel = "LOGGER_LEVEL"
-	// LogCtxIDKey holds the TraceId for log
+	// LogCtxIDKey holds the TraceId for log.
 	LogCtxIDKey = "TraceId"
 )
 


### PR DESCRIPTION
Simple cleanups for service.go.

We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should 
end with periods. In addition, I tried to make the text shorter than 80 columns.

I did more cleanups in the adjacent code.
1. Remove a redundant temporary variable.
2. Reduce long lines.