### PR TITLE
Use LogNewErrorCodef for syncer util.go

### DIFF
--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -2,10 +2,8 @@ package syncer
 
 import (
 	"context"
-	"fmt"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"k8s.io/client-go/tools/cache"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
@@ -151,11 +149,11 @@ func fullSyncGetQueryResults(ctx context.Context, volumeIds []cnstypes.CnsVolume
 	var allQueryResults []*cnstypes.CnsQueryResult
 	for {
 		log.Debugf("Query volumes with offset: %v and limit: %v", queryFilter.Cursor.Offset, queryFilter.Cursor.Limit)
-		queryResult, err := utils.QueryVolumeUtil(ctx, volumeManager, queryFilter, cnstypes.CnsQuerySelection{}, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+		queryResult, err := utils.QueryVolumeUtil(ctx, volumeManager, queryFilter, cnstypes.CnsQuerySelection{},
+			metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 		if err != nil {
-			msg := fmt.Sprintf("QueryVolume failed with err=%+v", err.Error())
-			log.Error(msg)
-			return nil, status.Error(codes.Internal, msg)
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"QueryVolume failed with err=%+v", err.Error())
 		}
 		if queryResult == nil {
 			log.Info("Observed empty queryResult")


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a pattern of log the error message, when creating a new error. This creates
duplicated code. This change uses LogNewErrorCode, and LogNewErrorCodef to
reduce duplicated code. In addition, using LogNewErrorCode consistently will make
sure that all generated errors will be logged (when log is available in the function).

This change fixes syncer/util.go.

The other files will be fixed in follow-up changes.

**Testing done**:
Local build and check.

E2E test (block vanilla)
1. Run 1
[Fail] [csi-block-vanilla] [csi-file-vanilla] CNS-CSI Cluster Distribution Telemetry [It] Verify dynamic provisioning of pvc has cluster-distribution value updated 
[Fail] [csi-block-vanilla] label-updates [It] [csi-supervisor] Verify label updates on PVC and PV attached to a stateful set. 
Ran 43 of 186 Specs in 9647.961 seconds
FAIL! -- 41 Passed | 2 Failed | 0 Pending | 143 Skipped

2. Run 2
[Fail] [csi-block-vanilla] [csi-file-vanilla] CNS-CSI Cluster Distribution Telemetry [It] Verify dynamic provisioning of pvc has cluster-distribution value updated 
Ran 43 of 186 Specs in 9495.555 seconds
FAIL! -- 42 Passed | 1 Failed | 0 Pending | 143 Skipped

3. Run 3 - PASS