### PR TITLE
Use LogNewErrorf in syncer

### DIFF
--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -175,7 +174,7 @@ func StartWebhookServer(ctx context.Context) error {
 		<-stopCh
 		return nil
 	}
-	return errors.New("can't start webhook. no features are enabled which requires webhook")
+	return logger.LogNewError(log, "can't start webhook. no features are enabled which requires webhook")
 }
 
 // restartWebhookServer stops the webhook server and start webhook using

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -18,7 +18,6 @@ package cnsregistervolume
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -108,9 +107,7 @@ func getK8sStorageClassName(ctx context.Context, k8sClient clientset.Interface,
 	log := logger.GetLogger(ctx)
 	scList, err := k8sClient.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		msg := fmt.Sprintf("Failed to get Storageclasses from API server. Error: %+v", err)
-		log.Error(msg)
-		return "", errors.New(msg)
+		return "", logger.LogNewErrorf(log, "Failed to get Storageclasses from API server. Error: %+v", err)
 	}
 	var scName string
 	for _, sc := range scList.Items {
@@ -133,9 +130,7 @@ func getK8sStorageClassName(ctx context.Context, k8sClient clientset.Interface,
 	*/
 	quotaList, err := k8sClient.CoreV1().ResourceQuotas(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		msg := fmt.Sprintf("Failed to get resource quotas on the namespace: %s", namespace)
-		log.Error(msg)
-		return "", errors.New(msg)
+		return "", logger.LogNewErrorf(log, "Failed to get resource quotas on the namespace: %s", namespace)
 	}
 
 	if scName != "" && len(quotaList.Items) > 0 {
@@ -152,11 +147,9 @@ func getK8sStorageClassName(ctx context.Context, k8sClient clientset.Interface,
 		}
 	}
 
-	msg := fmt.Sprintf("Failed to find matching K8s Storageclass. "+
+	return "", logger.LogNewErrorf(log, "Failed to find matching K8s Storageclass. "+
 		"Either storagepolicyId: %s doesn't match any storage class, or the policy is not assigned to namespace: %s",
 		storagePolicyID, namespace)
-	log.Error(msg)
-	return "", errors.New(msg)
 }
 
 // getPersistentVolumeSpec to create PV volume spec for the given input params.

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -18,7 +18,6 @@ package csinodetopology
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -250,9 +249,9 @@ func (r *ReconcileCSINodeTopology) Reconcile(ctx context.Context, request reconc
 		}
 	} else {
 		msg := "missing zone or region information in vSphere CSI config `Labels` section"
-		log.Error(msg)
+		err = logger.LogNewError(log, msg)
 		_ = updateCRStatus(ctx, r, instance, csinodetopologyv1alpha1.CSINodeTopologyError, msg)
-		return reconcile.Result{}, errors.New(msg)
+		return reconcile.Result{}, err
 	}
 
 	// On successful event, remove instance from backOffDuration.


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a pattern of log the error message, when creating a new error. This creates
duplicated code. This change uses LogNewError, and LogNewErrorf to reduce
duplicated code. In addition, using LogNewError consistently will make sure that
all generated errors will be logged (when log is available in the function).

This change fixes syncer code. The other files will be fixed in follow-up changes.

**Testing done**:
Local build and check.
WCP Precheckin Tests: SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 190 Skipped