### PR TITLE
Cherry-pick PR (#1013) to rel 2.3 - Add check for CSI volume spec in PVUpdated method 

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -986,8 +986,11 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 
 	// Dynamically provisioned PVs have a volume attribute called 'storage.kubernetes.io/csiProvisionerIdentity'
 	// in their CSI spec, which is set by external-provisioner.
-	_, dynamic := newPv.Spec.CSI.VolumeAttributes[attribCSIProvisionerID]
-	if oldPv.Status.Phase == v1.VolumePending && newPv.Status.Phase == v1.VolumeAvailable && !dynamic {
+	var isdynamicCSIPV bool
+	if newPv.Spec.CSI != nil {
+		_, isdynamicCSIPV = newPv.Spec.CSI.VolumeAttributes[attribCSIProvisionerID]
+	}
+	if oldPv.Status.Phase == v1.VolumePending && newPv.Status.Phase == v1.VolumeAvailable && !isdynamicCSIPV && newPv.Spec.CSI != nil {
 		// Static PV is Created
 		var volumeType string
 		if IsMultiAttachAllowed(oldPv) {


### PR DESCRIPTION
* Add check for volume spec to avoid NPE

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is cherry-picking https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1013 from master


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherry-pick PR (#1013) - Add check for CSI volume spec in PVUpdated method 
```
