### PR TITLE
Change DEBUG log to INFO in cnsnodevmattachment_controller.go .

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -325,7 +325,7 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 			}
 		}
 
-		log.Debugf("vSphere CSI driver is attaching volume: %q to nodevm: %+v for "+
+		log.Infof("vSphere CSI driver is attaching volume: %q to nodevm: %+v for "+
 			"CnsNodeVmAttachment request with name: %q on namespace: %q",
 			volumeID, nodeVM, request.Name, request.Namespace)
 		diskUUID, attachErr := r.volumeManager.AttachVolume(ctx, nodeVM, volumeID, false)
@@ -439,7 +439,7 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 			recordEvent(ctx, r, instance, v1.EventTypeWarning, msg)
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
-		log.Debugf("vSphere CSI driver is detaching volume: %q to nodevm: %+v for "+
+		log.Infof("vSphere CSI driver is detaching volume: %q to nodevm: %+v for "+
 			"CnsNodeVmAttachment request with name: %q on namespace: %q",
 			cnsVolumeID, nodeVM, request.Name, request.Namespace)
 		detachErr := r.volumeManager.DetachVolume(ctx, nodeVM, cnsVolumeID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Change the following logs from DEBUG level to INFO. We have a use case that when we search with volumeID in the Loki, we want to show all logs related to this volume. Since in prod env, the default log level is INFO. Without this change, this log will not show up when searching the log in Loki with volumeID.
```
2021-06-29T21:31:11.697Z        DEBUG   cnsnodevmattachment/cnsnodevmattachment_controller.go:284       vSphere CSI driver is attaching volume: "c33edbd6-923d-485b-94e4-e0087836ed0e" to nodevm: VirtualMachine:vm-74 [VirtualCenterHost: sc2-10-185-39-121.eng.vmware.com, UUID: 420b72e2-ccc5-a934-c512-79c9c61c9d5f, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-4, VirtualCenterHost: sc2-10-185-39-121.eng.vmware.com]] for CnsNodeVmAttachment request with name: "test-cluster-e2e-script-workers-wp5rq-67bdccc59b-nnxld-64af2f53-577a-4f3e-a1a2-ee6a3fb2e9c8-da353907-4622-4bac-8862-55d9fa339475" on namespace: "test-gc-e2e-demo-ns"
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
E2E test result:
WCP Precheckin test passed.  https://container-dp.svc.eng.vmware.com/view/Pre-Checkin-CSI/job/csi-wcp-pre-check-in/81/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
