### PR TITLE
Clean up white spaces in common_controller_helper.go

### DIFF
--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -36,12 +36,12 @@ import (
 // Function returns error if validation fails otherwise returns nil.
 func ValidateCreateVolumeRequest(ctx context.Context, req *csi.CreateVolumeRequest) error {
 	log := logger.GetLogger(ctx)
-	// Volume Name
+	// Volume Name.
 	volName := req.GetName()
 	if len(volName) == 0 {
 		return logger.LogNewErrorCode(log, codes.InvalidArgument, "volume name is a required parameter")
 	}
-	// Validate Volume Capabilities
+	// Validate Volume Capabilities.
 	volCaps := req.GetVolumeCapabilities()
 	if len(volCaps) == 0 {
 		return logger.LogNewErrorCode(log, codes.InvalidArgument, "volume capabilities not provided")
@@ -57,7 +57,7 @@ func ValidateCreateVolumeRequest(ctx context.Context, req *csi.CreateVolumeReque
 // Function returns error if validation fails otherwise returns nil.
 func ValidateDeleteVolumeRequest(ctx context.Context, req *csi.DeleteVolumeRequest) error {
 	log := logger.GetLogger(ctx)
-	//check for required parameters
+	// Check for required parameters.
 	if len(req.VolumeId) == 0 {
 		return logger.LogNewErrorCode(log, codes.InvalidArgument, "volume ID is a required parameter")
 	}
@@ -69,7 +69,7 @@ func ValidateDeleteVolumeRequest(ctx context.Context, req *csi.DeleteVolumeReque
 // Function returns error if validation fails otherwise returns nil.
 func ValidateControllerPublishVolumeRequest(ctx context.Context, req *csi.ControllerPublishVolumeRequest) error {
 	log := logger.GetLogger(ctx)
-	//check for required parameters
+	// Check for required parameters.
 	if len(req.VolumeId) == 0 {
 		return logger.LogNewErrorCode(log, codes.InvalidArgument, "volume ID is a required parameter")
 	} else if len(req.NodeId) == 0 {
@@ -91,7 +91,7 @@ func ValidateControllerPublishVolumeRequest(ctx context.Context, req *csi.Contro
 // Function returns error if validation fails otherwise returns nil.
 func ValidateControllerUnpublishVolumeRequest(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) error {
 	log := logger.GetLogger(ctx)
-	//check for required parameters
+	// Check for required parameters.
 	if len(req.VolumeId) == 0 {
 		return logger.LogNewErrorCode(log, codes.InvalidArgument, "volume ID is a required parameter")
 	} else if len(req.NodeId) == 0 {
@@ -100,7 +100,7 @@ func ValidateControllerUnpublishVolumeRequest(ctx context.Context, req *csi.Cont
 	return nil
 }
 
-// CheckAPI checks if specified version is 6.7.3 or higher
+// CheckAPI checks if specified version is 6.7.3 or higher.
 func CheckAPI(version string) error {
 	items := strings.Split(version, ".")
 	if len(items) < 2 || len(items) > 4 {
@@ -130,16 +130,16 @@ func CheckAPI(version string) error {
 	return nil
 }
 
-// UseVslmAPIs checks if specified version is between 6.7 Update 3l and 7.0
+// UseVslmAPIs checks if specified version is between 6.7 Update 3l and 7.0.
 // The method takes aboutInfo{} as input which contains details about
 // VC version, build number and so on.
-// If the version is between the upper and lower bounds, the method returns true, else returns false
-// and appropriate errors during failure cases
+// If the version is between the upper and lower bounds, the method returns
+// true, else returns false and appropriate errors during failure cases.
 func UseVslmAPIs(ctx context.Context, aboutInfo vim25types.AboutInfo) (bool, error) {
 	log := logger.GetLogger(ctx)
 	items := strings.Split(aboutInfo.ApiVersion, ".")
 	apiVersion := strings.Join(items[:], "")
-	// Convert version string to string, Ex: "6.7.3" becomes 673, "7.0.0.0" becomes 700
+	// Convert version string to int, e.g. "6.7.3" to 673, "7.0.0.0" to 700.
 	vSphereVersionInt, err := strconv.Atoi(apiVersion[0:3])
 	if err != nil {
 		msg := fmt.Sprintf("Error while converting ApiVersion %q to integer, err %+v", apiVersion, err)
@@ -160,17 +160,21 @@ func UseVslmAPIs(ctx context.Context, aboutInfo vim25types.AboutInfo) (bool, err
 		log.Errorf(msg)
 		return false, errors.New(msg)
 	}
-	// Check if the current vSphere version is between 6.7.3 and 7.0.0
+	// Check if the current vSphere version is between 6.7.3 and 7.0.0.
 	if vSphereVersionInt > vSphere67u3VersionInt && vSphereVersionInt <= vSphere7VersionInt {
 		return true, nil
 	}
-	// Check if version is 6.7.3
+	// Check if version is 6.7.3.
 	if vSphereVersionInt == vSphere67u3VersionInt {
-		// CSI migration feature will be supported only from 6.7 Update 3l vSphere version onwards
-		// For all older 6.7 Update 3 such as 3a, 3b and so on, we do not support the CSI migration feature.
-		// Because there is no patch version number in aboutInfo{}, we will rely on the build number to check for 6.7 Update 3l
-		// VC builds are always incremental and hence we can use the build info to check if VC version is 6.7 Update 3l
-		// Here is a snippet of the build info for the GA bits mentioned here: https://docs.vmware.com/en/VMware-vSphere/6.7/rn/vsphere-vcenter-server-67u3l-release-notes.html
+		// CSI migration feature will be supported only from 6.7 Update 3l vSphere
+		// version onwards. For all older 6.7 Update 3 such as 3a, 3b and so on,
+		// we do not support the CSI migration feature. Because there is no patch
+		// version number in aboutInfo{}, we will rely on the build number to
+		// check for 6.7 Update 3l. VC builds are always incremental and hence we
+		// can use the build info to check if VC version is 6.7 Update 3l.
+		//
+		// Here is a snippet of the build info for the GA bits mentioned:
+		// https://docs.vmware.com/en/VMware-vSphere/6.7/rn/vsphere-vcenter-server-67u3l-release-notes.html
 		// Name: "VMware vCenter Server",
 		// FullName: "VMware vCenter Server 6.7.0 build-17137327",
 		// Version: "6.7.0",
@@ -180,7 +184,9 @@ func UseVslmAPIs(ctx context.Context, aboutInfo vim25types.AboutInfo) (bool, err
 			if vcBuild >= VSphere67u3lBuildInfo {
 				return true, nil
 			}
-			msg := fmt.Sprintf("Found vCenter version :%q. The minimum supported vCenter version for CSI migration feature is vCenter Server 6.7 Update 3l.", aboutInfo.ApiVersion)
+			msg := fmt.Sprintf(
+				"Found vCenter version :%q. The minimum version for CSI migration is vCenter Server 6.7 Update 3l",
+				aboutInfo.ApiVersion)
 			log.Errorf(msg)
 			return false, errors.New(msg)
 		}
@@ -190,7 +196,7 @@ func UseVslmAPIs(ctx context.Context, aboutInfo vim25types.AboutInfo) (bool, err
 			return false, errors.New(msg)
 		}
 	}
-	// For all other versions
+	// For all other versions.
 	return false, nil
 }
 
@@ -199,7 +205,7 @@ func UseVslmAPIs(ctx context.Context, aboutInfo vim25types.AboutInfo) (bool, err
 // Function returns error if validation fails otherwise returns nil.
 func ValidateControllerExpandVolumeRequest(ctx context.Context, req *csi.ControllerExpandVolumeRequest) error {
 	log := logger.GetLogger(ctx)
-	// check for required parameters
+	// Check for required parameters.
 	if len(req.GetVolumeId()) == 0 {
 		return logger.LogNewErrorCode(log, codes.InvalidArgument, "volume id is a required parameter")
 	} else if req.GetCapacityRange() == nil {
@@ -207,13 +213,14 @@ func ValidateControllerExpandVolumeRequest(ctx context.Context, req *csi.Control
 	} else if req.GetCapacityRange().GetRequiredBytes() < 0 || req.GetCapacityRange().GetLimitBytes() < 0 {
 		return logger.LogNewErrorCode(log, codes.InvalidArgument, "capacity ranges values cannot be negative")
 	}
-	// Validate Volume Capabilities
+	// Validate Volume Capabilities.
 	volCaps := req.GetVolumeCapability()
 	if volCaps == nil {
 		return logger.LogNewErrorCode(log, codes.InvalidArgument, "volume capabilities is a required parameter")
 	}
 
-	// TODO: Remove this restriction when volume expansion is supported for File Volumes
+	// TODO: Remove this restriction when volume expansion is supported for
+	// File Volumes.
 	if IsFileVolumeRequest(ctx, []*csi.VolumeCapability{volCaps}) {
 		return logger.LogNewErrorCode(log, codes.Unimplemented,
 			"volume expansion is only supported for block volume type")
@@ -222,8 +229,8 @@ func ValidateControllerExpandVolumeRequest(ctx context.Context, req *csi.Control
 	return nil
 }
 
-// IsOnlineExpansion verifies if the input volume is attached to any of the given VirutalMachines, to prevent
-// online expansion of volumes.
+// IsOnlineExpansion verifies if the input volume is attached to any of the
+// given VirutalMachines, to prevent online expansion of volumes.
 // Returns an error if the volume is attached.
 func IsOnlineExpansion(ctx context.Context, volumeID string, nodes []*cnsvsphere.VirtualMachine) error {
 	log := logger.GetLogger(ctx)
@@ -233,7 +240,7 @@ func IsOnlineExpansion(ctx context.Context, volumeID string, nodes []*cnsvsphere
 			"failed to check if volume %q is attached to any node with error: %+v", volumeID, err)
 	} else if diskUUID != "" {
 		return logger.LogNewErrorCodef(log, codes.FailedPrecondition,
-			"failed to expand volume: %q. Volume is attached to node. Online volume expansion is not supported in this version",
+			"failed to expand volume: %q. Volume is attached to node. Online volume expansion is not supported",
 			volumeID)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. This change handles the
long lines in nodes.go. (In C/C++, I typically limit the line within 80 characters, for a reference.)
To wrap a long line, we need to pay attention to Golang's special grammar that it automatically
inserts a semicolon immediately after a line's final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles common_controller_helper.go.

**Testing done**:
Local build and check.