### PR TITLE
Clean up white spaces in syncer

### DIFF
--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -19,21 +19,25 @@ import (
 	csitypes "sigs.k8s.io/vsphere-csi-driver/pkg/csi/types"
 )
 
-// getPVsInBoundAvailableOrReleased return PVs in Bound, Available or Released state
-func getPVsInBoundAvailableOrReleased(ctx context.Context, metadataSyncer *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
+// getPVsInBoundAvailableOrReleased return PVs in Bound, Available or Released
+// state.
+func getPVsInBoundAvailableOrReleased(ctx context.Context,
+	metadataSyncer *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
 	log := logger.GetLogger(ctx)
 	var pvsInDesiredState []*v1.PersistentVolume
 	log.Debugf("FullSync: Getting all PVs in Bound, Available or Released state")
-	// Get all PVs from kubernetes
+	// Get all PVs from kubernetes.
 	allPVs, err := metadataSyncer.pvLister.List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
 	for _, pv := range allPVs {
-		if (pv.Spec.CSI != nil && pv.Spec.CSI.Driver == csitypes.Name) || (metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil &&
-			isValidvSphereVolume(ctx, pv.ObjectMeta)) {
+		if (pv.Spec.CSI != nil && pv.Spec.CSI.Driver == csitypes.Name) ||
+			(metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && pv.Spec.VsphereVolume != nil &&
+				isValidvSphereVolume(ctx, pv.ObjectMeta)) {
 			log.Debugf("FullSync: pv %v is in state %v", pv.Name, pv.Status.Phase)
-			if pv.Status.Phase == v1.VolumeBound || pv.Status.Phase == v1.VolumeAvailable || pv.Status.Phase == v1.VolumeReleased {
+			if pv.Status.Phase == v1.VolumeBound || pv.Status.Phase == v1.VolumeAvailable ||
+				pv.Status.Phase == v1.VolumeReleased {
 				pvsInDesiredState = append(pvsInDesiredState, pv)
 			}
 		}
@@ -41,18 +45,20 @@ func getPVsInBoundAvailableOrReleased(ctx context.Context, metadataSyncer *metad
 	return pvsInDesiredState, nil
 }
 
-// getBoundPVs is a helper function for VolumeHealthStatus feature and returns PVs in Bound state
+// getBoundPVs is a helper function for VolumeHealthStatus feature and returns
+// PVs in Bound state.
 func getBoundPVs(ctx context.Context, metadataSyncer *metadataSyncInformer) ([]*v1.PersistentVolume, error) {
 	log := logger.GetLogger(ctx)
 	var boundPVs []*v1.PersistentVolume
-	// Get all PVs from kubernetes
+	// Get all PVs from kubernetes.
 	allPVs, err := metadataSyncer.pvLister.List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
 	for _, pv := range allPVs {
 		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == csitypes.Name {
-			log.Debugf("getBoundPVs: pv %s with volumeHandle %s is in state %v", pv.Name, pv.Spec.CSI.VolumeHandle, pv.Status.Phase)
+			log.Debugf("getBoundPVs: pv %s with volumeHandle %s is in state %v",
+				pv.Name, pv.Spec.CSI.VolumeHandle, pv.Status.Phase)
 			if pv.Status.Phase == v1.VolumeBound {
 				boundPVs = append(boundPVs, pv)
 			}
@@ -61,11 +67,13 @@ func getBoundPVs(ctx context.Context, metadataSyncer *metadataSyncInformer) ([]*
 	return boundPVs, nil
 }
 
-// fullSyncGetInlineMigratedVolumesInfo is a helper function for retrieving  inline PV information from Pods
-func fullSyncGetInlineMigratedVolumesInfo(ctx context.Context, metadataSyncer *metadataSyncInformer, migrationFeatureState bool) (map[string]string, error) {
+// fullSyncGetInlineMigratedVolumesInfo is a helper function for retrieving
+// inline PV information from Pods.
+func fullSyncGetInlineMigratedVolumesInfo(ctx context.Context,
+	metadataSyncer *metadataSyncInformer, migrationFeatureState bool) (map[string]string, error) {
 	log := logger.GetLogger(ctx)
 	inlineVolumes := make(map[string]string)
-	// Get all Pods from kubernetes
+	// Get all Pods from kubernetes.
 	allPods, err := metadataSyncer.podLister.List(labels.Everything())
 	if err != nil {
 		log.Errorf("FullSync: failed to fetch the list of pods with err: %+v", err)
@@ -73,11 +81,15 @@ func fullSyncGetInlineMigratedVolumesInfo(ctx context.Context, metadataSyncer *m
 	}
 	for _, pod := range allPods {
 		for _, volume := range pod.Spec.Volumes {
-			// Check if migration is ON and volumes if of type vSphereVolume
+			// Check if migration is ON and volumes if of type vSphereVolume.
 			if migrationFeatureState && volume.VsphereVolume != nil {
-				volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, &migration.VolumeSpec{VolumePath: volume.VsphereVolume.VolumePath, StoragePolicyName: volume.VsphereVolume.StoragePolicyName})
+				volumeHandle, err := volumeMigrationService.GetVolumeID(ctx,
+					&migration.VolumeSpec{VolumePath: volume.VsphereVolume.VolumePath,
+						StoragePolicyName: volume.VsphereVolume.StoragePolicyName})
 				if err != nil {
-					log.Warnf("FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v", volume.VsphereVolume.VolumePath, err)
+					log.Warnf(
+						"FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v",
+						volume.VsphereVolume.VolumePath, err)
 					continue
 				}
 				inlineVolumes[volumeHandle] = volume.VsphereVolume.VolumePath
@@ -87,34 +99,39 @@ func fullSyncGetInlineMigratedVolumesInfo(ctx context.Context, metadataSyncer *m
 	return inlineVolumes, nil
 }
 
-// IsValidVolume determines if the given volume mounted by a POD is a valid vsphere volume. Returns the pv and pvc object if true.
-func IsValidVolume(ctx context.Context, volume v1.Volume, pod *v1.Pod, metadataSyncer *metadataSyncInformer) (bool, *v1.PersistentVolume, *v1.PersistentVolumeClaim) {
+// IsValidVolume determines if the given volume mounted by a POD is a valid
+// vsphere volume. Returns the pv and pvc object if true.
+func IsValidVolume(ctx context.Context, volume v1.Volume, pod *v1.Pod,
+	metadataSyncer *metadataSyncInformer) (bool, *v1.PersistentVolume, *v1.PersistentVolumeClaim) {
 	log := logger.GetLogger(ctx)
 	pvcName := volume.PersistentVolumeClaim.ClaimName
-	// Get pvc attached to pod
+	// Get pvc attached to pod.
 	pvc, err := metadataSyncer.pvcLister.PersistentVolumeClaims(pod.Namespace).Get(pvcName)
 	if err != nil {
 		log.Errorf("Error getting Persistent Volume Claim for volume %s with err: %v", volume.Name, err)
 		return false, nil, nil
 	}
 
-	// Get pv object attached to pvc
+	// Get pv object attached to pvc.
 	pv, err := metadataSyncer.pvLister.Get(pvc.Spec.VolumeName)
 	if err != nil {
 		log.Errorf("Error getting Persistent Volume for PVC %s in volume %s with err: %v", pvc.Name, volume.Name, err)
 		return false, nil, nil
 	}
 	if pv.Spec.CSI == nil {
-		// Verify volume is a in-tree VCP volume
+		// Verify volume is a in-tree VCP volume.
 		if pv.Spec.VsphereVolume != nil {
-			// Check if migration feature switch is enabled
+			// Check if migration feature switch is enabled.
 			if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) {
 				if !isValidvSphereVolume(ctx, pv.ObjectMeta) {
-					log.Debugf("Pod %s in namespace %s has a valid vSphereVolume but the volume is not migrated", pod.Name, pod.Namespace)
+					log.Debugf("Pod %s in namespace %s has a valid vSphereVolume but the volume is not migrated",
+						pod.Name, pod.Namespace)
 					return false, nil, nil
 				}
 			} else {
-				log.Debugf("%s feature switch is disabled. Cannot update vSphere volume metadata %s for the pod %s in namespace %s", common.CSIMigration, pv.Name, pod.Name, pod.Namespace)
+				log.Debugf(
+					"%s feature switch is disabled. Cannot update vSphere volume metadata %s for the pod %s in namespace %s",
+					common.CSIMigration, pv.Name, pod.Name, pod.Namespace)
 				return false, nil, nil
 			}
 		} else {
@@ -123,7 +140,8 @@ func IsValidVolume(ctx context.Context, volume v1.Volume, pod *v1.Pod, metadataS
 		}
 	} else {
 		if pv.Spec.CSI.Driver != csitypes.Name {
-			log.Debugf("Pod %s in namespace %s has a volume %s which is not provisioned by vSphere CSI driver", pod.Name, pod.Namespace, pv.Name)
+			log.Debugf("Pod %s in namespace %s has a volume %s which is not provisioned by vSphere CSI driver",
+				pod.Name, pod.Namespace, pv.Name)
 			return false, nil, nil
 		}
 	}
@@ -132,8 +150,10 @@ func IsValidVolume(ctx context.Context, volume v1.Volume, pod *v1.Pod, metadataS
 
 // fullSyncGetQueryResults returns list of CnsQueryResult retrieved using
 // queryFilter with offset and limit to query volumes using pagination
-// if volumeIds is empty, then all volumes from CNS will be retrieved by pagination
-func fullSyncGetQueryResults(ctx context.Context, volumeIds []cnstypes.CnsVolumeId, clusterID string, volumeManager volumes.Manager, metadataSyncer *metadataSyncInformer) ([]*cnstypes.CnsQueryResult, error) {
+// if volumeIds is empty, then all volumes from CNS will be retrieved by
+// pagination.
+func fullSyncGetQueryResults(ctx context.Context, volumeIds []cnstypes.CnsVolumeId, clusterID string,
+	volumeManager volumes.Manager, metadataSyncer *metadataSyncInformer) ([]*cnstypes.CnsQueryResult, error) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("FullSync: fullSyncGetQueryResults is called with volumeIds %v for clusterID %s", volumeIds, clusterID)
 	queryFilter := cnstypes.CnsQueryFilter{
@@ -170,7 +190,7 @@ func fullSyncGetQueryResults(ctx context.Context, volumeIds []cnstypes.CnsVolume
 	return allQueryResults, nil
 }
 
-// getPVCKey helps to get the PVC name from PVC object
+// getPVCKey helps to get the PVC name from PVC object.
 func getPVCKey(ctx context.Context, obj interface{}) (string, error) {
 	log := logger.GetLogger(ctx)
 
@@ -186,10 +206,12 @@ func getPVCKey(ctx context.Context, obj interface{}) (string, error) {
 	return objKey, nil
 }
 
-// HasMigratedToAnnotationUpdate returns true if the migrated-to annotation is found in the newer object
-func HasMigratedToAnnotationUpdate(ctx context.Context, prevAnnotations map[string]string, newAnnotations map[string]string, objectName string) bool {
+// HasMigratedToAnnotationUpdate returns true if the migrated-to annotation
+// is found in the newer object.
+func HasMigratedToAnnotationUpdate(ctx context.Context, prevAnnotations map[string]string,
+	newAnnotations map[string]string, objectName string) bool {
 	log := logger.GetLogger(ctx)
-	// Checking if the migrated-to annotation is found in the newer object
+	// Checking if the migrated-to annotation is found in the newer object.
 	if _, annMigratedToFound := newAnnotations[common.AnnMigratedTo]; annMigratedToFound {
 		if _, annMigratedToFound = prevAnnotations[common.AnnMigratedTo]; !annMigratedToFound {
 			log.Debugf("Received %v annotation update for %q", common.AnnMigratedTo, objectName)
@@ -200,48 +222,54 @@ func HasMigratedToAnnotationUpdate(ctx context.Context, prevAnnotations map[stri
 	return false
 }
 
-// isValidvSphereVolumeClaim returns true if the given PVC metadata of a vSphere Volume (in-tree volume)
-// has migrated-to annotation on the PVC
-// or if the PVC was provisioned by CSI driver using in-tree storage class
+// isValidvSphereVolumeClaim returns true if the given PVC metadata of a vSphere
+// Volume (in-tree volume) has migrated-to annotation on the PVC, or if the PVC
+// was provisioned by CSI driver using in-tree storage class.
 func isValidvSphereVolumeClaim(ctx context.Context, pvcMetadata metav1.ObjectMeta) bool {
 	log := logger.GetLogger(ctx)
-	// Checking if the migrated-to annotation is found in the PVC metadata
+	// Checking if the migrated-to annotation is found in the PVC metadata.
 	if annotation, annMigratedToFound := pvcMetadata.Annotations[common.AnnMigratedTo]; annMigratedToFound {
-		if annotation == csitypes.Name && pvcMetadata.Annotations[common.AnnStorageProvisioner] == common.InTreePluginName {
-			log.Debugf("%v annotation found with value %q for PVC: %q", common.AnnMigratedTo, csitypes.Name, pvcMetadata.Name)
+		if annotation == csitypes.Name &&
+			pvcMetadata.Annotations[common.AnnStorageProvisioner] == common.InTreePluginName {
+			log.Debugf("%v annotation found with value %q for PVC: %q",
+				common.AnnMigratedTo, csitypes.Name, pvcMetadata.Name)
 			return true
 		}
-	} else { // Checking if the PVC was provisioned by CSI
+	} else { // Checking if the PVC was provisioned by CSI.
 		if pvcMetadata.Annotations[common.AnnStorageProvisioner] == csitypes.Name {
-			log.Debugf("%v annotation found with value %q for PVC: %q", common.AnnStorageProvisioner, csitypes.Name, pvcMetadata.Name)
+			log.Debugf("%v annotation found with value %q for PVC: %q",
+				common.AnnStorageProvisioner, csitypes.Name, pvcMetadata.Name)
 			return true
 		}
 	}
 	return false
 }
 
-// isValidvSphereVolume returns true if the given PV metadata of a vSphere Volume (in-tree volume) and
-// has migrated-to annotation on the PV
-// or if the PV was provisioned by CSI driver using in-tree storage class
+// isValidvSphereVolume returns true if the given PV metadata of a vSphere
+// Volume (in-tree volume) and has migrated-to annotation on the PV,
+// or if the PV was provisioned by CSI driver using in-tree storage class.
 func isValidvSphereVolume(ctx context.Context, pvMetadata metav1.ObjectMeta) bool {
 	log := logger.GetLogger(ctx)
-	// Checking if the migrated-to annotation is found in the PV metadata
+	// Checking if the migrated-to annotation is found in the PV metadata.
 	if annotation, annMigratedToFound := pvMetadata.Annotations[common.AnnMigratedTo]; annMigratedToFound {
-		if annotation == csitypes.Name && pvMetadata.Annotations[common.AnnDynamicallyProvisioned] == common.InTreePluginName {
-			log.Debugf("%v annotation found with value %q for PV: %q", common.AnnMigratedTo, csitypes.Name, pvMetadata.Name)
+		if annotation == csitypes.Name &&
+			pvMetadata.Annotations[common.AnnDynamicallyProvisioned] == common.InTreePluginName {
+			log.Debugf("%v annotation found with value %q for PV: %q",
+				common.AnnMigratedTo, csitypes.Name, pvMetadata.Name)
 			return true
 		}
 	} else {
 		if pvMetadata.Annotations[common.AnnDynamicallyProvisioned] == csitypes.Name {
-			log.Debugf("%v annotation found with value %q for PV: %q", common.AnnDynamicallyProvisioned, csitypes.Name, pvMetadata.Name)
+			log.Debugf("%v annotation found with value %q for PV: %q",
+				common.AnnDynamicallyProvisioned, csitypes.Name, pvMetadata.Name)
 			return true
 		}
 	}
 	return false
 }
 
-// IsMultiAttachAllowed helps check accessModes on the PV and return true if volume can be attached to
-// multiple nodes.
+// IsMultiAttachAllowed helps check accessModes on the PV and return true if
+// volume can be attached to multiple nodes.
 func IsMultiAttachAllowed(pv *v1.PersistentVolume) bool {
 	if pv == nil {
 		return false
@@ -257,15 +285,17 @@ func IsMultiAttachAllowed(pv *v1.PersistentVolume) bool {
 	return false
 }
 
-// initVolumeMigrationService is a helper method to initialize volumeMigrationService in Syncer
+// initVolumeMigrationService is a helper method to initialize
+// volumeMigrationService in Syncer.
 func initVolumeMigrationService(ctx context.Context, metadataSyncer *metadataSyncInformer) error {
 	log := logger.GetLogger(ctx)
-	// This check is to prevent unnecessary RLocks on the volumeMigration instance
+	// This check prevents unnecessary RLocks on the volumeMigration instance.
 	if volumeMigrationService != nil {
 		return nil
 	}
 	var err error
-	volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &metadataSyncer.volumeManager, metadataSyncer.configInfo.Cfg, true)
+	volumeMigrationService, err = migration.GetVolumeMigrationService(ctx,
+		&metadataSyncer.volumeManager, metadataSyncer.configInfo.Cfg, true)
 	if err != nil {
 		log.Errorf("failed to get migration service. Err: %v", err)
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles files under syncer.

**Testing done**:
Local build and check.