### PR TITLE
Detect Homless Pod Error

### DIFF
--- a/manifests/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.19/cns-csi.yaml
@@ -72,6 +72,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeoperationrequests"]
     verbs: ["create", "get", "list", "update", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -342,6 +345,7 @@ data:
   "fake-attach": "true"
   "async-query-volume": "false"
   "improved-csi-idempotency": "false"
+  "sibling-replica-bound-pvc-check": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -72,6 +72,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeoperationrequests"]
     verbs: ["create", "get", "list", "update", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -343,6 +346,7 @@ data:
   "async-query-volume": "false"
   "improved-csi-idempotency": "false"
   "block-volume-snapshot": "false"
+  "sibling-replica-bound-pvc-check": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -72,6 +72,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeoperationrequests"]
     verbs: ["create", "get", "list", "update", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -343,6 +346,7 @@ data:
   "async-query-volume": "false"
   "improved-csi-idempotency": "false"
   "block-volume-snapshot": "false"
+  "sibling-replica-bound-pvc-check": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -266,4 +266,6 @@ const (
 	ImprovedVolumeTopology = "improved-volume-topology"
 	// BlockVolumeSnapshot is the feature to support CSI Snapshots for block volume on vSphere CSI driver.
 	BlockVolumeSnapshot = "block-volume-snapshot"
+	// SiblingReplicaBoundPvcCheck is the feature to check whether a PVC of a given replica can be placed on a node such that it does not have PVCs of any of its sibling replicas.
+	SiblingReplicaBoundPvcCheck = "sibling-replica-bound-pvc-check"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR detects homeless pod error when placing PVCs in the placement engine.

When a replica of an operator instance gets scheduled on a node that already has Bound PVCs of another replica of the same instance, we call it as a homeless pod issue.

One of the reasons we may end up in this scenario, is when we have a cluster with n nodes and an operator instance with n+1 replicas is deployed. One of the replicas will be in pending state as it can't find a node where the pod can be scheduled. Let's call this replica as homeless pod. The rest of the n pods would be in Running state and their PVCs bound. Now for some reason, one of the replicas in Running state gets deleted. Its PVCs continue to live on the node where it was scheduled. Before the deleted pod can come back and get scheduled on the same node (where it still has its PVCs bound), the homeless pod might get scheduled here.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Simulated homeless pod error scenario on a 4 node cluster with a sample instance having 5 replicas.
One pod stays in Pending state which we call as the homeless pod and the other 4 are in Running state. Deleted one of the Running pods and observed that it goes in Pending state as the homeless pod tries to take its place. The PVC got stamped with Homeless pod error:

```
root@420d77ffc08054a6c55b0fb8eda7d712 [ ~ ]# kubectl describe pvc -n sample-domain-c63 data3-sample94-4

Name:          data3-sample94-4
Namespace:     sample-domain-c63
StorageClass:  sample-vsan-sna-thick
Status:        Pending
Volume:        
Labels:        appplatform.vmware.com/extension-id=com.vmware.sample
               appplatform.vmware.com/instance-id=sample94
               sample.vmware.com/annotation=
               sample.vmware.com/name=sample94
Annotations:   failure-domain.beta.vmware.com/storagepool: FAILED_PLACEMENT-HasSiblingReplicaBoundPVC
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/selected-node: w3-rdops-vm01-dhcp-72-153.eng.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
```


Logs:

```
{"level":"error","time":"2021-06-18T09:48:59.079333025Z","caller":"k8scloudoperator/placement.go:625","msg":"No candidate hosts left for PVC data3-sample94-4. All nodes have bound PVCs of sibling replicas","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/k8scloudoperator.PlacePVConStoragePool\n\t/build/pkg/syncer/k8scloudoperator/placement.go:625\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer/k8scloudoperator.(*k8sCloudOperator).PlacePersistenceVolumeClaim\n\t/build/pkg/syncer/k8scloudoperator/k8scloudoperator.go:321\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer/k8scloudoperator._K8SCloudOperator_PlacePersistenceVolumeClaim_Handler\n\t/build/pkg/syncer/k8scloudoperator/k8scloudoperator.pb.go:625\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1024\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1313\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.1\n\t/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:722"}
{"level":"error","time":"2021-06-18T09:48:59.081083041Z","caller":"k8scloudoperator/k8scloudoperator.go:323","msg":"Failed to place this PVC on sp with error No candidate hosts left for PVC data3-sample94-4. All nodes have bound PVCs of sibling replicas","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/syncer/k8scloudoperator.(*k8sCloudOperator).PlacePersistenceVolumeClaim\n\t/build/pkg/syncer/k8scloudoperator/k8scloudoperator.go:323\nsigs.k8s.io/vsphere-csi-driver/pkg/syncer/k8scloudoperator._K8SCloudOperator_PlacePersistenceVolumeClaim_Handler\n\t/build/pkg/syncer/k8scloudoperator/k8scloudoperator.pb.go:625\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1024\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1313\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.1\n\t/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:722"}
```
psp-operator's PVC watcher then deletes the PVC and its corresponding homeless pod.
The original pod then comes to Running state after it got scheduled where it was previously present.

Ran regression pipeline for placement engine tests by replacing the image on a cluster.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
