### PR TITLE
Clean up white spaces in apis

### DIFF
--- a/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1/cnsregistervolume_types.go
+++ b/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1/cnsregistervolume_types.go
@@ -27,23 +27,30 @@ type CnsRegisterVolumeSpec struct {
 	// Name of the PVC
 	PvcName string `json:"pvcName"`
 
-	// VolumeID indicates an existing vsphere volume to be imported into Project Pacific cluster
-	// If the AccessMode is "ReadWriteMany" or "ReadOnlyMany", then this VolumeID can be either an existing FileShare (or) CNS file volume backed FileShare.
-	// If the AccessMode is "ReadWriteOnce", then this VolumeID can be either an existing FCD (or) a CNS backed FCD.
+	// VolumeID indicates an existing vsphere volume to be imported into Project
+	// Pacific cluster.
+	// If the AccessMode is "ReadWriteMany" or "ReadOnlyMany", then this VolumeID
+	// can be either an existing FileShare (or) CNS file volume backed FileShare.
+	// If the AccessMode is "ReadWriteOnce", then this VolumeID can be either an
+	// existing FCD (or) a CNS backed FCD.
 	// VolumeID and DiskUrlPath cannot be specified together.
 	VolumeID string `json:"volumeID,omitempty"`
 
-	// AccessMode contains the actual access mode the volume backing the CnsRegisterVolume has.
+	// AccessMode contains the actual access mode the volume backing the
+	// CnsRegisterVolume has.
 	// AccessMode must be specified if VolumeID is specified.
 	AccessMode v1.PersistentVolumeAccessMode `json:"accessMode,omitempty"`
 
-	// DiskUrlPath is URL path to an existing block volume to be imported into Project Pacific cluster.
+	// DiskUrlPath is URL path to an existing block volume to be imported into
+	// Project Pacific cluster.
 	// VolumeID and DiskUrlPath cannot be specified together.
-	// DiskUrlPath is explicitly used for block volumes. AccessMode need not be specified and will be defaulted to "ReadWriteOnce".
+	// DiskUrlPath is explicitly used for block volumes. AccessMode need not be
+	// specified and will be defaulted to "ReadWriteOnce".
 	// This field must be in the following format:
 	// Format:
 	// https://<vc_ip>/folder/<vm_vmdk_path>?dcPath=<datacenterName>&dsName=<datastoreName>
-	// Ex: https://10.192.255.221/folder/34a9c05d-5f03-e254-e692-02004479cb91/vm2_1.vmdk?dcPath=Datacenter-1&dsName=vsanDatastore
+	// Ex: https://10.192.255.221/folder/34a9c05d-5f03-e254-e692-02004479cb91/
+	//        vm2_1.vmdk?dcPath=Datacenter-1&dsName=vsanDatastore
 	// This is for a 34a9c05d-5f03-e254-e692-02004479cb91/vm2_1.vmdk
 	// file under datacenter "Datacenter-1" and datastore "vsanDatastore".
 	DiskURLPath string `json:"diskURLPath,omitempty"`

--- a/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
+++ b/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
@@ -49,26 +49,24 @@ type CnsVolumeMetadataSpec struct {
 	// A Pod in the guest cluster can refers to one or more PVCs in the guest cluster.
 	// A PVC in the guest cluster refers to a PV in the guest cluster.
 	// A PV in the guest cluster refers to a PVC in the supervisor cluster.
-	// A Pod/PVC in the guest cluster referring to a PVC/PV respectively in the guest
-	// cluster must set the ClusterID field.
-	// A PV in the guest cluster referring to a PVC in the supervisor cluster must leave
-	// the ClusterID field unset.
+	// A Pod/PVC in the guest cluster referring to a PVC/PV respectively in the
+	// guest cluster must set the ClusterID field.
+	// A PV in the guest cluster referring to a PVC in the supervisor cluster
+	// must leave the ClusterID field unset.
 	// This field is mandatory.
 	EntityReferences []CnsOperatorEntityReference `json:"entityreferences"`
 
-	// Labels indicates user labels assigned to the entity
-	// in the guest cluster. Should only be populated if
-	// EntityType is PERSISTENT_VOLUME OR PERSISTENT_VOLUME_CLAIM
-	// CNS Operator will return a failure to the client if labels
-	// are set for objects whose EntityType is POD.
+	// Labels indicates user labels assigned to the entity in the guest cluster.
+	// Should only be populated if EntityType is PERSISTENT_VOLUME OR
+	// PERSISTENT_VOLUME_CLAIM. CNS Operator will return a failure to the client
+	// if labels are set for objects whose EntityType is POD.
 	//+optional
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Namespace indicates namespace of entity in guest cluster.
-	// Should only be populated if EntityType is
-	// PERSISTENT_VOLUME_CLAIM or POD.
-	// CNS Operator will return a failure to the client if
-	// namespace is set for objects whose EntityType is PERSISTENT_VOLUME.
+	// Should only be populated if EntityType is PERSISTENT_VOLUME_CLAIM or POD.
+	// CNS Operator will return a failure to the client if namespace is set for
+	// objects whose EntityType is PERSISTENT_VOLUME.
 	//+optional
 	Namespace string `json:"namespace,omitempty"`
 
@@ -107,19 +105,19 @@ type CnsVolumeMetadata struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// CnsVolumeMetadataList contains a list of CnsVolumeMetadata
+// CnsVolumeMetadataList contains a list of CnsVolumeMetadata.
 type CnsVolumeMetadataList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []CnsVolumeMetadata `json:"items"`
 }
 
-// CnsOperatorEntityType defines the type for entitytype parameter
-// in cnsvolumemetadata API
+// CnsOperatorEntityType defines the type for entitytype parameter in
+// cnsvolumemetadata API.
 type CnsOperatorEntityType cnstypes.CnsKubernetesEntityType
 
-// CnsVolumeMetadataVolumeStatus defines the status of the last
-// update operation on CNS for the given volume.
+// CnsVolumeMetadataVolumeStatus defines the status of the last update operation
+// on CNS for the given volume.
 // Error message will be empty if no error was encountered.
 type CnsVolumeMetadataVolumeStatus struct {
 	VolumeName   string `json:"volumename"`
@@ -127,7 +125,7 @@ type CnsVolumeMetadataVolumeStatus struct {
 	ErrorMessage string `json:"errormessage,omitempty"`
 }
 
-// Allowed CnsOperatorEntityTypes for cnsvolumemetadata API
+// Allowed CnsOperatorEntityTypes for cnsvolumemetadata API.
 const (
 	CnsOperatorEntityTypePV  = CnsOperatorEntityType(cnstypes.CnsKubernetesEntityTypePV)
 	CnsOperatorEntityTypePVC = CnsOperatorEntityType(cnstypes.CnsKubernetesEntityTypePVC)
@@ -135,15 +133,19 @@ const (
 )
 
 // CnsOperatorEntityReference defines the type for entityreference
-// parameter in cnsvolumemetadata API
+// parameter in cnsvolumemetadata API.
 type CnsOperatorEntityReference cnstypes.CnsKubernetesEntityReference
 
-// CreateCnsVolumeMetadataSpec returns a cnsvolumemetadata object from the input parameters
-func CreateCnsVolumeMetadataSpec(volumeHandle []string, gcConfig config.GCConfig, uid string, name string, entityType CnsOperatorEntityType, labels map[string]string, namespace string, reference []CnsOperatorEntityReference) *CnsVolumeMetadata {
+// CreateCnsVolumeMetadataSpec returns a cnsvolumemetadata object from the
+// input parameters.
+func CreateCnsVolumeMetadataSpec(volumeHandle []string, gcConfig config.GCConfig, uid string, name string,
+	entityType CnsOperatorEntityType, labels map[string]string, namespace string,
+	reference []CnsOperatorEntityReference) *CnsVolumeMetadata {
 	return &CnsVolumeMetadata{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            GetCnsVolumeMetadataName(gcConfig.TanzuKubernetesClusterUID, uid),
-			OwnerReferences: []metav1.OwnerReference{GetCnsVolumeMetadataOwnerReference(cnsoperatortypes.GCAPIVersion, cnsoperatortypes.GCKind, gcConfig.TanzuKubernetesClusterName, gcConfig.TanzuKubernetesClusterUID)},
+			Name: GetCnsVolumeMetadataName(gcConfig.TanzuKubernetesClusterUID, uid),
+			OwnerReferences: []metav1.OwnerReference{GetCnsVolumeMetadataOwnerReference(cnsoperatortypes.GCAPIVersion,
+				cnsoperatortypes.GCKind, gcConfig.TanzuKubernetesClusterName, gcConfig.TanzuKubernetesClusterUID)},
 		},
 		Spec: CnsVolumeMetadataSpec{
 			VolumeNames:         volumeHandle,
@@ -158,13 +160,16 @@ func CreateCnsVolumeMetadataSpec(volumeHandle []string, gcConfig config.GCConfig
 	}
 }
 
-// GetCnsVolumeMetadataName returns the concatenated string of guestclusterid and entity id
+// GetCnsVolumeMetadataName returns the concatenated string of guestclusterid
+// and entity id.
 func GetCnsVolumeMetadataName(guestClusterID string, entityUID string) string {
 	return guestClusterID + "-" + entityUID
 }
 
-// GetCnsOperatorEntityReference returns the entityReference object from the input parameters
-func GetCnsOperatorEntityReference(name string, namespace string, entitytype CnsOperatorEntityType, clusterid string) CnsOperatorEntityReference {
+// GetCnsOperatorEntityReference returns the entityReference object from the
+// input parameters.
+func GetCnsOperatorEntityReference(name string, namespace string, entitytype CnsOperatorEntityType,
+	clusterid string) CnsOperatorEntityReference {
 	return CnsOperatorEntityReference{
 		EntityType: string(entitytype),
 		EntityName: name,
@@ -173,7 +178,8 @@ func GetCnsOperatorEntityReference(name string, namespace string, entitytype Cns
 	}
 }
 
-// GetCnsOperatorVolumeStatus returns a CnsVolumeMetadataVolumeStatus object from input parameters
+// GetCnsOperatorVolumeStatus returns a CnsVolumeMetadataVolumeStatus object
+// from input parameters.
 func GetCnsOperatorVolumeStatus(volumeName string, errorMessage string) CnsVolumeMetadataVolumeStatus {
 	return CnsVolumeMetadataVolumeStatus{
 		VolumeName:   volumeName,
@@ -182,8 +188,10 @@ func GetCnsOperatorVolumeStatus(volumeName string, errorMessage string) CnsVolum
 	}
 }
 
-// GetCnsVolumeMetadataOwnerReference returns the owner reference object from the input parameters
-func GetCnsVolumeMetadataOwnerReference(apiVersion string, kind string, clusterName string, clusterUID string) metav1.OwnerReference {
+// GetCnsVolumeMetadataOwnerReference returns the owner reference object from
+// the input parameters.
+func GetCnsVolumeMetadataOwnerReference(apiVersion string, kind string, clusterName string,
+	clusterUID string) metav1.OwnerReference {
 	bController := true
 	bOwnerDeletion := true
 	return metav1.OwnerReference{

--- a/pkg/apis/storagepool/apis.go
+++ b/pkg/apis/storagepool/apis.go
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 // Generate deepcopy for apis
-//go:generate go run ../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go -O zz_generated.deepcopy -i ./... -h ../../hack/boilerplate.go.txt
+// go:generate go run ../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go
+//    -O zz_generated.deepcopy -i ./... -h ../../hack/boilerplate.go.txt
 
 // Package apis contains Kubernetes API groups.
 package apis
@@ -24,10 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// AddToSchemes may be used to add all resources defined in the project to a Scheme
+// AddToSchemes may be used to add all resources defined in the project to
+// a Scheme.
 var AddToSchemes runtime.SchemeBuilder
 
-// AddToScheme adds all Resources to the Scheme
+// AddToScheme adds all Resources to the Scheme.
 func AddToScheme(s *runtime.Scheme) error {
 	return AddToSchemes.AddToScheme(s)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles a few files under apis.

**Testing done**:
Local build and check.