### PR TITLE
enable misspell golangci-linter on the repository

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+    - misspell

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -136,7 +136,7 @@ func CreateCnsKuberenetesEntityReference(entityType string, entityName string,
 }
 
 // GetVirtualCenterConfig returns VirtualCenterConfig Object created using
-// vSphere Configuration specified in the arguement.
+// vSphere Configuration specified in the argument.
 func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCenterConfig, error) {
 	log := logger.GetLogger(ctx)
 	var err error

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -2153,6 +2153,7 @@ func toggleCSIMigrationFeatureGatesOnKubeControllerManager(ctx context.Context, 
 	}
 	if result.Code != 0 {
 		if add {
+			//nolint:misspell
 			sshCmd = "gawk -i inplace '/--bind-addres/ { print; print \"    - --feature-gates=CSIMigration=true,CSIMigrationvSphere=true\"; next }1' " + kcmManifest
 		} else {
 			return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

We observed a lot of misspelling on the repository.  We are fixing them regularly. 
Refer following recent PRs

- https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/865
- https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/989

In this PR we are enabling misspell  golangci-linter check on the repository to avoid checking in code having misspell.

Added `.golangci.yml` to enable `misspell` linter.

Disabled checking misspell in tests/e2e/util.go for the following line. Note sure if this is intended or misspelled over here so disabling check for this line.

```
//nolint:misspell
sshCmd = "gawk -i inplace '/--bind-addres/ { print; print \"    - --feature-gates=CSIMigration=true,CSIMigrationvSphere=true\"; next }1' " + kcmManifest
```

fixed remaining misspell on the repository.



**Testing done**:
No Functional change.

Misspell is enabled for this PR - https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_vsphere-csi-driver/994/pull-vsphere-csi-driver-verify-golangci-lint/1405660103360647168/build-log.txt 
Local Testing
```
./hack/check-golangci-lint.sh                                    
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/divyenp/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver /Users/divyenp/go/src/github.com/divyenpatel /Users/divyenp/go/src/github.com /Users/divyenp/go/src /Users/divyenp/go /Users/divyenp /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 11 linters: [deadcode errcheck gosimple govet ineffassign misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|files|types_sizes|compiled_files|exports_file|imports|name) took 1.626156774s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 55.32441ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 78, after processing: 0 
INFO [runner] Processors filtering stat (out/in): cgo: 78/78, path_prettifier: 78/78, nolint: 0/1, filename_unadjuster: 78/78, identifier_marker: 18/18, exclude: 18/18, skip_dirs: 78/78, skip_files: 78/78, autogenerated_exclude: 18/78, exclude-rules: 1/18 
INFO [runner] processing took 7.465633ms with stages: nolint: 5.71187ms, autogenerated_exclude: 787.374µs, path_prettifier: 556.7µs, identifier_marker: 216.459µs, skip_dirs: 93.672µs, exclude-rules: 82.475µs, filename_unadjuster: 8.892µs, cgo: 5.058µs, max_same_issues: 499ns, uniq_by_line: 426ns, max_from_linter: 308ns, skip_files: 292ns, source_code: 284ns, diff: 244ns, exclude: 235ns, severity-rules: 218ns, path_shortener: 189ns, max_per_file_from_linter: 185ns, sort_results: 141ns, path_prefixer: 112ns 
INFO [runner] linters took 1.784454281s with stages: goanalysis_metalinter: 1.776923452s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 36 samples, avg is 108.3MB, max is 140.5MB 
INFO Execution took 3.478954285s   
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
enable misspell golangci-linter on the repository
```
