### PR TITLE
Use LogNewErrorf in csi

### DIFF
--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -1246,9 +1246,7 @@ func rescanDevice(ctx context.Context, dev *Device) error {
 
 	err = ioutil.WriteFile(devRescanPath, []byte{'1'}, 0666)
 	if err != nil {
-		msg := fmt.Sprintf("error rescanning block device %q. %v", dev.RealDev, err)
-		log.Error(msg)
-		return fmt.Errorf(msg)
+		return logger.LogNewErrorf(log, "error rescanning block device %q. %v", dev.RealDev, err)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a pattern of log the error message, when creating a new error. This creates
duplicated code. This change uses LogNewError, and LogNewErrorf to reduce
duplicated code. In addition, using LogNewError consistently will make sure that
all generated errors will be logged (when log is available in the function).

This change fixes csi/service/server.go and node.go.

**Testing done**:
Local build and check.
Vanilla: SUCCESS! -- 46 Passed | 0 Failed | 0 Pending | 161 Skipped