### PR TITLE
Use LogNewErrorCodef in node.go

### DIFF
--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -156,10 +156,9 @@ func nodeStageBlockVolume(
 	// Check that block device looks good
 	dev, err := getDevice(volPath)
 	if err != nil {
-		msg := fmt.Sprintf("error getting block device for volume: %q. Parameters: %v err: %v",
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"error getting block device for volume: %q. Parameters: %v err: %v",
 			params.volID, params, err)
-		log.Error(msg)
-		return nil, status.Error(codes.Internal, msg)
 
 	}
 	log.Debugf("nodeStageBlockVolume: getDevice %+v", *dev)
@@ -176,9 +175,8 @@ func nodeStageBlockVolume(
 	log.Debugf("nodeStageBlockVolume: Fetching device mounts")
 	mnts, err := gofsutil.GetDevMounts(ctx, dev.RealDev)
 	if err != nil {
-		msg := fmt.Sprintf("could not reliably determine existing mount status. Parameters: %v err: %v", params, err)
-		log.Error(msg)
-		return nil, status.Error(codes.Internal, msg)
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"could not reliably determine existing mount status. Parameters: %v err: %v", params, err)
 	}
 
 	if len(mnts) == 0 {
@@ -189,9 +187,8 @@ func nodeStageBlockVolume(
 				dev.FullPath, params.stagingTarget, params.mntFlags)
 			params.mntFlags = append(params.mntFlags, "ro")
 			if err := gofsutil.Mount(ctx, dev.FullPath, params.stagingTarget, params.fsType, params.mntFlags...); err != nil {
-				msg := fmt.Sprintf("error mounting volume. Parameters: %v err: %v", params, err)
-				log.Error(msg)
-				return nil, status.Errorf(codes.Internal, msg)
+				return nil, logger.LogNewErrorCodef(log, codes.Internal,
+					"error mounting volume. Parameters: %v err: %v", params, err)
 			}
 			log.Infof("nodeStageBlockVolume: Device mounted successfully at %q", params.stagingTarget)
 			return &csi.NodeStageVolumeResponse{}, nil
@@ -200,9 +197,8 @@ func nodeStageBlockVolume(
 		log.Debugf("nodeStageBlockVolume: Format and mount the device %q at %q with mount flags %v",
 			dev.FullPath, params.stagingTarget, params.mntFlags)
 		if err := gofsutil.FormatAndMount(ctx, dev.FullPath, params.stagingTarget, params.fsType, params.mntFlags...); err != nil {
-			msg := fmt.Sprintf("error in formating and mounting volume. Parameters: %v err: %v", params, err)
-			log.Error(msg)
-			return nil, status.Errorf(codes.Internal, msg)
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"error in formating and mounting volume. Parameters: %v err: %v", params, err)
 		}
 	} else {
 		// If Device is already mounted. Need to ensure that it is already
@@ -222,11 +218,11 @@ func nodeStageBlockVolume(
 						params.stagingTarget, rwo)
 					return &csi.NodeStageVolumeResponse{}, nil
 				}
-				return nil, status.Errorf(codes.AlreadyExists,
+				return nil, logger.LogNewErrorCodef(log, codes.AlreadyExists,
 					"access mode conflicts with existing mount at %q", params.stagingTarget)
 			}
 		}
-		return nil, status.Error(codes.Internal,
+		return nil, logger.LogNewErrorCode(log, codes.Internal,
 			"device already in use and mounted elsewhere")
 	}
 	log.Infof("nodeStageBlockVolume: Device mounted successfully at %q", params.stagingTarget)
@@ -245,7 +241,7 @@ func (driver *vsphereCSIDriver) NodeUnstageVolume(
 	// Fetch all the mount points
 	mnts, err := gofsutil.GetMounts(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal,
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
 			"could not retrieve existing mount points: %v", err)
 	}
 	log.Debugf("NodeUnstageVolume: node mounts %+v", mnts)
@@ -277,7 +273,7 @@ func (driver *vsphereCSIDriver) NodeUnstageVolume(
 	if isMounted {
 		log.Infof("Attempting to unmount target %q for volume %q", stagingTarget, volID)
 		if err := gofsutil.Unmount(ctx, stagingTarget); err != nil {
-			return nil, status.Errorf(codes.Internal,
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"Error unmounting stagingTarget: %v", err)
 		}
 	}
@@ -301,7 +297,7 @@ func isBlockVolumeMounted(
 	// mounted still indicates that unstaging is done.
 	dev, err := getDevFromMount(stagingTargetPath)
 	if err != nil {
-		return false, status.Errorf(codes.Internal,
+		return false, logger.LogNewErrorCodef(log, codes.Internal,
 			"isBlockVolumeMounted: error getting block device for volume: %s, err: %s",
 			volID, err.Error())
 	}
@@ -319,14 +315,14 @@ func isBlockVolumeMounted(
 	// Get mounts for device
 	mnts, err := gofsutil.GetDevMounts(ctx, dev.RealDev)
 	if err != nil {
-		return false, status.Errorf(codes.Internal,
+		return false, logger.LogNewErrorCodef(log, codes.Internal,
 			"isBlockVolumeMounted: could not reliably determine existing mount status: %s",
 			err.Error())
 	}
 
 	// device is mounted more than once. Should only be mounted to target
 	if len(mnts) > 1 {
-		return false, status.Errorf(codes.Internal,
+		return false, logger.LogNewErrorCodef(log, codes.Internal,
 			"isBlockVolumeMounted: volume: %s appears mounted in multiple places", volID)
 	}
 
@@ -354,7 +350,8 @@ func (driver *vsphereCSIDriver) NodePublishVolume(
 
 	params.stagingTarget = req.GetStagingTargetPath()
 	if params.stagingTarget == "" {
-		return nil, status.Errorf(codes.FailedPrecondition, "staging target path %q not set", params.stagingTarget)
+		return nil, logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+			"staging target path %q not set", params.stagingTarget)
 	}
 
 	// Check if this is a MountVolume or BlockVolume
@@ -376,9 +373,8 @@ func (driver *vsphereCSIDriver) NodePublishVolume(
 		// Get underlying block device
 		dev, err := getDevice(volPath)
 		if err != nil {
-			msg := fmt.Sprintf("error getting block device for volume: %q. Parameters: %v err: %v", params.volID, params, err)
-			log.Error(msg)
-			return nil, status.Errorf(codes.Internal, msg)
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"error getting block device for volume: %q. Parameters: %v err: %v", params.volID, params, err)
 		}
 		params.volumePath = dev.FullPath
 		params.device = dev.RealDev
@@ -415,16 +411,15 @@ func (driver *vsphereCSIDriver) NodeUnpublishVolume(
 			log.Infof("NodeUnpublishVolume: Target path %q does not exist. Assuming NodeUnpublish is complete", target)
 			return &csi.NodeUnpublishVolumeResponse{}, nil
 		}
-		return nil, status.Errorf(codes.Internal,
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to stat target %q, err: %v", target, err)
 	}
 
 	// Fetch all the mount points
 	mnts, err := gofsutil.GetMounts(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"could not retrieve existing mount points: %q",
-			err.Error())
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"could not retrieve existing mount points: %q", err.Error())
 	}
 	log.Debugf("NodeUnpublishVolume: node mounts %+v", mnts)
 
@@ -449,9 +444,8 @@ func (driver *vsphereCSIDriver) NodeUnpublishVolume(
 	if isPublished {
 		log.Infof("NodeUnpublishVolume: Attempting to unmount target %q for volume %q", target, volID)
 		if err := gofsutil.Unmount(ctx, target); err != nil {
-			msg := fmt.Sprintf("Error unmounting target %q for volume %q. %q", target, volID, err.Error())
-			log.Debug(msg)
-			return nil, status.Error(codes.Internal, msg)
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"Error unmounting target %q for volume %q. %q", target, volID, err.Error())
 		}
 		log.Debugf("Unmount successful for target %q for volume %q", target, volID)
 		// TODO Use a go routine here. The deletion of target path might not be a good reason to error out
@@ -474,9 +468,8 @@ func isBlockVolumePublished(ctx context.Context, volID string, target string) (b
 	// Look up block device mounted to target
 	dev, err := getDevFromMount(target)
 	if err != nil {
-		return false, status.Errorf(codes.Internal,
-			"error getting block device for volume: %s, err: %v",
-			volID, err)
+		return false, logger.LogNewErrorCodef(log, codes.Internal,
+			"error getting block device for volume: %s, err: %v", volID, err)
 	}
 
 	if dev == nil {
@@ -485,9 +478,8 @@ func isBlockVolumePublished(ctx context.Context, volID string, target string) (b
 		log.Debugf("isBlockVolumePublished: No device found. Assuming Unpublish is "+
 			"already complete for volume %q and target path %q", volID, target)
 		if err := rmpath(ctx, target); err != nil {
-			msg := fmt.Sprintf("Failed to delete the target path %q. Error: %v", target, err)
-			log.Debug(msg)
-			return false, status.Errorf(codes.Internal, msg)
+			return false, logger.LogNewErrorCodef(log, codes.Internal,
+				"Failed to delete the target path %q. Error: %v", target, err)
 		}
 		log.Debugf("isBlockVolumePublished: Target path %q successfully deleted", target)
 		return false, nil
@@ -506,12 +498,13 @@ func (driver *vsphereCSIDriver) NodeGetVolumeStats(
 	var err error
 	targetPath := req.GetVolumePath()
 	if targetPath == "" {
-		return nil, status.Errorf(codes.InvalidArgument, "received empty targetpath %q", targetPath)
+		return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			"received empty targetpath %q", targetPath)
 	}
 
 	volMetrics, err := getMetrics(targetPath)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, logger.LogNewErrorCode(log, codes.Internal, err.Error())
 	}
 
 	available, ok := (*(volMetrics.Available)).AsInt64()
@@ -520,8 +513,7 @@ func (driver *vsphereCSIDriver) NodeGetVolumeStats(
 	}
 	capacity, ok := (*(volMetrics.Capacity)).AsInt64()
 	if !ok {
-		log.Errorf("failed to fetch capacity bytes")
-		return nil, status.Error(codes.Unknown, "failed to fetch capacity bytes")
+		return nil, logger.LogNewErrorCode(log, codes.Unknown, "failed to fetch capacity bytes")
 	}
 	used, ok := (*(volMetrics.Used)).AsInt64()
 	if !ok {
@@ -529,8 +521,7 @@ func (driver *vsphereCSIDriver) NodeGetVolumeStats(
 	}
 	inodes, ok := (*(volMetrics.Inodes)).AsInt64()
 	if !ok {
-		log.Errorf("failed to fetch total number of inodes")
-		return nil, status.Error(codes.Unknown, "failed to fetch total number of inodes")
+		return nil, logger.LogNewErrorCode(log, codes.Unknown, "failed to fetch total number of inodes")
 	}
 	inodesFree, ok := (*(volMetrics.InodesFree)).AsInt64()
 	if !ok {
@@ -629,27 +620,25 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 
 	nodeID := os.Getenv("NODE_NAME")
 	if nodeID == "" {
-		return nil, status.Error(codes.Internal, "ENV NODE_NAME is not set")
+		return nil, logger.LogNewErrorCode(log, codes.Internal, "ENV NODE_NAME is not set")
 	}
 	var maxVolumesPerNode int64
 	if v := os.Getenv("MAX_VOLUMES_PER_NODE"); v != "" {
 		if value, err := strconv.ParseInt(v, 10, 64); err == nil {
 			if value < 0 {
-				msg := fmt.Sprintf("NodeGetInfo: MAX_VOLUMES_PER_NODE set in env variable %v is less than 0", v)
-				log.Errorf(msg)
-				return nil, status.Error(codes.Internal, msg)
+				return nil, logger.LogNewErrorCodef(log, codes.Internal,
+					"NodeGetInfo: MAX_VOLUMES_PER_NODE set in env variable %v is less than 0", v)
 			} else if value > maxAllowedBlockVolumesPerNode {
-				msg := fmt.Sprintf("NodeGetInfo: MAX_VOLUMES_PER_NODE set in env variable %v is more than %v", v, maxAllowedBlockVolumesPerNode)
-				log.Errorf(msg)
-				return nil, status.Error(codes.Internal, msg)
+				return nil, logger.LogNewErrorCodef(log, codes.Internal,
+					"NodeGetInfo: MAX_VOLUMES_PER_NODE set in env variable %v is more than %v",
+					v, maxAllowedBlockVolumesPerNode)
 			} else {
 				maxVolumesPerNode = value
 				log.Infof("NodeGetInfo: MAX_VOLUMES_PER_NODE is set to %v", maxVolumesPerNode)
 			}
 		} else {
-			msg := fmt.Sprintf("NodeGetInfo: MAX_VOLUMES_PER_NODE set in env variable %v is invalid", v)
-			log.Errorf(msg)
-			return nil, status.Error(codes.Internal, msg)
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"NodeGetInfo: MAX_VOLUMES_PER_NODE set in env variable %v is invalid", v)
 		}
 	}
 
@@ -678,8 +667,8 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 			log.Infof("NodeGetInfo response: %v", nodeInfoResponse)
 			return nodeInfoResponse, nil
 		}
-		log.Errorf("failed to read cnsconfig. Error: %v", err)
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to read cnsconfig. err: %v", err)
 	}
 	var accessibleTopology map[string]string
 	topology := &csi.Topology{}
@@ -688,14 +677,14 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 		log.Infof("Config file provided to node daemonset with zones and regions. Assuming topology aware cluster.")
 		vcenterconfig, err := cnsvsphere.GetVirtualCenterConfig(ctx, cfg)
 		if err != nil {
-			log.Errorf("failed to get VirtualCenterConfig from cns config. err=%v", err)
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to get VirtualCenterConfig from cns config. err: %v", err)
 		}
 		vcManager := cnsvsphere.GetVirtualCenterManager(ctx)
 		vcenter, err := vcManager.RegisterVirtualCenter(ctx, vcenterconfig)
 		if err != nil {
-			log.Errorf("failed to register vcenter with virtualCenterManager.")
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to register vcenter with virtualCenterManager. err: %v", err)
 		}
 		defer func() {
 			if vcManager != nil {
@@ -708,14 +697,14 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 		//Connect to vCenter
 		err = vcenter.Connect(ctx)
 		if err != nil {
-			log.Errorf("failed to connect to vcenter host: %s. err=%v", vcenter.Config.Host, err)
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to connect to vcenter host: %s. err: %v", vcenter.Config.Host, err)
 		}
 		// Get VM UUID
 		uuid, err := getSystemUUID(ctx)
 		if err != nil {
-			log.Errorf("failed to get system uuid for node VM")
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to get system uuid for node VM. err: %v", err)
 		}
 		log.Debugf("Successfully retrieved uuid:%s  from the node: %s", uuid, nodeID)
 		nodeVM, err := cnsvsphere.GetVirtualMachineByUUID(ctx, uuid, false)
@@ -723,19 +712,19 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 			log.Errorf("failed to get nodeVM for uuid: %s. err: %+v", uuid, err)
 			uuid, err = convertUUID(uuid)
 			if err != nil {
-				log.Errorf("convertUUID failed with error: %v", err)
-				return nil, status.Errorf(codes.Internal, err.Error())
+				return nil, logger.LogNewErrorCodef(log, codes.Internal,
+					"convertUUID failed with error: %v", err)
 			}
 			nodeVM, err = cnsvsphere.GetVirtualMachineByUUID(ctx, uuid, false)
 			if err != nil || nodeVM == nil {
-				log.Errorf("failed to get nodeVM for uuid: %s. err: %+v", uuid, err)
-				return nil, status.Errorf(codes.Internal, err.Error())
+				return nil, logger.LogNewErrorCodef(log, codes.Internal,
+					"failed to get nodeVM for uuid: %s. err: %+v", uuid, err)
 			}
 		}
 		tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
 		if err != nil {
-			log.Errorf("failed to create tagManager. Err: %v", err)
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to create tagManager. err: %v", err)
 		}
 		defer func() {
 			err := tagManager.Logout(ctx)
@@ -745,8 +734,8 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 		}()
 		zone, region, err := nodeVM.GetZoneRegion(ctx, cfg.Labels.Zone, cfg.Labels.Region, tagManager)
 		if err != nil {
-			log.Errorf("failed to get accessibleTopology for vm: %v, err: %v", nodeVM.Reference(), err)
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to get accessibleTopology for vm: %v, err: %v", nodeVM.Reference(), err)
 		}
 		log.Debugf("zone: [%s], region: [%s], Node VM: [%s]", zone, region, nodeID)
 		if zone != "" && region != "" {
@@ -777,11 +766,11 @@ func (driver *vsphereCSIDriver) NodeExpandVolume(
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "volume id must be provided")
+		return nil, logger.LogNewErrorCode(log, codes.InvalidArgument, "volume id must be provided")
 	} else if req.GetCapacityRange() == nil {
-		return nil, status.Error(codes.InvalidArgument, "capacity range must be provided")
+		return nil, logger.LogNewErrorCode(log, codes.InvalidArgument, "capacity range must be provided")
 	} else if req.GetCapacityRange().GetRequiredBytes() < 0 || req.GetCapacityRange().GetLimitBytes() < 0 {
-		return nil, status.Error(codes.InvalidArgument, "capacity ranges values cannot be negative")
+		return nil, logger.LogNewErrorCode(log, codes.InvalidArgument, "capacity ranges values cannot be negative")
 	}
 
 	reqVolSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
@@ -794,17 +783,18 @@ func (driver *vsphereCSIDriver) NodeExpandVolume(
 
 	volumePath := req.GetVolumePath()
 	if len(volumePath) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "volume path must be provided to expand volume on node")
+		return nil, logger.LogNewErrorCode(log, codes.InvalidArgument,
+			"volume path must be provided to expand volume on node")
 	}
 
 	// Look up block device mounted to staging target path
 	dev, err := getDevFromMount(volumePath)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal,
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
 			"error getting block device for volume: %q, err: %v",
 			volumeID, err)
 	} else if dev == nil {
-		return nil, status.Errorf(codes.Internal,
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
 			"volume %q is not mounted at the path %s",
 			volumeID, volumePath)
 	}
@@ -821,7 +811,8 @@ func (driver *vsphereCSIDriver) NodeExpandVolume(
 		// Fetch the current block size
 		currentBlockSizeBytes, err := getBlockSizeBytes(mounter, dev.RealDev)
 		if err != nil {
-			return nil, status.Error(codes.Internal, fmt.Sprintf("error when getting size of block volume at path %s: %v", dev.RealDev, err))
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"error when getting size of block volume at path %s: %v", dev.RealDev, err)
 		}
 		// Check if a rescan is required
 		if currentBlockSizeBytes < reqVolSizeBytes {
@@ -830,7 +821,7 @@ func (driver *vsphereCSIDriver) NodeExpandVolume(
 			// Refer to https://kb.vmware.com/s/article/1006371
 			err = rescanDevice(ctx, dev)
 			if err != nil {
-				return nil, status.Error(codes.Internal, err.Error())
+				return nil, logger.LogNewErrorCode(log, codes.Internal, err.Error())
 			}
 		}
 	}
@@ -839,20 +830,23 @@ func (driver *vsphereCSIDriver) NodeExpandVolume(
 	resizer := resizefs.NewResizeFs(mounter)
 	_, err = resizer.Resize(dev.RealDev, volumePath)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("error when resizing filesystem on volume %q on node: %v", volumeID, err))
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"error when resizing filesystem on volume %q on node: %v", volumeID, err)
 	}
 	log.Debugf("NodeExpandVolume: Resized filesystem with devicePath %s volumePath %s", dev.RealDev, volumePath)
 
 	// Check the block size
 	currentBlockSizeBytes, err := getBlockSizeBytes(mounter, dev.RealDev)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("error when getting size of block volume at path %s: %v", dev.RealDev, err))
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"error when getting size of block volume at path %s: %v", dev.RealDev, err)
 	}
 	// NOTE(xyang): Make sure new size is greater than or equal to the
 	// requested size. It is possible for volume size to be rounded up
 	// and therefore bigger than the requested size.
 	if currentBlockSizeBytes < reqVolSizeBytes {
-		return nil, status.Errorf(codes.Internal, "requested volume size was %d, but got volume with size %d", reqVolSizeBytes, currentBlockSizeBytes)
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"requested volume size was %d, but got volume with size %d", reqVolSizeBytes, currentBlockSizeBytes)
 	}
 
 	log.Infof("NodeExpandVolume: expanded volume successfully. devicePath %s volumePath %s size %d", dev.RealDev, volumePath, int64(units.FileSize(reqVolSizeMB*common.MbInBytes)))
@@ -894,7 +888,7 @@ func publishMountVol(
 	// We are responsible for creating target dir, per spec, if not already present
 	_, err = mkdir(ctx, params.target)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal,
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
 			"Unable to create target dir: %q, err: %v", params.target, err)
 	}
 	log.Debugf("PublishMountVolume: Created target path %q", params.target)
@@ -908,9 +902,8 @@ func publishMountVol(
 	// Check if device is already mounted
 	devMnts, err := getDevMounts(ctx, dev)
 	if err != nil {
-		msg := fmt.Sprintf("could not reliably determine existing mount status. Parameters: %v err: %v", params, err)
-		log.Error(msg)
-		return nil, status.Error(codes.Internal, msg)
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"could not reliably determine existing mount status. Parameters: %v err: %v", params, err)
 	}
 	log.Debugf("publishMountVol: device %+v, device mounts %q", *dev, devMnts)
 
@@ -928,7 +921,7 @@ func publishMountVol(
 				}
 				if !contains(m.Opts, rwo) {
 					//TODO make sure that all the mount options match
-					return nil, status.Error(codes.AlreadyExists,
+					return nil, logger.LogNewErrorCode(log, codes.AlreadyExists,
 						"volume previously published with different options")
 				}
 
@@ -938,7 +931,7 @@ func publishMountVol(
 			}
 		}
 	} else if len(devMnts) == 0 {
-		return nil, status.Errorf(codes.FailedPrecondition,
+		return nil, logger.LogNewErrorCodef(log, codes.FailedPrecondition,
 			"Volume ID: %q does not appear staged to %q", req.GetVolumeId(), params.stagingTarget)
 	}
 
@@ -949,9 +942,8 @@ func publishMountVol(
 	log.Debugf("PublishMountVolume: Attempting to bind mount %q to %q with mount flags %v",
 		params.stagingTarget, params.target, mntFlags)
 	if err := gofsutil.BindMount(ctx, params.stagingTarget, params.target, mntFlags...); err != nil {
-		msg := fmt.Sprintf("error mounting volume. Parameters: %v err: %v", params, err)
-		log.Error(msg)
-		return nil, status.Error(codes.Internal, msg)
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"error mounting volume. Parameters: %v err: %v", params, err)
 	}
 	log.Infof("NodePublishVolume for %q successful to path %q", req.GetVolumeId(), params.target)
 	return &csi.NodePublishVolumeResponse{}, nil
@@ -970,7 +962,7 @@ func publishBlockVol(
 	// We are responsible for creating target file, per spec, if not already present
 	_, err := mkfile(ctx, params.target)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal,
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
 			"Unable to create target file: %q, err: %v", params.target, err)
 	}
 	log.Debugf("publishBlockVol: Target %q created", params.target)
@@ -980,16 +972,15 @@ func publishBlockVol(
 	// the underlying block device from being modified, so don't
 	// advertise a false sense of security
 	if params.ro {
-		return nil, status.Error(codes.InvalidArgument,
+		return nil, logger.LogNewErrorCode(log, codes.InvalidArgument,
 			"read only not supported for Block Volume")
 	}
 
 	// get block device mounts
 	devMnts, err := getDevMounts(ctx, dev)
 	if err != nil {
-		msg := fmt.Sprintf("could not reliably determine existing mount status. Parameters: %v err: %v", params, err)
-		log.Error(msg)
-		return nil, status.Error(codes.Internal, msg)
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"could not reliably determine existing mount status. Parameters: %v err: %v", params, err)
 	}
 	log.Debugf("publishBlockVol: device %+v, device mounts %q", *dev, devMnts)
 
@@ -1000,20 +991,19 @@ func publishBlockVol(
 		log.Debugf("PublishBlockVolume: Attempting to bind mount %q to %q with mount flags %v",
 			dev.FullPath, params.target, mntFlags)
 		if err := gofsutil.BindMount(ctx, dev.FullPath, params.target, mntFlags...); err != nil {
-			msg := fmt.Sprintf("error mounting volume. Parameters: %v err: %v", params, err)
-			log.Error(msg)
-			return nil, status.Error(codes.Internal, msg)
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"error mounting volume. Parameters: %v err: %v", params, err)
 		}
 		log.Debugf("PublishBlockVolume: Bind mount successful to path %q", params.target)
 	} else if len(devMnts) == 1 {
 		// already mounted, make sure it's what we want
 		if devMnts[0].Path != params.target {
-			return nil, status.Error(codes.Internal,
+			return nil, logger.LogNewErrorCode(log, codes.Internal,
 				"device already in use and mounted elsewhere")
 		}
 		log.Debugf("Volume already published to target. Parameters: [%+v]", params)
 	} else {
-		return nil, status.Error(codes.AlreadyExists,
+		return nil, logger.LogNewErrorCode(log, codes.AlreadyExists,
 			"block volume already mounted in more than one place")
 	}
 	log.Infof("NodePublishVolume successful to path %q", params.target)
@@ -1038,7 +1028,7 @@ func publishFileVol(
 	// We are responsible for creating target dir, per spec, if not already present
 	_, err = mkdir(ctx, params.target)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal,
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
 			"Unable to create target dir: %q, err: %v", params.target, err)
 	}
 	log.Debugf("PublishFileVolume: Created target path %q", params.target)
@@ -1046,9 +1036,8 @@ func publishFileVol(
 	// Check if target already mounted
 	mnts, err := gofsutil.GetMounts(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"could not retrieve existing mount points: %q",
-			err.Error())
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"could not retrieve existing mount points: %v", err)
 	}
 	log.Debugf("PublishFileVolume: Mounts - %+v", mnts)
 	for _, m := range mnts {
@@ -1061,7 +1050,7 @@ func publishFileVol(
 			}
 			if !contains(m.Opts, rwo) {
 				//TODO make sure that all the mount options match
-				return nil, status.Error(codes.AlreadyExists,
+				return nil, logger.LogNewErrorCode(log, codes.AlreadyExists,
 					"volume previously published with different options")
 			}
 
@@ -1081,15 +1070,15 @@ func publishFileVol(
 	// Retrieve the file share access point from publish context
 	mntSrc, ok := req.GetPublishContext()[common.Nfsv4AccessPoint]
 	if !ok {
-		return nil, status.Error(codes.Internal, "NFSv4 accesspoint not set in publish context")
+		return nil, logger.LogNewErrorCode(log, codes.Internal,
+			"NFSv4 accesspoint not set in publish context")
 	}
 	// Directly mount the file share volume to the pod. No bind mount required.
 	log.Debugf("PublishFileVolume: Attempting to mount %q to %q with fstype %q and mountflags %v",
 		mntSrc, params.target, fsType, mntFlags)
 	if err := gofsutil.Mount(ctx, mntSrc, params.target, fsType, mntFlags...); err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"error publish volume to target path: %q",
-			err.Error())
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"error publish volume to target path: %v", err)
 	}
 	log.Infof("NodePublishVolume successful to path %q", params.target)
 	return &csi.NodePublishVolumeResponse{}, nil
@@ -1203,11 +1192,11 @@ func verifyVolumeAttached(ctx context.Context, diskID string) (string, error) {
 	// Check that volume is attached
 	volPath, err := getDiskPath(diskID, nil)
 	if err != nil {
-		return "", status.Errorf(codes.Internal,
+		return "", logger.LogNewErrorCodef(log, codes.Internal,
 			"Error trying to read attached disks: %v", err)
 	}
 	if volPath == "" {
-		return "", status.Errorf(codes.NotFound,
+		return "", logger.LogNewErrorCodef(log, codes.NotFound,
 			"disk: %s not attached to node", diskID)
 	}
 
@@ -1221,7 +1210,7 @@ func verifyVolumeAttached(ctx context.Context, diskID string) (string, error) {
 func verifyTargetDir(ctx context.Context, target string, targetShouldExist bool) (bool, error) {
 	log := logger.GetLogger(ctx)
 	if target == "" {
-		return false, status.Error(codes.InvalidArgument,
+		return false, logger.LogNewErrorCode(log, codes.InvalidArgument,
 			"target path required")
 	}
 
@@ -1230,21 +1219,21 @@ func verifyTargetDir(ctx context.Context, target string, targetShouldExist bool)
 		if os.IsNotExist(err) {
 			if targetShouldExist {
 				// target path does not exist but targetShouldExist is set to true
-				return false, status.Errorf(codes.FailedPrecondition,
+				return false, logger.LogNewErrorCodef(log, codes.FailedPrecondition,
 					"target: %s not pre-created", target)
 			}
 			// target path does not exist but targetShouldExist is set to false, so no error
 			return false, nil
 		}
-		return false, status.Errorf(codes.Internal,
-			"failed to stat target, err: %s", err.Error())
+		return false, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to stat target, err: %v", err)
 	}
 
 	// This check is mandated by the spec, but this would/should fail if the
 	// volume has a block accessType as we get a file for raw block volumes
 	// during NodePublish/Unpublish. Do not use this function for Publish/Unpublish
 	if !tgtStat.IsDir() {
-		return false, status.Errorf(codes.FailedPrecondition,
+		return false, logger.LogNewErrorCodef(log, codes.FailedPrecondition,
 			"existing path: %s is not a directory", target)
 	}
 
@@ -1304,7 +1293,7 @@ func rmpath(ctx context.Context, target string) error {
 	// target should be empty
 	log.Debugf("removing target path: %q", target)
 	if err := os.Remove(target); err != nil {
-		return status.Errorf(codes.Internal,
+		return logger.LogNewErrorCodef(log, codes.Internal,
 			"Unable to remove target path: %s, err: %v", target, err)
 	}
 	return nil
@@ -1313,8 +1302,7 @@ func rmpath(ctx context.Context, target string) error {
 func ensureMountVol(ctx context.Context, volCap *csi.VolumeCapability) (string, []string, error) {
 	mountVol := volCap.GetMount()
 	if mountVol == nil {
-		return "", nil, status.Error(codes.InvalidArgument,
-			"access type missing")
+		return "", nil, status.Error(codes.InvalidArgument, "access type missing")
 	}
 	fs := common.GetVolumeCapabilityFsType(ctx, volCap)
 	mntFlags := mountVol.GetMountFlags()


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a pattern of log the error message, when creating a new error. This creates
duplicated code. This change uses LogNewErrorCode, and LogNewErrorCodef to
reduce duplicated code. In addition, using LogNewErrorCode consistently will make
sure that all generated errors will be logged (when log is available in the function).

This change fixes node.go. It reduces 10133 bytes in binary.

The other files will be fixed in follow-up changes.

**Testing done**:
Local build and check.
E2E: Block vanilla build status: SUCCESS 