### PR TITLE
Clean up pbm.go

### DIFF
--- a/pkg/common/cns-lib/vsphere/pbm.go
+++ b/pkg/common/cns-lib/vsphere/pbm.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
-// SpbmPolicyRule is an individual policy rule
+// SpbmPolicyRule is an individual policy rule.
 // Not all providers use Ns, CapID, PropID in the same way,
 // so one needs to look at each one individually.
 // Ns + CapID + PropID together are a unique key in all cases
@@ -38,12 +38,13 @@ type SpbmPolicyRule struct {
 	Value  string `json:"value,omitempty"`
 }
 
-// SpbmPolicySubProfile is a combination of rules which are ANDed to form a sub profile
+// SpbmPolicySubProfile is a combination of rules, which are ANDed to form
+// a sub profile.
 type SpbmPolicySubProfile struct {
 	Rules []SpbmPolicyRule `json:"rules"`
 }
 
-// SpbmPolicyContent corresponds to a single VC SPBM policy
+// SpbmPolicyContent corresponds to a single VC SPBM policy.
 // The various sub profilles are ORed. For vSAN there should only
 // be a single sub profile.
 type SpbmPolicyContent struct {
@@ -95,8 +96,10 @@ func (vc *VirtualCenter) GetStoragePolicyIDByName(ctx context.Context, storagePo
 	return storagePolicyID, nil
 }
 
-// PbmCheckCompatibility performs a compatibility check for the given profileID with the given datastores
-func (vc *VirtualCenter) PbmCheckCompatibility(ctx context.Context, datastores []vimtypes.ManagedObjectReference, profileID string) (pbm.PlacementCompatibilityResult, error) {
+// PbmCheckCompatibility performs a compatibility check for the given profileID
+// with the given datastores.
+func (vc *VirtualCenter) PbmCheckCompatibility(ctx context.Context,
+	datastores []vimtypes.ManagedObjectReference, profileID string) (pbm.PlacementCompatibilityResult, error) {
 	hubs := make([]pbmtypes.PbmPlacementHub, 0)
 	for _, ds := range datastores {
 		hubs = append(hubs, pbmtypes.PbmPlacementHub{
@@ -120,7 +123,7 @@ func (vc *VirtualCenter) PbmCheckCompatibility(ctx context.Context, datastores [
 	return res.Returnval, nil
 }
 
-// PbmRetrieveContent fetches the policy content of all given policies from SPBM
+// PbmRetrieveContent fetches the policy content of all given policies from SPBM.
 func (vc *VirtualCenter) PbmRetrieveContent(ctx context.Context, policyIds []string) ([]SpbmPolicyContent, error) {
 	pbmPolicyIds := make([]pbmtypes.PbmProfileId, 0)
 	for _, policyID := range policyIds {


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. This change handles the
long lines in nodes.go. (In C/C++, I typically limit the line within 80 characters, for a reference.)
To wrap a long line, we need to pay attention to Golang's special grammar that it automatically
inserts a semicolon immediately after a line's final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles pbm.go.

**Testing done**:
Local build and check.