### PR TITLE
Remove namespace creation from cns-csi yaml

### DIFF
--- a/manifests/supervisorcluster/1.15/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.15/cns-csi.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vmware-system-csi
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/manifests/supervisorcluster/1.16/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.16/cns-csi.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vmware-system-csi
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/manifests/supervisorcluster/1.17/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.17/cns-csi.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vmware-system-csi
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/manifests/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.18/cns-csi.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vmware-system-csi
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/manifests/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.19/cns-csi.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vmware-system-csi
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vmware-system-csi
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vmware-system-csi
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is removing namespace creation from cns-csi yaml since it affects the CSI upgrade path. CSI upgrade path in supervisor cluster is just deleting the old yaml and creating the new driver with new yaml. Because the namespace creation was moved to driver yaml, the entire namespace got deleted during upgrade. To address this issue, we will keep namespace creation in online cluster setup scripts and keep csi driver installation in a single yaml. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
The namespace creation will be added to cluster setup scripts on Supervisor cluster repos. This is needed to resolve recent CSI upgrade related issues

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove namespace creation from cns-csi yaml
```
