### PR TITLE
Create volume implementation with idempotency handling

### DIFF
--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest"
 )
 
 // FakeK8SOrchestrator is used to mock common K8S Orchestrator instance to store FSS values
@@ -52,4 +53,10 @@ type MockVolumeMigrationService interface {
 
 	// DeleteVolumeInfo helps delete mapping of volumePath to VolumeID for specified volumeID
 	DeleteVolumeInfo(ctx context.Context, volumeID string) error
+}
+
+// fakeVolumeOperationRequestInterface implements the VolumeOperationRequest
+// interface by storing the operation details in an in-memory map.
+type fakeVolumeOperationRequestInterface struct {
+	volumeOperationRequestMap map[string]*cnsvolumeoperationrequest.VolumeOperationRequestDetails
 }

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -24,12 +24,16 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
+
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest"
+	cnsvolumeoperationrequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
 )
 
 var mapVolumePathToID map[string]map[string]string
@@ -66,7 +70,11 @@ func (c *FakeK8SOrchestrator) IsFSSEnabled(ctx context.Context, featureName stri
 }
 
 // IsFakeAttachAllowed checks if the passed volume can be fake attached and mark it as fake attached.
-func (c *FakeK8SOrchestrator) IsFakeAttachAllowed(ctx context.Context, volumeID string, volumeManager cnsvolume.Manager) (bool, error) {
+func (c *FakeK8SOrchestrator) IsFakeAttachAllowed(
+	ctx context.Context,
+	volumeID string,
+	volumeManager cnsvolume.Manager,
+) (bool, error) {
 	// TODO - This can be implemented if we add WCP controller tests for attach volume
 	log := logger.GetLogger(ctx)
 	msg := "IsFakeAttachAllowed for FakeK8SOrchestrator is not yet implemented."
@@ -93,7 +101,11 @@ func (c *FakeK8SOrchestrator) ClearFakeAttached(ctx context.Context, volumeID st
 }
 
 // GetFakeVolumeMigrationService returns the mocked VolumeMigrationService
-func GetFakeVolumeMigrationService(ctx context.Context, volumeManager *cnsvolume.Manager, cnsConfig *cnsconfig.Config) (MockVolumeMigrationService, error) {
+func GetFakeVolumeMigrationService(
+	ctx context.Context,
+	volumeManager *cnsvolume.Manager,
+	cnsConfig *cnsconfig.Config,
+) (MockVolumeMigrationService, error) {
 	// fakeVolumeMigrationInstance is a mocked instance of volumeMigration
 	fakeVolumeMigrationInstance := &mockVolumeMigration{
 		volumePathToVolumeID: sync.Map{},
@@ -112,7 +124,10 @@ func GetFakeVolumeMigrationService(ctx context.Context, volumeManager *cnsvolume
 }
 
 // GetVolumeID mocks the method with returns Volume Id for a given Volume Path
-func (dummyInstance *mockVolumeMigration) GetVolumeID(ctx context.Context, volumeSpec *migration.VolumeSpec) (string, error) {
+func (dummyInstance *mockVolumeMigration) GetVolumeID(
+	ctx context.Context,
+	volumeSpec *migration.VolumeSpec,
+) (string, error) {
 	return mapVolumePathToID["dummy-vms-CR"][volumeSpec.VolumePath], nil
 }
 
@@ -124,5 +139,37 @@ func (dummyInstance *mockVolumeMigration) GetVolumePath(ctx context.Context, vol
 // DeleteVolumeInfo mocks the method to delete mapping of volumePath to VolumeID for specified volumeID
 func (dummyInstance *mockVolumeMigration) DeleteVolumeInfo(ctx context.Context, volumeID string) error {
 	delete(mapVolumePathToID, "dummy-vms-CR")
+	return nil
+}
+
+// InitFakeVolumeOperationRequestInterface returns a fake implementation
+// of the VolumeOperationRequest interface.
+func InitFakeVolumeOperationRequestInterface() (cnsvolumeoperationrequest.VolumeOperationRequest, error) {
+	return &fakeVolumeOperationRequestInterface{
+		volumeOperationRequestMap: make(map[string]*cnsvolumeoperationrequest.VolumeOperationRequestDetails),
+	}, nil
+}
+
+// GetRequestDetails returns the VolumeOperationRequestDetails for the given
+// name, if any, stored by the fake VolumeOperationRequest interface.
+func (f *fakeVolumeOperationRequestInterface) GetRequestDetails(
+	ctx context.Context,
+	name string,
+) (*cnsvolumeoperationrequest.VolumeOperationRequestDetails, error) {
+	instance, ok := f.volumeOperationRequestMap[name]
+	if !ok {
+		return nil, apierrors.NewNotFound(cnsvolumeoperationrequestv1alpha1.Resource(
+			"cnsvolumeoperationrequests"), name)
+	}
+	return instance, nil
+
+}
+
+// StoreRequestDetails stores the input fake VolumeOperationRequestDetails.
+func (f *fakeVolumeOperationRequestInterface) StoreRequestDetails(
+	ctx context.Context,
+	instance *cnsvolumeoperationrequest.VolumeOperationRequestDetails,
+) error {
+	f.volumeOperationRequestMap[instance.Name] = instance
 	return nil
 }

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -277,11 +277,15 @@ func getControllerTest(t *testing.T) *controllerTest {
 		if err != nil {
 			t.Fatal(err)
 		}
+		fakeOpStore, err := unittestcommon.InitFakeVolumeOperationRequestInterface()
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		manager := &common.Manager{
 			VcenterConfig:  vcenterconfig,
 			CnsConfig:      config,
-			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, nil, false),
+			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true),
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -38,9 +38,11 @@ import (
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/unittestcommon"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 )
 
@@ -150,10 +152,15 @@ func getControllerTest(t *testing.T) *controllerTest {
 			t.Fatal(err)
 		}
 
+		fakeOpStore, err := unittestcommon.InitFakeVolumeOperationRequestInterface()
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		manager := &common.Manager{
 			VcenterConfig:  vcenterconfig,
 			CnsConfig:      config,
-			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, nil, false),
+			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true),
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR introduces changes to CreateVolume implementation to handle idempotency by using the `CnsVolumeOperationRequest` CRD. 
Also includes changes to unit/integration tests to utilize a fake VolumeOperationRequest interface.

If the feature is not enabled during CSI startup, CreateVolume falls back to in-memory map mechanism to handle idempotency. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual tests (with Idempotency FSS enabled):
https://gist.github.com/RaunakShah/f6aa7ddc215e9686699ac37535f19694

E2E regression tests (without idempotency FSS enabled):

1. Block vanilla precheckin pipeline (job number 8):
>  Summarizing 3 Failures:
21:02:57  
21:02:57  [Fail] Basic Static Provisioning [BeforeEach] [csi-block-vanilla] Verify basic static provisioning workflow 
21:02:57  /home/worker/workspace/csi-block-vanilla-pre-check-in/8/vsphere-csi-driver/tests/e2e/e2e_common.go:170
21:02:57  
21:02:57  [Fail] [csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy [It] Verify dynamic provisioning of PV fails with user specified non-shared datastore and no storage policy specified in the storage class 
21:02:57  /home/worker/workspace/csi-block-vanilla-pre-check-in/8/vsphere-csi-driver/tests/e2e/e2e_common.go:170
21:02:57  
21:02:57  [Fail] [csi-block-vanilla] Relocate detached volume  [BeforeEach] Verify relocating detached volume works fine 
21:02:57  /home/worker/workspace/csi-block-vanilla-pre-check-in/8/vsphere-csi-driver/tests/e2e/e2e_common.go:170
21:02:57  
21:02:57  Ran 43 of 187 Specs in 9782.300 seconds
21:02:57  FAIL! -- 40 Passed | 3 Failed | 0 Pending | 144 Skipped
21:02:57  --- FAIL: TestE2E (9782.37s)
21:02:57  FAIL

3 failures due to ENV variable not being set by the pipeline:
```
19:22:50    ENV NONSHARED_VSPHERE_DATASTORE_URL is not set
19:22:50    Expected
19:22:50        <string>: 
19:22:50    not to be empty
```

2. File vanilla precheckin pipeline (job number 7):
> 02:57:18  Ran 24 of 187 Specs in 5948.636 seconds
02:57:18  FAIL! -- 22 Passed | 2 Failed | 0 Pending | 163 Skipped
02:57:18  --- FAIL: TestE2E (5948.71s)
02:57:18  FAIL

Issues unrelated to the change. Will file bugs for the same. 

3. WCP precheckin pipeline (job number 9):
> Ran 14 of 187 Specs in 3343.493 seconds
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 173 Skipped
PASS




**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Create volume implementation with idempotency handling
```
