### PR TITLE
SVC - Online resize test cases (set4)

### DIFF
--- a/tests/e2e/docs/supervisor_cluster_setup.md
+++ b/tests/e2e/docs/supervisor_cluster_setup.md
@@ -88,6 +88,12 @@ datacenters should be comma separated if deployed on multi-datacenters
     # Set this variable to run static provisioning VMDK test cases.
     export DISK_URL_PATH="https://<VC_IP>/folder/<vmName>/<vmName_1.vmdk>?dcPath=<DatacenterPath>&dsName=<dataStoreName>"
     export COMPUTE_CLUSTER_NAME="<your_cluster_name>"
+    #shared VVOL datastore url
+    export SHARED_VVOL_DATASTORE_URL="ds:///vmfs/volumes/vvol:5c5ddeccfb2f476c-ac17f22d228af0f1/"
+    #shared NFS datastore url
+    export SHARED_NFS_DATASTORE_URL="ds:///vmfs/volumes/fb4efbd8-6e969410/"
+    #shared VMFS datastore url
+    export SHARED_VMFS_DATASTORE_URL="ds:///vmfs/volumes/6009698f-424076e2-c60d-02008c6fa7e4/"
 
 ### To run full sync test, need do extra following steps
 


### PR DESCRIPTION
What this PR does / why we need it: Added SVC offline andonline volume expansion test cases - set4

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

Release notes:
Online volume expansion test cases for supervisor flavour - set4

Special notes for your reviewer:

Below tests are combines 
1. Offline and Online volume resize shared VVOL datastore
2. Offline and Online volume resize shared NFS datastore
3. Offline and Online volume resize shared VMFS datastore
4. Verify online volume expansion when PVC is deleted
5. Verify online volume expansion when POD is deleted and re-created

https://gist.github.com/kavyashree-r/15c56f47fe74a56aa6842c59217f9082
