### PR TITLE
Clean up white spaces in vsphere-csi

### DIFF
--- a/cmd/vsphere-csi/main.go
+++ b/cmd/vsphere-csi/main.go
@@ -35,11 +35,13 @@ import (
 var (
 	printVersion = flag.Bool("version", false, "Print driver version and exit")
 
-	supervisorFSSName      = flag.String("supervisor-fss-name", "", "Name of the feature state switch configmap in supervisor cluster")
-	supervisorFSSNamespace = flag.String("supervisor-fss-namespace", "", "Namespace of the feature state switch configmap in supervisor cluster")
-	internalFSSName        = flag.String("fss-name", "", "Name of the feature state switch configmap")
-	internalFSSNamespace   = flag.String("fss-namespace", "", "Namespace of the feature state switch configmap")
-	useGocsi               = flag.Bool("use-gocsi", true, "Flag to specify to use gocsi or not")
+	supervisorFSSName = flag.String("supervisor-fss-name", "",
+		"Name of the feature state switch configmap in supervisor cluster")
+	supervisorFSSNamespace = flag.String("supervisor-fss-namespace", "",
+		"Namespace of the feature state switch configmap in supervisor cluster")
+	internalFSSName      = flag.String("fss-name", "", "Name of the feature state switch configmap")
+	internalFSSNamespace = flag.String("fss-namespace", "", "Namespace of the feature state switch configmap")
+	useGocsi             = flag.Bool("use-gocsi", true, "Flag to specify to use gocsi or not")
 )
 
 // main is ignored when this package is built as a go plug-in.
@@ -54,7 +56,7 @@ func main() {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Infof("Version : %s", service.Version)
 
-	// Set CO Init params
+	// Set CO Init params.
 	clusterFlavor, err := csiconfig.GetClusterFlavor(ctx)
 	if err != nil {
 		log.Errorf("Failed retrieving cluster flavor. Error: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles vsphere-csi main.go.

**Testing done**:
Local build and check.