### PR TITLE
Fix VC Config init in Syncer

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -178,8 +178,8 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 							log.Infof("Successfully re-established connection with VC from: %q", cnsconfig.SupervisorCAFilePath)
 							break
 						}
-						log.Errorf("failed to re-establish VC connection. Will retry again in 5 seconds. err: %+v", reconnectVCErr)
-						time.Sleep(5 * time.Second)
+						log.Errorf("failed to re-establish VC connection. Will retry again in 60 seconds. err: %+v", reconnectVCErr)
+						time.Sleep(60 * time.Second)
 					}
 				}
 			case err, ok := <-watcher.Errors:

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -228,8 +228,8 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 							log.Infof("Successfully re-established connection with VC from: %q", cnsconfig.SupervisorCAFilePath)
 							break
 						}
-						log.Errorf("failed to re-establish VC connection. Will retry again in 5 seconds. err: %+v", reconnectVCErr)
-						time.Sleep(5 * time.Second)
+						log.Errorf("failed to re-establish VC connection. Will retry again in 60 seconds. err: %+v", reconnectVCErr)
+						time.Sleep(60 * time.Second)
 					}
 				}
 			case err, ok := <-watcher.Errors:
@@ -489,10 +489,9 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 		}
 		if newVCConfig != nil {
 			var vcenter *cnsvsphere.VirtualCenter
-			if metadataSyncer.configInfo.Cfg.Global.VCenterIP != newVCConfig.Host ||
-				metadataSyncer.configInfo.Cfg.Global.User != newVCConfig.Username ||
-				metadataSyncer.configInfo.Cfg.Global.Password != newVCConfig.Password || reconnectToVCFromNewConfig {
-
+			if metadataSyncer.host != newVCConfig.Host ||
+				metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User != newVCConfig.Username ||
+				metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].Password != newVCConfig.Password || reconnectToVCFromNewConfig {
 				// Verify if new configuration has valid credentials by connecting to vCenter.
 				// Proceed only if the connection succeeds, else return error.
 				newVC := &cnsvsphere.VirtualCenter{Config: newVCConfig}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

While debugging the incorrect login attempts from CSI syncer, I observed that syncer VC config was actually never initialized correctly, as a result of which ReloadConfig() gets invoked even when password is not changed. i.e., the below logic was getting executed successfully
```
metadataSyncer.configInfo.Cfg.Global.User != newVCConfig.Username ||
				metadataSyncer.configInfo.Cfg.Global.Password != newVCConfig.Password
```
When I printed the `metadataSyncer.configInfo.Cfg.Global.User` & `metadataSyncer.configInfo.Cfg.Global.Password` was actually empty. See here:

```
2021-06-11T19:57:50.149Z	INFO	syncer/metadatasyncer.go:502	Existing username: "", password: ""	{"TraceId": "aefdc21e-5135-498f-a0a3-c84ef49d5c92"}
```
I have fixed the InitMetadataSyncer to address the issue

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before this change:
```
./vpxd/vpxd-7.log:2021-06-10T06:36:17.811Z error vpxd[16023] [Originator@6876 sub=User opID=42224782] Failed to authenticate user <workload_storage_management-69c4b155-03ae-42b1-8611-86d53da85c2c@vsphere.local>
./vpxd/vpxd-7.log:2021-06-10T06:36:27.880Z error vpxd[15997] [Originator@6876 sub=User opID=754dd10d] Failed to authenticate user <workload_storage_management-69c4b155-03ae-42b1-8611-86d53da85c2c@vsphere.local>
./vpxd/vpxd-7.log:2021-06-10T06:36:35.938Z error vpxd[16110] [Originator@6876 sub=User opID=5e035829] Failed to authenticate user <workload_storage_management-69c4b155-03ae-42b1-8611-86d53da85c2c@vsphere.local>
./vpxd/vpxd-7.log:2021-06-10T06:36:45.024Z error vpxd[16009] [Originator@6876 sub=User opID=1750be1a] Failed to authenticate user <workload_storage_management-69c4b155-03ae-42b1-8611-86d53da85c2c@vsphere.local>
./vpxd/vpxd-7.log:2021-06-10T06:36:54.117Z error vpxd[16056] [Originator@6876 sub=User opID=6fbb2cfb] Failed to authenticate user <workload_storage_management-69c4b155-03ae-42b1-8611-86d53da85c2c@vsphere.local>
```

Account remains locked for next 5 minutes:
```
./vpxd/vpxd-7.log:2021-06-10T06:36:54.113Z error vpxd[16056] [Originator@6876 sub=UserDirectorySso opID=6fbb2cfb] AcquireToken exception: N9SsoClient27InvalidCredentialsExceptionE(Authentication failed: The account of the user trying to authenticate is locked. :: The account of the user trying to authenticate is locked. :: User account locked: {Name: workload_storage_management-69c4b155-03ae-42b1-8611-86d53da85c2c, Domain: vsphere.local})
./vpxd/vpxd-7.log:2021-06-10T06:37:03.168Z error vpxd[15999] [Originator@6876 sub=UserDirectorySso opID=1498796f] AcquireToken exception: N9SsoClient27InvalidCredentialsExceptionE(Authentication failed: The account of the user trying to authenticate is locked. :: The account of the user trying to authenticate is locked. :: User account locked: {Name: workload_storage_management-69c4b155-03ae-42b1-8611-86d53da85c2c, Domain: vsphere.local})
...
...
./vpxd/vpxd-7.log:2021-06-10T06:41:56.431Z error vpxd[16029] [Originator@6876 sub=UserDirectorySso opID=410f9ed4] AcquireToken exception: N9SsoClient27InvalidCredentialsExceptionE(Authentication failed: The account of the user trying to authenticate is locked. :: The account of the user trying to authenticate is locked. :: User account locked: {Name: workload_storage_management-69c4b155-03ae-42b1-8611-86d53da85c2c, Domain: vsphere.local})
```


After this change:
```
workload_storage_management-69c4b155-03ae-42b1-8611-86d53da85c2c user account locking was not observed
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix VC Config init in Syncer
```
