### PR TITLE
Set QPS and burst for external attacher in supervisor

### DIFF
--- a/manifests/supervisorcluster/1.17/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.17/cns-csi.yaml
@@ -177,6 +177,8 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.18/cns-csi.yaml
@@ -180,6 +180,8 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.19/cns-csi.yaml
@@ -189,6 +189,8 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -189,6 +189,8 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -189,6 +189,8 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Performance team reported that after upgrading external attacher to v3.2.1, the CSI mixed workload performance on wcp supervisor cluster regressed by almost half. They have already confirmed that after increasing the csi-attacher QPS to 100, the csibench throughput is the same as the previous good run.
This PR adds QPS and burst parameters for external attacher v3.2 in supervisor clusters.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP e2e pipeline should be good enough to ensure that this does not cause any regression.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Set QPS and burst for external attacher in supervisor
```
