### PR TITLE
Clean up white spaces in utils.go

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -26,23 +26,26 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
-// QueryVolumeUtil helps to invoke query volume API based on the feature state set for using query async volume.
-// If useQueryVolumeAsync is set to true, the function invokes CNS QueryVolumeAsync, otherwise it invokes synchronous QueryVolume API
-// The function also take volume manager instance, query filters, query selection as params
-// Returns queryResult when query volume succeeds, otherwise returns appropriate errors
-func QueryVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cnstypes.CnsQueryFilter, querySelection cnstypes.CnsQuerySelection, useQueryVolumeAsync bool) (*cnstypes.CnsQueryResult, error) {
+// QueryVolumeUtil helps to invoke query volume API based on the feature
+// state set for using query async volume. If useQueryVolumeAsync is set to
+// true, the function invokes CNS QueryVolumeAsync, otherwise it invokes
+// synchronous QueryVolume API. The function also take volume manager instance,
+// query filters, query selection as params. Returns queryResult when query
+// volume succeeds, otherwise returns appropriate errors.
+func QueryVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cnstypes.CnsQueryFilter,
+	querySelection cnstypes.CnsQuerySelection, useQueryVolumeAsync bool) (*cnstypes.CnsQueryResult, error) {
 	log := logger.GetLogger(ctx)
 	var queryAsyncNotSupported bool
 	var queryResult *cnstypes.CnsQueryResult
 	var err error
 	if useQueryVolumeAsync {
-		// AsyncQueryVolume feature switch is disabled
+		// AsyncQueryVolume feature switch is disabled.
 		queryResult, err = m.QueryVolumeAsync(ctx, queryFilter, querySelection)
 		if err != nil {
 			if err.Error() == cnsvsphere.ErrNotSupported.Error() {
 				log.Warn("QueryVolumeAsync is not supported. Invoking QueryVolume API")
 				queryAsyncNotSupported = true
-			} else { // Return for any other failures
+			} else { // Return for any other failures.
 				return nil, logger.LogNewErrorCodef(log, codes.Internal,
 					"queryVolumeAsync failed for queryFilter: %v. Err=%+v", queryFilter, err.Error())
 			}
@@ -58,23 +61,26 @@ func QueryVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cnsty
 	return queryResult, nil
 }
 
-// QueryAllVolumeUtil helps to invoke query volume API based on the feature state set for using query async volume.
-// If useQueryVolumeAsync is set to true, the function invokes CNS QueryVolumeAsync, otherwise it invokes synchronous QueryAllVolume API
-// The function also take volume manager instance, query filters, query selection as params
-// Returns queryResult when query volume succeeds, otherwise returns appropriate errors
-func QueryAllVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cnstypes.CnsQueryFilter, querySelection cnstypes.CnsQuerySelection, useQueryVolumeAsync bool) (*cnstypes.CnsQueryResult, error) {
+// QueryAllVolumeUtil helps to invoke query volume API based on the feature
+// state set for using query async volume. If useQueryVolumeAsync is set to
+// true, the function invokes CNS QueryVolumeAsync, otherwise it invokes
+// synchronous QueryAllVolume API. The function also take volume manager
+// instance, query filters, query selection as params. Returns queryResult
+// when query volume succeeds, otherwise returns appropriate errors.
+func QueryAllVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cnstypes.CnsQueryFilter,
+	querySelection cnstypes.CnsQuerySelection, useQueryVolumeAsync bool) (*cnstypes.CnsQueryResult, error) {
 	log := logger.GetLogger(ctx)
 	var queryAsyncNotSupported bool
 	var queryResult *cnstypes.CnsQueryResult
 	var err error
 	if useQueryVolumeAsync {
-		// AsyncQueryVolume feature switch is disabled
+		// AsyncQueryVolume feature switch is disabled.
 		queryResult, err = m.QueryVolumeAsync(ctx, queryFilter, querySelection)
 		if err != nil {
 			if err.Error() == cnsvsphere.ErrNotSupported.Error() {
 				log.Warn("QueryVolumeAsync is not supported. Invoking QueryAllVolume API")
 				queryAsyncNotSupported = true
-			} else { // Return for any other failures
+			} else { // Return for any other failures.
 				return nil, logger.LogNewErrorCodef(log, codes.Internal,
 					"queryVolumeAsync failed for queryFilter: %v. Err=%+v", queryFilter, err.Error())
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles pkg/common/utils/utils.go.

**Testing done**:
Local build and check.