### PR TITLE
Cherry-pick PR 1077 : Add DatastoreMigrationParam to unsupported storage class params Set

### DIFF
--- a/pkg/syncer/admissionhandler/validatestorageclass.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass.go
@@ -31,6 +31,7 @@ import (
 var (
 	unSupportedParameters = parameterSet{
 		common.CSIMigrationParams:                   struct{}{},
+		common.DatastoreMigrationParam:              struct{}{},
 		common.DiskFormatMigrationParam:             struct{}{},
 		common.HostFailuresToTolerateMigrationParam: struct{}{},
 		common.ForceProvisioningMigrationParam:      struct{}{},

--- a/pkg/syncer/admissionhandler/validatestorageclass_test.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass_test.go
@@ -61,6 +61,13 @@ func TestValidateStorageClassForMigrationParameter(t *testing.T) {
 	if !strings.Contains(string(admissionResponse.Result.Reason), migrationParamErrorMessage) || admissionResponse.Allowed {
 		t.Fatalf("TestValidateStorageClassForMigrationParameter failed. admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
 	}
+	admissionReview.Request.Object = runtime.RawExtension{
+		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": {\n    \"name\": \"sc\",\n    \"uid\": \"a9ed134e-aab1-4624-8de4-b9d961cad861\",\n    \"creationTimestamp\": \"2020-08-27T20:57:00Z\"\n  },\n  \"provisioner\": \"csi.vsphere.vmware.com\",\n  \"parameters\": {\n    \"datastore-migrationparam\": \"vsanDatastore\"\n  },\n  \"reclaimPolicy\": \"Delete\",\n  \"volumeBindingMode\": \"Immediate\"\n}"),
+	}
+	admissionResponse = validateStorageClass(ctx, &admissionReview)
+	if !strings.Contains(string(admissionResponse.Result.Reason), migrationParamErrorMessage) || admissionResponse.Allowed {
+		t.Fatalf("TestValidateStorageClassForMigrationParameter failed. admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
+	}
 	t.Log("TestValidateStorageClassForMigrationParameter Passed")
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is cherry-picking PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1077 from master to 2.3 release branch 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Please see the original PR from above for testing details

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherry-pick PR 1077 : Add DatastoreMigrationParam to unsupported storage class params Set
```
