### PR TITLE
Make changes to pvcsi yamls to upgrade node driver registrar to v2.1.0

### DIFF
--- a/manifests/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/guestcluster/1.19/pvcsi.yaml
@@ -304,14 +304,11 @@ spec:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>
         imagePullPolicy: "IfNotPresent"
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com-reg.sock /csi/csi.sock"]
         args:
           - "--v=5"
           - "--csi-address=$(ADDRESS)"
           - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          - "--health-port=9809"
         env:
           - name: ADDRESS
             value: /csi/csi.sock
@@ -322,6 +319,15 @@ spec:
             mountPath: /csi
           - name: registration-dir
             mountPath: /registration
+        ports:
+          - containerPort: 9809
+            name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
         args:

--- a/manifests/guestcluster/1.20/pvcsi.yaml
+++ b/manifests/guestcluster/1.20/pvcsi.yaml
@@ -304,14 +304,11 @@ spec:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>
         imagePullPolicy: "IfNotPresent"
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com-reg.sock /csi/csi.sock"]
         args:
           - "--v=5"
           - "--csi-address=$(ADDRESS)"
           - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          - "--health-port=9809"
         env:
           - name: ADDRESS
             value: /csi/csi.sock
@@ -322,6 +319,15 @@ spec:
             mountPath: /csi
           - name: registration-dir
             mountPath: /registration
+        ports:
+          - containerPort: 9809
+            name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
         args:

--- a/manifests/guestcluster/1.21/pvcsi.yaml
+++ b/manifests/guestcluster/1.21/pvcsi.yaml
@@ -304,14 +304,11 @@ spec:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>
         imagePullPolicy: "IfNotPresent"
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com-reg.sock /csi/csi.sock"]
         args:
           - "--v=5"
           - "--csi-address=$(ADDRESS)"
           - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          - "--health-port=9809"
         env:
           - name: ADDRESS
             value: /csi/csi.sock
@@ -322,6 +319,15 @@ spec:
             mountPath: /csi
           - name: registration-dir
             mountPath: /registration
+        ports:
+          - containerPort: 9809
+            name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
         args:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR brings parity between Vanilla CSI yaml and pvCSI yaml for node driver registrar since we will be upgrading the image in pvcsi to `v2.1.0`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified that Node daemonset is up and running 
```
# kubectl get pod -n vmware-system-csi
NAME                                     READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-9f88cd444-pxnw7   6/6     Running   42         18h
vsphere-csi-node-9xpcx                   3/3     Running   0          2m53s
vsphere-csi-node-9zfvk                   3/3     Running   0          2m55s
vsphere-csi-node-ll94k                   3/3     Running   0          3m
vsphere-csi-node-qbmwd                   3/3     Running   0          3m1s
```

Created a PVC and Pod successfully:

```
# kubectl get pvc
NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
example-vanilla-block-pvc   Bound    pvc-a6cf2035-78b3-49be-b143-f0c55b0a23f7   1Mi        RWO            wcpglobal-storage-profile   12s
# kubectl get pod
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   1/1     Running   0          39s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Make changes to pvcsi yamls to upgrade node driver registrar to v2.1.0
```
