### PR TITLE
[WIP] Upgrade sidecars to be used with k8s 1.21 in WCP

### DIFF
--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -179,7 +179,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.1.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -197,7 +197,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.1.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -257,7 +257,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.2.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
           args:
             - "--csi-address=$(ADDRESS)"
           env:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR updates the sidecar container tags in 1.21 yaml for supervisor cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manually updated the 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
