### PR TITLE
Enhance log in k8scloudoperator.go.

### DIFF
--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -227,8 +227,9 @@ func (k8sCloudOperator *k8sCloudOperator) getPod(ctx context.Context, pvcName st
 		for _, volume := range pod.Spec.Volumes {
 			pvClaim := volume.VolumeSource.PersistentVolumeClaim
 			if pvClaim != nil && pvClaim.ClaimName == pvcName {
-				log.Debugf("Returned pod: %s with pvClaim name: %s and namespace: %s running on node: %s",
-					spew.Sdump(&pod), pvcName, pvcNamespace, nodeName)
+				log.Debugf("Returned pod: %s", spew.Sdump(&pod))
+				log.Infof("Returned pod: %s/%s with pvClaim name: %s running on node: %s",
+					pod.Name, pod.Namespace, pvcName, nodeName)
 				return &pod, nil
 			}
 		}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This change is to add a simple info log that prints the pod name, namespace, PVC and PV names in k8scloudoperator.go. Currently we have a debug log for the same but that is not enabled in production env.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing
```
#  in WCP SVC, create a PVC and POD. Make sure PVC is bounded and pod is running.
root@420b9d50c5b2c55eb83f244aeec9c4d5 [ ~ ]# kubectl create -f sv-pvc.yaml -n test-gc-e2e-demo-ns 
persistentvolumeclaim/sv-block-pvc created

root@420b9d50c5b2c55eb83f244aeec9c4d5 [ ~ ]# kubectl get pvc -n test-gc-e2e-demo-ns 
NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
64af2f53-577a-4f3e-a1a2-ee6a3fb2e9c8-3bc3012f-47dd-49c1-ba15-22b34c918137   Bound    pvc-e7fdefe6-4db8-49d2-ac31-5bbefb1c1b83   500Mi      RWO            gc-storage-profile          5d
64af2f53-577a-4f3e-a1a2-ee6a3fb2e9c8-7c6054dd-2ee4-436b-8cd4-23f1c9f853c5   Bound    pvc-24bc2a59-f5c6-4970-98a6-147a60d8c0f1   500Mi      RWO            wcpglobal-storage-profile   25m
sv-block-pvc                                                                Bound    pvc-9265268f-4dca-43f2-af8b-f260162e844e   500Mi      RWO            wcpglobal-storage-profile   13s
root@420b9d50c5b2c55eb83f244aeec9c4d5 [ ~ ]# kubectl create -f sv-pod.yaml -n test-gc-e2e-demo-ns 
pod/sv-block-pod created

root@420b9d50c5b2c55eb83f244aeec9c4d5 [ ~ ]# kubectl get pod -n test-gc-e2e-demo-ns 
NAME           READY   STATUS    RESTARTS   AGE
sv-block-pod   1/1     Running   0          58m

# check the CSI syncer log in SVC, see the following log message:
{"level":"info","time":"2021-06-08T22:29:28.022513543Z","caller":"k8scloudoperator/k8scloudoperator.go:232","msg":"Returned pod: sv-block-pod-1/test-gc-e2e-demo-ns with pvClaim name: 64af2f53-577a-4f3e-a1a2-ee6a3fb2e9c8-7c6054dd-2ee4-436b-8cd4-23f1c9f853c5 running on node: test-gc-e2e-demo-ns%!(EXTRA string=sc2-10-185-45-27.eng.vmware.com)"}

```
pre-checkin for WCP passed:
https://container-dp.svc.eng.vmware.com/view/Pre-Checkin-CSI/job/csi-wcp-pre-check-in/40/parameters/
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
