### PR TITLE
Fix trivial typo in comments for config.go

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -103,7 +103,7 @@ var (
 	ErrMissingTanzuKubernetesClusterUID = errors.New("no Tanzu Kubernetes Cluster UID defined in Guest Cluster config")
 
 	// ErrInvalidNetPermission is returned when the value of Permission in
-	// NetPermissions is not among the  ones listed.
+	// NetPermissions is not among the ones listed.
 	ErrInvalidNetPermission = errors.New("invalid value for Permissions under NetPermission Config")
 )
 
@@ -466,7 +466,7 @@ func GetGCconfig(ctx context.Context, cfgPath string) (*Config, error) {
 	return cfg, nil
 }
 
-// validateGCConfig validates the Guest Cluster config contains all the
+// validateGCConfig validates that Guest Cluster config contains all the
 // necessary fields.
 func validateGCConfig(ctx context.Context, cfg *Config) error {
 	log := logger.GetLogger(ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:
Address earlier review comments, remove an extra white space and fix a typo.
This is a trivial change.

**Testing done**:
Local build and check.