### PR TITLE
Topic/nigupta/placement engine vsan

### DIFF
--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -324,7 +324,7 @@ func (k8sCloudOperator *k8sCloudOperator) PlacePersistenceVolumeClaim(ctx contex
 
 	spTypes, present := sc.Annotations[spTypeAnnotationKey]
 	if !present || (!strings.Contains(spTypes, vsanType) && !strings.Contains(spTypes, vsanDirectType) && !strings.Contains(spTypes, vsanSnaType)) {
-		log.Debug("storage class is not of type vsan direct or vsan-sna, aborting placement")
+		log.Debug("storage class is not of type vsan direct or vsan-sna or vsan, aborting placement")
 		return out, nil
 	}
 

--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -52,6 +52,7 @@ const (
 	nodeAffinityAnnotationKey = "failure-domain.beta.vmware.com/node"
 	vsanDirectType            = spTypePrefix + "vsanD"
 	vsanSnaType               = spTypePrefix + "vsan-sna"
+	vsanType                  = spTypePrefix + "vsan"
 	spTypeLabelKey            = spTypePrefix + "StoragePoolType"
 	diskDecommissionModeField = "decommMode"
 )
@@ -311,12 +312,6 @@ func (k8sCloudOperator *k8sCloudOperator) PlacePersistenceVolumeClaim(ctx contex
 		return out, err
 	}
 
-	spTypes, present := sc.Annotations[spTypeAnnotationKey]
-	if !present || (!strings.Contains(spTypes, vsanDirectType) && !strings.Contains(spTypes, vsanSnaType)) {
-		log.Debug("storage class is not of type vsan direct or vsan-sna, aborting placement")
-		return out, nil
-	}
-
 	// Abort placement if the storage class has Immediate volume binding and
 	// nodeAffinity PVC annotation is not specified.
 	if *sc.VolumeBindingMode != storagev1.VolumeBindingWaitForFirstConsumer {
@@ -325,6 +320,12 @@ func (k8sCloudOperator *k8sCloudOperator) PlacePersistenceVolumeClaim(ctx contex
 				"nor nodeAffinity PVC annotation is specified", pvc.Name, storagev1.VolumeBindingWaitForFirstConsumer)
 			return out, nil
 		}
+	}
+
+	spTypes, present := sc.Annotations[spTypeAnnotationKey]
+	if !present || (!strings.Contains(spTypes, vsanType) && !strings.Contains(spTypes, vsanDirectType) && !strings.Contains(spTypes, vsanSnaType)) {
+		log.Debug("storage class is not of type vsan direct or vsan-sna, aborting placement")
+		return out, nil
 	}
 
 	log.Debugf("Enter placementEngine %s", req)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is to solve following issue: When a pvc is requested with host affinity parameter and a storage class having vsan policy the placement engine does not process the request.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
reated a storage policy with vsan capabilities(non affinity related). Tested pvc creation with the storage class having this storage policy and node affinity parameter
without fix:
kubectl describe sc vsanhftt-7l7bw1
Name: vsanhftt-7l7bw1
IsDefaultClass: No
Annotations: cns.vmware.com/StoragePoolTypeHint=cns.vmware.com/vsan
Provisioner: csi.vsphere.vmware.com
Parameters: storagePolicyID=89ac2f8c-e984-4ec1-8c52-b6bff9c5783b
AllowVolumeExpansion: True
MountOptions: 
ReclaimPolicy: Delete
VolumeBindingMode: Immediate
Events:

root@4200ab58b14b04c2ccfcf5e0dde70668 [ ~ ]# cat pvc_vsan1.yaml
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
name: pvc-only-vsan5
namespace: host-affinity-pvc-placement-test
annotations:
volume.beta.kubernetes.io/storage-class: vsanhftt-7l7bw1
failure-domain.beta.vmware.com/node: sc2-10-186-200-62.eng.vmware.com
labels:
spec:
accessModes:
- ReadWriteOnce
resources:
requests:
storage: 1Mi
storageClassName: vsanhftt-7l7bw1

root@4200ab58b14b04c2ccfcf5e0dde70668 [ ~ ]# kubectl apply -f pvc_vsan1.yaml
persistentvolumeclaim/pvc-only-vsan5 created
root@4200ab58b14b04c2ccfcf5e0dde70668 [ ~ ]# kubectl describe pvc pvc-only-vsan5 -nhost-affinity-pvc-placement-test
Name: pvc-only-vsan5
Namespace: host-affinity-pvc-placement-test
StorageClass: vsanhftt-7l7bw1
Status: Bound
Volume: pvc-dd70a438-65e0-45bd-8564-0cc60233abb3
Labels: 
Annotations: failure-domain.beta.vmware.com/node: sc2-10-186-200-62.eng.vmware.com
pv.kubernetes.io/bind-completed: yes
pv.kubernetes.io/bound-by-controller: yes
volume.beta.kubernetes.io/storage-class: vsanhftt-7l7bw1
volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers: [kubernetes.io/pvc-protection]
Capacity: 1Mi
Access Modes: RWO
VolumeMode: Filesystem
Used By: 
Events:
Type Reason Age From Message

Normal ExternalProvisioning 16s persistentvolume-controller waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
Normal Provisioning 15s csi.vsphere.vmware.com_4200ab58b14b04c2ccfcf5e0dde70668_34bc34a9-541e-4a0a-9604-202c229a6af8 External provisioner is provisioning volume for claim "host-affinity-pvc-placement-test/pvc-only-vsan5"
Normal ProvisioningSucceeded 12s csi.vsphere.vmware.com_4200ab58b14b04c2ccfcf5e0dde70668_34bc34a9-541e-4a0a-9604-202c229a6af8 Successfully provisioned volume pvc-dd70a438-65e0-45bd-8564-0cc60233abb3

With this fix:
root@4200ab58b14b04c2ccfcf5e0dde70668 [ ~ ]# kubectl describe pvc pvc-only-vsan5 -nhost-affinity-pvc-placement-test
Name: pvc-only-vsan5
Namespace: host-affinity-pvc-placement-test
StorageClass: vsanhftt-7l7bw1
Status: Pending
Volume:
Labels: 
Annotations: failure-domain.beta.vmware.com/node: sc2-10-186-200-62.eng.vmware.com
failure-domain.beta.vmware.com/storagepool: FAILED_PLACEMENT-NotEnoughResources
volume.beta.kubernetes.io/storage-class: vsanhftt-7l7bw1
volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers: [kubernetes.io/pvc-protection]
Capacity:
Access Modes:
VolumeMode: Filesystem
Used By: 
Events:
Type Reason Age From Message

Normal ExternalProvisioning 12s (x2 over 13s) persistentvolume-controller waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
Normal Provisioning 7s (x4 over 13s) csi.vsphere.vmware.com_42001c9ff967c8f43c69498681025f28_aa95f0f8-4d3c-478c-8787-84a1b428c404 External provisioner is provisioning volume for claim "host-affinity-pvc-placement-test/pvc-only-vsan5"
Warning ProvisioningFailed 7s (x4 over 12s) csi.vsphere.vmware.com_42001c9ff967c8f43c69498681025f28_aa95f0f8-4d3c-478c-8787-84a1b428c404 failed to provision volume with StorageClass "vsanhftt-7l7bw1": rpc error: code = Unknown desc = fail to find a StoragePool passing all criteria

Also Tested with storage classes having tag based policies and the results were same with and without this change
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
