### PR TITLE
dedupe prometheus metrics for csi

### DIFF
--- a/pkg/common/prometheus/metrics.go
+++ b/pkg/common/prometheus/metrics.go
@@ -17,6 +17,8 @@ limitations under the License.
 package prometheus
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -116,3 +118,18 @@ var (
 		// Possible status - "pass", "fail"
 		[]string{"optype", "status"})
 )
+
+// ObserveCsiControlOps adds an observation of a CSI operation of 'opType' on
+// a volume of 'volumeType', started at time 'start'. The CSI operation might
+// have failed, if 'err' is not null,
+func ObserveCsiControlOps(volumeType string, opType string, err error, start time.Time) {
+	var status string
+	if err != nil {
+		status = PrometheusFailStatus
+	} else {
+		status = PrometheusPassStatus
+	}
+
+	CsiControlOpsHistVec.WithLabelValues(volumeType, opType, status).
+		Observe(time.Since(start).Seconds())
+}

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -669,13 +669,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return c.createBlockVolume(ctx, req)
 	}
 	resp, err := createVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusCreateVolumeOpType, err, start)
 	return resp, err
 }
 
@@ -741,13 +735,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 	resp, err := deleteVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusDeleteVolumeOpType, err, start)
 	return resp, err
 }
 
@@ -861,13 +849,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 		}, nil
 	}
 	resp, err := controllerPublishVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusAttachVolumeOpType, err, start)
 	return resp, err
 }
 
@@ -968,13 +950,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 	resp, err := controllerUnpublishVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusDetachVolumeOpType, err, start)
 	return resp, err
 }
 

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -523,13 +523,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return c.createBlockVolume(ctx, req)
 	}
 	resp, err := createVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusCreateVolumeOpType, err, start)
 	return resp, err
 }
 
@@ -562,13 +556,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 	resp, err := deleteVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusDeleteVolumeOpType, err, start)
 	return resp, err
 }
 
@@ -688,13 +676,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 		return resp, nil
 	}
 	resp, err := controllerPublishVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusAttachVolumeOpType, err, start)
 	return resp, err
 }
 
@@ -728,13 +710,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 	resp, err := controllerUnpublishVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusDetachVolumeOpType, err, start)
 	return resp, err
 }
 
@@ -868,12 +844,6 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		return resp, nil
 	}
 	resp, err := controllerExpandVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusExpandVolumeOpType, err, start)
 	return resp, err
 }

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -316,13 +316,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return resp, nil
 	}
 	resp, err := createVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusCreateVolumeOpType, err, start)
 	return resp, err
 }
 
@@ -376,13 +370,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 	resp, err := deleteVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusDeleteVolumeOpType, err, start)
 	return resp, err
 }
 
@@ -423,13 +411,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 		return controllerPublishForBlockVolume(ctx, req, c)
 	}
 	resp, err := controllerPublishVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusAttachVolumeOpType, err, start)
 	return resp, err
 }
 
@@ -737,13 +719,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		return controllerUnpublishForBlockVolume(ctx, req, c)
 	}
 	resp, err := controllerUnpublishVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusDetachVolumeOpType, err, start)
 	return resp, err
 }
 
@@ -1071,13 +1047,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		return resp, nil
 	}
 	resp, err := controllerExpandVolumeInternal()
-	if err != nil {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
-	} else {
-		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
-	}
+	prometheus.ObserveCsiControlOps(volumeType, prometheus.PrometheusExpandVolumeOpType, err, start)
 	return resp, err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The prometheus code for CSI has a lot of duplication. Let's add a common function,
'ObserveCsiControlOps', and reuse the same. This change reduces code size by
8435 bytes. In addition, the code is more readable.

**Testing done**:
Local build and check.

E2E tests in progress:
1) WCP build status: SUCCESS 
Ran 32 of 186 Specs in 6348.589 seconds
SUCCESS! -- 32 Passed | 0 Failed | 0 Pending | 154 Skipped
PASS
2) Block vanilla build status: SUCCESS 
SUCCESS! -- 43 Passed | 0 Failed | 0 Pending | 143 Skipped
PASS

I will probably drop out this change, because GC test is always failing and I have too
many cleanup tasks in parallel. So, I would only keep this change for a few days, in
case any of you are interested in reviewing it. Then, I will close it.
