### PR TITLE
[e2e-test]: RWX automation - Adding utilities for CnsFileAccessConfig CRD creation and deletion

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -32,6 +32,7 @@ const (
 	configSecret                               = "vsphere-config-secret"
 	crdCNSNodeVMAttachment                     = "cnsnodevmattachments"
 	crdCNSVolumeMetadatas                      = "cnsvolumemetadatas"
+	crdCNSFileAccessConfig                     = "cnsfileaccessconfigs"
 	crdGroup                                   = "cns.vmware.com"
 	crdVersion                                 = "v1alpha1"
 	csiSystemNamespace                         = "vmware-system-csi"

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -65,6 +65,7 @@ import (
 	fssh "k8s.io/kubernetes/test/e2e/framework/ssh"
 
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator"
+	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
 	cnsnodevmattachmentv1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1"
 	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
@@ -1305,6 +1306,16 @@ func verifyCRDInSupervisor(ctx context.Context, f *framework.Framework, expected
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if expectedInstanceName == instance.Name {
 				ginkgo.By(fmt.Sprintf("Found CNSVolumeMetadata crd: %v, expected: %v", instance, expectedInstanceName))
+				instanceFound = true
+				break
+			}
+		}
+		if crdName == "cnsfileaccessconfigs" {
+			instance := &cnsfileaccessconfigv1alpha1.CnsFileAccessConfig{}
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(crd.Object, instance)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			if expectedInstanceName == instance.Name {
+				ginkgo.By(fmt.Sprintf("Found CNSFileAccessConfig crd: %v, expected: %v", instance, expectedInstanceName))
 				instanceFound = true
 				break
 			}


### PR DESCRIPTION
[e2e-test]: RWX automation - Adding utilities for CnsFileAccessConfig CRD creation and deletion

Addition Utilities for the CnsFileAccessConfig CRD 's lifecycle

Test Logs:
https://gist.github.com/rpanduranga/9bda17d737e68ceeaab136be38aa4ecc