### PR TITLE
[WIP] Add options in logger to skip logger in callers list

### DIFF
--- a/pkg/csi/service/logger/logger.go
+++ b/pkg/csi/service/logger/logger.go
@@ -87,6 +87,7 @@ func newLogger() *zap.Logger {
 		loggerConfig.EncoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
 		logger, _ = loggerConfig.Build()
 	}
+	logger.WithOptions(zap.AddCallerSkip(1))
 	return logger
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Since the introduction of `LogNewErrorCodef` in CSI source code, the error messages printed from source files show up in the logs with logger.go as filename:
Ex: `{"level":"error","time":"2021-06-17T17:48:21.654945712Z","caller":"logger/logger.go:113","msg":"error in formating and mounting volume.`

Previously CSI was printing the exact line number and filename from where the error was thrown.

This PR is adding options for logger to remove the logger.go itself from the callers list in order to print the exact line numbers and file names for error scenarios

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running e2e pipelines

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add options in logger to skip logger in callers list
```
