### PR TITLE
Change PKS to TKGI in readme and installation guide

### DIFF
--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -1,6 +1,6 @@
 # Kubernetes vSphere CSI Driver
 
-vSphere Storage for Kubernetes, also called vSphere Cloud Provider, was introduced in 2017 and became the first vSphere storage solution for Kubernetes. The main goal of that project was to expose vSphere storage and features to Kubernetes users. The project offered an in-tree volume driver that has been actively used by various Kubernetes as a service solutions, such as PKS, OpenShift, GKE On-Prem, and so on. Cloud Native Storage (CNS) is a result of evolution and productization of vSphere Storage for Kubernetes and is also enterprise ready.
+vSphere Storage for Kubernetes, also called vSphere Cloud Provider, was introduced in 2017 and became the first vSphere storage solution for Kubernetes. The main goal of that project was to expose vSphere storage and features to Kubernetes users. The project offered an in-tree volume driver that has been actively used by various Kubernetes as a service solutions, such as TKGI, OpenShift, GKE On-Prem, and so on. Cloud Native Storage (CNS) is a result of evolution and productization of vSphere Storage for Kubernetes and is also enterprise ready.
 
 The main goal of CNS is to make vSphere and vSphere storage, including vSAN, a platform to run stateful Kubernetes workloads. vSphere has a great data path that is highly reliable, highly performant and mature for enterprise use. CNS enables access of this data path to Kubernetes and brings an understanding of Kubernetes volume and pod abstractions to vSphere. CNS was first released in vSphere 6.7 Update 3.
 

--- a/docs/book/driver-deployment/installation.md
+++ b/docs/book/driver-deployment/installation.md
@@ -73,7 +73,7 @@ Where the entries have the following meaning:
 
 - `cluster-id` - represents the unique cluster identifier. Each kubernetes cluster should have it's own unique cluster-id set in the configuration file. The cluster ID should not exceed 64 characters.
 
-- `cluster-distribution` - represents the distribution of the kubernetes cluster. This parameter is optional but will be made mandatory in a future release. Examples are `Openshift`, `Anthos` and `PKS`.
+- `cluster-distribution` - represents the distribution of the kubernetes cluster. This parameter is optional but will be made mandatory in a future release. Examples are `Openshift`, `Anthos` and `TKGI`.
 
   - values with special character `\r` causes vSphere CSI controller to go into CrashLoopBackOff state.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
PKS is the old name, and the new name should be TKGI. So we should change all "PKS" to "TKGI" in all documentation. 

**Testing done**:
N/A

**Issue**: 
https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/984 