### PR TITLE
Add a "Testing done" section in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,13 @@
 
 **Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
 
+**Testing done**:
+A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
+The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
+For new features, new tests should be done, in addition to regression tests.
+If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
+The review cycle will start, only after "[WIP]" is removed from the PR subject.
+
 **Special notes for your reviewer**:
 
 **Release note**:


### PR DESCRIPTION
Add a "Testing Done" section in PR template.

The principle is we do not start the review cycle, until testing is done. Therefore, we guarantee that every PR has a good quality early in the stage. If testing is not done, the PR is "work in progress".

** Testing done **:
No test is required for a document change. We will see the effect for new pull requests, after this PR is merged.