### PR TITLE
Refactor code to remove redundant function calls and dependencies between packages

### DIFF
--- a/pkg/apis/cnsoperator/register.go
+++ b/pkg/apis/cnsoperator/register.go
@@ -29,7 +29,6 @@ import (
 	cnsnodevmattachmentv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1"
 	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
-	triggercsifullsyncv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1"
 )
 
 // GroupName represents the group for cns operator apis
@@ -97,12 +96,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		SchemeGroupVersion,
 		&cnsnodevmattachmentv1alpha1.CnsNodeVmAttachment{},
 		&cnsnodevmattachmentv1alpha1.CnsNodeVmAttachmentList{},
-	)
-
-	scheme.AddKnownTypes(
-		SchemeGroupVersion,
-		&triggercsifullsyncv1alpha1.TriggerCsiFullSync{},
-		&triggercsifullsyncv1alpha1.TriggerCsiFullSyncList{},
 	)
 
 	scheme.AddKnownTypes(

--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -139,7 +139,7 @@ func GetVolumeMigrationService(ctx context.Context, volumeManager *cnsvolume.Man
 			go func() {
 				log.Debugf("Starting Informer for cnsvspherevolumemigrations")
 				informer, err := k8s.GetDynamicInformer(ctx, migrationv1alpha1.SchemeGroupVersion.Group, migrationv1alpha1.SchemeGroupVersion.Version,
-					"cnsvspherevolumemigrations", metav1.NamespaceNone, true)
+					"cnsvspherevolumemigrations", metav1.NamespaceNone, config, true)
 				if err != nil {
 					log.Errorf("failed to create dynamic informer for volume migration CRD. Err: %v", err)
 				}

--- a/pkg/common/cns-lib/vsphere/virtualmachine.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/vmware/govmomi/vapi/tags"
@@ -111,6 +112,9 @@ const (
 	// dcBufferSize is the buffer size for the channel that is used to
 	// asynchronously receive *Datacenter instances.
 	dcBufferSize = poolSize * 10
+	//ProviderPrefix is the prefix used for the ProviderID set on the node
+	// Example: vsphere://4201794a-f26b-8914-d95a-edeb7ecc4a8f
+	providerPrefix = "vsphere://"
 )
 
 // GetVirtualMachineByUUID returns virtual machine given its UUID in entire VC.
@@ -317,4 +321,9 @@ func (vm *VirtualMachine) IsInZoneRegion(ctx context.Context, zoneCategoryName s
 		return true, nil
 	}
 	return false, nil
+}
+
+// GetUUIDFromProviderID Returns VM UUID from Node's providerID
+func GetUUIDFromProviderID(providerID string) string {
+	return strings.TrimPrefix(providerID, providerPrefix)
 }

--- a/pkg/csi/service/vanilla/nodes.go
+++ b/pkg/csi/service/vanilla/nodes.go
@@ -24,7 +24,6 @@ import (
 
 	cnsnode "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/node"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
 
@@ -62,7 +61,7 @@ func (nodes *Nodes) nodeAdd(obj interface{}) {
 		log.Warnf("nodeAdd: unrecognized object %+v", obj)
 		return
 	}
-	err := nodes.cnsNodeManager.RegisterNode(ctx, common.GetUUIDFromProviderID(node.Spec.ProviderID), node.Name)
+	err := nodes.cnsNodeManager.RegisterNode(ctx, cnsvsphere.GetUUIDFromProviderID(node.Spec.ProviderID), node.Name)
 	if err != nil {
 		log.Warnf("failed to register node:%q. err=%v", node.Name, err)
 	}
@@ -83,7 +82,7 @@ func (nodes *Nodes) nodeUpdate(oldObj interface{}, newObj interface{}) {
 	if oldNode.Spec.ProviderID != newNode.Spec.ProviderID {
 		log.Infof("nodeUpdate: Observed ProviderID change from %q to %q for the node: %q", oldNode.Spec.ProviderID, newNode.Spec.ProviderID, newNode.Name)
 
-		err := nodes.cnsNodeManager.RegisterNode(ctx, common.GetUUIDFromProviderID(newNode.Spec.ProviderID), newNode.Name)
+		err := nodes.cnsNodeManager.RegisterNode(ctx, cnsvsphere.GetUUIDFromProviderID(newNode.Spec.ProviderID), newNode.Name)
 		if err != nil {
 			log.Warnf("nodeUpdate: Failed to register node:%q. err=%v", newNode.Name, err)
 		}

--- a/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1/triggercsifullsync_types.go
+++ b/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1/triggercsifullsync_types.go
@@ -18,8 +18,11 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 )
+
+// TriggerCsiFullSyncCRName is the name of the instance
+// created to trigger full sync on demand.
+const TriggerCsiFullSyncCRName = "csifullsync"
 
 // TriggerCsiFullSyncSpec is the spec for TriggerCsiFullSync
 type TriggerCsiFullSyncSpec struct {
@@ -85,7 +88,7 @@ type TriggerCsiFullSyncList struct {
 func CreateTriggerCsiFullSyncInstance() *TriggerCsiFullSync {
 	return &TriggerCsiFullSync{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: common.TriggerCsiFullSyncCRName,
+			Name: TriggerCsiFullSyncCRName,
 		},
 		Spec: TriggerCsiFullSyncSpec{
 			TriggerSyncID: 0,

--- a/pkg/internalapis/featurestates/featurestates.go
+++ b/pkg/internalapis/featurestates/featurestates.go
@@ -153,7 +153,7 @@ func StartSvFSSReplicationService(ctx context.Context, svFeatureStatConfigMapNam
 
 	// Create a dynamic informer for the cnscsisvfeaturestates CR
 	dynInformer, err := k8s.GetDynamicInformer(ctx, CRDGroupName, internalapis.SchemeGroupVersion.Version,
-		CRDPlural, metav1.NamespaceAll, true)
+		CRDPlural, metav1.NamespaceAll, config, true)
 	if err != nil {
 		log.Errorf("failed to create dynamic informer for %s CR. Error: %+v", CRDPlural, err)
 		return err

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -48,8 +48,8 @@ import (
 
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator"
 	migrationv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration/v1alpha1"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 	internalapis "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis"
@@ -264,7 +264,7 @@ func GetNodeVMUUID(ctx context.Context, k8sclient clientset.Interface, nodeName 
 		log.Errorf("failed to get kubernetes node with the name: %q. Err: %v", nodeName, err)
 		return "", err
 	}
-	k8sNodeUUID := common.GetUUIDFromProviderID(node.Spec.ProviderID)
+	k8sNodeUUID := cnsvsphere.GetUUIDFromProviderID(node.Spec.ProviderID)
 	log.Infof("Retrieved node UUID: %q for the node: %q", k8sNodeUUID, nodeName)
 	return k8sNodeUUID, nil
 }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
/kind cleanup
This PR refactors existing code to remove some redundant function calls and remove dependencies between different packages. 
For example, `pkg/kubernetes` and `pkg/internalapis` import `pkg/csi` just for some constants.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Refactor code to remove redundant function calls and dependencies between packages
```
