### PR TITLE
Cleanup of stale CnsVolumeOperationRequest CRD instances

### DIFF
--- a/example/vanilla-k8s-block-driver/vsphere.conf
+++ b/example/vanilla-k8s-block-driver/vsphere.conf
@@ -1,6 +1,7 @@
 [Global]
 cluster-id = "unique-kubernetes-cluster-id"
 volumemigration-cr-cleanup-intervalinmin = "120"
+cnsvolumeoperationrequest-cleanup-intervalinmin = "1440"
 csi-auth-check-intervalinmin = "5"
 
 [VirtualCenter "1.2.3.4"]

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -72,6 +72,10 @@ const (
 	// DefaultCSIAuthCheckIntervalInMin is the default time interval to refresh
 	// DatastoreMap.
 	DefaultCSIAuthCheckIntervalInMin = 5
+	// DefaultCnsVolumeOperationRequestCleanupIntervalInMin is the default time
+	// interval after which stale CnsVSphereVolumeMigration CRs will be cleaned up.
+	// Current default value is set to 24 hours.
+	DefaultCnsVolumeOperationRequestCleanupIntervalInMin = 1440
 )
 
 // Errors
@@ -332,6 +336,10 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 	}
 	if cfg.Global.CSIAuthCheckIntervalInMin == 0 {
 		cfg.Global.CSIAuthCheckIntervalInMin = DefaultCSIAuthCheckIntervalInMin
+	}
+	if cfg.Global.CnsVolumeOperationRequestCleanupIntervalInMin == 0 {
+		cfg.Global.CnsVolumeOperationRequestCleanupIntervalInMin =
+			DefaultCnsVolumeOperationRequestCleanupIntervalInMin
 	}
 	return nil
 }

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -57,6 +57,9 @@ type Config struct {
 
 		//CSIAuthCheckIntervalInMin specifies the interval that the auth check for datastores will be trigger
 		CSIAuthCheckIntervalInMin int `gcfg:"csi-auth-check-intervalinmin"`
+		// CnsVolumeOperationRequestCleanupIntervalInMin specifies the interval after which
+		// stale CnsVolumeOperationRequest instances will be cleaned up.
+		CnsVolumeOperationRequestCleanupIntervalInMin int `gcfg:"cnsvolumeoperationrequest-cleanup-intervalinmin"`
 	}
 
 	// Multiple sets of Net Permissions applied to all file shares

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -93,7 +93,8 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		common.CSIVolumeManagerIdempotency)
 	if idempotencyHandlingEnabled {
 		log.Info("CSI Volume manager idempotency handling feature flag is enabled.")
-		operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx)
+		operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx,
+			config.Global.CnsVolumeOperationRequestCleanupIntervalInMin)
 		if err != nil {
 			log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
 			return err
@@ -297,7 +298,8 @@ func (c *controller) ReloadConfiguration() error {
 			common.CSIVolumeManagerIdempotency)
 		if idempotencyHandlingEnabled {
 			log.Info("CSI Volume manager idempotency handling feature flag is enabled.")
-			operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx)
+			operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx,
+				c.manager.CnsConfig.Global.CnsVolumeOperationRequestCleanupIntervalInMin)
 			if err != nil {
 				log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
 				return err

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -94,7 +94,8 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		common.CSIVolumeManagerIdempotency)
 	if idempotencyHandlingEnabled {
 		log.Info("CSI Volume manager idempotency handling feature flag is enabled.")
-		operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx)
+		operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx,
+			c.manager.CnsConfig.Global.CnsVolumeOperationRequestCleanupIntervalInMin)
 		if err != nil {
 			log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
 			return err
@@ -135,15 +136,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		// TODO: Invoke similar method for block volumes
 		go common.ComputeFSEnabledClustersToDsMap(authMgr.(*common.AuthManager), config.Global.CSIAuthCheckIntervalInMin)
 	}
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency) {
-		log.Infof("CSI Volume manager idempotency handling feature flag is enabled.")
-		// TODO: Assign VolumeOperationRequest object to a variable
-		_, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx)
-		if err != nil {
-			log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
-			return err
-		}
-	}
+
 	go func() {
 		for {
 			log.Debugf("Waiting for event on fsnotify watcher")
@@ -279,7 +272,8 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 			common.CSIVolumeManagerIdempotency)
 		if idempotencyHandlingEnabled {
 			log.Info("CSI Volume manager idempotency handling feature flag is enabled.")
-			operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx)
+			operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx,
+				c.manager.CnsConfig.Global.CnsVolumeOperationRequestCleanupIntervalInMin)
 			if err != nil {
 				log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
 				return err

--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
@@ -325,20 +325,20 @@ func (or *operationRequestStore) cleanupStaleInstances(cleanupInterval int) {
 		cnsVolumeOperationRequestList := &cnsvolumeoperationrequestv1alpha1.CnsVolumeOperationRequestList{}
 		err := or.k8sclient.List(ctx, cnsVolumeOperationRequestList)
 		if err != nil {
-			log.Errorf("failed to list CnsVolumeOperationRequests with error %v. Abandoning"+
+			log.Errorf("failed to list CnsVolumeOperationRequests with error %v. Abandoning "+
 				"CnsVolumeOperationRequests clean up ...", err)
 			continue
 		}
 
 		k8sclient, err := k8s.NewClient(ctx)
 		if err != nil {
-			log.Errorf("failed to get k8sclient with error: %v. Abandoning CnsVolumeOperationRequests"+
+			log.Errorf("failed to get k8sclient with error: %v. Abandoning CnsVolumeOperationRequests "+
 				"clean up ...", err)
 			continue
 		}
 		pvList, err := k8sclient.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
 		if err != nil {
-			log.Errorf("failed to list PersistentVolumes with error %v. Abandoning"+
+			log.Errorf("failed to list PersistentVolumes with error %v. Abandoning "+
 				"CnsVolumeOperationRequests clean up ...", err)
 			continue
 		}

--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
@@ -31,6 +33,7 @@ import (
 
 	csiconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 	cnsvolumeoperationrequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
 )
@@ -70,7 +73,7 @@ var (
 // details to read and persist volume operation details.
 // This function is not thread safe. Multiple serial calls to this function will
 // return multiple new instances of the VolumeOperationRequest interface.
-func InitVolumeOperationRequestInterface(ctx context.Context) (VolumeOperationRequest, error) {
+func InitVolumeOperationRequestInterface(ctx context.Context, cleanupInterval int) (VolumeOperationRequest, error) {
 	log := logger.GetLogger(ctx)
 
 	operationStoreInitLock.Lock()
@@ -117,6 +120,7 @@ func InitVolumeOperationRequestInterface(ctx context.Context) (VolumeOperationRe
 		operationRequestStoreInstance = &operationRequestStore{
 			k8sclient: k8sclient,
 		}
+		go operationRequestStoreInstance.cleanupStaleInstances(cleanupInterval)
 	}
 
 	return operationRequestStoreInstance, nil
@@ -285,4 +289,88 @@ func (or *operationRequestStore) StoreRequestDetails(
 		operationDetailsToStore.TaskID,
 	)
 	return nil
+}
+
+// deleteRequestDetails deletes the input CnsVolumeOperationRequest instance from the operationRequestStore.
+func (or *operationRequestStore) deleteRequestDetails(ctx context.Context, name string) error {
+	log := logger.GetLogger(ctx)
+	log.Debugf("Deleting CnsVolumeOperationRequest instance with name %s/%s", csiconfig.DefaultCSINamespace, name)
+	err := or.k8sclient.Delete(ctx, &cnsvolumeoperationrequestv1alpha1.CnsVolumeOperationRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: csiconfig.DefaultCSINamespace,
+		},
+	})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Errorf("failed to delete CnsVolumeOperationRequest instance %s/%s with error: %v",
+				csiconfig.DefaultCSINamespace, name, err)
+			return err
+		}
+	}
+	return nil
+}
+
+// cleanupStaleInstances cleans up CnsVolumeOperationRequest instances for volumes that are no longer present in the
+// kubernetes cluster.
+func (or *operationRequestStore) cleanupStaleInstances(cleanupInterval int) {
+	ticker := time.NewTicker(time.Duration(cleanupInterval) * time.Minute)
+	ctx, log := logger.GetNewContextWithLogger()
+	log.Infof("CnsVolumeOperationRequest clean up interval is set to %d minutes", cleanupInterval)
+	for range ticker.C {
+		instanceMap := make(map[string]bool)
+
+		cnsVolumeOperationRequestList := &cnsvolumeoperationrequestv1alpha1.CnsVolumeOperationRequestList{}
+		err := or.k8sclient.List(ctx, cnsVolumeOperationRequestList)
+		if err != nil {
+			log.Errorf("failed to list CnsVolumeOperationRequests with error %v. Abandoning"+
+				"CnsVolumeOperationRequests clean up ...", err)
+			return
+		}
+
+		k8sclient, err := k8s.NewClient(ctx)
+		if err != nil {
+			log.Errorf("failed to get k8sclient with error: %v. Abandoning CnsVolumeOperationRequests"+
+				"clean up ...", err)
+			return
+		}
+		pvList, err := k8sclient.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			log.Errorf("failed to list PersistentVolumes with error %v. Abandoning"+
+				"CnsVolumeOperationRequests clean up ...", err)
+			return
+		}
+
+		for _, pv := range pvList.Items {
+			if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == csitypes.Name {
+				instanceMap[pv.Name] = true
+				instanceMap[pv.Spec.CSI.VolumeHandle] = true
+			}
+		}
+
+		for _, instance := range cnsVolumeOperationRequestList.Items {
+			latestOperationDetailsLength := len(instance.Status.LatestOperationDetails)
+			if latestOperationDetailsLength != 0 &&
+				instance.Status.LatestOperationDetails[latestOperationDetailsLength-1].TaskStatus ==
+					TaskInvocationStatusInProgress {
+				continue
+			}
+			var trimmedName string
+			switch {
+			case strings.HasPrefix(instance.Name, "pvc"):
+				trimmedName = instance.Name
+			case strings.HasPrefix(instance.Name, "delete"):
+				trimmedName = strings.TrimPrefix(instance.Name, "delete-")
+			case strings.HasPrefix(instance.Name, "extend"):
+				trimmedName = strings.TrimPrefix(instance.Name, "extend-")
+			}
+			if _, ok := instanceMap[trimmedName]; !ok {
+				err = or.deleteRequestDetails(ctx, instance.Name)
+				if err != nil {
+					log.Errorf("failed to delete CnsVolumeOperationRequest instance %s with error %v",
+						instance.Name, err)
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds changes to clean up stale CnsVolumeOperationRequest instances, as described in the design spec. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before this change: 
```
# kubectl get cnsvolumeoperationrequest -A
NAMESPACE           NAME                                          AGE
vmware-system-csi   expand-017d9265-ebe8-4f86-b658-a33df1a99edb   3h39m
vmware-system-csi   expand-1572cde9-b55f-4678-8f51-ab664a16217a   38h
vmware-system-csi   expand-43fc6f32-ec36-4b45-a06b-4b6a83174890   40h
vmware-system-csi   expand-51ff5070-96ef-4496-a3ca-e97a9a342331   28h
vmware-system-csi   expand-7310668c-0851-4bc4-b731-89a7329dc3f2   3h33m
vmware-system-csi   expand-7b8ce4ec-ebf7-4afd-a2a4-4407b8d94c8b   37h
vmware-system-csi   expand-8c5800a7-dbf6-4ae6-bdb4-9f6c3080bd3d   3h52m
vmware-system-csi   expand-97d6682a-50bf-4385-a199-45dd90cea1ae   27h
vmware-system-csi   expand-ad637265-5da2-4699-9828-20ed6ba23e45   3h46m
vmware-system-csi   expand-bdb5f6dd-c8bd-4b29-914f-5acd20a4210c   3h44m
vmware-system-csi   expand-d7d71347-0298-4347-99cb-5bbfc09e7054   3h50m
vmware-system-csi   expand-fdbbfa76-8f2e-4189-ad1f-40c03476a0d7   3h35m
vmware-system-csi   pvc-16c6ddc1-6940-40a3-8203-252d0e4c98b4      3h37m
vmware-system-csi   pvc-17b80ef4-7f56-4a0c-b734-3130e14e6eff      4h41m
vmware-system-csi   pvc-2cea9fec-62a0-47c1-86d8-fe1400bab1d1      4h41m
vmware-system-csi   pvc-4aa72e74-b262-4571-8cf7-53aec98d8114      4h41m
vmware-system-csi   pvc-5abf4440-8239-4a87-8797-50760a3982dd      3h35m
vmware-system-csi   pvc-5f8543e8-d265-4413-947c-ae5bd9964bce      4h41m
vmware-system-csi   pvc-77b08c76-e3cd-4e9d-a056-3a4b69ef32a8      3h31m
vmware-system-csi   pvc-7a4ea147-e49c-4d3b-b17d-bb17a270fc01      4h41m
vmware-system-csi   pvc-82c22c80-86af-4abb-9eae-9bd8a16b4b98      3h34m
vmware-system-csi   pvc-8956f2ab-7b66-429b-8002-876c02af2d0a      4h41m
vmware-system-csi   pvc-8e032e08-a195-4f88-8ee8-866b5ba00759      4h41m
vmware-system-csi   pvc-a8b7ba4a-1272-4b78-971e-cfeeeb593ad9      3h36m
vmware-system-csi   pvc-b5015ae6-0326-4f7e-92f0-d1e33068bd02      3h40m
vmware-system-csi   pvc-b8ea9f66-b520-489a-8d42-4c8d4ee97d80      3h52m
vmware-system-csi   pvc-e594c20a-e91c-4ad4-8e1d-d865225a135f      3h45m
vmware-system-csi   pvc-e8e665b9-1a40-4ead-9ea2-725c75022149      3h51m
```

After one cycle of clean up:
```
# kubectl get cnsvolumeoperationrequest -A
No resources found
```

Relevant debug level logs:
```
tem-csi/expand-8c5800a7-dbf6-4ae6-bdb4-9f6c3080bd3d\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:24.395893881Z"}
{"log":"2021-06-04T21:01:24.412Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/expand-97d6682a-50bf-4385-a199-45dd90cea1ae\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:24.413070043Z"}
{"log":"2021-06-04T21:01:24.435Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/expand-ad637265-5da2-4699-9828-20ed6ba23e45\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:24.436209196Z"}
{"log":"2021-06-04T21:01:24.460Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/expand-bdb5f6dd-c8bd-4b29-914f-5acd20a4210c\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:24.461136903Z"}
{"log":"2021-06-04T21:01:24.710Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/expand-d7d71347-0298-4347-99cb-5bbfc09e7054\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:24.714896465Z"}
{"log":"2021-06-04T21:01:24.809Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/expand-fdbbfa76-8f2e-4189-ad1f-40c03476a0d7\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:24.810799102Z"}
{"log":"2021-06-04T21:01:24.899Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-16c6ddc1-6940-40a3-8203-252d0e4c98b4\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:24.899907132Z"}
{"log":"2021-06-04T21:01:24.955Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-17b80ef4-7f56-4a0c-b734-3130e14e6eff\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:24.95617842Z"}
{"log":"2021-06-04T21:01:24.973Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-2cea9fec-62a0-47c1-86d8-fe1400bab1d1\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:24.974187915Z"}
{"log":"2021-06-04T21:01:25.000Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-4aa72e74-b262-4571-8cf7-53aec98d8114\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:25.001051361Z"}
{"log":"2021-06-04T21:01:25.012Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-5abf4440-8239-4a87-8797-50760a3982dd\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:25.012436508Z"}
{"log":"2021-06-04T21:01:25.023Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-5f8543e8-d265-4413-947c-ae5bd9964bce\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:25.024091798Z"}
{"log":"2021-06-04T21:01:25.033Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-77b08c76-e3cd-4e9d-a056-3a4b69ef32a8\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:25.033829668Z"}
{"log":"2021-06-04T21:01:25.060Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-7a4ea147-e49c-4d3b-b17d-bb17a270fc01\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:25.061171528Z"}
{"log":"2021-06-04T21:01:25.070Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-82c22c80-86af-4abb-9eae-9bd8a16b4b98\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:25.070989905Z"}
{"log":"2021-06-04T21:01:25.082Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-8956f2ab-7b66-429b-8002-876c02af2d0a\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:25.082920303Z"}
{"log":"2021-06-04T21:01:25.117Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-8e032e08-a195-4f88-8ee8-866b5ba00759\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:25.118072311Z"}
{"log":"2021-06-04T21:01:25.129Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-a8b7ba4a-1272-4b78-971e-cfeeeb593ad9\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:25.130172775Z"}
{"log":"2021-06-04T21:01:25.147Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-b5015ae6-0326-4f7e-92f0-d1e33068bd02\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:25.148651544Z"}
{"log":"2021-06-04T21:01:25.173Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-b8ea9f66-b520-489a-8d42-4c8d4ee97d80\u0009{\"TraceId\": \"f466a4e8-88ad-42b7-bd50-28071565371d\"}\n","stream":"stderr","time":"2021-06-04T21:01:25.174359814Z"}
{"log":"2021-06-04T21:01:25.185Z\u0009DEBUG\u0009cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:297\u0009Deleting CnsVolumeOperationRequest instance with name vmwa
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cleanup of stale CnsVolumeOperationRequest CRD instances
```
