### PR TITLE
Use LogNewErrorCodef in wcp controller

### DIFF
--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -126,9 +126,8 @@ func validateWCPControllerExpandVolumeRequest(ctx context.Context, req *csi.Cont
 		// Get datacenter object from config
 		vc, err := common.GetVCenter(ctx, manager)
 		if err != nil {
-			msg := fmt.Sprintf("failed to get vcenter object with error: %+v", err)
-			log.Errorf(msg)
-			return status.Errorf(codes.Internal, msg)
+			return logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to get vcenter object with error: %+v", err)
 		}
 		dc := &vsphere.Datacenter{
 			Datacenter: object.NewDatacenter(vc.Client.Client,
@@ -142,22 +141,19 @@ func validateWCPControllerExpandVolumeRequest(ctx context.Context, req *csi.Cont
 		// Create client to list virtualmachine instances from the supervisor cluster API server
 		cfg, err := config.GetConfig()
 		if err != nil {
-			msg := fmt.Sprintf("failed to get config with error: %+v", err)
-			log.Error(msg)
-			return status.Errorf(codes.Internal, msg)
+			return logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to get config with error: %+v", err)
 		}
 		vmOperatorClient, err := k8s.NewClientForGroup(ctx, cfg, vmoperatorv1alpha1.GroupName)
 		if err != nil {
-			msg := fmt.Sprintf("failed to get client for group %s with error: %+v", vmoperatorv1alpha1.GroupName, err)
-			log.Error(msg)
-			return status.Errorf(codes.Internal, msg)
+			return logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to get client for group %s with error: %+v", vmoperatorv1alpha1.GroupName, err)
 		}
 		vmList := &vmoperatorv1alpha1.VirtualMachineList{}
 		err = vmOperatorClient.List(ctx, vmList)
 		if err != nil {
-			msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
-			log.Error(msg)
-			return status.Errorf(codes.Internal, msg)
+			return logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to list virtualmachines with error: %+v", err)
 		}
 
 		// Get BIOS UUID from virtualmachine instances to create VirtualMachine object
@@ -165,9 +161,8 @@ func validateWCPControllerExpandVolumeRequest(ctx context.Context, req *csi.Cont
 			biosUUID := vmInstance.Status.BiosUUID
 			vm, err := dc.GetVirtualMachineByUUID(ctx, biosUUID, false)
 			if err != nil {
-				msg := fmt.Sprintf("failed to get vm with biosUUID: %q with error: %+v", biosUUID, err)
-				log.Error(msg)
-				return status.Errorf(codes.Internal, msg)
+				return logger.LogNewErrorCodef(log, codes.Internal,
+					"failed to get vm with biosUUID: %q with error: %+v", biosUUID, err)
 			}
 			nodes = append(nodes, vm)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a pattern of log the error message, when creating a new error. This creates
duplicated code. This change uses LogNewErrorCode, and LogNewErrorCodef to
reduce duplicated code. In addition, using LogNewErrorCode consistently will make
sure that all generated errors will be logged (when log is available in the function).

This change fixes wcp controller code. It reduces 6K bytes in binary.

The other files will be fixed in follow-up changes.

**Testing done**:
Local build and check.
WCP run: SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 178 Skipped
