### PR TITLE
Clean up manager.go

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -39,15 +39,16 @@ import (
 )
 
 const (
-	// defaultTaskCleanupIntervalInMinutes is default interval for cleaning up expired create volume tasks
-	// TODO: This timeout will be configurable in future releases
+	// defaultTaskCleanupIntervalInMinutes is default interval for cleaning up
+	// expired create volume tasks.
+	// TODO: This timeout will be configurable in future releases.
 	defaultTaskCleanupIntervalInMinutes = 1
 
-	// defaultOpsExpirationTimeInHours is expiration time for create volume operations
+	// defaultOpsExpirationTimeInHours is expiration time for create volume operations.
 	// TODO: This timeout will be configurable in future releases
 	defaultOpsExpirationTimeInHours = 1
 
-	// maxLengthOfVolumeNameInCNS is the maximum length of CNS volume name
+	// maxLengthOfVolumeNameInCNS is the maximum length of CNS volume name.
 	maxLengthOfVolumeNameInCNS = 80
 )
 
@@ -63,31 +64,36 @@ type Manager interface {
 	DeleteVolume(ctx context.Context, volumeID string, deleteDisk bool) error
 	// UpdateVolumeMetadata updates a volume metadata given its spec.
 	UpdateVolumeMetadata(ctx context.Context, spec *cnstypes.CnsVolumeMetadataUpdateSpec) error
-	// QueryVolumeInfo calls the CNS QueryVolumeInfo API and return a task, from which CnsQueryVolumeInfoResult is extracted
+	// QueryVolumeInfo calls the CNS QueryVolumeInfo API and return a task, from
+	// which CnsQueryVolumeInfoResult is extracted.
 	QueryVolumeInfo(ctx context.Context, volumeIDList []cnstypes.CnsVolumeId) (*cnstypes.CnsQueryVolumeInfoResult, error)
 	// QueryAllVolume returns all volumes matching the given filter and selection.
-	QueryAllVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter, querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error)
-	// QueryVolumeAsync returns CnsQueryResult matching the given filter by using CnsQueryAsync API. QueryVolumeAsync takes querySelection spec
-	// which helps to specify which fields have to be returned for the query entities. All volume fields would be returned as part of the CnsQueryResult
-	// if the querySelection parameters are not specified
-	QueryVolumeAsync(ctx context.Context, queryFilter cnstypes.CnsQueryFilter, querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error)
+	QueryAllVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
+		querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error)
+	// QueryVolumeAsync returns CnsQueryResult matching the given filter by using
+	// CnsQueryAsync API. QueryVolumeAsync takes querySelection spec, which helps
+	// to specify which fields have to be returned for the query entities. All
+	// volume fields would be returned as part of the CnsQueryResult, if the
+	// querySelection parameters are not specified.
+	QueryVolumeAsync(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
+		querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error)
 	// QueryVolume returns volumes matching the given filter.
 	QueryVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error)
-	// RelocateVolume migrates volumes to their target datastore as specified in relocateSpecList
+	// RelocateVolume migrates volumes to their target datastore as specified in relocateSpecList.
 	RelocateVolume(ctx context.Context, relocateSpecList ...cnstypes.BaseCnsVolumeRelocateSpec) (*object.Task, error)
 	// ExpandVolume expands a volume to a new size.
 	ExpandVolume(ctx context.Context, volumeID string, size int64) error
-	// ResetManager helps set new manager instance and VC configuration
+	// ResetManager helps set new manager instance and VC configuration.
 	ResetManager(ctx context.Context, vcenter *cnsvsphere.VirtualCenter)
-	// ConfigureVolumeACLs configures net permissions for a given CnsVolumeACLConfigureSpec
+	// ConfigureVolumeACLs configures net permissions for a given CnsVolumeACLConfigureSpec.
 	ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error
-	// RegisterDisk registers virtual disks as First Class disks using Vslm endpoint
+	// RegisterDisk registers virtual disks as FCDs using Vslm endpoint.
 	RegisterDisk(ctx context.Context, path string, name string) (string, error)
-	// RetrieveVStorageObject helps in retreiving virtual disk information for a given volume id
+	// RetrieveVStorageObject helps in retreiving virtual disk information for a given volume id.
 	RetrieveVStorageObject(ctx context.Context, volumeID string) (*vim25types.VStorageObject, error)
 }
 
-// CnsVolumeInfo hold information related to volume created by CNS
+// CnsVolumeInfo hold information related to volume created by CNS.
 type CnsVolumeInfo struct {
 	DatastoreURL string
 	VolumeID     cnstypes.CnsVolumeId
@@ -96,12 +102,13 @@ type CnsVolumeInfo struct {
 var (
 	// managerInstance is a Manager singleton.
 	managerInstance *defaultManager
-	// managerInstanceLock is used for mitigating race condition during read/write on manager instance.
+	// managerInstanceLock is used for mitigating race condition during
+	// read/write on manager instance.
 	managerInstanceLock sync.Mutex
 	volumeTaskMap       = make(map[string]*createVolumeTaskDetails)
 )
 
-// createVolumeTaskDetails contains taskInfo object and expiration time
+// createVolumeTaskDetails contains taskInfo object and expiration time.
 type createVolumeTaskDetails struct {
 	sync.Mutex
 	task           *object.Task
@@ -129,19 +136,24 @@ type defaultManager struct {
 	virtualCenter *cnsvsphere.VirtualCenter
 }
 
-// ClearTaskInfoObjects is a go routine which runs in the background to clean up expired taskInfo objects from volumeTaskMap
+// ClearTaskInfoObjects is a go routine which runs in the background to clean
+// up expired taskInfo objects from volumeTaskMap.
 func ClearTaskInfoObjects() {
 	log := logger.GetLoggerWithNoContext()
-	// At a frequency of every 1 minute, check if there are expired taskInfo objects and delete them from the volumeTaskMap
+	// At a frequency of every 1 minute, check if there are expired taskInfo
+	// objects and delete them from the volumeTaskMap.
 	ticker := time.NewTicker(time.Duration(defaultTaskCleanupIntervalInMinutes) * time.Minute)
 	for range ticker.C {
 		for pvc, taskDetails := range volumeTaskMap {
-			// Get the time difference between current time and the expiration time from the volumeTaskMap
+			// Get the time difference between current time and the expiration
+			// time from the volumeTaskMap.
 			diff := time.Until(taskDetails.expirationTime)
-			// Checking if the expiration time has elapsed
+			// Checking if the expiration time has elapsed.
 			if int(diff.Hours()) < 0 || int(diff.Minutes()) < 0 || int(diff.Seconds()) < 0 {
-				// If one of the parameters in the time object is negative, it means the entry has to be deleted
-				log.Debugf("ClearTaskInfoObjects : Found an expired taskInfo object : %+v for the VolumeName: %q. Deleting the object entry from volumeTaskMap", volumeTaskMap[pvc].task, pvc)
+				// If one of the parameters in the time object is negative, it means
+				// the entry has to be deleted.
+				log.Debugf("Found an expired taskInfo: %+v for volume %q. Deleting it from task map",
+					volumeTaskMap[pvc].task, pvc)
 				taskDetails.Lock()
 				delete(volumeTaskMap, pvc)
 				taskDetails.Unlock()
@@ -150,7 +162,7 @@ func ClearTaskInfoObjects() {
 	}
 }
 
-// ResetManager helps set new manager instance and VC configuration
+// ResetManager helps set new manager instance and VC configuration.
 func (m *defaultManager) ResetManager(ctx context.Context, vcenter *cnsvsphere.VirtualCenter) {
 	log := logger.GetLogger(ctx)
 	managerInstanceLock.Lock()
@@ -177,13 +189,14 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 		if err != nil {
 			return nil, err
 		}
-		// Set up the VC connection
+		// Set up the VC connection.
 		err = m.virtualCenter.ConnectCns(ctx)
 		if err != nil {
 			log.Errorf("ConnectCns failed with err: %+v", err)
 			return nil, err
 		}
-		// If the VSphereUser in the CreateSpec is different from session user, update the CreateSpec
+		// If the VSphereUser in the CreateSpec is different from session user,
+		// update the CreateSpec.
 		s, err := m.virtualCenter.Client.SessionManager.UserSession(ctx)
 		if err != nil {
 			log.Errorf("failed to get usersession with err: %v", err)
@@ -194,23 +207,24 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 			spec.Metadata.ContainerCluster.VSphereUser = s.UserName
 		}
 
-		// Construct the CNS VolumeCreateSpec list
+		// Construct the CNS VolumeCreateSpec list.
 		var cnsCreateSpecList []cnstypes.CnsVolumeCreateSpec
 		var task *object.Task
 		var taskInfo *vim25types.TaskInfo
-		// store the volume name passed in by input spec, this name may exceed 80 characters
+		// Store the volume name passed in by input spec, this name may exceed 80 characters.
 		volNameFromInputSpec := spec.Name
-		// Call the CNS CreateVolume
+		// Call the CNS CreateVolume.
 		taskDetailsInMap, ok := volumeTaskMap[volNameFromInputSpec]
 		if ok {
 			task = taskDetailsInMap.task
-			log.Infof("CreateVolume task still pending for VolumeName: %q, with taskInfo: %+v", volNameFromInputSpec, task)
+			log.Infof("CreateVolume task still pending for Volume: %q, with taskInfo: %+v",
+				volNameFromInputSpec, task)
 		} else {
-			// truncate the volume name to make sure the name is within 80 characters before calling CNS
+			// Truncate the volume name to make sure the name is within 80 characters before calling CNS.
 			if len(spec.Name) > maxLengthOfVolumeNameInCNS {
 				volNameAfterTruncate := spec.Name[0 : maxLengthOfVolumeNameInCNS-1]
 				spec.Name = volNameAfterTruncate
-				log.Infof("Create Volume with name %s is too long, truncate the name to %s", volNameFromInputSpec, spec.Name)
+				log.Infof("Create Volume with name %s is too long, truncate it to %s", volNameFromInputSpec, spec.Name)
 				log.Debugf("CNS Create Volume is called with %v", spew.Sdump(*spec))
 			}
 			cnsCreateSpecList = append(cnsCreateSpecList, *spec)
@@ -233,28 +247,30 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 					isStaticallyProvisionedFileVolume = true
 				}
 			}
-			// Add the task details to volumeTaskMap only for dynamically provisioned volumes.
-			// For static volume provisioning we need not store the taskDetails as it doesn't result in orphaned volumes
+			// Add the task details to volumeTaskMap only for dynamically
+			// provisioned volumes. For static volume provisioning we need not
+			// store the taskDetails as it doesn't result in orphaned volumes.
 			if !isStaticallyProvisionedBlockVolume && !isStaticallyProvisionedFileVolume {
 				var taskDetails createVolumeTaskDetails
-				// Store the task details and task object expiration time in volumeTaskMap
+				// Store task details and expiration time in volumeTaskMap.
 				taskDetails.task = task
 				taskDetails.expirationTime = time.Now().Add(time.Hour * time.Duration(defaultOpsExpirationTimeInHours))
 				volumeTaskMap[volNameFromInputSpec] = &taskDetails
 			}
 		}
-		// Get the taskInfo
+		// Get the taskInfo.
 		taskInfo, err = cns.GetTaskInfo(ctx, task)
 		if err != nil || taskInfo == nil {
-			log.Errorf("failed to get taskInfo for CreateVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			log.Errorf("failed to get taskInfo for CreateVolume task from vCenter %q with err: %v",
+				m.virtualCenter.Config.Host, err)
 			return nil, err
 		}
 		log.Infof("CreateVolume: VolumeName: %q, opId: %q", volNameFromInputSpec, taskInfo.ActivationId)
-		// Get the taskResult
+		// Get the taskResult.
 		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
 
 		if err != nil {
-			log.Errorf("unable to find the task result for CreateVolume task from vCenter %q. taskID: %q, opId: %q createResults: %+v",
+			log.Errorf("failed to get CreateVolume result from vCenter %q, taskID: %q, opId: %q result: %+v",
 				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskInfo.ActivationId, taskResult)
 			return nil, err
 		}
@@ -267,14 +283,16 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 		if volumeOperationRes.Fault != nil {
 			fault, ok := volumeOperationRes.Fault.Fault.(cnstypes.CnsAlreadyRegisteredFault)
 			if ok {
-				log.Infof("CreateVolume: Volume is already registered with CNS. VolumeName: %q, volumeID: %q, opId: %q", spec.Name, fault.VolumeId.Id, taskInfo.ActivationId)
+				log.Infof("Volume is already registered with CNS. VolumeName: %q, volumeID: %q, opId: %q",
+					spec.Name, fault.VolumeId.Id, taskInfo.ActivationId)
 				return &CnsVolumeInfo{
 					DatastoreURL: "",
 					VolumeID:     fault.VolumeId,
 				}, nil
 			}
-			// Remove the taskInfo object associated with the volume name when the current task fails.
-			//  This is needed to ensure the sub-sequent create volume call from the external provisioner invokes Create Volume
+			// Remove the taskInfo object associated with the volume name when the
+			// current task fails. This is needed to ensure the sub-sequent create
+			// volume call from the external provisioner invokes Create Volume.
 			taskDetailsInMap, ok := volumeTaskMap[volNameFromInputSpec]
 			if ok {
 				taskDetailsInMap.Lock()
@@ -282,7 +300,9 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 				delete(volumeTaskMap, volNameFromInputSpec)
 				taskDetailsInMap.Unlock()
 			}
-			msg := fmt.Sprintf("failed to create cns volume %s. createSpec: %q, fault: %q, opId: %q", volNameFromInputSpec, spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			msg := fmt.Sprintf("failed to create cns volume %s. createSpec: %q, fault: %q, opId: %q",
+				volNameFromInputSpec, spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault),
+				taskInfo.ActivationId)
 			log.Error(msg)
 			return nil, errors.New(msg)
 		}
@@ -291,7 +311,7 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 		if volumeCreateResult.PlacementResults != nil {
 			var datastoreMoRef vim25types.ManagedObjectReference
 			for _, placementResult := range volumeCreateResult.PlacementResults {
-				// For the datastore which the volume is provisioned, placementFaults will not be set
+				// For the datastore which the volume is provisioned, placementFaults will not be set.
 				if len(placementResult.PlacementFaults) == 0 {
 					datastoreMoRef = placementResult.Datastore
 					break
@@ -308,8 +328,10 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 			datastoreURL = dsMo.Summary.Url
 		}
 
-		log.Infof("CreateVolume: Volume created successfully. VolumeName: %q, opId: %q, volumeID: %q", volNameFromInputSpec, taskInfo.ActivationId, volumeOperationRes.VolumeId.Id)
-		log.Debugf("CreateVolume volumeId %q is placed on datastore %q", volumeOperationRes.VolumeId.Id, datastoreURL)
+		log.Infof("Volume created successfully. VolumeName: %q, opId: %q, volumeID: %q",
+			volNameFromInputSpec, taskInfo.ActivationId, volumeOperationRes.VolumeId.Id)
+		log.Debugf("CreateVolume volumeId %q is placed on datastore %q",
+			volumeOperationRes.VolumeId.Id, datastoreURL)
 		return &CnsVolumeInfo{
 			DatastoreURL: datastoreURL,
 			VolumeID:     volumeOperationRes.VolumeId,
@@ -329,20 +351,21 @@ func (m *defaultManager) CreateVolume(ctx context.Context, spec *cnstypes.CnsVol
 }
 
 // AttachVolume attaches a volume to a virtual machine given the spec.
-func (m *defaultManager) AttachVolume(ctx context.Context, vm *cnsvsphere.VirtualMachine, volumeID string) (string, error) {
+func (m *defaultManager) AttachVolume(ctx context.Context,
+	vm *cnsvsphere.VirtualMachine, volumeID string) (string, error) {
 	internalAttachVolume := func() (string, error) {
 		log := logger.GetLogger(ctx)
 		err := validateManager(ctx, m)
 		if err != nil {
 			return "", err
 		}
-		// Set up the VC connection
+		// Set up the VC connection.
 		err = m.virtualCenter.ConnectCns(ctx)
 		if err != nil {
 			log.Errorf("ConnectCns failed with err: %+v", err)
 			return "", err
 		}
-		// Construct the CNS AttachSpec list
+		// Construct the CNS AttachSpec list.
 		var cnsAttachSpecList []cnstypes.CnsVolumeAttachDetachSpec
 		cnsAttachSpec := cnstypes.CnsVolumeAttachDetachSpec{
 			VolumeId: cnstypes.CnsVolumeId{
@@ -360,20 +383,22 @@ func (m *defaultManager) AttachVolume(ctx context.Context, vm *cnsvsphere.Virtua
 		// Get the taskInfo
 		taskInfo, err := cns.GetTaskInfo(ctx, task)
 		if err != nil || taskInfo == nil {
-			log.Errorf("failed to get taskInfo for AttachVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			log.Errorf("failed to get taskInfo for AttachVolume task from vCenter %q with err: %v",
+				m.virtualCenter.Config.Host, err)
 			return "", err
 		}
 		log.Infof("AttachVolume: volumeID: %q, vm: %q, opId: %q", volumeID, vm.String(), taskInfo.ActivationId)
 		// Get the taskResult
 		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
 		if err != nil {
-			log.Errorf("unable to find the task result for AttachVolume task from vCenter %q with taskID %s and attachResults %v",
+			log.Errorf("unable to find AttachVolume result from vCenter %q with taskID %s and attachResults %v",
 				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
 			return "", err
 		}
 
 		if taskResult == nil {
-			log.Errorf("taskResult is empty for AttachVolume task: %q, opId: %q", taskInfo.Task.Value, taskInfo.ActivationId)
+			log.Errorf("taskResult is empty for AttachVolume task: %q, opId: %q",
+				taskInfo.Task.Value, taskInfo.ActivationId)
 			return "", errors.New("taskResult is empty")
 		}
 
@@ -382,7 +407,7 @@ func (m *defaultManager) AttachVolume(ctx context.Context, vm *cnsvsphere.Virtua
 			_, isResourceInUseFault := volumeOperationRes.Fault.Fault.(*vim25types.ResourceInUse)
 			if isResourceInUseFault {
 				log.Infof("observed ResourceInUse fault while attaching volume: %q with vm: %q", volumeID, vm.String())
-				// check if volume is already attached to the requested node
+				// Check if volume is already attached to the requested node.
 				diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
 				if err != nil {
 					return "", err
@@ -391,12 +416,14 @@ func (m *defaultManager) AttachVolume(ctx context.Context, vm *cnsvsphere.Virtua
 					return diskUUID, nil
 				}
 			}
-			msg := fmt.Sprintf("failed to attach cns volume: %q to node vm: %q. fault: %q. opId: %q", volumeID, vm.String(), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			msg := fmt.Sprintf("failed to attach cns volume: %q to node vm: %q. fault: %q. opId: %q",
+				volumeID, vm.String(), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 			log.Error(msg)
 			return "", errors.New(msg)
 		}
 		diskUUID := interface{}(taskResult).(*cnstypes.CnsVolumeAttachResult).DiskUUID
-		log.Infof("AttachVolume: Volume attached successfully. volumeID: %q, opId: %q, vm: %q, diskUUID: %q", volumeID, taskInfo.ActivationId, vm.String(), diskUUID)
+		log.Infof("AttachVolume: Volume attached successfully. volumeID: %q, opId: %q, vm: %q, diskUUID: %q",
+			volumeID, taskInfo.ActivationId, vm.String(), diskUUID)
 		return diskUUID, nil
 	}
 	start := time.Now()
@@ -419,13 +446,13 @@ func (m *defaultManager) DetachVolume(ctx context.Context, vm *cnsvsphere.Virtua
 		if err != nil {
 			return err
 		}
-		// Set up the VC connection
+		// Set up the VC connection.
 		err = m.virtualCenter.ConnectCns(ctx)
 		if err != nil {
 			log.Errorf("ConnectCns failed with err: %+v", err)
 			return err
 		}
-		// Construct the CNS DetachSpec list
+		// Construct the CNS DetachSpec list.
 		var cnsDetachSpecList []cnstypes.CnsVolumeAttachDetachSpec
 		cnsDetachSpec := cnstypes.CnsVolumeAttachDetachSpec{
 			VolumeId: cnstypes.CnsVolumeId{
@@ -434,25 +461,28 @@ func (m *defaultManager) DetachVolume(ctx context.Context, vm *cnsvsphere.Virtua
 			Vm: vm.Reference(),
 		}
 		cnsDetachSpecList = append(cnsDetachSpecList, cnsDetachSpec)
-		// Call the CNS DetachVolume
+		// Call the CNS DetachVolume.
 		task, err := m.virtualCenter.CnsClient.DetachVolume(ctx, cnsDetachSpecList)
 		if err != nil {
 			if cnsvsphere.IsManagedObjectNotFound(err, cnsDetachSpec.Vm) {
-				// Detach failed with managed object not found, marking detach as successful, as Node VM is deleted and not present in the vCenter inventory
-				log.Infof("Node VM: %v not found on the vCenter. Marking Detach for volume:%q successful. err: %v", vm, volumeID, err)
+				// Detach failed with managed object not found, marking detach as
+				// successful, as Node VM is deleted and not present in the vCenter
+				// inventory.
+				log.Infof("Node VM: %v not found on vCenter. Marking Detach for volume:%q successful. err: %v",
+					vm, volumeID, err)
 				return nil
 			}
 			if cnsvsphere.IsNotFoundError(err) {
-				// Detach failed with NotFound error, check if the volume is already detached
+				// Detach failed with NotFound error, check if the volume is already detached.
 				log.Infof("VolumeID: %q, not found. Checking whether the volume is already detached", volumeID)
 				diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
 				if err != nil {
-					log.Errorf("DetachVolume: CNS Detach has failed with err: %+v. Unable to check if volume: %q is already detached from vm: %+v",
+					log.Errorf("DetachVolume err: %+v. Unable to check if volume: %q is already detached from vm: %+v",
 						err, volumeID, vm)
 					return err
 				}
 				if diskUUID == "" {
-					log.Infof("DetachVolume: volumeID: %q not found on vm: %+v. Assuming volume is already detached", volumeID, vm)
+					log.Infof("volumeID: %q not found on vm: %+v. Assuming it is already detached", volumeID, vm)
 					return nil
 				}
 			}
@@ -460,22 +490,24 @@ func (m *defaultManager) DetachVolume(ctx context.Context, vm *cnsvsphere.Virtua
 			log.Error(msg)
 			return errors.New(msg)
 		}
-		// Get the taskInfo
+		// Get the taskInfo.
 		taskInfo, err := cns.GetTaskInfo(ctx, task)
 		if err != nil || taskInfo == nil {
-			log.Errorf("failed to get taskInfo for DetachVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			log.Errorf("failed to get taskInfo for DetachVolume task from vCenter %q with err: %v",
+				m.virtualCenter.Config.Host, err)
 			return err
 		}
 		log.Infof("DetachVolume: volumeID: %q, vm: %q, opId: %q", volumeID, vm.String(), taskInfo.ActivationId)
-		// Get the task results for the given task
+		// Get the task results for the given task.
 		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
 		if err != nil {
-			log.Errorf("unable to find the task result for DetachVolume task from vCenter %q with taskID %s and detachResults %v",
+			log.Errorf("unable to find DetachVolume task result from vCenter %q with taskID %s and detachResults %v",
 				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
 			return err
 		}
 		if taskResult == nil {
-			log.Errorf("taskResult is empty for DetachVolume task: %q, opId: %q", taskInfo.Task.Value, taskInfo.ActivationId)
+			log.Errorf("taskResult is empty for DetachVolume task: %q, opId: %q",
+				taskInfo.Task.Value, taskInfo.ActivationId)
 			return errors.New("taskResult is empty")
 		}
 		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
@@ -485,20 +517,23 @@ func (m *defaultManager) DetachVolume(ctx context.Context, vm *cnsvsphere.Virtua
 				// check if volume is already detached from the VM
 				diskUUID, err := IsDiskAttached(ctx, vm, volumeID)
 				if err != nil {
-					log.Errorf("DetachVolume: CNS Detach has failed with fault: %+v. Unable to check if volume: %q is already detached from vm: %+v",
+					log.Errorf("DetachVolume fault: %+v. Unable to check if volume: %q is already detached from vm: %+v",
 						spew.Sdump(volumeOperationRes.Fault), volumeID, vm)
 					return err
 				}
 				if diskUUID == "" {
-					log.Infof("DetachVolume: volumeID: %q not found on vm: %+v. Assuming volume is already detached", volumeID, vm)
+					log.Infof("DetachVolume: volumeID: %q not found on vm: %+v. Assuming it is already detached",
+						volumeID, vm)
 					return nil
 				}
 			}
-			msg := fmt.Sprintf("failed to detach cns volume:%q from node vm: %+v. fault: %+v, opId: %q", volumeID, vm, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			msg := fmt.Sprintf("failed to detach cns volume: %q from node vm: %+v. fault: %+v, opId: %q",
+				volumeID, vm, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 			log.Error(msg)
 			return errors.New(msg)
 		}
-		log.Infof("DetachVolume: Volume detached successfully. volumeID: %q, vm: %q, opId: %q", volumeID, taskInfo.ActivationId, vm.String())
+		log.Infof("DetachVolume: Volume detached successfully. volumeID: %q, vm: %q, opId: %q",
+			volumeID, taskInfo.ActivationId, vm.String())
 		return nil
 	}
 	start := time.Now()
@@ -521,53 +556,57 @@ func (m *defaultManager) DeleteVolume(ctx context.Context, volumeID string, dele
 		if err != nil {
 			return err
 		}
-		// Set up the VC connection
+		// Set up the VC connection.
 		err = m.virtualCenter.ConnectCns(ctx)
 		if err != nil {
 			log.Errorf("ConnectCns failed with err: %+v", err)
 			return err
 		}
-		// Construct the CNS VolumeId list
+		// Construct the CNS VolumeId list.
 		var cnsVolumeIDList []cnstypes.CnsVolumeId
 		cnsVolumeID := cnstypes.CnsVolumeId{
 			Id: volumeID,
 		}
-		// Call the CNS DeleteVolume
+		// Call the CNS DeleteVolume.
 		cnsVolumeIDList = append(cnsVolumeIDList, cnsVolumeID)
 		task, err := m.virtualCenter.CnsClient.DeleteVolume(ctx, cnsVolumeIDList, deleteDisk)
 		if err != nil {
 			if cnsvsphere.IsNotFoundError(err) {
-				log.Infof("VolumeID: %q, not found. Returning success for this operation since the volume is not present", volumeID)
+				log.Infof("VolumeID: %q, not found, thus returning success", volumeID)
 				return nil
 			}
 			log.Errorf("CNS DeleteVolume failed from the  vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 			return err
 		}
-		// Get the taskInfo
+		// Get the taskInfo.
 		taskInfo, err := cns.GetTaskInfo(ctx, task)
 		if err != nil || taskInfo == nil {
-			log.Errorf("failed to get taskInfo for DeleteVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			log.Errorf("failed to get DeleteVolume taskInfo from vCenter %q with err: %v",
+				m.virtualCenter.Config.Host, err)
 			return err
 		}
 		log.Infof("DeleteVolume: volumeID: %q, opId: %q", volumeID, taskInfo.ActivationId)
-		// Get the task results for the given task
+		// Get the task results for the given task.
 		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
 		if err != nil {
-			log.Errorf("unable to find the task result for DeleteVolume task from vCenter %q with taskID %s and deleteResults %v",
+			log.Errorf("unable to find DeleteVolume task result from vCenter %q with taskID %s and deleteResults %v",
 				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
 			return err
 		}
 		if taskResult == nil {
-			log.Errorf("taskResult is empty for DeleteVolume task: %q, opID: %q", taskInfo.Task.Value, taskInfo.ActivationId)
+			log.Errorf("taskResult is empty for DeleteVolume task: %q, opID: %q",
+				taskInfo.Task.Value, taskInfo.ActivationId)
 			return errors.New("taskResult is empty")
 		}
 		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
 		if volumeOperationRes.Fault != nil {
-			msg := fmt.Sprintf("failed to delete volume: %q, fault: %q, opID: %q", volumeID, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			msg := fmt.Sprintf("failed to delete volume: %q, fault: %q, opID: %q",
+				volumeID, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 			log.Error(msg)
 			return errors.New(msg)
 		}
-		log.Infof("DeleteVolume: Volume deleted successfully. volumeID: %q, opId: %q", volumeID, taskInfo.ActivationId)
+		log.Infof("DeleteVolume: Volume deleted successfully. volumeID: %q, opId: %q",
+			volumeID, taskInfo.ActivationId)
 		return nil
 	}
 	start := time.Now()
@@ -590,13 +629,14 @@ func (m *defaultManager) UpdateVolumeMetadata(ctx context.Context, spec *cnstype
 		if err != nil {
 			return err
 		}
-		// Set up the VC connection
+		// Set up the VC connection.
 		err = m.virtualCenter.ConnectCns(ctx)
 		if err != nil {
 			log.Errorf("ConnectCns failed with err: %+v", err)
 			return err
 		}
-		// If the VSphereUser in the VolumeMetadataUpdateSpec is different from session user, update the VolumeMetadataUpdateSpec
+		// If the VSphereUser in the VolumeMetadataUpdateSpec is different from
+		// session user, update the VolumeMetadataUpdateSpec.
 		s, err := m.virtualCenter.Client.SessionManager.UserSession(ctx)
 		if err != nil {
 			log.Errorf("failed to get usersession with err: %v", err)
@@ -619,31 +659,35 @@ func (m *defaultManager) UpdateVolumeMetadata(ctx context.Context, spec *cnstype
 			log.Errorf("CNS UpdateVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 			return err
 		}
-		// Get the taskInfo
+		// Get the taskInfo.
 		taskInfo, err := cns.GetTaskInfo(ctx, task)
 		if err != nil || taskInfo == nil {
-			log.Errorf("failed to get taskInfo for UpdateVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			log.Errorf("failed to get UpdateVolume taskInfo from vCenter %q with err: %v",
+				m.virtualCenter.Config.Host, err)
 			return err
 		}
 		log.Infof("UpdateVolumeMetadata: volumeID: %q, opId: %q", spec.VolumeId.Id, taskInfo.ActivationId)
-		// Get the task results for the given task
+		// Get the task results for the given task.
 		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
 		if err != nil {
-			log.Errorf("unable to find the task result for UpdateVolume task from vCenter %q with taskID %q, opId: %q and updateResults %+v",
+			log.Errorf("unable to find UpdateVolume result from vCenter %q: taskID %q, opId %q and updateResults %+v",
 				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskInfo.ActivationId, taskResult)
 			return err
 		}
 		if taskResult == nil {
-			log.Errorf("taskResult is empty for UpdateVolume task: %q, opId: %q", taskInfo.Task.Value, taskInfo.ActivationId)
+			log.Errorf("taskResult is empty for UpdateVolume task: %q, opId: %q",
+				taskInfo.Task.Value, taskInfo.ActivationId)
 			return errors.New("taskResult is empty")
 		}
 		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
 		if volumeOperationRes.Fault != nil {
-			msg := fmt.Sprintf("failed to update volume. updateSpec: %q, fault: %q, opID: %q", spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			msg := fmt.Sprintf("failed to update volume. updateSpec: %q, fault: %q, opID: %q",
+				spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 			log.Error(msg)
 			return errors.New(msg)
 		}
-		log.Infof("UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: %q, opId: %q", spec.VolumeId.Id, taskInfo.ActivationId)
+		log.Infof("UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: %q, opId: %q",
+			spec.VolumeId.Id, taskInfo.ActivationId)
 		return nil
 	}
 	start := time.Now()
@@ -667,13 +711,13 @@ func (m *defaultManager) ExpandVolume(ctx context.Context, volumeID string, size
 			log.Errorf("validateManager failed with err: %+v", err)
 			return err
 		}
-		// Set up the VC connection
+		// Set up the VC connection.
 		err = m.virtualCenter.ConnectCns(ctx)
 		if err != nil {
 			log.Errorf("ConnectCns failed with err: %+v", err)
 			return err
 		}
-		// Construct the CNS ExtendSpec list
+		// Construct the CNS ExtendSpec list.
 		var cnsExtendSpecList []cnstypes.CnsVolumeExtendSpec
 		cnsExtendSpec := cnstypes.CnsVolumeExtendSpec{
 			VolumeId: cnstypes.CnsVolumeId{
@@ -682,8 +726,9 @@ func (m *defaultManager) ExpandVolume(ctx context.Context, volumeID string, size
 			CapacityInMb: size,
 		}
 		cnsExtendSpecList = append(cnsExtendSpecList, cnsExtendSpec)
-		// Call the CNS ExtendVolume
-		log.Infof("Calling CnsClient.ExtendVolume: VolumeID [%q] Size [%d] cnsExtendSpecList [%#v]", volumeID, size, cnsExtendSpecList)
+		// Call the CNS ExtendVolume.
+		log.Infof("Calling CnsClient.ExtendVolume: VolumeID [%q] Size [%d] cnsExtendSpecList [%#v]",
+			volumeID, size, cnsExtendSpecList)
 		task, err := m.virtualCenter.CnsClient.ExtendVolume(ctx, cnsExtendSpecList)
 		if err != nil {
 			if cnsvsphere.IsNotFoundError(err) {
@@ -693,27 +738,30 @@ func (m *defaultManager) ExpandVolume(ctx context.Context, volumeID string, size
 			log.Errorf("CNS ExtendVolume failed from the vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 			return err
 		}
-		// Get the taskInfo
+		// Get the taskInfo.
 		taskInfo, err := cns.GetTaskInfo(ctx, task)
 		if err != nil || taskInfo == nil {
-			log.Errorf("failed to get taskInfo for ExtendVolume task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			log.Errorf("failed to get taskInfo for ExtendVolume task from vCenter %q with err: %v",
+				m.virtualCenter.Config.Host, err)
 			return err
 		}
 		log.Infof("ExpandVolume: volumeID: %q, opId: %q", volumeID, taskInfo.ActivationId)
-		// Get the task results for the given task
+		// Get the task results for the given task.
 		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
 		if err != nil {
-			log.Errorf("Unable to find the task result for ExtendVolume task from vCenter %q with taskID %s and extend volume Results %v",
+			log.Errorf("Unable to find ExtendVolume task result from vCenter %q: taskID %s and result %v",
 				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
 			return err
 		}
 		if taskResult == nil {
-			log.Errorf("TaskResult is empty for ExtendVolume task: %q, opID: %q", taskInfo.Task.Value, taskInfo.ActivationId)
+			log.Errorf("TaskResult is empty for ExtendVolume task: %q, opID: %q",
+				taskInfo.Task.Value, taskInfo.ActivationId)
 			return errors.New("taskResult is empty")
 		}
 		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
 		if volumeOperationRes.Fault != nil {
-			msg := fmt.Sprintf("failed to extend volume: %q, fault: %q, opID: %q", volumeID, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			msg := fmt.Sprintf("failed to extend volume: %q, fault: %q, opID: %q",
+				volumeID, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 			log.Error(msg)
 			return errors.New(msg)
 		}
@@ -733,20 +781,21 @@ func (m *defaultManager) ExpandVolume(ctx context.Context, volumeID string, size
 }
 
 // QueryVolume returns volumes matching the given filter.
-func (m *defaultManager) QueryVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
+func (m *defaultManager) QueryVolume(ctx context.Context,
+	queryFilter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error) {
 	internalQueryVolume := func() (*cnstypes.CnsQueryResult, error) {
 		log := logger.GetLogger(ctx)
 		err := validateManager(ctx, m)
 		if err != nil {
 			return nil, err
 		}
-		// Set up the VC connection
+		// Set up the VC connection.
 		err = m.virtualCenter.ConnectCns(ctx)
 		if err != nil {
 			log.Errorf("ConnectCns failed with err: %+v", err)
 			return nil, err
 		}
-		//Call the CNS QueryVolume
+		// Call the CNS QueryVolume.
 		res, err := m.virtualCenter.CnsClient.QueryVolume(ctx, queryFilter)
 		if err != nil {
 			log.Errorf("CNS QueryVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
@@ -768,20 +817,21 @@ func (m *defaultManager) QueryVolume(ctx context.Context, queryFilter cnstypes.C
 }
 
 // QueryAllVolume returns all volumes matching the given filter and selection.
-func (m *defaultManager) QueryAllVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter, querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+func (m *defaultManager) QueryAllVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
+	querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
 	internalQueryAllVolume := func() (*cnstypes.CnsQueryResult, error) {
 		log := logger.GetLogger(ctx)
 		err := validateManager(ctx, m)
 		if err != nil {
 			return nil, err
 		}
-		// Set up the VC connection
+		// Set up the VC connection.
 		err = m.virtualCenter.ConnectCns(ctx)
 		if err != nil {
 			log.Errorf("ConnectCns failed with err: %+v", err)
 			return nil, err
 		}
-		//Call the CNS QueryAllVolume
+		// Call the CNS QueryAllVolume.
 		res, err := m.virtualCenter.CnsClient.QueryAllVolume(ctx, queryFilter, querySelection)
 		if err != nil {
 			log.Errorf("CNS QueryAllVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
@@ -802,53 +852,59 @@ func (m *defaultManager) QueryAllVolume(ctx context.Context, queryFilter cnstype
 	return resp, err
 }
 
-// QueryVolumeInfo calls the CNS QueryVolumeInfo API and return a task, from which CnsQueryVolumeInfoResult is extracted
-func (m *defaultManager) QueryVolumeInfo(ctx context.Context, volumeIDList []cnstypes.CnsVolumeId) (*cnstypes.CnsQueryVolumeInfoResult, error) {
+// QueryVolumeInfo calls the CNS QueryVolumeInfo API and return a task, from
+// which CnsQueryVolumeInfoResult is extracted.
+func (m *defaultManager) QueryVolumeInfo(ctx context.Context,
+	volumeIDList []cnstypes.CnsVolumeId) (*cnstypes.CnsQueryVolumeInfoResult, error) {
 	internalQueryVolumeInfo := func() (*cnstypes.CnsQueryVolumeInfoResult, error) {
 		log := logger.GetLogger(ctx)
 		err := validateManager(ctx, m)
 		if err != nil {
 			return nil, err
 		}
-		// Set up the VC connection
+		// Set up the VC connection.
 		err = m.virtualCenter.ConnectCns(ctx)
 		if err != nil {
 			log.Errorf("ConnectCns failed with err: %+v", err)
 			return nil, err
 		}
-		//Call the CNS QueryVolumeInfo
+		// Call the CNS QueryVolumeInfo.
 		queryVolumeInfoTask, err := m.virtualCenter.CnsClient.QueryVolumeInfo(ctx, volumeIDList)
 		if err != nil {
 			log.Errorf("CNS QueryAllVolume failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 			return nil, err
 		}
 
-		// Get the taskInfo
+		// Get the taskInfo.
 		taskInfo, err := cns.GetTaskInfo(ctx, queryVolumeInfoTask)
 		if err != nil || taskInfo == nil {
-			log.Errorf("failed to get taskInfo for QueryVolumeInfo task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			log.Errorf("failed to get QueryVolumeInfo taskInfo from vCenter %q with err: %v",
+				m.virtualCenter.Config.Host, err)
 			return nil, err
 		}
 		log.Infof("QueryVolumeInfo: volumeIDList: %v, opId: %q", volumeIDList, taskInfo.ActivationId)
-		// Get the task results for the given task
+		// Get the task results for the given task.
 		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
 		if err != nil {
-			log.Errorf("unable to find the task result for QueryVolumeInfo task from vCenter %q with taskID %s and taskResult %v",
+			log.Errorf("unable to find QueryVolumeInfo task result from vCenter %q: taskID %s and result %v",
 				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskResult)
 			return nil, err
 		}
 		if taskResult == nil {
-			log.Errorf("taskResult is empty for DeleteVolume task: %q, opID: %q", taskInfo.Task.Value, taskInfo.ActivationId)
+			log.Errorf("taskResult is empty for DeleteVolume task: %q, opID: %q",
+				taskInfo.Task.Value, taskInfo.ActivationId)
 			return nil, errors.New("taskResult is empty")
 		}
 		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
 		if volumeOperationRes.Fault != nil {
-			msg := fmt.Sprintf("failed to Query volumes: %v, fault: %q, opID: %q", volumeIDList, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			msg := fmt.Sprintf("failed to Query volumes: %v, fault: %q, opID: %q",
+				volumeIDList, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 			log.Error(msg)
 			return nil, errors.New(msg)
 		}
 		volumeInfoResult := interface{}(taskResult).(*cnstypes.CnsQueryVolumeInfoResult)
-		log.Infof("QueryVolumeInfo successfully returned volumeInfo volumeIDList %v:, opId: %q", volumeIDList, taskInfo.ActivationId)
+		log.Infof("QueryVolumeInfo successfully returned volumeInfo volumeIDList %v:, opId: %q",
+			volumeIDList, taskInfo.ActivationId)
 		return volumeInfoResult, nil
 	}
 	start := time.Now()
@@ -863,7 +919,8 @@ func (m *defaultManager) QueryVolumeInfo(ctx context.Context, volumeIDList []cns
 	return resp, err
 }
 
-func (m *defaultManager) RelocateVolume(ctx context.Context, relocateSpecList ...cnstypes.BaseCnsVolumeRelocateSpec) (*object.Task, error) {
+func (m *defaultManager) RelocateVolume(ctx context.Context,
+	relocateSpecList ...cnstypes.BaseCnsVolumeRelocateSpec) (*object.Task, error) {
 	internalRelocateVolume := func() (*object.Task, error) {
 		log := logger.GetLogger(ctx)
 		err := validateManager(ctx, m)
@@ -872,7 +929,7 @@ func (m *defaultManager) RelocateVolume(ctx context.Context, relocateSpecList ..
 			return nil, err
 		}
 
-		// Set up the VC connection
+		// Set up the VC connection.
 		err = m.virtualCenter.ConnectCns(ctx)
 		if err != nil {
 			log.Errorf("ConnectCns failed with err: %+v", err)
@@ -897,7 +954,7 @@ func (m *defaultManager) RelocateVolume(ctx context.Context, relocateSpecList ..
 	return resp, err
 }
 
-// ConfigureVolumeACLs configures net permissions for a given CnsVolumeACLConfigureSpec
+// ConfigureVolumeACLs configures net permissions for a given CnsVolumeACLConfigureSpec.
 func (m *defaultManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.CnsVolumeACLConfigureSpec) error {
 	internalConfigureVolumeACLs := func() error {
 		log := logger.GetLogger(ctx)
@@ -905,7 +962,7 @@ func (m *defaultManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.
 		if err != nil {
 			return err
 		}
-		// Set up the VC connection
+		// Set up the VC connection.
 		err = m.virtualCenter.ConnectCns(ctx)
 		if err != nil {
 			log.Errorf("ConnectCns failed with err: %+v", err)
@@ -921,32 +978,36 @@ func (m *defaultManager) ConfigureVolumeACLs(ctx context.Context, spec cnstypes.
 			return err
 		}
 
-		// Get the taskInfo
+		// Get the taskInfo.
 		taskInfo, err = cns.GetTaskInfo(ctx, task)
 		if err != nil {
-			log.Errorf("failed to get taskInfo for ConfigureVolumeACLs task from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
+			log.Errorf("failed to get ConfigureVolumeACLs taskInfo from vCenter %q with err: %v",
+				m.virtualCenter.Config.Host, err)
 			return err
 		}
-		// Get the taskResult
+		// Get the taskResult.
 		taskResult, err := cns.GetTaskResult(ctx, taskInfo)
 		if err != nil {
-			log.Errorf("unable to find the task result for ConfigureVolumeACLs task from vCenter %q. taskID: %q, opId: %q ConfigureVolumeACL results: %+v . Error: %v",
+			log.Errorf("unable to find ConfigureVolumeACLs result from vCenter %q: taskID %q opId %q result: %+v err: %v",
 				m.virtualCenter.Config.Host, taskInfo.Task.Value, taskInfo.ActivationId, taskResult, err)
 			return err
 		}
 
 		if taskResult == nil {
-			log.Errorf("taskResult is empty for ConfigureVolumeACLs task: %q. ConfigureVolumeACLsSpec: %q", taskInfo.ActivationId, spew.Sdump(spec))
+			log.Errorf("taskResult is empty for ConfigureVolumeACLs task: %q. ConfigureVolumeACLsSpec: %q",
+				taskInfo.ActivationId, spew.Sdump(spec))
 			return errors.New("taskResult is empty")
 		}
 		volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
 		if volumeOperationRes.Fault != nil {
-			msg := fmt.Sprintf("failed to apply ConfigureVolumeACLs. Volume ID: %s. ConfigureVolumeACLsSpec: %q, fault: %q, opId: %q", spec.VolumeId.Id, spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
+			msg := fmt.Sprintf("failed to apply ConfigureVolumeACLs. VolumeID: %s spec: %q, fault: %q, opId: %q",
+				spec.VolumeId.Id, spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 			log.Error(msg)
 			return errors.New(msg)
 		}
 
-		log.Infof("ConfigureVolumeACLs: Volume ACLs configured successfully. VolumeName: %q, opId: %q, volumeID: %q", spec.VolumeId.Id, taskInfo.ActivationId, volumeOperationRes.VolumeId.Id)
+		log.Infof("ConfigureVolumeACLs: Volume ACLs configured successfully. VolumeName: %q, opId: %q, volumeID: %q",
+			spec.VolumeId.Id, taskInfo.ActivationId, volumeOperationRes.VolumeId.Id)
 		return nil
 	}
 	start := time.Now()
@@ -974,7 +1035,7 @@ func (m *defaultManager) RegisterDisk(ctx context.Context, path string, name str
 		log.Errorf("failed to validate volume manager with err: %+v", err)
 		return "", err
 	}
-	// Set up the VC connection
+	// Set up the VC connection.
 	err = m.virtualCenter.ConnectVslm(ctx)
 	if err != nil {
 		log.Errorf("ConnectVslm failed with err: %+v", err)
@@ -985,7 +1046,7 @@ func (m *defaultManager) RegisterDisk(ctx context.Context, path string, name str
 	if err != nil {
 		alreadyExists, objectID := cnsvsphere.IsAlreadyExists(err)
 		if alreadyExists {
-			log.Infof("vStorageObject: %q, already exists and registered as First Class Disk. Returning success for RegisterDisk operation", objectID)
+			log.Infof("vStorageObject: %q, already exists and registered as FCD, returning success", objectID)
 			return objectID, nil
 		}
 		log.Errorf("failed to register virtual disk %q as first class disk with err: %v", path, err)
@@ -994,8 +1055,10 @@ func (m *defaultManager) RegisterDisk(ctx context.Context, path string, name str
 	return vStorageObject.Config.Id.Id, nil
 }
 
-// RetrieveVStorageObject helps in retreiving virtual disk information for a given volume id
-func (m *defaultManager) RetrieveVStorageObject(ctx context.Context, volumeID string) (*vim25types.VStorageObject, error) {
+// RetrieveVStorageObject helps in retreiving virtual disk information for
+// a given volume id.
+func (m *defaultManager) RetrieveVStorageObject(ctx context.Context,
+	volumeID string) (*vim25types.VStorageObject, error) {
 	log := logger.GetLogger(ctx)
 	err := validateManager(ctx, m)
 	if err != nil {
@@ -1019,16 +1082,20 @@ func (m *defaultManager) RetrieveVStorageObject(ctx context.Context, volumeID st
 	return vStorageObject, nil
 }
 
-// QueryVolumeAsync returns volumes matching the given filter by using CnsQueryAsync API. QueryVolumeAsync takes querySelection spec which helps to specify which fields
-// for the query entities to be returned. All volume fields would be returned as part of the CnsQueryResult if the querySelection parameters are not specified
-func (m *defaultManager) QueryVolumeAsync(ctx context.Context, queryFilter cnstypes.CnsQueryFilter, querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+// QueryVolumeAsync returns volumes matching the given filter by using
+// CnsQueryAsync API. QueryVolumeAsync takes querySelection spec which helps
+// to specify which fields for the query entities to be returned. All volume
+// fields would be returned as part of the CnsQueryResult if the querySelection
+// parameters are not specified.
+func (m *defaultManager) QueryVolumeAsync(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
+	querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
 	log := logger.GetLogger(ctx)
 	err := validateManager(ctx, m)
 	if err != nil {
 		log.Errorf("validateManager failed with err: %+v", err)
 		return nil, err
 	}
-	// Set up the VC connection
+	// Set up the VC connection.
 	err = m.virtualCenter.ConnectCns(ctx)
 	if err != nil {
 		log.Errorf("ConnectCns failed with err: %+v", err)
@@ -1036,17 +1103,19 @@ func (m *defaultManager) QueryVolumeAsync(ctx context.Context, queryFilter cnsty
 	}
 	isvSphere70U3orAbove, err := cnsvsphere.IsvSphereVersion70U3orAbove(ctx, m.virtualCenter.Client.ServiceContent.About)
 	if err != nil {
-		msg := fmt.Sprintf("Error while checking the vSphere Version %q to invoke QueryVolumeAsync, Error= %+v", m.virtualCenter.Client.ServiceContent.About.Version, err)
+		msg := fmt.Sprintf("Error while checking the vSphere Version %q to invoke QueryVolumeAsync, Err= %+v",
+			m.virtualCenter.Client.ServiceContent.About.Version, err)
 		log.Errorf(msg)
 		return nil, errors.New(msg)
 	}
 	if !isvSphere70U3orAbove {
-		msg := fmt.Sprintf("QueryVolumeAsync is not supported in vSphere Version %q", m.virtualCenter.Client.ServiceContent.About.Version)
+		msg := fmt.Sprintf("QueryVolumeAsync is not supported in vSphere Version %q",
+			m.virtualCenter.Client.ServiceContent.About.Version)
 		log.Warnf(msg)
 		return nil, cnsvsphere.ErrNotSupported
 	}
 
-	// Call the CNS QueryVolumeAsync
+	// Call the CNS QueryVolumeAsync.
 	queryVolumeAsyncTask, err := m.virtualCenter.CnsClient.QueryVolumeAsync(ctx, queryFilter, querySelection)
 	if err != nil {
 		log.Errorf("CNS QueryVolumeAsync failed from vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
@@ -1063,12 +1132,14 @@ func (m *defaultManager) QueryVolumeAsync(ctx context.Context, queryFilter cnsty
 		return nil, err
 	}
 	if queryVolumeAsyncTaskResult == nil {
-		log.Errorf("TaskResult is empty for QueryVolumeAsync task: %q, opID: %q", queryVolumeAsyncTaskInfo.Task.Value, queryVolumeAsyncTaskInfo.ActivationId)
+		log.Errorf("TaskResult is empty for QueryVolumeAsync task: %q, opID: %q",
+			queryVolumeAsyncTaskInfo.Task.Value, queryVolumeAsyncTaskInfo.ActivationId)
 		return nil, errors.New("taskResult is empty")
 	}
 	volumeOperationRes := queryVolumeAsyncTaskResult.GetCnsVolumeOperationResult()
 	if volumeOperationRes.Fault != nil {
-		msg := fmt.Sprintf("failed to query volumes using CnsQueryVolumeAsync, fault: %q, opID: %q", spew.Sdump(volumeOperationRes.Fault), queryVolumeAsyncTaskInfo.ActivationId)
+		msg := fmt.Sprintf("failed to query volumes using CnsQueryVolumeAsync, fault: %q, opID: %q",
+			spew.Sdump(volumeOperationRes.Fault), queryVolumeAsyncTaskInfo.ActivationId)
 		log.Error(msg)
 		return nil, errors.New(msg)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. This change handles the
long lines in nodes.go. (In C/C++, I typically limit the line within 80 characters, for a reference.)
To wrap a long line, we need to pay attention to Golang's special grammar that it automatically
inserts a semicolon immediately after a line's final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }
Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles manager.go.

**Testing done**:
Local build and check, which should be sufficient for cosmetic changes.

Run E2E tests - csi-block-vanilla, hit a known failure (a bug is filed)
[Fail] [csi-block-vanilla] full-sync-test [It] Verify PVC metadata is deleted in CNS after PVC is deleted in k8s 
-- 42 Passed | 1 Failed | 0 Pending | 136 Skipped
