### PR TITLE
Clean up white spaces in e2e tests

### DIFF
--- a/tests/e2e/connection.go
+++ b/tests/e2e/connection.go
@@ -50,8 +50,9 @@ var (
 	clientLock sync.Mutex
 )
 
-// connect helps make a connection to vCenter Server
-// No actions are taken if a connection exists and alive. Otherwise, a new client will be created.
+// connect helps make a connection to vCenter Server.
+// No actions are taken if a connection exists and alive. Otherwise, a new
+// client will be created.
 func connect(ctx context.Context, vs *vSphere) {
 	clientLock.Lock()
 	var err error
@@ -71,9 +72,10 @@ func connect(ctx context.Context, vs *vSphere) {
 	vs.Client = newClient(ctx, vs)
 }
 
-// newClient creates a new client for vSphere connection
+// newClient creates a new client for vSphere connection.
 func newClient(ctx context.Context, vs *vSphere) *govmomi.Client {
-	url, err := neturl.Parse(fmt.Sprintf("https://%s:%s/sdk", vs.Config.Global.VCenterHostname, vs.Config.Global.VCenterPort))
+	url, err := neturl.Parse(fmt.Sprintf("https://%s:%s/sdk",
+		vs.Config.Global.VCenterHostname, vs.Config.Global.VCenterPort))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	url.User = neturl.UserPassword(vs.Config.Global.User, vs.Config.Global.Password)
 	client, err := govmomi.NewClient(ctx, url, true)
@@ -84,7 +86,7 @@ func newClient(ctx context.Context, vs *vSphere) *govmomi.Client {
 	return client
 }
 
-// newCnsClient creates a new CNS client
+// newCnsClient creates a new CNS client.
 func newCnsClient(ctx context.Context, c *vim25.Client) (*cnsClient, error) {
 	sc := c.Client.NewServiceClient(vsanHealthPath, vsanNamespace)
 	return &cnsClient{sc}, nil
@@ -102,7 +104,7 @@ func connectCns(ctx context.Context, vs *vSphere) error {
 	return nil
 }
 
-//newVsanHealthSvcClient returns vSANhealth client
+//newVsanHealthSvcClient returns vSANhealth client.
 func newVsanHealthSvcClient(ctx context.Context, c *vim25.Client) (*VsanClient, error) {
 	sc := c.Client.NewServiceClient(vsanHealthPath, vsanNamespace)
 	return &VsanClient{c, sc}, nil

--- a/tests/e2e/csi_cns_telemetry_vc_reboot.go
+++ b/tests/e2e/csi_cns_telemetry_vc_reboot.go
@@ -62,7 +62,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 		}
 
 		if vanillaCluster {
-			//Reset the cluster distribution value to default value "CSI-Vanilla"
+			// Reset the cluster distribution value to default value "CSI-Vanilla".
 			setClusterDistribution(ctx, client, vanillaClusterDistribution)
 		}
 	})
@@ -71,27 +71,25 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 		defer cancel()
 
 		if vanillaCluster {
-			//Reset the cluster distribution value to default value "CSI-Vanilla"
+			// Reset the cluster distribution value to default value "CSI-Vanilla".
 			setClusterDistribution(ctx, client, vanillaClusterDistribution)
 		}
 	})
 
-	/*
-		Steps
-		1. Create StorageClass.
-		2. Create PVC which uses the StorageClass created in step 1.
-		3. Wait for PV to be provisioned.
-		4. Wait for PVC's status to become bound.
-		5. Create pod using PVC.
-		6. Wait for Disk to be attached to the node.
-		7. Reboot VC.
-		8. Update cluster-distribution value and create PVC while VC reboots.
-		9. Wait for the VC to reboot completely and PVC to be bound.
-		10. Create pod using the PVC.
-		12. Wait for Disk to be attached to the node.
-		13. Delete pod and Wait for Volume Disk to be detached from the Node.
-		14. Delete PVC, PV and Storage Class.
-	*/
+	// Steps
+	// 1. Create StorageClass.
+	// 2. Create PVC which uses the StorageClass created in step 1.
+	// 3. Wait for PV to be provisioned.
+	// 4. Wait for PVC's status to become bound.
+	// 5. Create pod using PVC.
+	// 6. Wait for Disk to be attached to the node.
+	// 7. Reboot VC.
+	// 8. Update cluster-distribution value and create PVC while VC reboots.
+	// 9. Wait for the VC to reboot completely and PVC to be bound.
+	// 10. Create pod using the PVC.
+	// 12. Wait for Disk to be attached to the node.
+	// 13. Delete pod and Wait for Volume Disk to be detached from the Node.
+	// 14. Delete PVC, PV and Storage Class.
 
 	ginkgo.It("[csi-block-vanilla] [csi-file-vanilla] verify volume operations while vc reboot", func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -103,7 +101,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 		var fullSyncWaitTime int
 		var err error
 
-		// Read full-sync value
+		// Read full-sync value.
 		if os.Getenv(envFullSyncWaitTime) != "" {
 			fullSyncWaitTime, err = strconv.Atoi(os.Getenv(envFullSyncWaitTime))
 			framework.Logf("Full-Sync interval time value is = %v", fullSyncWaitTime)
@@ -111,7 +109,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 		}
 
 		ginkgo.By("Creating Storage Class and PVC")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if vanillaCluster {
 			ginkgo.By("CNS_TEST: Running for Vanilla setup")
 			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, nil, "", nil, "", false, "")
@@ -129,7 +127,8 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 		}()
 
 		ginkgo.By("Waiting for claim to be in bound phase")
-		pvc, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvclaim}, framework.ClaimProvisionTimeout)
+		pvc, err := fpv.WaitForPVClaimBoundPhase(client,
+			[]*v1.PersistentVolumeClaim{pvclaim}, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvc).NotTo(gomega.BeEmpty())
 		pv := getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)
@@ -157,24 +156,25 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 		err = invokeVCenterReboot(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Sleep for a short while for the VC to shutdown, before invoking PVC creation and cluster-distribution value
+		// Sleep for a short while for the VC to shutdown, before invoking PVC
+		// creation and cluster-distribution value.
 		time.Sleep(pollTimeoutShort)
 
 		ginkgo.By("Set cluster-distribution value while the VC reboot in progress")
 
 		if vanillaCluster {
-			// Set Cluster-distribution while the VC reboot in progress
+			// Set Cluster-distribution while the VC reboot in progress.
 			setClusterDistribution(ctx, client, vanillaClusterDistributionWithSpecialChar)
 		}
 
 		defer func() {
 			if vanillaCluster {
-				//Reset the cluster distribution value to default value "CSI-Vanilla"
+				// Reset the cluster distribution value to default value "CSI-Vanilla".
 				setClusterDistribution(ctx, client, vanillaClusterDistribution)
 			}
 		}()
 
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if vanillaCluster {
 			ginkgo.By("Creating another PVC for Vanilla setup")
 			storageclass2, pvclaim2, err = createPVCAndStorageClass(client, namespace, nil, nil, "", nil, "", false, "")
@@ -197,11 +197,12 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 		time.Sleep(time.Duration(vcRebootWaitTime) * time.Second)
 		ginkgo.By("Done with reboot")
 
-		//After reboot
+		// After reboot.
 		bootstrap()
 
 		ginkgo.By("Waiting for PVC2 claim to be in bound phase")
-		pvc2, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvclaim2}, framework.ClaimProvisionTimeout)
+		pvc2, err := fpv.WaitForPVClaimBoundPhase(client,
+			[]*v1.PersistentVolumeClaim{pvclaim2}, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvc2).NotTo(gomega.BeEmpty())
 		pv2 := getPvFromClaim(client, pvclaim2.Namespace, pvclaim2.Name)
@@ -222,14 +223,16 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached2).To(gomega.BeTrue(), "Volume is not attached to the node")
 
-		// Verify the attached volume has cluster-distribution value set
+		// Verify the attached volume has cluster-distribution value set.
 		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult for PVC with VolumeID: %s", pv2.Spec.CSI.VolumeHandle))
 		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(pv2.Spec.CSI.VolumeHandle)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(len(queryResult.Volumes) > 0).To(gomega.BeTrue())
 
-		framework.Logf("Cluster-distribution value on CNS is %s", queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution)
-		gomega.Expect(queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution).Should(gomega.Equal(vanillaClusterDistributionWithSpecialChar), "Wrong/empty cluster-distribution name present on CNS")
+		framework.Logf("Cluster-distribution value on CNS is %s",
+			queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution)
+		gomega.Expect(queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution).Should(
+			gomega.Equal(vanillaClusterDistributionWithSpecialChar), "Wrong/empty cluster-distribution name present on CNS")
 
 		ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
 		err = fpod.DeletePodWithWait(client, pod)
@@ -241,34 +244,36 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 
 		if vanillaCluster {
 			ginkgo.By("Verify volume is detached from the node")
-			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 
 			ginkgo.By("Verify volume is detached from the node")
-			isDiskDetached2, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv2.Spec.CSI.VolumeHandle, pod2.Spec.NodeName)
+			isDiskDetached2, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv2.Spec.CSI.VolumeHandle, pod2.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(isDiskDetached2).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv2.Spec.CSI.VolumeHandle, pod2.Spec.NodeName))
+			gomega.Expect(isDiskDetached2).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", pv2.Spec.CSI.VolumeHandle, pod2.Spec.NodeName))
 
 		}
 	})
 
-	/*
-		Steps
-		1. Create StorageClass.
-		2. Create PVC which uses the StorageClass created in step 1.
-		3. Wait for PV to be provisioned.
-		4. Wait for PVC's status to become bound.
-		5. Create pod using PVC.
-		6. Wait for Disk to be attached to the node.
-		7. Reboot VC.
-		8. Update cluster-distribution value and create PVC after VC reboots.
-		9. Wait for PVC to be bound.
-		10. Create pod using the PVC.
-		12. Wait for Disk to be attached to the node.
-		13. Delete pod and Wait for Volume Disk to be detached from the Node.
-		14. Delete PVC, PV and Storage Class.
-	*/
+	// Steps
+	// 1. Create StorageClass.
+	// 2. Create PVC which uses the StorageClass created in step 1.
+	// 3. Wait for PV to be provisioned.
+	// 4. Wait for PVC's status to become bound.
+	// 5. Create pod using PVC.
+	// 6. Wait for Disk to be attached to the node.
+	// 7. Reboot VC.
+	// 8. Update cluster-distribution value and create PVC after VC reboots.
+	// 9. Wait for PVC to be bound.
+	// 10. Create pod using the PVC.
+	// 12. Wait for Disk to be attached to the node.
+	// 13. Delete pod and Wait for Volume Disk to be detached from the Node.
+	// 14. Delete PVC, PV and Storage Class.
 	ginkgo.It("[csi-block-vanilla] [csi-file-vanilla] verify volume operations after vc reboots", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -277,7 +282,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 		var fullSyncWaitTime int
 		var err error
 
-		// Read full-sync value
+		// Read full-sync value.
 		if os.Getenv(envFullSyncWaitTime) != "" {
 			fullSyncWaitTime, err = strconv.Atoi(os.Getenv(envFullSyncWaitTime))
 			framework.Logf("Full-Sync interval time value is = %v", fullSyncWaitTime)
@@ -294,23 +299,24 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 		time.Sleep(time.Duration(vcRebootWaitTime) * time.Second)
 		ginkgo.By("Done with reboot")
 
-		//After reboot
+		// After reboot.
 		bootstrap()
 
-		// Sleep for a short while for the VC to shutdown, before invoking PVC creation and cluster-distribution value
+		// Sleep for a short while for the VC to shutdown, before invoking PVC
+		// creation and cluster-distribution value.
 		time.Sleep(pollTimeoutShort)
 
 		ginkgo.By("Set cluster-distribution value after the VC reboot in progress")
-		// Set Cluster-distribution while the VC reboot in progress
+		// Set Cluster-distribution while the VC reboot in progress.
 		setClusterDistribution(ctx, client, vanillaClusterDistributionWithSpecialChar)
 
 		defer func() {
-			//Reset the cluster distribution value to default value "CSI-Vanilla"
+			// Reset the cluster distribution value to default value "CSI-Vanilla".
 			setClusterDistribution(ctx, client, vanillaClusterDistribution)
 		}()
 
 		ginkgo.By("Creating Storage Class and PVC")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if vanillaCluster {
 			ginkgo.By("CNS_TEST: Running for Vanilla setup")
 			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, nil, "", nil, "", false, "")
@@ -323,7 +329,8 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 		}()
 
 		ginkgo.By("Waiting for claim to be in bound phase")
-		pvc, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvclaim}, framework.ClaimProvisionTimeout)
+		pvc, err := fpv.WaitForPVClaimBoundPhase(client,
+			[]*v1.PersistentVolumeClaim{pvclaim}, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvc).NotTo(gomega.BeEmpty())
 		pv := getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)
@@ -351,14 +358,16 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
 
-		// Verify the attached volume has cluster-distribution value set
+		// Verify the attached volume has cluster-distribution value set.
 		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult for PVC with VolumeID: %s", pv.Spec.CSI.VolumeHandle))
 		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(pv.Spec.CSI.VolumeHandle)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(len(queryResult.Volumes) > 0).To(gomega.BeTrue())
 
-		framework.Logf("Cluster-distribution value on CNS is %s", queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution)
-		gomega.Expect(queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution).Should(gomega.Equal(vanillaClusterDistributionWithSpecialChar), "Wrong/empty cluster-distribution name present on CNS")
+		framework.Logf("Cluster-distribution value on CNS is %s",
+			queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution)
+		gomega.Expect(queryResult.Volumes[0].Metadata.ContainerClusterArray[0].ClusterDistribution).Should(
+			gomega.Equal(vanillaClusterDistributionWithSpecialChar), "Wrong/empty cluster-distribution name present on CNS")
 
 		ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
 		err = fpod.DeletePodWithWait(client, pod)
@@ -366,9 +375,11 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Clu
 
 		if vanillaCluster {
 			ginkgo.By("Verify volume is detached from the node")
-			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 		}
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles a few files under e2e tests.

**Testing done**:
Local build and check.