### PR TITLE
Use LogNewErrorf in cns-lib util

### DIFF
--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -18,8 +18,6 @@ package volume
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
@@ -38,9 +36,7 @@ import (
 func validateManager(ctx context.Context, m *defaultManager) error {
 	log := logger.GetLogger(ctx)
 	if m.virtualCenter == nil {
-		log.Error(
-			"Virtual Center connection not established")
-		return errors.New("virtual Center connection not established")
+		return logger.LogNewError(log, "virtual Center connection not established")
 	}
 	return nil
 }
@@ -290,9 +286,7 @@ func validateCreateVolumeResponseFault(ctx context.Context, name string,
 		}, nil
 	}
 
-	msg := fmt.Sprintf("failed to create volume with fault: %q", spew.Sdump(resp.Fault))
-	log.Error(msg)
-	return nil, errors.New(msg)
+	return nil, logger.LogNewErrorf(log, "failed to create volume with fault: %q", spew.Sdump(resp.Fault))
 
 }
 

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -199,11 +199,10 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 	for idx := range vcConfig.TargetvSANFileShareDatastoreURLs {
 		vcConfig.TargetvSANFileShareDatastoreURLs[idx] = strings.TrimSpace(vcConfig.TargetvSANFileShareDatastoreURLs[idx])
 		if vcConfig.TargetvSANFileShareDatastoreURLs[idx] == "" {
-			return nil, errors.New("invalid datastore URL specified in targetvSANFileShareDatastoreURLs")
+			return nil, logger.LogNewError(log, "invalid datastore URL specified in targetvSANFileShareDatastoreURLs")
 		}
 		if !strings.HasPrefix(vcConfig.TargetvSANFileShareDatastoreURLs[idx], "ds:///vmfs/volumes/vsan:") {
-			err = errors.New("non vSAN datastore specified for targetvSANFileShareDatastoreURLs")
-			return nil, err
+			return nil, logger.LogNewError(log, "non vSAN datastore specified for targetvSANFileShareDatastoreURLs")
 		}
 	}
 	return vcConfig, nil
@@ -434,9 +433,7 @@ func IsvSphereVersion70U3orAbove(ctx context.Context, aboutInfo types.AboutInfo)
 	if len(version) >= 3 {
 		vSphereVersionInt, err := strconv.Atoi(version[0:3])
 		if err != nil {
-			msg := fmt.Sprintf("error while converting version %q to integer, err %+v", version, err)
-			log.Errorf(msg)
-			return false, errors.New(msg)
+			return false, logger.LogNewErrorf(log, "error while converting version %q to integer, err %+v", version, err)
 		}
 		// Check if the current vSphere version is 7.0.3 or higher.
 		if vSphereVersionInt >= VSphere70u3Version {


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a pattern of log the error message, when creating a new error. This creates
duplicated code. This change uses LogNewError, and LogNewErrorf to reduce
duplicated code. In addition, using LogNewError consistently will make sure that
all generated errors will be logged (when log is available in the function).

This change fixes vsphere util code. The other files will be fixed in follow-up changes.

**Testing done**:
Local build and check.
Vanilla: SUCCESS! -- 46 Passed | 0 Failed | 0 Pending | 161 Skipped