### PR TITLE
Change homeless pod opt out label name

### DIFF
--- a/pkg/syncer/k8scloudoperator/placement.go
+++ b/pkg/syncer/k8scloudoperator/placement.go
@@ -73,7 +73,7 @@ const (
 	// Appplatform label that all vDPP PVCs must have.
 	appplatformLabel = "appplatform.vmware.com/instance-id"
 	// Opt out label present on pod to look for bound PVCs of all sibling replicas
-	siblingReplicaNodeSnatchingCheckOptOutLabel = "psp.vmware.com/sibling-replica-node-snatching-check-opt-out"
+	siblingReplicaCheckOptOutLabel = "psp.vmware.com/sibling-replica-check-opt-out"
 )
 
 // StoragePoolInfo is abstraction of a storage pool list.
@@ -585,8 +585,8 @@ func eliminateNodesWithPvcOfSiblingReplica(ctx context.Context, client kubernete
 		return candidateHosts, nil
 	}
 
-	if val, ok := pvcLabels[siblingReplicaNodeSnatchingCheckOptOutLabel]; ok && val == "true" {
-		// siblingReplicaNodeSnatchingCheckOptOut is opted in by default unless specified otherwise
+	if val, ok := pvcLabels[siblingReplicaCheckOptOutLabel]; ok && val == "true" {
+		// siblingReplicaCheckOptOutLabel is opted in by default unless specified otherwise
 		log.Infof("Sibling Replica Bound PVC check is not opted, skip this step for PVC %s.", currPVC.Name)
 		return candidateHosts, nil
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This is a small change to homeless pod opt out label name.
Changing name from sibling-replica-node-snatching-check-opt-out to sibling-replica-check-opt-out

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Simulated homeless pod issue by creating an instance with 5 replicas on a cluster with 4 nodes. One pod remains in Pending state, this is the homeless pod. I then deleted one of the Running pods so that the homeless pod gets scheduled on the node. The PVC and its pods did not get deleted with the opt out label set to true on the PVC. The PVC did not get stamped with homeless pod error as well.

Logs:
```
{"level":"info","time":"2021-07-01T13:10:32.036815877Z","caller":"k8scloudoperator/placement.go:590","msg":"Sibling Replica Bound PVC check is not opted, skip this step for PVC data0-sample995-4."}
{"level":"info","time":"2021-07-01T13:10:32.200515357Z","caller":"k8scloudoperator/placement.go:590","msg":"Sibling Replica Bound PVC check is not opted, skip this step for PVC data1-sample995-4."}
```

When no value is provided for the opt-out label, it stamps the PVC with FAILED_PLACEMENT-HasSiblingReplicaBoundPVC and the PVC watcher then goes on to delete the homeless pod and its PVCs.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
