### PR TITLE
clean up long lines in informers.go

### DIFF
--- a/pkg/kubernetes/informers.go
+++ b/pkg/kubernetes/informers.go
@@ -63,7 +63,8 @@ func NewInformer(client clientset.Interface) *InformerManager {
 }
 
 // AddNodeListener hooks up add, update, delete callbacks.
-func (im *InformerManager) AddNodeListener(add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
+func (im *InformerManager) AddNodeListener(
+	add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.nodeInformer == nil {
 		im.nodeInformer = im.informerFactory.Core().V1().Nodes().Informer()
 	}
@@ -76,7 +77,8 @@ func (im *InformerManager) AddNodeListener(add func(obj interface{}), update fun
 }
 
 // AddPVCListener hooks up add, update, delete callbacks.
-func (im *InformerManager) AddPVCListener(add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
+func (im *InformerManager) AddPVCListener(
+	add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.pvcInformer == nil {
 		im.pvcInformer = im.informerFactory.Core().V1().PersistentVolumeClaims().Informer()
 	}
@@ -90,7 +92,8 @@ func (im *InformerManager) AddPVCListener(add func(obj interface{}), update func
 }
 
 // AddPVListener hooks up add, update, delete callbacks.
-func (im *InformerManager) AddPVListener(add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
+func (im *InformerManager) AddPVListener(
+	add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.pvInformer == nil {
 		im.pvInformer = im.informerFactory.Core().V1().PersistentVolumes().Informer()
 	}
@@ -104,7 +107,8 @@ func (im *InformerManager) AddPVListener(add func(obj interface{}), update func(
 }
 
 // AddNamespaceListener hooks up add, update, delete callbacks.
-func (im *InformerManager) AddNamespaceListener(add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
+func (im *InformerManager) AddNamespaceListener(
+	add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.namespaceInformer == nil {
 		im.namespaceInformer = im.informerFactory.Core().V1().Namespaces().Informer()
 	}
@@ -118,9 +122,12 @@ func (im *InformerManager) AddNamespaceListener(add func(obj interface{}), updat
 }
 
 // AddConfigMapListener hooks up add, update, delete callbacks.
-func (im *InformerManager) AddConfigMapListener(ctx context.Context, client clientset.Interface, namespace string, add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
+func (im *InformerManager) AddConfigMapListener(
+	ctx context.Context, client clientset.Interface, namespace string,
+	add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.configMapInformer == nil {
-		im.configMapInformer = v1.NewFilteredConfigMapInformer(client, namespace, resyncPeriodConfigMapInformer, cache.Indexers{}, nil)
+		im.configMapInformer = v1.NewFilteredConfigMapInformer(client, namespace,
+			resyncPeriodConfigMapInformer, cache.Indexers{}, nil)
 	}
 	im.configMapSynced = im.configMapInformer.HasSynced
 
@@ -136,7 +143,8 @@ func (im *InformerManager) AddConfigMapListener(ctx context.Context, client clie
 }
 
 // AddPodListener hooks up add, update, delete callbacks.
-func (im *InformerManager) AddPodListener(add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
+func (im *InformerManager) AddPodListener(
+	add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
 	if im.podInformer == nil {
 		im.podInformer = im.informerFactory.Core().V1().Pods().Informer()
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. This change handles the
long lines in nodes.go. (In C/C++, I typically limit the line within 80 characters, for a reference.)
To wrap a long line, we need to pay attention to Golang's special grammar that it automatically
inserts a semicolon immediately after a line's final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles informers.go.

**Testing done**:
Local build and check.