### PR TITLE
Use LogNewErrorf in csi

### DIFF
--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -18,7 +18,6 @@ package common
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -165,23 +164,20 @@ func UseVslmAPIs(ctx context.Context, aboutInfo vim25types.AboutInfo) (bool, err
 	// Convert version string to int, e.g. "6.7.3" to 673, "7.0.0.0" to 700.
 	vSphereVersionInt, err := strconv.Atoi(apiVersion[0:3])
 	if err != nil {
-		msg := fmt.Sprintf("Error while converting ApiVersion %q to integer, err %+v", apiVersion, err)
-		log.Errorf(msg)
-		return false, errors.New(msg)
+		return false, logger.LogNewErrorf(log,
+			"Error while converting ApiVersion %q to integer, err %+v", apiVersion, err)
 	}
 	vSphere67u3VersionStr := strings.Join(strings.Split(VSphere67u3Version, "."), "")
 	vSphere67u3VersionInt, err := strconv.Atoi(vSphere67u3VersionStr[0:3])
 	if err != nil {
-		msg := fmt.Sprintf("Error while converting VSphere67u3Version %q to integer, err %+v", VSphere67u3Version, err)
-		log.Errorf(msg)
-		return false, errors.New(msg)
+		return false, logger.LogNewErrorf(log,
+			"Error while converting VSphere67u3Version %q to integer, err %+v", VSphere67u3Version, err)
 	}
 	vSphere7VersionStr := strings.Join(strings.Split(VSphere7Version, "."), "")
 	vSphere7VersionInt, err := strconv.Atoi(vSphere7VersionStr[0:3])
 	if err != nil {
-		msg := fmt.Sprintf("Error while converting VSphere7Version %q to integer, err %+v", VSphere7Version, err)
-		log.Errorf(msg)
-		return false, errors.New(msg)
+		return false, logger.LogNewErrorf(log,
+			"Error while converting VSphere7Version %q to integer, err %+v", VSphere7Version, err)
 	}
 	// Check if the current vSphere version is between 6.7.3 and 7.0.0.
 	if vSphereVersionInt > vSphere67u3VersionInt && vSphereVersionInt <= vSphere7VersionInt {
@@ -207,16 +203,13 @@ func UseVslmAPIs(ctx context.Context, aboutInfo vim25types.AboutInfo) (bool, err
 			if vcBuild >= VSphere67u3lBuildInfo {
 				return true, nil
 			}
-			msg := fmt.Sprintf(
+			return false, logger.LogNewErrorf(log,
 				"Found vCenter version :%q. The minimum version for CSI migration is vCenter Server 6.7 Update 3l",
 				aboutInfo.ApiVersion)
-			log.Errorf(msg)
-			return false, errors.New(msg)
 		}
 		if err != nil {
-			msg := fmt.Sprintf("Error while converting VC Build info %q to integer, err %+v", aboutInfo.Build, err)
-			log.Errorf(msg)
-			return false, errors.New(msg)
+			return false, logger.LogNewErrorf(log,
+				"Error while converting VC Build info %q to integer, err %+v", aboutInfo.Build, err)
 		}
 	}
 	// For all other versions.

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -18,7 +18,6 @@ package k8sorchestrator
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -272,9 +271,7 @@ func initFSS(ctx context.Context, k8sClient clientset.Interface,
 				return err
 			}
 		} else {
-			msg := "csi-sv-feature-states-replication FSS not present"
-			log.Error(msg)
-			return errors.New(msg)
+			return logger.LogNewError(log, "csi-sv-feature-states-replication FSS not present")
 		}
 
 		// Initialize supervisor FSS map values in GC using the

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_helper.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_helper.go
@@ -18,8 +18,6 @@ package k8sorchestrator
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -95,9 +93,7 @@ func (c *K8sOrchestrator) updatePVCAnnotations(ctx context.Context, volumeID str
 		return nil
 	}
 
-	errMsg := fmt.Sprintf("could not find pvc for volumeID: %s", volumeID)
-	log.Debugf(errMsg)
-	return errors.New(errMsg)
+	return logger.LogNewErrorf(log, "could not find pvc for volumeID: %s", volumeID)
 }
 
 // isFileVolume checks if the Persistent Volume has ReadWriteMany or ReadOnlyMany support

--- a/pkg/csi/service/server.go
+++ b/pkg/csi/service/server.go
@@ -17,7 +17,6 @@ limitations under the License.
 package service
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -130,11 +129,11 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer,
 	// Register the CSI services.
 	// Always require the identity service.
 	if ids == nil {
-		return errors.New("identity service is required")
+		return logger.LogNewError(log, "identity service is required")
 	}
 	// Either a Controller or Node service should be supplied.
 	if cs == nil && ns == nil {
-		return errors.New("either a controller or node service is required")
+		return logger.LogNewError(log, "either a controller or node service is required")
 	}
 
 	// Always register the identity service.
@@ -145,13 +144,13 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer,
 	mode := os.Getenv(csitypes.EnvVarMode)
 	if strings.EqualFold(mode, "controller") {
 		if cs == nil {
-			return errors.New("controller service required when running in controller mode")
+			return logger.LogNewError(log, "controller service required when running in controller mode")
 		}
 		csi.RegisterControllerServer(s.server, cs)
 		log.Info("controller service registered")
 	} else if strings.EqualFold(mode, "node") {
 		if ns == nil {
-			return errors.New("node service required when running in node mode")
+			return logger.LogNewError(log, "node service required when running in node mode")
 		}
 		csi.RegisterNodeServer(s.server, ns)
 		log.Info("node service registered")


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a pattern of log the error message, when creating a new error. This creates
duplicated code. This change uses LogNewError, and LogNewErrorf to reduce
duplicated code. In addition, using LogNewError consistently will make sure that
all generated errors will be logged (when log is available in the function).

This change fixes csi code. The other files will be fixed in follow-up changes.

**Testing done**:
Local build and check.
Vanilla E2E:
Run 1) FAIL! -- 44 Passed | 1 Failed | 0 Pending | 159 Skipped
Irrelevant test csi_cns_telemetry_vc_reboot.go failed. Filed Bug#2796405
Run 2) FAIL! -- 44 Passed | 1 Failed | 0 Pending | 159 Skipped
Irrelevant test vsphere_volume_expansion.go:432. Filed Bug#2796587