### PR TITLE
Clean white spaces in kubernetes

### DIFF
--- a/pkg/kubernetes/dynamicInformers.go
+++ b/pkg/kubernetes/dynamicInformers.go
@@ -38,7 +38,8 @@ var (
 
 // newDynamicInformerFactory creates a dynamic informer factory for a given
 // namespace if it doesn't exist already.
-func newDynamicInformerFactory(ctx context.Context, cfg *restclient.Config, namespace string, isInCluster bool) (dynamicinformer.DynamicSharedInformerFactory, error) {
+func newDynamicInformerFactory(ctx context.Context, cfg *restclient.Config, namespace string,
+	isInCluster bool) (dynamicinformer.DynamicSharedInformerFactory, error) {
 	log := logger.GetLogger(ctx)
 	var (
 		dynamicInformerFactory dynamicinformer.DynamicSharedInformerFactory
@@ -86,7 +87,8 @@ func newDynamicInformerFactory(ctx context.Context, cfg *restclient.Config, name
 // If isInCluster is set to true, the config contains credentials to the in
 // cluster API server. If isInCluster is set to false, config contains
 // credentials to the supervisor cluster.
-func GetDynamicInformer(ctx context.Context, crdGroup, crdVersion, crdName, namespace string, cfg *restclient.Config, isInCluster bool) (informers.GenericInformer, error) {
+func GetDynamicInformer(ctx context.Context, crdGroup, crdVersion, crdName, namespace string,
+	cfg *restclient.Config, isInCluster bool) (informers.GenericInformer, error) {
 	log := logger.GetLogger(ctx)
 	var err error
 

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -199,7 +199,8 @@ func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName
 
 // NewCnsFileAccessConfigWatcher creates a new ListWatch for VirtualMachines
 // given rest client config.
-func NewCnsFileAccessConfigWatcher(ctx context.Context, config *restclient.Config, namespace string) (*cache.ListWatch, error) {
+func NewCnsFileAccessConfigWatcher(ctx context.Context, config *restclient.Config,
+	namespace string) (*cache.ListWatch, error) {
 	var err error
 	log := logger.GetLogger(ctx)
 
@@ -224,7 +225,8 @@ func NewCnsFileAccessConfigWatcher(ctx context.Context, config *restclient.Confi
 
 // NewVirtualMachineWatcher creates a new ListWatch for VirtualMachines given
 // rest client config.
-func NewVirtualMachineWatcher(ctx context.Context, config *restclient.Config, namespace string) (*cache.ListWatch, error) {
+func NewVirtualMachineWatcher(ctx context.Context, config *restclient.Config,
+	namespace string) (*cache.ListWatch, error) {
 	var err error
 	log := logger.GetLogger(ctx)
 
@@ -247,8 +249,8 @@ func NewVirtualMachineWatcher(ctx context.Context, config *restclient.Config, na
 	return cache.NewListWatchFromClient(client, virtualMachineKind, namespace, fields.Everything()), nil
 }
 
-// NewCSINodeTopologyWatcher creates a new ListWatch for CSINodeTopology objects given
-// rest client config.
+// NewCSINodeTopologyWatcher creates a new ListWatch for CSINodeTopology objects
+// given rest client config.
 func NewCSINodeTopologyWatcher(ctx context.Context, config *restclient.Config) (*cache.ListWatch, error) {
 	var err error
 	log := logger.GetLogger(ctx)
@@ -273,7 +275,8 @@ func NewCSINodeTopologyWatcher(ctx context.Context, config *restclient.Config) (
 	return cache.NewListWatchFromClient(client, csiNodeTopologyKind, v1.NamespaceAll, fields.Everything()), nil
 }
 
-// CreateKubernetesClientFromConfig creaates a newk8s client from given kubeConfig file.
+// CreateKubernetesClientFromConfig creaates a newk8s client from given
+// kubeConfig file.
 func CreateKubernetesClientFromConfig(kubeConfigPath string) (clientset.Interface, error) {
 
 	cfg, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
@@ -321,7 +324,8 @@ func getClientThroughput(ctx context.Context, isSupervisorClient bool) (float32,
 	}
 
 	if v := os.Getenv(envClientQPS); v != "" {
-		if value, err := strconv.ParseFloat(v, 32); err != nil || float32(value) < minClientQPS || float32(value) > maxClientQPS {
+		value, err := strconv.ParseFloat(v, 32)
+		if err != nil || float32(value) < minClientQPS || float32(value) > maxClientQPS {
 			log.Warnf("Invalid value set for env variable %s: %v. Using default value.", envClientQPS, v)
 		} else {
 			qps = float32(value)
@@ -395,9 +399,11 @@ func createCustomResourceDefinition(ctx context.Context, newCrd *apiextensionsv1
 	}
 
 	crdName := newCrd.ObjectMeta.Name
-	crd, err := apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
+	crd, err := apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(ctx,
+		crdName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx, newCrd, metav1.CreateOptions{})
+		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx,
+			newCrd, metav1.CreateOptions{})
 		if err != nil {
 			log.Errorf("Failed to create %q CRD with err: %+v", crdName, err)
 			return err
@@ -407,7 +413,8 @@ func createCustomResourceDefinition(ctx context.Context, newCrd *apiextensionsv1
 		// Update the existing CRD with new CRD.
 		crd.Spec = newCrd.Spec
 		crd.Status = newCrd.Status
-		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Update(ctx, crd, metav1.UpdateOptions{})
+		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Update(ctx,
+			crd, metav1.UpdateOptions{})
 		if err != nil {
 			log.Errorf("Failed to update %q CRD with err: %+v", crdName, err)
 			return err
@@ -451,7 +458,8 @@ func waitForCustomResourceToBeEstablished(ctx context.Context,
 	// If there is an error, delete the object to keep it clean.
 	if err != nil {
 		log.Infof("Cleanup %q CRD because the CRD created was not successfully established. Err: %+v", crdName, err)
-		deleteErr := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(ctx, crdName, *metav1.NewDeleteOptions(0))
+		deleteErr := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(ctx,
+			crdName, *metav1.NewDeleteOptions(0))
 		if deleteErr != nil {
 			log.Errorf("Failed to delete %q CRD with err: %+v", crdName, deleteErr)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles files under pkg/kubernetes.

**Testing done**:
Local build and check.