### PR TITLE
ginkgo bump to 1.16.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kubernetes-csi/csi-lib-utils v0.7.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/onsi/ginkgo v1.16.1
+	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.10.5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,8 @@ github.com/onsi/ginkgo v1.10.2/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
-github.com/onsi/ginkgo v1.16.1 h1:foqVmeWDD6yYpK+Yz3fHyNIxFYNxswxqNFjSKe+vI54=
-github.com/onsi/ginkgo v1.16.1/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
+github.com/onsi/ginkgo v1.16.2 h1:HFB2fbVIlhIfCfOW81bZFbiC/RvnpXSdhbF2/DJr134=
+github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.3.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/tests/e2e/docs/vanilla_cluster_setup.md
+++ b/tests/e2e/docs/vanilla_cluster_setup.md
@@ -58,6 +58,7 @@ list of datastore URLs where you want to deploy file share volumes. Retrieve thi
     export FULL_SYNC_WAIT_TIME=350    # In seconds
     export USER=root
     export CLUSTER_FLAVOR="VANILLA"
+    export CSI_NAMESPACE="vmware-system-csi"
     # To run e2e test for block volume, need to set the following env variable
     export GINKGO_FOCUS="csi-block-vanilla"
     # To run e2e test for file volume, need to set the following env variable


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Bumping ginkgo to v1.16.2 to utilize ACK_GINKGO_DEPRECATIONS=<semver> variable added to ignore deprecation warnings.

**Testing done**:
Logs from a temp jenkins job to test the fix:
[gingko_deprecation_warn_ignore.log](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/6530713/gingko_deprecation_warn_ignore.log)

Subsequently we need to make changes to the pipeline as well to add ACK_GINKGO_DEPRECATIONS env variable
