### PR TITLE
Clean up white spaces in validatestorageclass_test

### DIFF
--- a/pkg/syncer/admissionhandler/validatestorageclass_test.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass_test.go
@@ -79,11 +79,19 @@ func TestValidateStorageClassForMigrationParameter(t *testing.T) {
 			"admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
 	}
 	admissionReview.Request.Object = runtime.RawExtension{
-		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": {\n    \"name\": \"sc\",\n    \"uid\": \"a9ed134e-aab1-4624-8de4-b9d961cad861\",\n    \"creationTimestamp\": \"2020-08-27T20:57:00Z\"\n  },\n  \"provisioner\": \"csi.vsphere.vmware.com\",\n  \"parameters\": {\n    \"datastore-migrationparam\": \"vsanDatastore\"\n  },\n  \"reclaimPolicy\": \"Delete\",\n  \"volumeBindingMode\": \"Immediate\"\n}"),
+		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": " +
+			"{\n    \"name\": \"sc\",\n    \"uid\": \"a9ed134e-aab1-4624-8de4-b9d961cad861\",\n    " +
+			"\"creationTimestamp\": \"2020-08-27T20:57:00Z\"\n  },\n  " +
+			"\"provisioner\": \"csi.vsphere.vmware.com\",\n  " +
+			"\"parameters\": {\n    \"datastore-migrationparam\": \"vsanDatastore\"\n  },\n  " +
+			"\"reclaimPolicy\": \"Delete\",\n  \"volumeBindingMode\": \"Immediate\"\n}"),
 	}
 	admissionResponse = validateStorageClass(ctx, &admissionReview)
-	if !strings.Contains(string(admissionResponse.Result.Reason), migrationParamErrorMessage) || admissionResponse.Allowed {
-		t.Fatalf("TestValidateStorageClassForMigrationParameter failed. admissionReview.Request: %v, admissionResponse: %v", admissionReview.Request, admissionResponse)
+	if !strings.Contains(string(admissionResponse.Result.Reason), migrationParamErrorMessage) ||
+		admissionResponse.Allowed {
+		t.Fatalf(
+			"TestValidateStorageClassForMigrationParameter failed. admissionReview.Request: %v, admissionResponse: %v",
+			admissionReview.Request, admissionResponse)
 	}
 	t.Log("TestValidateStorageClassForMigrationParameter Passed")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles some regression in validatestorageclass_test, due to new changes.

**Testing done**:
Local build, check.