### PR TITLE
Reset Volume Manager during reload config & ca file rotation

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -182,7 +182,6 @@ func (m *defaultManager) ResetManager(ctx context.Context, vcenter *cnsvsphere.V
 	defer managerInstanceLock.Unlock()
 	log.Infof("Re-initializing defaultManager.virtualCenter")
 	managerInstance.virtualCenter = vcenter
-	m.virtualCenter.Config = vcenter.Config
 	if m.virtualCenter.Client != nil {
 		m.virtualCenter.Client.Timeout = time.Duration(vcenter.Config.VCClientTimeout) * time.Minute
 		log.Infof("VC client timeout is set to %v", m.virtualCenter.Client.Timeout)

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -180,10 +180,8 @@ func (m *defaultManager) ResetManager(ctx context.Context, vcenter *cnsvsphere.V
 	log := logger.GetLogger(ctx)
 	managerInstanceLock.Lock()
 	defer managerInstanceLock.Unlock()
-	if vcenter.Config.Host != managerInstance.virtualCenter.Config.Host {
-		log.Infof("Re-initializing defaultManager.virtualCenter")
-		managerInstance.virtualCenter = vcenter
-	}
+	log.Infof("Re-initializing defaultManager.virtualCenter")
+	managerInstance.virtualCenter = vcenter
 	m.virtualCenter.Config = vcenter.Config
 	if m.virtualCenter.Client != nil {
 		m.virtualCenter.Client.Timeout = time.Duration(vcenter.Config.VCClientTimeout) * time.Minute


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is resetting VC instance in volume manager during reload config. Currently, the VC instance is reset only when VC hostname is changed. However with secure connection supported in WCP & Vanilla, the existing secure connections before reload config(before certificates regeneration) do not continue to work. Instead, the VC instance has to be invalidated(reset) during reload config.

Before the change:
```
2021-06-25T04:02:05.824Z	ERROR	vsphere/virtualcenter.go:380	failed to logout with err: Post "https://wdc-10-206-211-101.eng.vmware.com:443/sdk": x509: certificate signed by unknown authority	{"TraceId": "7424f9b9-7943-4115-94d1-e169eb5ecda3"}
...
...
2021-06-25T02:49:16.337Z	ERROR	wcp/controller.go:394	failed to create volume. Error: Post "https://wdc-10-206-211-101.eng.vmware.com:443/sdk": x509: certificate signed by unknown authority	{"TraceId": "83579658-378c-40c3-8b8f-78a0810da4ff"}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
After the change:
```
2021-06-25T04:02:05.824Z	ERROR	vsphere/virtualcenter.go:380	failed to logout with err: Post "https://wdc-10-206-211-101.eng.vmware.com:443/sdk": x509: certificate signed by unknown authority
...
...
2021-06-25T04:08:08.945Z	INFO	volume/manager.go:373	CreateVolume: VolumeName: "pvc-4d686822-d5b4-4c1c-a482-4eb2ce806429", opId: "70232970"	{"TraceId": "885b6eda-de09-4220-aea5-05d57743a1be"}
2021-06-25T04:08:08.950Z	INFO	volume/util.go:324	Volume created successfully. VolumeName: "pvc-4d686822-d5b4-4c1c-a482-4eb2ce806429", volumeID: "1cecb4cc-2441-45ae-ab73-cf0c1757002f"	{"TraceId": "885b6eda-de09-4220-aea5-05d57743a1be"}
2021-06-25T04:08:08.950Z	DEBUG	volume/util.go:326	CreateVolume volumeId {{} "1cecb4cc-2441-45ae-ab73-cf0c1757002f"} is placed on datastore "ds:///vmfs/volumes/31851da9-724c4301/"	{"TraceId": "885b6eda-de09-4220-aea5-05d57743a1be"}
2021-06-25T04:08:08.955Z	DEBUG	wcp/controller.go:418	Volume Accessible Topology: []	{"TraceId": "885b6eda-de09-4220-aea5-05d57743a1be"}
2021-06-25T04:08:09.056Z	DEBUG	k8sorchestrator/k8sorchestrator.go:680	pvUpdated: PV pvc-4d686822-d5b4-4c1c-a482-4eb2ce806429 went to Bound phase	{"TraceId": "3997e870-15fb-49c0-bb92-9c6d70fd0401"}
2021-06-25T04:08:09.056Z	DEBUG	k8sorchestrator/k8sorchestrator.go:686	pvUpdated: Added '1cecb4cc-2441-45ae-ab73-cf0c1757002f -> storage-class-test-1/example-vanilla-block-pvc' pair to volumeIDToPvcMap	{"TraceId": "3997e870-15fb-49c0-bb92-9c6d70fd0401"}
2021-06-25T04:08:27.894Z	INFO	wcp/controller.go:556	DeleteVolume: called with args: {VolumeId:1cecb4cc-2441-45ae-ab73-cf0c1757002f Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "a0a7affd-5575-497c-bf8e-a26b873c1a0d"}
2021-06-25T04:08:27.894Z	DEBUG	common/vsphereutil.go:469	vSphere CSI driver is deleting volume: 1cecb4cc-2441-45ae-ab73-cf0c1757002f with deleteDisk flag: true	{"TraceId": "a0a7affd-5575-497c-bf8e-a26b873c1a0d"}
2021-06-25T04:08:27.902Z	INFO	vsphere/virtualcenter.go:269	vc.Config.CAFile /etc/vmware/wcp/tls/vmca.pem	{"TraceId": "a0a7affd-5575-497c-bf8e-a26b873c1a0d"}
2021-06-25T04:08:28.547Z	INFO	volume/manager.go:696	DeleteVolume: volumeID: "1cecb4cc-2441-45ae-ab73-cf0c1757002f", opId: "7023297e"	{"TraceId": "a0a7affd-5575-497c-bf8e-a26b873c1a0d"}
```

Steps performed for testing:
```
Step 1: Create volumes
Step 2: Performed CA file rotation
Step 3: Delete volumes succeeded
Step 4: Performed CA file rotation
Step 5: Created volume again & succeeded
```
Logs: https://gist.github.com/chethanv28/aa96a69c906627e6fb27bb4c6ee14b20

Running e2e pipelines

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Reset Volume Manager during reload config & ca file rotation
```
