### PR TITLE
Clean white spaces under cns-lib

### DIFF
--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -35,7 +35,7 @@ var (
 
 // Manager provides functionality to manage nodes.
 type Manager interface {
-	// SetKubernetesClient sets kubernetes client for node manager
+	// SetKubernetesClient sets kubernetes client for node manager.
 	SetKubernetesClient(client clientset.Interface)
 	// RegisterNode registers a node given its UUID, name.
 	RegisterNode(ctx context.Context, nodeUUID string, nodeName string) error
@@ -45,10 +45,11 @@ type Manager interface {
 	DiscoverNode(ctx context.Context, nodeUUID string) error
 	// GetNode refreshes and returns the VirtualMachine for a registered node
 	// given its UUID. If datacenter is present, GetNode will search within this
-	// datacenter given its UUID. If not, it will search in all registered datacenters.
+	// datacenter given its UUID. If not, it will search in all registered
+	// datacenters.
 	GetNode(ctx context.Context, nodeUUID string, dc *vsphere.Datacenter) (*vsphere.VirtualMachine, error)
-	// GetNodeByName refreshes and returns the VirtualMachine for a registered node
-	// given its name.
+	// GetNodeByName refreshes and returns the VirtualMachine for a registered
+	// node given its name.
 	GetNodeByName(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error)
 	// GetAllNodes refreshes and returns VirtualMachine for all registered
 	// nodes. If nodes are added or removed concurrently, they may or may not be
@@ -87,7 +88,7 @@ type defaultManager struct {
 	nodeVMs sync.Map
 	// node name to node UUI map.
 	nodeNameToUUID sync.Map
-	// k8s client
+	// k8s client.
 	k8sClient clientset.Interface
 }
 
@@ -111,7 +112,8 @@ func (m *defaultManager) RegisterNode(ctx context.Context, nodeUUID string, node
 }
 
 // DiscoverNode discovers a registered node given its UUID from vCenter.
-// If node is not found in the vCenter for the given UUID, for ErrVMNotFound is returned to the caller
+// If node is not found in the vCenter for the given UUID, for ErrVMNotFound
+// is returned to the caller.
 func (m *defaultManager) DiscoverNode(ctx context.Context, nodeUUID string) error {
 	log := logger.GetLogger(ctx)
 	vm, err := vsphere.GetVirtualMachineByUUID(ctx, nodeUUID, false)
@@ -148,8 +150,9 @@ func (m *defaultManager) GetNodeByName(ctx context.Context, nodeName string) (*v
 }
 
 // GetNode refreshes and returns the VirtualMachine for a registered node
-// given its UUID
-func (m *defaultManager) GetNode(ctx context.Context, nodeUUID string, dc *vsphere.Datacenter) (*vsphere.VirtualMachine, error) {
+// given its UUID.
+func (m *defaultManager) GetNode(ctx context.Context,
+	nodeUUID string, dc *vsphere.Datacenter) (*vsphere.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
 	vmInf, discovered := m.nodeVMs.Load(nodeUUID)
 	if !discovered {


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles files under cns-lib.

**Testing done**:
Local build and check.