### PR TITLE
Edit error message for config read during controller init

### DIFF
--- a/pkg/csi/service/driver.go
+++ b/pkg/csi/service/driver.go
@@ -127,7 +127,7 @@ func (driver *vsphereCSIDriver) BeforeServe(
 		// Controller service is needed.
 		cfg, err = common.GetConfig(ctx)
 		if err != nil {
-			log.Errorf("failed to read config. Error: %+v", err)
+			log.Errorf("failed to read config during controller init. Error: %+v", err)
 			return err
 		}
 		if err := driver.cnscs.Init(cfg, Version); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR updates the error message while reading vsphere-csi config during controller init. The reason to update this is to have a unique message if controller init fails, so that an alert can be generated. Right now, our WCP on VMC alert mechanism is based on log messages. So we need a log to identify that this failed during controller init. We're using the message `failed to read config` in other places as well.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running e2e pipeline for WCP

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Edit error message for config read during controller init
```
