### PR TITLE
Warn user about clashing IPs in NetPermissions for file volume configuration

### DIFF
--- a/docs/book/driver-deployment/installation.md
+++ b/docs/book/driver-deployment/installation.md
@@ -110,24 +110,19 @@ cluster-distribution = "<cluster-distribution>"
 ca-file = <ca file path> # optional, use with insecure-flag set to false
 
 [NetPermissions "A"]
-ips = "*"
-permissions = "READ_WRITE"
-rootsquash = false
-
-[NetPermissions "B"]
 ips = "10.20.20.0/24"
 permissions = "READ_ONLY"
 rootsquash = true
 
-[NetPermissions "C"]
+[NetPermissions "B"]
 ips = "10.30.30.0/24"
 permissions = "NO_ACCESS"
 
-[NetPermissions "D"]
+[NetPermissions "C"]
 ips = "10.30.10.0/24"
 rootsquash = true
 
-[NetPermissions "E"]
+[NetPermissions "D"]
 ips = "10.30.1.0/24"
 
 [VirtualCenter "<IP or FQDN>"]
@@ -149,7 +144,7 @@ Some of the parameters have been explained in the previous section for block vol
 
 The parameters grouped by `NetPermissions` are as follows:
 
-- `Ips` - defines the IP range or IP subnet to which these restrictions will be levied upon. The default value for `Ips` is "*" which means all the IPs.
+- `Ips` - defines the IP range or IP subnet to which these restrictions will be levied upon. The default value for `Ips` is "*" which means all the IPs. Make sure there are no clashes in the IP ranges across all the NetPermissions as this will lead to undefined behavior for the clashing IPs.
 
 - `Permissions` - can either be "READ_WRITE", "READ_ONLY" or "NO_ACCESS". The default value for `Permissions` is "READ_WRITE" for the given IP range.
 

--- a/docs/book/releases/v2.0.0.md
+++ b/docs/book/releases/v2.0.0.md
@@ -74,6 +74,8 @@
    - Impact: Volume will not re-appear on the CNS UI. If volume needs to be detached and attached to newer node, it will not happen.
    - Workaround:
        - This issue is fixed in [v2.1.0](./v2.1.0.md) release. Please consider upgrading driver to v2.1.0
+9. vSAN file share might fail to get mounted on a pod, or a pod is unable to write unto a file volume
+   - Workaround: User needs to modify the `vsphere-config-secret` secret to remove the clashing IPs (or IP ranges) in the NetPermissions section and re-create the PVC pointing to such a file volume.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.0.1.md
+++ b/docs/book/releases/v2.0.1.md
@@ -53,6 +53,8 @@
    - Impact: Volume will not re-appear on the CNS UI. If volume needs to be detached and attached to newer node, it will not happen.
    - Workaround:
       - This issue is fixed in [v2.1.0](./v2.1.0.md) release. Please consider upgrading driver to v2.1.0
+7. vSAN file share might fail to get mounted on a pod, or a pod is unable to write unto a file volume
+   - Workaround: User needs to modify the `vsphere-config-secret` secret to remove the clashing IPs (or IP ranges) in the NetPermissions section and re-create the PVC pointing to such a file volume.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.1.0.md
+++ b/docs/book/releases/v2.1.0.md
@@ -58,6 +58,8 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
 9. If there are no datastores present in any one of the datacenters in your vSphere environment, CSI file volume provisioning fails with `failed to get all the datastores` error.
    - Impact: File volume provisioning keeps failing.
    - Workaround: Either remove the `ReadOnly` privilege on this datacenter for the user listed in the `vsphere-config-secret` secret or add a datastore to this datacenter. Refer to `vsphere-roles-and-privileges` section in the [prerequisites](../driver-deployment/prerequisites.md) page to change the permissions on this datacenter. Note: This issue is fixed in [v2.2.0](v2.2.0.md)
+10. vSAN file share might fail to get mounted on a pod, or a pod is unable to write unto a file volume.
+    - Workaround: User needs to modify the `vsphere-config-secret` secret to remove the clashing IPs (or IP ranges) in the NetPermissions section and re-create the PVC pointing to such a file volume.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.1.1.md
+++ b/docs/book/releases/v2.1.1.md
@@ -59,6 +59,8 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
 8. If there are no datastores present in any one of the datacenters in your vSphere environment, CSI file volume provisioning fails with `failed to get all the datastores` error.
    - Impact: File volume provisioning keeps failing.
    - Workaround: Either remove the `ReadOnly` privilege on this datacenter for the user listed in the `vsphere-config-secret` secret or add a datastore to this datacenter. Refer to `vsphere-roles-and-privileges` section in the [prerequisites](../driver-deployment/prerequisites.md) page to change the permissions on this datacenter. Note: This issue is fixed in [v2.2.0](v2.2.0.md)
+9. vSAN file share might fail to get mounted on a pod, or a pod is unable to write unto a file volume
+   - Workaround: User needs to modify the `vsphere-config-secret` secret to remove the clashing IPs (or IP ranges) in the NetPermissions section and re-create the PVC pointing to such a file volume.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.2.0.md
+++ b/docs/book/releases/v2.2.0.md
@@ -50,6 +50,8 @@
     - Workaround:
         - No workaround. User should not attempt to delete PV which is bound to PVC. User should only delete a PV if they know that the underlying volume in the storage system is gone.
         - If user has accidentally left orphan volumes on the datastore by not following the guideline, and if user has captured the volume handles or First Class Disk IDs of deleted PVs, storage admin can help delete those volumes using `govc disk.rm <volume-handle/FCD ID>` command.
+4. vSAN file share might fail to get mounted on a pod, or a pod is unable to write unto a file volume
+    - Workaround: User needs to modify the `vsphere-config-secret` secret to remove the clashing IPs (or IP ranges) in the NetPermissions section and re-create the PVC pointing to such a file volume.
 
 ### Kubernetes issues
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR clarifies that clashing IPs/IP ranges in NetPermissions for file volume configuration can result in undefined behavior. There is an internal bug created to resolve this behavior for future.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #870

**Testing done**:
Testing not required. Changes are limited to documentation.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Warn user about clashing IPs in NetPermissions for file volume configuration
```
