### PR TITLE
operationRequestStore implementation of VolumeOperationRequest interface

### DIFF
--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
@@ -21,9 +21,14 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/davecgh/go-spew/spew"
+	"github.com/pkg/errors"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	csiconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	cnsvolumeoperationrequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
@@ -37,7 +42,6 @@ type VolumeOperationRequest interface {
 	// that is persisted by the VolumeOperationRequest interface.
 	// Returns an error if any error is encountered while attempting to
 	// read the previously persisted information.
-	// If no previous information has been persisted, it returns an empty object.
 	GetRequestDetails(ctx context.Context, name string) (*VolumeOperationRequestDetails, error)
 	// StoreRequestDetails persists the details of the operation taking
 	// place on the volume.
@@ -46,29 +50,13 @@ type VolumeOperationRequest interface {
 	StoreRequestDetails(ctx context.Context, instance *VolumeOperationRequestDetails) error
 }
 
-// VolumeOperationRequestDetails stores details about a single operation
-// on the given volume. These details are persisted by
-// VolumeOperationRequestInterface and the persisted details will be
-// returned by the interface on request by the caller.
-type VolumeOperationRequestDetails struct {
-}
-
-// operationRequestStoreOnETCD implements the VolumeOperationsRequest interface.
+// operationRequestStore implements the VolumeOperationsRequest interface.
 // This implementation persists the operation information on etcd via a client
 // to the API server. Reads are also done directly on etcd; there is no caching
 // layer involved.
-type operationRequestStoreOnETCD struct {
+type operationRequestStore struct {
 	k8sclient client.Client
 }
-
-const (
-	// CRDName represent the name of cnsvolumeoperationrequest CRD
-	CRDName = "cnsvolumeoperationrequests.cns.vmware.com"
-	// CRDSingular represent the singular name of cnsvolumeoperationrequest CRD
-	CRDSingular = "cnsvolumeoperationrequest"
-	// CRDPlural represent the plural name of cnsvolumeoperationrequest CRD
-	CRDPlural = "cnsvolumeoperationrequests"
-)
 
 // InitVolumeOperationRequestInterface creates the CnsVolumeOperationRequest
 // definition on the API server and returns an implementation of
@@ -79,10 +67,9 @@ const (
 // TODO: Make this thread-safe and a singleton.
 func InitVolumeOperationRequestInterface(ctx context.Context) (VolumeOperationRequest, error) {
 	log := logger.GetLogger(ctx)
-
 	// Create CnsVolumeOperationRequest definition on API server
 	log.Info("Creating cnsvolumeoperationrequest definition on API server")
-	err := k8s.CreateCustomResourceDefinitionFromSpec(ctx, CRDName, CRDSingular, CRDPlural,
+	err := k8s.CreateCustomResourceDefinitionFromSpec(ctx, crdName, crdSingular, crdPlural,
 		reflect.TypeOf(cnsvolumeoperationrequestv1alpha1.CnsVolumeOperationRequest{}).Name(), cnsvolumeoperationrequestv1alpha1.SchemeGroupVersion.Group, cnsvolumeoperationrequestv1alpha1.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
 	if err != nil {
 		log.Errorf("failed to create cnsvolumeoperationrequest CRD with error: %v", err)
@@ -102,11 +89,11 @@ func InitVolumeOperationRequestInterface(ctx context.Context) (VolumeOperationRe
 		return nil, err
 	}
 
-	// Initialize the operationRequestStoreOnETCD implementation of VolumeOperationRequest
+	// Initialize the operationRequestStore implementation of VolumeOperationRequest
 	// interface.
 	// NOTE: Currently there is only a single implementation of this interface.
 	// Future implementations will need modify this step.
-	operationRequestStore := &operationRequestStoreOnETCD{
+	operationRequestStore := &operationRequestStore{
 		k8sclient: k8sclient,
 	}
 
@@ -119,23 +106,121 @@ func InitVolumeOperationRequestInterface(ctx context.Context) (VolumeOperationRe
 // name.
 // Returns an error if any error is encountered while attempting to
 // read the previously persisted information from the API server.
-// If no previous information has been persisted, it returns an empty object.
-func (or *operationRequestStoreOnETCD) GetRequestDetails(ctx context.Context, name string) (*VolumeOperationRequestDetails, error) {
+// Callers need to differentiate NotFound errors if required.
+func (or *operationRequestStore) GetRequestDetails(ctx context.Context, name string) (*VolumeOperationRequestDetails, error) {
 	log := logger.GetLogger(ctx)
-	// TODO: Implement GetRequestDetails for operationRequestStoreOnETCD
-	err := fmt.Errorf("GetRequestDetails not implemented for operationRequestStoreOnETCD")
-	log.Error(err)
-	return nil, err
+	instanceKey := client.ObjectKey{Name: name, Namespace: csiconfig.DefaultCSINamespace}
+	log.Debugf("Getting CnsVolumeOperationRequest instance with name %s/%s", instanceKey.Namespace, instanceKey.Name)
+
+	instance := &cnsvolumeoperationrequestv1alpha1.CnsVolumeOperationRequest{}
+	err := or.k8sclient.Get(ctx, instanceKey, instance)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("Found CnsVolumeOperationRequest instance %v", spew.Sdump(instance))
+
+	if len(instance.Status.LatestOperationDetails) == 0 {
+		return nil, fmt.Errorf("length of LatestOperationDetails expected to be greater than 1 if the instance exists")
+	}
+
+	// Callers only need to know about the last operation that was invoked on a volume.
+	operationDetailsToReturn := instance.Status.LatestOperationDetails[len(instance.Status.LatestOperationDetails)-1]
+
+	return CreateVolumeOperationRequestDetails(instance.Spec.Name, instance.Status.VolumeID, instance.Status.SnapshotID,
+			instance.Status.Capacity, operationDetailsToReturn.TaskInvocationTimestamp, operationDetailsToReturn.TaskID,
+			operationDetailsToReturn.OpID, operationDetailsToReturn.TaskStatus, operationDetailsToReturn.Error),
+		nil
 }
 
 // StoreRequestDetails persists the details of the operation taking
 // place on the volume by storing it on the API server.
 // Returns an error if any error is encountered. Clients must assume
 // that the attempt to persist the information failed if an error is returned.
-func (or *operationRequestStoreOnETCD) StoreRequestDetails(ctx context.Context, instance *VolumeOperationRequestDetails) error {
+func (or *operationRequestStore) StoreRequestDetails(ctx context.Context, operationToStore *VolumeOperationRequestDetails) error {
 	log := logger.GetLogger(ctx)
-	// TODO: Implement StoreRequestDetails for operationRequestStoreOnETCD
-	err := fmt.Errorf("StoreRequestDetails not implemented for operationRequestStoreOnETCD")
-	log.Error(err)
-	return err
+	if operationToStore == nil {
+		msg := "cannot store empty operation"
+		log.Error(msg)
+		return errors.New(msg)
+	}
+	log.Debugf("Storing CnsVolumeOperationRequest instance with spec %v", spew.Sdump(operationToStore))
+
+	operationDetailsToStore := convertToCnsVolumeOperationRequestDetails(*operationToStore.OperationDetails)
+	instance := &cnsvolumeoperationrequestv1alpha1.CnsVolumeOperationRequest{}
+	instanceKey := client.ObjectKey{Name: operationToStore.Name, Namespace: csiconfig.DefaultCSINamespace}
+
+	if err := or.k8sclient.Get(ctx, instanceKey, instance); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Create new instance on API server if it doesnt exist. Implies that this is the first time this object is being stored.
+			newInstance := &cnsvolumeoperationrequestv1alpha1.CnsVolumeOperationRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceKey.Name,
+					Namespace: instanceKey.Namespace,
+				},
+				Spec: cnsvolumeoperationrequestv1alpha1.CnsVolumeOperationRequestSpec{
+					Name: instanceKey.Name,
+				},
+				Status: cnsvolumeoperationrequestv1alpha1.CnsVolumeOperationRequestStatus{
+					VolumeID:              operationToStore.VolumeID,
+					SnapshotID:            operationToStore.SnapshotID,
+					Capacity:              operationToStore.Capacity,
+					FirstOperationDetails: *operationDetailsToStore,
+					LatestOperationDetails: []cnsvolumeoperationrequestv1alpha1.OperationDetails{
+						*operationDetailsToStore,
+					},
+				},
+			}
+			err = or.k8sclient.Create(ctx, newInstance)
+			if err != nil {
+				log.Errorf("failed to create CnsVolumeOperationRequest instance %s/%s with error: %v", instanceKey.Namespace, instanceKey.Name, err)
+				return err
+			}
+			log.Debugf("Created CnsVolumeOperationRequest instance %s/%s with latest information for task with ID: %s", instanceKey.Namespace, instanceKey.Name, operationDetailsToStore.TaskID)
+			return nil
+		}
+		log.Errorf("failed to get CnsVolumeOperationRequest instance %s/%s with error: %v", instanceKey.Namespace, instanceKey.Name, err)
+		return err
+	}
+
+	// Create a deep copy since we modify the object.
+	updatedInstance := instance.DeepCopy()
+
+	// Modify VolumeID, SnapshotID and Capacity
+	updatedInstance.Status.VolumeID = operationToStore.VolumeID
+	updatedInstance.Status.SnapshotID = operationToStore.SnapshotID
+	updatedInstance.Status.Capacity = operationToStore.Capacity
+
+	// Modify FirstOperationDetails only if it doesnt exist or TaskID's match.
+	firstOp := instance.Status.FirstOperationDetails
+	if firstOp.TaskID == "" || firstOp.TaskID == operationToStore.OperationDetails.TaskID {
+		updatedInstance.Status.FirstOperationDetails = *operationDetailsToStore
+	}
+
+	operationExistsInList := false
+	// If the task details already exist in the status, update it with the latest information.
+	for index := len(instance.Status.LatestOperationDetails) - 1; index >= 0; index-- {
+		operationDetail := instance.Status.LatestOperationDetails[index]
+		if operationDetailsToStore.TaskID == operationDetail.TaskID {
+			updatedInstance.Status.LatestOperationDetails[index] = *operationDetailsToStore
+			operationExistsInList = true
+			break
+		}
+	}
+
+	if !operationExistsInList {
+		// Append the latest task details to the local instance and ensure length of LatestOperationDetails is not greater than 10.
+		updatedInstance.Status.LatestOperationDetails = append(updatedInstance.Status.LatestOperationDetails, *operationDetailsToStore)
+		if len(updatedInstance.Status.LatestOperationDetails) > maxEntriesInLatestOperationDetails {
+			updatedInstance.Status.LatestOperationDetails = updatedInstance.Status.LatestOperationDetails[1:]
+		}
+	}
+
+	// Store the local instance on the API server.
+	err := or.k8sclient.Update(ctx, updatedInstance)
+	if err != nil {
+		log.Errorf("failed to update CnsVolumeOperationRequest instance %s/%s with error: %v", instanceKey.Namespace, instanceKey.Name, err)
+		return err
+	}
+	log.Debugf("Updated CnsVolumeOperationRequest instance %s/%s with latest information for task with ID: %s", instanceKey.Namespace, instanceKey.Name, operationDetailsToStore.TaskID)
+	return nil
 }

--- a/pkg/internalapis/cnsvolumeoperationrequest/util.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/util.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnsvolumeoperationrequest
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cnsvolumeoperationrequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
+)
+
+const (
+	// CRDName represent the name of cnsvolumeoperationrequest CRD
+	crdName = "cnsvolumeoperationrequests.cns.vmware.com"
+	// CRDSingular represent the singular name of cnsvolumeoperationrequest CRD
+	crdSingular = "cnsvolumeoperationrequest"
+	// CRDPlural represent the plural name of cnsvolumeoperationrequest CRD
+	crdPlural = "cnsvolumeoperationrequests"
+	// maxEntriesInLatestOperationDetails specifies the maximum length of
+	// the LatestOperationDetails allowed in a cnsvolumeoperationrequest instance
+	maxEntriesInLatestOperationDetails = 10
+)
+
+// VolumeOperationRequestDetails stores details about a single operation
+// on the given volume. These details are persisted by
+// VolumeOperationRequestInterface and the persisted details will be
+// returned by the interface on request by the caller via this structure.
+type VolumeOperationRequestDetails struct {
+	Name             string
+	VolumeID         string
+	SnapshotID       string
+	Capacity         int64
+	OperationDetails *OperationDetails
+}
+
+// OperationDetails stores information about a particular operation.
+type OperationDetails struct {
+	TaskInvocationTimestamp metav1.Time
+	TaskID                  string
+	OpID                    string
+	TaskStatus              string
+	Error                   string
+}
+
+// CreateVolumeOperationRequestDetails returns an object of type VolumeOperationRequestDetails from the input parameters.
+func CreateVolumeOperationRequestDetails(name, volumeID, snapshotID string, capacity int64, taskInvocationTimestamp metav1.Time, taskID, opID, taskStatus, error string) *VolumeOperationRequestDetails {
+	return &VolumeOperationRequestDetails{
+		Name:       name,
+		VolumeID:   volumeID,
+		SnapshotID: snapshotID,
+		Capacity:   capacity,
+		OperationDetails: &OperationDetails{
+			TaskInvocationTimestamp: taskInvocationTimestamp,
+			TaskID:                  taskID,
+			OpID:                    opID,
+			TaskStatus:              taskStatus,
+			Error:                   error,
+		},
+	}
+}
+
+// convertToCnsVolumeOperationRequestDetails converts an object of type OperationDetails to the OperationDetails type
+// defined by the CnsVolumeOperationRequest Custom Resource.
+func convertToCnsVolumeOperationRequestDetails(details OperationDetails) *cnsvolumeoperationrequestv1alpha1.OperationDetails {
+	return &cnsvolumeoperationrequestv1alpha1.OperationDetails{
+		TaskInvocationTimestamp: details.TaskInvocationTimestamp,
+		TaskID:                  details.TaskID,
+		OpID:                    details.OpID,
+		TaskStatus:              details.TaskStatus,
+		Error:                   details.Error,
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR introduce the implementation of `operationRequestStore` interface. `Get` and `Store` calls are made directly on the API server without any caching layer. 
These functions will be called by CSI Volume Manager

**Testing**

The test was to hack CSI controller to create a single instance of `CnsVolumeOperationRequest` and modify it. Following functionality was tested:
1. Create an instance and set operation details for first request to `InProgress`.
2. Get the operation details for this instance and modify the status to `Success`.
3. Update instance 11 times with new operation details and verify that the length of `LatestOperationDetails` is truncated at 10. 
4. Modify some of these operation details and verify that a new entry is NOT added (the existing entry is modified). 

NOTE: The intention of this interface is to simply `Get` and `Store` information correctly. It will be up to callers (CSI Volume manager) to ensure the correctness of the logic for idempotency. For example, CSI Volume manager must decide whether to invoke another operation based on the results of the `Get` call. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
operationRequestStoreOnETCD implementation of VolumeOperationRequest interface
```
