### PR TITLE
Clean up white spaces in k8sorchestrator_helper

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_helper.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_helper.go
@@ -27,8 +27,8 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
-// getPVCAnnotations fetches annotations from PVC bound to passed volumeID and returns
-// annotation key-value pairs as a map
+// getPVCAnnotations fetches annotations from PVC bound to passed volumeID and
+// returns annotation key-value pairs as a map.
 func (c *K8sOrchestrator) getPVCAnnotations(ctx context.Context, volumeID string) (map[string]string, error) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("Getting annotations on pvc corresponding to volume: %s", volumeID)
@@ -40,7 +40,7 @@ func (c *K8sOrchestrator) getPVCAnnotations(ctx context.Context, volumeID string
 		pvcObj, err := c.informerManager.GetPVCLister().PersistentVolumeClaims(pvcNamespace).Get(pvcName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				//PVC may have been deleted.
+				// PVC may have been deleted.
 				log.Debugf("PVC %s is not found in namespace %s using informer manager", pvcName, pvcNamespace)
 				return nil, common.ErrNotFound
 			}
@@ -56,8 +56,9 @@ func (c *K8sOrchestrator) getPVCAnnotations(ctx context.Context, volumeID string
 }
 
 // updatePVCAnnotations updates annotations passed as key-value pairs
-// on PVC bound to passed volumeID
-func (c *K8sOrchestrator) updatePVCAnnotations(ctx context.Context, volumeID string, annotations map[string]string) error {
+// on PVC bound to passed volumeID.
+func (c *K8sOrchestrator) updatePVCAnnotations(ctx context.Context,
+	volumeID string, annotations map[string]string) error {
 	log := logger.GetLogger(ctx)
 	if pvc := c.volumeIDToPvcMap.get(volumeID); pvc != "" {
 		parts := strings.Split(pvc, "/")
@@ -67,7 +68,7 @@ func (c *K8sOrchestrator) updatePVCAnnotations(ctx context.Context, volumeID str
 		pvcObj, err := c.informerManager.GetPVCLister().PersistentVolumeClaims(pvcNamespace).Get(pvcName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				//PVC may have been deleted. Return.
+				// PVC may have been deleted. Return.
 				log.Debugf("PVC %s is not found in namespace %s using informer manager", pvcName, pvcNamespace)
 				return common.ErrNotFound
 			}
@@ -76,7 +77,7 @@ func (c *K8sOrchestrator) updatePVCAnnotations(ctx context.Context, volumeID str
 		}
 
 		for key, val := range annotations {
-			// If value is not set, remove the annotation
+			// If value is not set, remove the annotation.
 			if val == "" {
 				delete(pvcObj.ObjectMeta.Annotations, key)
 				log.Debugf("Removing annotation %s on pvc %s/%s", key, pvcNamespace, pvcName)
@@ -96,7 +97,8 @@ func (c *K8sOrchestrator) updatePVCAnnotations(ctx context.Context, volumeID str
 	return logger.LogNewErrorf(log, "could not find pvc for volumeID: %s", volumeID)
 }
 
-// isFileVolume checks if the Persistent Volume has ReadWriteMany or ReadOnlyMany support
+// isFileVolume checks if the Persistent Volume has ReadWriteMany or
+// ReadOnlyMany support.
 func isFileVolume(pv *v1.PersistentVolume) bool {
 	if len(pv.Spec.AccessModes) == 0 {
 		return false


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles k8sorchestrator_helper.

**Testing done**:
Local build, check.