### PR TITLE
Clean up white spaces in pvcsi_metadatasyncer

### DIFF
--- a/pkg/syncer/pvcsi_metadatasyncer.go
+++ b/pkg/syncer/pvcsi_metadatasyncer.go
@@ -29,8 +29,11 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
-// pvcsiVolumeUpdated updates persistent volume claim and persistent volume CnsVolumeMetadata on supervisor cluster when pvc/pv labels on K8S cluster have been updated
-func pvcsiVolumeUpdated(ctx context.Context, resourceType interface{}, volumeHandle string, metadataSyncer *metadataSyncInformer) {
+// pvcsiVolumeUpdated updates persistent volume claim and persistent volume
+// CnsVolumeMetadata on supervisor cluster when pvc/pv labels on K8S cluster
+// have been updated.
+func pvcsiVolumeUpdated(ctx context.Context, resourceType interface{},
+	volumeHandle string, metadataSyncer *metadataSyncInformer) {
 	log := logger.GetLogger(ctx)
 	supervisorNamespace, err := cnsconfig.GetSupervisorNamespace(ctx)
 	if err != nil {
@@ -38,17 +41,27 @@ func pvcsiVolumeUpdated(ctx context.Context, resourceType interface{}, volumeHan
 		return
 	}
 	var newMetadata *cnsvolumemetadatav1alpha1.CnsVolumeMetadata
-	// Create CnsVolumeMetaDataSpec based on the resource type
+	// Create CnsVolumeMetaDataSpec based on the resource type.
 	switch resource := resourceType.(type) {
 	case *v1.PersistentVolume:
-		entityReference := cnsvolumemetadatav1alpha1.GetCnsOperatorEntityReference(resource.Spec.CSI.VolumeHandle, supervisorNamespace, cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePVC, "")
-		newMetadata = cnsvolumemetadatav1alpha1.CreateCnsVolumeMetadataSpec([]string{volumeHandle}, metadataSyncer.configInfo.Cfg.GC, string(resource.GetUID()), resource.Name, cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePV, resource.Labels, "", []cnsvolumemetadatav1alpha1.CnsOperatorEntityReference{entityReference})
+		entityReference := cnsvolumemetadatav1alpha1.GetCnsOperatorEntityReference(
+			resource.Spec.CSI.VolumeHandle, supervisorNamespace, cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePVC, "")
+		newMetadata = cnsvolumemetadatav1alpha1.CreateCnsVolumeMetadataSpec([]string{volumeHandle},
+			metadataSyncer.configInfo.Cfg.GC, string(resource.GetUID()), resource.Name,
+			cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePV, resource.Labels, "",
+			[]cnsvolumemetadatav1alpha1.CnsOperatorEntityReference{entityReference})
 	case *v1.PersistentVolumeClaim:
-		entityReference := cnsvolumemetadatav1alpha1.GetCnsOperatorEntityReference(resource.Spec.VolumeName, "", cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePV, metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID)
-		newMetadata = cnsvolumemetadatav1alpha1.CreateCnsVolumeMetadataSpec([]string{volumeHandle}, metadataSyncer.configInfo.Cfg.GC, string(resource.GetUID()), resource.Name, cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePVC, resource.Labels, resource.Namespace, []cnsvolumemetadatav1alpha1.CnsOperatorEntityReference{entityReference})
+		entityReference := cnsvolumemetadatav1alpha1.GetCnsOperatorEntityReference(
+			resource.Spec.VolumeName, "", cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePV,
+			metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID)
+		newMetadata = cnsvolumemetadatav1alpha1.CreateCnsVolumeMetadataSpec([]string{volumeHandle},
+			metadataSyncer.configInfo.Cfg.GC, string(resource.GetUID()), resource.Name,
+			cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePVC, resource.Labels, resource.Namespace,
+			[]cnsvolumemetadatav1alpha1.CnsOperatorEntityReference{entityReference})
 	default:
 	}
-	// Check if cnsvolumemetadata object exists for this entity in the supervisor cluster
+	// Check if cnsvolumemetadata object exists for this entity in the supervisor
+	// cluster.
 	currentMetadata := &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{}
 	key := types.NamespacedName{Namespace: supervisorNamespace, Name: newMetadata.Name}
 	if err := metadataSyncer.cnsOperatorClient.Get(ctx, key, currentMetadata); err != nil {
@@ -72,7 +85,8 @@ func pvcsiVolumeUpdated(ctx context.Context, resourceType interface{}, volumeHan
 	log.Infof("pvCSI VolumeUpdated: Successfully updated CnsVolumeMetadata: %v", currentMetadata.Name)
 }
 
-// pvcsiVolumeDeleted deletes pvc/pv CnsVolumeMetadata on supervisor cluster when pvc/pv has been deleted on K8s cluster
+// pvcsiVolumeDeleted deletes pvc/pv CnsVolumeMetadata on supervisor cluster
+// when pvc/pv has been deleted on K8s cluster.
 func pvcsiVolumeDeleted(ctx context.Context, uID string, metadataSyncer *metadataSyncInformer) {
 	log := logger.GetLogger(ctx)
 	supervisorNamespace, err := cnsconfig.GetSupervisorNamespace(ctx)
@@ -80,7 +94,8 @@ func pvcsiVolumeDeleted(ctx context.Context, uID string, metadataSyncer *metadat
 		log.Errorf("pvCSI VolumeDeleted: Unable to fetch supervisor namespace. Err: %v", err)
 		return
 	}
-	volumeMetadataName := cnsvolumemetadatav1alpha1.GetCnsVolumeMetadataName(metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID, uID)
+	volumeMetadataName := cnsvolumemetadatav1alpha1.GetCnsVolumeMetadataName(
+		metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID, uID)
 	log.Debugf("pvCSI VolumeDeleted: Invoking delete on CnsVolumeMetadata : %v", volumeMetadataName)
 	err = metadataSyncer.cnsOperatorClient.Delete(ctx, &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{
 		ObjectMeta: metav1.ObjectMeta{
@@ -95,7 +110,8 @@ func pvcsiVolumeDeleted(ctx context.Context, uID string, metadataSyncer *metadat
 	log.Infof("pvCSI VolumeDeleted: Successfully deleted CnsVolumeMetadata: %v", volumeMetadataName)
 }
 
-// pvcsiUpdatePod creates/deletes cnsvolumemetadata for POD entities on the supervisor cluster when pod has been created/deleted on the guest cluster
+// pvcsiUpdatePod creates/deletes cnsvolumemetadata for POD entities on the
+// supervisor cluster when pod has been created/deleted on the guest cluster.
 func pvcsiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSyncInformer, deleteFlag bool) {
 	log := logger.GetLogger(ctx)
 	supervisorNamespace, err := cnsconfig.GetSupervisorNamespace(ctx)
@@ -105,19 +121,24 @@ func pvcsiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSy
 	}
 	var entityReferences []cnsvolumemetadatav1alpha1.CnsOperatorEntityReference
 	var volumes []string
-	// Iterate through volumes attached to pod
+	// Iterate through volumes attached to pod.
 	for _, volume := range pod.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil {
 			valid, pv, pvc := IsValidVolume(ctx, volume, pod, metadataSyncer)
 			if valid {
-				entityReferences = append(entityReferences, cnsvolumemetadatav1alpha1.GetCnsOperatorEntityReference(pvc.Name, pvc.Namespace, cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePVC, metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID))
+				entityReferences = append(entityReferences,
+					cnsvolumemetadatav1alpha1.GetCnsOperatorEntityReference(pvc.Name, pvc.Namespace,
+						cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePVC,
+						metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID))
 				volumes = append(volumes, pv.Spec.CSI.VolumeHandle)
 			}
 		}
 	}
 	if len(volumes) > 0 {
 		if !deleteFlag {
-			newMetadata := cnsvolumemetadatav1alpha1.CreateCnsVolumeMetadataSpec(volumes, metadataSyncer.configInfo.Cfg.GC, string(pod.GetUID()), pod.Name, cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePOD, nil, pod.Namespace, entityReferences)
+			newMetadata := cnsvolumemetadatav1alpha1.CreateCnsVolumeMetadataSpec(volumes,
+				metadataSyncer.configInfo.Cfg.GC, string(pod.GetUID()), pod.Name,
+				cnsvolumemetadatav1alpha1.CnsOperatorEntityTypePOD, nil, pod.Namespace, entityReferences)
 			log.Debugf("pvCSI PodUpdated: Invoking create CnsVolumeMetadata : %v", newMetadata)
 			newMetadata.Namespace = supervisorNamespace
 			if err := metadataSyncer.cnsOperatorClient.Create(ctx, newMetadata); err != nil {
@@ -126,7 +147,8 @@ func pvcsiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSy
 			}
 			log.Infof("pvCSI PodUpdated: Successfully created CnsVolumeMetadata: %v", newMetadata.Name)
 		} else {
-			volumeMetadataName := cnsvolumemetadatav1alpha1.GetCnsVolumeMetadataName(metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID, string(pod.GetUID()))
+			volumeMetadataName := cnsvolumemetadatav1alpha1.GetCnsVolumeMetadataName(
+				metadataSyncer.configInfo.Cfg.GC.TanzuKubernetesClusterUID, string(pod.GetUID()))
 			log.Debugf("pvCSI PodDeleted: Invoking delete on CnsVolumeMetadata : %v", volumeMetadataName)
 			err = metadataSyncer.cnsOperatorClient.Delete(ctx, &cnsvolumemetadatav1alpha1.CnsVolumeMetadata{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles pvcsi_metadatasyncer.go.

**Testing done**:
Local build and check.