### PR TITLE
remove CPI installation requirement for topology feature

### DIFF
--- a/docs/book/driver-deployment/installation.md
+++ b/docs/book/driver-deployment/installation.md
@@ -47,6 +47,8 @@ Create a configuration file that will contain details to connect to vSphere.
 
 The default file to write these configuration details is the `csi-vsphere.conf` file. If you would like to use a file with another name, change the environment variable `VSPHERE_CSI_CONFIG` in the deployment YAMLs described in the section [Install vSphere CSI driver](#install) below.
 
+For deployment with zones refer to https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/deploying_csi_with_zones.html
+
 ### vSphere configuration file for block volumes <a id="vsphereconf_for_block"></a>
 
 Here is an example vSphere configuration file for block volumes, with dummy values:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is removing CPI installation requirement for the topology feature. CSI is sufficient to apply required topology node labels without CPI.

**Special notes for your reviewer**:
We have verified CSI driver without adding zone/region labels in the CPI config-map.
cc: @shalini-b 

Doc Preview link - https://deploy-preview-886--kubernetes-sigs-vsphere-csi-driver.netlify.app/driver-deployment/deploying_csi_with_zones.html#enable_zones_for_vsphere_csi

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
remove CPI installation requirement for topology feature
```
