### PR TITLE
Use LogNewErrorCodef in utils

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
 
@@ -77,27 +76,24 @@ func (c *FakeK8SOrchestrator) IsFakeAttachAllowed(
 ) (bool, error) {
 	// TODO - This can be implemented if we add WCP controller tests for attach volume
 	log := logger.GetLogger(ctx)
-	msg := "IsFakeAttachAllowed for FakeK8SOrchestrator is not yet implemented."
-	log.Error(msg)
-	return false, status.Error(codes.Unimplemented, msg)
+	return false, logger.LogNewErrorCode(log, codes.Unimplemented,
+		"IsFakeAttachAllowed for FakeK8SOrchestrator is not yet implemented.")
 }
 
 // MarkFakeAttached marks the volume as fake attached.
 func (c *FakeK8SOrchestrator) MarkFakeAttached(ctx context.Context, volumeID string) error {
 	// TODO - This can be implemented if we add WCP controller tests for attach volume
 	log := logger.GetLogger(ctx)
-	msg := "MarkFakeAttached for FakeK8SOrchestrator is not yet implemented."
-	log.Error(msg)
-	return status.Error(codes.Unimplemented, msg)
+	return logger.LogNewErrorCode(log, codes.Unimplemented,
+		"MarkFakeAttached for FakeK8SOrchestrator is not yet implemented.")
 }
 
 // ClearFakeAttached checks if the volume was fake attached, and unmark it as not fake attached.
 func (c *FakeK8SOrchestrator) ClearFakeAttached(ctx context.Context, volumeID string) error {
 	// TODO - This can be implemented if we add WCP controller tests for attach volume
 	log := logger.GetLogger(ctx)
-	msg := "ClearFakeAttached for FakeK8SOrchestrator is not yet implemented."
-	log.Error(msg)
-	return status.Error(codes.Unimplemented, msg)
+	return logger.LogNewErrorCode(log, codes.Unimplemented,
+		"ClearFakeAttached for FakeK8SOrchestrator is not yet implemented.")
 }
 
 // GetFakeVolumeMigrationService returns the mocked VolumeMigrationService

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -18,11 +18,9 @@ package utils
 
 import (
 	"context"
-	"fmt"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
@@ -45,18 +43,16 @@ func QueryVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cnsty
 				log.Warn("QueryVolumeAsync is not supported. Invoking QueryVolume API")
 				queryAsyncNotSupported = true
 			} else { // Return for any other failures
-				msg := fmt.Sprintf("QueryVolumeAsync failed for queryFilter: %v. Err=%+v", queryFilter, err.Error())
-				log.Error(msg)
-				return nil, status.Error(codes.Internal, msg)
+				return nil, logger.LogNewErrorCodef(log, codes.Internal,
+					"QueryVolumeAsync failed for queryFilter: %v. Err=%+v", queryFilter, err.Error())
 			}
 		}
 	}
 	if !useQueryVolumeAsync || queryAsyncNotSupported {
 		queryResult, err = m.QueryVolume(ctx, queryFilter)
 		if err != nil {
-			msg := fmt.Sprintf("QueryVolume failed for queryFilter: %+v. Err=%+v", queryFilter, err.Error())
-			log.Error(msg)
-			return nil, status.Error(codes.Internal, msg)
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"QueryVolume failed for queryFilter: %+v. Err=%+v", queryFilter, err.Error())
 		}
 	}
 	return queryResult, nil
@@ -79,18 +75,16 @@ func QueryAllVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cn
 				log.Warn("QueryVolumeAsync is not supported. Invoking QueryAllVolume API")
 				queryAsyncNotSupported = true
 			} else { // Return for any other failures
-				msg := fmt.Sprintf("QueryVolumeAsync failed for queryFilter: %v. Err=%+v", queryFilter, err.Error())
-				log.Error(msg)
-				return nil, status.Error(codes.Internal, msg)
+				return nil, logger.LogNewErrorCodef(log, codes.Internal,
+					"QueryVolumeAsync failed for queryFilter: %v. Err=%+v", queryFilter, err.Error())
 			}
 		}
 	}
 	if !useQueryVolumeAsync || queryAsyncNotSupported {
 		queryResult, err = m.QueryAllVolume(ctx, queryFilter, querySelection)
 		if err != nil {
-			msg := fmt.Sprintf("QueryAllVolume failed for queryFilter: %+v. Err=%+v", queryFilter, err.Error())
-			log.Error(msg)
-			return nil, status.Error(codes.Internal, msg)
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"QueryAllVolume failed for queryFilter: %+v. Err=%+v", queryFilter, err.Error())
 		}
 	}
 	return queryResult, nil

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -28,7 +28,6 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	vim25types "github.com/vmware/govmomi/vim25/types"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
@@ -193,9 +192,8 @@ func GenerateDatastoreMapForBlockVolumes(ctx context.Context,
 	// Get all datastores from VC.
 	dcList, err := vc.GetDatacenters(ctx)
 	if err != nil {
-		msg := fmt.Sprintf("failed to get datacenter list. err: %+v", err)
-		log.Error(msg)
-		return nil, status.Errorf(codes.Internal, msg)
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to get datacenter list. err: %+v", err)
 	}
 	var dsURLTodsInfoMap map[string]*cnsvsphere.DatastoreInfo
 	var dsURLs []string


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a pattern of log the error message, when creating a new error. This creates
duplicated code. This change uses LogNewErrorCode, and LogNewErrorCodef to
reduce duplicated code. In addition, using LogNewErrorCode consistently will make
sure that all generated errors will be logged (when log is available in the function).

This change fixes a few utils method. It reduces 1K+ bytes in binary.

The other files will be fixed in follow-up changes.

**Testing done**:
Local build and check.
Run1: E2E: (Known Bug #2777528)
[Fail] [csi-block-vanilla] [csi-file-vanilla] CNS-CSI Cluster Distribution Telemetry [It] Verify dynamic provisioning of pvc has cluster-distribution value updated 
FAIL! -- 43 Passed | 1 Failed | 0 Pending | 143 Skipped