### PR TITLE
Clean up white spaces in vanilla helper

### DIFF
--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -38,33 +38,37 @@ func validateVanillaDeleteVolumeRequest(ctx context.Context, req *csi.DeleteVolu
 }
 
 // validateControllerPublishVolumeRequest is the helper function to validate
-// ControllerPublishVolumeRequest. Function returns error if validation fails otherwise returns nil.
-func validateVanillaControllerPublishVolumeRequest(ctx context.Context, req *csi.ControllerPublishVolumeRequest) error {
+// ControllerPublishVolumeRequest. Function returns error if validation fails
+// otherwise returns nil.
+func validateVanillaControllerPublishVolumeRequest(ctx context.Context,
+	req *csi.ControllerPublishVolumeRequest) error {
 	return common.ValidateControllerPublishVolumeRequest(ctx, req)
 }
 
 // validateControllerUnpublishVolumeRequest is the helper function to validate
-// ControllerUnpublishVolumeRequest. Function returns error if validation fails otherwise returns nil.
-func validateVanillaControllerUnpublishVolumeRequest(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) error {
+// ControllerUnpublishVolumeRequest. Function returns error if validation fails
+// otherwise returns nil.
+func validateVanillaControllerUnpublishVolumeRequest(ctx context.Context,
+	req *csi.ControllerUnpublishVolumeRequest) error {
 	return common.ValidateControllerUnpublishVolumeRequest(ctx, req)
 }
 
-// validateVanillaControllerExpandVolumeRequest is the helper function to validate
-// ExpandVolumeRequest for Vanilla CSI driver.
+// validateVanillaControllerExpandVolumeRequest is the helper function to
+// validate ExpandVolumeRequest for Vanilla CSI driver.
 // Function returns error if validation fails otherwise returns nil.
-func validateVanillaControllerExpandVolumeRequest(ctx context.Context, req *csi.ControllerExpandVolumeRequest,
-	isOnlineExpansionEnabled, isOnlineExpansionSupported bool) error {
+func validateVanillaControllerExpandVolumeRequest(ctx context.Context,
+	req *csi.ControllerExpandVolumeRequest, isOnlineExpansionEnabled, isOnlineExpansionSupported bool) error {
 	log := logger.GetLogger(ctx)
 	if err := common.ValidateControllerExpandVolumeRequest(ctx, req); err != nil {
 		return err
 	}
 
-	// Check online extend FSS and vCenter support
+	// Check online extend FSS and vCenter support.
 	if isOnlineExpansionEnabled && isOnlineExpansionSupported {
 		return nil
 	}
 
-	// Check if it is an online expansion scenario and raise error
+	// Check if it is an online expansion scenario and raise error.
 	nodeManager := node.GetManager(ctx)
 	nodes, err := nodeManager.GetAllNodes(ctx)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles vanilla controller helper.

**Testing done**:
Local build and check.