### PR TITLE
raw block volume

### DIFF
--- a/docs/book/SUMMARY.md
+++ b/docs/book/SUMMARY.md
@@ -25,6 +25,7 @@
   * [Volume Expansion](features/volume_expansion.md)
   * [Volume Topology](features/volume_topology.md)
   * [vSphere CSI Migration](features/vsphere_csi_migration.md)
+  * [Raw Block Volume](features/raw_block_volume.md)
 * [Known Issues](known_issues.md)
 * [Troubleshooting](troubleshooting.md)
 * [Development](development.md)

--- a/docs/book/features/raw_block_volume.md
+++ b/docs/book/features/raw_block_volume.md
@@ -1,0 +1,52 @@
+# vSphere CSI Driver - Raw Block Volume
+
+[Raw Block Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#raw-block-volume-support) feature in Kubernetes was promoted to stable in Kubernetes 1.18.
+vSphere CSI Driver release `v2.3.0` will have Raw Block Volume feature released as `Alpha`. We do not recommend `Alpha` features for production use.
+
+This feature allows persistent volumes to be exposed inside containers as a block device instead of as a mounted file system.
+
+There are some specialized applications that require direct access to a block device because the file system layer introduces unneeded overhead.
+The ability to use a raw block device without a filesystem will allow Kubernetes better support for high-performance applications that are capable of consuming and manipulating block storage for their needs. The most common case is databases (MongoDB, Cassandra) that require consistent I/O performance and low latency, which prefer to organize their data directly on the underlying storage.
+
+## Creating a new raw block PVC
+
+To request a raw block PersistentVolumeClaim, volumeMode = "Block" must be specified in the PersistentVolumeClaimSpec.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: block-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Block
+  storageClassName: example-vanilla-block-sc
+  resources:
+    requests:
+      storage: 1Gi
+```
+
+## Using a raw block PVC
+
+When you use the PVC in a pod definition, you get to choose the device path for the block device rather than the mount path for the file system.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: block-pod
+spec:
+  containers:
+  - name: test-container
+    image: gcr.io/google_containers/busybox:1.24
+    command: ["/bin/sh", "-c", "while true ; do sleep 2 ; done"]
+    volumeDevices:
+    - devicePath: /dev/xvda
+      name: data
+  restartPolicy: Never
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: block-pvc
+```

--- a/example/vanilla-k8s-block-driver/example-raw-block-pod.yaml
+++ b/example/vanilla-k8s-block-driver/example-raw-block-pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example-raw-block-pod
+spec:
+  containers:
+    - name: test-container
+      image: gcr.io/google_containers/busybox:1.24
+      command: ["/bin/sh", "-c", "while true ; do sleep 2 ; done"]
+      volumeDevices:
+        - devicePath: /dev/xvda
+          name: data
+  restartPolicy: Never
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: example-raw-block-pvc

--- a/example/vanilla-k8s-block-driver/example-raw-block-pvc.yaml
+++ b/example/vanilla-k8s-block-driver/example-raw-block-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: example-raw-block-pvc
+spec:
+  volumeMode: Block
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: example-vanilla-block-sc


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding documentation and example yaml files for Raw Block Volume feature which we will be releasing as alpha in the vSphere CSI Driver 2.3 release.

Doc Preview link - https://deploy-preview-979--kubernetes-sigs-vsphere-csi-driver.netlify.app/features/raw_block_volume.html 

**Testing done**:
Verified Creating Pod with Raw Block Volume. Formatting of the filesystem is skipped by Node Daemonset.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
raw block volume
```
