### PR TITLE
Add support for Snapshot configuration

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -76,6 +76,8 @@ const (
 	// interval after which stale CnsVSphereVolumeMigration CRs will be cleaned up.
 	// Current default value is set to 24 hours.
 	DefaultCnsVolumeOperationRequestCleanupIntervalInMin = 1440
+	// DefaultGlobalMaxSnapshotsPerBlockVolume is the default maximum number of block volume snapshots per volume.
+	DefaultGlobalMaxSnapshotsPerBlockVolume = 3
 )
 
 // Errors
@@ -181,6 +183,14 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 	}
 	if v := os.Getenv("VSPHERE_LABEL_ZONE"); v != "" {
 		cfg.Labels.Zone = v
+	}
+	if v := os.Getenv("GLOBAL_MAX_SNAPSHOTS_PER_BLOCK_VOLUME"); v != "" {
+		maxSnaps, err := strconv.Atoi(v)
+		if err != nil {
+			log.Errorf("failed to parse GLOBAL_MAX_SNAPSHOTS_PER_BLOCK_VOLUME: %s", err)
+		} else {
+			cfg.Snapshot.GlobalMaxSnapshotsPerBlockVolume = maxSnaps
+		}
 	}
 	// Build VirtualCenter from ENVs.
 	for _, e := range os.Environ() {
@@ -340,6 +350,9 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 	if cfg.Global.CnsVolumeOperationRequestCleanupIntervalInMin == 0 {
 		cfg.Global.CnsVolumeOperationRequestCleanupIntervalInMin =
 			DefaultCnsVolumeOperationRequestCleanupIntervalInMin
+	}
+	if cfg.Snapshot.GlobalMaxSnapshotsPerBlockVolume == 0 {
+		cfg.Snapshot.GlobalMaxSnapshotsPerBlockVolume = DefaultGlobalMaxSnapshotsPerBlockVolume
 	}
 	return nil
 }

--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -159,6 +159,36 @@ func TestValidateConfigWithInvalidClusterId(t *testing.T) {
 	}
 }
 
+func TestSnapshotConfigWhenMaxUnspecified(t *testing.T) {
+	cfg := &Config{
+		VirtualCenter: idealVCConfig,
+	}
+	err := validateConfig(ctx, cfg)
+	if err != nil {
+		t.Errorf("Unexpected error during confid validation - %+v", *cfg)
+	}
+	if cfg.Snapshot.GlobalMaxSnapshotsPerBlockVolume != DefaultGlobalMaxSnapshotsPerBlockVolume {
+		t.Errorf("Default max number of snaps incorrect")
+	}
+}
+
+func TestSnapshotConfigWhenMaxSpecifiedAsEnv(t *testing.T) {
+	cfg := &Config{
+		VirtualCenter: idealVCConfig,
+	}
+	// Temporarily set env variable.
+	os.Setenv("GLOBAL_MAX_SNAPSHOTS_PER_BLOCK_VOLUME", "5")
+	err := FromEnv(ctx, cfg)
+	if err != nil {
+		t.Errorf("Unexpected error during confid validation - %+v", *cfg)
+	}
+	// Unset after reading to prevent effects on future tests.
+	os.Unsetenv("GLOBAL_MAX_SNAPSHOTS_PER_BLOCK_VOLUME")
+	if cfg.Snapshot.GlobalMaxSnapshotsPerBlockVolume != 5 {
+		t.Errorf("Max number of snapshots from env variable ignored")
+	}
+}
+
 func isConfigEqual(actual *Config, expected *Config) bool {
 	// TODO: Compare Global struct
 	// Compare VC Config

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -69,6 +69,9 @@ type Config struct {
 	// Virtual Center configurations
 	VirtualCenter map[string]*VirtualCenterConfig
 
+	// Snapshot configurations.
+	Snapshot SnapshotConfig
+
 	// Guest Cluster configurations, only used by GC
 	GC GCConfig
 
@@ -133,4 +136,10 @@ type GCConfig struct {
 	TanzuKubernetesClusterName string `gcfg:"tanzukubernetescluster-name"`
 	// Cluster Distribution Name
 	ClusterDistribution string `gcfg:"cluster-distribution"`
+}
+
+// SnapshotConfig contains snapshot configuration.
+type SnapshotConfig struct {
+	// GlobalMaxSnapshotsPerBlockVolume specifies the maximum number of block volume snapshots per volume.
+	GlobalMaxSnapshotsPerBlockVolume int `gcfg:"global-max-snapshots-per-block-volume"`
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add support for Snapshot configuration.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Pre-checkins: https://container-dp.svc.eng.vmware.com/job/csi-block-vanilla-pre-check-in/86/

Added Unit tests and verified that they PASS
```
=== RUN   TestSnapshotConfigWhenMaxUnspecified
{"level":"info","time":"2021-06-11T13:27:04.448096-07:00","caller":"config/config.go:321","msg":"No Net Permissions given in Config. Using default permissions."}
--- PASS: TestSnapshotConfigWhenMaxUnspecified (0.00s)
=== RUN   TestSnapshotConfigWhenMaxSpecifiedAsEnv
{"level":"info","time":"2021-06-11T13:27:04.448433-07:00","caller":"config/config.go:321","msg":"No Net Permissions given in Config. Using default permissions."}
--- PASS: TestSnapshotConfigWhenMaxSpecifiedAsEnv (0.00s)
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>