### PR TITLE
Clean up white spaces in validatestorageclass_test

### DIFF
--- a/pkg/syncer/admissionhandler/validatestorageclass_test.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass_test.go
@@ -34,32 +34,49 @@ var admissionReview = v1.AdmissionReview{
 	},
 }
 
-// TestValidateStorageClassForAllowVolumeExpansion is the unit test for validating admissionReview request containing
-// StorageClass with allowVolumeExpansion set to true
+// TestValidateStorageClassForAllowVolumeExpansion is the unit test for
+// validating admissionReview request containing StorageClass with
+// allowVolumeExpansion set to true.
 func TestValidateStorageClassForAllowVolumeExpansion(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	admissionReview.Request.Object = runtime.RawExtension{
-		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": {\n    \"name\": \"sc\",\n    \"uid\": \"e5d6b37e-db23-4c1d-9aed-e38cdd0f9ec6\",\n    \"creationTimestamp\": \"2020-08-27T20:19:00Z\"\n  },\n  \"provisioner\": \"kubernetes.io/vsphere-volume\",\n  \"parameters\": {\n    \"hostFailuresToTolerate\": \"2\"\n  },\n  \"reclaimPolicy\": \"Delete\",\n  \"allowVolumeExpansion\": true,\n  \"volumeBindingMode\": \"Immediate\"\n}"),
+		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": " +
+			"{\n    \"name\": \"sc\",\n    \"uid\": \"e5d6b37e-db23-4c1d-9aed-e38cdd0f9ec6\",\n    " +
+			"\"creationTimestamp\": \"2020-08-27T20:19:00Z\"\n  },\n  " +
+			"\"provisioner\": \"kubernetes.io/vsphere-volume\",\n  " +
+			"\"parameters\": {\n    \"hostFailuresToTolerate\": \"2\"\n  },\n  " +
+			"\"reclaimPolicy\": \"Delete\",\n  \"allowVolumeExpansion\": true,\n  " +
+			"\"volumeBindingMode\": \"Immediate\"\n}"),
 	}
 	admissionResponse := validateStorageClass(ctx, &admissionReview)
-	if !strings.Contains(string(admissionResponse.Result.Reason), volumeExpansionErrorMessage) || admissionResponse.Allowed {
-		t.Fatalf("TestValidateStorageClassForAllowVolumeExpansion failed. admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
+	if !strings.Contains(string(admissionResponse.Result.Reason), volumeExpansionErrorMessage) ||
+		admissionResponse.Allowed {
+		t.Fatalf("TestValidateStorageClassForAllowVolumeExpansion failed. "+
+			"admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
 	}
 	t.Log("TestValidateStorageClassForAllowVolumeExpansion Passed")
 }
 
-// TestValidateStorageClassForMigrationParameter is the unit test for validating admissionReview request containing
-// StorageClass with migration related parameters
+// TestValidateStorageClassForMigrationParameter is the unit test for validating
+// admissionReview request containing StorageClass with migration related
+// parameters.
 func TestValidateStorageClassForMigrationParameter(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	admissionReview.Request.Object = runtime.RawExtension{
-		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": {\n    \"name\": \"sc\",\n    \"uid\": \"a9ed134e-aab1-4624-8de4-b9d961cad861\",\n    \"creationTimestamp\": \"2020-08-27T20:57:00Z\"\n  },\n  \"provisioner\": \"csi.vsphere.vmware.com\",\n  \"parameters\": {\n    \"hostfailurestotolerate-migrationparam\": \"2\"\n  },\n  \"reclaimPolicy\": \"Delete\",\n  \"volumeBindingMode\": \"Immediate\"\n}"),
+		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": " +
+			"{\n    \"name\": \"sc\",\n    \"uid\": \"a9ed134e-aab1-4624-8de4-b9d961cad861\",\n    " +
+			"\"creationTimestamp\": \"2020-08-27T20:57:00Z\"\n  },\n  " +
+			"\"provisioner\": \"csi.vsphere.vmware.com\",\n  " +
+			"\"parameters\": {\n    \"hostfailurestotolerate-migrationparam\": \"2\"\n  },\n  " +
+			"\"reclaimPolicy\": \"Delete\",\n  \"volumeBindingMode\": \"Immediate\"\n}"),
 	}
 	admissionResponse := validateStorageClass(ctx, &admissionReview)
-	if !strings.Contains(string(admissionResponse.Result.Reason), migrationParamErrorMessage) || admissionResponse.Allowed {
-		t.Fatalf("TestValidateStorageClassForMigrationParameter failed. admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
+	if !strings.Contains(string(admissionResponse.Result.Reason), migrationParamErrorMessage) ||
+		admissionResponse.Allowed {
+		t.Fatalf("TestValidateStorageClassForMigrationParameter failed. "+
+			"admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
 	}
 	admissionReview.Request.Object = runtime.RawExtension{
 		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": {\n    \"name\": \"sc\",\n    \"uid\": \"a9ed134e-aab1-4624-8de4-b9d961cad861\",\n    \"creationTimestamp\": \"2020-08-27T20:57:00Z\"\n  },\n  \"provisioner\": \"csi.vsphere.vmware.com\",\n  \"parameters\": {\n    \"datastore-migrationparam\": \"vsanDatastore\"\n  },\n  \"reclaimPolicy\": \"Delete\",\n  \"volumeBindingMode\": \"Immediate\"\n}"),
@@ -71,17 +88,23 @@ func TestValidateStorageClassForMigrationParameter(t *testing.T) {
 	t.Log("TestValidateStorageClassForMigrationParameter Passed")
 }
 
-// TestValidateStorageClassForValidStorageClass is the unit test for validating admissionReview request containing
-// a valid StorageClass
+// TestValidateStorageClassForValidStorageClass is the unit test for validating
+// admissionReview request containing a valid StorageClass.
 func TestValidateStorageClassForValidStorageClass(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	admissionReview.Request.Object = runtime.RawExtension{
-		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": {\n    \"name\": \"sc\",\n    \"uid\": \"a896f427-929a-4fc5-be95-078d99d57774\",\n    \"creationTimestamp\": \"2020-08-27T20:20:28Z\"\n  },\n  \"provisioner\": \"kubernetes.io/vsphere-volume\",\n  \"parameters\": {\n    \"hostFailuresToTolerate\": \"2\"\n  },\n  \"reclaimPolicy\": \"Delete\",\n  \"volumeBindingMode\": \"Immediate\"\n}"),
+		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": " +
+			"{\n    \"name\": \"sc\",\n    \"uid\": \"a896f427-929a-4fc5-be95-078d99d57774\",\n    " +
+			"\"creationTimestamp\": \"2020-08-27T20:20:28Z\"\n  },\n  " +
+			"\"provisioner\": \"kubernetes.io/vsphere-volume\",\n  " +
+			"\"parameters\": {\n    \"hostFailuresToTolerate\": \"2\"\n  },\n  " +
+			"\"reclaimPolicy\": \"Delete\",\n  \"volumeBindingMode\": \"Immediate\"\n}"),
 	}
 	admissionResponse := validateStorageClass(ctx, &admissionReview)
 	if admissionResponse.Result != nil || !admissionResponse.Allowed {
-		t.Fatalf("TestValidateStorageClassForValidStorageClass failed. admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
+		t.Fatalf("TestValidateStorageClassForValidStorageClass failed. "+
+			"admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
 	}
 	t.Log("TestValidateStorageClassForValidStorageClass Passed")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles validatestorageclass_test.

**Testing done**:
Local build, check and unit tests.