### PR TITLE
Increase wait time to 1 minute in e2e tests for Volume Metadata informer updates

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -123,6 +123,7 @@ const (
 	scParamStoragePolicyID                    = "StoragePolicyId"
 	scParamStoragePolicyName                  = "StoragePolicyName"
 	sleepTimeOut                              = 30
+	oneMinuteWaitTimeInSeconds                = 60
 	spsServiceName                            = "sps"
 	sshdPort                                  = "22"
 	startOperation                            = "start"

--- a/tests/e2e/labelupdates.go
+++ b/tests/e2e/labelupdates.go
@@ -421,8 +421,8 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] label-updates", func() {
 		err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		// Waiting for some time for PVC to be deleted correctly
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow PVC deletion", sleepTimeOut))
-		time.Sleep(time.Duration(sleepTimeOut) * time.Second)
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow PVC deletion", oneMinuteWaitTimeInSeconds))
+		time.Sleep(time.Duration(oneMinuteWaitTimeInSeconds) * time.Second)
 
 		_, err = e2eVSphere.getLabelsForCNSVolume(pv.Spec.CSI.VolumeHandle, string(cnstypes.CnsKubernetesEntityTypePVC), pvc.Name, namespace)
 		gomega.Expect(err).To(gomega.HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is changing the wait time to 1 minute for update volume metadata invocations and respective wait time.
We have observed while testing label updates test suite that, update volume metadata can get invoked  tradily and 30 seconds wait time is not enough. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran e2e pipelines

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Increase wait time to 1 minute in e2e tests for Volume Metadata informer updates
```
