### PR TITLE
Set volume health to inaccessible when PVC not found in CNS

### DIFF
--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -87,6 +87,8 @@ type (
 	podMap = map[string][]*v1.Pod
 	// Maps K8s PV's Spec.CSI.VolumeHandle to corresponding PVC object
 	volumeHandlePVCMap = map[string]*v1.PersistentVolumeClaim
+	// Maps CnsVolume's VolumeId.Id to vol.HealthStatus
+	volumeIdHealthStatusMap = map[string]string
 )
 
 type metadataSyncInformer struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Set volume health to inaccessible when PVC not found in CNS

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
https://container-dp.svc.eng.vmware.com/view/Pre-Checkin-CSI/job/csi-wcp-pre-check-in/29/testReport/(root)/CNS%20CSI%20Driver%20End-to-End%20Tests/

13 tests passed, 1 failed.

CNS CSI Driver End-to-End Tests.Basic Static Provisioning [csi-supervisor] Verify static provisioning workflow - when DuplicateFCD is used

/home/worker/workspace/csi-wcp-pre-check-in@2/Results/29/vsphere-csi-driver/tests/e2e/csi_static_provisioning_basic.go:882
Unexpected error:
    <*errors.errorString | 0xc000eaed10>: {
        s: "PersistentVolume static-pv-561ef975-ada8-4c07-a801-5a5a5c78f4ad still exists within 3m0s",
    }
    PersistentVolume static-pv-561ef975-ada8-4c07-a801-5a5a5c78f4ad still exists within 3m0s
occurred
/home/worker/workspace/csi-wcp-pre-check-in@2/Results/29/vsphere-csi-driver/tests/e2e/csi_static_provisioning_basic.go:959

The test failure is not caused by the change.

**Special notes for your reviewer**:

**Release note**:
```release-note
Set volume health to inaccessible when PVC is not found in CNS
```
