### PR TITLE
[WIP] [release-2.3] enable released features without the need of creating internal-feature-states.csi.vsphere.vmware.com config-map

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -96,7 +96,7 @@ roleRef:
 ---
 apiVersion: v1
 data:
-  "csi-migration": "false"
+  "csi-migration": "true"
   "csi-auth-check": "true"
   "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
enabling `csi-migration`, `csi-auth-check` and `online-volume-extend` features even when `internal-feature-states.csi.vsphere.vmware.com` config-map is not present on the cluster.

If config-map is added later to disable `csi-migration`, `csi-auth-check` and `online-volume-extend` features, it will not be honored.

if config-map is added later to enable other features for example - `trigger-csi-fullsync`, it will be honored.


**Testing done**:
Testing is in progress

**Special notes for your reviewer**:
This change is required for TKGI 1.12 + release.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
enable released features without the need of creating internal-feature-states.csi.vsphere.vmware.com config-map
```

cc: @shalini-b