### PR TITLE
Clean up comments in pkg/kubernetes

### DIFF
--- a/pkg/kubernetes/informers.go
+++ b/pkg/kubernetes/informers.go
@@ -30,10 +30,14 @@ import (
 )
 
 const (
-	// resyncPeriodConfigMapInformer is the time interval between each resync operation for the configmap informer
-	// Note: Whenever there is a update on the configmap, we do get a callback to the handler immediately.
-	// However if for some reason update was missed, we need to set a resync interval for resync check operations that happens as part of NewFilteredConfigMapInformer()
-	// Since we do not anticipate frequent changes to the configmaps, the resync interval is set to 30 minutes.
+	// resyncPeriodConfigMapInformer is the time interval between each resync
+	// operation for the configmap informer.
+	//
+	// Whenever there is a update on the configmap, we do get a callback to the
+	// handler immediately. However, if for some reason update was missed, we
+	// need to set a resync interval for resync check operations that happens
+	// as part of NewFilteredConfigMapInformer(). Since we do not anticipate
+	// frequent changes to the configmaps, the resync interval is set to 30 min.
 	resyncPeriodConfigMapInformer = 30 * time.Minute
 )
 
@@ -46,7 +50,7 @@ func noResyncPeriodFunc() time.Duration {
 	return 0
 }
 
-// NewInformer creates a new K8S client based on a service account
+// NewInformer creates a new K8S client based on a service account.
 func NewInformer(client clientset.Interface) *InformerManager {
 	onceForInformerManager.Do(func() {
 		informerManagerInstance = &InformerManager{
@@ -58,7 +62,7 @@ func NewInformer(client clientset.Interface) *InformerManager {
 	return informerManagerInstance
 }
 
-// AddNodeListener hooks up add, update, delete callbacks
+// AddNodeListener hooks up add, update, delete callbacks.
 func (im *InformerManager) AddNodeListener(add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.nodeInformer == nil {
 		im.nodeInformer = im.informerFactory.Core().V1().Nodes().Informer()
@@ -71,7 +75,7 @@ func (im *InformerManager) AddNodeListener(add func(obj interface{}), update fun
 	})
 }
 
-// AddPVCListener hooks up add, update, delete callbacks
+// AddPVCListener hooks up add, update, delete callbacks.
 func (im *InformerManager) AddPVCListener(add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.pvcInformer == nil {
 		im.pvcInformer = im.informerFactory.Core().V1().PersistentVolumeClaims().Informer()
@@ -85,7 +89,7 @@ func (im *InformerManager) AddPVCListener(add func(obj interface{}), update func
 	})
 }
 
-// AddPVListener hooks up add, update, delete callbacks
+// AddPVListener hooks up add, update, delete callbacks.
 func (im *InformerManager) AddPVListener(add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.pvInformer == nil {
 		im.pvInformer = im.informerFactory.Core().V1().PersistentVolumes().Informer()
@@ -99,7 +103,7 @@ func (im *InformerManager) AddPVListener(add func(obj interface{}), update func(
 	})
 }
 
-// AddNamespaceListener hooks up add, update, delete callbacks
+// AddNamespaceListener hooks up add, update, delete callbacks.
 func (im *InformerManager) AddNamespaceListener(add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.namespaceInformer == nil {
 		im.namespaceInformer = im.informerFactory.Core().V1().Namespaces().Informer()
@@ -113,7 +117,7 @@ func (im *InformerManager) AddNamespaceListener(add func(obj interface{}), updat
 	})
 }
 
-// AddConfigMapListener hooks up add, update, delete callbacks
+// AddConfigMapListener hooks up add, update, delete callbacks.
 func (im *InformerManager) AddConfigMapListener(ctx context.Context, client clientset.Interface, namespace string, add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.configMapInformer == nil {
 		im.configMapInformer = v1.NewFilteredConfigMapInformer(client, namespace, resyncPeriodConfigMapInformer, cache.Indexers{}, nil)
@@ -126,11 +130,12 @@ func (im *InformerManager) AddConfigMapListener(ctx context.Context, client clie
 		DeleteFunc: remove,
 	})
 	stopCh := make(chan struct{})
-	//Since NewFilteredConfigMapInformer is not part of the informer factory, we need to invoke the Run() explicitly to start the shared informer
+	// Since NewFilteredConfigMapInformer is not part of the informer factory,
+	// we need to invoke the Run() explicitly to start the shared informer.
 	go im.configMapInformer.Run(stopCh)
 }
 
-// AddPodListener hooks up add, update, delete callbacks
+// AddPodListener hooks up add, update, delete callbacks.
 func (im *InformerManager) AddPodListener(add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.podInformer == nil {
 		im.podInformer = im.informerFactory.Core().V1().Pods().Informer()
@@ -144,27 +149,27 @@ func (im *InformerManager) AddPodListener(add func(obj interface{}), update func
 	})
 }
 
-// GetPVLister returns Persistent Volume Lister for the calling informer manager
+// GetPVLister returns PV Lister for the calling informer manager.
 func (im *InformerManager) GetPVLister() corelisters.PersistentVolumeLister {
 	return im.informerFactory.Core().V1().PersistentVolumes().Lister()
 }
 
-// GetPVCLister returns PVC Lister for the calling informer manager
+// GetPVCLister returns PVC Lister for the calling informer manager.
 func (im *InformerManager) GetPVCLister() corelisters.PersistentVolumeClaimLister {
 	return im.informerFactory.Core().V1().PersistentVolumeClaims().Lister()
 }
 
-// GetConfigMapLister returns ConfigMap Lister for the calling informer manager
+// GetConfigMapLister returns ConfigMap Lister for the calling informer manager.
 func (im *InformerManager) GetConfigMapLister() corelisters.ConfigMapLister {
 	return im.informerFactory.Core().V1().ConfigMaps().Lister()
 }
 
-// GetPodLister returns Pod Lister for the calling informer manager
+// GetPodLister returns Pod Lister for the calling informer manager.
 func (im *InformerManager) GetPodLister() corelisters.PodLister {
 	return im.informerFactory.Core().V1().Pods().Lister()
 }
 
-// Listen starts the Informers
+// Listen starts the Informers.
 func (im *InformerManager) Listen() (stopCh <-chan struct{}) {
 	go im.informerFactory.Start(im.stopCh)
 	if im.pvSynced != nil && im.pvcSynced != nil && im.podSynced != nil && im.configMapSynced != nil {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -61,14 +61,15 @@ const (
 	manifestPath = "/config"
 )
 
-// GetKubeConfig helps retrieve Kubernetes Config
+// GetKubeConfig helps retrieve Kubernetes Config.
 func GetKubeConfig(ctx context.Context) (*restclient.Config, error) {
 	log := logger.GetLogger(ctx)
 	var config *restclient.Config
 	var err error
 	kubecfgPath := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
-	if flag.Lookup("kubeconfig") != nil {
-		kubecfgPath = flag.Lookup("kubeconfig").Value.(flag.Getter).Get().(string)
+	kubecfgFlag := flag.Lookup("kubeconfig")
+	if kubecfgFlag != nil {
+		kubecfgPath = kubecfgFlag.Value.(flag.Getter).Get().(string)
 	}
 	if kubecfgPath != "" {
 		log.Infof("k8s client using kubeconfig from %s", kubecfgPath)
@@ -89,7 +90,7 @@ func GetKubeConfig(ctx context.Context) (*restclient.Config, error) {
 	return config, nil
 }
 
-// NewClient creates a newk8s client based on a service account
+// NewClient creates a newk8s client based on a service account.
 func NewClient(ctx context.Context) (clientset.Interface, error) {
 	log := logger.GetLogger(ctx)
 	config, err := GetKubeConfig(ctx)
@@ -100,7 +101,8 @@ func NewClient(ctx context.Context) (clientset.Interface, error) {
 	return clientset.NewForConfig(config)
 }
 
-// GetRestClientConfigForSupervisor returns restclient config for given endpoint, port, certificate and token
+// GetRestClientConfigForSupervisor returns restclient config for given
+// endpoint, port, certificate and token.
 func GetRestClientConfigForSupervisor(ctx context.Context, endpoint string, port string) *restclient.Config {
 	log := logger.GetLogger(ctx)
 	var config *restclient.Config
@@ -127,7 +129,7 @@ func GetRestClientConfigForSupervisor(ctx context.Context, endpoint string, port
 	return config
 }
 
-// NewSupervisorClient creates a new supervisor client for given restClient config
+// NewSupervisorClient creates a new supervisor client for given restClient config.
 func NewSupervisorClient(ctx context.Context, config *restclient.Config) (clientset.Interface, error) {
 	log := logger.GetLogger(ctx)
 	log.Info("Connecting to supervisor cluster using the certs/token in Guest Cluster config")
@@ -182,7 +184,8 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 
 }
 
-// NewCnsFileAccessConfigWatcher creates a new ListWatch for VirtualMachines given rest client config
+// NewCnsFileAccessConfigWatcher creates a new ListWatch for VirtualMachines
+// given rest client config.
 func NewCnsFileAccessConfigWatcher(ctx context.Context, config *restclient.Config, namespace string) (*cache.ListWatch, error) {
 	var err error
 	log := logger.GetLogger(ctx)
@@ -206,7 +209,8 @@ func NewCnsFileAccessConfigWatcher(ctx context.Context, config *restclient.Confi
 	return cache.NewListWatchFromClient(client, cnsfileaccessconfigKind, namespace, fields.Everything()), nil
 }
 
-// NewVirtualMachineWatcher creates a new ListWatch for VirtualMachines given rest client config
+// NewVirtualMachineWatcher creates a new ListWatch for VirtualMachines given
+// rest client config.
 func NewVirtualMachineWatcher(ctx context.Context, config *restclient.Config, namespace string) (*cache.ListWatch, error) {
 	var err error
 	log := logger.GetLogger(ctx)
@@ -230,7 +234,7 @@ func NewVirtualMachineWatcher(ctx context.Context, config *restclient.Config, na
 	return cache.NewListWatchFromClient(client, virtualMachineKind, namespace, fields.Everything()), nil
 }
 
-// CreateKubernetesClientFromConfig creaates a newk8s client from given kubeConfig file
+// CreateKubernetesClientFromConfig creaates a newk8s client from given kubeConfig file.
 func CreateKubernetesClientFromConfig(kubeConfigPath string) (clientset.Interface, error) {
 
 	cfg, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
@@ -245,7 +249,7 @@ func CreateKubernetesClientFromConfig(kubeConfigPath string) (clientset.Interfac
 	return client, nil
 }
 
-// GetNodeVMUUID returns vSphere VM UUID set by CCM on the Kubernetes Node
+// GetNodeVMUUID returns vSphere VM UUID set by CCM on the Kubernetes Node.
 func GetNodeVMUUID(ctx context.Context, k8sclient clientset.Interface, nodeName string) (string, error) {
 	log := logger.GetLogger(ctx)
 	log.Infof("GetNodeVMUUID called for the node: %q", nodeName)
@@ -295,8 +299,8 @@ func getClientThroughput(ctx context.Context, isSupervisorClient bool) (float32,
 	return qps, burst
 }
 
-// CreateCustomResourceDefinitionFromSpec creates the custom resource definition from given spec
-// If there is error, function will do the clean up
+// CreateCustomResourceDefinitionFromSpec creates the custom resource definition
+// from given spec. If there is error, function will do the clean up.
 func CreateCustomResourceDefinitionFromSpec(ctx context.Context, crdName string, crdSingular string, crdPlural string,
 	crdKind string, crdGroup string, crdVersion string, crdScope apiextensionsv1beta1.ResourceScope) error {
 	crdSpec := &apiextensionsv1beta1.CustomResourceDefinition{
@@ -322,8 +326,8 @@ func CreateCustomResourceDefinitionFromSpec(ctx context.Context, crdName string,
 	return createCustomResourceDefinition(ctx, crdSpec)
 }
 
-// CreateCustomResourceDefinitionFromManifest creates custom resource definition spec from
-// manifest file
+// CreateCustomResourceDefinitionFromManifest creates custom resource definition
+// spec from manifest file.
 func CreateCustomResourceDefinitionFromManifest(ctx context.Context, fileName string) error {
 	log := logger.GetLogger(ctx)
 	manifestcrd, err := getCRDFromManifest(ctx, fileName)
@@ -335,10 +339,11 @@ func CreateCustomResourceDefinitionFromManifest(ctx context.Context, fileName st
 
 }
 
-// createCustomResourceDefinition takes a custom resource definition spec and creates it on the API server
+// createCustomResourceDefinition takes a custom resource definition spec and
+// creates it on the API server.
 func createCustomResourceDefinition(ctx context.Context, newCrd *apiextensionsv1beta1.CustomResourceDefinition) error {
 	log := logger.GetLogger(ctx)
-	// Get a config to talk to the apiserver
+	// Get a config to talk to the apiserver.
 	cfg, err := GetKubeConfig(ctx)
 	if err != nil {
 		log.Errorf("failed to get Kubernetes config. Err: %+v", err)
@@ -360,7 +365,7 @@ func createCustomResourceDefinition(ctx context.Context, newCrd *apiextensionsv1
 		}
 		log.Infof("%q CRD created successfully", crdName)
 	} else {
-		// Update the existing CRD with new CRD
+		// Update the existing CRD with new CRD.
 		crd.Spec = newCrd.Spec
 		crd.Status = newCrd.Status
 		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Update(ctx, crd, metav1.UpdateOptions{})
@@ -379,7 +384,7 @@ func createCustomResourceDefinition(ctx context.Context, newCrd *apiextensionsv1
 	return err
 }
 
-// waitForCustomResourceToBeEstablished waits until the CRD status is Established
+// waitForCustomResourceToBeEstablished waits until the CRD status is Established.
 func waitForCustomResourceToBeEstablished(ctx context.Context,
 	clientSet apiextensionsclientset.Interface, crdName string) error {
 	log := logger.GetLogger(ctx)


### PR DESCRIPTION
Clean up comments in pkg/kubernetes.

We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

I removed some trivial comments that just repeat the code (the immediate function call), because
it is simply clutter.

I did one more cleanup in GetKubeConfig(), which I saved the result of flag.Lookup("kubeconfig") 
in a temporary variable. This way, I can avoid a redundant call.