### PR TITLE
NodeGetInfo and RBAC changes for topology feature improvement

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -73,6 +73,31 @@ metadata:
   name: vsphere-csi-node
   namespace: vmware-system-csi
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-role
+rules:
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["csinodetopologies"]
+    verbs: ["create", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: vmware-system-csi
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-node-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
@@ -71,8 +71,6 @@ var (
 // definition on the API server and returns an implementation of
 // VolumeOperationRequest interface. Clients are unaware of the implementation
 // details to read and persist volume operation details.
-// This function is not thread safe. Multiple serial calls to this function will
-// return multiple new instances of the VolumeOperationRequest interface.
 func InitVolumeOperationRequestInterface(ctx context.Context, cleanupInterval int) (VolumeOperationRequest, error) {
 	log := logger.GetLogger(ctx)
 

--- a/pkg/internalapis/csinodetopology/csinodetopology.go
+++ b/pkg/internalapis/csinodetopology/csinodetopology.go
@@ -16,9 +16,240 @@ limitations under the License.
 
 package csinodetopology
 
+import (
+	"context"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+	csinodetopologyv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/csinodetopology/v1alpha1"
+	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
+)
+
 const (
 	// CRDSingular represents the singular name of csinodetopology CRD.
 	CRDSingular = "csinodetopology"
 	// CRDPlural represents the plural name of csinodetopology CRD.
 	CRDPlural = "csinodetopologies"
+	// defaultTopologyCRWatcherTimeoutInMin is the default duration for which
+	// the topology service client will watch on the CSINodeTopology instance to check
+	// if the Status has been updated successfully.
+	defaultTopologyCRWatcherTimeoutInMin = 1
+	// maxTopologyCRWatcherTimeoutInMin is the maximum duration for which
+	// the topology service client will watch on the CSINodeTopology instance to check
+	// if the Status has been updated successfully.
+	maxTopologyCRWatcherTimeoutInMin = 2
 )
+
+// NodeInfo contains the information required for the TopologyService to
+// identify a node and retrieve its topology information.
+type NodeInfo struct {
+	// NodeName uniquely identifies the node in kubernetes.
+	NodeName string
+	// NodeID is a unique identifier of the NodeVM in vSphere.
+	NodeID string
+}
+
+// TopologyService is an interface which exposes functionality related to topology feature.
+type TopologyService interface {
+	// GetNodeTopologyLabels fetches the topology labels on the ancestors of NodeVM given the NodeInfo.
+	GetNodeTopologyLabels(ctx context.Context, info *NodeInfo) (map[string]string, error)
+}
+
+// volumeTopology stores information required for the TopologyService interface.
+type volumeTopology struct {
+	// k8sClient helps operate on CSINodeTopology custom resource.
+	k8sClient client.Client
+	// csiNodeTopologyWatcher is a watcher instance on the CSINodeTopology custom resource.
+	csiNodeTopologyWatcher *cache.ListWatch
+}
+
+var (
+	// volumeTopologyInstance is instance of volumeTopology and implements TopologyService interface.
+	volumeTopologyInstance *volumeTopology
+	// volumeTopologyInstanceLock is used for handling race conditions during read, write on volumeTopologyInstance
+	volumeTopologyInstanceLock = &sync.RWMutex{}
+)
+
+// InitTopologyServiceInterface returns a singleton implementation of the
+// TopologyService interface.
+func InitTopologyServiceInterface(ctx context.Context) (TopologyService, error) {
+	log := logger.GetLogger(ctx)
+
+	volumeTopologyInstanceLock.RLock()
+	if volumeTopologyInstance == nil {
+		volumeTopologyInstanceLock.RUnlock()
+		volumeTopologyInstanceLock.Lock()
+		defer volumeTopologyInstanceLock.Unlock()
+		if volumeTopologyInstance == nil {
+
+			// Get in cluster config for client to API server.
+			config, err := k8s.GetKubeConfig(ctx)
+			if err != nil {
+				log.Errorf("failed to get kubeconfig with error: %v", err)
+				return nil, err
+			}
+
+			// Create client to API server.
+			k8sclient, err := k8s.NewClientForGroup(ctx, config, csinodetopologyv1alpha1.GroupName)
+			if err != nil {
+				log.Errorf("failed to create k8sClient with error: %v", err)
+				return nil, err
+			}
+
+			// Create watcher for CSINodeTopology instances
+			crWatcher, err := k8s.NewCSINodeTopologyWatcher(ctx, config)
+			if err != nil {
+				log.Errorf("failed to create a watcher for CSINodeTopology CR. Error: %+v", err)
+				return nil, err
+			}
+
+			volumeTopologyInstance = &volumeTopology{
+				k8sClient:              k8sclient,
+				csiNodeTopologyWatcher: crWatcher,
+			}
+		}
+	} else {
+		volumeTopologyInstanceLock.RUnlock()
+	}
+
+	return volumeTopologyInstance, nil
+}
+
+// GetNodeTopologyLabels uses the CSINodeTopology CR to retrieve topology information of a node.
+func (volTopology *volumeTopology) GetNodeTopologyLabels(ctx context.Context, info *NodeInfo) (
+	map[string]string, error) {
+	log := logger.GetLogger(ctx)
+
+	// Fetch node object to set owner ref.
+	nodeObj, err := getNodeObject(ctx, info.NodeName)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	// Create spec for CSINodeTopology.
+	csiNodeTopologySpec := &csinodetopologyv1alpha1.CSINodeTopology{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: info.NodeName,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Node",
+					Name:       nodeObj.Name,
+					UID:        nodeObj.UID,
+				},
+			},
+		},
+		Spec: csinodetopologyv1alpha1.CSINodeTopologySpec{
+			NodeID: info.NodeID,
+		},
+	}
+	// Create CSINodeTopology CR for the node.
+	err = volTopology.k8sClient.Create(ctx, csiNodeTopologySpec)
+	if err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to create CSINodeTopology CR. Error: %+v", err)
+		}
+	} else {
+		log.Infof("Successfully created a CSINodeTopology instance for NodeName: %q", info.NodeName)
+	}
+
+	timeoutSeconds := int64((time.Duration(getCSINodeTopologyWatchTimeoutInMin(ctx)) * time.Minute).Seconds())
+	watchCSINodeTopology, err := volTopology.csiNodeTopologyWatcher.Watch(metav1.ListOptions{
+		FieldSelector:  fields.OneTermEqualSelector("metadata.name", info.NodeName).String(),
+		TimeoutSeconds: &timeoutSeconds,
+		Watch:          true,
+	})
+	if err != nil {
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to watch on CSINodeTopology instance with name %q. Error: %+v", info.NodeName, err)
+	}
+	defer watchCSINodeTopology.Stop()
+
+	// Check if status gets updated in the instance within the given timeout seconds.
+	for event := range watchCSINodeTopology.ResultChan() {
+		csiNodeTopologyInstance, ok := event.Object.(*csinodetopologyv1alpha1.CSINodeTopology)
+		if !ok {
+			log.Warnf("Received unidentified object - %+v", event.Object)
+			continue
+		}
+		if csiNodeTopologyInstance.Name != info.NodeName {
+			continue
+		}
+		switch csiNodeTopologyInstance.Status.Status {
+		case csinodetopologyv1alpha1.CSINodeTopologySuccess:
+			accessibleTopology := make(map[string]string)
+			for _, label := range csiNodeTopologyInstance.Status.TopologyLabels {
+				accessibleTopology[label.Key] = label.Value
+			}
+			return accessibleTopology, nil
+		case csinodetopologyv1alpha1.CSINodeTopologyError:
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to retrieve topology information for Node: %q. Error: %q", info.NodeName,
+				csiNodeTopologyInstance.Status.ErrorMessage)
+		}
+	}
+	return nil, logger.LogNewErrorCodef(log, codes.Internal,
+		"timed out while waiting for topology labels to be updated in %q CSINodeTopology instance.",
+		info.NodeName)
+}
+
+// getNodeObject fetches the node instance given the nodeName
+func getNodeObject(ctx context.Context, nodeName string) (*v1.Node, error) {
+	log := logger.GetLogger(ctx)
+
+	// Create the kubernetes client.
+	k8sClient, err := k8s.NewClient(ctx)
+	if err != nil {
+		log.Errorf("failed to create K8s client. Error: %v", err)
+		return nil, err
+	}
+	// Fetch node object.
+	nodeObj, err := k8sClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("failed to fetch node object with name %q. Error: %v", nodeName, err)
+		return nil, err
+	}
+	return nodeObj, nil
+}
+
+// getCSINodeTopologyWatchTimeoutInMin returns the timeout for watching
+// on CSINodeTopology instances for any updates.
+// If environment variable NODEGETINFO_WATCH_TIMEOUT_MINUTES is set and
+// has a valid value between [1, 2], return the interval value read
+// from environment variable. Otherwise, use the default timeout of 1 min.
+func getCSINodeTopologyWatchTimeoutInMin(ctx context.Context) int {
+	log := logger.GetLogger(ctx)
+	watcherTimeoutInMin := defaultTopologyCRWatcherTimeoutInMin
+	if v := os.Getenv("NODEGETINFO_WATCH_TIMEOUT_MINUTES"); v != "" {
+		if value, err := strconv.Atoi(v); err == nil {
+			switch {
+			case value <= 0:
+				log.Warnf("Timeout set in env variable NODEGETINFO_WATCH_TIMEOUT_MINUTES %q is equal or "+
+					"less than 0, will use the default timeout of %d minute(s)", v, watcherTimeoutInMin)
+			case value > maxTopologyCRWatcherTimeoutInMin:
+				log.Warnf("Timeout set in env variable NODEGETINFO_WATCH_TIMEOUT_MINUTES %q is greater than "+
+					"%d, will use the default timeout of %d minute(s)", v, maxTopologyCRWatcherTimeoutInMin,
+					watcherTimeoutInMin)
+			default:
+				watcherTimeoutInMin = value
+				log.Infof("Timeout is set to %d minute(s)", watcherTimeoutInMin)
+			}
+		} else {
+			log.Warnf("Timeout set in env variable NODEGETINFO_WATCH_TIMEOUT_MINUTES %q is invalid, "+
+				"using the default timeout of %d minute(s)", v, watcherTimeoutInMin)
+		}
+	}
+	return watcherTimeoutInMin
+}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -55,7 +55,6 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 	internalapis "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis"
 	cnsvolumeoperationrequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
-	csinodetopology "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/csinodetopology"
 	csinodetopologyv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/csinodetopology/v1alpha1"
 )
 
@@ -263,15 +262,15 @@ func NewCSINodeTopologyWatcher(ctx context.Context, config *restclient.Config) (
 	gvk := schema.GroupVersionKind{
 		Group:   csinodetopologyv1alpha1.GroupName,
 		Version: csinodetopologyv1alpha1.Version,
-		Kind:    csinodetopology.CRDPlural,
+		Kind:    csiNodeTopologyKind,
 	}
 
 	client, err := apiutils.RESTClientForGVK(gvk, false, config, serializer.NewCodecFactory(scheme))
 	if err != nil {
-		log.Errorf("failed to create RESTClient for %s CR with err: %+v", csinodetopology.CRDSingular, err)
+		log.Errorf("failed to create RESTClient for %s CR with err: %+v", csiNodeTopologyKind, err)
 		return nil, err
 	}
-	return cache.NewListWatchFromClient(client, csinodetopology.CRDPlural, v1.NamespaceAll, fields.Everything()), nil
+	return cache.NewListWatchFromClient(client, csiNodeTopologyKind, v1.NamespaceAll, fields.Everything()), nil
 }
 
 // CreateKubernetesClientFromConfig creaates a newk8s client from given kubeConfig file.

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -39,6 +39,8 @@ const (
 	virtualMachineKind = "virtualmachines"
 	// Kind for cnsfileaccessconfig resources
 	cnsfileaccessconfigKind = "cnsfileaccessconfigs"
+	// Kind for csiNodeTopology resources
+	csiNodeTopologyKind = "csinodetopologies"
 )
 
 // InformerManager is a service that notifies subscribers about changes


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR contains the client side changes required in NodeGetInfo API to read the CSINodeTopology CR and pick the topology labels from it. These code changes are a continuation to the work listed in the following PRs:
#947
#969 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #980 

**Testing done**:
Vanilla E2E tests:
```
Ran 42 of 190 Specs in 10059.042 seconds
SUCCESS! -- 42 Passed | 0 Failed | 0 Pending | 148 Skipped
PASS
```

Manual testing:
1. FSS enabled
csinodetopology controller code included
Not a topology setup

Syncer logs -
```
kubernetes/kubernetes.go:415	"csinodetopologies.cns.vmware.com" CRD updated successfully
2021-06-10T06:26:57.334Z	INFO	node/manager.go:75	Initializing node.defaultManager...
2021-06-10T06:26:57.334Z	INFO	node/manager.go:79	node.defaultManager initialized
......
2021-06-10T06:26:58.045Z	INFO	manager/init.go:209	Starting Cns Operator
2021-06-10T06:26:58.147Z	DEBUG	node/manager.go:180	Renewing virtual machine VirtualMachine:vm-48 [VirtualCenterHost: 10.186.224.205, UUID: 423471b9-4274-1ae1-0458-8ef9ef977aed, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.224.205]] with nodeUUID "423471b9-4274-1ae1-0458-8ef9ef977aed"
2021-06-10T06:26:58.152Z	DEBUG	node/manager.go:187	VM VirtualMachine:vm-48 [VirtualCenterHost: 10.186.224.205, UUID: 423471b9-4274-1ae1-0458-8ef9ef977aed, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] was successfully renewed with nodeUUID "423471b9-4274-1ae1-0458-8ef9ef977aed"
2021-06-10T06:26:58.152Z	DEBUG	config/config.go:361	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
2021-06-10T06:26:58.152Z	DEBUG	config/config.go:268	Initializing vc server 10.186.224.205
2021-06-10T06:26:58.152Z	INFO	config/config.go:307	No Net Permissions given in Config. Using default permissions.
2021-06-10T06:26:58.166Z	INFO	csinodetopology/csinodetopology_controller.go:272	Successfully updated topology labels for nodeVM with ID "k8s-node-0429"
2021-06-10T06:26:58.166Z	DEBUG	node/manager.go:180	Renewing virtual machine VirtualMachine:vm-49 [VirtualCenterHost: 10.186.224.205, UUID: 4234170e-2b3a-aa41-0bea-3ee6f00fa486, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.224.205]] with nodeUUID "4234170e-2b3a-aa41-0bea-3ee6f00fa486"
2021-06-10T06:26:58.169Z	DEBUG	node/manager.go:187	VM VirtualMachine:vm-49 [VirtualCenterHost: 10.186.224.205, UUID: 4234170e-2b3a-aa41-0bea-3ee6f00fa486, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] was successfully renewed with nodeUUID "4234170e-2b3a-aa41-0bea-3ee6f00fa486"
2021-06-10T06:26:58.169Z	DEBUG	config/config.go:361	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
2021-06-10T06:26:58.170Z	DEBUG	config/config.go:268	Initializing vc server 10.186.224.205
2021-06-10T06:26:58.170Z	INFO	config/config.go:307	No Net Permissions given in Config. Using default permissions.
2021-06-10T06:26:58.192Z	INFO	csinodetopology/csinodetopology_controller.go:272	Successfully updated topology labels for nodeVM with ID "k8s-node-0720"
2021-06-10T06:26:58.193Z	DEBUG	node/manager.go:180	Renewing virtual machine VirtualMachine:vm-47 [VirtualCenterHost: 10.186.224.205, UUID: 42344143-2b6e-cbad-ad21-ddcf96e79190, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.224.205]] with nodeUUID "42344143-2b6e-cbad-ad21-ddcf96e79190"
2021-06-10T06:26:58.200Z	DEBUG	node/manager.go:187	VM VirtualMachine:vm-47 [VirtualCenterHost: 10.186.224.205, UUID: 42344143-2b6e-cbad-ad21-ddcf96e79190, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] was successfully renewed with nodeUUID "42344143-2b6e-cbad-ad21-ddcf96e79190"
2021-06-10T06:26:58.201Z	DEBUG	config/config.go:361	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
2021-06-10T06:26:58.201Z	DEBUG	config/config.go:268	Initializing vc server 10.186.224.205
2021-06-10T06:26:58.201Z	INFO	config/config.go:307	No Net Permissions given in Config. Using default permissions.
2021-06-10T06:26:58.223Z	INFO	csinodetopology/csinodetopology_controller.go:272	Successfully updated topology labels for nodeVM with ID "k8s-master-968"
2021-06-10T06:26:58.224Z	DEBUG	node/manager.go:180	Renewing virtual machine VirtualMachine:vm-50 [VirtualCenterHost: 10.186.224.205, UUID: 4234b569-05f7-a0d3-cf9a-6e41614efe98, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.224.205]] with nodeUUID "4234b569-05f7-a0d3-cf9a-6e41614efe98"
2021-06-10T06:26:58.229Z	DEBUG	node/manager.go:187	VM VirtualMachine:vm-50 [VirtualCenterHost: 10.186.224.205, UUID: 4234b569-05f7-a0d3-cf9a-6e41614efe98, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] was successfully renewed with nodeUUID "4234b569-05f7-a0d3-cf9a-6e41614efe98"
2021-06-10T06:26:58.229Z	DEBUG	config/config.go:361	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
2021-06-10T06:26:58.230Z	DEBUG	config/config.go:268	Initializing vc server 10.186.224.205
2021-06-10T06:26:58.230Z	INFO	config/config.go:307	No Net Permissions given in Config. Using default permissions.
2021-06-10T06:26:58.239Z	INFO	csinodetopology/csinodetopology_controller.go:272	Successfully updated topology labels for nodeVM with ID "k8s-node-0249"
```

2. FSS enabled
csinodetopology controller code included
Topology aware environment

Syncer logs - 
```
2021-06-11T01:01:56.621Z	DEBUG	node/manager.go:180	Renewing virtual machine VirtualMachine:vm-49 [VirtualCenterHost: 10.186.224.205, UUID: 4234170e-2b3a-aa41-0bea-3ee6f00fa486, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.224.205]] with nodeUUID "4234170e-2b3a-aa41-0bea-3ee6f00fa486"
2021-06-11T01:01:56.629Z	DEBUG	node/manager.go:187	VM VirtualMachine:vm-49 [VirtualCenterHost: 10.186.224.205, UUID: 4234170e-2b3a-aa41-0bea-3ee6f00fa486, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] was successfully renewed with nodeUUID "4234170e-2b3a-aa41-0bea-3ee6f00fa486"
2021-06-11T01:01:56.629Z	DEBUG	config/config.go:361	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
2021-06-11T01:01:56.630Z	DEBUG	config/config.go:268	Initializing vc server 10.186.224.205
2021-06-11T01:01:56.630Z	INFO	config/config.go:307	No Net Permissions given in Config. Using default permissions.
2021-06-11T01:01:56.630Z	INFO	csinodetopology/csinodetopology_controller.go:233	Detected a topology aware cluster
2021-06-11T01:01:56.790Z	DEBUG	vsphere/virtualmachine.go:253	GetZoneRegion: called with zoneCategoryName: k8s-zone, regionCategoryName: k8s-region
2021-06-11T01:01:56.815Z	DEBUG	vsphere/virtualmachine.go:214	Host owning node vm: VirtualMachine:vm-49 [VirtualCenterHost: 10.186.224.205, UUID: 4234170e-2b3a-aa41-0bea-3ee6f00fa486, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] is 10.186.224.94
2021-06-11T01:01:56.821Z	DEBUG	vsphere/virtualmachine.go:246	Ancestors of node vm: VirtualMachine:vm-49 [VirtualCenterHost: 10.186.224.205, UUID: 4234170e-2b3a-aa41-0bea-3ee6f00fa486, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] are : [[{ExtensibleManagedObject:{Self:Folder:group-d1 Value:[] AvailableField:[]} Parent:<nil> CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:Datacenters DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Datacenter:datacenter-3 Value:[] AvailableField:[]} Parent:Folder:group-d1 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:VSAN-DC DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Folder:group-h5 Value:[] AvailableField:[]} Parent:Datacenter:datacenter-3 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:host DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:ClusterComputeResource:domain-c8 Value:[] AvailableField:[]} Parent:Folder:group-h5 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:vSAN-FVT-Cluster DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:HostSystem:host-16 Value:[] AvailableField:[]} Parent:ClusterComputeResource:domain-c8 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:10.186.224.94 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]}]]
2021-06-11T01:01:56.821Z	DEBUG	vsphere/virtualmachine.go:263	Name: host-16, Type: HostSystem
2021-06-11T01:01:56.940Z	DEBUG	vsphere/virtualmachine.go:263	Name: domain-c8, Type: ClusterComputeResource
2021-06-11T01:01:56.962Z	DEBUG	vsphere/virtualmachine.go:270	Object [{{ClusterComputeResource:domain-c8 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:50472815-d90f-4dc8-afe5-e1277180bfa8:GLOBAL]]
2021-06-11T01:01:56.972Z	INFO	vsphere/virtualmachine.go:278	Found tag: zone-a for object {{ClusterComputeResource:domain-c8 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster [] [] [] [] <nil> []}
2021-06-11T01:01:57.004Z	DEBUG	vsphere/virtualmachine.go:284	Found category: k8s-zone for object {{ClusterComputeResource:domain-c8 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster [] [] [] [] <nil> []} with tag: zone-a
2021-06-11T01:01:57.004Z	DEBUG	vsphere/virtualmachine.go:263	Name: group-h5, Type: Folder
2021-06-11T01:01:57.021Z	DEBUG	vsphere/virtualmachine.go:263	Name: datacenter-3, Type: Datacenter
2021-06-11T01:01:57.043Z	DEBUG	vsphere/virtualmachine.go:270	Object [{{Datacenter:datacenter-3 [] []} Folder:group-d1 []   [] [] [] VSAN-DC [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:a078cc38-12b4-4ff2-86ca-f8f3b028b206:GLOBAL]]
2021-06-11T01:01:57.056Z	INFO	vsphere/virtualmachine.go:278	Found tag: region-1 for object {{Datacenter:datacenter-3 [] []} Folder:group-d1 []   [] [] [] VSAN-DC [] [] [] [] <nil> []}
2021-06-11T01:01:57.083Z	DEBUG	vsphere/virtualmachine.go:284	Found category: k8s-region for object {{Datacenter:datacenter-3 [] []} Folder:group-d1 []   [] [] [] VSAN-DC [] [] [] [] <nil> []} with tag: region-1
2021-06-11T01:01:57.083Z	INFO	csinodetopology/csinodetopology_controller.go:336	NodeVM "VirtualMachine:vm-49" belongs to zone: "zone-a" and region: "region-1"
2021-06-11T01:01:57.083Z	INFO	csinodetopology/csinodetopology_controller.go:341	Topology Labels 1: [{Key:topology.kubernetes.io/zone Value:zone-a} {Key:topology.kubernetes.io/region Value:region-1}]
2021-06-11T01:01:57.108Z	INFO	csinodetopology/csinodetopology_controller.go:247	Topology Labels 2: [{Key:topology.kubernetes.io/zone Value:zone-a} {Key:topology.kubernetes.io/region Value:region-1}]
2021-06-11T01:01:57.155Z	INFO	csinodetopology/csinodetopology_controller.go:273	Successfully updated topology labels for nodeVM with ID "k8s-node-0720"
```
Overview of nodes and csinodetopology instances in the k8s cluster:
```
root@k8s-master-968:~# k get nodes
NAME             STATUS   ROLES                  AGE   VERSION
k8s-master-968   Ready    control-plane,master   8d    v1.21.1
k8s-node-0249    Ready    <none>                 8d    v1.21.1
k8s-node-0429    Ready    <none>                 8d    v1.21.1
k8s-node-0720    Ready    <none>                 8d    v1.21.1
root@k8s-master-968:~# k get csinodetopology
NAME             AGE
k8s-master-968   25h
k8s-node-0249    28h
k8s-node-0429    28h
k8s-node-0720    25h
```
Describe output of CSINodeTopology instance:
```
Name:         k8s-node-0249
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2021-06-09T20:56:59Z
  Generation:          5
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
      f:spec:
        .:
        f:nodeID:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2021-06-09T20:56:59Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
        f:topologyLabels:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2021-06-11T01:01:55Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-0249
    UID:             4cddb802-e0b9-46f5-993c-b5586969892e
  Resource Version:  1899691
  UID:               85d573c7-39ec-49b8-ad18-2faca94c9e7c
Spec:
  Node ID:  k8s-node-0249
Status:
  Status:  Success
  Topology Labels:
    Key:    topology.kubernetes.io/zone
    Value:  zone-a
    Key:    topology.kubernetes.io/region
    Value:  region-1
Events:
  Type     Reason                    Age                    From            Message
  ----     ------                    ----                   ----            -------
  Normal   CSINodeTopologySucceeded  12m                    cns.vmware.com  Topology labels updated for nodeVM "k8s-node-0249"
```
Describe output of node after NodeGetInfo response is successful:
```
root@k8s-master-968:~# kdsc node k8s-node-0249
Name:               k8s-node-0249
Roles:              <none>
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu
                    beta.kubernetes.io/os=linux
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=k8s-node-0249
                    kubernetes.io/os=linux
                    topology.kubernetes.io/region=region-1
                    topology.kubernetes.io/zone=zone-a
Annotations:        csi.volume.kubernetes.io/nodeid: {"csi.vsphere.vmware.com":"k8s-node-0249"}
                    flannel.alpha.coreos.com/backend-data: {"VtepMAC":"1e:e6:4e:87:28:20"}
                    flannel.alpha.coreos.com/backend-type: vxlan
                    flannel.alpha.coreos.com/kube-subnet-manager: true
                    flannel.alpha.coreos.com/public-ip: 10.186.231.12
                    kubeadm.alpha.kubernetes.io/cri-socket: /var/run/dockershim.sock
                    node.alpha.kubernetes.io/ttl: 0
                    volumes.kubernetes.io/controller-managed-attach-detach: true
.....
```
NodeGetInfo logs:
```
2021-06-11T01:24:33.410Z	INFO	service/node.go:646	NodeGetInfo: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
2021-06-11T01:24:33.410Z	INFO	service/node.go:669	NodeGetInfo: MAX_VOLUMES_PER_NODE is set to 0	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
2021-06-11T01:24:33.410Z	INFO	kubernetes/kubernetes.go:86	k8s client using in-cluster config	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
2021-06-11T01:24:33.411Z	INFO	kubernetes/kubernetes.go:337	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
2021-06-11T01:24:33.489Z	INFO	kubernetes/kubernetes.go:86	k8s client using in-cluster config	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
2021-06-11T01:24:33.489Z	INFO	kubernetes/kubernetes.go:337	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
2021-06-11T01:24:33.597Z	INFO	service/node.go:728	NodeGetInfo response: node_id:"k8s-node-0249" accessible_topology:<segments:<key:"topology.kubernetes.io/region" value:"region-1" > segments:<key:"topology.kubernetes.io/zone" value:"zone-a" > > 	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
```

3. FSS enabled
csinodetopology controller code NOT included
Tested time out waiting for CSINodeTopology instance to get updated

NodeGetInfo logs - 
```
2021-06-09T22:53:35.072Z	INFO	service/node.go:646	NodeGetInfo: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "0692ced4-cbc0-4a04-b922-c8dfe093986a"}
2021-06-09T22:53:35.072Z	INFO	service/node.go:669	NodeGetInfo: MAX_VOLUMES_PER_NODE is set to 0	{"TraceId": "0692ced4-cbc0-4a04-b922-c8dfe093986a"}
2021-06-09T22:53:35.072Z	INFO	kubernetes/kubernetes.go:86	k8s client using in-cluster config	{"TraceId": "0692ced4-cbc0-4a04-b922-c8dfe093986a"}
2021-06-09T22:53:35.073Z	INFO	kubernetes/kubernetes.go:337	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "0692ced4-cbc0-4a04-b922-c8dfe093986a"}
2021-06-09T22:53:35.109Z	INFO	kubernetes/kubernetes.go:86	k8s client using in-cluster config	{"TraceId": "0692ced4-cbc0-4a04-b922-c8dfe093986a"}
2021-06-09T22:53:35.110Z	INFO	kubernetes/kubernetes.go:337	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "0692ced4-cbc0-4a04-b922-c8dfe093986a"}
2021-06-09T22:54:35.176Z	ERROR	logger/logger.go:113	timed out while waiting for topology labels in CSINodeTopology instance with name "k8s-node-0429" to be updated.	{"TraceId": "0692ced4-cbc0-4a04-b922-c8dfe093986a"}
sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.LogNewErrorCode
	/build/pkg/csi/service/logger/logger.go:113
sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.LogNewErrorCodef
	/build/pkg/csi/service/logger/logger.go:120
sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.fetchTopologyLabelsUsingCR
	/build/pkg/csi/service/node.go:822
sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.(*vsphereCSIDriver).NodeGetInfo
	/build/pkg/csi/service/node.go:692
github.com/container-storage-interface/spec/lib/go/csi._Node_NodeGetInfo_Handler.func1
	/go/pkg/mod/github.com/container-storage-interface/spec@v1.2.0/lib/go/csi/csi.pb.go:5684
github.com/rexray/gocsi/middleware/serialvolume.(*interceptor).handle
	/go/pkg/mod/github.com/rexray/gocsi@v1.2.2/middleware/serialvolume/serial_volume_locker.go:99
github.com/rexray/gocsi/utils.ChainUnaryServer.func2.1.1
	/go/pkg/mod/github.com/rexray/gocsi@v1.2.2/utils/utils_middleware.go:99
github.com/rexray/gocsi.(*StoragePlugin).injectContext
	/go/pkg/mod/github.com/rexray/gocsi@v1.2.2/middleware.go:231
github.com/rexray/gocsi/utils.ChainUnaryServer.func2.1.1
	/go/pkg/mod/github.com/rexray/gocsi@v1.2.2/utils/utils_middleware.go:99
github.com/rexray/gocsi/utils.ChainUnaryServer.func2
	/go/pkg/mod/github.com/rexray/gocsi@v1.2.2/utils/utils_middleware.go:106
github.com/container-storage-interface/spec/lib/go/csi._Node_NodeGetInfo_Handler
	/go/pkg/mod/github.com/container-storage-interface/spec@v1.2.0/lib/go/csi/csi.pb.go:5686
google.golang.org/grpc.(*Server).processUnaryRPC
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1024
google.golang.org/grpc.(*Server).handleStream
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1313
google.golang.org/grpc.(*Server).serveStreams.func1.1
	/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:722
2021-06-09T22:54:38.302Z	INFO	service/node.go:646	NodeGetInfo: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "210bff15-9b89-4dc9-81eb-f6a7ce89cecf"}
.....
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NodeGetInfo and RBAC changes for topology feature improvement
```
