### PR TITLE
Extend volume implementation with idempotency handling

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -477,28 +477,42 @@ func DeleteVolumeUtil(ctx context.Context, volManager cnsvolume.Manager, volumeI
 }
 
 // ExpandVolumeUtil is the helper function to extend CNS volume for given volumeId
-func ExpandVolumeUtil(ctx context.Context, manager *Manager, volumeID string, capacityInMb int64, useAsyncQueryVolume bool) error {
+func ExpandVolumeUtil(ctx context.Context, manager *Manager, volumeID string, capacityInMb int64, useAsyncQueryVolume,
+	isIdempotencyHandlingEnabled bool) error {
 	var err error
 	log := logger.GetLogger(ctx)
 	log.Debugf("vSphere CSI driver expanding volume %q to new size %d Mb.", volumeID, capacityInMb)
 
-	expansionRequired, err := isExpansionRequired(ctx, volumeID, capacityInMb, manager, useAsyncQueryVolume)
-	if err != nil {
-		return err
-	}
-	if expansionRequired {
-		log.Infof("Requested size %d Mb is greater than current size for volumeID: %q. Need volume expansion.", capacityInMb, volumeID)
+	if isIdempotencyHandlingEnabled {
+		// Avoid querying volume when idempotency handling is enabled.
 		err = manager.VolumeManager.ExpandVolume(ctx, volumeID, capacityInMb)
 		if err != nil {
 			log.Errorf("failed to expand volume %q with error %+v", volumeID, err)
 			return err
 		}
 		log.Infof("Successfully expanded volume for volumeid %q to new size %d Mb.", volumeID, capacityInMb)
-
+		return nil
 	} else {
-		log.Infof("Requested volume size is equal to current size %d Mb. Expansion not required.", capacityInMb)
+		expansionRequired, err := isExpansionRequired(ctx, volumeID, capacityInMb, manager, useAsyncQueryVolume)
+		if err != nil {
+			return err
+		}
+		if expansionRequired {
+			log.Infof("Requested size %d Mb is greater than current size for volumeID: %q. Need volume expansion.",
+				capacityInMb, volumeID)
+			err = manager.VolumeManager.ExpandVolume(ctx, volumeID, capacityInMb)
+			if err != nil {
+				log.Errorf("failed to expand volume %q with error %+v", volumeID, err)
+				return err
+			}
+			log.Infof("Successfully expanded volume for volumeid %q to new size %d Mb.", volumeID, capacityInMb)
+
+		} else {
+			log.Infof("Requested volume size is equal to current size %d Mb. Expansion not required.", capacityInMb)
+		}
+		return err
+
 	}
-	return err
 }
 
 // QueryVolumeByID is the helper function to query volume by volumeID

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1031,7 +1031,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 	volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
 
-	err = common.ExpandVolumeUtil(ctx, c.manager, volumeID, volSizeMB, commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+	err = common.ExpandVolumeUtil(ctx, c.manager, volumeID, volSizeMB, commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume), commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency))
 	if err != nil {
 		msg := fmt.Sprintf("failed to expand volume: %q to size: %d with error: %+v", volumeID, volSizeMB, err)
 		log.Error(msg)

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -860,7 +860,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 		volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
 
-		err = common.ExpandVolumeUtil(ctx, c.manager, volumeID, volSizeMB, commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+		err = common.ExpandVolumeUtil(ctx, c.manager, volumeID, volSizeMB, commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume), commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency))
 		if err != nil {
 			msg := fmt.Sprintf("failed to expand volume: %+q to size: %d err %+v", volumeID, volSizeMB, err)
 			log.Error(msg)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
e2e block expansion tests with FSS enabled:

```
10:30:23  Ran 11 of 187 Specs in 1302.444 seconds
10:30:23  SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 176 Skipped
10:30:23  PASS
```

Manual tests:

1. Expanded volume successfully for volume. 
2. Expanded volume multiple times concurrently. Final size is reflected correctly:
```
# kubectl describe cnsvolumeoperationrequest -A
Name:         expand-43fc6f32-ec36-4b45-a06b-4b6a83174890
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsVolumeOperationRequest
Metadata:
  Creation Timestamp:  2021-06-03T04:15:55Z
  Generation:          16
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:name:
      f:status:
        .:
        f:capacity:
        f:firstOperationDetails:
          .:
          f:opId:
          f:taskId:
          f:taskInvocationTimestamp:
          f:taskStatus:
        f:latestOperationDetails:
    Manager:         vsphere-csi
    Operation:       Update
    Time:            2021-06-03T04:16:00Z
  Resource Version:  202320
  UID:               c46bdb58-64cf-447f-8774-ed6267c20d1d
Spec:
  Name:  expand-43fc6f32-ec36-4b45-a06b-4b6a83174890
Status:
  Capacity:  4096
  First Operation Details:
    Op Id:                      11f1576a
    Task Id:                    task-3036
    Task Invocation Timestamp:  2021-06-03T04:15:55Z
    Task Status:                Success
  Latest Operation Details:
    Op Id:                      11f1576a
    Task Id:                    task-3036
    Task Invocation Timestamp:  2021-06-03T04:15:55Z
    Task Status:                Success
    Op Id:                      11f157b4
    Task Id:                    task-3038
    Task Invocation Timestamp:  2021-06-03T04:18:36Z
    Task Status:                Success
    Op Id:                      11f1584a
    Task Id:                    task-3040
    Task Invocation Timestamp:  2021-06-03T04:22:05Z
    Task Status:                Success
    Op Id:                      11f15851
    Task Id:                    task-3042
    Task Invocation Timestamp:  2021-06-03T04:22:12Z
    Task Status:                Success
    Op Id:                      11f16043
    Task Id:                    task-3047
    Task Invocation Timestamp:  2021-06-03T04:26:54Z
    Task Status:                Success
    Op Id:                      11f16054
    Task Id:                    task-3049
    Task Invocation Timestamp:  2021-06-03T04:27:07Z
    Task Status:                Success
    Op Id:                      11f160be
    Task Id:                    task-3051
    Task Invocation Timestamp:  2021-06-03T04:27:22Z
    Task Status:                Success
    Op Id:                      11f160c3
    Task Id:                    task-3053
    Task Invocation Timestamp:  2021-06-03T04:27:31Z
    Task Status:                Success
Events:                         <none>
```

3. Concurrent expand volume requests of different sizes. Logs showing that the second request waits for the first task to complete and then makes a decision.

First the call fails since the pending task returned with a smaller size:
```
{"log":"2021-06-03T17:13:25.573Z\u0009INFO\u0009vanilla/controller.go:997\u0009ControllerExpandVolume: called with args {VolumeId:97d6682a-50bf-4385-a199-45dd90cea1ae CapacityRange:required_bytes:108447924224  Secrets:map[] VolumeCapability:mount:\u003cfs_type:\"ext4\" \u003e access_mode:\u003cmode:SINGLE_NODE_WRITER \u003e  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}\u0009{\"TraceId\": \"15abe2ae-88eb-4ab5-bdf5-ea2609f54ebb\"}\n","stream":"stderr","time":"2021-06-03T17:13:25.574774464Z"}
{"log":"2021-06-03T17:13:25.575Z\u0009DEBUG\u0009common/vsphereutil.go:484\u0009vSphere CSI driver expanding volume \"97d6682a-50bf-4385-a199-45dd90cea1ae\" to new size 103424 Mb.\u0009{\"TraceId\": \"15abe2ae-88eb-4ab5-bdf5-ea2609f54ebb\"}\n","stream":"stderr","time":"2021-06-03T17:13:25.575538921Z"}
{"log":"2021-06-03T17:13:25.592Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:145\u0009Found CnsVolumeOperationRequest instance (*v1alpha1.CnsVolumeOperationRequest)(0xc000aa70e0)({\n","stream":"stderr","time":"2021-06-03T17:13:25.593540129Z"}
{"log":"2021-06-03T17:13:25.592Z\u0009INFO\u0009volume/manager.go:827\u0009Volume with ID 97d6682a-50bf-4385-a199-45dd90cea1ae has ExtendVolume task task-3166 pending on CNS.\u0009{\"TraceId\": \"15abe2ae-88eb-4ab5-bdf5-ea2609f54ebb\"}\n","stream":"stderr","time":"2021-06-03T17:13:25.594631033Z"}
{"log":"2021-06-03T17:13:25.607Z\u0009INFO\u0009volume/manager.go:911\u0009ExpandVolume: Volume expanded successfully to size 102400. volumeID: \"97d6682a-50bf-4385-a199-45dd90cea1ae\", opId: \"ed306da7\"\u0009{\"TraceId\": \"15abe2ae-88eb-4ab5-bdf5-ea2609f54ebb\"}\n","stream":"stderr","time":"2021-06-03T17:13:25.608051564Z"}
{"log":"2021-06-03T17:13:25.607Z\u0009ERROR\u0009logger/logger.go:101\u0009volume expanded to size 102400 but requested size is 103424\u0009{\"TraceId\": \"15abe2ae-88eb-4ab5-bdf5-ea2609f54ebb\"}\n","stream":"stderr","time":"2021-06-03T17:13:25.608256103Z"}
{"log":"2021-06-03T17:13:25.636Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:281\u0009Updated CnsVolumeOperationRequest instance vmware-system-csi/expand-97d6682a-50bf-4385-a199-45dd90cea1ae with latest information for task with ID: task-3166\u0009{\"TraceId\": \"15abe2ae-88eb-4ab5-bdf5-ea2609f54ebb\"}\n","stream":"stderr","time":"2021-06-03T17:13:25.637037852Z"}
{"log":"2021-06-03T17:13:25.636Z\u0009ERROR\u0009common/vsphereutil.go:490\u0009failed to expand volume \"97d6682a-50bf-4385-a199-45dd90cea1ae\" with error volume expanded to size 102400 but requested size is 103424\u0009{\"TraceId\": \"15abe2ae-88eb-4ab5-bdf5-ea2609f54ebb\"}\n","stream":"stderr","time":"2021-06-03T17:13:25.637072227Z"}
```

Then the subsequent call invokes CNS and succeeds:

```
{"log":"2021-06-03T17:13:58.068Z\u0009INFO\u0009vanilla/controller.go:997\u0009ControllerExpandVolume: called with args {VolumeId:97d6682a-50bf-4385-a199-45dd90cea1ae CapacityRange:required_bytes:108447924224  Secrets:map[] VolumeCapability:mount:\u003cfs_type:\"ext4\" \u003e access_mode:\u003cmode:SINGLE_NODE_WRITER \u003e  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}\u0009{\"TraceId\": \"57a60aee-92a8-4460-83bc-47cdbf0a3779\"}\n","stream":"stderr","time":"2021-06-03T17:13:58.132217332Z"}
{"log":"2021-06-03T17:13:58.256Z\u0009INFO\u0009volume/manager.go:865\u0009Calling CnsClient.ExtendVolume: VolumeID [\"97d6682a-50bf-4385-a199-45dd90cea1ae\"] Size [103424] cnsExtendSpecList [[]types.CnsVolumeExtendSpec{types.CnsVolumeExtendSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:\"97d6682a-50bf-4385-a199-45dd90cea1ae\"}, CapacityInMb:103424}}]\u0009{\"TraceId\": \"57a60aee-92a8-4460-83bc-47cdbf0a3779\"}\n","stream":"stderr","time":"2021-06-03T17:13:58.257999394Z"}
{"log":"2021-06-03T17:15:03.240Z\u0009INFO\u0009volume/manager.go:911\u0009ExpandVolume: Volume expanded successfully to size 103424. volumeID: \"97d6682a-50bf-4385-a199-45dd90cea1ae\", opId: \"ed306ddd\"\u0009{\"TraceId\": \"59bf41fb-8f10-410b-b81c-945156a798c9\"}\n","stream":"stderr","time":"2021-06-03T17:15:03.241178582Z"}

``` 

1. Block vanilla precheckin pipeline (job number 12):
> Ran 43 of 187 Specs in 9659.327 seconds
FAIL! -- 40 Passed | 3 Failed | 0 Pending | 144 Skipped
--- FAIL: TestE2E (9659.41s)

3 failures due to ENV variable not being set
```
17:28:02    ENV DESTINATION_VSPHERE_DATASTORE_URL is not set
17:28:02    Expected
17:28:02        <string>: 
17:28:02    not to be empty
```

However all Expansion tests passed.

2. File vanilla precheckin pipeline (job number 9):
> 17:37:15  Ran 24 of 187 Specs in 5520.030 seconds
17:37:15  SUCCESS! -- 24 Passed | 0 Failed | 0 Pending | 163 Skipped
17:37:15  PASS

3. WCP precheckin pipeline (job number 16):

>  Ran 14 of 187 Specs in 3367.143 seconds
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 173 Skipped
PASS

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Extend volume implementation with idempotency handling
```
