### PR TITLE
Introduce controller for CSINodeTopology CR

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -65,6 +65,9 @@ rules:
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update", "patch" ]
+  - apiGroups: [ "cns.vmware.com" ]
+    resources: [ "csinodetopologies" ]
+    verbs: ["get", "update", "watch", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vanilla
+package node
 
 import (
 	"context"
@@ -24,7 +24,6 @@ import (
 	"github.com/vmware/govmomi/vapi/tags"
 	v1 "k8s.io/api/core/v1"
 
-	cnsnode "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/node"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
@@ -32,13 +31,13 @@ import (
 
 // Nodes comprises cns node manager and kubernetes informer.
 type Nodes struct {
-	cnsNodeManager cnsnode.Manager
+	cnsNodeManager Manager
 	informMgr      *k8s.InformerManager
 }
 
 // Initialize helps initialize node manager and node informer manager.
 func (nodes *Nodes) Initialize(ctx context.Context) error {
-	nodes.cnsNodeManager = cnsnode.GetManager(ctx)
+	nodes.cnsNodeManager = GetManager(ctx)
 	k8sclient, err := k8s.NewClient(ctx)
 	if err != nil {
 		log := logger.GetLogger(ctx)

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"sigs.k8s.io/vsphere-csi-driver/pkg/apis/migration"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/node"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
@@ -147,7 +148,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		log.Errorf("checkAPI failed for vcenter API version: %s, err=%v", vc.Client.ServiceContent.About.ApiVersion, err)
 		return err
 	}
-	c.nodeMgr = &Nodes{}
+	c.nodeMgr = &node.Nodes{}
 	err = c.nodeMgr.Initialize(ctx)
 	if err != nil {
 		log.Errorf("failed to initialize nodeMgr. err=%v", err)
@@ -310,7 +311,7 @@ func (c *controller) ReloadConfiguration() error {
 		c.manager.VcenterConfig = newVCConfig
 		c.manager.VolumeManager = cnsvolume.GetManager(ctx, vcenter, operationStore, idempotencyHandlingEnabled)
 		// Re-Initialize Node Manager to cache latest vCenter config.
-		c.nodeMgr = &Nodes{}
+		c.nodeMgr = &node.Nodes{}
 		err = c.nodeMgr.Initialize(ctx)
 		if err != nil {
 			log.Errorf("failed to re-initialize nodeMgr. err=%v", err)

--- a/pkg/syncer/cnsoperator/controller/add_csinodetopology.go
+++ b/pkg/syncer/cnsoperator/controller/add_csinodetopology.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/cnsoperator/controller/csinodetopology"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, csinodetopology.Add)
+}

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -1,0 +1,335 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csinodetopology
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/node"
+	volumes "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+	csinodetopologyv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/csinodetopology/v1alpha1"
+	k8s "sigs.k8s.io/vsphere-csi-driver/pkg/kubernetes"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/syncer"
+)
+
+const defaultMaxWorkerThreadsForCSINodeTopology = 1
+
+// backOffDuration is a map of csinodetopology instance name to the time after which a request
+// for this instance will be requeued.
+// Initialized to 1 second for new instances and for instances whose latest reconcile
+// operation succeeded.
+// If the reconcile fails, backoff is incremented exponentially.
+var (
+	backOffDuration         map[string]time.Duration
+	backOffDurationMapMutex = sync.Mutex{}
+)
+
+// Add creates a new CSINodeTopology Controller and adds it to the Manager, ConfigurationInfo
+// and VirtualCenterTypes. The Manager will set fields on the Controller
+// and start it when the Manager is started.
+func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
+	configInfo *cnsconfig.ConfigurationInfo, volumeManager volumes.Manager) error {
+	ctx, log := logger.GetNewContextWithLogger()
+	if clusterFlavor != cnstypes.CnsClusterFlavorVanilla {
+		log.Debug("Not initializing the CSINodetopology Controller as it is not a Vanilla CSI deployment")
+		return nil
+	}
+
+	coCommonInterface, err := commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor, &syncer.COInitParams)
+	if err != nil {
+		log.Errorf("failed to create CO agnostic interface. Err: %v", err)
+		return err
+	}
+	if !coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeTopology) {
+		log.Infof("Not initializing the CSINodetopology Controller as %s FSS is disabled", common.ImprovedVolumeTopology)
+		return nil
+	}
+
+	// Initialize kubernetes client.
+	k8sclient, err := k8s.NewClient(ctx)
+	if err != nil {
+		log.Errorf("creating Kubernetes client failed. Err: %v", err)
+		return err
+	}
+	// eventBroadcaster broadcasts events on csinodetopology instances to the event sink.
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(
+		&typedcorev1.EventSinkImpl{
+			Interface: k8sclient.CoreV1().Events(""),
+		},
+	)
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: csinodetopologyv1alpha1.GroupName})
+	return add(mgr, newReconciler(mgr, configInfo, recorder))
+}
+
+// newReconciler returns a new `reconcile.Reconciler`.
+func newReconciler(mgr manager.Manager, configInfo *cnsconfig.ConfigurationInfo,
+	recorder record.EventRecorder) reconcile.Reconciler {
+	return &ReconcileCSINodeTopology{client: mgr.GetClient(), scheme: mgr.GetScheme(),
+		configInfo: configInfo, recorder: recorder}
+}
+
+// add adds a new Controller to mgr with r as the `reconcile.Reconciler`.
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	log := logger.GetLoggerWithNoContext()
+
+	// Create a new controller.
+	c, err := controller.New("csinodetopology-controller", mgr, controller.Options{Reconciler: r,
+		MaxConcurrentReconciles: defaultMaxWorkerThreadsForCSINodeTopology})
+	if err != nil {
+		log.Errorf("failed to create new CSINodetopology controller with error: %+v", err)
+		return err
+	}
+
+	// Initialize backoff duration map.
+	backOffDuration = make(map[string]time.Duration)
+
+	// Predicates are used to determine under which conditions
+	// the reconcile callback will be made for an instance.
+	pred := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			// The CO calls NodeGetInfo API just once during the node registration,
+			// therefore we do not support updates to the spec after the CR has been reconciled.
+			log.Debug("Ignoring CSINodeTopology reconciliation on update event")
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// Instances are deleted by the garbage collector automatically after the corresponding NodeVM is deleted.
+			// No reconcile operations are required.
+			log.Debug("Ignoring CSINodeTopology reconciliation on delete event")
+			return false
+		},
+	}
+
+	// Watch for changes to primary resource CSINodeTopology.
+	err = c.Watch(&source.Kind{Type: &csinodetopologyv1alpha1.CSINodeTopology{}}, &handler.EnqueueRequestForObject{}, pred)
+	if err != nil {
+		log.Errorf("Failed to watch for changes to CSINodeTopology resource with error: %+v", err)
+		return err
+	}
+	log.Info("Started watching on CSINodeTopology resources")
+	return nil
+}
+
+// blank assignment to verify that ReconcileCSINodeTopology implements `reconcile.Reconciler`.
+var _ reconcile.Reconciler = &ReconcileCSINodeTopology{}
+
+// ReconcileCSINodeTopology reconciles a CSINodeTopology object.
+type ReconcileCSINodeTopology struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver.
+	client     client.Client
+	scheme     *runtime.Scheme
+	configInfo *cnsconfig.ConfigurationInfo
+	recorder   record.EventRecorder
+}
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// Note: The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileCSINodeTopology) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := logger.GetLogger(ctx)
+
+	// Fetch the CSINodeTopology instance.
+	instance := &csinodetopologyv1alpha1.CSINodeTopology{}
+	err := r.client.Get(ctx, request.NamespacedName, instance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Infof("CSINodeTopology resource with name %q not found. Ignoring since object must have been deleted.", request.Name)
+			return reconcile.Result{}, nil
+		}
+		log.Errorf("Failed to fetch the CSINodeTopology instance with name: %q. Error: %+v", request.Name, err)
+		// Error reading the object - return with err.
+		return reconcile.Result{}, err
+	}
+
+	// Get NodeVM instance.
+	nodeID := instance.Spec.NodeID
+	nodeManager := node.GetManager(ctx)
+	// NOTE: NodeID is set to NodeName for now. Will be changed to NodeUUID in future.
+	nodeVM, err := nodeManager.GetNodeByName(ctx, nodeID)
+	if err != nil {
+		// If nodeVM not found, ignore reconcile call.
+		log.Warnf("Ignoring update to CSINodeTopology CR with name %s as corresponding NodeVM seems to be deleted. "+
+			"Error: %v", nodeID, err)
+		return reconcile.Result{}, nil
+	}
+
+	// Initialize backOffDuration for the instance, if required.
+	backOffDurationMapMutex.Lock()
+	var timeout time.Duration
+	if _, exists := backOffDuration[instance.Name]; !exists {
+		backOffDuration[instance.Name] = time.Second
+	}
+	timeout = backOffDuration[instance.Name]
+	backOffDurationMapMutex.Unlock()
+
+	// TODO: Make this check generic by checking for the length of topologyCategories in future
+	// Retrieve topology labels for nodeVM.
+	if r.configInfo.Cfg.Labels.Zone == "" && r.configInfo.Cfg.Labels.Region == "" {
+		// Not a topology aware setup. No need to check for labels on nodeVM.
+		// Set the Status to Success and return.
+		instance.Status.TopologyLabels = make([]csinodetopologyv1alpha1.TopologyLabel, 0)
+		err = updateCRStatus(ctx, r, instance, csinodetopologyv1alpha1.CSINodeTopologySuccess,
+			"Not a topology aware cluster.")
+		if err != nil {
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+	} else if r.configInfo.Cfg.Labels.Zone != "" && r.configInfo.Cfg.Labels.Region != "" {
+		log.Infof("Detected a topology aware cluster")
+
+		// Fetch topology labels for nodeVM.
+		topologyLabels, err := getNodeTopologyInfo(ctx, nodeVM, r.configInfo.Cfg)
+		if err != nil {
+			msg := fmt.Sprintf("failed to fetch topology information for the nodeVM with ID %q", nodeID)
+			log.Errorf("%s. Error: %v", msg, err)
+			_ = updateCRStatus(ctx, r, instance, csinodetopologyv1alpha1.CSINodeTopologyError, msg)
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+
+		// Raise error if nodeVM does not have a topology label associated with each category in the
+		// vSphere config secret `Labels` section. For now, as we support only zone, region, hardcoded the value to 2.
+		// TODO: Count the number of topology categories given and verify against that number.
+		if len(topologyLabels) != 2 {
+			msg := fmt.Sprintf("Detected a topology aware cluster. However, nodeVM with ID %q does not have a "+
+				"topology label for each category mentioned under the vSphere CSI config secret `Labels` section.", nodeID)
+			log.Error(msg)
+			_ = updateCRStatus(ctx, r, instance, csinodetopologyv1alpha1.CSINodeTopologyError, msg)
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+
+		// Update CSINodeTopology instance.
+		instance.Status.TopologyLabels = topologyLabels
+		err = updateCRStatus(ctx, r, instance, csinodetopologyv1alpha1.CSINodeTopologySuccess,
+			fmt.Sprintf("Topology labels successfully updated for nodeVM %q", nodeID))
+		if err != nil {
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+	} else {
+		msg := "missing zone or region information in vSphere CSI config `Labels` section"
+		log.Error(msg)
+		_ = updateCRStatus(ctx, r, instance, csinodetopologyv1alpha1.CSINodeTopologyError, msg)
+		return reconcile.Result{}, errors.New(msg)
+	}
+
+	// On successful event, remove instance from backOffDuration.
+	backOffDurationMapMutex.Lock()
+	delete(backOffDuration, instance.Name)
+	backOffDurationMapMutex.Unlock()
+	log.Infof("Successfully updated topology labels for nodeVM with ID %q", nodeID)
+	return reconcile.Result{}, nil
+}
+
+func updateCRStatus(ctx context.Context, r *ReconcileCSINodeTopology, instance *csinodetopologyv1alpha1.CSINodeTopology,
+	status csinodetopologyv1alpha1.CRDStatus, eventMessage string) error {
+	log := logger.GetLogger(ctx)
+
+	instance.Status.Status = status
+	switch status {
+	case csinodetopologyv1alpha1.CSINodeTopologySuccess:
+		// Reset error message if previously populated.
+		instance.Status.ErrorMessage = ""
+		// Record an event on the CR.
+		r.recorder.Event(instance, corev1.EventTypeNormal, "CSINodeTopologySucceeded", eventMessage)
+	case csinodetopologyv1alpha1.CSINodeTopologyError:
+		// Increase backoff duration for the instance.
+		backOffDurationMapMutex.Lock()
+		backOffDuration[instance.Name] = backOffDuration[instance.Name] * 2
+		backOffDurationMapMutex.Unlock()
+
+		// Record an event on the CR.
+		instance.Status.ErrorMessage = eventMessage
+		r.recorder.Event(instance, corev1.EventTypeWarning, "CSINodeTopologyFailed", eventMessage)
+	}
+
+	// Update CSINodeTopology instance.
+	err := r.client.Update(ctx, instance)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to update the CSINodeTopology instance with name %q.", instance.Spec.NodeID)
+		log.Errorf("%s. Error: %+v", msg, err)
+		r.recorder.Event(instance, corev1.EventTypeWarning, "CSINodeTopologyFailed", msg)
+		return err
+	}
+	return nil
+}
+
+func getNodeTopologyInfo(ctx context.Context, nodeVM *cnsvsphere.VirtualMachine, cfg *cnsconfig.Config) (
+	[]csinodetopologyv1alpha1.TopologyLabel, error) {
+	log := logger.GetLogger(ctx)
+
+	// Get VC instance.
+	vcenter, err := cnsvsphere.GetVirtualCenterInstance(ctx, &cnsconfig.ConfigurationInfo{Cfg: cfg}, false)
+	if err != nil {
+		log.Errorf("failed to get virtual center instance with error: %v", err)
+		return nil, err
+	}
+
+	// Get tag manager instance.
+	tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
+	if err != nil {
+		log.Errorf("failed to create tagManager. Error: %v", err)
+		return nil, err
+	}
+	defer func() {
+		err := tagManager.Logout(ctx)
+		if err != nil {
+			log.Errorf("failed to logout tagManager. Error: %v", err)
+		}
+	}()
+
+	// Get zone, region info for NodeVM.
+	zone, region, err := nodeVM.GetZoneRegion(ctx, cfg.Labels.Zone, cfg.Labels.Region, tagManager)
+	if err != nil {
+		log.Errorf("failed to get accessibleTopology for nodeVM: %v, Error: %v", nodeVM.Reference(), err)
+		return nil, err
+	}
+	log.Infof("NodeVM %q belongs to zone: %q and region: %q", nodeVM.Reference(), zone, region)
+	topologyLabels := []csinodetopologyv1alpha1.TopologyLabel{
+		{Key: corev1.LabelTopologyZone, Value: zone},
+		{Key: corev1.LabelTopologyRegion, Value: region},
+	}
+	return topologyLabels, nil
+}

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -35,13 +35,13 @@ import (
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator"
 	cnsnodevmattachmentv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/node"
 	volumes "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
 	commonconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
-	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis"
 	triggercsifullsyncv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/csinodetopology"
@@ -170,7 +170,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			}
 			// Initialize node manager so that CSINodeTopology controller
 			// can retrieve NodeVM using the NodeID in the spec
-			nodeMgr := &vanilla.Nodes{}
+			nodeMgr := &node.Nodes{}
 			err = nodeMgr.Initialize(ctx)
 			if err != nil {
 				log.Errorf("failed to initialize nodeManager. Error: %+v", err)

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/vanilla"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis"
 	triggercsifullsyncv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/internalapis/csinodetopology"
@@ -167,6 +168,14 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 				log.Errorf("Failed to create %q CRD. Error: %+v", csinodetopology.CRDSingular, err)
 				return err
 			}
+			// Initialize node manager so that CSINodeTopology controller
+			// can retrieve NodeVM using the NodeID in the spec
+			nodeMgr := &vanilla.Nodes{}
+			err = nodeMgr.Initialize(ctx)
+			if err != nil {
+				log.Errorf("failed to initialize nodeManager. Error: %+v", err)
+				return err
+			}
 		}
 	}
 
@@ -186,6 +195,10 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 	// Setup Scheme for all resources for external APIs
 	if err := cnsoperatorv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Errorf("failed to set the scheme for Cns operator. Err: %+v", err)
+		return err
+	}
+	if err = csinodetopologyv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Errorf("failed to add CSINodeTopology to scheme with error: %+v", err)
 		return err
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR contains the controller changes required to reconcile CSINodeTopology instances. These code changes are a continuation to the work listed in the following PRs:
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/947
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/964

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Vanilla E2E testing -
```
Ran 42 of 190 Specs in 10193.450 seconds
SUCCESS! -- 42 Passed | 0 Failed | 0 Pending | 148 Skipped
PASS
```

Manual testing:
1. FSS enabled
Not a topology setup
Testing along with changes in PR #964 

Syncer logs -
```
kubernetes/kubernetes.go:415	"csinodetopologies.cns.vmware.com" CRD updated successfully
2021-06-10T06:26:57.334Z	INFO	node/manager.go:75	Initializing node.defaultManager...
2021-06-10T06:26:57.334Z	INFO	node/manager.go:79	node.defaultManager initialized
......
2021-06-10T06:26:58.045Z	INFO	manager/init.go:209	Starting Cns Operator
2021-06-10T06:26:58.147Z	DEBUG	node/manager.go:180	Renewing virtual machine VirtualMachine:vm-48 [VirtualCenterHost: 10.186.224.205, UUID: 423471b9-4274-1ae1-0458-8ef9ef977aed, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.224.205]] with nodeUUID "423471b9-4274-1ae1-0458-8ef9ef977aed"
2021-06-10T06:26:58.152Z	DEBUG	node/manager.go:187	VM VirtualMachine:vm-48 [VirtualCenterHost: 10.186.224.205, UUID: 423471b9-4274-1ae1-0458-8ef9ef977aed, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] was successfully renewed with nodeUUID "423471b9-4274-1ae1-0458-8ef9ef977aed"
2021-06-10T06:26:58.152Z	DEBUG	config/config.go:361	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
2021-06-10T06:26:58.152Z	DEBUG	config/config.go:268	Initializing vc server 10.186.224.205
2021-06-10T06:26:58.152Z	INFO	config/config.go:307	No Net Permissions given in Config. Using default permissions.
2021-06-10T06:26:58.166Z	INFO	csinodetopology/csinodetopology_controller.go:272	Successfully updated topology labels for nodeVM with ID "k8s-node-0429"
2021-06-10T06:26:58.166Z	DEBUG	node/manager.go:180	Renewing virtual machine VirtualMachine:vm-49 [VirtualCenterHost: 10.186.224.205, UUID: 4234170e-2b3a-aa41-0bea-3ee6f00fa486, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.224.205]] with nodeUUID "4234170e-2b3a-aa41-0bea-3ee6f00fa486"
2021-06-10T06:26:58.169Z	DEBUG	node/manager.go:187	VM VirtualMachine:vm-49 [VirtualCenterHost: 10.186.224.205, UUID: 4234170e-2b3a-aa41-0bea-3ee6f00fa486, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] was successfully renewed with nodeUUID "4234170e-2b3a-aa41-0bea-3ee6f00fa486"
2021-06-10T06:26:58.169Z	DEBUG	config/config.go:361	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
2021-06-10T06:26:58.170Z	DEBUG	config/config.go:268	Initializing vc server 10.186.224.205
2021-06-10T06:26:58.170Z	INFO	config/config.go:307	No Net Permissions given in Config. Using default permissions.
2021-06-10T06:26:58.192Z	INFO	csinodetopology/csinodetopology_controller.go:272	Successfully updated topology labels for nodeVM with ID "k8s-node-0720"
2021-06-10T06:26:58.193Z	DEBUG	node/manager.go:180	Renewing virtual machine VirtualMachine:vm-47 [VirtualCenterHost: 10.186.224.205, UUID: 42344143-2b6e-cbad-ad21-ddcf96e79190, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.224.205]] with nodeUUID "42344143-2b6e-cbad-ad21-ddcf96e79190"
2021-06-10T06:26:58.200Z	DEBUG	node/manager.go:187	VM VirtualMachine:vm-47 [VirtualCenterHost: 10.186.224.205, UUID: 42344143-2b6e-cbad-ad21-ddcf96e79190, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] was successfully renewed with nodeUUID "42344143-2b6e-cbad-ad21-ddcf96e79190"
2021-06-10T06:26:58.201Z	DEBUG	config/config.go:361	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
2021-06-10T06:26:58.201Z	DEBUG	config/config.go:268	Initializing vc server 10.186.224.205
2021-06-10T06:26:58.201Z	INFO	config/config.go:307	No Net Permissions given in Config. Using default permissions.
2021-06-10T06:26:58.223Z	INFO	csinodetopology/csinodetopology_controller.go:272	Successfully updated topology labels for nodeVM with ID "k8s-master-968"
2021-06-10T06:26:58.224Z	DEBUG	node/manager.go:180	Renewing virtual machine VirtualMachine:vm-50 [VirtualCenterHost: 10.186.224.205, UUID: 4234b569-05f7-a0d3-cf9a-6e41614efe98, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.224.205]] with nodeUUID "4234b569-05f7-a0d3-cf9a-6e41614efe98"
2021-06-10T06:26:58.229Z	DEBUG	node/manager.go:187	VM VirtualMachine:vm-50 [VirtualCenterHost: 10.186.224.205, UUID: 4234b569-05f7-a0d3-cf9a-6e41614efe98, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] was successfully renewed with nodeUUID "4234b569-05f7-a0d3-cf9a-6e41614efe98"
2021-06-10T06:26:58.229Z	DEBUG	config/config.go:361	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
2021-06-10T06:26:58.230Z	DEBUG	config/config.go:268	Initializing vc server 10.186.224.205
2021-06-10T06:26:58.230Z	INFO	config/config.go:307	No Net Permissions given in Config. Using default permissions.
2021-06-10T06:26:58.239Z	INFO	csinodetopology/csinodetopology_controller.go:272	Successfully updated topology labels for nodeVM with ID "k8s-node-0249"
```

2. FSS enabled
Topology aware environment
Testing along with changes in PR #964 

Syncer logs - 
```
2021-06-11T01:01:56.621Z	DEBUG	node/manager.go:180	Renewing virtual machine VirtualMachine:vm-49 [VirtualCenterHost: 10.186.224.205, UUID: 4234170e-2b3a-aa41-0bea-3ee6f00fa486, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.224.205]] with nodeUUID "4234170e-2b3a-aa41-0bea-3ee6f00fa486"
2021-06-11T01:01:56.629Z	DEBUG	node/manager.go:187	VM VirtualMachine:vm-49 [VirtualCenterHost: 10.186.224.205, UUID: 4234170e-2b3a-aa41-0bea-3ee6f00fa486, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] was successfully renewed with nodeUUID "4234170e-2b3a-aa41-0bea-3ee6f00fa486"
2021-06-11T01:01:56.629Z	DEBUG	config/config.go:361	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf
2021-06-11T01:01:56.630Z	DEBUG	config/config.go:268	Initializing vc server 10.186.224.205
2021-06-11T01:01:56.630Z	INFO	config/config.go:307	No Net Permissions given in Config. Using default permissions.
2021-06-11T01:01:56.630Z	INFO	csinodetopology/csinodetopology_controller.go:233	Detected a topology aware cluster
2021-06-11T01:01:56.790Z	DEBUG	vsphere/virtualmachine.go:253	GetZoneRegion: called with zoneCategoryName: k8s-zone, regionCategoryName: k8s-region
2021-06-11T01:01:56.815Z	DEBUG	vsphere/virtualmachine.go:214	Host owning node vm: VirtualMachine:vm-49 [VirtualCenterHost: 10.186.224.205, UUID: 4234170e-2b3a-aa41-0bea-3ee6f00fa486, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] is 10.186.224.94
2021-06-11T01:01:56.821Z	DEBUG	vsphere/virtualmachine.go:246	Ancestors of node vm: VirtualMachine:vm-49 [VirtualCenterHost: 10.186.224.205, UUID: 4234170e-2b3a-aa41-0bea-3ee6f00fa486, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.224.205]] are : [[{ExtensibleManagedObject:{Self:Folder:group-d1 Value:[] AvailableField:[]} Parent:<nil> CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:Datacenters DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Datacenter:datacenter-3 Value:[] AvailableField:[]} Parent:Folder:group-d1 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:VSAN-DC DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Folder:group-h5 Value:[] AvailableField:[]} Parent:Datacenter:datacenter-3 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:host DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:ClusterComputeResource:domain-c8 Value:[] AvailableField:[]} Parent:Folder:group-h5 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:vSAN-FVT-Cluster DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:HostSystem:host-16 Value:[] AvailableField:[]} Parent:ClusterComputeResource:domain-c8 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:10.186.224.94 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]}]]
2021-06-11T01:01:56.821Z	DEBUG	vsphere/virtualmachine.go:263	Name: host-16, Type: HostSystem
2021-06-11T01:01:56.940Z	DEBUG	vsphere/virtualmachine.go:263	Name: domain-c8, Type: ClusterComputeResource
2021-06-11T01:01:56.962Z	DEBUG	vsphere/virtualmachine.go:270	Object [{{ClusterComputeResource:domain-c8 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:50472815-d90f-4dc8-afe5-e1277180bfa8:GLOBAL]]
2021-06-11T01:01:56.972Z	INFO	vsphere/virtualmachine.go:278	Found tag: zone-a for object {{ClusterComputeResource:domain-c8 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster [] [] [] [] <nil> []}
2021-06-11T01:01:57.004Z	DEBUG	vsphere/virtualmachine.go:284	Found category: k8s-zone for object {{ClusterComputeResource:domain-c8 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster [] [] [] [] <nil> []} with tag: zone-a
2021-06-11T01:01:57.004Z	DEBUG	vsphere/virtualmachine.go:263	Name: group-h5, Type: Folder
2021-06-11T01:01:57.021Z	DEBUG	vsphere/virtualmachine.go:263	Name: datacenter-3, Type: Datacenter
2021-06-11T01:01:57.043Z	DEBUG	vsphere/virtualmachine.go:270	Object [{{Datacenter:datacenter-3 [] []} Folder:group-d1 []   [] [] [] VSAN-DC [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:a078cc38-12b4-4ff2-86ca-f8f3b028b206:GLOBAL]]
2021-06-11T01:01:57.056Z	INFO	vsphere/virtualmachine.go:278	Found tag: region-1 for object {{Datacenter:datacenter-3 [] []} Folder:group-d1 []   [] [] [] VSAN-DC [] [] [] [] <nil> []}
2021-06-11T01:01:57.083Z	DEBUG	vsphere/virtualmachine.go:284	Found category: k8s-region for object {{Datacenter:datacenter-3 [] []} Folder:group-d1 []   [] [] [] VSAN-DC [] [] [] [] <nil> []} with tag: region-1
2021-06-11T01:01:57.083Z	INFO	csinodetopology/csinodetopology_controller.go:336	NodeVM "VirtualMachine:vm-49" belongs to zone: "zone-a" and region: "region-1"
2021-06-11T01:01:57.083Z	INFO	csinodetopology/csinodetopology_controller.go:341	Topology Labels 1: [{Key:topology.kubernetes.io/zone Value:zone-a} {Key:topology.kubernetes.io/region Value:region-1}]
2021-06-11T01:01:57.108Z	INFO	csinodetopology/csinodetopology_controller.go:247	Topology Labels 2: [{Key:topology.kubernetes.io/zone Value:zone-a} {Key:topology.kubernetes.io/region Value:region-1}]
2021-06-11T01:01:57.155Z	INFO	csinodetopology/csinodetopology_controller.go:273	Successfully updated topology labels for nodeVM with ID "k8s-node-0720"
```
Overview of nodes and csinodetopology instances in the k8s cluster:
```
root@k8s-master-968:~# k get nodes
NAME             STATUS   ROLES                  AGE   VERSION
k8s-master-968   Ready    control-plane,master   8d    v1.21.1
k8s-node-0249    Ready    <none>                 8d    v1.21.1
k8s-node-0429    Ready    <none>                 8d    v1.21.1
k8s-node-0720    Ready    <none>                 8d    v1.21.1
root@k8s-master-968:~# k get csinodetopology
NAME             AGE
k8s-master-968   25h
k8s-node-0249    28h
k8s-node-0429    28h
k8s-node-0720    25h
```
Describe output of CSINodeTopology instance:
```
Name:         k8s-node-0249
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2021-06-09T20:56:59Z
  Generation:          5
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
      f:spec:
        .:
        f:nodeID:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2021-06-09T20:56:59Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
        f:topologyLabels:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2021-06-11T01:01:55Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-0249
    UID:             4cddb802-e0b9-46f5-993c-b5586969892e
  Resource Version:  1899691
  UID:               85d573c7-39ec-49b8-ad18-2faca94c9e7c
Spec:
  Node ID:  k8s-node-0249
Status:
  Status:  Success
  Topology Labels:
    Key:    topology.kubernetes.io/zone
    Value:  zone-a
    Key:    topology.kubernetes.io/region
    Value:  region-1
Events:
  Type     Reason                    Age                    From            Message
  ----     ------                    ----                   ----            -------
  Normal   CSINodeTopologySucceeded  12m                    cns.vmware.com  Topology labels updated for nodeVM "k8s-node-0249"
```
Describe output of node after NodeGetInfo response is successful:
```
root@k8s-master-968:~# kdsc node k8s-node-0249
Name:               k8s-node-0249
Roles:              <none>
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu
                    beta.kubernetes.io/os=linux
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=k8s-node-0249
                    kubernetes.io/os=linux
                    topology.kubernetes.io/region=region-1
                    topology.kubernetes.io/zone=zone-a
Annotations:        csi.volume.kubernetes.io/nodeid: {"csi.vsphere.vmware.com":"k8s-node-0249"}
                    flannel.alpha.coreos.com/backend-data: {"VtepMAC":"1e:e6:4e:87:28:20"}
                    flannel.alpha.coreos.com/backend-type: vxlan
                    flannel.alpha.coreos.com/kube-subnet-manager: true
                    flannel.alpha.coreos.com/public-ip: 10.186.231.12
                    kubeadm.alpha.kubernetes.io/cri-socket: /var/run/dockershim.sock
                    node.alpha.kubernetes.io/ttl: 0
                    volumes.kubernetes.io/controller-managed-attach-detach: true
.....
```
NodeGetInfo logs:
```
2021-06-11T01:24:33.410Z	INFO	service/node.go:646	NodeGetInfo: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
2021-06-11T01:24:33.410Z	INFO	service/node.go:669	NodeGetInfo: MAX_VOLUMES_PER_NODE is set to 0	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
2021-06-11T01:24:33.410Z	INFO	kubernetes/kubernetes.go:86	k8s client using in-cluster config	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
2021-06-11T01:24:33.411Z	INFO	kubernetes/kubernetes.go:337	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
2021-06-11T01:24:33.489Z	INFO	kubernetes/kubernetes.go:86	k8s client using in-cluster config	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
2021-06-11T01:24:33.489Z	INFO	kubernetes/kubernetes.go:337	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
2021-06-11T01:24:33.597Z	INFO	service/node.go:728	NodeGetInfo response: node_id:"k8s-node-0249" accessible_topology:<segments:<key:"topology.kubernetes.io/region" value:"region-1" > segments:<key:"topology.kubernetes.io/zone" value:"zone-a" > > 	{"TraceId": "e9a6ac20-b559-4c5c-a069-c9737340b137"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Introduce controller for CSINodeTopology CR
```
