### PR TITLE
Add healthz port for CSI controller and use emptyDir for CSI socket file

### DIFF
--- a/manifests/supervisorcluster/1.15/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.15/cns-csi.yaml
@@ -98,8 +98,6 @@ metadata:
   name: vsphere-csi-controller
   namespace: vmware-system-csi
 spec:
-  strategy:
-    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -136,7 +134,7 @@ spec:
             - "--enable-hostlocal-placement=true"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -146,7 +144,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-attacher
           image: localhost:5000/vmware/csi-attacher/csi-attacher:v1.1.1
           args:
@@ -157,7 +155,7 @@ spec:
             - "--leader-election-type=leases"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -165,20 +163,33 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
+          ports:
+           - containerPort: 2112
+             name: prometheus
+             protocol: TCP
+           - name: healthz
+             containerPort: 9808
+             protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
             - name: X_CSI_MODE
               value: "controller"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -194,17 +205,14 @@ spec:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: liveness-probe
           image: localhost:5000/vmware/csi-livenessprobe/csi-livenessprobe:v1.1.0
           args:
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - "--csi-address=/csi/csi.sock"
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: localhost:5000/vmware/syncer:<syncer_ver>
@@ -228,6 +236,10 @@ spec:
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
           imagePullPolicy: "IfNotPresent"
+          ports:
+          - containerPort: 2113
+            name: prometheus
+            protocol: TCP
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -237,9 +249,7 @@ spec:
           secret:
             secretName: vsphere-config-secret
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
 ---
 apiVersion: v1
 data:

--- a/manifests/supervisorcluster/1.16/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.16/cns-csi.yaml
@@ -110,8 +110,6 @@ metadata:
   name: vsphere-csi-controller
   namespace: vmware-system-csi
 spec:
-  strategy:
-    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -148,7 +146,7 @@ spec:
             - "--enable-hostlocal-placement=true"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -158,7 +156,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-attacher
           image: localhost:5000/vmware/csi-attacher/csi-attacher:v1.1.1
           args:
@@ -169,7 +167,7 @@ spec:
             - "--leader-election-type=leases"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -177,7 +175,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-resizer
           image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.0.0_vmware.1
           imagePullPolicy: IfNotPresent
@@ -199,17 +197,30 @@ spec:
               name: socket-dir
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
+          ports:
+           - containerPort: 2112
+             name: prometheus
+             protocol: TCP
+           - name: healthz
+             containerPort: 9808
+             protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
             - name: X_CSI_MODE
               value: "controller"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -225,17 +236,14 @@ spec:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: liveness-probe
           image: localhost:5000/vmware/csi-livenessprobe/csi-livenessprobe:v1.1.0
           args:
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - "--csi-address=/csi/csi.sock"
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: localhost:5000/vmware/syncer:<syncer_ver>
@@ -270,9 +278,7 @@ spec:
           secret:
             secretName: vsphere-config-secret
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
 ---
 apiVersion: v1
 data:

--- a/manifests/supervisorcluster/1.17/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.17/cns-csi.yaml
@@ -119,8 +119,6 @@ metadata:
   name: vsphere-csi-controller
   namespace: vmware-system-csi
 spec:
-  strategy:
-    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -159,7 +157,7 @@ spec:
             - "--default-fstype=ext4"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -169,7 +167,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-attacher
           image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
           args:
@@ -181,7 +179,7 @@ spec:
             - "--kube-api-burst=100"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -189,7 +187,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-resizer
           image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
           imagePullPolicy: IfNotPresent
@@ -215,17 +213,26 @@ spec:
            - containerPort: 2112
              name: prometheus
              protocol: TCP
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
+           - name: healthz
+             containerPort: 9808
+             protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
             - name: X_CSI_MODE
               value: "controller"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -241,19 +248,16 @@ spec:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
           args:
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - "--csi-address=/csi/csi.sock"
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: localhost:5000/vmware/syncer:<syncer_ver>
@@ -294,9 +298,7 @@ spec:
           secret:
             secretName: vsphere-config-secret
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
         - name: host-vmca
           hostPath:
             path: /etc/vmware/wcp/tls/

--- a/manifests/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.18/cns-csi.yaml
@@ -122,8 +122,6 @@ metadata:
   name: vsphere-csi-controller
   namespace: vmware-system-csi
 spec:
-  strategy:
-    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -162,7 +160,7 @@ spec:
             - "--default-fstype=ext4"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -172,7 +170,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-attacher
           image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
           args:
@@ -184,7 +182,7 @@ spec:
             - "--kube-api-burst=100"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -192,7 +190,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-resizer
           image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
           imagePullPolicy: IfNotPresent
@@ -218,17 +216,26 @@ spec:
            - containerPort: 2112
              name: prometheus
              protocol: TCP
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
+           - name: healthz
+             containerPort: 9808
+             protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
             - name: X_CSI_MODE
               value: "controller"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -244,19 +251,16 @@ spec:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
           args:
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - "--csi-address=/csi/csi.sock"
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: localhost:5000/vmware/syncer:<syncer_ver>
@@ -297,9 +301,7 @@ spec:
           secret:
             secretName: vsphere-config-secret
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
         - name: host-vmca
           hostPath:
             path: /etc/vmware/wcp/tls/

--- a/manifests/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.19/cns-csi.yaml
@@ -134,8 +134,6 @@ metadata:
   name: vsphere-csi-controller
   namespace: vmware-system-csi
 spec:
-  strategy:
-    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -174,7 +172,7 @@ spec:
             - "--default-fstype=ext4"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -184,7 +182,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-attacher
           image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
           args:
@@ -196,7 +194,7 @@ spec:
             - "--kube-api-burst=100"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -204,7 +202,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-resizer
           image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
           imagePullPolicy: IfNotPresent
@@ -231,17 +229,26 @@ spec:
            - containerPort: 2112
              name: prometheus
              protocol: TCP
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
+           - name: healthz
+             containerPort: 9808
+             protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
             - name: X_CSI_MODE
               value: "controller"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -261,19 +268,16 @@ spec:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
           args:
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - "--csi-address=/csi/csi.sock"
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: localhost:5000/vmware/syncer:<syncer_ver>
@@ -318,9 +322,7 @@ spec:
           secret:
             secretName: vsphere-config-secret
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
         - name: host-vmca
           hostPath:
             path: /etc/vmware/wcp/tls/

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -134,8 +134,6 @@ metadata:
   name: vsphere-csi-controller
   namespace: vmware-system-csi
 spec:
-  strategy:
-    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -174,7 +172,7 @@ spec:
             - "--default-fstype=ext4"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -184,7 +182,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-attacher
           image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
           args:
@@ -196,7 +194,7 @@ spec:
             - "--kube-api-burst=100"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -204,7 +202,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-resizer
           image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
           imagePullPolicy: IfNotPresent
@@ -231,17 +229,26 @@ spec:
            - containerPort: 2112
              name: prometheus
              protocol: TCP
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
+           - name: healthz
+             containerPort: 9808
+             protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
             - name: X_CSI_MODE
               value: "controller"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -261,19 +268,16 @@ spec:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
           args:
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - "--csi-address=/csi/csi.sock"
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: localhost:5000/vmware/syncer:<syncer_ver>
@@ -318,9 +322,7 @@ spec:
           secret:
             secretName: vsphere-config-secret
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
         - name: host-vmca
           hostPath:
             path: /etc/vmware/wcp/tls/

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -134,8 +134,6 @@ metadata:
   name: vsphere-csi-controller
   namespace: vmware-system-csi
 spec:
-  strategy:
-    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -174,7 +172,7 @@ spec:
             - "--default-fstype=ext4"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -184,7 +182,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-attacher
           image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
           args:
@@ -196,7 +194,7 @@ spec:
             - "--kube-api-burst=100"
           env:
             - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+              value: /csi/csi.sock
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -204,7 +202,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
+              mountPath: /csi
         - name: csi-resizer
           image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
           imagePullPolicy: IfNotPresent
@@ -231,17 +229,26 @@ spec:
            - containerPort: 2112
              name: prometheus
              protocol: TCP
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com"]
+           - name: healthz
+             containerPort: 9808
+             protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"
             - name: X_CSI_MODE
               value: "controller"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
             - name: KUBERNETES_SERVICE_HOST
               value: "127.0.0.1"
             - name: KUBERNETES_SERVICE_PORT
@@ -261,19 +268,16 @@ spec:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
           image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
           args:
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - "--csi-address=/csi/csi.sock"
           volumeMounts:
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
         - name: vsphere-syncer
           image: localhost:5000/vmware/syncer:<syncer_ver>
@@ -318,9 +322,7 @@ spec:
           secret:
             secretName: vsphere-config-secret
         - name: socket-dir
-          hostPath:
-            path: /var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com
-            type: DirectoryOrCreate
+          emptyDir: {}
         - name: host-vmca
           hostPath:
             path: /etc/vmware/wcp/tls/


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding healthz port for CSI controller in supervisor yamls and also use emptyDir for CSI socket file

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Built a custom SV OVA and deployed a WCP testbed to verify the yaml changes:

```
kubectl describe pod vsphere-csi-controller-79cc79c4b6-q5szd -n vmware-system-csi
Name:         vsphere-csi-controller-79cc79c4b6-q5szd
Namespace:    vmware-system-csi
Priority:     0
Node:         421a09a4a38c64f93e418ed4705c7490/10.92.227.63
Start Time:   Thu, 24 Jun 2021 15:44:43 +0000
Labels:       app=vsphere-csi-controller
              pod-template-hash=79cc79c4b6
              role=vsphere-csi
Annotations:  kubernetes.io/psp: wcp-privileged-psp
Status:       Running
IP:           10.92.227.63
IPs:
  IP:           10.92.227.63
Controlled By:  ReplicaSet/vsphere-csi-controller-79cc79c4b6
Containers:
  csi-provisioner:
    Container ID:  containerd://e6627effd906a3ec9c4325231415eb285096347bfcc82ca2e271085d0cd9bbb9
    Image:         localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4
    Image ID:      localhost:5000/vmware/csi-provisioner/csi-provisioner@sha256:f3783faf0e57904cde3702f7f0fb1f6e959c3160c90d399ea90931acd77abc18
    Port:          <none>
    Host Port:     <none>
    Args:
      --v=4
      --timeout=300s
      --csi-address=$(ADDRESS)
      --feature-gates=Topology=true
      --strict-topology
      --leader-election
      --enable-hostlocal-placement=true
      --kube-api-qps=100
      --kube-api-burst=100
      --default-fstype=ext4
    State:          Running
      Started:      Thu, 24 Jun 2021 15:44:44 +0000
    Ready:          True
    Restart Count:  0
    Environment:
      ADDRESS:                              /csi/csi.sock
      KUBERNETES_SERVICE_HOST:              127.0.0.1
      KUBERNETES_SERVICE_PORT:              6443
      VSPHERE_CLOUD_OPERATOR_SERVICE_PORT:  29000
    Mounts:
      /csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from vsphere-csi-controller-token-fxvmm (ro)
  csi-attacher:
    Container ID:  containerd://20c157b8663ad84f6df2413b9b095ad593725f486dac7a86e65faf6c408f831d
    Image:         localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
    Image ID:      localhost:5000/vmware.io/csi-attacher@sha256:ef84a54cab084305c3b6638bcf3616539a1ece71054e519ce72c74a85ed6883c
    Port:          <none>
    Host Port:     <none>
    Args:
      --v=4
      --timeout=300s
      --csi-address=$(ADDRESS)
      --leader-election
    State:          Running
      Started:      Thu, 24 Jun 2021 15:44:45 +0000
    Ready:          True
    Restart Count:  0
    Environment:
      ADDRESS:                  /csi/csi.sock
      KUBERNETES_SERVICE_HOST:  127.0.0.1
      KUBERNETES_SERVICE_PORT:  6443
    Mounts:
      /csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from vsphere-csi-controller-token-fxvmm (ro)
  csi-resizer:
    Container ID:  containerd://c717435838c8b88a16a85d0a19f35594be175a77fa3406647482caf9fb125115
    Image:         localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
    Image ID:      localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer@sha256:eafb68e3367ac1b840b55b115351163cd24dfc1752e402c8d83210ab35d251eb
    Port:          <none>
    Host Port:     <none>
    Args:
      --v=4
      --timeout=300s
      --handle-volume-inuse-error=false
      --csi-address=$(ADDRESS)
      --leader-election
      --kube-api-qps=100
      --kube-api-burst=100
    State:          Running
      Started:      Thu, 24 Jun 2021 15:44:45 +0000
    Ready:          True
    Restart Count:  0
    Environment:
      ADDRESS:  /csi/csi.sock
    Mounts:
      /csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from vsphere-csi-controller-token-fxvmm (ro)
  vsphere-csi-controller:
    Container ID:   containerd://b72de8333121e3511dd1431d4d4f70438f9f77de6fa460f5d0bb3bab36a6ea11
    Image:          localhost:5000/vmware/vsphere-csi:vsphere70u3-a312aa0
    Image ID:       localhost:5000/vmware/vsphere-csi@sha256:e2346afe1d9b005658c74a6e75e0f752e4a2d7fefeced6366afec8f56d5ad531
    Ports:          2112/TCP, 9808/TCP
    Host Ports:     2112/TCP, 9808/TCP
    State:          Running
      Started:      Thu, 24 Jun 2021 15:44:45 +0000
    Ready:          True
    Restart Count:  0
    Liveness:       http-get http://:healthz/healthz delay=10s timeout=3s period=5s #success=1 #failure=3
    Environment:
      CSI_ENDPOINT:               unix:///csi/csi.sock
      CLUSTER_FLAVOR:             WORKLOAD
      X_CSI_MODE:                 controller
      KUBERNETES_SERVICE_HOST:    127.0.0.1
      KUBERNETES_SERVICE_PORT:    6443
      POD_LISTENER_SERVICE_PORT:  29000
      VSPHERE_CSI_CONFIG:         /etc/vmware/wcp/vsphere-cloud-provider.conf
      LOGGER_LEVEL:               PRODUCTION
      INCLUSTER_CLIENT_QPS:       50
      INCLUSTER_CLIENT_BURST:     50
    Mounts:
      /csi from socket-dir (rw)
      /etc/vmware/wcp from vsphere-config-volume (ro)
      /etc/vmware/wcp/tls/ from host-vmca (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from vsphere-csi-controller-token-fxvmm (ro)
  liveness-probe:
    Container ID:  containerd://0096e9650d16ab136e7ebd4914b35bcc0612bcb30ac4d05b02008c4aba42c850
    Image:         localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
    Image ID:      localhost:5000/vmware.io/csi-livenessprobe@sha256:7790ca0da41bfc8cd05c35c9309a36d060f847402147fddc32ca14063f9adc89
    Port:          <none>
    Host Port:     <none>
    Args:
      --csi-address=/csi/csi.sock
    State:          Running
      Started:      Thu, 24 Jun 2021 15:44:45 +0000
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from vsphere-csi-controller-token-fxvmm (ro)
  vsphere-syncer:
    Container ID:  containerd://7396cc8d1e26cde6e09098baaa008bd85113002d85c36dafa507848216b2d843
    Image:         localhost:5000/vmware/syncer:vsphere70u3-a312aa0
    Image ID:      localhost:5000/vmware/syncer@sha256:bdce12273ea688ab18d3f2d81cefce183d56d6dff621c8d4a1ed9546c382b96d
    Port:          2113/TCP
    Host Port:     2113/TCP
    Args:
      --leader-election
    State:          Running
      Started:      Thu, 24 Jun 2021 15:44:45 +0000
    Ready:          True
    Restart Count:  0
    Environment:
      CLUSTER_FLAVOR:                  WORKLOAD
      KUBERNETES_SERVICE_HOST:         127.0.0.1
      KUBERNETES_SERVICE_PORT:         6443
      FULL_SYNC_INTERVAL_MINUTES:      30
      VOLUME_HEALTH_INTERVAL_MINUTES:  5
      POD_POLL_INTERVAL_SECONDS:       2
      POD_LISTENER_SERVICE_PORT:       29000
      VSPHERE_CSI_CONFIG:              /etc/vmware/wcp/vsphere-cloud-provider.conf
      LOGGER_LEVEL:                    PRODUCTION
      INCLUSTER_CLIENT_QPS:            50
      INCLUSTER_CLIENT_BURST:          50
    Mounts:
      /etc/vmware/wcp from vsphere-config-volume (ro)
      /etc/vmware/wcp/tls/ from host-vmca (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from vsphere-csi-controller-token-fxvmm (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  vsphere-config-volume:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  vsphere-config-secret
    Optional:    false
  socket-dir:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:     
    SizeLimit:  <unset>
  host-vmca:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/vmware/wcp/tls/
    HostPathType:  Directory
  vsphere-csi-controller-token-fxvmm:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  vsphere-csi-controller-token-fxvmm
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  node-role.kubernetes.io/master=
Tolerations:     kubeadmNode=master:NoSchedule
                 node-role.kubernetes.io/master:NoSchedule op=Exists
                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                 node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  101s  default-scheduler  Successfully assigned vmware-system-csi/vsphere-csi-controller-79cc79c4b6-q5szd to 421a09a4a38c64f93e418ed4705c7490
  Normal  Pulled     101s  kubelet            Container image "localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4" already present on machine
  Normal  Created    101s  kubelet            Created container csi-provisioner
  Normal  Started    101s  kubelet            Started container csi-provisioner
  Normal  Pulled     101s  kubelet            Container image "localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1" already present on machine
  Normal  Created    101s  kubelet            Created container csi-attacher
  Normal  Started    100s  kubelet            Started container csi-resizer
  Normal  Pulled     100s  kubelet            Container image "localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1" already present on machine
  Normal  Created    100s  kubelet            Created container csi-resizer
  Normal  Started    100s  kubelet            Started container csi-attacher
  Normal  Pulled     100s  kubelet            Container image "localhost:5000/vmware/vsphere-csi:vsphere70u3-a312aa0" already present on machine
  Normal  Created    100s  kubelet            Created container vsphere-csi-controller
  Normal  Started    100s  kubelet            Started container vsphere-csi-controller
  Normal  Pulled     100s  kubelet            Container image "localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1" already present on machine
  Normal  Created    100s  kubelet            Created container liveness-probe
  Normal  Started    100s  kubelet            Started container liveness-probe
  Normal  Pulled     100s  kubelet            Container image "localhost:5000/vmware/syncer:vsphere70u3-a312aa0" already present on machine
  Normal  Created    100s  kubelet            Created container vsphere-syncer
  Normal  Started    100s  kubelet            Started container vsphere-syncer
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add healthz port for CSI controller and use emptyDir for CSI socket file
```
