### PR TITLE
Add methods to log and return an error

### DIFF
--- a/pkg/csi/service/logger/logger.go
+++ b/pkg/csi/service/logger/logger.go
@@ -2,10 +2,14 @@ package logger
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // LogLevel represents the level for the log.
@@ -90,4 +94,28 @@ func newLogger() *zap.Logger {
 // Returned logger is not associated with any context.
 func GetLoggerWithNoContext() *zap.SugaredLogger {
 	return newLogger().Sugar()
+}
+
+// LogNewError logs an error msg, and returns error with msg.
+func LogNewError(log *zap.SugaredLogger, msg string) error {
+	log.Error(msg)
+	return errors.New(msg)
+}
+
+// LogNewErrorf logs a formated msg, and returns error with msg.
+func LogNewErrorf(log *zap.SugaredLogger, format string, a ...interface{}) error {
+	msg := fmt.Sprintf(format, a...)
+	return LogNewError(log, msg)
+}
+
+// LogNewErrorCode logs an error msg, and returns error with code and msg.
+func LogNewErrorCode(log *zap.SugaredLogger, c codes.Code, msg string) error {
+	log.Error(msg)
+	return status.Error(c, msg)
+}
+
+// LogNewErrorCodef logs a formated msg, and returns error with code and msg.
+func LogNewErrorCodef(log *zap.SugaredLogger, c codes.Code, format string, a ...interface{}) error {
+	msg := fmt.Sprintf(format, a...)
+	return LogNewErrorCode(log, c, msg)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a pattern of log the error message, when creating a new error. This creates
duplicated code. This change introduces four methods, so that the rest of code can
follow the same pattern, while remove code duplication. The four methods are:
LogNewError, LogNewErrorf, LogNewErrorCode, and LogNewErrorCodef.

This change only fixes common_controller_helper.go. It reduces 3699 bytes in binary.
The other files will be fixed in follow-up changes.

**Testing done**:
Local build and check.

E2E test: Passed after stitching results. I will monitor the stability of the pipeline and file PRs, if the same happens again. There seems random failures. I will skip this time, because others are focusing on stability bugs already.

1) First run.
[Fail] [csi-block-vanilla] full-sync-test [It] Verify PVC metadata is deleted in CNS after PVC is deleted in k8s 
[Fail] Verify volume life_cycle operations works fine after VC Reboots [It] [csi-block-vanilla] [csi-supervisor] [csi-guest] verify volume operations on VC works fine after vc reboots 
[Fail] Data Persistence [It] [csi-block-vanilla] [csi-supervisor] [csi-guest] Should create and delete pod with the same volume source 
[Fail] [csi-block-vanilla] full-sync-test [It] Verify Multiple PVCs are deleted/updated after full sync 
Ran 43 of 186 Specs in 12516.136 seconds
FAIL! -- 39 Passed | 4 Failed | 0 Pending | 143 Skipped

2) Second run.
[Fail] [csi-block-vanilla] [csi-file-vanilla] CNS-CSI Cluster Distribution Telemetry [It] Verify dynamic provisioning of pvc has cluster-distribution value updated 
[Fail] [csi-block-vanilla] [csi-file-vanilla] CNS-CSI Cluster Distribution Operations during VC reboot [It] [csi-block-vanilla] [csi-file-vanilla] verify volume operations after vc reboots 
Ran 43 of 186 Specs in 10012.595 seconds
FAIL! -- 41 Passed | 2 Failed | 0 Pending | 143 Skipped
