### PR TITLE
online volume expansion on deployment set (vanilla and SVC)

### DIFF
--- a/tests/e2e/docs/supervisor_cluster_setup.md
+++ b/tests/e2e/docs/supervisor_cluster_setup.md
@@ -73,6 +73,8 @@ datacenters should be comma separated if deployed on multi-datacenters
     export KUBECONFIG=~/.kube/config
     export STORAGE_POLICY_FOR_SHARED_DATASTORES="shared-ds-policy"
     export STORAGE_POLICY_FOR_NONSHARED_DATASTORES="non-shared-ds-policy"
+    # For few SVC block volume expansion tests we need a storage policy which has thick provisioning enabled
+    export STORAGE_POLICY_WITH_THICK_PROVISIONING="<policy-name>"
     # Make sure env var FULL_SYNC_WAIT_TIME should be at least double of the manifest variable FULL_SYNC_INTERVAL_MINUTES in csi-driver-deploy.yaml
     export FULL_SYNC_WAIT_TIME=350    # In seconds
     export USER=root


### PR DESCRIPTION
What this PR does / why we need it:  Online volume expansion on deployment set 

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

Release notes:
Online volume expansion test cases for vanilla and supervisor
Special notes for your reviewer:

1.  Vanilla + SVC - Verify online volume expansion on deployment set  
2. SVC - Verify offline volume expansion when PVC is deleted 
3. Vanilla - Verify online volume expansion when PVC is deleted
4. Vanilla - Verify online volume expansion when POD is deleted and re-created

Vanilla : https://gist.github.com/kavyashree-r/2586d6f4e9e7b88eb5625f6fee1bafd2
SVC: https://gist.github.com/kavyashree-r/096c2cbbd771667c7c378bc504590bb3