### PR TITLE
Remove file path check from reload config event

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -142,7 +142,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 					return
 				}
 				log.Debugf("fsnotify event: %q", event.String())
-				if event.Op&fsnotify.Remove == fsnotify.Remove && event.Name == cfgPath {
+				if event.Op&fsnotify.Remove == fsnotify.Remove {
 					for {
 						reloadConfigErr := c.ReloadConfiguration(false)
 						if reloadConfigErr == nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is removing the file path check in reload configuration method for wcp. When password rotation happens in wcp, the event Name does not contain the path of the csi conf. This extra check skips the reload configuration when session is not active. Hence removing this check

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Restarted wcp service to update secret:
```
root@sc2-rdops-vm06-dhcp-203-58 [ ~ ]# vi /etc/vmware/wcp/.storageUser 
root@sc2-rdops-vm06-dhcp-203-58 [ ~ ]# vmon-cli -r wcp
Completed Restart service request.
root@sc2-rdops-vm06-dhcp-203-58 [ ~ ]# cat /etc/vmware/wcp/.storageUser 
workload_storage_management-40dc25f7-7bab-4e49-b234-bc877087362a
q~y'3x9k[zYbd<,8:_D#
1622161454root@sc2-rdops-vm06-dhcp-203-58 [ ~ ]#
```

Capture CSI logs to reload configuration:
```
2021-05-28T00:24:46.023Z	DEBUG	wcp/controller.go:144	fsnotify event: "\"/etc/vmware/wcp/..2021_05_28_00_08_32.025273441\": REMOVE"	{"TraceId": "27655c01-ab5e-4f50-be70-d03828aed118"}
2021-05-28T00:24:46.023Z	INFO	wcp/controller.go:221	Reloading Configuration	{"TraceId": "3d72324a-4cac-4300-a593-1d8c87d81f4d"}
2021-05-28T00:24:46.023Z	DEBUG	config/config.go:357	GetCnsconfig called with cfgPath: /etc/vmware/wcp/vsphere-cloud-provider.conf	{"TraceId": "3d72324a-4cac-4300-a593-1d8c87d81f4d"}
2021-05-28T00:24:46.024Z	DEBUG	config/config.go:264	Initializing vc server sc2-rdops-vm06-dhcp-203-58.eng.vmware.com	{"TraceId": "3d72324a-4cac-4300-a593-1d8c87d81f4d"}
2021-05-28T00:24:46.024Z	INFO	config/config.go:303	No Net Permissions given in Config. Using default permissions.	{"TraceId": "3d72324a-4cac-4300-a593-1d8c87d81f4d"}
2021-05-28T00:24:46.024Z	INFO	vsphere/utils.go:161	Defaulting timeout for vCenter Client to 5 minutes	{"TraceId": "3d72324a-4cac-4300-a593-1d8c87d81f4d"}
2021-05-28T00:24:46.024Z	INFO	volume/manager.go:181	Done resetting volume.defaultManager	{"TraceId": "3d72324a-4cac-4300-a593-1d8c87d81f4d"}
2021-05-28T00:24:46.024Z	INFO	volume/manager.go:124	Retrieving existing volume.defaultManager...	{"TraceId": "3d72324a-4cac-4300-a593-1d8c87d81f4d"}
2021-05-28T00:24:46.024Z	DEBUG	wcp/controller.go:276	Updated manager.CnsConfig	{"TraceId": "3d72324a-4cac-4300-a593-1d8c87d81f4d"}
2021-05-28T00:24:46.024Z	INFO	wcp/controller.go:278	Successfully reloaded configuration	{"TraceId": "3d72324a-4cac-4300-a593-1d8c87d81f4d"}
2021-05-28T00:24:46.024Z	INFO	wcp/controller.go:149	Successfully reloaded configuration from: "/etc/vmware/wcp/vsphere-cloud-provider.conf"
```

Create PVC after secret update:
```
kubectl create -f pvc.yaml -n test
persistentvolumeclaim/example-vanilla-block-pvc created
root@42261ba8ed8c7e6a39407533b441428f [ ~ ]# kubectl get pvc -A
NAMESPACE   NAME                        STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS       AGE
test        example-vanilla-block-pvc   Pending                                      shared-ds-policy   7s


root@42261ba8ed8c7e6a39407533b441428f [ ~ ]# kubectl get pvc -A
NAMESPACE   NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS       AGE
test        example-vanilla-block-pvc   Bound    pvc-0d73b9ad-448a-4be7-83c2-cfc0fc836a36   1Gi        RWO            shared-ds-policy   26s
```
Create POD after secret update:
```
kubectl create -f pod.yaml -n test
pod/example-vanilla-block-pod created

 kubectl get pods -n test
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   1/1     Running   0          30s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove file path check from reload config event
```
