### PR TITLE
Running vanilla e2e tests concurrently to reduce e2e run time

### DIFF
--- a/hack/run-e2e-test.sh
+++ b/hack/run-e2e-test.sh
@@ -54,12 +54,19 @@ fi
 if [ "$FOCUS" == "csi-block-vanilla" ]
 then
     ginkgo -mod=mod "${OPTS[@]}" --focus="csi-block-vanilla-destructive" tests/e2e
-    # Checking for test status
+    # Checking for destructive test status
     TEST_PASS=$?
     if [[ $TEST_PASS -ne 0 ]]; then
         exit 1
     fi
-    ginkgo -mod=mod "${OPTS[@]}" --focus="csi-block-vanilla" tests/e2e
+    ginkgo -mod=mod "${OPTS[@]}" --focus="csi-block-vanilla-serialized" tests/e2e
+    # Checking for serialized test status
+    TEST_PASS=$?
+    if [[ $TEST_PASS -ne 0 ]]; then
+        exit 1
+    fi
+    OPTS+=(-p)
+    ginkgo -mod=mod "${OPTS[@]}" --focus="csi-block-vanilla-parallelized" tests/e2e
 else
     ginkgo -mod=mod "${OPTS[@]}" --focus="$FOCUS" tests/e2e
 fi

--- a/tests/e2e/csi_cns_telemetry.go
+++ b/tests/e2e/csi_cns_telemetry.go
@@ -34,7 +34,9 @@ import (
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 )
 
-var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Cluster Distribution Telemetry", func() {
+var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-block-vanilla-parallelized] "+
+	"CNS-CSI Cluster Distribution Telemetry", func() {
+
 	f := framework.NewDefaultFramework("csi-cns-telemetry")
 	var (
 		client       clientset.Interface

--- a/tests/e2e/csi_cns_telemetry_vc_reboot.go
+++ b/tests/e2e/csi_cns_telemetry_vc_reboot.go
@@ -92,7 +92,8 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 	// 13. Delete pod and Wait for Volume Disk to be detached from the Node.
 	// 14. Delete PVC, PV and Storage Class.
 
-	ginkgo.It("[csi-block-vanilla] [csi-file-vanilla] verify volume operations while vc reboot", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-file-vanilla] [csi-block-vanilla-serialized] "+
+		"verify volume operations while vc reboot", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var storageclass *storagev1.StorageClass
@@ -275,7 +276,8 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 	// 12. Wait for Disk to be attached to the node.
 	// 13. Delete pod and Wait for Volume Disk to be detached from the Node.
 	// 14. Delete PVC, PV and Storage Class.
-	ginkgo.It("[csi-block-vanilla] [csi-file-vanilla] verify volume operations after vc reboots", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-file-vanilla] [csi-block-vanilla-serialized] "+
+		"verify volume operations after vc reboots", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var storageclass *storagev1.StorageClass

--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -49,6 +49,7 @@ import (
 )
 
 var _ = ginkgo.Describe("Basic Static Provisioning", func() {
+
 	f := framework.NewDefaultFramework("e2e-csistaticprovision")
 
 	var (
@@ -268,7 +269,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 9. Verify volume is detached from the node.
 	// 10. Delete PVC.
 	// 11. Verify PV is deleted automatically.
-	ginkgo.It("[csi-block-vanilla] Verify basic static provisioning workflow", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Verify basic static provisioning workflow", func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -375,7 +376,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 7. Wait for the volume entry to be created in CNS.
 	// 8. Delete PV2.
 	// 9. Wait for PV2 to be deleted, and also entry is deleted from CNS.
-	ginkgo.It("[csi-block-vanilla] Verify static provisioning workflow using same PV name twice", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
+		"Verify static provisioning workflow using same PV name twice", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 

--- a/tests/e2e/data_persistence.go
+++ b/tests/e2e/data_persistence.go
@@ -56,6 +56,7 @@ import (
 // 11. Wait for volume to be detached.
 
 var _ = ginkgo.Describe("Data Persistence", func() {
+
 	f := framework.NewDefaultFramework("e2e-data-persistence")
 	var (
 		client            clientset.Interface
@@ -112,7 +113,7 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		}
 	})
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] "+
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] "+
 		"Should create and delete pod with the same volume source", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -131,7 +131,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		}
 	})
 
-	ginkgo.It("[csi-block-vanilla] Verify CNS volume is created after full sync when pv entry is present", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-serialized] "+
+		"Verify CNS volume is created after full sync when pv entry is present", func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -210,7 +211,7 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 
 	})
 
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] "+
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-block-vanilla-serialized] "+
 		"Verify labels are created in CNS after updating pvc and/or pv with new labels", func() {
 		ginkgo.By("Invoking test to verify labels creation")
 		var sc *storagev1.StorageClass
@@ -299,7 +300,7 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 
 	})
 
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] "+
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-block-vanilla-serialized] "+
 		"Verify CNS volume is deleted after full sync when pv entry is delete", func() {
 		ginkgo.By("Invoking test to verify CNS volume creation")
 		ctx, cancel := context.WithCancel(context.Background())
@@ -405,7 +406,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 	// 9. verify that pvc labels for pvclaim[2] has been updated.
 	// 10. verify that pv labels for pvs[3] has been updated.
 	// 11. cleanup to remove pvs and pvcliams.
-	ginkgo.It("[csi-block-vanilla] Verify Multiple PVCs are deleted/updated after full sync", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-serialized] "+
+		"Verify Multiple PVCs are deleted/updated after full sync", func() {
 		sc, err := createStorageClass(client, nil, nil, v1.PersistentVolumeReclaimRetain, "", false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ctx, cancel := context.WithCancel(context.Background())
@@ -520,7 +522,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		}
 	})
 
-	ginkgo.It("[csi-block-vanilla] Verify PVC metadata is created in CNS after PVC is created in k8s", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-serialized] "+
+		"Verify PVC metadata is created in CNS after PVC is created in k8s", func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -600,7 +603,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	ginkgo.It("[csi-block-vanilla] Verify PVC metadata is deleted in CNS after PVC is deleted in k8s", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-serialized] "+
+		"Verify PVC metadata is deleted in CNS after PVC is deleted in k8s", func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/tests/e2e/operationstorm.go
+++ b/tests/e2e/operationstorm.go
@@ -54,7 +54,8 @@ import (
 		10. Delete storage class.
 */
 
-var _ = utils.SIGDescribe("[csi-block-vanilla] Volume Operations Storm", func() {
+var _ = utils.SIGDescribe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Volume Operations Storm", func() {
+
 	// TODO: Enable this test for WCP after it provides consistent results
 	f := framework.NewDefaultFramework("volume-ops-storm")
 	const defaultVolumeOpsScale = 30
@@ -239,7 +240,7 @@ var _ = utils.SIGDescribe("[csi-block-vanilla] Volume Operations Storm", func() 
 		7. Delete Namespace  and Wait for volumes to be deleted and Volume Disk to be detached from the Node.
 	*/
 
-	ginkgo.It("[csi-block-vanilla] [csi-file-vanilla] [csi-guest] "+
+	ginkgo.It("[csi-block-vanilla] [csi-file-vanilla] [csi-guest] [csi-block-vanilla-parallelized] "+
 		"Delete namespace to confirm all volumes and pods are deleted", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/storagepolicy.go
+++ b/tests/e2e/storagepolicy.go
@@ -49,7 +49,9 @@ import (
 // 7. Delete pod and Wait for Volume Disk to be detached from the Node.
 // 8. Delete PVC, PV and Storage Class.
 
-var _ = ginkgo.Describe("[csi-block-vanilla] Storage Policy Based Volume Provisioning", func() {
+var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
+	"Storage Policy Based Volume Provisioning", func() {
+
 	f := framework.NewDefaultFramework("e2e-spbm-policy")
 	var (
 		client    clientset.Interface

--- a/tests/e2e/svmotion_detached_volume.go
+++ b/tests/e2e/svmotion_detached_volume.go
@@ -45,7 +45,7 @@ import (
 	5. Invoke CNS Query API and validate datastore URL value changed correctly
 */
 
-var _ = ginkgo.Describe("[csi-block-vanilla] Relocate detached volume ", func() {
+var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Relocate detached volume ", func() {
 	f := framework.NewDefaultFramework("svmotion-detached-disk")
 	var (
 		client          clientset.Interface

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -475,8 +475,8 @@ func updateDeploymentReplica(client clientset.Interface,
 	*deployment.Spec.Replicas = count
 	deployment, err = client.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	ginkgo.By("Waiting for update operation on deployment to take effect")
-	time.Sleep(1 * time.Minute)
+	err = fdep.WaitForDeploymentComplete(client, deployment)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	return deployment
 }
 

--- a/tests/e2e/vc_reboot_volume_lifecycle.go
+++ b/tests/e2e/vc_reboot_volume_lifecycle.go
@@ -92,7 +92,7 @@ var _ bool = ginkgo.Describe("Verify volume life_cycle operations works fine aft
 		9. Delete PVC, PV and Storage Class
 	*/
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] "+
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-serialized] "+
 		"verify volume operations on VC works fine after vc reboots", func() {
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/tests/e2e/vcp_to_csi_syncer.go
+++ b/tests/e2e/vcp_to_csi_syncer.go
@@ -1451,7 +1451,7 @@ func createVmdk(host string, size string, objType string, diskFormat string) (st
 	if size == "" {
 		size = "2g"
 	}
-	rand.Seed(time.Now().UnixNano())
+
 	vmdkPath := fmt.Sprintf("%s/test-%v-%v.vmdk", dir, time.Now().UnixNano(), rand.Intn(1000))
 	sshCmd := fmt.Sprintf("vmkfstools -c %s -d %s -W %s %s", size, diskFormat, objType, vmdkPath)
 	framework.Logf("Invoking command '%v' on ESX host %v", sshCmd, host)

--- a/tests/e2e/volume_health_test.go
+++ b/tests/e2e/volume_health_test.go
@@ -38,6 +38,7 @@ import (
 )
 
 var _ = ginkgo.Describe("Volume health check", func() {
+
 	f := framework.NewDefaultFramework("volume-healthcheck")
 	var (
 		client                     clientset.Interface
@@ -2590,7 +2591,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// Verify PV entry is deleted from CNS.
 	// Delete the SC.
 
-	ginkgo.It("[csi-block-vanilla] Verify pvc is not annotated with health status in vanilla setup", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Verify pvc is not annotated "+
+		"with health status in vanilla setup", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Invoking Test volume health status")

--- a/tests/e2e/vsphere_shared_datastore.go
+++ b/tests/e2e/vsphere_shared_datastore.go
@@ -45,7 +45,9 @@ import (
 // 1. SHARED_VSPHERE_DATASTORE_URL (set to shared datastore URL).
 // 2. NONSHARED_VSPHERE_DATASTORE_URL (set to non-shared datastor URL).
 
-var _ = ginkgo.Describe("[csi-block-vanilla] Datastore Based Volume Provisioning With No Storage Policy", func() {
+var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
+	"Datastore Based Volume Provisioning With No Storage Policy", func() {
+
 	f := framework.NewDefaultFramework("e2e-vsphere-volume-provisioning-no-storage-policy")
 	var (
 		client                clientset.Interface

--- a/tests/e2e/vsphere_volume_disksize.go
+++ b/tests/e2e/vsphere_volume_disksize.go
@@ -44,7 +44,7 @@ import (
 */
 
 var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor] [csi-guest] "+
-	"Volume Disk Size ", func() {
+	"[csi-block-vanilla-parallelized] Volume Disk Size ", func() {
 	f := framework.NewDefaultFramework("volume-disksize")
 	var (
 		client            clientset.Interface

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -51,6 +51,7 @@ import (
 )
 
 var _ = ginkgo.Describe("Volume Expansion Test", func() {
+
 	f := framework.NewDefaultFramework("volume-expansion")
 	var (
 		client                     clientset.Interface
@@ -143,7 +144,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 9. Delete pod and Wait for Volume Disk to be detached from the Node.
 	// 10. Delete PVC, PV and Storage Class.
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] "+
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] "+
 		"Verify volume expansion with no filesystem before expansion", func() {
 		invokeTestForVolumeExpansion(f, client, namespace, "", storagePolicyName, profileID)
 	})
@@ -167,7 +168,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 12. Delete pod and Wait for Volume Disk to be detached from the Node.
 	// 13. Delete PVC, PV and Storage Class.
 
-	ginkgo.It("[csi-block-vanilla] [csi-guest] "+
+	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized] "+
 		"Verify volume expansion with initial filesystem before expansion", func() {
 		invokeTestForVolumeExpansionWithFilesystem(f, client, namespace, "", storagePolicyName, profileID)
 	})
@@ -183,7 +184,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 5. Modify PVC's size to trigger offline volume expansion.
 	// 6. Verify if the PVC expansion fails.
 
-	ginkgo.It("[csi-block-vanilla] [csi-guest] Verify volume expansion not allowed", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-guest]  [csi-block-vanilla-parallelized] "+
+		"Verify volume expansion not allowed", func() {
 		invokeTestForInvalidVolumeExpansion(f, client, namespace, storagePolicyName, profileID)
 	})
 
@@ -198,7 +200,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 5. Modify PVC's size to a smaller size.
 	// 6. Verify if the PVC expansion fails.
 
-	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-supervisor] Verify volume shrinking not allowed", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-supervisor]  [csi-block-vanilla-parallelized] "+
+		"Verify volume shrinking not allowed", func() {
 		invokeTestForInvalidVolumeShrink(f, client, namespace, storagePolicyName, profileID)
 	})
 
@@ -215,7 +218,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 7. Delete PVC.
 	// 8. Verify PV is deleted automatically.
 
-	ginkgo.It("[csi-block-vanilla] "+
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 		"Verify volume expansion is not supported for PVC using vSAN-Default-Storage-Policy", func() {
 		invokeTestForInvalidVolumeExpansionStaticProvision(f, client, namespace, storagePolicyName, profileID)
 	})
@@ -235,7 +238,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 9. Delete pod and Wait for Volume Disk to be detached from the Node.
 	// 10. Delete PVC, PV and Storage Class.
 
-	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-supervisor] "+
+	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-supervisor] [csi-block-vanilla-parallelized] "+
 		"Verify volume expansion can happen multiple times", func() {
 		invokeTestForExpandVolumeMultipleTimes(f, client, namespace, "", storagePolicyName, profileID)
 	})
@@ -268,7 +271,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		10.  Make sure file system has increased
 
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] Verify online volume expansion on dynamic volume", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor]  [csi-block-vanilla-parallelized] "+
+		"Verify online volume expansion on dynamic volume", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -335,7 +339,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 9. Make sure data is intact on the PV mounted on the pod.
 	// 10. Make sure file system has increased.
 
-	ginkgo.It("[csi-block-vanilla] Verify online volume expansion on static volume", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
+		"Verify online volume expansion on static volume", func() {
 		ginkgo.By("Invoking Test for Volume Expansion on statically created PVC ")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -382,7 +387,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		6. Modify PVC to be a smaller size.
 		7. Verify that the PVC size does not change because volume shrinking is not supported.
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] "+
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] "+
 		"Verify online volume expansion shrinking volume not allowed", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
@@ -450,7 +455,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			8. Verify the PVC Size should increased by 10Gi
 			9. Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] "+
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] "+
 		"Verify online volume expansion multiple times on the same PVC", func() {
 
 		ginkgo.By("Invoking Test for Volume Expansion")
@@ -512,7 +517,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		11. Make sure file system has increased
 	*/
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] "+
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-serialized] "+
 		"Verify online volume expansion when VSAN-health is down", func() {
 
 		ginkgo.By("Invoking Test for Volume Expansion")
@@ -636,7 +641,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		10. Make sure data is intact on the PV mounted on the pod
 		11. Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] "+
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-serialized] "+
 		"Verify online volume expansion when SPS-Service is down", func() {
 
 		ginkgo.By("Invoking Test for Volume Expansion")
@@ -761,7 +766,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		10. Make sure file system has increased
 	*/
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] "+
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized] "+
 		"Verify online volume expansion by updating PVC with different sizes concurrently", func() {
 
 		ginkgo.By("Invoking Test for Volume Expansion")
@@ -879,7 +884,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		9. Make sure data is intact on the PV mounted on the pod
 		10.  Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] Volume expansion on shared VVOL datastore", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] "+
+		"Volume expansion on shared VVOL datastore", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -966,7 +972,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		9. Make sure data is intact on the PV mounted on the pod
 		10.  Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] Volume expansion on shared NFS datastore", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] "+
+		"Volume expansion on shared NFS datastore", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1054,7 +1061,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		9. Make sure data is intact on the PV mounted on the pod
 		10.  Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] Volume expansion on shared VMFS datastore", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] "+
+		"Volume expansion on shared VMFS datastore", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1713,7 +1721,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		11.  Make sure file system has increased
 
 	*/
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-guest] "+
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized] "+
 		"Verify online volume expansion when POD is deleted and re-created", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1834,7 +1842,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		7. Delete Pod and PVC
 		8. Verify there should not be any PVC entry in CNS
 	*/
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-guest] "+
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized] "+
 		"Verify online volume expansion when PVC is deleted", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
@@ -2243,7 +2251,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		11. Scale down deployment set to 0 replicas and delete all pods, PVC and SC
 
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] Verify online volume expansion on deployment", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] "+
+		"Verify online volume expansion on deployment", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/vsphere_volume_fsgroup.go
+++ b/tests/e2e/vsphere_volume_fsgroup.go
@@ -51,7 +51,7 @@ Steps
 */
 
 var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-guest] [csi-supervisor] "+
-	"Volume Filesystem Group Test", func() {
+	"[csi-block-vanilla-parallelized] Volume Filesystem Group Test", func() {
 	f := framework.NewDefaultFramework("volume-fsgroup")
 	var (
 		client            clientset.Interface

--- a/tests/e2e/vsphere_volume_fstype.go
+++ b/tests/e2e/vsphere_volume_fstype.go
@@ -61,6 +61,7 @@ import (
 //    the file system executable file on the node.
 
 var _ = ginkgo.Describe("[csi-block-vanilla] Volume Filesystem Type Test", func() {
+
 	f := framework.NewDefaultFramework("volume-fstype")
 	var (
 		client            clientset.Interface
@@ -79,15 +80,15 @@ var _ = ginkgo.Describe("[csi-block-vanilla] Volume Filesystem Type Test", func(
 		}
 	})
 
-	ginkgo.It("CSI - verify fstype - ext3 formatted volume", func() {
+	ginkgo.It("[csi-block-vanilla-serialized] CSI - verify fstype - ext3 formatted volume", func() {
 		invokeTestForFstype(f, client, namespace, ext3FSType, ext3FSType, storagePolicyName, profileID)
 	})
 
-	ginkgo.It("CSI - verify fstype - default value should be ext4", func() {
+	ginkgo.It("[csi-block-vanilla-parallelized] CSI - verify fstype - default value should be ext4", func() {
 		invokeTestForFstype(f, client, namespace, "", ext4FSType, storagePolicyName, profileID)
 	})
 
-	ginkgo.It("CSI - verify invalid fstype", func() {
+	ginkgo.It("[csi-block-vanilla-parallelized] CSI - verify invalid fstype", func() {
 		invokeTestForInvalidFstype(f, client, namespace, invalidFSType, storagePolicyName, profileID)
 	})
 })
@@ -126,7 +127,8 @@ func invokeTestForFstype(f *framework.Framework, client clientset.Interface,
 
 	// Create a Pod to use this PVC, and verify volume has been attached
 	ginkgo.By("Creating pod to attach PV to the node")
-	pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
+	pod, _ := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
+	err = fpod.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	pv := persistentvolumes[0]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is testing e2e pipeline with concurrency tests to reduce time consumed during vanilla e2e tests

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran e2e pipelines

Average time taken by vanilla e2e tests before this change: **3 hrs**
After this change, time taken by vanilla e2e2 tests: **1 hr 50min**
Total time we can save is around **1 hr 10 min**

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Running vanilla e2e tests concurrently to reduce e2e run time
```
