### PR TITLE
Doc updates

### DIFF
--- a/docs/book/compatiblity_matrix.md
+++ b/docs/book/compatiblity_matrix.md
@@ -21,6 +21,7 @@ Note:
   - Features added in the newer vSphere releases does not work on the older vSphere CSI driver. Refer to [feature matrix](supported_features_matrix.md) to learn about what features added in each release of vSphere and CSI driver.
 
 - vSphere CSI driver is not supported on Windows based vCenter.
+- vSphere CSI driver does not support Windows based nodes.
 - vSphere CSI driver is not supported on vSAN stretch cluster.
 - vSphere CSI driver does not support provisioning volumes on NFSv4 Datastore.
 - vSphere CSI driver does not currently support vCenter HA.

--- a/docs/book/driver-deployment/prerequisites.md
+++ b/docs/book/driver-deployment/prerequisites.md
@@ -71,6 +71,8 @@ Considering the above inventory, roles should be assigned as specified below:
 | CNS-VM | ![CNS-VM-USAGE](https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/docs/images/CNS-VM-USAGE.png)|
 | CNS-SEARCH-AND-SPBM | ![CNS-SEARCH-AND-SPBM-USAGE](https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/docs/images/CNS-SEARCH-AND-SPBM-USAGE.png)|
 
+**Note: When the new entity (Node VM, Datastore) is added in the vCenter inventory for the Kubernetes cluster, roles need to be applied to them.**
+
 ## Setting up the management network <a id="setup_management_network"></a>
 
 By default, CPI and CSI Pods are scheduled on k8s master nodes. In this case, for non-topology aware Kubernetes clusters, it is sufficient to provide the k8s master node(s) credentials to the vCenter that this cluster runs on.

--- a/docs/book/overview.md
+++ b/docs/book/overview.md
@@ -14,12 +14,13 @@ The vSphere CSI driver includes the following components:
 ### vSphere CSI Controller<a id="vsphere_csi_controller"></a>
 
 The vSphere Container Storage Interface (CSI) Controller provides a CSI interface used by Container Orchestrators to manage the lifecycle of vSphere volumes.
-
-The vSphere CSI Controller is responsible for volume provisioning, attaching and detaching the volume to VMs, mounting, formatting and unmounting volumes from the pod within the node VM, and so on.
+The vSphere CSI Controller is responsible for creating, expanding and deleting volumes, attaching and detaching the volumes to Node VMs.
 
 ### vSphere CSI Node<a id="vsphere_csi_node"></a>
 
-The vSphere CSI Node is responsible for formatting, mounting the volumes to nodes, and using bind mounts for the volumes inside the pod. The vSphere CSI Node runs as a deamonset inside the cluster.
+The vSphere CSI Node is responsible for formatting, mounting the volumes to nodes, and using bind mounts for the volumes inside the pod.
+Before volume needs to be detached, CSI Node is helping to unmount volume from the node.
+The vSphere CSI Node runs as a daemonset inside the cluster.
 
 ### Syncer<a id="syncer"></a>
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Updating what CSI controller is responsible for.
- Adding a note that vSphere CSI driver is not supported on Windows nodes.


**Special notes for your reviewer**:

Preview pages
- https://deploy-preview-888--kubernetes-sigs-vsphere-csi-driver.netlify.app/compatiblity_matrix.html
- https://deploy-preview-888--kubernetes-sigs-vsphere-csi-driver.netlify.app/overview.html
- https://deploy-preview-888--kubernetes-sigs-vsphere-csi-driver.netlify.app/driver-deployment/prerequisites.html#roles_and_privileges

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Doc updates
```
