### PR TITLE
Clean up white spaces in featurestates

### DIFF
--- a/pkg/internalapis/featurestates/featurestates.go
+++ b/pkg/internalapis/featurestates/featurestates.go
@@ -41,31 +41,34 @@ import (
 )
 
 const (
-	// CRDName represent the name of cnscsisvfeaturestate CRD
+	// CRDName represent the name of cnscsisvfeaturestate CRD.
 	CRDName = "cnscsisvfeaturestates.cns.vmware.com"
-	// CRDGroupName represent the group of cnscsisvfeaturestate CRD
+	// CRDGroupName represent the group of cnscsisvfeaturestate CRD.
 	CRDGroupName = "cns.vmware.com"
-	// CRDSingular represent the singular name of cnscsisvfeaturestate CRD
+	// CRDSingular represent the singular name of cnscsisvfeaturestate CRD.
 	CRDSingular = "cnscsisvfeaturestate"
-	// CRDPlural represent the plural name of cnscsisvfeaturestates CRD
+	// CRDPlural represent the plural name of cnscsisvfeaturestates CRD.
 	CRDPlural = "cnscsisvfeaturestates"
-	// WorkLoadNamespaceLabelKey is the label key found on the workload namespace in the supervisor k8s cluster
+	// WorkLoadNamespaceLabelKey is the label key found on the workload namespace
+	// in the supervisor k8s cluster.
 	WorkLoadNamespaceLabelKey = "vSphereClusterID"
-	// SVFeatureStateCRName to be used for CR in workload namespaces
+	// SVFeatureStateCRName to be used for CR in workload namespaces.
 	SVFeatureStateCRName = "svfeaturestates"
-	// crUpdateRetryInterval is the interval at which pending CR update/create tasks are executed
+	// crUpdateRetryInterval is the interval at which pending CR update/create
+	// tasks are executed.
 	crUpdateRetryInterval = 30 * time.Second
 )
 
-// pendingCRUpdates holds latest states of the namespaces to push CR update, latest feature states and the lock to operate
-// on namespaceUpdateMap and latestFeatureStates
+// pendingCRUpdates holds latest states of the namespaces to push CR update,
+// latest feature states and the lock to operate on namespaceUpdateMap and
+// latestFeatureStates.
 type pendingCRUpdates struct {
-	// lock to acquire before updating namespaceUpdateMap and latestFeatureStates
+	// lock for updating namespaceUpdateMap and latestFeatureStates.
 	lock *sync.RWMutex
-	// holds namespace name and status to update CR in the namespace
-	// map value true, means update is pending, false means no update is required.
+	// Holds namespace name and status to update CR in the namespace.
+	// True means update is pending, false means no update is required.
 	namespaceUpdateMap map[string]bool
-	// latest featureStates
+	// Latest featureStates.
 	latestFeatureStates []featurestatesv1alpha1.FeatureState
 }
 
@@ -77,8 +80,9 @@ var (
 	controllerRuntimeClient                  client.Client
 )
 
-// StartSvFSSReplicationService Starts SvFSSReplicationService
-func StartSvFSSReplicationService(ctx context.Context, svFeatureStatConfigMapName string, svFeatureStateConfigMapNamespace string) error {
+// StartSvFSSReplicationService Starts SvFSSReplicationService.
+func StartSvFSSReplicationService(ctx context.Context, svFeatureStatConfigMapName string,
+	svFeatureStateConfigMapNamespace string) error {
 	log := logger.GetLogger(ctx)
 	log.Info("Starting SvFSSReplicationService")
 
@@ -90,68 +94,70 @@ func StartSvFSSReplicationService(ctx context.Context, svFeatureStatConfigMapNam
 		latestFeatureStates: make([]featurestatesv1alpha1.FeatureState, 0),
 	}
 	var err error
-	// This is idempotent if CRD is pre-created then we continue with initialization of svFSSReplicationService
+	// This is idempotent if CRD is pre-created then we continue with
+	// initialization of svFSSReplicationService.
 	err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, CRDName, CRDSingular, CRDPlural,
-		reflect.TypeOf(featurestatesv1alpha1.CnsCsiSvFeatureStates{}).Name(), CRDGroupName, internalapis.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
+		reflect.TypeOf(featurestatesv1alpha1.CnsCsiSvFeatureStates{}).Name(), CRDGroupName,
+		internalapis.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
 	if err != nil {
 		log.Errorf("failed to create CnsCsiSvFeatureStates CRD. Error: %v", err)
 		return err
 	}
 
-	// Create the kubernetes client
+	// Create the kubernetes client.
 	k8sClient, err = k8s.NewClient(ctx)
 	if err != nil {
 		log.Errorf("create k8s client failed. Err: %v", err)
 		return err
 	}
-	// get kube config
+	// Get kube config.
 	config, err := k8s.GetKubeConfig(ctx)
 	if err != nil {
 		log.Errorf("failed to get kubeconfig. Error: %v", err)
 		return err
 	}
-	// create controller runtime client
+	// Create controller runtime client.
 	controllerRuntimeClient, err = k8s.NewClientForGroup(ctx, config, CRDGroupName)
 	if err != nil {
 		log.Errorf("failed to create controllerRuntimeClient. Err: %v", err)
 		return err
 	}
 
-	// Create k8s Informer and watch on configmaps and namespaces
+	// Create k8s Informer and watch on configmaps and namespaces.
 	informer := k8s.NewInformer(k8sClient)
-	// configmap informer to watch on SV featurestate config-map
+	// Configmap informer to watch on SV featurestate config-map.
 	informer.AddConfigMapListener(ctx, k8sClient, svFeatureStateConfigMapNamespace,
-		// Add
+		// Add.
 		func(Obj interface{}) {
 			configMapAdded(Obj)
 		},
-		// Update
+		// Update.
 		func(oldObj interface{}, newObj interface{}) {
 			configMapUpdated(oldObj, newObj)
 		},
-		// Delete
+		// Delete.
 		func(obj interface{}) {
 			configMapDeleted(obj)
 		})
 
-	// namespace informer to watch on namespaces
+	// Namespace informer to watch on namespaces.
 	informer.AddNamespaceListener(
-		// Add
+		// Add.
 		func(obj interface{}) {
 			namespaceAdded(obj)
 		},
-		// Update
+		// Update.
 		func(oldObj interface{}, newObj interface{}) {
 			namespaceUpdated(oldObj, newObj)
 		},
-		// Delete
+		// Delete.
 		func(obj interface{}) {
 			namespaceDeleted(obj)
 		})
 	informer.Listen()
 	log.Infof("Informer on config-map and namespaces started")
 
-	// Create a dynamic informer for the cnscsisvfeaturestates CR
+	// Create a dynamic informer for the cnscsisvfeaturestates CR.
 	dynInformer, err := k8s.GetDynamicInformer(ctx, CRDGroupName, internalapis.SchemeGroupVersion.Version,
 		CRDPlural, metav1.NamespaceAll, config, true)
 	if err != nil {
@@ -159,11 +165,11 @@ func StartSvFSSReplicationService(ctx context.Context, svFeatureStatConfigMapNam
 		return err
 	}
 	dynInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		// Add
+		// Add.
 		AddFunc: nil,
-		// Update
+		// Update.
 		UpdateFunc: nil,
-		// Delete
+		// Delete.
 		DeleteFunc: func(obj interface{}) {
 			fssCRDeleted(obj)
 		},
@@ -173,7 +179,7 @@ func StartSvFSSReplicationService(ctx context.Context, svFeatureStatConfigMapNam
 		dynInformer.Informer().Run(make(chan struct{}))
 	}()
 
-	// Start routine to process pending feature state updates
+	// Start routine to process pending feature state updates.
 	go pendingCRUpdatesObj.processPendingCRUpdates()
 	log.Infof("Started background routine to process pending feature state updates at regular interval")
 	log.Infof("SvFSSReplicationService is running")
@@ -182,7 +188,7 @@ func StartSvFSSReplicationService(ctx context.Context, svFeatureStatConfigMapNam
 	return nil
 }
 
-// processPendingCRUpdates helps process pending CR updates at regular interval
+// processPendingCRUpdates helps process pending CR updates at regular interval.
 func (pendingCRUpdatesObj *pendingCRUpdates) processPendingCRUpdates() {
 	ticker := time.NewTicker(crUpdateRetryInterval)
 	for range ticker.C {
@@ -193,7 +199,8 @@ func (pendingCRUpdatesObj *pendingCRUpdates) processPendingCRUpdates() {
 			ctx, log := logger.GetNewContextWithLogger()
 			var err error
 			if len(pendingCRUpdatesObj.latestFeatureStates) == 0 {
-				log.Warn("empty feature states observed. feature state config-map might be deleted. Trying to obtain latest feature states.")
+				log.Warn("empty feature states observed. feature state config-map might be deleted. " +
+					"Trying to obtain latest feature states.")
 				pendingCRUpdatesObj.latestFeatureStates, err = getFeatureStates(ctx)
 				if err != nil {
 					log.Errorf("failed to get feature states. error: %v", err)
@@ -206,16 +213,17 @@ func (pendingCRUpdatesObj *pendingCRUpdates) processPendingCRUpdates() {
 					continue
 				}
 				log.Infof("Feature state update is required for namespace: %q", namespace)
-				// check if CR is present on the namespace
+				// Check if CR is present on the namespace.
 				featurestateCR := &featurestatesv1alpha1.CnsCsiSvFeatureStates{}
 				err := controllerRuntimeClient.Get(ctx, client.ObjectKey{Name: SVFeatureStateCRName,
 					Namespace: namespace}, featurestateCR)
 				if err == nil {
-					// Attempt to Update CR
+					// Attempt to Update CR.
 					featurestateCR.Spec.FeatureStates = pendingCRUpdatesObj.latestFeatureStates
 					err = controllerRuntimeClient.Update(ctx, featurestateCR)
 					if err != nil {
-						log.Errorf("failed to update cnsCsiSvFeatureStates CR instance in the namespace: %q, Err: %v", namespace, err)
+						log.Errorf("failed to update cnsCsiSvFeatureStates CR instance in the namespace: %q, Err: %v",
+							namespace, err)
 						continue
 					}
 					pendingCRUpdatesObj.namespaceUpdateMap[namespace] = false
@@ -224,7 +232,7 @@ func (pendingCRUpdatesObj *pendingCRUpdates) processPendingCRUpdates() {
 					if apierrors.IsNotFound(err) {
 						log.Infof("cnsCsiSvFeatureStates CR instance is not present in the namespace: %q. "+
 							"Creating CR with latest feature switch state, Err: %v", namespace, err)
-						// attempt to Create the CR
+						// Attempt to Create the CR.
 						cnsCsiSvFeatureStates := &featurestatesv1alpha1.CnsCsiSvFeatureStates{
 							ObjectMeta: metav1.ObjectMeta{Name: SVFeatureStateCRName, Namespace: namespace},
 							Spec: featurestatesv1alpha1.CnsCsiSvFeatureStatesSpec{
@@ -234,13 +242,15 @@ func (pendingCRUpdatesObj *pendingCRUpdates) processPendingCRUpdates() {
 						err = controllerRuntimeClient.Create(ctx, cnsCsiSvFeatureStates)
 						if err != nil {
 							log.Errorf("failed to create cnsCsiSvFeatureStates CR instance in the "+
-								"namespace: %q. Continuing the FSS replication to other namespaces.., Err: %v", namespace, err)
+								"namespace: %q. Continuing the FSS replication to other namespaces.., Err: %v",
+								namespace, err)
 							continue
 						}
 						pendingCRUpdatesObj.namespaceUpdateMap[namespace] = false
 						log.Infof("Created cnsCsiSvFeatureStates CR instance in the namespace: %q", namespace)
 					} else {
-						log.Errorf("failed to check if cnsCsiSvFeatureStates CR is present in the namespace :%q, err: %v", namespace, err)
+						log.Errorf("failed to check if cnsCsiSvFeatureStates CR is present in the namespace :%q, err: %v",
+							namespace, err)
 					}
 				}
 			}
@@ -248,8 +258,10 @@ func (pendingCRUpdatesObj *pendingCRUpdates) processPendingCRUpdates() {
 	}
 }
 
-// enqueueFeatureStateUpdatesForAllWorkloadNamespaces helps enqueue featurestates updates for all workload namespaces
-func (pendingCRUpdatesObj *pendingCRUpdates) enqueueFeatureStateUpdatesForAllWorkloadNamespaces(ctx context.Context, featurestates []featurestatesv1alpha1.FeatureState) {
+// enqueueFeatureStateUpdatesForAllWorkloadNamespaces helps enqueue
+// featurestates updates for all workload namespaces.
+func (pendingCRUpdatesObj *pendingCRUpdates) enqueueFeatureStateUpdatesForAllWorkloadNamespaces(
+	ctx context.Context, featurestates []featurestatesv1alpha1.FeatureState) {
 	pendingCRUpdatesObj.lock.Lock()
 	defer pendingCRUpdatesObj.lock.Unlock()
 
@@ -261,8 +273,10 @@ func (pendingCRUpdatesObj *pendingCRUpdates) enqueueFeatureStateUpdatesForAllWor
 	log.Infof("Enqueued CR updates for all workload namespaces")
 }
 
-// enqueueFeatureStateUpdatesForWorkloadNamespace enqueues CR updates for specified workload namespaces
-func (pendingCRUpdatesObj *pendingCRUpdates) enqueueFeatureStateUpdatesForWorkloadNamespace(ctx context.Context, namespace string) {
+// enqueueFeatureStateUpdatesForWorkloadNamespace enqueues CR updates for
+// specified workload namespaces.
+func (pendingCRUpdatesObj *pendingCRUpdates) enqueueFeatureStateUpdatesForWorkloadNamespace(
+	ctx context.Context, namespace string) {
 	pendingCRUpdatesObj.lock.Lock()
 	defer pendingCRUpdatesObj.lock.Unlock()
 
@@ -271,7 +285,7 @@ func (pendingCRUpdatesObj *pendingCRUpdates) enqueueFeatureStateUpdatesForWorklo
 	log.Infof("Enqueued CR updates for workload namespace: %q", namespace)
 }
 
-// configMapAdded is called when configmap is created
+// configMapAdded is called when configmap is created.
 func configMapAdded(obj interface{}) {
 	ctx, log := logger.GetNewContextWithLogger()
 	fssConfigMap, ok := obj.(*v1.ConfigMap)
@@ -298,7 +312,7 @@ func configMapAdded(obj interface{}) {
 	}
 }
 
-// configMapUpdated is called when configmap is updated
+// configMapUpdated is called when configmap is updated.
 func configMapUpdated(oldObj, newObj interface{}) {
 	ctx, log := logger.GetNewContextWithLogger()
 	newfssConfigMap, ok := newObj.(*v1.ConfigMap)
@@ -334,7 +348,7 @@ func configMapUpdated(oldObj, newObj interface{}) {
 	}
 }
 
-// configMapDeleted is called when config-map is deleted
+// configMapDeleted is called when config-map is deleted.
 func configMapDeleted(obj interface{}) {
 	_, log := logger.GetNewContextWithLogger()
 	fssConfigMap, ok := obj.(*v1.ConfigMap)
@@ -344,7 +358,8 @@ func configMapDeleted(obj interface{}) {
 	}
 	if fssConfigMap.Name == supervisorFeatureStatConfigMapName &&
 		fssConfigMap.Namespace == supervisorFeatureStateConfigMapNamespace {
-		log.Errorf("supervisor feature switch state configmap %q from the namespace: %q is deleted", supervisorFeatureStatConfigMapName, supervisorFeatureStateConfigMapNamespace)
+		log.Errorf("supervisor feature switch state configmap %q from the namespace: %q is deleted",
+			supervisorFeatureStatConfigMapName, supervisorFeatureStateConfigMapNamespace)
 		os.Exit(1)
 	}
 }
@@ -363,7 +378,7 @@ func namespaceAdded(obj interface{}) {
 	}
 }
 
-// namespaceUpdated is called when namespace is updated
+// namespaceUpdated is called when namespace is updated.
 func namespaceUpdated(oldObj, newObj interface{}) {
 	ctx, log := logger.GetNewContextWithLogger()
 	oldNamespace, ok := oldObj.(*v1.Namespace)
@@ -381,19 +396,21 @@ func namespaceUpdated(oldObj, newObj interface{}) {
 	_, labelPresentInNewNamespace := newNamespace.Labels[WorkLoadNamespaceLabelKey]
 
 	if !labelPresentInOldNamespace && labelPresentInNewNamespace {
-		// Label with Key vSphereClusterID is added on the namespace
+		// Label with Key vSphereClusterID is added on the namespace.
 		log.Infof("Observed new workload namespace: %v", newNamespace.Name)
 		pendingCRUpdatesObj.enqueueFeatureStateUpdatesForWorkloadNamespace(ctx, newNamespace.Name)
 	} else if labelPresentInOldNamespace && !labelPresentInNewNamespace {
-		// Label with Key vSphereClusterID is removed from the namespace
-		log.Infof("label vSphereClusterID is removed from namespace: %q Removing namespace from listing of further feature states CR updates", newNamespace.Name)
+		// Label with Key vSphereClusterID is removed from the namespace.
+		log.Infof("label vSphereClusterID is removed from namespace: %q "+
+			"Removing namespace from listing of further feature states CR updates",
+			newNamespace.Name)
 		pendingCRUpdatesObj.lock.Lock()
 		defer pendingCRUpdatesObj.lock.Unlock()
 		delete(pendingCRUpdatesObj.namespaceUpdateMap, newNamespace.Name)
 	}
 }
 
-// namespaceDeleted is called when namespace is deleted
+// namespaceDeleted is called when namespace is deleted.
 func namespaceDeleted(obj interface{}) {
 	_, log := logger.GetNewContextWithLogger()
 	namespace, ok := obj.(*v1.Namespace)
@@ -409,21 +426,26 @@ func namespaceDeleted(obj interface{}) {
 }
 
 // getFeatureStates returns latest feature states from supervisor config-map
-// if failed to retrieve feature states, func returns error with empty array of FeatureState
+// if failed to retrieve feature states, func returns error with empty array
+// of FeatureState.
 func getFeatureStates(ctx context.Context) ([]featurestatesv1alpha1.FeatureState, error) {
 	log := logger.GetLogger(ctx)
-	//  Retrieve SV FeatureStates configmap
-	fssConfigMap, err := k8sClient.CoreV1().ConfigMaps(supervisorFeatureStateConfigMapNamespace).Get(ctx, supervisorFeatureStatConfigMapName, metav1.GetOptions{})
+	//  Retrieve SV FeatureStates configmap.
+	fssConfigMap, err := k8sClient.CoreV1().ConfigMaps(supervisorFeatureStateConfigMapNamespace).Get(ctx,
+		supervisorFeatureStatConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Errorf("supervisor feature switch state with name: %q not found in the namespace: %q", supervisorFeatureStatConfigMapName, supervisorFeatureStateConfigMapNamespace)
+			log.Errorf("supervisor feature switch state with name: %q not found in the namespace: %q",
+				supervisorFeatureStatConfigMapName, supervisorFeatureStateConfigMapNamespace)
 			os.Exit(1)
 		}
-		log.Errorf("failed to retrieve SV feature switch state from namespace:%q with name: %q", supervisorFeatureStateConfigMapNamespace, supervisorFeatureStatConfigMapName)
+		log.Errorf("failed to retrieve SV feature switch state from namespace:%q with name: %q",
+			supervisorFeatureStateConfigMapNamespace, supervisorFeatureStatConfigMapName)
 		return nil, err
 	}
 
-	log.Infof("Successfully retrieved SV feature switch state from namespace:%q with name: %q", supervisorFeatureStateConfigMapNamespace, supervisorFeatureStatConfigMapName)
+	log.Infof("Successfully retrieved SV feature switch state from namespace:%q with name: %q",
+		supervisorFeatureStateConfigMapNamespace, supervisorFeatureStatConfigMapName)
 	var featureStates []featurestatesv1alpha1.FeatureState
 	for feature, state := range fssConfigMap.Data {
 		var featureState featurestatesv1alpha1.FeatureState
@@ -438,7 +460,7 @@ func getFeatureStates(ctx context.Context) ([]featurestatesv1alpha1.FeatureState
 	return featureStates, nil
 }
 
-// fssCRDeleted is called when cnscsisvfeaturestates is deleted
+// fssCRDeleted is called when cnscsisvfeaturestates is deleted.
 func fssCRDeleted(obj interface{}) {
 	ctx, log := logger.GetNewContextWithLogger()
 	var fssObj featurestatesv1alpha1.CnsCsiSvFeatureStates
@@ -451,15 +473,18 @@ func fssCRDeleted(obj interface{}) {
 		log.Warnf("fssCRDeleted: Ignoring %s CR object with name %q", CRDPlural, fssObj.Name)
 		return
 	}
-	log.Infof("fssCRDeleted: cnscsisvfeaturestates with name: %q is deleted from namespace: %q", fssObj.Name, fssObj.Namespace)
+	log.Infof("fssCRDeleted: cnscsisvfeaturestates with name: %q is deleted from namespace: %q",
+		fssObj.Name, fssObj.Namespace)
 	if isNamespaceDeleted(ctx, fssObj.Namespace) {
 		return
 	}
-	log.Infof("Namespace: %q is not being deleted. putting back cnscsisvfeaturestates CR on the namespace", fssObj.Namespace)
+	log.Infof("Namespace: %q is not being deleted. putting back cnscsisvfeaturestates CR on the namespace",
+		fssObj.Namespace)
 	pendingCRUpdatesObj.enqueueFeatureStateUpdatesForWorkloadNamespace(ctx, fssObj.Namespace)
 }
 
-// isNamespaceDeleted return true if namespace is deleted or DeletionTimestamp is present on the namespace
+// isNamespaceDeleted return true if namespace is deleted or DeletionTimestamp
+// is present on the namespace.
 func isNamespaceDeleted(ctx context.Context, namespace string) bool {
 	log := logger.GetLogger(ctx)
 	for {


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles featurestates.go.

**Testing done**:
Local build and check.