### PR TITLE
Clean up white spaces in admissionhandler

### DIFF
--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -42,7 +42,7 @@ type (
 	parameterSet map[string]struct{}
 )
 
-// Has checks if specified paramName present in the paramSet
+// Has checks if specified paramName present in the paramSet.
 func (paramSet parameterSet) Has(paramName string) bool {
 	_, ok := paramSet[paramName]
 	return ok
@@ -52,13 +52,13 @@ var (
 	server *http.Server
 	cfg    *config
 	// COInitParams stores the input params required for initiating the
-	// CO agnostic orchestrator in the admission handler package
+	// CO agnostic orchestrator in the admission handler package.
 	COInitParams                 *interface{}
 	containerOrchestratorUtility commonco.COCommonInterface
 )
 
-// watchConfigChange watches on the webhook configuration directory for changes like cert, key etc.
-// this is required for certificate rotation
+// watchConfigChange watches on the webhook configuration directory for changes
+// like cert, key etc. This is required for certificate rotation.
 func watchConfigChange() {
 	ctx, log := logger.GetNewContextWithLogger()
 	cfg, err := getWebHookConfig(ctx)
@@ -114,7 +114,7 @@ func watchConfigChange() {
 	}
 }
 
-// StartWebhookServer starts the webhook server
+// StartWebhookServer starts the webhook server.
 func StartWebhookServer(ctx context.Context) error {
 	var stopCh = make(chan bool)
 	log := logger.GetLogger(ctx)
@@ -133,7 +133,8 @@ func StartWebhookServer(ctx context.Context) error {
 			log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
 			return err
 		}
-		containerOrchestratorUtility, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, clusterFlavor, *COInitParams)
+		containerOrchestratorUtility, err = commonco.GetContainerOrchestratorInterface(ctx,
+			common.Kubernetes, clusterFlavor, *COInitParams)
 		if err != nil {
 			log.Errorf("failed to get k8s interface. err: %v", err)
 			return err
@@ -142,7 +143,8 @@ func StartWebhookServer(ctx context.Context) error {
 	if containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
 		certs, err := tls.LoadX509KeyPair(cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile)
 		if err != nil {
-			log.Errorf("failed to load key pair. certFile: %q, keyFile: %q err: %v", cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile, err)
+			log.Errorf("failed to load key pair. certFile: %q, keyFile: %q err: %v",
+				cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile, err)
 			return err
 		}
 		if cfg.WebHookConfig.Port == "" {
@@ -152,12 +154,12 @@ func StartWebhookServer(ctx context.Context) error {
 			Addr:      fmt.Sprintf(":%v", cfg.WebHookConfig.Port),
 			TLSConfig: &tls.Config{Certificates: []tls.Certificate{certs}},
 		}
-		// define http server and server handler
+		// Define http server and server handler.
 		mux := http.NewServeMux()
 		mux.HandleFunc("/validate", validationHandler)
 		server.Handler = mux
 
-		// start webhook server
+		// Start webhook server.
 		log.Debugf("Starting webhook server on port: %v", cfg.WebHookConfig.Port)
 		go func() {
 			if err = server.ListenAndServeTLS(cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile); err != nil {
@@ -176,7 +178,8 @@ func StartWebhookServer(ctx context.Context) error {
 	return errors.New("can't start webhook. no features are enabled which requires webhook")
 }
 
-// restartWebhookServer stops the webhook server and start webhook using updated config
+// restartWebhookServer stops the webhook server and start webhook using
+// updated config.
 func restartWebhookServer(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
 	cfg, err := getWebHookConfig(ctx)
@@ -194,8 +197,9 @@ func restartWebhookServer(ctx context.Context) error {
 	return StartWebhookServer(ctx)
 }
 
-// validationHandler is the handler for webhook http multiplexer to help validate resources
-// depending on the URL validation of AdmissionReview will be redirected to appropriate validation function
+// validationHandler is the handler for webhook http multiplexer to help
+// validate resources. Depending on the URL validation of AdmissionReview
+// will be redirected to appropriate validation function.
 func validationHandler(w http.ResponseWriter, r *http.Request) {
 	var body []byte
 	ctx, log := logger.GetNewContextWithLogger()
@@ -210,7 +214,7 @@ func validationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Debugf("Received request")
-	// verify the content type is accurate
+	// Verify the content type is accurate.
 	contentType := r.Header.Get("Content-Type")
 	if contentType != "application/json" {
 		log.Errorf("content-Type=%s, expect application/json", contentType)

--- a/pkg/syncer/admissionhandler/validatestorageclass.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass.go
@@ -43,14 +43,15 @@ var (
 
 const (
 	volumeExpansionErrorMessage = "AllowVolumeExpansion can not be set to true on the in-tree vSphere StorageClass"
-	migrationParamErrorMessage  = "Invalid StorageClass Parameters. Migration specific parameters should not be used in the StorageClass"
+	migrationParamErrorMessage  = "Invalid StorageClass Parameters. " +
+		"Migration specific parameters should not be used in the StorageClass"
 )
 
-// validateStorageClass helps validate AdmissionReview requests for StroageClass
+// validateStorageClass helps validate AdmissionReview requests for StroageClass.
 func validateStorageClass(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if containerOrchestratorUtility != nil && !containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
-		// if CSI migration is disabled and webhook is running
-		// skip validation for StorageClass
+		// If CSI migration is disabled and webhook is running,
+		// skip validation for StorageClass.
 		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
@@ -73,7 +74,7 @@ func validateStorageClass(ctx context.Context, ar *admissionv1.AdmissionReview) 
 			}
 		}
 		log.Infof("Validating StorageClass: %q", sc.Name)
-		// AllowVolumeExpansion check for kubernetes.io/vsphere-volume provisioner
+		// AllowVolumeExpansion check for kubernetes.io/vsphere-volume provisioner.
 		if sc.Provisioner == "kubernetes.io/vsphere-volume" {
 			if sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion {
 				allowed = false
@@ -82,7 +83,7 @@ func validateStorageClass(ctx context.Context, ar *admissionv1.AdmissionReview) 
 				}
 			}
 		} else if sc.Provisioner == "csi.vsphere.vmware.com" {
-			// Migration parameters check for csi.vsphere.vmware.com provisioner
+			// Migration parameters check for csi.vsphere.vmware.com provisioner.
 			for param := range sc.Parameters {
 				if unSupportedParameters.Has(param) {
 					allowed = false


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles files under admissionhandler.

**Testing done**:
Local build and check.