### PR TITLE
Log volumeId string instead of Cns VolumeID struct in create volume call

### DIFF
--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -307,7 +307,7 @@ func getCnsVolumeInfoFromTaskResult(ctx context.Context, virtualCenter *cnsvsphe
 		datastoreURL = dsMo.Summary.Url
 	}
 	log.Infof("Volume created successfully. VolumeName: %q, volumeID: %q",
-		volumeName, volumeID)
+		volumeName, volumeID.Id)
 	log.Debugf("CreateVolume volumeId %q is placed on datastore %q",
 		volumeID, datastoreURL)
 	return &CnsVolumeInfo{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding a minor change in the create volume logs. At the moment create volume success message prints an empty field & CnsTypes.VolumeId in the message. We only have to print **volumeID** string in the message.
Before:
```
{"level":"info","time":"2021-06-16T19:39:16.773850796Z","caller":"volume/util.go:309","msg":"Volume created successfully. VolumeName: \"pvc-6096de63-0473-4ee9-9a4c-30799f7858b6\", volumeID: {{} \"4b3445e9-013f-4682-9231-c68f5c14c562\"}","TraceId":"3c239a88-db5e-42e8-8bfa-4f3f85096124"}
``` 

After:
```
{"level":"info","time":"2021-06-16T19:39:16.773850796Z","caller":"volume/util.go:309","msg":"Volume created successfully. VolumeName: \"pvc-6096de63-0473-4ee9-9a4c-30799f7858b6\", volumeID: \"4b3445e9-013f-4682-9231-c68f5c14c562\","TraceId":"3c239a88-db5e-42e8-8bfa-4f3f85096124"}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
No additional testing needed. Running e2e pipeline for sanity

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Log volumeId string instead of Cns VolumeID struct in create volume call
```
