### PR TITLE
Add default fstype parameter to cns-csi yamls

### DIFF
--- a/manifests/supervisorcluster/1.17/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.17/cns-csi.yaml
@@ -156,6 +156,7 @@ spec:
             - "--enable-hostlocal-placement=true"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.18/cns-csi.yaml
@@ -156,6 +156,7 @@ spec:
             - "--enable-hostlocal-placement=true"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.19/cns-csi.yaml
@@ -165,6 +165,7 @@ spec:
             - "--enable-hostlocal-placement=true"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -165,6 +165,7 @@ spec:
             - "--enable-hostlocal-placement=true"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -165,6 +165,7 @@ spec:
             - "--enable-hostlocal-placement=true"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The default-fstype parameter was added to cns-csi yamls in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/788 but was removed during a refactoring effort. 
This change adds the parameter back to the yamls. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Pipelines do not pick up YAMLs from github. Verified that CSI runs with this parameter and Pods which run as a user can read/write to the directory. 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add default fstype parameter to cns-csi yamls
```
