### PR TITLE
Clean up white spaces under common

### DIFF
--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -139,7 +139,8 @@ func CheckAPI(versionToCheck string,
 	}
 
 	if major < minSupportedVCenterMajor || (major == minSupportedVCenterMajor && minor < minSupportedVCenterMinor) {
-		return fmt.Errorf("the minimum supported vCenter is %d.%d.%d", minSupportedVCenterMajor, minSupportedVCenterMinor, minSupportedVCenterPatch)
+		return fmt.Errorf("the minimum supported vCenter is %d.%d.%d",
+			minSupportedVCenterMajor, minSupportedVCenterMinor, minSupportedVCenterPatch)
 	}
 
 	if major == minSupportedVCenterMajor && minor == minSupportedVCenterMinor {

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -26,79 +26,81 @@ const (
 	GbInBytes = int64(1024 * 1024 * 1024)
 
 	// DefaultGbDiskSize is the default disk size in gibibytes.
-	// TODO: will make the DefaultGbDiskSize configurable in the future
+	// TODO: will make the DefaultGbDiskSize configurable in the future.
 	DefaultGbDiskSize = int64(10)
 
-	// DiskTypeBlockVolume is the value for the PersistentVolume's attribute "type"
+	// DiskTypeBlockVolume is the value for PersistentVolume's attribute "type".
 	DiskTypeBlockVolume = "vSphere CNS Block Volume"
 
-	// DiskTypeFileVolume is the value for the PersistentVolume's attribute "type"
+	// DiskTypeFileVolume is the value for PersistentVolume's attribute "type".
 	DiskTypeFileVolume = "vSphere CNS File Volume"
 
 	// AttributeDiskType is a PersistentVolume's attribute.
 	AttributeDiskType = "type"
 
-	// AttributeDatastoreURL represents URL of the datastore in the StorageClass
-	// For Example: DatastoreURL: "ds:///vmfs/volumes/5c9bb20e-009c1e46-4b85-0200483b2a97/"
+	// AttributeDatastoreURL represents URL of the datastore in the StorageClass.
+	// For Example: DatastoreURL: "ds:///vmfs/volumes/5c9bb20e-009c1e46-4b85-0200483b2a97/".
 	AttributeDatastoreURL = "datastoreurl"
 
-	// AttributeStoragePolicyName represents name of the Storage Policy in the Storage Class
-	// For Example: StoragePolicy: "vSAN Default Storage Policy"
+	// AttributeStoragePolicyName represents name of the Storage Policy in the
+	// Storage Class.
+	// For Example: StoragePolicy: "vSAN Default Storage Policy".
 	AttributeStoragePolicyName = "storagepolicyname"
 
-	// AttributeStoragePolicyID represents Storage Policy Id in the Storage Classs
-	// For Example: StoragePolicyId: "251bce41-cb24-41df-b46b-7c75aed3c4ee"
+	// AttributeStoragePolicyID represents Storage Policy Id in the Storage Classs.
+	// For Example: StoragePolicyId: "251bce41-cb24-41df-b46b-7c75aed3c4ee".
 	AttributeStoragePolicyID = "storagepolicyid"
 
-	// AttributeSupervisorStorageClass represents name of the Storage Class
-	// For example: StorageClassName: "silver"
+	// AttributeSupervisorStorageClass represents name of the Storage Class.
+	// For example: StorageClassName: "silver".
 	AttributeSupervisorStorageClass = "svstorageclass"
 
-	// AttributeFsType represents filesystem type in the Storage Classs
-	// For Example: FsType: "ext4"
+	// AttributeFsType represents filesystem type in the Storage Classs.
+	// For Example: FsType: "ext4".
 	AttributeFsType = "fstype"
 
-	// AttributeStoragePool represents name of the StoragePool on which to place the PVC
-	// For example: StoragePool: "storagepool-vsandatastore"
+	// AttributeStoragePool represents name of the StoragePool on which to place
+	// the PVC. For example: StoragePool: "storagepool-vsandatastore".
 	AttributeStoragePool = "storagepool"
 
 	// AttributeHostLocal represents the presence of HostLocal functionality in
-	// the given storage policy. For Example: HostLocal: "True"
+	// the given storage policy. For Example: HostLocal: "True".
 	AttributeHostLocal = "hostlocal"
 
 	// HostMoidAnnotationKey represents the Node annotation key that has the value
 	// of VC's ESX host moid of this node.
 	HostMoidAnnotationKey = "vmware-system-esxi-node-moid"
 
-	// Ext4FsType represents the default filesystem type for block volume
+	// Ext4FsType represents the default filesystem type for block volume.
 	Ext4FsType = "ext4"
 
-	// NfsV4FsType represents nfs4 mount type
+	// NfsV4FsType represents nfs4 mount type.
 	NfsV4FsType = "nfs4"
 
-	// NfsFsType represents nfs mount type
+	// NfsFsType represents nfs mount type.
 	NfsFsType = "nfs"
 
-	//ProviderPrefix is the prefix used for the ProviderID set on the node
+	// ProviderPrefix is the prefix used for the ProviderID set on the node.
 	// Example: vsphere://4201794a-f26b-8914-d95a-edeb7ecc4a8f
 	ProviderPrefix = "vsphere://"
 
-	// AttributeFirstClassDiskUUID is the SCSI Disk Identifier
+	// AttributeFirstClassDiskUUID is the SCSI Disk Identifier.
 	AttributeFirstClassDiskUUID = "diskUUID"
 
-	// AttributeFakeAttached is the flag that indicates if a volume is fake attached
+	// AttributeFakeAttached is the flag that indicates if a volume is fake
+	// attached.
 	AttributeFakeAttached = "fake-attach"
 
-	// BlockVolumeType is the VolumeType for CNS Volume
+	// BlockVolumeType is the VolumeType for CNS Volume.
 	BlockVolumeType = "BLOCK"
 
-	// FileVolumeType is the VolumeType for CNS File Share Volume
+	// FileVolumeType is the VolumeType for CNS File Share Volume.
 	FileVolumeType = "FILE"
 
-	// Nfsv4AccessPointKey is the key for NFSv4 access point
+	// Nfsv4AccessPointKey is the key for NFSv4 access point.
 	Nfsv4AccessPointKey = "NFSv4.1"
 
-	// Nfsv4AccessPoint is the access point of file volume
+	// Nfsv4AccessPoint is the access point of file volume.
 	Nfsv4AccessPoint = "Nfsv4AccessPoint"
 
 	// MinSupportedVCenterMajor is the minimum, major version of vCenter
@@ -126,146 +128,160 @@ const (
 	SnapshotSupportedVCenterPatch int = 3
 
 	// VSphere67u3Version is the minimum vSphere version to use Vslm APIs
-	// to support volume migration feature
+	// to support volume migration feature.
 	VSphere67u3Version string = "6.7.3"
 
 	// VSphere7Version is the maximum vSphere version to use Vslm APIs
-	// to support volume migration feature
+	// to support volume migration feature.
 	VSphere7Version string = "7.0.0"
 
-	// VSphere67u3lBuildInfo is the build number for vCenter in 6.7 Update 3l GA bits
+	// VSphere67u3lBuildInfo is the build number for vCenter in 6.7 Update 3l
+	// GA bits.
 	VSphere67u3lBuildInfo int = 17137327
 
-	// VsanAffinityKey is the profile param key to indicate which node the FCD should be affinitized to.
+	// VsanAffinityKey is the profile param key to indicate which node the FCD
+	// should be affinitized to.
 	VsanAffinityKey string = "VSAN/affinity/affinity"
 
-	// VsanAffinityMandatory is the profile param key to turn on affinity of the volume to a specific ESX host.
+	// VsanAffinityMandatory is the profile param key to turn on affinity of
+	// the volume to a specific ESX host.
 	VsanAffinityMandatory string = "VSAN/affinityMandatory/affinityMandatory"
 
-	// VsanMigrateForDecom is the profile param key to set the migrate mode for the volume.
+	// VsanMigrateForDecom is the profile param key to set the migrate mode
+	// for the volume.
 	VsanMigrateForDecom string = "VSAN/migrateForDecom/migrateForDecom"
 
 	// VsanDatastoreType is the string to identify datastore type as vsan.
 	VsanDatastoreType string = "vsan"
 
 	// CSIMigrationParams helps identify if volume creation is requested by
-	// in-tree storageclass or CSI storageclass
+	// in-tree storageclass or CSI storageclass.
 	CSIMigrationParams = "csimigration"
 
-	// AttributeInitialVolumeFilepath represents the path of volume where volume is created
+	// AttributeInitialVolumeFilepath represents the path of volume where volume
+	// is created.
 	AttributeInitialVolumeFilepath = "initialvolumefilepath"
 
-	// DatastoreMigrationParam is used to supply datastore name for Volume provisioning
+	// DatastoreMigrationParam is used to supply datastore name for Volume
+	// provisioning.
 	DatastoreMigrationParam = "datastore-migrationparam"
 
-	// DiskFormatMigrationParam supplies disk foramt (thin, thick, zeoredthick) for Volume provisioning
+	// DiskFormatMigrationParam supplies disk foramt (thin, thick, zeoredthick)
+	// for Volume provisioning.
 	DiskFormatMigrationParam = "diskformat-migrationparam"
 
-	// HostFailuresToTolerateMigrationParam is raw vSAN Policy Parameter
+	// HostFailuresToTolerateMigrationParam is raw vSAN Policy Parameter.
 	HostFailuresToTolerateMigrationParam = "hostfailurestotolerate-migrationparam"
 
-	// ForceProvisioningMigrationParam is raw vSAN Policy Parameter
+	// ForceProvisioningMigrationParam is raw vSAN Policy Parameter.
 	ForceProvisioningMigrationParam = "forceprovisioning-migrationparam"
 
-	// CacheReservationMigrationParam is raw vSAN Policy Parameter
+	// CacheReservationMigrationParam is raw vSAN Policy Parameter.
 	CacheReservationMigrationParam = "cachereservation-migrationparam"
 
-	// DiskstripesMigrationParam is raw vSAN Policy Parameter
+	// DiskstripesMigrationParam is raw vSAN Policy Parameter.
 	DiskstripesMigrationParam = "diskstripes-migrationparam"
 
-	// ObjectspacereservationMigrationParam is raw vSAN Policy Parameter
+	// ObjectspacereservationMigrationParam is raw vSAN Policy Parameter.
 	ObjectspacereservationMigrationParam = "objectspacereservation-migrationparam"
 
-	// IopslimitMigrationParam is raw vSAN Policy Parameter
+	// IopslimitMigrationParam is raw vSAN Policy Parameter.
 	IopslimitMigrationParam = "iopslimit-migrationparam"
 
 	// AnnMigratedTo annotation is added to a PVC and PV that is supposed to be
-	// provisioned/deleted by its corresponding CSI driver
+	// provisioned/deleted by its corresponding CSI driver.
 	AnnMigratedTo = "pv.kubernetes.io/migrated-to"
 
-	// AnnStorageProvisioner annotation is added to a PVC that is supposed to be dynamically
-	// provisioned. Its value is name of volume plugin that is supposed to provision
-	// a volume for this PVC.
+	// AnnStorageProvisioner annotation is added to a PVC that is supposed to
+	// be dynamically provisioned. Its value is name of volume plugin that is
+	// supposed to provision a volume for this PVC.
 	AnnStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
 
-	// AnnDynamicallyProvisioned annotation is added to a PV that has been dynamically provisioned by
-	// Kubernetes. Its value is name of volume plugin that created the volume.
-	// It serves both user (to show where a PV comes from) and Kubernetes (to
-	// recognize dynamically provisioned PVs in its decisions).
+	// AnnDynamicallyProvisioned annotation is added to a PV that has been
+	// dynamically provisioned by Kubernetes. Its value is name of volume plugin
+	// that created the volume. It serves both user (to show where a PV comes
+	// from) and Kubernetes (to recognize dynamically provisioned PVs in its
+	// decisions).
 	AnnDynamicallyProvisioned = "pv.kubernetes.io/provisioned-by"
 
-	// InTreePluginName is the name of vsphere cloud provider in kubernetes
+	// InTreePluginName is the name of vsphere cloud provider in kubernetes.
 	InTreePluginName = "kubernetes.io/vsphere-volume"
 
-	// DsPriv is the privilege need to write on that datastore
+	// DsPriv is the privilege need to write on that datastore.
 	DsPriv = "Datastore.FileManagement"
 
-	// SysReadPriv is the privilege to view an entity
+	// SysReadPriv is the privilege to view an entity.
 	SysReadPriv = "System.Read"
 
-	// HostConfigStoragePriv is the privilege for file volumes
+	// HostConfigStoragePriv is the privilege for file volumes.
 	HostConfigStoragePriv = "Host.Config.Storage"
 
-	// AnnVolumeHealth is the key for HealthStatus annotation on volume claim
+	// AnnVolumeHealth is the key for HealthStatus annotation on volume claim.
 	AnnVolumeHealth = "volumehealth.storage.kubernetes.io/health"
 
-	// AnnFakeAttached is the key for fake attach annotation on volume claim
+	// AnnFakeAttached is the key for fake attach annotation on volume claim.
 	AnnFakeAttached = "csi.vmware.com/fake-attached"
 
-	// VolHealthStatusAccessible is volume health status for accessible volume
+	// VolHealthStatusAccessible is volume health status for accessible volume.
 	VolHealthStatusAccessible = "accessible"
 
-	// VolHealthStatusInaccessible is volume health status for inaccessible volume
+	// VolHealthStatusInaccessible is volume health status for inaccessible volume.
 	VolHealthStatusInaccessible = "inaccessible"
 
 	// AnnIgnoreInaccessiblePV is annotation key on volume claim to indicate
-	// if inaccessible PV can be fake attached
+	// if inaccessible PV can be fake attached.
 	AnnIgnoreInaccessiblePV = "pv.attach.kubernetes.io/ignore-if-inaccessible"
 
 	// TriggerCsiFullSyncCRName is the instance name of TriggerCsiFullSync
-	// All other names will be rejected by TriggerCsiFullSync controller
+	// All other names will be rejected by TriggerCsiFullSync controller.
 	TriggerCsiFullSyncCRName = "csifullsync"
 )
 
-// Supported container orchestrators
+// Supported container orchestrators.
 const (
-	Kubernetes = iota // Default container orchestrator for TKC, Supervisor Cluster and Vanilla K8s
+	// Default container orchestrator for TKC, Supervisor Cluster and Vanilla K8s.
+	Kubernetes = iota
 )
 
 // Constants related to Feature state
 const (
-	// default interval to check if the feature is enabled or not
+	// Default interval to check if the feature is enabled or not.
 	DefaultFeatureEnablementCheckInterval = 1 * time.Minute
-	// VolumeHealth is the feature flag name for volume health
+	// VolumeHealth is the feature flag name for volume health.
 	VolumeHealth = "volume-health"
-	// VolumeExtend is feature flag name for volume expansion
+	// VolumeExtend is feature flag name for volume expansion.
 	VolumeExtend = "volume-extend"
-	// OnlineVolumeExtend guards the feature for online volume expansion
+	// OnlineVolumeExtend guards the feature for online volume expansion.
 	OnlineVolumeExtend = "online-volume-extend"
-	// CSIMigration is feature flag for migrating in-tree vSphere volumes to CSI
+	// CSIMigration is feature flag for migrating in-tree vSphere volumes to CSI.
 	CSIMigration = "csi-migration"
-	// CSIAuthCheck is feature flag for auth check
+	// CSIAuthCheck is feature flag for auth check.
 	CSIAuthCheck = "csi-auth-check"
-	// AsyncQueryVolume is feature flag for using async query volume API
+	// AsyncQueryVolume is feature flag for using async query volume API.
 	AsyncQueryVolume = "async-query-volume"
-	// CSISVFeatureStateReplication is feature flag for SV feature state replication feature
+	// CSISVFeatureStateReplication is feature flag for SV feature state
+	// replication feature.
 	CSISVFeatureStateReplication = "csi-sv-feature-states-replication"
-	// VSANDirectDiskDecommission is feature flag for vsanD disk decommission
+	// VSANDirectDiskDecommission is feature flag for vsanD disk decommission.
 	VSANDirectDiskDecommission = "vsan-direct-disk-decommission"
-	// FileVolume is feature flag name for file volume support in WCP
+	// FileVolume is feature flag name for file volume support in WCP.
 	FileVolume = "file-volume"
-	// FakeAttach is the feature flag for fake attach support in WCP
+	// FakeAttach is the feature flag for fake attach support in WCP.
 	FakeAttach = "fake-attach"
-	// TriggerCSIFullSyync is feature flag to trigger full sync
+	// TriggerCSIFullSyync is feature flag to trigger full sync.
 	TriggerCsiFullSync = "trigger-csi-fullsync"
-	// CSIVolumeManagerIdempotency is the feature flag for idempotency handling in CSI volume manager
+	// CSIVolumeManagerIdempotency is the feature flag for idempotency handling
+	// in CSI volume manager.
 	CSIVolumeManagerIdempotency = "improved-csi-idempotency"
-	// ImprovedVolumeTopology is the feature flag used to make the following improvements
-	// to topology feature:
+	// ImprovedVolumeTopology is the feature flag used to make the following
+	// improvements to topology feature:
 	// 1. Avoid taking in VC credentials in node daemonset.
 	ImprovedVolumeTopology = "improved-volume-topology"
-	// BlockVolumeSnapshot is the feature to support CSI Snapshots for block volume on vSphere CSI driver.
+	// BlockVolumeSnapshot is the feature to support CSI Snapshots for block
+	// volume on vSphere CSI driver.
 	BlockVolumeSnapshot = "block-volume-snapshot"
-	// SiblingReplicaBoundPvcCheck is the feature to check whether a PVC of a given replica can be placed on a node such that it does not have PVCs of any of its sibling replicas.
+	// SiblingReplicaBoundPvcCheck is the feature to check whether a PVC of
+	// a given replica can be placed on a node such that it does not have PVCs
+	// of any of its sibling replicas.
 	SiblingReplicaBoundPvcCheck = "sibling-replica-bound-pvc-check"
 )

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -42,7 +42,8 @@ const (
 )
 
 // GetVCenter returns VirtualCenter object from specified Manager object.
-// Before returning VirtualCenter object, vcenter connection is established if session doesn't exist.
+// Before returning VirtualCenter object, vcenter connection is established if
+// session doesn't exist.
 func GetVCenter(ctx context.Context, manager *Manager) (*cnsvsphere.VirtualCenter, error) {
 	var err error
 	log := logger.GetLogger(ctx)
@@ -59,13 +60,14 @@ func GetVCenter(ctx context.Context, manager *Manager) (*cnsvsphere.VirtualCente
 	return vcenter, nil
 }
 
-// GetUUIDFromProviderID Returns VM UUID from Node's providerID
+// GetUUIDFromProviderID Returns VM UUID from Node's providerID.
 func GetUUIDFromProviderID(providerID string) string {
 	return strings.TrimPrefix(providerID, ProviderPrefix)
 }
 
-// FormatDiskUUID removes any spaces and hyphens in UUID
-// Example UUID input is 42375390-71f9-43a3-a770-56803bcd7baa and output after format is 4237539071f943a3a77056803bcd7baa
+// FormatDiskUUID removes any spaces and hyphens in UUID.
+// Example UUID input is 42375390-71f9-43a3-a770-56803bcd7baa and output after
+// format is 4237539071f943a3a77056803bcd7baa.
 func FormatDiskUUID(uuid string) string {
 	uuidwithNoSpace := strings.Replace(uuid, " ", "", -1)
 	uuidWithNoHypens := strings.Replace(uuidwithNoSpace, "-", "", -1)
@@ -82,7 +84,7 @@ func RoundUpSize(volumeSizeBytes int64, allocationUnitBytes int64) int64 {
 	return roundedUp
 }
 
-// GetLabelsMapFromKeyValue creates a  map object from given parameter
+// GetLabelsMapFromKeyValue creates a  map object from given parameter.
 func GetLabelsMapFromKeyValue(labels []types.KeyValue) map[string]string {
 	labelsMap := make(map[string]string)
 	for _, label := range labels {
@@ -104,9 +106,9 @@ func IsFileVolumeRequest(ctx context.Context, capabilities []*csi.VolumeCapabili
 }
 
 // GetVolumeCapabilityFsType retrieves fstype from VolumeCapability.
-// Defaults to nfs4 for file volume and ext4 for block volume when empty string is observed.
-// This function also ignores default ext4 fstype supplied by external-provisioner when none is
-// specified in the StorageClass
+// Defaults to nfs4 for file volume and ext4 for block volume when empty string
+// is observed. This function also ignores default ext4 fstype supplied by
+// external-provisioner when none is specified in the StorageClass
 func GetVolumeCapabilityFsType(ctx context.Context, capability *csi.VolumeCapability) string {
 	log := logger.GetLogger(ctx)
 	fsType := strings.ToLower(capability.GetMount().GetFsType())
@@ -122,7 +124,8 @@ func GetVolumeCapabilityFsType(ctx context.Context, capability *csi.VolumeCapabi
 	return fsType
 }
 
-// IsVolumeReadOnly checks the access mode in Volume Capability and decides if volume is readonly or not
+// IsVolumeReadOnly checks the access mode in Volume Capability and decides
+// if volume is readonly or not.
 func IsVolumeReadOnly(capability *csi.VolumeCapability) bool {
 	accMode := capability.GetAccessMode().GetMode()
 	ro := false
@@ -133,10 +136,11 @@ func IsVolumeReadOnly(capability *csi.VolumeCapability) bool {
 	return ro
 }
 
-// validateVolumeCapabilities validates the access mode in given volume capabilities in validAccessModes.
-func validateVolumeCapabilities(volCaps []*csi.VolumeCapability, validAccessModes []csi.VolumeCapability_AccessMode, volumeType string) error {
-	// Validate if all capabilities of the volume
-	// are supported.
+// validateVolumeCapabilities validates the access mode in given volume
+// capabilities in validAccessModes.
+func validateVolumeCapabilities(volCaps []*csi.VolumeCapability,
+	validAccessModes []csi.VolumeCapability_AccessMode, volumeType string) error {
+	// Validate if all capabilities of the volume are supported.
 	for _, volCap := range volCaps {
 		found := false
 		for _, validAccessMode := range validAccessModes {
@@ -146,10 +150,12 @@ func validateVolumeCapabilities(volCaps []*csi.VolumeCapability, validAccessMode
 			}
 		}
 		if !found {
-			return fmt.Errorf("%s access mode is not supported for %q volumes", csi.VolumeCapability_AccessMode_Mode_name[int32(volCap.AccessMode.GetMode())], volumeType)
+			return fmt.Errorf("%s access mode is not supported for %q volumes",
+				csi.VolumeCapability_AccessMode_Mode_name[int32(volCap.AccessMode.GetMode())], volumeType)
 		}
 		if volCap.AccessMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
-			if volCap.GetMount() != nil && (volCap.GetMount().FsType == NfsV4FsType || volCap.GetMount().FsType == NfsFsType) {
+			if volCap.GetMount() != nil && (volCap.GetMount().FsType == NfsV4FsType ||
+				volCap.GetMount().FsType == NfsFsType) {
 				return fmt.Errorf("NFS fstype not supported for ReadWriteOnce volume creation")
 			}
 		}
@@ -157,7 +163,8 @@ func validateVolumeCapabilities(volCaps []*csi.VolumeCapability, validAccessMode
 	return nil
 }
 
-// IsValidVolumeCapabilities helps validate the given volume capabilities based on volume type.
+// IsValidVolumeCapabilities helps validate the given volume capabilities
+// based on volume type.
 func IsValidVolumeCapabilities(ctx context.Context, volCaps []*csi.VolumeCapability) error {
 	if IsFileVolumeRequest(ctx, volCaps) {
 		return validateVolumeCapabilities(volCaps, FileVolumeCaps, FileVolumeType)
@@ -166,8 +173,8 @@ func IsValidVolumeCapabilities(ctx context.Context, volCaps []*csi.VolumeCapabil
 }
 
 // IsFileVolumeMount loops through the list of mount points and
-// checks if the target path mount point is a file volume type or not
-// Returns an error if the target path is not found in the mount points
+// checks if the target path mount point is a file volume type or not.
+// Returns an error if the target path is not found in the mount points.
 func IsFileVolumeMount(ctx context.Context, target string, mnts []gofsutil.Info) (bool, error) {
 	log := logger.GetLogger(ctx)
 	for _, m := range mnts {
@@ -180,11 +187,12 @@ func IsFileVolumeMount(ctx context.Context, target string, mnts []gofsutil.Info)
 			return false, nil
 		}
 	}
-	// Target path mount point not found in list of mounts
+	// Target path mount point not found in list of mounts.
 	return false, fmt.Errorf("could not find target path %q in list of mounts", target)
 }
 
-// IsTargetInMounts checks if the given target path is present in list of mount points
+// IsTargetInMounts checks if the given target path is present in list of
+// mount points.
 func IsTargetInMounts(ctx context.Context, target string, mnts []gofsutil.Info) bool {
 	log := logger.GetLogger(ctx)
 	for _, m := range mnts {
@@ -197,9 +205,10 @@ func IsTargetInMounts(ctx context.Context, target string, mnts []gofsutil.Info) 
 	return false
 }
 
-// ParseStorageClassParams parses the params in the CSI CreateVolumeRequest API call back
-// to StorageClassParams structure.
-func ParseStorageClassParams(ctx context.Context, params map[string]string, csiMigrationFeatureState bool) (*StorageClassParams, error) {
+// ParseStorageClassParams parses the params in the CSI CreateVolumeRequest API
+// call back to StorageClassParams structure.
+func ParseStorageClassParams(ctx context.Context, params map[string]string,
+	csiMigrationFeatureState bool) (*StorageClassParams, error) {
 	log := logger.GetLogger(ctx)
 	scParams := &StorageClassParams{
 		DatastoreURL:      "",
@@ -234,7 +243,7 @@ func ParseStorageClassParams(ctx context.Context, params map[string]string, csiM
 				otherParams[param] = value
 			}
 		}
-		// check otherParams belongs to in-tree migrated Parameters
+		// check otherParams belongs to in-tree migrated Parameters.
 		if scParams.CSIMigration == "true" {
 			for param, value := range otherParams {
 				param = strings.ToLower(param)
@@ -246,7 +255,8 @@ func ParseStorageClassParams(ctx context.Context, params map[string]string, csiM
 					param == ForceProvisioningMigrationParam || param == CacheReservationMigrationParam ||
 					param == DiskstripesMigrationParam || param == ObjectspacereservationMigrationParam ||
 					param == IopslimitMigrationParam {
-					return nil, fmt.Errorf("vSphere CSI driver does not support creating volume using in-tree vSphere volume plugin parameter key:%v, value:%v", param, value)
+					return nil, fmt.Errorf("vSphere CSI driver does not support creating volume using "+
+						"in-tree vSphere volume plugin parameter key:%v, value:%v", param, value)
 				} else {
 					return nil, fmt.Errorf("invalid parameter. key:%v, value:%v", param, value)
 				}
@@ -260,7 +270,8 @@ func ParseStorageClassParams(ctx context.Context, params map[string]string, csiM
 	return scParams, nil
 }
 
-// GetConfigPath returns ConfigPath depending on the environment variable specified and the cluster flavor set
+// GetConfigPath returns ConfigPath depending on the environment variable
+// specified and the cluster flavor set.
 func GetConfigPath(ctx context.Context) string {
 	var cfgPath string
 	clusterFlavor := cnstypes.CnsClusterFlavor(os.Getenv(csitypes.EnvClusterFlavor))
@@ -268,13 +279,13 @@ func GetConfigPath(ctx context.Context) string {
 		clusterFlavor = cnstypes.CnsClusterFlavorVanilla
 	}
 	if clusterFlavor == cnstypes.CnsClusterFlavorGuest {
-		// Config path for Guest Cluster
+		// Config path for Guest Cluster.
 		cfgPath = os.Getenv(cnsconfig.EnvGCConfig)
 		if cfgPath == "" {
 			cfgPath = cnsconfig.DefaultGCConfigPath
 		}
 	} else {
-		// Config path for SuperVisor and Vanilla Cluster
+		// Config path for SuperVisor and Vanilla Cluster.
 		cfgPath = os.Getenv(cnsconfig.EnvVSphereCSIConfig)
 		if cfgPath == "" {
 			cfgPath = cnsconfig.DefaultCloudConfigPath
@@ -283,7 +294,7 @@ func GetConfigPath(ctx context.Context) string {
 	return cfgPath
 }
 
-// GetConfig loads configuration from secret and returns config object
+// GetConfig loads configuration from secret and returns config object.
 func GetConfig(ctx context.Context) (*cnsconfig.Config, error) {
 	var cfg *cnsconfig.Config
 	var err error
@@ -302,7 +313,7 @@ func GetConfig(ctx context.Context) (*cnsconfig.Config, error) {
 	return cfg, err
 }
 
-// InitConfigInfo initializes the ConfigurationInfo struct
+// InitConfigInfo initializes the ConfigurationInfo struct.
 func InitConfigInfo(ctx context.Context) (*cnsconfig.ConfigurationInfo, error) {
 	log := logger.GetLogger(ctx)
 	cfg, err := GetConfig(ctx)
@@ -316,29 +327,35 @@ func InitConfigInfo(ctx context.Context) (*cnsconfig.ConfigurationInfo, error) {
 	return configInfo, nil
 }
 
-// GetK8sCloudOperatorServicePort return the port to connect the K8sCloudOperator gRPC service.
+// GetK8sCloudOperatorServicePort return the port to connect the
+// K8sCloudOperator gRPC service.
 // If environment variable POD_LISTENER_SERVICE_PORT is set and valid,
-// return the interval value read from environment variable
-// otherwise, use the default port
+// return the interval value read from environment variable.
+// Otherwise, use the default port.
 func GetK8sCloudOperatorServicePort(ctx context.Context) int {
 	k8sCloudOperatorServicePort := defaultK8sCloudOperatorServicePort
 	log := logger.GetLogger(ctx)
 	if v := os.Getenv("POD_LISTENER_SERVICE_PORT"); v != "" {
 		if value, err := strconv.Atoi(v); err == nil {
 			if value <= 0 {
-				log.Warnf("Connecting to K8s Cloud Operator Service on port set in env variable POD_LISTENER_SERVICE_PORT %s is equal or less than 0, will use the default port %d", v, defaultK8sCloudOperatorServicePort)
+				log.Warnf("Connecting to K8s Cloud Operator Service on port set in env variable "+
+					"POD_LISTENER_SERVICE_PORT %s is equal or less than 0, will use the default port %d",
+					v, defaultK8sCloudOperatorServicePort)
 			} else {
 				k8sCloudOperatorServicePort = value
 				log.Infof("Connecting to K8s Cloud Operator Service on port %d", k8sCloudOperatorServicePort)
 			}
 		} else {
-			log.Warnf("Connecting to K8s Cloud Operator Service on port set in env variable POD_LISTENER_SERVICE_PORT %s is invalid, will use the default port %d", v, defaultK8sCloudOperatorServicePort)
+			log.Warnf("Connecting to K8s Cloud Operator Service on port set in env variable "+
+				"POD_LISTENER_SERVICE_PORT %s is invalid, will use the default port %d",
+				v, defaultK8sCloudOperatorServicePort)
 		}
 	}
 	return k8sCloudOperatorServicePort
 }
 
-// ConvertVolumeHealthStatus convert the volume health status into accessible/inaccessible status
+// ConvertVolumeHealthStatus convert the volume health status into
+// accessible/inaccessible status.
 func ConvertVolumeHealthStatus(ctx context.Context, volID string, volHealthStatus string) (string, error) {
 	log := logger.GetLogger(ctx)
 	switch volHealthStatus {
@@ -353,8 +370,8 @@ func ConvertVolumeHealthStatus(ctx context.Context, volID string, volHealthStatu
 	default:
 		// NOTE: volHealthStatus is not set by SPBM in this case.
 		// This implies the volume does not exist any more.
-		// Set health annotation to "Inaccessible" so that
-		// the caller can make appropriate reactions based on this status
+		// Set health annotation to "Inaccessible" so that the caller
+		// can make appropriate reactions based on this status.
 		log.Debugf("Volume health is not set for volume: %s", volID)
 		return VolHealthStatusInaccessible, nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles a few files under service/common.

**Testing done**:
Local build and check.