### PR TITLE
Clean up white spaces in internalapis

### DIFF
--- a/pkg/internalapis/cnsvolumeoperationrequest/util.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/util.go
@@ -23,14 +23,14 @@ import (
 )
 
 const (
-	// CRDName represent the name of cnsvolumeoperationrequest CRD
+	// CRDName represent the name of cnsvolumeoperationrequest CRD.
 	crdName = "cnsvolumeoperationrequests.cns.vmware.com"
-	// CRDSingular represent the singular name of cnsvolumeoperationrequest CRD
+	// CRDSingular represent the singular name of cnsvolumeoperationrequest CRD.
 	crdSingular = "cnsvolumeoperationrequest"
-	// CRDPlural represent the plural name of cnsvolumeoperationrequest CRD
+	// CRDPlural represent the plural name of cnsvolumeoperationrequest CRD.
 	crdPlural = "cnsvolumeoperationrequests"
-	// maxEntriesInLatestOperationDetails specifies the maximum length of
-	// the LatestOperationDetails allowed in a cnsvolumeoperationrequest instance
+	// maxEntriesInLatestOperationDetails specifies the maximum length of the
+	// LatestOperationDetails allowed in a cnsvolumeoperationrequest instance.
 	maxEntriesInLatestOperationDetails = 10
 	// TaskInvocationStatusInProgress represents a task thats status is InProgress.
 	TaskInvocationStatusInProgress = "InProgress"
@@ -61,8 +61,10 @@ type OperationDetails struct {
 	Error                   string
 }
 
-// CreateVolumeOperationRequestDetails returns an object of type VolumeOperationRequestDetails from the input parameters.
-func CreateVolumeOperationRequestDetails(name, volumeID, snapshotID string, capacity int64, taskInvocationTimestamp metav1.Time, taskID, opID, taskStatus, error string) *VolumeOperationRequestDetails {
+// CreateVolumeOperationRequestDetails returns an object of type
+// VolumeOperationRequestDetails from the input parameters.
+func CreateVolumeOperationRequestDetails(name, volumeID, snapshotID string, capacity int64,
+	taskInvocationTimestamp metav1.Time, taskID, opID, taskStatus, error string) *VolumeOperationRequestDetails {
 	return &VolumeOperationRequestDetails{
 		Name:       name,
 		VolumeID:   volumeID,
@@ -78,9 +80,11 @@ func CreateVolumeOperationRequestDetails(name, volumeID, snapshotID string, capa
 	}
 }
 
-// convertToCnsVolumeOperationRequestDetails converts an object of type OperationDetails to the OperationDetails type
-// defined by the CnsVolumeOperationRequest Custom Resource.
-func convertToCnsVolumeOperationRequestDetails(details OperationDetails) *cnsvolumeoperationrequestv1alpha1.OperationDetails {
+// convertToCnsVolumeOperationRequestDetails converts an object of type
+// OperationDetails to the OperationDetails type defined by the
+// CnsVolumeOperationRequest Custom Resource.
+func convertToCnsVolumeOperationRequestDetails(
+	details OperationDetails) *cnsvolumeoperationrequestv1alpha1.OperationDetails {
 	return &cnsvolumeoperationrequestv1alpha1.OperationDetails{
 		TaskInvocationTimestamp: details.TaskInvocationTimestamp,
 		TaskID:                  details.TaskID,


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles one file under internalapis.

**Testing done**:
Local build and check.