### PR TITLE
Clean up white spaces under vsphere

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcentermanager.go
+++ b/pkg/common/cns-lib/vsphere/virtualcentermanager.go
@@ -54,7 +54,8 @@ type VirtualCenterManager interface {
 	IsvSANFileServicesSupported(ctx context.Context, host string) (bool, error)
 	// IsExtendVolumeSupported checks if extend volume is supported or not.
 	IsExtendVolumeSupported(ctx context.Context, host string) (bool, error)
-	// IsOnlineExtendVolumeSupported checks if online extend volume is supported or not on the vCenter Host
+	// IsOnlineExtendVolumeSupported checks if online extend volume is supported
+	// or not on the vCenter Host.
 	IsOnlineExtendVolumeSupported(ctx context.Context, host string) (bool, error)
 }
 
@@ -106,14 +107,16 @@ func (m *defaultVirtualCenterManager) GetAllVirtualCenters() []*VirtualCenter {
 	return vcs
 }
 
-func (m *defaultVirtualCenterManager) RegisterVirtualCenter(ctx context.Context, config *VirtualCenterConfig) (*VirtualCenter, error) {
+func (m *defaultVirtualCenterManager) RegisterVirtualCenter(ctx context.Context,
+	config *VirtualCenterConfig) (*VirtualCenter, error) {
 	log := logger.GetLogger(ctx)
 	if _, exists := m.virtualCenters.Load(config.Host); exists {
 		log.Errorf("VC was already found in registry, failed to register with config %v", config)
 		return nil, ErrVCAlreadyRegistered
 	}
 
-	vc := &VirtualCenter{Config: config} // Note that the Client isn't initialized here.
+	// Note that the Client isn't initialized here.
+	vc := &VirtualCenter{Config: config}
 	m.virtualCenters.Store(config.Host, vc)
 	log.Infof("Successfully registered VC %q", vc.Config.Host)
 	return vc, nil
@@ -179,14 +182,15 @@ func (m *defaultVirtualCenterManager) IsExtendVolumeSupported(ctx context.Contex
 func (m *defaultVirtualCenterManager) IsOnlineExtendVolumeSupported(ctx context.Context, host string) (bool, error) {
 	log := logger.GetLogger(ctx)
 
-	// Get VC instance
+	// Get VC instance.
 	vcenter, err := m.GetVirtualCenter(ctx, host)
 	if err != nil {
 		log.Errorf("Failed to get vCenter. Err: %v", err)
 		return false, err
 	}
 	vCenterVersion := vcenter.Client.Version
-	if vCenterVersion != cns.ReleaseVSAN67u3 && vCenterVersion != cns.ReleaseVSAN70 && vCenterVersion != cns.ReleaseVSAN70u1 {
+	if vCenterVersion != cns.ReleaseVSAN67u3 && vCenterVersion != cns.ReleaseVSAN70 &&
+		vCenterVersion != cns.ReleaseVSAN70u1 {
 		return true, nil
 	}
 	log.Infof("Online volume expansion is not supported on vCenter version %q", vCenterVersion)


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles files under cns-lib/vsphere.

**Testing done**:
Local build and check.