### PR TITLE
Clean up cnsctl

### DIFF
--- a/cnsctl/cmd/ov/cleanup.go
+++ b/cnsctl/cmd/ov/cleanup.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// cleanupCmd represents the cleanup command
+// cleanupCmd represents the cleanup command.
 var cleanupCmd = &cobra.Command{
 	Use:   "cleanup",
 	Short: "Identifies orphan volumes and deletes them",
@@ -36,14 +36,16 @@ var cleanupCmd = &cobra.Command{
 			fmt.Printf("error: no arguments allowed for cleanup\n")
 			os.Exit(1)
 		}
-		// TODO: Add implementation
+		// TODO: Add implementation.
 	},
 }
 
-// InitCleanup help initialize cleanupCmd
+// InitCleanup help initialize cleanupCmd.
 func InitCleanup() {
-	cleanupCmd.PersistentFlags().StringVarP(&datastores, "datastores", "d", viper.GetString("datastores"), "comma-separated datastore names (alternatively use CNSCTL_DATASTORES env variable)")
-	cleanupCmd.PersistentFlags().StringVarP(&cfgFile, "kubeconfig", "k", viper.GetString("kubeconfig"), "kubeconfig file (alternatively use CNSCTL_KUBECONFIG env variable)")
+	cleanupCmd.PersistentFlags().StringVarP(&datastores, "datastores", "d", viper.GetString("datastores"),
+		"comma-separated datastore names (alternatively use CNSCTL_DATASTORES env variable)")
+	cleanupCmd.PersistentFlags().StringVarP(&cfgFile, "kubeconfig", "k", viper.GetString("kubeconfig"),
+		"kubeconfig file (alternatively use CNSCTL_KUBECONFIG env variable)")
 	cleanupCmd.PersistentFlags().BoolVarP(&forceDelete, "force", "f", false, "force delete the volumes")
 	ovCmd.AddCommand(cleanupCmd)
 }

--- a/cnsctl/cmd/ov/ls.go
+++ b/cnsctl/cmd/ov/ls.go
@@ -27,7 +27,7 @@ import (
 var datastores, cfgFile string
 var all, long bool
 
-// lsCmd represents the ls command
+// lsCmd represents the ls command.
 var lsCmd = &cobra.Command{
 	Use:   "ls",
 	Short: "List Orphan volumes",
@@ -35,14 +35,16 @@ var lsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		validateOvFlags()
 		validateLsFlags()
-		// TODO: Add implementation
+		// TODO: Add implementation.
 	},
 }
 
-// InitLs helps initialize lsCmd
+// InitLs helps initialize lsCmd.
 func InitLs() {
-	lsCmd.PersistentFlags().StringVarP(&datastores, "datastores", "d", viper.GetString("datastores"), "comma-separated datastore names (alternatively use CNSCTL_DATASTORES env variable)")
-	lsCmd.PersistentFlags().StringVarP(&cfgFile, "kubeconfig", "k", viper.GetString("kubeconfig"), "comma-separated kubeconfig file(s) (alternatively use CNSCTL_KUBECONFIG env variable)")
+	lsCmd.PersistentFlags().StringVarP(&datastores, "datastores", "d", viper.GetString("datastores"),
+		"comma-separated datastore names (alternatively use CNSCTL_DATASTORES env variable)")
+	lsCmd.PersistentFlags().StringVarP(&cfgFile, "kubeconfig", "k", viper.GetString("kubeconfig"),
+		"comma-separated kubeconfig file(s) (alternatively use CNSCTL_KUBECONFIG env variable)")
 	lsCmd.PersistentFlags().BoolVarP(&all, "all", "a", false, "Show orphan and used volumes")
 	lsCmd.PersistentFlags().BoolVarP(&long, "long-list", "l", false, "Show additional details of the volumes")
 	ovCmd.AddCommand(lsCmd)

--- a/cnsctl/cmd/ov/ov.go
+++ b/cnsctl/cmd/ov/ov.go
@@ -26,7 +26,7 @@ import (
 
 var datacenter, vcHost, vcUser, vcPwd string
 
-// ovCmd represents the ov command
+// ovCmd represents the ov command.
 var ovCmd = &cobra.Command{
 	Use:   "ov",
 	Short: "Orphan volume commands",
@@ -37,16 +37,20 @@ var ovCmd = &cobra.Command{
 	},
 }
 
-// InitOv helps initialize ovCmd
+// InitOv helps initialize ovCmd.
 func InitOv(rootCmd *cobra.Command) {
 	InitLs()
 	InitRm()
 	InitCleanup()
 
-	ovCmd.PersistentFlags().StringVarP(&vcHost, "host", "H", viper.GetString("host"), "vCenter host (alternatively use CNSCTL_HOST env variable)")
-	ovCmd.PersistentFlags().StringVarP(&vcUser, "user", "u", viper.GetString("user"), "vCenter user (alternatively use CNSCTL_USER env variable)")
-	ovCmd.PersistentFlags().StringVarP(&vcPwd, "password", "p", viper.GetString("password"), "vCenter password (alternatively use CNSCTL_PASSWORD env variable)")
-	ovCmd.PersistentFlags().StringVarP(&datacenter, "datacenter", "D", viper.GetString("datacenter"), "datacenter name (alternatively use CNSCTL_DATACENTER env variable)")
+	ovCmd.PersistentFlags().StringVarP(&vcHost, "host", "H", viper.GetString("host"),
+		"vCenter host (alternatively use CNSCTL_HOST env variable)")
+	ovCmd.PersistentFlags().StringVarP(&vcUser, "user", "u", viper.GetString("user"),
+		"vCenter user (alternatively use CNSCTL_USER env variable)")
+	ovCmd.PersistentFlags().StringVarP(&vcPwd, "password", "p", viper.GetString("password"),
+		"vCenter password (alternatively use CNSCTL_PASSWORD env variable)")
+	ovCmd.PersistentFlags().StringVarP(&datacenter, "datacenter", "D", viper.GetString("datacenter"),
+		"datacenter name (alternatively use CNSCTL_DATACENTER env variable)")
 
 	rootCmd.AddCommand(ovCmd)
 }

--- a/cnsctl/cmd/ov/rm.go
+++ b/cnsctl/cmd/ov/rm.go
@@ -27,7 +27,7 @@ import (
 var datastore string
 var forceDelete bool
 
-// rmCmd represents the rm command
+// rmCmd represents the rm command.
 var rmCmd = &cobra.Command{
 	Use:   "rm",
 	Short: "Remove specified volume IDs",
@@ -39,15 +39,16 @@ var rmCmd = &cobra.Command{
 			fmt.Printf("error: no volumes specified to be deleted.\n")
 			os.Exit(1)
 		}
-		// TODO: Add implementation
+		// TODO: Add implementation.
 	},
 }
 
-// InitRm helps initialize rmCmd
+// InitRm helps initialize rmCmd.
 func InitRm() {
 	rmCmd.PersistentFlags().StringVarP(&datastore, "datastore", "d", "", "a single datastore name")
 	rmCmd.PersistentFlags().BoolVarP(&forceDelete, "force", "f", false, "force delete the volume")
-	rmCmd.PersistentFlags().StringVarP(&cfgFile, "kubeconfig", "k", viper.GetString("kubeconfig"), "kubeconfig file (alternatively use CNSCTL_KUBECONFIG env variable)")
+	rmCmd.PersistentFlags().StringVarP(&cfgFile, "kubeconfig", "k", viper.GetString("kubeconfig"),
+		"kubeconfig file (alternatively use CNSCTL_KUBECONFIG env variable)")
 	ovCmd.AddCommand(rmCmd)
 }
 

--- a/cnsctl/cmd/ova/cleanup.go
+++ b/cnsctl/cmd/ova/cleanup.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// cleanupCmd represents the cleanup command
+// cleanupCmd represents the cleanup command.
 var cleanupCmd = &cobra.Command{
 	Use:   "cleanup",
 	Short: "Identifies orphan volume attachment CRs and deletes them",
@@ -40,9 +40,10 @@ var cleanupCmd = &cobra.Command{
 	},
 }
 
-// InitCleanup helps initialize cleanupCmd
+// InitCleanup helps initialize cleanupCmd.
 func InitCleanup() {
-	cleanupCmd.PersistentFlags().StringVarP(&cfgFile, "kubeconfig", "k", viper.GetString("kubeconfig"), "kubeconfig file (alternatively use CNSCTL_KUBECONFIG env variable)")
+	cleanupCmd.PersistentFlags().StringVarP(&cfgFile, "kubeconfig", "k", viper.GetString("kubeconfig"),
+		"kubeconfig file (alternatively use CNSCTL_KUBECONFIG env variable)")
 	ovaCmd.AddCommand(cleanupCmd)
 }
 

--- a/cnsctl/cmd/ova/ls.go
+++ b/cnsctl/cmd/ova/ls.go
@@ -27,21 +27,23 @@ import (
 var cfgFile string
 var all bool
 
-// lsCmd represents the ls command
+// lsCmd represents the ls command.
 var lsCmd = &cobra.Command{
 	Use:   "ls",
 	Short: "List orphan VolumeAttachment CRs in Kubernetes",
 	Long:  "List orphan VolumeAttachment CRs in Kubernetes",
 	Run: func(cmd *cobra.Command, args []string) {
 		validateLsFlags()
-		// TODO: Add implementation
+		// TODO: Add implementation.
 	},
 }
 
-// InitLs helps initialize lsCmd
+// InitLs helps initialize lsCmd.
 func InitLs() {
-	lsCmd.PersistentFlags().StringVarP(&cfgFile, "kubeconfig", "k", viper.GetString("kubeconfig"), "kubeconfig file (alternatively use CNSCTL_KUBECONFIG env variable)")
-	lsCmd.PersistentFlags().BoolVarP(&all, "all", "a", false, "Show orphan and used volume attachment CRs in the Kubernetes cluster")
+	lsCmd.PersistentFlags().StringVarP(&cfgFile, "kubeconfig", "k", viper.GetString("kubeconfig"),
+		"kubeconfig file (alternatively use CNSCTL_KUBECONFIG env variable)")
+	lsCmd.PersistentFlags().BoolVarP(&all, "all", "a", false,
+		"Show orphan and used volume attachment CRs in the Kubernetes cluster")
 	ovaCmd.AddCommand(lsCmd)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. This change handles the
long lines in nodes.go. (In C/C++, I typically limit the line within 80 characters, for a reference.)
To wrap a long line, we need to pay attention to Golang's special grammar that it automatically
inserts a semicolon immediately after a line's final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles cnsctl/cmd.

**Testing done**:
Local build and check.
Block vanilla build status: SUCCESS 