### PR TITLE
Clean up comments in vanilla controller

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -48,7 +48,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest"
 )
 
-// NodeManagerInterface provides functionality to manage nodes.
+// NodeManagerInterface provides functionality to manage (VM) nodes.
 type NodeManagerInterface interface {
 	Initialize(ctx context.Context) error
 	GetSharedDatastoresInK8SCluster(ctx context.Context) ([]*cnsvsphere.DatastoreInfo, error)
@@ -63,15 +63,15 @@ type controller struct {
 	authMgr common.AuthorizationService
 }
 
-// volumeMigrationService holds the pointer to VolumeMigration instance
+// volumeMigrationService holds the pointer to VolumeMigration instance.
 var volumeMigrationService migration.VolumeMigrationService
 
-// New creates a CNS controller
+// New creates a CNS controller.
 func New() csitypes.CnsController {
 	return &controller{}
 }
 
-// Init is initializing controller struct
+// Init is initializing controller struct.
 func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -80,7 +80,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 
 	log.Infof("Initializing CNS controller")
 	var err error
-	// Get VirtualCenterManager instance and validate version
+	// Get VirtualCenterManager instance and validate version.
 	vcenterconfig, err := cnsvsphere.GetVirtualCenterConfig(ctx, config)
 	if err != nil {
 		log.Errorf("failed to get VirtualCenterConfig. err=%v", err)
@@ -106,7 +106,8 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	}
 
 	isAuthCheckFSSEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIAuthCheck)
-	// Check if vSAN FS is enabled for TargetvSANFileShareDatastoreURLs only if CSIAuthCheck FSS is not enabled
+	// Check if vSAN FS is enabled for TargetvSANFileShareDatastoreURLs only if
+	// CSIAuthCheck FSS is not enabled.
 	if !isAuthCheckFSSEnabled && len(c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs) > 0 {
 		datacenters, err := vc.ListDatacenters(ctx)
 		if err != nil {
@@ -114,7 +115,8 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			log.Error(msg)
 			return errors.New(msg)
 		}
-		// Check if file service is enabled on datastore present in targetvSANFileShareDatastoreURLs.
+		// Check if file service is enabled on datastore present in
+		// targetvSANFileShareDatastoreURLs.
 		dsToFileServiceEnabledMap, err := common.IsFileServiceEnabled(ctx, c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs, vc, datacenters)
 		if err != nil {
 			msg := fmt.Sprintf("file service enablement check failed for datastore specified in TargetvSANFileShareDatastoreURLs. err=%v", err)
@@ -131,7 +133,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		}
 	}
 
-	// Check vCenter API Version
+	// Check vCenter API Version.
 	if err = common.CheckAPI(vc.Client.ServiceContent.About.ApiVersion); err != nil {
 		log.Errorf("checkAPI failed for vcenter API version: %s, err=%v", vc.Client.ServiceContent.About.ApiVersion, err)
 		return err
@@ -218,7 +220,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	}
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency) {
 		log.Infof("CSI Volume manager idempotency handling feature flag is enabled.")
-		// TODO: Assign VolumeOperationRequest object to a variable
+		// TODO: Assign VolumeOperationRequest object to a variable.
 		_, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx)
 		if err != nil {
 			log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
@@ -241,8 +243,8 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	return nil
 }
 
-// ReloadConfiguration reloads configuration from the secret, and update controller's config cache
-// and VolumeManager's VC Config cache.
+// ReloadConfiguration reloads configuration from the secret, and update
+// controller's config cache and VolumeManager's VC Config cache.
 func (c *controller) ReloadConfiguration() error {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Info("Reloading Configuration")
@@ -263,8 +265,8 @@ func (c *controller) ReloadConfiguration() error {
 			c.manager.VcenterConfig.Username != newVCConfig.Username ||
 			c.manager.VcenterConfig.Password != newVCConfig.Password {
 
-			// Verify if new configuration has valid credentials by connecting to vCenter.
-			// Proceed only if the connection succeeds, else return error.
+			// Verify if new configuration has valid credentials by connecting to
+			// vCenter. Proceed only if the connection succeeds, else return error.
 			newVC := &cnsvsphere.VirtualCenter{Config: newVCConfig}
 			if err = newVC.Connect(ctx); err != nil {
 				msg := fmt.Sprintf("failed to connect to VirtualCenter host: %q, Err: %+v", newVCConfig.Host, err)
@@ -272,7 +274,7 @@ func (c *controller) ReloadConfiguration() error {
 				return errors.New(msg)
 			}
 
-			// Reset virtual center singleton instance by passing reload flag as true
+			// Reset vCenter singleton instance by passing reload flag as true.
 			log.Info("Obtaining new vCenterInstance using new credentials")
 			vcenter, err = cnsvsphere.GetVirtualCenterInstance(ctx, &cnsconfig.ConfigurationInfo{Cfg: cfg}, true)
 			if err != nil {
@@ -281,8 +283,8 @@ func (c *controller) ReloadConfiguration() error {
 				return errors.New(msg)
 			}
 		} else {
-			// If it's not a VC host or VC credentials update, same singleton instance can be used
-			// and it's Config field can be updated
+			// If it's not a VC host or VC credentials update, same singleton
+			// instance can be used and it's Config field can be updated.
 			vcenter, err = cnsvsphere.GetVirtualCenterInstance(ctx, &cnsconfig.ConfigurationInfo{Cfg: cfg}, false)
 			if err != nil {
 				msg := fmt.Sprintf("failed to get VirtualCenter. err=%v", err)
@@ -294,7 +296,7 @@ func (c *controller) ReloadConfiguration() error {
 		c.manager.VolumeManager.ResetManager(ctx, vcenter)
 		c.manager.VcenterConfig = newVCConfig
 		c.manager.VolumeManager = cnsvolume.GetManager(ctx, vcenter)
-		// Re-Initialize Node Manager to cache latest vCenter config
+		// Re-Initialize Node Manager to cache latest vCenter config.
 		c.nodeMgr = &Nodes{}
 		err = c.nodeMgr.Initialize(ctx)
 		if err != nil {
@@ -333,14 +335,15 @@ func (c *controller) filterDatastores(ctx context.Context, sharedDatastores []*c
 func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolumeRequest) (
 	*csi.CreateVolumeResponse, error) {
 	log := logger.GetLogger(ctx)
-	// Volume Size - Default is 10 GiB
+	// Volume Size - Default is 10 GiB.
 	volSizeBytes := int64(common.DefaultGbDiskSize * common.GbInBytes)
 	if req.GetCapacityRange() != nil && req.GetCapacityRange().RequiredBytes != 0 {
 		volSizeBytes = int64(req.GetCapacityRange().GetRequiredBytes())
 	}
 	volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
 
-	// Fetching the feature state for csi-migration before parsing storage class params
+	// Fetching the feature state for csi-migration before parsing storage class
+	// params.
 	csiMigrationFeatureState := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration)
 	scParams, err := common.ParseStorageClassParams(ctx, req.Parameters, csiMigrationFeatureState)
 	if err != nil {
@@ -352,7 +355,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	if csiMigrationFeatureState && scParams.CSIMigration == "true" {
 		if len(scParams.Datastore) != 0 {
 			log.Infof("Converting datastore name: %q to Datastore URL", scParams.Datastore)
-			// Get vCenter
+			// Get vCenter.
 			vCenter, err := cnsvsphere.GetVirtualCenterManager(ctx).GetVirtualCenter(ctx, c.manager.VcenterConfig.Host)
 			if err != nil {
 				msg := fmt.Sprintf("failed to get vCenter. err: %+v", err)
@@ -402,13 +405,13 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	var sharedDatastores []*cnsvsphere.DatastoreInfo
 	var datastoreTopologyMap = make(map[string][]map[string]string)
 
-	// Get accessibility
+	// Get accessibility.
 	topologyRequirement := req.GetAccessibilityRequirements()
 	if topologyRequirement != nil {
-		// Get shared accessible datastores for matching topology requirement
+		// Get shared accessible datastores for matching topology requirement.
 		if c.manager.CnsConfig.Labels.Zone == "" || c.manager.CnsConfig.Labels.Region == "" {
-			// if zone and region label (vSphere category names) not specified in the config secret, then return
-			// NotFound error.
+			// If zone and region label (vSphere category names) not specified in
+			// the config secret, then return NotFound error.
 			errMsg := "Zone/Region vsphere category names not specified in the vsphere config secret"
 			log.Errorf(errMsg)
 			return nil, status.Error(codes.NotFound, errMsg)
@@ -439,7 +442,8 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		}
 		log.Debugf("Shared datastores [%+v] retrieved for topologyRequirement [%+v] with datastoreTopologyMap [+%v]", sharedDatastores, topologyRequirement, datastoreTopologyMap)
 		if createVolumeSpec.ScParams.DatastoreURL != "" {
-			// Check datastoreURL specified in the storageclass is accessible from topology
+			// Check datastoreURL specified in the storageclass is accessible from
+			// topology.
 			isDataStoreAccessible := false
 			for _, sharedDatastore := range sharedDatastores {
 				if sharedDatastore.Info.Url == createVolumeSpec.ScParams.DatastoreURL {
@@ -465,7 +469,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	}
 
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIAuthCheck) {
-		// filter datastores which in datastoreMap from sharedDatastores
+		// Filter datastores which in datastoreMap from sharedDatastores.
 		sharedDatastores = c.filterDatastores(ctx, sharedDatastores)
 	}
 	volumeInfo, err := common.CreateBlockVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla, c.manager, &createVolumeSpec, sharedDatastores)
@@ -478,12 +482,13 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	attributes := make(map[string]string)
 	attributes[common.AttributeDiskType] = common.DiskTypeBlockVolume
 	if csiMigrationFeatureState && scParams.CSIMigration == "true" {
-		// In case if feature state switch is enabled after controller is deployed, we need to initialize the volumeMigrationService
+		// In case if feature state switch is enabled after controller is
+		// deployed, we need to initialize the volumeMigrationService.
 		if err := initVolumeMigrationService(ctx, c); err != nil {
-			// Error is already wrapped in CSI error code
+			// Error is already wrapped in CSI error code.
 			return nil, err
 		}
-		// Return InitialVolumeFilepath in the response for TranslateCSIPVToInTree
+		// Return InitialVolumeFilepath in the response for TranslateCSIPVToInTree.
 		volumePath, err := volumeMigrationService.GetVolumePath(ctx, volumeInfo.VolumeID.Id)
 		if err != nil {
 			msg := fmt.Sprintf("failed to get volume path for volume id: %q. Error: %+v", volumeInfo.VolumeID.Id, err)
@@ -501,9 +506,10 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		},
 	}
 
-	// Retrieve the datastoreURL of the Provisioned Volume
-	// If CNS CreateVolume API does not return datastoreURL, retrieve this by calling QueryVolume
-	// otherwise, retrieve this from PlacementResults from the response of CreateVolume API
+	// Retrieve the datastoreURL of the Provisioned Volume. If CNS CreateVolume
+	// API does not return datastoreURL, retrieve this by calling QueryVolume.
+	// Otherwise, retrieve this from PlacementResults from the response of
+	// CreateVolume API.
 	var volumeAccessibleTopology = make(map[string]string)
 	var datastoreAccessibleTopology []map[string]string
 	var datastoreURL string
@@ -519,7 +525,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 				return nil, status.Error(codes.Internal, err.Error())
 			}
 			if len(queryResult.Volumes) > 0 {
-				// Find datastore topology from the retrieved datastoreURL
+				// Find datastore topology from the retrieved datastoreURL.
 				if queryResult.Volumes[0].DatastoreUrl == "" {
 					msg := fmt.Sprintf("could not retrieve datastore of volume: %q", volumeInfo.VolumeID.Id)
 					log.Error(msg)
@@ -534,7 +540,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 				return nil, status.Error(codes.Internal, msg)
 			}
 		} else {
-			// retrieve datastoreURL from placementResults
+			// Retrieve datastoreURL from placementResults.
 			datastoreAccessibleTopology = datastoreTopologyMap[volumeInfo.DatastoreURL]
 			datastoreURL = volumeInfo.DatastoreURL
 			log.Debugf("Volume: %s is provisioned on the datastore: %s ", volumeInfo.VolumeID.Id, datastoreURL)
@@ -558,19 +564,20 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolumeRequest) (
 	*csi.CreateVolumeResponse, error) {
 	log := logger.GetLogger(ctx)
-	// ignore TopologyRequirement for file volume provisioning
+	// Ignore TopologyRequirement for file volume provisioning.
 	if req.GetAccessibilityRequirements() != nil {
 		log.Info("Ignoring TopologyRequirement for file volume")
 	}
 
-	// Volume Size - Default is 10 GiB
+	// Volume Size - Default is 10 GiB.
 	volSizeBytes := int64(common.DefaultGbDiskSize * common.GbInBytes)
 	if req.GetCapacityRange() != nil && req.GetCapacityRange().RequiredBytes != 0 {
 		volSizeBytes = int64(req.GetCapacityRange().GetRequiredBytes())
 	}
 	volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
 
-	// Fetching the feature state for csi-migration before parsing storage class params
+	// Fetching the feature state for csi-migration before parsing storage class
+	// params.
 	csiMigrationFeatureState := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration)
 	scParams, err := common.ParseStorageClassParams(ctx, req.Parameters, csiMigrationFeatureState)
 	if err != nil {
@@ -628,8 +635,8 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 	return resp, nil
 }
 
-// CreateVolume is creating CNS Volume using volume request specified
-// in CreateVolumeRequest
+// CreateVolume is creating CNS Volume using volume request specified in
+// CreateVolumeRequest.
 func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (
 	*csi.CreateVolumeResponse, error) {
 	start := time.Now()
@@ -672,7 +679,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	return resp, err
 }
 
-// DeleteVolume is deleting CNS Volume specified in DeleteVolumeRequest
+// DeleteVolume is deleting CNS Volume specified in DeleteVolumeRequest.
 func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (
 	*csi.DeleteVolumeResponse, error) {
 	start := time.Now()
@@ -691,18 +698,19 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		var volumePath string
 		if strings.Contains(req.VolumeId, ".vmdk") {
 			volumeType = prometheus.PrometheusBlockVolumeType
-			// in-tree volume support
+			// In-tree volume support.
 			if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
-				// Migration feature switch is disabled
+				// Migration feature switch is disabled.
 				msg := fmt.Sprintf("volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", req.VolumeId)
 				log.Error(msg)
 				return nil, status.Errorf(codes.Internal, msg)
 			}
-			// Migration feature switch is enabled
+			// Migration feature switch is enabled.
 			volumePath = req.VolumeId
-			// In case if feature state switch is enabled after controller is deployed, we need to initialize the volumeMigrationService
+			// In case if feature state switch is enabled after controller is
+			// deployed, we need to initialize the volumeMigrationService.
 			if err := initVolumeMigrationService(ctx, c); err != nil {
-				// Error is already wrapped in CSI error code
+				// Error is already wrapped in CSI error code.
 				return nil, err
 			}
 			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, &migration.VolumeSpec{VolumePath: req.VolumeId})
@@ -712,16 +720,17 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 				return nil, status.Errorf(codes.Internal, msg)
 			}
 		}
-		// TODO: Add code to determine the volume type and set volumeType for Prometheus metric accordingly.
+		// TODO: Add code to determine the volume type and set volumeType for
+		// Prometheus metric accordingly.
 		err = common.DeleteVolumeUtil(ctx, c.manager.VolumeManager, req.VolumeId, true)
 		if err != nil {
 			msg := fmt.Sprintf("failed to delete volume: %q. Error: %+v", req.VolumeId, err)
 			log.Error(msg)
 			return nil, status.Errorf(codes.Internal, msg)
 		}
-		// Migration feature switch is enabled and volumePath is set
+		// Migration feature switch is enabled and volumePath is set.
 		if volumePath != "" {
-			// Delete VolumePath to VolumeID mapping
+			// Delete VolumePath to VolumeID mapping.
 			err = volumeMigrationService.DeleteVolumeInfo(ctx, req.VolumeId)
 			if err != nil {
 				msg := fmt.Sprintf("failed to delete volumeInfo CR for volume: %q. Error: %+v", req.VolumeId, err)
@@ -743,7 +752,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 }
 
 // ControllerPublishVolume attaches a volume to the Node VM.
-// volume id and node name is retrieved from ControllerPublishVolumeRequest
+// Volume id and node name is retrieved from ControllerPublishVolumeRequest.
 func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (
 	*csi.ControllerPublishVolumeResponse, error) {
 	start := time.Now()
@@ -762,10 +771,10 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 			return nil, status.Errorf(codes.Internal, msg)
 		}
 		publishInfo := make(map[string]string)
-		// Check whether its a block or file volume
+		// Check whether its a block or file volume.
 		if common.IsFileVolumeRequest(ctx, []*csi.VolumeCapability{req.GetVolumeCapability()}) {
 			volumeType = prometheus.PrometheusFileVolumeType
-			// File Volume
+			// File Volume.
 			queryFilter := cnstypes.CnsQueryFilter{
 				VolumeIds: []cnstypes.CnsVolumeId{{Id: req.VolumeId}},
 			}
@@ -804,22 +813,23 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 				return nil, status.Errorf(codes.Internal, msg)
 			}
 		} else {
-			// Block Volume
+			// Block Volume.
 			volumeType = prometheus.PrometheusBlockVolumeType
 			if strings.Contains(req.VolumeId, ".vmdk") {
-				// in-tree volume support
+				// In-tree volume support.
 				if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
-					// Migration feature switch is disabled
+					// Migration feature switch is disabled.
 					msg := fmt.Sprintf("volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", req.VolumeId)
 					log.Error(msg)
 					return nil, status.Errorf(codes.Internal, msg)
 				}
-				// Migration feature switch is enabled
+				// Migration feature switch is enabled.
 				storagePolicyName := req.VolumeContext[common.AttributeStoragePolicyName]
 				volumePath := req.VolumeId
-				// In case if feature state switch is enabled after controller is deployed, we need to initialize the volumeMigrationService
+				// In case if feature state switch is enabled after controller is
+				// deployed, we need to initialize the volumeMigrationService.
 				if err := initVolumeMigrationService(ctx, c); err != nil {
-					// Error is already wrapped in CSI error code
+					// Error is already wrapped in CSI error code.
 					return nil, err
 				}
 				req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, &migration.VolumeSpec{VolumePath: volumePath, StoragePolicyName: storagePolicyName})
@@ -861,8 +871,8 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	return resp, err
 }
 
-// ControllerUnpublishVolume detaches a volume from the Node VM.
-// volume id and node name is retrieved from ControllerUnpublishVolumeRequest
+// ControllerUnpublishVolume detaches a volume from the Node VM. Volume id and
+// node name is retrieved from ControllerUnpublishVolumeRequest.
 func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (
 	*csi.ControllerUnpublishVolumeResponse, error) {
 	start := time.Now()
@@ -880,7 +890,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			return nil, status.Errorf(codes.Internal, msg)
 		}
 		if !strings.Contains(req.VolumeId, ".vmdk") {
-			// check if volume is block or file, skip detach for file volume
+			// Check if volume is block or file, skip detach for file volume.
 			queryFilter := cnstypes.CnsQueryFilter{
 				VolumeIds: []cnstypes.CnsVolumeId{{Id: req.VolumeId}},
 			}
@@ -908,25 +918,29 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 				return &csi.ControllerUnpublishVolumeResponse{}, nil
 			}
 		} else {
-			// in-tree volume support
+			// In-tree volume support.
 			volumeType = prometheus.PrometheusBlockVolumeType
 			if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
-				// Migration feature switch is disabled
+				// Migration feature switch is disabled.
 				msg := fmt.Sprintf("volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", req.VolumeId)
 				log.Error(msg)
 				return nil, status.Errorf(codes.Internal, msg)
 			}
-			// Migration feature switch is enabled
-			// ControllerUnpublishVolume will never be the first call back for vmdk registration with CNS.
-			// Here in the migration.VolumeSpec, we do not supply SPBM Policy name.
-			// Node drain is the pre-requisite for volume migration, so volume will be registered with SPBM policy
-			// during ControllerPublish if metadata-syncer fails to register volume using associated SPBM Policy.
-			// for ControllerUnpublishVolume we anticipate volume is already registered with CNS, and volumeMigrationService
-			// should return volumeID for requested VolumePath
+			// Migration feature switch is enabled.
+			//
+			// ControllerUnpublishVolume will never be the first call back for vmdk
+			// registration with CNS. Here in the migration.VolumeSpec, we do not
+			// supply SPBM Policy name. Node drain is the pre-requisite for volume
+			// migration, so volume will be registered with SPBM policy during
+			// ControllerPublish if metadata-syncer fails to register volume using
+			// associated SPBM Policy. For ControllerUnpublishVolume, we anticipate
+			// volume is already registered with CNS, and volumeMigrationService
+			// should return volumeID for requested VolumePath.
 			volumePath := req.VolumeId
-			// In case if feature state switch is enabled after controller is deployed, we need to initialize the volumeMigrationService
+			// In case if feature state switch is enabled after controller is
+			// deployed, we need to initialize the volumeMigrationService.
 			if err := initVolumeMigrationService(ctx, c); err != nil {
-				// Error is already wrapped in CSI error code
+				// Error is already wrapped in CSI error code.
 				return nil, err
 			}
 			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, &migration.VolumeSpec{VolumePath: volumePath})
@@ -936,7 +950,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 				return nil, status.Errorf(codes.Internal, msg)
 			}
 		}
-		// Block Volume
+		// Block Volume.
 		volumeType = prometheus.PrometheusBlockVolumeType
 		node, err := c.nodeMgr.GetNodeByName(ctx, req.NodeId)
 		if err != nil {
@@ -965,7 +979,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 }
 
 // ControllerExpandVolume expands a volume.
-// volume id and size is retrieved from ControllerExpandVolumeRequest
+// Volume id and size is retrieved from ControllerExpandVolumeRequest.
 func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (
 	*csi.ControllerExpandVolumeResponse, error) {
 	ctx = logger.NewContextWithLogger(ctx)
@@ -1014,13 +1028,14 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		return nil, status.Errorf(codes.Internal, msg)
 	}
 
-	// Always set nodeExpansionRequired to true, even if requested size is equal to current size.
-	// Volume expansion may succeed on CNS but external-resizer may fail to update API server.
-	// Requests are requeued in this case. Setting nodeExpandsionRequired to false marks PVC
-	// resize as finished which prevents kubelet from expanding the filesystem.
+	// Always set nodeExpansionRequired to true, even if requested size is equal
+	// to current size. Volume expansion may succeed on CNS but external-resizer
+	// may fail to update API server. Requests are requeued in this case. Setting
+	// nodeExpandsionRequired to false marks PVC resize as finished which
+	// prevents kubelet from expanding the filesystem.
 	// Ref: https://github.com/kubernetes-csi/external-resizer/blob/master/pkg/controller/controller.go#L335
 	nodeExpansionRequired := true
-	// Node expansion is not required for raw block volumes
+	// Node expansion is not required for raw block volumes.
 	if _, ok := req.GetVolumeCapability().GetAccessType().(*csi.VolumeCapability_Block); ok {
 		nodeExpansionRequired = false
 	}
@@ -1063,14 +1078,16 @@ func (c *controller) GetCapacity(ctx context.Context, req *csi.GetCapacityReques
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// initVolumeMigrationService is a helper method to initialize volumeMigrationService in controller
+// initVolumeMigrationService is a helper method to initialize
+// volumeMigrationService in controller.
 func initVolumeMigrationService(ctx context.Context, c *controller) error {
 	log := logger.GetLogger(ctx)
-	// This check is to prevent unnecessary RLocks on the volumeMigration instance
+	// This check prevents unnecessary RLocks on the volumeMigration instance.
 	if volumeMigrationService != nil {
 		return nil
 	}
-	// In case if feature state switch is enabled after controller is deployed, we need to initialize the volumeMigrationService
+	// In case if feature state switch is enabled after controller is deployed,
+	// we need to initialize the volumeMigrationService.
 	var err error
 	volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &c.manager.VolumeManager, c.manager.CnsConfig, false)
 	if err != nil {


### PR DESCRIPTION
Simple cleanups for controller.go.

We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

** Testing Done: **
csi-block-vanilla: two irrelevant known failures.

14:12:34  [Fail] [csi-block-vanilla] full-sync-test [It] Verify Multiple PVCs are deleted/updated after full sync 
14:12:34  [Fail] [csi-block-vanilla] full-sync-test [It] Verify PVC metadata is deleted in CNS after PVC is deleted in k8s 
14:12:34  Ran 43 of 179 Specs in 11672.476 seconds
14:12:34  FAIL! -- 41 Passed | 2 Failed | 0 Pending | 136 Skipped