### PR TITLE
QuerySnapshots implmentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage_report.out
 /pkg/csi/service/vanilla/test_vsphere.conf
 /pkg/csi/service/wcp/test_vsphere.conf
 /pkg/syncer/test_vsphere.conf
+/pkg/common/utils/test_vsphere.conf
 
 # Ignore the build output.
 /.build

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ else
             ifndef KUBECONFIG
                 $(error Requires KUBECONFIG from a deployed testbed to run integration-unit-test)
             else
-		$(eval INTEGRATION_TEST_PKGS += ./pkg/csi/service/vanilla ./pkg/syncer)
+		$(eval INTEGRATION_TEST_PKGS += ./pkg/csi/service/vanilla ./pkg/syncer ./pkg/common/utils)
             endif
         endif
     endif

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -147,6 +147,7 @@ func (vc *VirtualCenter) newClient(ctx context.Context) (*govmomi.Client, error)
 		soapClient.SetThumbprint(url.Host, vc.Config.Thumbprint)
 		log.Debugf("using thumbprint %s for url %s ", vc.Config.Thumbprint, url.Host)
 	}
+
 	soapClient.Timeout = time.Duration(vc.Config.VCClientTimeout) * time.Minute
 	log.Debugf("Setting vCenter soap client timeout to %v", soapClient.Timeout)
 	vimClient, err := vim25.NewClient(ctx, soapClient)
@@ -161,7 +162,6 @@ func (vc *VirtualCenter) newClient(ctx context.Context) (*govmomi.Client, error)
 		return nil, err
 	}
 	vimClient.UserAgent = "k8s-csi-useragent"
-
 	client := &govmomi.Client{
 		Client:         vimClient,
 		SessionManager: session.NewManager(vimClient),

--- a/pkg/common/prometheus/metrics.go
+++ b/pkg/common/prometheus/metrics.go
@@ -66,6 +66,8 @@ const (
 	PrometheusCnsRelocateVolumeOpType = "relocate-volume"
 	// PrometheusCnsConfigureVolumeACLOpType represents the ConfigureVolumeAcl operation.
 	PrometheusCnsConfigureVolumeACLOpType = "configure-volume-acl"
+	// PrometheusQuerySnapshotsOpType represents QuerySnapshots operation.
+	PrometheusQuerySnapshotsOpType = "query-snapshots"
 
 	// PrometheusPassStatus represents a successful API run.
 	PrometheusPassStatus = "pass"

--- a/pkg/common/utils/test_vsphere.conf
+++ b/pkg/common/utils/test_vsphere.conf
@@ -1,0 +1,7 @@
+[Global]
+insecure-flag = "true"
+[VirtualCenter "127.0.0.1"]
+user = "user"
+password = "pass"
+datacenters = "DC0"
+port = "64872"

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -1,0 +1,158 @@
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	cnssim "github.com/vmware/govmomi/cns/simulator"
+	"github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/simulator"
+	cnsvolumes "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/pkg/common/config"
+)
+
+const (
+	testClusterName = "test-cluster"
+)
+
+var (
+	csiConfig            *cnsconfig.Config
+	ctx                  context.Context
+	cnsVCenterConfig     *cnsvsphere.VirtualCenterConfig
+	err                  error
+	virtualCenterManager cnsvsphere.VirtualCenterManager
+	virtualCenter        *cnsvsphere.VirtualCenter
+	volumeManager        cnsvolumes.Manager
+	cancel               context.CancelFunc
+)
+
+// configFromSim starts a vcsim instance and returns config for use against the vcsim instance.
+// The vcsim instance is configured with an empty tls.Config.
+func configFromSim() (*cnsconfig.Config, func()) {
+	return configFromSimWithTLS(new(tls.Config), true)
+}
+
+// configFromSimWithTLS starts a vcsim instance and returns config for use against the vcsim instance.
+// The vcsim instance is configured with a tls.Config. The returned client
+// config can be configured to allow/decline insecure connections.
+func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*cnsconfig.Config, func()) {
+	cfg := &cnsconfig.Config{}
+	model := simulator.VPX()
+	defer model.Remove()
+
+	err := model.Create()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	model.Service.TLS = tlsConfig
+	s := model.Service.NewServer()
+
+	// CNS Service simulator
+	model.Service.RegisterSDK(cnssim.New())
+
+	cfg.Global.InsecureFlag = insecureAllowed
+
+	cfg.Global.VCenterIP = s.URL.Hostname()
+	cfg.Global.VCenterPort = s.URL.Port()
+	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.Password, _ = s.URL.User.Password()
+	cfg.Global.Datacenters = "DC0"
+
+	// Write values to test_vsphere.conf
+	os.Setenv("VSPHERE_CSI_CONFIG", "test_vsphere.conf")
+	conf := []byte(fmt.Sprintf("[Global]\ninsecure-flag = \"%t\"\n[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"",
+		cfg.Global.InsecureFlag, cfg.Global.VCenterIP, cfg.Global.User, cfg.Global.Password, cfg.Global.Datacenters, cfg.Global.VCenterPort))
+	err = ioutil.WriteFile("test_vsphere.conf", conf, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cfg.VirtualCenter = make(map[string]*cnsconfig.VirtualCenterConfig)
+	cfg.VirtualCenter[s.URL.Hostname()] = &cnsconfig.VirtualCenterConfig{
+		User:         cfg.Global.User,
+		Password:     cfg.Global.Password,
+		VCenterPort:  cfg.Global.VCenterPort,
+		InsecureFlag: cfg.Global.InsecureFlag,
+		Datacenters:  cfg.Global.Datacenters,
+	}
+
+	return cfg, func() {
+		s.Close()
+		model.Remove()
+	}
+
+}
+
+func configFromEnvOrSim() (*cnsconfig.Config, func()) {
+	cfg := &cnsconfig.Config{}
+	if err := cnsconfig.FromEnv(ctx, cfg); err != nil {
+		return configFromSim()
+	}
+	return cfg, func() {}
+}
+
+func TestQuerySnapshotsUtil(t *testing.T) {
+	// Create context
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Log("TestQuerySnapshotsUtil: start")
+	var cleanup func()
+	csiConfig, cleanup = configFromEnvOrSim()
+	defer cleanup()
+
+	// CNS based CSI requires a valid cluster name
+	csiConfig.Global.ClusterID = testClusterName
+
+	// Init VC configuration
+	cnsVCenterConfig, err = cnsvsphere.GetVirtualCenterConfig(ctx, csiConfig)
+	if err != nil {
+		t.Errorf("failed to get virtualCenter. err=%v", err)
+		t.Fatal(err)
+	}
+
+	virtualCenterManager = cnsvsphere.GetVirtualCenterManager(ctx)
+
+	virtualCenter, err = virtualCenterManager.RegisterVirtualCenter(ctx, cnsVCenterConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = virtualCenter.ConnectCns(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if virtualCenter != nil {
+			err = virtualCenter.Disconnect(ctx)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+	}()
+
+	volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false)
+	queryFilter := types.CnsSnapshotQueryFilter{
+		SnapshotQuerySpecs: nil,
+		Cursor: &types.CnsCursor{
+			Offset: 0,
+			Limit:  10,
+		},
+	}
+	queryResultEntries, err := QuerySnapshotsUtil(ctx, volumeManager, queryFilter)
+	if err != nil {
+		t.Error(err)
+	}
+	//TODO: Create Snapshots using CreateSnapshot API.
+	t.Log("Snapshots: ")
+	for _, entry := range queryResultEntries {
+		t.Log(entry)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
QuerySnapshots implementation.
QuerySnapshots will be internally used to determine snapshots based on spec. QuerySnapshots will be used internally by CreateSnapshot/DeleteSnapshot and ListSnapshot CSI apis.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
dkinni@dkinni-a02 vsphere-csi-driver % VSPHERE_DATACENTER='VSAN-DC' VSPHERE_USER='Administrator@vsphere.local' VSPHERE_PASSWORD='Admin!23' VSPHERE_DATASTORE_URL='ds:///vmfs/volumes/vsan:52b9363f3f598109-9b1397535c937173/' VSPHERE_INSECURE='true' VSPHERE_VCENTER='10.168.223.132' VSPHERE_STORAGE_POLICY_NAME='vSAN Default Storage Policy' TYPE='vanilla' VSPHERE_K8S_NODE='k8s-master-169' KUBECONFIG='/Users/dkinni/testconfig.yaml' make integration-unit-test

=== RUN   TestQuerySnapshotsUtil
    utils_test.go:123: TestQuerySnapshotsUtil: start
{"level":"info","time":"2021-07-07T15:42:15.851025-07:00","caller":"config/config.go:321","msg":"No Net Permissions given in Config. Using default permissions."}
{"level":"info","time":"2021-07-07T15:42:15.851543-07:00","caller":"vsphere/utils.go:165","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2021-07-07T15:42:15.851588-07:00","caller":"vsphere/virtualcentermanager.go:72","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2021-07-07T15:42:15.851601-07:00","caller":"vsphere/virtualcentermanager.go:74","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2021-07-07T15:42:15.851627-07:00","caller":"vsphere/virtualcentermanager.go:118","msg":"Successfully registered VC \"10.168.223.132\""}
{"level":"info","time":"2021-07-07T15:42:15.992591-07:00","caller":"vsphere/virtualcenter.go:177","msg":"New session ID for 'VSPHERE.LOCAL\\Administrator' = 52d3cca1-a669-c7b7-2d48-aa10a6351e2a"}
{"level":"info","time":"2021-07-07T15:42:15.992988-07:00","caller":"volume/manager.go:138","msg":"Initializing new defaultManager..."}
{"level":"info","time":"2021-07-07T15:42:15.993228-07:00","caller":"utils/utils.go:98","msg":"Attempting to retrieve all the Snapshots available in the vCenter inventory."}
{"level":"info","time":"2021-07-07T15:42:16.231573-07:00","caller":"utils/utils.go:118","msg":"0 more snapshots to be queried"}
{"level":"info","time":"2021-07-07T15:42:16.23173-07:00","caller":"utils/utils.go:120","msg":"QuerySnapshots retrieved all records (2) for the SnapshotQuerySpec: {DynamicData:{} VolumeId:{DynamicData:{} Id:} SnapshotId:<nil>} in 1 iterations"}
    utils_test.go:171: Snapshots:
    utils_test.go:173: {{} {{} {{} 758d4144-67e6-4058-a497-81e1e1a4aec6} {{} 8d2e4b62-d073-4eb0-b84d-ade17ac0d6bf} cns1 2021-07-07 22:34:38.079999 +0000 UTC} <nil>}
    utils_test.go:173: {{} {{} {{} 2ca22363-4698-47e4-9ac9-5cbb2f2b517c} {{} 8d2e4b62-d073-4eb0-b84d-ade17ac0d6bf} cns2 2021-07-07 22:35:03.81 +0000 UTC} <nil>}
--- PASS: TestQuerySnapshotsUtil (0.40s)
PASS
ok  	sigs.k8s.io/vsphere-csi-driver/pkg/common/utils	0.823s
```

https://container-dp.svc.eng.vmware.com/job/Block-Vanilla/374/

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None.
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>