### PR TITLE
Clean up white spaces in e2e data_persistence

### DIFF
--- a/tests/e2e/data_persistence.go
+++ b/tests/e2e/data_persistence.go
@@ -40,22 +40,20 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
-/*
-	Steps
-
-	1. Create a PVC.
-	2. Create pod and wait for pod to become ready.
-	3. Verify volume is attached.
-	4. Create empty file on the volume to verify volume is writable.
-	5. Verify newly created file and previously created files exist on the volume.
-	6. Delete pod.
-	7. Create a new pod using the previously created volume and wait for pod to become ready.
-	8. Create another empty file on the volume .
-	9. Verify newly created file and previously created files exist on the volume.
-	10. Delete pod.
-	11. Wait for volume to be detached.
-
-*/
+// Steps
+//
+// 1. Create a PVC.
+// 2. Create pod and wait for pod to become ready.
+// 3. Verify volume is attached.
+// 4. Create empty file on the volume to verify volume is writable.
+// 5. Verify newly created file and previously created files exist on the volume.
+// 6. Delete pod.
+// 7. Create a new pod using the previously created volume and wait for pod to
+//    become ready.
+// 8. Create another empty file on the volume .
+// 9. Verify newly created file and previously created files exist on the volume.
+// 10. Delete pod.
+// 11. Wait for volume to be detached.
 
 var _ = ginkgo.Describe("Data Persistence", func() {
 	f := framework.NewDefaultFramework("e2e-data-persistence")
@@ -66,7 +64,7 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		namespace         string
 		scParameters      map[string]string
 		storagePolicyName string
-		svcPVCName        string // PVC Name in the Supervisor Cluster
+		svcPVCName        string // PVC Name in the Supervisor Cluster.
 		datastoreURL      string
 	)
 	ginkgo.BeforeEach(func() {
@@ -121,7 +119,7 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		var pvc *v1.PersistentVolumeClaim
 		var err error
 		ginkgo.By("Creating Storage Class and PVC")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if vanillaCluster {
 			ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
 			sc, pvc, err = createPVCAndStorageClass(client, namespace, nil, nil, "", nil, "", false, "")
@@ -130,9 +128,10 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 			ginkgo.By(fmt.Sprintf("storagePolicyName: %s", storagePolicyName))
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, storagePolicyName)
-			sc, pvc, err = createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "", false, "", storagePolicyName)
+			sc, pvc, err = createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "", false, "",
+				storagePolicyName)
 		} else {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = storagePolicyName
@@ -146,13 +145,14 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		}()
 
 		ginkgo.By(fmt.Sprintf("Waiting for claim %s to be in bound phase", pvc.Name))
-		pvs, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
+		pvs, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvc},
+			framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
 		pv := pvs[0]
 		volumeID := pv.Spec.CSI.VolumeHandle
 		if guestCluster {
-			// svcPVCName refers to PVC Name in the supervisor cluster
+			// svcPVCName refers to PVC Name in the supervisor cluster.
 			svcPVCName = volumeID
 			volumeID = getVolumeIDFromSupervisorCluster(svcPVCName)
 			gomega.Expect(volumeID).NotTo(gomega.BeEmpty())
@@ -168,7 +168,8 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 		var vmUUID string
 		var exists bool
 		if vanillaCluster {
@@ -182,14 +183,15 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		} else {
 			vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName, crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
+			verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName,
+				crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
 		}
 		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volumeID, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), fmt.Sprintf("Volume is not attached to the node, %s", vmUUID))
 
 		var volumeFiles []string
-		// Create an empty file on the mounted volumes on the pod
+		// Create an empty file on the mounted volumes on the pod.
 		ginkgo.By(fmt.Sprintf("Creating an empty file on the volume mounted on: %v", pod.Name))
 		newEmptyFileName := fmt.Sprintf("/mnt/volume1/%v_file_A.txt", namespace)
 		volumeFiles = append(volumeFiles, newEmptyFileName)
@@ -198,17 +200,23 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		err = fpod.DeletePodWithWait(client, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		if supervisorCluster {
-			ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s", pv.Spec.CSI.VolumeHandle, vmUUID))
+			ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s",
+				pv.Spec.CSI.VolumeHandle, vmUUID))
 			_, err := e2eVSphere.getVMByUUIDWithWait(ctx, vmUUID, supervisorClusterOperationsTimeout)
-			gomega.Expect(err).To(gomega.HaveOccurred(), fmt.Sprintf("PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM", vmUUID, pv.Spec.CSI.VolumeHandle))
+			gomega.Expect(err).To(gomega.HaveOccurred(),
+				fmt.Sprintf("PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM",
+					vmUUID, pv.Spec.CSI.VolumeHandle))
 		} else {
 			ginkgo.By("Verify volume is detached from the node")
-			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 			if guestCluster {
 				ginkgo.By("Waiting for CnsNodeVMAttachment controller to reconcile resource")
-				verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName, crdCNSNodeVMAttachment, crdVersion, crdGroup, false)
+				verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName,
+					crdCNSNodeVMAttachment, crdVersion, crdGroup, false)
 			}
 		}
 
@@ -216,7 +224,8 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 
 		if vanillaCluster {
 			vmUUID = getNodeUUID(client, pod.Spec.NodeName)
@@ -229,14 +238,16 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		} else {
 			vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName, crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
+			verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName,
+				crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
 		}
 		isDiskAttached, err = e2eVSphere.isVolumeAttachedToVM(client, volumeID, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
 
 		// Create another empty file on the mounted volume on the pod and
-		// verify newly and previously created files present on the volume mounted on the pod
+		// verify newly and previously created files present on the volume
+		// mounted on the pod.
 		ginkgo.By(fmt.Sprintf("Creating a second empty file on the same volume mounted on: %v", pod.Name))
 		newEmptyFileName = fmt.Sprintf("/mnt/volume1/%v_file_B.txt", namespace)
 		volumeFiles = append(volumeFiles, newEmptyFileName)
@@ -245,44 +256,50 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		err = fpod.DeletePodWithWait(client, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		if supervisorCluster {
-			ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s", pv.Spec.CSI.VolumeHandle, vmUUID))
+			ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s",
+				pv.Spec.CSI.VolumeHandle, vmUUID))
 			_, err := e2eVSphere.getVMByUUIDWithWait(ctx, vmUUID, supervisorClusterOperationsTimeout)
-			gomega.Expect(err).To(gomega.HaveOccurred(), fmt.Sprintf("PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM", vmUUID, pv.Spec.CSI.VolumeHandle))
+			gomega.Expect(err).To(gomega.HaveOccurred(),
+				fmt.Sprintf("PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM",
+					vmUUID, pv.Spec.CSI.VolumeHandle))
 		} else {
 			ginkgo.By("Verify volume is detached from the node")
-			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 			if guestCluster {
 				ginkgo.By("Waiting for 30 seconds to allow CnsNodeVMAttachment controller to reconcile resource")
 				time.Sleep(waitTimeForCNSNodeVMAttachmentReconciler)
-				verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName, crdCNSNodeVMAttachment, crdVersion, crdGroup, false)
+				verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName,
+					crdCNSNodeVMAttachment, crdVersion, crdGroup, false)
 			}
 		}
 	})
 
-	/*
-		Data Persistence in case of Static Volume Provisioning on SVC
-
-		Steps
-
-		1. Create FCD with valid storage policy.
-		2. Create Resource quota
-		3. Create CNS register volume with above created FCD
-		4. verify PV, PVC got created , check the bidirectional referance.
-		5. Create POD, with above created PVC
-		6. Verify volume is attached to the node and volume is accessible in the pod.
-		7. Create an empty file on the mounted volumes on the pod
-		7. Delete POD.
-		8. Create a new pod using the previously created volume and wait for pod to become ready.
-		9. Create an empty file again and Verify newly created file and previously created files exist on the volume.
-		10. Delete Newly created POD.
-		11. Delete PVC
-		12. Verify PV is deleted automatically.
-		13. Verify Volume id deleted automatically.
-		14. Verify CRD deleted automatically
-		15. Delete resource quota
-	*/
+	// Data Persistence in case of Static Volume Provisioning on SVC.
+	// Steps
+	//
+	// 1. Create FCD with valid storage policy.
+	// 2. Create Resource quota.
+	// 3. Create CNS register volume with above created FCD.
+	// 4. verify PV, PVC got created , check the bidirectional referance.
+	// 5. Create POD, with above created PVC.
+	// 6. Verify volume is attached to the node and volume is accessible in the
+	//    pod.
+	// 7. Create an empty file on the mounted volumes on the pod.
+	// 8. Delete POD.
+	// 9. Create a new pod using the previously created volume and wait for pod
+	//    to become ready.
+	// 10. Create an empty file again and Verify newly created file and
+	//     previously created files exist on the volume.
+	// 11. Delete Newly created POD.
+	// 12. Delete PVC.
+	// 13. Verify PV is deleted automatically.
+	// 14. Verify Volume id deleted automatically.
+	// 15. Verify CRD deleted automatically.
+	// 16. Delete resource quota.
 	ginkgo.It("[csi-supervisor] Data Persistence in case of Static Volume Provisioning on SVC", func() {
 		var pvc *v1.PersistentVolumeClaim
 		var err error
@@ -294,7 +311,7 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		log := logger.GetLogger(ctx)
 		defer cancel()
 
-		// Get a config to talk to the apiserver
+		// Get a config to talk to the apiserver.
 		k8senv := GetAndExpectStringEnvVar("KUBECONFIG")
 		restConfig, err := clientcmd.BuildConfigFromFlags("", k8senv)
 		if err != nil {
@@ -328,7 +345,8 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		}()
 
 		ginkgo.By("Create FCD with valid storage policy.")
-		fcdID, err := e2eVSphere.createFCDwithValidProfileID(ctx, "staticfcd"+curtimeinstring, profileID, diskSizeInMb, defaultDatastore.Reference())
+		fcdID, err := e2eVSphere.createFCDwithValidProfileID(ctx, "staticfcd"+curtimeinstring,
+			profileID, diskSizeInMb, defaultDatastore.Reference())
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow newly created FCD:%s to sync with pandora", 90, fcdID))
 		time.Sleep(time.Duration(90) * time.Second)
@@ -340,7 +358,8 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		cnsRegisterVolume := getCNSRegisterVolumeSpec(ctx, namespace, fcdID, "", pvcName, v1.ReadWriteOnce)
 		err = createCNSRegisterVolume(ctx, restConfig, cnsRegisterVolume)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		framework.ExpectNoError(waitForCNSRegisterVolumeToGetCreated(ctx, restConfig, namespace, cnsRegisterVolume, poll, pollTimeout))
+		framework.ExpectNoError(waitForCNSRegisterVolumeToGetCreated(ctx,
+			restConfig, namespace, cnsRegisterVolume, poll, pollTimeout))
 		cnsRegisterVolumeName := cnsRegisterVolume.GetName()
 		log.Infof("cnsRegisterVolumeName : %s", cnsRegisterVolumeName)
 
@@ -355,7 +374,8 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 
 		volumeID := pv.Spec.CSI.VolumeHandle
 		annotations := pod.Annotations
@@ -377,16 +397,20 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		err = fpod.DeletePodWithWait(client, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s", pv.Spec.CSI.VolumeHandle, vmUUID))
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s",
+			pv.Spec.CSI.VolumeHandle, vmUUID))
 
 		_, err = e2eVSphere.getVMByUUIDWithWait(ctx, vmUUID, supervisorClusterOperationsTimeout)
-		gomega.Expect(err).To(gomega.HaveOccurred(), fmt.Sprintf("PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM", vmUUID, pv.Spec.CSI.VolumeHandle))
+		gomega.Expect(err).To(gomega.HaveOccurred(),
+			fmt.Sprintf("PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM",
+				vmUUID, pv.Spec.CSI.VolumeHandle))
 
 		ginkgo.By("Creating a new pod using the same volume")
 		pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 		annotations = pod.Annotations
 		vmUUID, exists = annotations[vmUUIDLabel]
 		gomega.Expect(exists).To(gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
@@ -397,7 +421,8 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
 
-		ginkgo.By("Create another empty file on the mounted volume on the pod and verify newly and previously created files present on the volume mounted on the pod")
+		ginkgo.By("Create another empty file on the mounted volume on the pod and " +
+			"verify newly and previously created files present on the volume mounted on the pod")
 		ginkgo.By(fmt.Sprintf("Creating a second empty file on the same volume mounted on: %v", pod.Name))
 		newEmptyFileName = fmt.Sprintf("/mnt/volume1/%v_file_B.txt", namespace)
 		volumeFiles = append(volumeFiles, newEmptyFileName)
@@ -406,12 +431,16 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		ginkgo.By("Deleting the pod")
 		framework.ExpectNoError(fpod.DeletePodWithWait(client, pod), "Failed to delete pod ", pod.Name)
 
-		ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s", pv.Spec.CSI.VolumeHandle, vmUUID))
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s",
+			pv.Spec.CSI.VolumeHandle, vmUUID))
 		_, err = e2eVSphere.getVMByUUIDWithWait(ctx, vmUUID, supervisorClusterOperationsTimeout)
-		gomega.Expect(err).To(gomega.HaveOccurred(), fmt.Sprintf("PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM", vmUUID, pv.Spec.CSI.VolumeHandle))
+		gomega.Expect(err).To(gomega.HaveOccurred(),
+			fmt.Sprintf("PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM",
+				vmUUID, pv.Spec.CSI.VolumeHandle))
 
 		ginkgo.By("Deleting the PV Claim")
-		framework.ExpectNoError(fpv.DeletePersistentVolumeClaim(client, pvc.Name, namespace), "Failed to delete PVC ", pvc.Name)
+		framework.ExpectNoError(fpv.DeletePersistentVolumeClaim(client, pvc.Name, namespace),
+			"Failed to delete PVC ", pvc.Name)
 		pvc = nil
 
 		ginkgo.By("Verify PV should be deleted automatically")
@@ -419,14 +448,16 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		pv = nil
 
 		ginkgo.By("Verify CRD should be deleted automatically")
-		framework.ExpectNoError(waitForCNSRegisterVolumeToGetDeleted(ctx, restConfig, namespace, cnsRegisterVolume, poll, supervisorClusterOperationsTimeout))
+		framework.ExpectNoError(waitForCNSRegisterVolumeToGetDeleted(ctx,
+			restConfig, namespace, cnsRegisterVolume, poll, supervisorClusterOperationsTimeout))
 
 		ginkgo.By("Delete Resource quota")
 		deleteResourceQuota(client, namespace)
 	})
 })
 
-func createAndVerifyFilesOnVolume(namespace string, podname string, newEmptyfilesToCreate []string, filesToCheck []string) {
+func createAndVerifyFilesOnVolume(namespace string, podname string,
+	newEmptyfilesToCreate []string, filesToCheck []string) {
 	createEmptyFilesOnVSphereVolume(namespace, podname, newEmptyfilesToCreate)
 	ginkgo.By(fmt.Sprintf("Verify files exist on volume mounted on: %v", podname))
 	verifyFilesExistOnVSphereVolume(namespace, podname, filesToCheck...)


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles e2e data_persistence.

**Testing done**:
Local build, check.