### PR TITLE
Use LogNewErrorCodef in node.go - 2/2

### DIFF
--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -30,9 +30,9 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/units"
+	"go.uber.org/zap"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -104,11 +104,13 @@ func (driver *vsphereCSIDriver) NodeStageVolume(
 	}
 
 	if volCap == nil {
-		return nil, status.Error(codes.InvalidArgument, "Volume capability not provided")
+		return nil, logger.LogNewErrorCode(log, codes.InvalidArgument,
+			"Volume capability not provided")
 	}
 	caps := []*csi.VolumeCapability{volCap}
 	if err := common.IsValidVolumeCapabilities(ctx, caps); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Volume capability not supported. Err: %+v", err)
+		return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			"Volume capability not supported. Err: %+v", err)
 	}
 
 	var err error
@@ -124,7 +126,7 @@ func (driver *vsphereCSIDriver) NodeStageVolume(
 		// Mount Volume
 		// Extract mount volume details
 		log.Debug("NodeStageVolume: Volume detected as a mount volume")
-		params.fsType, params.mntFlags, err = ensureMountVol(ctx, volCap)
+		params.fsType, params.mntFlags, err = ensureMountVol(ctx, log, volCap)
 		if err != nil {
 			return nil, err
 		}
@@ -146,7 +148,7 @@ func nodeStageBlockVolume(
 	log := logger.GetLogger(ctx)
 	// Block Volume
 	pubCtx := req.GetPublishContext()
-	diskID, err := getDiskID(pubCtx)
+	diskID, err := getDiskID(pubCtx, log)
 	if err != nil {
 		return nil, err
 	}
@@ -362,21 +364,24 @@ func (driver *vsphereCSIDriver) NodePublishVolume(
 			"staging target path %q not set", params.stagingTarget)
 	}
 	if params.target == "" {
-		return nil, status.Errorf(codes.FailedPrecondition, "target path %q not set", params.target)
+		return nil, logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+			"target path %q not set", params.target)
 	}
 
 	volCap := req.GetVolumeCapability()
 	if volCap == nil {
-		return nil, status.Error(codes.InvalidArgument, "Volume capability not provided")
+		return nil, logger.LogNewErrorCode(log, codes.InvalidArgument,
+			"Volume capability not provided")
 	}
 	caps := []*csi.VolumeCapability{volCap}
 	if err := common.IsValidVolumeCapabilities(ctx, caps); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Volume capability not supported. Err: %+v", err)
+		return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+			"Volume capability not supported. Err: %+v", err)
 	}
 
 	// Check if this is a MountVolume or BlockVolume
 	if !common.IsFileVolumeRequest(ctx, caps) {
-		params.diskID, err = getDiskID(req.GetPublishContext())
+		params.diskID, err = getDiskID(req.GetPublishContext(), log)
 		if err != nil {
 			log.Errorf("error fetching DiskID. Parameters: %v", params)
 			return nil, err
@@ -422,7 +427,8 @@ func (driver *vsphereCSIDriver) NodeUnpublishVolume(
 	target := req.GetTargetPath()
 
 	if target == "" {
-		return nil, status.Errorf(codes.FailedPrecondition, "target path %q not set", target)
+		return nil, logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+			"target path %q not set", target)
 	}
 
 	// Verify if the path exists
@@ -903,7 +909,7 @@ func publishMountVol(
 	log.Infof("PublishMountVolume called with args: %+v", params)
 
 	// Extract fs details
-	_, mntFlags, err := ensureMountVol(ctx, req.GetVolumeCapability())
+	_, mntFlags, err := ensureMountVol(ctx, log, req.GetVolumeCapability())
 	if err != nil {
 		return nil, err
 	}
@@ -1043,7 +1049,7 @@ func publishFileVol(
 	log.Infof("PublishFileVolume called with args: %+v", params)
 
 	// Extract mount details
-	fsType, mntFlags, err := ensureMountVol(ctx, req.GetVolumeCapability())
+	fsType, mntFlags, err := ensureMountVol(ctx, log, req.GetVolumeCapability())
 	if err != nil {
 		return nil, err
 	}
@@ -1322,10 +1328,11 @@ func rmpath(ctx context.Context, target string) error {
 	return nil
 }
 
-func ensureMountVol(ctx context.Context, volCap *csi.VolumeCapability) (string, []string, error) {
+func ensureMountVol(ctx context.Context, log *zap.SugaredLogger,
+	volCap *csi.VolumeCapability) (string, []string, error) {
 	mountVol := volCap.GetMount()
 	if mountVol == nil {
-		return "", nil, status.Error(codes.InvalidArgument, "access type missing")
+		return "", nil, logger.LogNewErrorCode(log, codes.InvalidArgument, "access type missing")
 	}
 	fs := common.GetVolumeCapabilityFsType(ctx, volCap)
 	mntFlags := mountVol.GetMountFlags()
@@ -1379,11 +1386,11 @@ func convertUUID(uuid string) (string, error) {
 	return strings.ToLower(convertedUUID), nil
 }
 
-func getDiskID(pubCtx map[string]string) (string, error) {
+func getDiskID(pubCtx map[string]string, log *zap.SugaredLogger) (string, error) {
 	var diskID string
 	var ok bool
 	if diskID, ok = pubCtx[common.AttributeFirstClassDiskUUID]; !ok {
-		return "", status.Errorf(codes.InvalidArgument,
+		return "", logger.LogNewErrorCodef(log, codes.InvalidArgument,
 			"Attribute: %s required in publish context",
 			common.AttributeFirstClassDiskUUID)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a pattern of log the error message, when creating a new error. This creates
duplicated code. This change uses LogNewErrorCode, and LogNewErrorCodef to
reduce duplicated code. In addition, using LogNewErrorCode consistently will make
sure that all generated errors will be logged (when log is available in the function).

This change fixes node.go.

The other files will be fixed in follow-up changes.

**Testing done**:
Local build and check.
Run 1: PR#2780424
CNS CSI Driver End-to-End Tests.[csi-block-vanilla] [csi-supervisor] statefulset Statefulset testing with parallel podManagementPolicy
FAIL! -- 43 Passed | 1 Failed | 0 Pending | 143 Skipped

Run 2:  PR#2769530
CNS CSI Driver End-to-End Tests.Volume Expansion Test [csi-block-vanilla] Verify online volume expansion on static volume
FAIL! -- 42 Passed | 1 Failed | 0 Pending | 147 Skipped
