### PR TITLE
Add CallerSkip option for logger wrappers

### DIFF
--- a/pkg/csi/service/logger/logger.go
+++ b/pkg/csi/service/logger/logger.go
@@ -98,24 +98,26 @@ func GetLoggerWithNoContext() *zap.SugaredLogger {
 
 // LogNewError logs an error msg, and returns error with msg.
 func LogNewError(log *zap.SugaredLogger, msg string) error {
-	log.Error(msg)
+	log.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar().Error(msg)
 	return errors.New(msg)
 }
 
 // LogNewErrorf logs a formated msg, and returns error with msg.
 func LogNewErrorf(log *zap.SugaredLogger, format string, a ...interface{}) error {
 	msg := fmt.Sprintf(format, a...)
-	return LogNewError(log, msg)
+	log.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar().Error(msg)
+	return errors.New(msg)
 }
 
 // LogNewErrorCode logs an error msg, and returns error with code and msg.
 func LogNewErrorCode(log *zap.SugaredLogger, c codes.Code, msg string) error {
-	log.Error(msg)
+	log.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar().Error(msg)
 	return status.Error(c, msg)
 }
 
 // LogNewErrorCodef logs a formated msg, and returns error with code and msg.
 func LogNewErrorCodef(log *zap.SugaredLogger, c codes.Code, format string, a ...interface{}) error {
 	msg := fmt.Sprintf(format, a...)
-	return LogNewErrorCode(log, c, msg)
+	log.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar().Error(msg)
+	return status.Error(c, msg)
 }

--- a/pkg/csi/service/logger/logger_test.go
+++ b/pkg/csi/service/logger/logger_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/csi/service/logger/logger_test.go
+++ b/pkg/csi/service/logger/logger_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+)
+
+func TestLogNewError(t *testing.T) {
+	log := GetLoggerWithNoContext()
+	e := LogNewError(log, "Error Test")
+	if e == nil {
+		t.Error("Failed to create an error")
+	}
+}
+
+func TestLogNewErrorf(t *testing.T) {
+	log := GetLoggerWithNoContext()
+	e := LogNewErrorf(log, "%s", "Error Test")
+	if e == nil {
+		t.Error("Failed to create an error")
+	}
+}
+
+func TestLogNewErrorCode(t *testing.T) {
+	log := GetLoggerWithNoContext()
+	e := LogNewErrorCode(log, codes.Unknown, "Error Test")
+	if e == nil {
+		t.Error("Failed to create an error")
+	}
+}
+
+func TestLogNewErrorCodef(t *testing.T) {
+	log := GetLoggerWithNoContext()
+	e := LogNewErrorCodef(log, codes.Unknown, "%s", "Error Test")
+	if e == nil {
+		t.Error("Failed to create an error")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
If we use a log wrapper, the caller will always be the wrapper. Though the backtrace contains the entire call stack, it is inconvenient for debugging.

Instead, let's use the AddCallerSkip option to skip the wrapper. Then, the "caller" of the log message is correct.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes bug 2789535

**Testing done**:
Added unit tests.

= Before the fix =
=== RUN   TestLogNewError
{"level":"error","time":"2021-06-23T08:58:10.07937865-07:00","caller":"logger/logger.go:101","msg":"Error Test","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.LogNewError\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger.go:101\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.TestLogNewError\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger_test.go:26\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1127"}
--- PASS: TestLogNewError (0.00s)
=== RUN   TestLogNewErrorf
{"level":"error","time":"2021-06-23T08:58:10.079488202-07:00","caller":"logger/logger.go:101","msg":"Error Test","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.LogNewError\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger.go:101\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.LogNewErrorf\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger.go:108\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.TestLogNewErrorf\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger_test.go:34\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1127"}
--- PASS: TestLogNewErrorf (0.00s)
=== RUN   TestLogNewErrorCode
{"level":"error","time":"2021-06-23T08:58:10.07955121-07:00","caller":"logger/logger.go:113","msg":"Error Test","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.LogNewErrorCode\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger.go:113\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.TestLogNewErrorCode\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger_test.go:42\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1127"}
--- PASS: TestLogNewErrorCode (0.00s)
=== RUN   TestLogNewErrorCodef
{"level":"error","time":"2021-06-23T08:58:10.079585636-07:00","caller":"logger/logger.go:113","msg":"Error Test","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.LogNewErrorCode\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger.go:113\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.LogNewErrorCodef\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger.go:120\nsigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.TestLogNewErrorCodef\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger_test.go:50\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1127"}
--- PASS: TestLogNewErrorCodef (0.00s)

= After the fix =
=== RUN   TestLogNewError
{"level":"error","time":"2021-06-23T09:10:55.010746026-07:00","caller":"logger/logger_test.go:27","msg":"Error Test","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.TestLogNewError\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger_test.go:27\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1127"}
--- PASS: TestLogNewError (0.00s)
=== RUN   TestLogNewErrorf
{"level":"error","time":"2021-06-23T09:10:55.010873824-07:00","caller":"logger/logger_test.go:35","msg":"Error Test","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.TestLogNewErrorf\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger_test.go:35\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1127"}
--- PASS: TestLogNewErrorf (0.00s)
=== RUN   TestLogNewErrorCode
{"level":"error","time":"2021-06-23T09:10:55.010918577-07:00","caller":"logger/logger_test.go:43","msg":"Error Test","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.TestLogNewErrorCode\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger_test.go:43\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1127"}
--- PASS: TestLogNewErrorCode (0.00s)
=== RUN   TestLogNewErrorCodef
{"level":"error","time":"2021-06-23T09:10:55.01095497-07:00","caller":"logger/logger_test.go:51","msg":"Error Test","stacktrace":"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger.TestLogNewErrorCodef\n\t/home/zpan/vsphere-csi-driver/pkg/csi/service/logger/logger_test.go:51\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1127"}
--- PASS: TestLogNewErrorCodef (0.00s)