### PR TITLE
Modify Volume Manager to handle idempotency

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -88,10 +88,21 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		log.Errorf("failed to register VC with virtualCenterManager. err=%v", err)
 		return err
 	}
+	var operationStore cnsvolumeoperationrequest.VolumeOperationRequest
+	idempotencyHandlingEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.CSIVolumeManagerIdempotency)
+	if idempotencyHandlingEnabled {
+		log.Info("CSI Volume manager idempotency handling feature flag is enabled.")
+		operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx)
+		if err != nil {
+			log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
+			return err
+		}
+	}
 	c.manager = &common.Manager{
 		VcenterConfig:  vcenterconfig,
 		CnsConfig:      config,
-		VolumeManager:  cnsvolume.GetManager(ctx, vcenter),
+		VolumeManager:  cnsvolume.GetManager(ctx, vcenter, operationStore, idempotencyHandlingEnabled),
 		VcenterManager: vcManager,
 	}
 
@@ -214,15 +225,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			return err
 		}
 	}
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency) {
-		log.Infof("CSI Volume manager idempotency handling feature flag is enabled.")
-		// TODO: Assign VolumeOperationRequest object to a variable.
-		_, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx)
-		if err != nil {
-			log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
-			return err
-		}
-	}
+
 	// Go module to keep the metrics http server running all the time.
 	go func() {
 		prometheus.CsiInfo.WithLabelValues(version).Set(1)
@@ -289,9 +292,20 @@ func (c *controller) ReloadConfiguration() error {
 			}
 			vcenter.Config = newVCConfig
 		}
+		var operationStore cnsvolumeoperationrequest.VolumeOperationRequest
+		idempotencyHandlingEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+			common.CSIVolumeManagerIdempotency)
+		if idempotencyHandlingEnabled {
+			log.Info("CSI Volume manager idempotency handling feature flag is enabled.")
+			operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx)
+			if err != nil {
+				log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
+				return err
+			}
+		}
 		c.manager.VolumeManager.ResetManager(ctx, vcenter)
 		c.manager.VcenterConfig = newVCConfig
-		c.manager.VolumeManager = cnsvolume.GetManager(ctx, vcenter)
+		c.manager.VolumeManager = cnsvolume.GetManager(ctx, vcenter, operationStore, idempotencyHandlingEnabled)
 		// Re-Initialize Node Manager to cache latest vCenter config.
 		c.nodeMgr = &Nodes{}
 		err = c.nodeMgr.Initialize(ctx)

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -281,7 +281,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 		manager := &common.Manager{
 			VcenterConfig:  vcenterconfig,
 			CnsConfig:      config,
-			VolumeManager:  cnsvolume.GetManager(ctx, vcenter),
+			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, nil, false),
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 

--- a/pkg/csi/service/vanilla/nodes.go
+++ b/pkg/csi/service/vanilla/nodes.go
@@ -20,15 +20,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/vmware/govmomi/vapi/tags"
+	v1 "k8s.io/api/core/v1"
 
 	cnsnode "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/node"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
-
-	"github.com/container-storage-interface/spec/lib/go/csi"
-	v1 "k8s.io/api/core/v1"
 )
 
 // Nodes comprises cns node manager and kubernetes informer.

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -153,7 +153,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 		manager := &common.Manager{
 			VcenterConfig:  vcenterconfig,
 			CnsConfig:      config,
-			VolumeManager:  cnsvolume.GetManager(ctx, vcenter),
+			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, nil, false),
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 

--- a/pkg/internalapis/cnsvolumeoperationrequest/util.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/util.go
@@ -18,6 +18,7 @@ package cnsvolumeoperationrequest
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	cnsvolumeoperationrequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
 )
 
@@ -31,6 +32,12 @@ const (
 	// maxEntriesInLatestOperationDetails specifies the maximum length of
 	// the LatestOperationDetails allowed in a cnsvolumeoperationrequest instance
 	maxEntriesInLatestOperationDetails = 10
+	// TaskInvocationStatusInProgress represents a task thats status is InProgress.
+	TaskInvocationStatusInProgress = "InProgress"
+	// TaskInvocationStatusError represents a task thats status is Error.
+	TaskInvocationStatusError = "Error"
+	// TaskInvocationStatusSuccess represents a task thats status is Success.
+	TaskInvocationStatusSuccess = "Success"
 )
 
 // VolumeOperationRequestDetails stores details about a single operation

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -26,12 +26,12 @@ import (
 	"github.com/fsnotify/fsnotify"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator"
 	cnsnodevmattachmentv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
@@ -41,7 +41,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
-	internalapis "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis"
 	triggercsifullsyncv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/cnsoperator/controller"
@@ -72,7 +72,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 		if err != nil {
 			return err
 		}
-		volumeManager = volumes.GetManager(ctx, vCenter)
+		volumeManager = volumes.GetManager(ctx, vCenter, nil, false)
 	}
 
 	// Get a config to talk to the apiserver

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -32,29 +32,27 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
-
-	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/featurestates"
-
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
 	volumes "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco/k8sorchestrator"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 	triggercsifullsyncv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/featurestates"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/storagepool"
 )
@@ -168,7 +166,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			return err
 		}
 		metadataSyncer.host = vCenter.Config.Host
-		metadataSyncer.volumeManager = volumes.GetManager(ctx, vCenter)
+		metadataSyncer.volumeManager = volumes.GetManager(ctx, vCenter, nil, false)
 	}
 
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
@@ -524,7 +522,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 				vcenter.Config = newVCConfig
 			}
 			metadataSyncer.volumeManager.ResetManager(ctx, vcenter)
-			metadataSyncer.volumeManager = volumes.GetManager(ctx, vcenter)
+			metadataSyncer.volumeManager = volumes.GetManager(ctx, vcenter, nil, false)
 			if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 				storagepool.ResetVC(ctx, vcenter)
 			}

--- a/pkg/syncer/storagepool/diskDecommissionController.go
+++ b/pkg/syncer/storagepool/diskDecommissionController.go
@@ -93,7 +93,8 @@ func (w *DiskDecommController) detachVolumes(ctx context.Context, storagePoolNam
 			}),
 		VirtualCenterHost: vc.Config.Host,
 	}
-	volManager := volume.GetManager(ctx, &vc)
+
+	volManager := volume.GetManager(ctx, &vc, nil, false)
 
 	volumes, _, err := k8scloudoperator.GetVolumesOnStoragePool(ctx, k8sClient, storagePoolName)
 	if err != nil {

--- a/pkg/syncer/storagepool/migrationController.go
+++ b/pkg/syncer/storagepool/migrationController.go
@@ -71,7 +71,7 @@ func (m *migrationController) relocateCNSVolume(ctx context.Context, volumeID st
 		return fmt.Errorf("failed to get datastore corressponding to URL %v", datastoreURL)
 	}
 
-	volManager := volume.GetManager(ctx, m.vc)
+	volManager := volume.GetManager(ctx, m.vc, nil, false)
 	relocateSpec := cnstypes.NewCnsBlockVolumeRelocateSpec(volumeID, dsInfo.Reference())
 
 	task, err := volManager.RelocateVolume(ctx, relocateSpec)

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -190,14 +190,14 @@ func TestSyncerWorkflows(t *testing.T) {
 		}
 	}()
 
-	volumeManager = cnsvolumes.GetManager(ctx, virtualCenter)
+	volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false)
 
 	// Initialize metadata syncer object
 	metadataSyncer = &metadataSyncInformer{}
 	configInfo := &cnsconfig.ConfigurationInfo{}
 	configInfo.Cfg = csiConfig
 	metadataSyncer.configInfo = configInfo
-	metadataSyncer.volumeManager = cnsvolumes.GetManager(ctx, virtualCenter)
+	metadataSyncer.volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false)
 	metadataSyncer.host = virtualCenter.Config.Host
 
 	// Create the kubernetes client from config or env


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR modifies the CSI Volume manager for future PR's that will utilize the idempotency feature. This PR doesnt add any functionality but was created to reduce the scope of the changes.

This PR does the following: 
1. Introduce `operationStore` variable in the `defaultManager` structure. This variable will be used to load and store task details using `VolumeOperationRequest` interface. 
2. Introduce `isIdempotencyHandlingEnabled` variable in the `defaultManager` structure. Volume Manager cannot import the K8sOrchestrator package because that creates a cyclic dependancy. This variable will serve as the FSS for volumemanager.
3. Remove `ResetManager` as a function of the `Manager` interface. Like `GetManager`, `ResetManager` initializes the `vcenter` and `operationStore` objects and does not need to be part of the interface. 
4. Only initialize `operaitonStore` and `isIdempotencyEnabled` in callers of `GetManager` if idempotency fss is enabled. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Since this PR doesnt make any functional changes, pipelines will be run in the follow up PR (https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/898).
Verified that CSI pods are running and basic PVC/Pod creation succeeds and volume metadata updates succeed:

```
# kubectl get pod -n vmware-system-csi
NAME                                      READY   STATUS             RESTARTS   AGE
vsphere-csi-controller-6855db7bcc-z2b57   6/6     Running            0          3m10s
vsphere-csi-node-bjn48                    3/3     Running            9          9d
vsphere-csi-node-fqgg5                    3/3     Running            15         9d

# kubectl get pvc,pod
NAME                                                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS               AGE
persistentvolumeclaim/example-vanilla-block-pvc-2   Bound    pvc-cb841639-49d8-48a5-ae69-c4044c65f616   1Mi        RWO            example-vanilla-block-sc   2m34s

NAME                                     READY   STATUS    RESTARTS   AGE
pod/example-vanilla-block-pod            1/1     Running   0          2m9s

# kubectl label pvc example-vanilla-block-pvc-2 a=b
persistentvolumeclaim/example-vanilla-block-pvc-2 labeled
```
<img width="1125" alt="Screen Shot 2021-05-21 at 1 15 50 PM" src="https://user-images.githubusercontent.com/5894281/119193630-be619a80-ba36-11eb-8b58-1626b0030e0e.png">

**Special notes for your reviewer**:
This change also uses `golines` (https://github.com/segmentio/golines) to shorten the lines and comments. Thanks to @SandeepPissay for finding this tool!

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Introduce operationStore variable in volume manager for idempotency handling
```
