### PR TITLE
Add benchmarks for LogNewError methods

### DIFF
--- a/pkg/csi/service/logger/logger_test.go
+++ b/pkg/csi/service/logger/logger_test.go
@@ -53,3 +53,47 @@ func TestLogNewErrorCodef(t *testing.T) {
 		t.Error("Failed to create an error")
 	}
 }
+
+func BenchmarkLogNewError(b *testing.B) {
+	log := GetLoggerWithNoContext()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e := LogNewError(log, "Error Benchmark")
+		if e == nil {
+			b.Error("Failed to create an error")
+		}
+	}
+}
+
+func BenchmarkLogNewErrorf(b *testing.B) {
+	log := GetLoggerWithNoContext()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e := LogNewErrorf(log, "%s", "Error Benchmark")
+		if e == nil {
+			b.Error("Failed to create an error")
+		}
+	}
+}
+
+func BenchmarkLogNewErrorCode(b *testing.B) {
+	log := GetLoggerWithNoContext()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e := LogNewErrorCode(log, codes.Unknown, "Error Benchmark")
+		if e == nil {
+			b.Error("Failed to create an error")
+		}
+	}
+}
+
+func BenchmarkLogNewErrorCodef(b *testing.B) {
+	log := GetLoggerWithNoContext()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e := LogNewErrorCodef(log, codes.Unknown, "%s", "Error Benchmark")
+		if e == nil {
+			b.Error("Failed to create an error")
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add four benchmarks to measure the overhead of LogNewError methods.

**Testing done**:
Local build and test.

BenchmarkLogNewError-2        	 2715090	       439 ns/op
BenchmarkLogNewErrorf-2       	 2144805	       528 ns/op
BenchmarkLogNewErrorCode-2    	 2473299	       457 ns/op
BenchmarkLogNewErrorCodef-2   	 2064558	       589 ns/op
