### PR TITLE
Upgrade sidecar container images to latest stable releases

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -188,7 +188,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -203,7 +203,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -267,7 +267,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.2.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -305,7 +305,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -353,7 +353,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -444,7 +444,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.2.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is upgrading sidecar containers to most recent & stable releases in Vanilla vsphere CSI driver deployment

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Testing done**:
Running e2e pipeline

**Special notes for your reviewer**:
Here is the changelog url for sidecars which provide details about recent bug fixes & enhancements:
https://github.com/kubernetes-csi/node-driver-registrar/blob/master/CHANGELOG/CHANGELOG-2.2.md
https://github.com/kubernetes-csi/external-provisioner/blob/release-2.2/CHANGELOG/CHANGELOG-2.2.md
https://github.com/kubernetes-csi/livenessprobe/blob/master/CHANGELOG/CHANGELOG-2.3.md
https://github.com/kubernetes-csi/external-attacher/blob/release-3.2/CHANGELOG/CHANGELOG-3.2.md
https://github.com/kubernetes-csi/external-resizer/blob/release-1.2/CHANGELOG/CHANGELOG-1.2.md

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Upgrade sidecar container images to latest stable releases
```
