### PR TITLE
Clean up white spaces in e2e util

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -735,7 +735,7 @@ func getPersistentVolumeSpecForRWX(fcdID string, persistentVolumeReclaimPolicy v
 	}
 
 	if accessMode == "" {
-		// If accessMode is not specified, set the default accessMode
+		// If accessMode is not specified, set the default accessMode.
 		accessMode = v1.ReadWriteMany
 	}
 
@@ -902,8 +902,8 @@ func invokeVCenterChangePassword(user, adminPassword, newPassword, host string) 
 	return nil
 }
 
-// verifyVolumeTopology verifies that the Node Affinity rules in the volume
-// match the topology constraints specified in the storage class.
+// verifyVolumeTopology verifies that the Node Affinity rules in the volume.
+// Match the topology constraints specified in the storage class.
 func verifyVolumeTopology(pv *v1.PersistentVolume, zoneValues []string, regionValues []string) (string, string, error) {
 	if pv.Spec.NodeAffinity == nil || len(pv.Spec.NodeAffinity.Required.NodeSelectorTerms) == 0 {
 		return "", "", fmt.Errorf("node Affinity rules for PV should exist in topology aware provisioning")
@@ -2575,7 +2575,7 @@ func createPod(client clientset.Interface, namespace string, nodeSelector map[st
 	if err != nil {
 		return pod, fmt.Errorf("pod %q is not Running: %v", pod.Name, err)
 	}
-	// get fresh pod info.
+	// Get fresh pod info.
 	pod, err = client.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 	if err != nil {
 		return pod, fmt.Errorf("pod Get API error: %v", err)
@@ -2683,7 +2683,7 @@ func createPodForFSGroup(client clientset.Interface, namespace string,
 	if err != nil {
 		return pod, fmt.Errorf("pod %q is not Running: %v", pod.Name, err)
 	}
-	// get fresh pod info.
+	// Get fresh pod info.
 	pod, err = client.CoreV1().Pods(namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 	if err != nil {
 		return pod, fmt.Errorf("pod Get API error: %v", err)
@@ -3004,7 +3004,8 @@ func getRestConfigClient() *rest.Config {
 	return restConfig
 }
 
-//GetResizedStatefulSetFromManifest returns a StatefulSet from a manifest stored in fileName by adding namespace and a newSize
+// GetResizedStatefulSetFromManifest returns a StatefulSet from a manifest
+// stored in fileName by adding namespace and a newSize.
 func GetResizedStatefulSetFromManifest(ns string) *appsv1.StatefulSet {
 	ssManifestFilePath := filepath.Join(manifestPath, "statefulset.yaml")
 	framework.Logf("Parsing statefulset from %v", ssManifestFilePath)
@@ -3015,7 +3016,8 @@ func GetResizedStatefulSetFromManifest(ns string) *appsv1.StatefulSet {
 	return ss
 }
 
-// statefulSetFromManifest returns a StatefulSet from a manifest stored in fileName in the Namespace indicated by ns.
+// statefulSetFromManifest returns a StatefulSet from a manifest stored in
+// fileName in the Namespace indicated by ns.
 func statefulSetFromManifest(fileName string, ss *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
 	currentSize := ss.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests.Storage()
 	newSize := currentSize.DeepCopy()


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles vsphereutil.

**Testing done**:
Local build and check.