### PR TITLE
Clean up white spaces in cnsoperator init

### DIFF
--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -61,7 +61,7 @@ type cnsOperator struct {
 	coCommonInterface commonco.COCommonInterface
 }
 
-// InitCnsOperator initializes the Cns Operator
+// InitCnsOperator initializes the Cns Operator.
 func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
 	configInfo *commonconfig.ConfigurationInfo, coInitParams *interface{}) error {
 	log := logger.GetLogger(ctx)
@@ -94,30 +94,36 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 	}
 
 	// TODO: Verify leader election for CNS Operator in multi-master mode
-	// Create CRD's for WCP flavor
+	// Create CRD's for WCP flavor.
 	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
-		// Create CnsNodeVmAttachment CRD
+		// Create CnsNodeVmAttachment CRD.
 		crdKindNodeVMAttachment := reflect.TypeOf(cnsnodevmattachmentv1alpha1.CnsNodeVmAttachment{}).Name()
-		crdNameNodeVMAttachment := cnsoperatorv1alpha1.CnsNodeVMAttachmentPlural + "." + cnsoperatorv1alpha1.SchemeGroupVersion.Group
-		err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, crdNameNodeVMAttachment, cnsoperatorv1alpha1.CnsNodeVMAttachmentSingular, cnsoperatorv1alpha1.CnsNodeVMAttachmentPlural,
-			crdKindNodeVMAttachment, cnsoperatorv1alpha1.SchemeGroupVersion.Group, cnsoperatorv1alpha1.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
+		crdNameNodeVMAttachment := cnsoperatorv1alpha1.CnsNodeVMAttachmentPlural + "." +
+			cnsoperatorv1alpha1.SchemeGroupVersion.Group
+		err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, crdNameNodeVMAttachment,
+			cnsoperatorv1alpha1.CnsNodeVMAttachmentSingular, cnsoperatorv1alpha1.CnsNodeVMAttachmentPlural,
+			crdKindNodeVMAttachment, cnsoperatorv1alpha1.SchemeGroupVersion.Group,
+			cnsoperatorv1alpha1.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
 		if err != nil {
 			log.Errorf("failed to create %q CRD. Err: %+v", crdNameNodeVMAttachment, err)
 			return err
 		}
 
-		// Create CnsVolumeMetadata CRD
+		// Create CnsVolumeMetadata CRD.
 		crdKindVolumeMetadata := reflect.TypeOf(cnsvolumemetadatav1alpha1.CnsVolumeMetadata{}).Name()
-		crdNameVolumeMetadata := cnsoperatorv1alpha1.CnsVolumeMetadataPlural + "." + cnsoperatorv1alpha1.SchemeGroupVersion.Group
+		crdNameVolumeMetadata := cnsoperatorv1alpha1.CnsVolumeMetadataPlural + "." +
+			cnsoperatorv1alpha1.SchemeGroupVersion.Group
 
-		err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, crdNameVolumeMetadata, cnsoperatorv1alpha1.CnsVolumeMetadataSingular, cnsoperatorv1alpha1.CnsVolumeMetadataPlural,
-			crdKindVolumeMetadata, cnsoperatorv1alpha1.SchemeGroupVersion.Group, cnsoperatorv1alpha1.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
+		err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, crdNameVolumeMetadata,
+			cnsoperatorv1alpha1.CnsVolumeMetadataSingular, cnsoperatorv1alpha1.CnsVolumeMetadataPlural,
+			crdKindVolumeMetadata, cnsoperatorv1alpha1.SchemeGroupVersion.Group,
+			cnsoperatorv1alpha1.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
 		if err != nil {
 			log.Errorf("failed to create %q CRD. Err: %+v", crdKindVolumeMetadata, err)
 			return err
 		}
 
-		// Create CnsRegisterVolume CRD from manifest
+		// Create CnsRegisterVolume CRD from manifest.
 		err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cnsregistervolume_crd.yaml")
 		if err != nil {
 			log.Errorf("Failed to create %q CRD. Err: %+v", cnsoperatorv1alpha1.CnsRegisterVolumePlural, err)
@@ -125,13 +131,15 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 		}
 
 		if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.FileVolume) {
-			// Create CnsFileAccessConfig CRD from manifest if file volume feature is enabled
+			// Create CnsFileAccessConfig CRD from manifest if file volume feature
+			// is enabled.
 			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cnsfileaccessconfig_crd.yaml")
 			if err != nil {
 				log.Errorf("Failed to create %q CRD. Err: %+v", cnsoperatorv1alpha1.CnsFileAccessConfigPlural, err)
 				return err
 			}
-			// Create FileVolumeClients CRD from manifest if file volume feature is enabled
+			// Create FileVolumeClients CRD from manifest if file volume feature
+			// is enabled.
 			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cnsfilevolumeclient_crd.yaml")
 			if err != nil {
 				log.Errorf("Failed to create %q CRD. Err: %+v", internalapis.CnsFileVolumeClientPlural, err)
@@ -139,18 +147,19 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			}
 		}
 
-		// Clean up routine to cleanup successful CnsRegisterVolume instances
+		// Clean up routine to cleanup successful CnsRegisterVolume instances.
 		err = watcher(ctx, cnsOperator)
 		if err != nil {
-			log.Error("Failed to watch on config file for changes to CnsRegisterVolumesCleanupIntervalInMin. Error: %+v", err)
+			log.Error("Failed to watch on config file for changes to CnsRegisterVolumesCleanupIntervalInMin. Error: %+v",
+				err)
 			return err
-
 		}
 		go func() {
 			for {
 				ctx, log = logger.GetNewContextWithLogger()
 				log.Infof("Triggering CnsRegisterVolume cleanup routine")
-				cleanUpCnsRegisterVolumeInstances(ctx, restConfig, cnsOperator.configInfo.Cfg.Global.CnsRegisterVolumesCleanupIntervalInMin)
+				cleanUpCnsRegisterVolumeInstances(ctx, restConfig,
+					cnsOperator.configInfo.Cfg.Global.CnsRegisterVolumesCleanupIntervalInMin)
 				log.Infof("Completed CnsRegisterVolume cleanup")
 				for i := 1; i <= cnsOperator.configInfo.Cfg.Global.CnsRegisterVolumesCleanupIntervalInMin; i++ {
 					time.Sleep(time.Duration(1 * time.Minute))
@@ -168,8 +177,8 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 				log.Errorf("Failed to create %q CRD. Error: %+v", csinodetopology.CRDSingular, err)
 				return err
 			}
-			// Initialize node manager so that CSINodeTopology controller
-			// can retrieve NodeVM using the NodeID in the spec
+			// Initialize node manager so that CSINodeTopology controller can
+			// retrieve NodeVM using the NodeID in the spec.
 			nodeMgr := &node.Nodes{}
 			err = nodeMgr.Initialize(ctx)
 			if err != nil {
@@ -192,7 +201,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 
 	log.Info("Registering Components for Cns Operator")
 
-	// Setup Scheme for all resources for external APIs
+	// Setup Scheme for all resources for external APIs.
 	if err := cnsoperatorv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Errorf("failed to set the scheme for Cns operator. Err: %+v", err)
 		return err
@@ -202,7 +211,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 		return err
 	}
 
-	// Setup all Controllers
+	// Setup all Controllers.
 	if err := controller.AddToManager(mgr, clusterFlavor, cnsOperator.configInfo, volumeManager); err != nil {
 		log.Errorf("failed to setup the controller for Cns operator. Err: %+v", err)
 		return err
@@ -210,7 +219,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 
 	log.Info("Starting Cns Operator")
 
-	// Start the operator
+	// Start the operator.
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
 		log.Errorf("failed to start Cns operator. Err: %+v", err)
 		return err
@@ -218,7 +227,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 	return nil
 }
 
-// InitCommonModules initializes the common modules for all flavors
+// InitCommonModules initializes the common modules for all flavors.
 func InitCommonModules(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
 	coInitParams *interface{}) error {
 	ctx = logger.NewContextWithLogger(ctx)
@@ -226,11 +235,14 @@ func InitCommonModules(ctx context.Context, clusterFlavor cnstypes.CnsClusterFla
 	var coCommonInterface commonco.COCommonInterface
 	var err error
 	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
-		coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, cnstypes.CnsClusterFlavorWorkload, *coInitParams)
+		coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx,
+			common.Kubernetes, cnstypes.CnsClusterFlavorWorkload, *coInitParams)
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-		coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, cnstypes.CnsClusterFlavorVanilla, *coInitParams)
+		coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx,
+			common.Kubernetes, cnstypes.CnsClusterFlavorVanilla, *coInitParams)
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorGuest {
-		coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx, common.Kubernetes, cnstypes.CnsClusterFlavorGuest, *coInitParams)
+		coCommonInterface, err = commonco.GetContainerOrchestratorInterface(ctx,
+			common.Kubernetes, cnstypes.CnsClusterFlavorGuest, *coInitParams)
 	}
 	if err != nil {
 		log.Errorf("failed to create CO agnostic interface. Err: %v", err)
@@ -243,7 +255,7 @@ func InitCommonModules(ctx context.Context, clusterFlavor cnstypes.CnsClusterFla
 			log.Errorf("Failed to create %q CRD. Err: %+v", internalapis.TriggerCsiFullSyncPlural, err)
 			return err
 		}
-		// Get a config to talk to the apiserver
+		// Get a config to talk to the apiserver.
 		restConfig, err := config.GetConfig()
 		if err != nil {
 			log.Errorf("failed to get Kubernetes config. Err: %+v", err)
@@ -254,31 +266,36 @@ func InitCommonModules(ctx context.Context, clusterFlavor cnstypes.CnsClusterFla
 			log.Errorf("Failed to create CnsOperator client. Err: %+v", err)
 			return err
 		}
-		// Check if TriggerCsiFullSync instance is present
-		// If not present, create the TriggerCsiFullSync instance with name "csifullsync"
+		// Check if TriggerCsiFullSync instance is present. If not present,
+		// create the TriggerCsiFullSync instance with name "csifullsync".
 		// If present, update the TriggerCsiFullSync.Status.InProgress to false if
-		// a full sync is already running
+		// a full sync is already running.
 		triggerCsiFullSyncInstance := &triggercsifullsyncv1alpha1.TriggerCsiFullSync{}
 		key := k8stypes.NamespacedName{Namespace: "", Name: common.TriggerCsiFullSyncCRName}
 		if err := cnsOperatorClient.Get(ctx, key, triggerCsiFullSyncInstance); err != nil {
 			if apierrors.IsNotFound(err) {
 				newtriggerCsiFullSyncInstance := triggercsifullsyncv1alpha1.CreateTriggerCsiFullSyncInstance()
 				if err := cnsOperatorClient.Create(ctx, newtriggerCsiFullSyncInstance); err != nil {
-					log.Errorf("Failed to create TriggerCsiFullSync instance: %q. Error: %v", common.TriggerCsiFullSyncCRName, err)
+					log.Errorf("Failed to create TriggerCsiFullSync instance: %q. Error: %v",
+						common.TriggerCsiFullSyncCRName, err)
 					return err
 				}
-				log.Infof("Created the a new instance of %q TriggerCsiFullSync instance as it was not found.", common.TriggerCsiFullSyncCRName)
+				log.Infof("Created the a new instance of %q TriggerCsiFullSync instance as it was not found.",
+					common.TriggerCsiFullSyncCRName)
 			} else {
-				log.Errorf("Failed to get TriggerCsiFullSync instance: %q. Error: %v", common.TriggerCsiFullSyncCRName, err)
+				log.Errorf("Failed to get TriggerCsiFullSync instance: %q. Error: %v",
+					common.TriggerCsiFullSyncCRName, err)
 				return err
 			}
 		}
 		if triggerCsiFullSyncInstance.Status.InProgress {
-			log.Infof("Found %q instance with InProgress set to true on syncer startup. Resetting InProgress field to false as no full sync is currently running",
+			log.Infof("Found %q instance with InProgress set to true on syncer startup. "+
+				"Resetting InProgress field to false as no full sync is currently running",
 				common.TriggerCsiFullSyncCRName)
 			triggerCsiFullSyncInstance.Status.InProgress = false
 			if err := cnsOperatorClient.Update(ctx, triggerCsiFullSyncInstance); err != nil {
-				log.Errorf("Failed to update TriggerCsiFullSync instance: %q with Status.InProgress set to false. Error: %v", common.TriggerCsiFullSyncCRName, err)
+				log.Errorf("Failed to update TriggerCsiFullSync instance: %q with Status.InProgress set to false. "+
+					"Error: %v", common.TriggerCsiFullSyncCRName, err)
 				return err
 			}
 		}
@@ -286,7 +303,8 @@ func InitCommonModules(ctx context.Context, clusterFlavor cnstypes.CnsClusterFla
 	return nil
 }
 
-// watcher watches on the vsphere.conf file mounted as secret within the syncer container
+// watcher watches on the vsphere.conf file mounted as secret within the syncer
+// container.
 func watcher(ctx context.Context, cnsOperator *cnsOperator) error {
 	log := logger.GetLogger(ctx)
 	cfgPath := common.GetConfigPath(ctx)
@@ -331,8 +349,8 @@ func watcher(ctx context.Context, cnsOperator *cnsOperator) error {
 	return err
 }
 
-//reloadConfiguration reloads configuration from the secret, and cnsOperator
-//with the latest configInfo
+// reloadConfiguration reloads configuration from the secret, and cnsOperator
+// with the latest configInfo.
 func reloadConfiguration(ctx context.Context, cnsOperator *cnsOperator) error {
 	log := logger.GetLogger(ctx)
 	cfg, err := common.GetConfig(ctx)
@@ -341,6 +359,7 @@ func reloadConfiguration(ctx context.Context, cnsOperator *cnsOperator) error {
 		return err
 	}
 	cnsOperator.configInfo = &commonconfig.ConfigurationInfo{Cfg: cfg}
-	log.Infof("Reloaded the value for CnsRegisterVolumesCleanupIntervalInMin to %d", cnsOperator.configInfo.Cfg.Global.CnsRegisterVolumesCleanupIntervalInMin)
+	log.Infof("Reloaded the value for CnsRegisterVolumesCleanupIntervalInMin to %d",
+		cnsOperator.configInfo.Cfg.Global.CnsRegisterVolumesCleanupIntervalInMin)
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles cnsoperator init methods.

**Testing done**:
Local build and check.