### PR TITLE
Add check for CSI volume spec in PVUpdated method

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -990,7 +990,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 	if newPv.Spec.CSI != nil {
 		_, isdynamicCSIPV = newPv.Spec.CSI.VolumeAttributes[attribCSIProvisionerID]
 	}
-	if oldPv.Status.Phase == v1.VolumePending && newPv.Status.Phase == v1.VolumeAvailable && !isdynamicCSIPV {
+	if oldPv.Status.Phase == v1.VolumePending && newPv.Status.Phase == v1.VolumeAvailable && !isdynamicCSIPV && newPv.Spec.CSI != nil {
 		// Static PV is Created
 		var volumeType string
 		if IsMultiAttachAllowed(oldPv) {

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -986,11 +986,11 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 
 	// Dynamically provisioned PVs have a volume attribute called 'storage.kubernetes.io/csiProvisionerIdentity'
 	// in their CSI spec, which is set by external-provisioner.
-	var dynamic bool
+	var isdynamicCSIPV bool
 	if newPv.Spec.CSI != nil {
-		_, dynamic = newPv.Spec.CSI.VolumeAttributes[attribCSIProvisionerID]
+		_, isdynamicCSIPV = newPv.Spec.CSI.VolumeAttributes[attribCSIProvisionerID]
 	}
-	if oldPv.Status.Phase == v1.VolumePending && newPv.Status.Phase == v1.VolumeAvailable && !dynamic {
+	if oldPv.Status.Phase == v1.VolumePending && newPv.Status.Phase == v1.VolumeAvailable && !isdynamicCSIPV {
 		// Static PV is Created
 		var volumeType string
 		if IsMultiAttachAllowed(oldPv) {

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -986,7 +986,10 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 
 	// Dynamically provisioned PVs have a volume attribute called 'storage.kubernetes.io/csiProvisionerIdentity'
 	// in their CSI spec, which is set by external-provisioner.
-	_, dynamic := newPv.Spec.CSI.VolumeAttributes[attribCSIProvisionerID]
+	var dynamic bool
+	if newPv.Spec.CSI != nil {
+		_, dynamic = newPv.Spec.CSI.VolumeAttributes[attribCSIProvisionerID]
+	}
 	if oldPv.Status.Phase == v1.VolumePending && newPv.Status.Phase == v1.VolumeAvailable && !dynamic {
 		// Static PV is Created
 		var volumeType string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding CSI check for volume spec in metadatasyncer. Currently we are assuming that the volumes are always CSI volumes, however for migrated volumes the spec does not contain CSI field and hence a crash was observed during CSI migration testing. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before:
```
1. Create in-tree volumes
2. Deploy CSI driver
3. Enable CSI migration FSS
4. Enable Migration flags on kube-controller-manager and kubelet

k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.21.1/pkg/util/runtime/runtime.go:55 +0x109
panic(0x203bdc0, 0x385fbb0)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
sigs.k8s.io/vsphere-csi-driver/pkg/syncer.csiPVUpdated(0x27e8c78, 0xc0010a8090, 0xc0008ff900, 0xc00024b900, 0xc0000ec000)
	/build/pkg/syncer/metadatasyncer.go:989 +0x304
```

Performed same steps after the fix and no crash was observed

&
Running e2e pipelines

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add check for volume spec in PVUpdated
```
