### PR TITLE
Changes to pvcsi full sync to push cluster-distribution if it doesnt match

### DIFF
--- a/pkg/syncer/pvcsi_fullsync.go
+++ b/pkg/syncer/pvcsi_fullsync.go
@@ -199,8 +199,9 @@ func createCnsVolumeMetadataList(ctx context.Context, metadataSyncer *metadataSy
 // compareCnsVolumeMetadatas compares input cnsvolumemetadata objects
 // and returns false if their labels are not deeply equal
 func compareCnsVolumeMetadatas(guestObject *cnsvolumemetadatav1alpha1.CnsVolumeMetadataSpec, supervisorObject *cnsvolumemetadatav1alpha1.CnsVolumeMetadataSpec) bool {
-	if !reflect.DeepEqual(guestObject.Labels, supervisorObject.Labels) {
+	if !reflect.DeepEqual(guestObject.Labels, supervisorObject.Labels) || !reflect.DeepEqual(guestObject.ClusterDistribution, supervisorObject.ClusterDistribution) {
 		supervisorObject.Labels = guestObject.Labels
+		supervisorObject.ClusterDistribution = guestObject.ClusterDistribution
 		return false
 	}
 	return true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before this change, when a TKG was upgraded, the cluster-distribution value was not updated by pvCSI. The result is that volumes created before the upgrade only got the updated cluster-distribution value if there was a separate update on the volume. 

After this change, pvCSI updates the `CnsVolumeMetadata` object. Logs:
```
2021-06-09T22:50:54.502Z	INFO	syncer/pvcsi_fullsync.go:105	FullSync: Updating CnsVolumeMetadata 3a0fd975-256a-4289-b044-0c829e70c87f-ec3c2939-c525-4ad9-9f95-787471bf7dae on the supervisor cluster	{"TraceId": "b7d4ade6-c6fb-4b20-9e53-df4bbf1a2a87"}
2021-06-09T22:50:54.655Z	INFO	syncer/pvcsi_fullsync.go:105	FullSync: Updating CnsVolumeMetadata 3a0fd975-256a-4289-b044-0c829e70c87f-22ddfafb-416d-4114-b388-e25b4489465a on the supervisor cluster	{"TraceId": "b7d4ade6-c6fb-4b20-9e53-df4bbf1a2a87"}
2021-06-09T22:50:54.841Z	INFO	syncer/pvcsi_fullsync.go:105	FullSync: Updating CnsVolumeMetadata 3a0fd975-256a-4289-b044-0c829e70c87f-f1a695aa-9474-43a1-8459-b19b9ab991f5 on the supervisor cluster	{"TraceId": "b7d4ade6-c6fb-4b20-9e53-df4bbf1a2a87"}
2021-06-09T22:50:54.932Z	INFO	syncer/pvcsi_fullsync.go:105	FullSync: Updating CnsVolumeMetadata 3a0fd975-256a-4289-b044-0c829e70c87f-5eb8d09a-3442-4e38-bc9a-81cc939d8c2d on the supervisor cluster	{"TraceId": "b7d4ade6-c6fb-4b20-9e53-df4bbf1a2a87"}
```

And Logs in CnsVolumeMetadata controller showing updates to CNS:
```
{"level":"info","time":"2021-06-10T00:01:53.940744422Z","caller":"cnsvolumemetadata/cnsvolumemetadata_controller.go:476","msg":"ReconcileCnsVolumeMetadata: Successfully updated entry in CNS for instance with name \"upgrade-block-pvc-5\" and entity type \"PERSISTENT_VOLUME_CLAIM\" in the guest cluster."}

```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Changes to pvcsi full sync to push cluster-distribution if it doesnt match
```
