### PR TITLE
Clean up server.go

### DIFF
--- a/pkg/csi/service/server.go
+++ b/pkg/csi/service/server.go
@@ -38,14 +38,13 @@ var (
 
 // NonBlockingGRPCServer defines non-blocking GRPC server interfaces.
 type NonBlockingGRPCServer interface {
-	// Start services at the endpoint
+	// Start services at the endpoint.
 	Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer)
 
-	// Stop stops the gRPC server. It immediately closes all open
-	// connections and listeners.
-	// It cancels all active RPCs on the server side and the corresponding
-	// pending RPCs on the client side will get notified by connection
-	// errors.
+	// Stop stops the gRPC server. It immediately closes all open connections
+	// and listeners. It cancels all active RPCs on the server side and the
+	// corresponding pending RPCs on the client side will get notified by
+	// connection errors.
 	Stop()
 
 	// GracefulStop stops the gRPC server gracefully. It stops the server
@@ -64,7 +63,8 @@ type nonBlockingGRPCServer struct {
 	server *grpc.Server
 }
 
-func (s *nonBlockingGRPCServer) Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer) {
+func (s *nonBlockingGRPCServer) Start(endpoint string, ids csi.IdentityServer,
+	cs csi.ControllerServer, ns csi.NodeServer) {
 	log := logger.GetLoggerWithNoContext()
 	if err := s.serve(endpoint, ids, cs, ns); err != nil {
 		log.Errorf("failed to start grpc server. Err: %v", err)
@@ -91,7 +91,8 @@ func (s *nonBlockingGRPCServer) Stop() {
 	})
 }
 
-func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer) error {
+func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer,
+	cs csi.ControllerServer, ns csi.NodeServer) error {
 	log := logger.GetLoggerWithNoContext()
 	u, err := url.Parse(endpoint)
 	if err != nil {
@@ -109,7 +110,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 
 	addr := u.Path
 
-	// remove UNIX sock file if present.
+	// Remove UNIX sock file if present.
 	if err := os.Remove(addr); err != nil && !os.IsNotExist(err) {
 		msg := fmt.Sprintf("failed to remove %s. Err: %v", addr, err)
 		log.Error(msg)
@@ -140,7 +141,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 	csi.RegisterIdentityServer(s.server, ids)
 	log.Info("identity service registered")
 
-	// Determine which of the controller/node services to register
+	// Determine which of the controller/node services to register.
 	mode := os.Getenv(csitypes.EnvVarMode)
 	if strings.EqualFold(mode, "controller") {
 		if cs == nil {
@@ -155,7 +156,8 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 		csi.RegisterNodeServer(s.server, ns)
 		log.Info("node service registered")
 	} else {
-		msg := fmt.Sprintf("invalid value %q specified for %s. Expected values are 'node' or 'controller'", mode, csitypes.EnvVarMode)
+		msg := fmt.Sprintf("invalid value %q specified for %s, expecting 'node' or 'controller'",
+			mode, csitypes.EnvVarMode)
 		log.Error(msg)
 		return fmt.Errorf(msg)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. This change handles the
long lines in nodes.go. (In C/C++, I typically limit the line within 80 characters, for a reference.)
To wrap a long line, we need to pay attention to Golang's special grammar that it automatically
inserts a semicolon immediately after a line's final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }
Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles server.go.

**Testing done**:
Local build and check, which should be sufficient for cosmetic changes.