### PR TITLE
[cherry-pick-2.3] Add CallerSkip option for logger wrappers (#1011)

### DIFF
--- a/pkg/csi/service/logger/logger.go
+++ b/pkg/csi/service/logger/logger.go
@@ -98,24 +98,26 @@ func GetLoggerWithNoContext() *zap.SugaredLogger {
 
 // LogNewError logs an error msg, and returns error with msg.
 func LogNewError(log *zap.SugaredLogger, msg string) error {
-	log.Error(msg)
+	log.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar().Error(msg)
 	return errors.New(msg)
 }
 
 // LogNewErrorf logs a formated msg, and returns error with msg.
 func LogNewErrorf(log *zap.SugaredLogger, format string, a ...interface{}) error {
 	msg := fmt.Sprintf(format, a...)
-	return LogNewError(log, msg)
+	log.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar().Error(msg)
+	return errors.New(msg)
 }
 
 // LogNewErrorCode logs an error msg, and returns error with code and msg.
 func LogNewErrorCode(log *zap.SugaredLogger, c codes.Code, msg string) error {
-	log.Error(msg)
+	log.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar().Error(msg)
 	return status.Error(c, msg)
 }
 
 // LogNewErrorCodef logs a formated msg, and returns error with code and msg.
 func LogNewErrorCodef(log *zap.SugaredLogger, c codes.Code, format string, a ...interface{}) error {
 	msg := fmt.Sprintf(format, a...)
-	return LogNewErrorCode(log, c, msg)
+	log.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar().Error(msg)
+	return status.Error(c, msg)
 }

--- a/pkg/csi/service/logger/logger_test.go
+++ b/pkg/csi/service/logger/logger_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+)
+
+func TestLogNewError(t *testing.T) {
+	log := GetLoggerWithNoContext()
+	e := LogNewError(log, "Error Test")
+	if e == nil {
+		t.Error("Failed to create an error")
+	}
+}
+
+func TestLogNewErrorf(t *testing.T) {
+	log := GetLoggerWithNoContext()
+	e := LogNewErrorf(log, "%s", "Error Test")
+	if e == nil {
+		t.Error("Failed to create an error")
+	}
+}
+
+func TestLogNewErrorCode(t *testing.T) {
+	log := GetLoggerWithNoContext()
+	e := LogNewErrorCode(log, codes.Unknown, "Error Test")
+	if e == nil {
+		t.Error("Failed to create an error")
+	}
+}
+
+func TestLogNewErrorCodef(t *testing.T) {
+	log := GetLoggerWithNoContext()
+	e := LogNewErrorCodef(log, codes.Unknown, "%s", "Error Test")
+	if e == nil {
+		t.Error("Failed to create an error")
+	}
+}


### PR DESCRIPTION
This PR is cherry-picking https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1011 to release-2.3 branch.