### PR TITLE
Upgrade sidecars in WCP

### DIFF
--- a/manifests/supervisorcluster/1.17/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.17/cns-csi.yaml
@@ -170,7 +170,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.1.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -188,7 +188,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.1.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -243,7 +243,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.2.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/manifests/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.18/cns-csi.yaml
@@ -170,7 +170,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.1.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -188,7 +188,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.1.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -243,7 +243,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.2.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/manifests/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.19/cns-csi.yaml
@@ -179,7 +179,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.1.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -197,7 +197,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.1.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -257,7 +257,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.2.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -179,7 +179,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.1.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -197,7 +197,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.1.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -257,7 +257,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.2.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -179,7 +179,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.1.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -197,7 +197,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.1.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -257,7 +257,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.2.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
           args:
             - "--csi-address=$(ADDRESS)"
           env:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR updates the sidecar container tags for supervisor cluster.
The supervisor main branch has dropped support for k8s 1.16. So updating the yamls k8s 1.17 onwards should be good enough.

Here are the upgraded sidecars and the minimum kubernetes version they support.
- External attacher - [v3.2.1](https://github.com/kubernetes-csi/external-attacher/releases/tag/v3.2.1). Minimum k8s version is 1.17.
- Liveness probe - [v2.3.0](https://github.com/kubernetes-csi/livenessprobe/releases/tag/v2.3.0). Minimum k8s version is 1.13.
- External resizer - [v1.2.0](https://github.com/kubernetes-csi/external-resizer/releases/tag/v1.2.0). Minimum k8s version is 1.16.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Deployed a wcp 1.20 testbed with custom CSP build that packages the upgraded sidecars.
Initially the CSI pod wasn't coming up, as it was not able to find images for existing sidecars.
After manually updating the deployment yaml to use upgraded sidecars, the CSI container was able to pull those images and started running fine.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Upgrade sidecars in WCP
```
