### PR TITLE
Clean up white spaces in gc_block_resize_retain_policy

### DIFF
--- a/tests/e2e/gc_block_resize_retain_policy.go
+++ b/tests/e2e/gc_block_resize_retain_policy.go
@@ -74,11 +74,11 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 
 		scParameters := make(map[string]string)
 		scParameters[scParamFsType] = ext4FSType
-		//Set resource quota
+		// Set resource quota.
 		ginkgo.By("Set Resource quota for GC")
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, rqLimit)
-		// Create Storage class and PVC
+		// Create Storage class and PVC.
 		ginkgo.By("Creating Storage Class and PVC with allowVolumeExpansion = true")
 
 		scParameters[svStorageClassName] = storagePolicyName
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		pvclaim, err = createPVC(client, namespace, nil, "", storageclass, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Waiting for PVC to be bound
+		// Waiting for PVC to be bound.
 		var pvclaims []*v1.PersistentVolumeClaim
 		pvclaims = append(pvclaims, pvclaim)
 		ginkgo.By("Waiting for all claims to be in bound state")
@@ -102,8 +102,9 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		pvcDeletedInSvc = false
 		pvDeleted = false
 
-		// replace second element with pod.Name
-		cmd = []string{"exec", "", fmt.Sprintf("--namespace=%v", namespace), "--", "/bin/sh", "-c", "df -Tkm | grep /mnt/volume1"}
+		// Replace second element with pod.Name.
+		cmd = []string{"exec", "", fmt.Sprintf("--namespace=%v", namespace),
+			"--", "/bin/sh", "-c", "df -Tkm | grep /mnt/volume1"}
 	})
 
 	ginkgo.AfterEach(func() {
@@ -119,7 +120,8 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		}
 		if !pvcDeletedInSvc {
 			svcClient, svcNamespace := getSvcClientAndNamespace()
-			err := svcClient.CoreV1().PersistentVolumeClaims(svcNamespace).Delete(ctx, svcPVCName, *metav1.NewDeleteOptions(0))
+			err := svcClient.CoreV1().PersistentVolumeClaims(svcNamespace).Delete(ctx,
+				svcPVCName, *metav1.NewDeleteOptions(0))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
@@ -133,41 +135,46 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
 	})
 
-	/*
-		Combined:
-		PV with reclaim policy retain can be resized using new GC PVC
-		PV with reclaim policy can be resized using new GC PVC with pod
-		Steps:
-		1. Create a SC with allowVolumeExpansion set to 'true' and with reclaim policy set to 'Retain'
-		2. create a GC PVC using the SC created in step 1 and wait for binding with PV
-		3. Create a pod  in GC to use PVC created in step 2 and file system init
-		4. delete GC pod created in step 3
-		5. Delete GC PVC created in step 2
-		6. verify GC PVC is removed but SVC PVC, PV and GC PV still exists
-		7. remove claimRef from the PV lingering in GC  to get it to Available state
-		8. Create new PVC in GC using the PV lingering in GC using the same SC from step 1
-		9. verify same SVC PVC is reused
-		10. Resize PVC in GC
-		11. Wait for PVC in GC to reach "FilesystemResizePending" state
-		12. Check using CNS query that size has got updated to what was used in step 8
-		13. Verify size of PV in SVC and GC to same as the one used in the step 8
-		14. Create a pod in GC to use PVC create in step 6
-		15. wait for FS resize
-		16. Verify size of PVC SVC and GC are equal and bigger than what it was after step 3
-		17. delete pod created in step 12
-		18. delete PVC created in step 6
-		19. delete PV leftover in GC
-		20. delete SC created in step 1
-	*/
+	// Combined:
+	// PV with reclaim policy retain can be resized using new GC PVC.
+	// PV with reclaim policy can be resized using new GC PVC with pod.
+	// Steps:
+	// 1. Create a SC with allowVolumeExpansion set to 'true' and with reclaim
+	//    policy set to 'Retain'.
+	// 2. create a GC PVC using the SC created in step 1 and wait for binding
+	//    with PV.
+	// 3. Create a pod  in GC to use PVC created in step 2 and file system init.
+	// 4. Delete GC pod created in step 3.
+	// 5. Delete GC PVC created in step 2.
+	// 6. Verify GC PVC is removed but SVC PVC, PV and GC PV still exists.
+	// 7. Remove claimRef from the PV lingering in GC  to get it to Available
+	//    state.
+	// 8. Create new PVC in GC using the PV lingering in GC using the same SC
+	//    from step 1.
+	// 9. Verify same SVC PVC is reused.
+	// 10. Resize PVC in GC.
+	// 11. Wait for PVC in GC to reach "FilesystemResizePending" state.
+	// 12. Check using CNS query that size has got updated to what was used in
+	//     step 8.
+	// 13. Verify size of PV in SVC and GC to same as the one used in the step 8.
+	// 14. Create a pod in GC to use PVC create in step 6.
+	// 15. Wait for FS resize.
+	// 16. Verify size of PVC SVC and GC are equal and bigger than what it was
+	//     after step 3.
+	// 17. Delete pod created in step 12.
+	// 18. Delete PVC created in step 6.
+	// 19. Delete PV leftover in GC.
+	// 20. Delete SC created in step 1.
 	ginkgo.It("PV with reclaim policy can be reused and resized with pod", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a POD to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 		vmUUID, err := getVMUUIDFromNodeName(pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
@@ -183,15 +190,17 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		originalFsSize, err := getFSSizeMb(f, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Delete POD
+		// Delete POD.
 		ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
 		err = fpod.DeletePodWithWait(client, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify volume is detached from the node")
-		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+			fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 
 		ginkgo.By("Delete PVC in GC")
 		err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvclaim.Name, *metav1.NewDeleteOptions(0))
@@ -223,10 +232,11 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		}()
 
 		ginkgo.By("Wait for the PVC in guest cluster to bind the lingering pv")
-		framework.ExpectNoError(fpv.WaitOnPVandPVC(client, framework.NewTimeoutContextWithDefaults(), namespace, pv, pvclaim))
+		framework.ExpectNoError(fpv.WaitOnPVandPVC(client, framework.NewTimeoutContextWithDefaults(),
+			namespace, pv, pvclaim))
 
-		// Modify PVC spec to trigger volume expansion
-		// We expand the PVC while no pod is using it to ensure offline expansion
+		// Modify PVC spec to trigger volume expansion.
+		// We expand the PVC while no pod is using it to ensure offline expansion.
 		ginkgo.By("Expanding current pvc")
 		currentPvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
 		newSize := currentPvcSize.DeepCopy()
@@ -275,12 +285,13 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Create a new POD to use this PVC, and verify volume has been attached
+		// Create a new POD to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating a new pod to attach PV again to the node")
 		pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Verify volume after expansion: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		ginkgo.By(fmt.Sprintf("Verify volume after expansion: %s is attached to the node: %s",
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 		vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -313,40 +324,44 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		ginkgo.By("Checking for PVC resize completion on SVC PVC")
 		gomega.Expect(verifyResizeCompletedInSupervisor(svcPVCName)).To(gomega.BeTrue())
 
-		// Delete POD
+		// Delete POD.
 		ginkgo.By(fmt.Sprintf("Deleting the new pod %s in namespace %s after expansion", pod.Name, namespace))
 		err = fpod.DeletePodWithWait(client, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify volume is detached from the node after expansion")
-		isDiskDetached, err = e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+		isDiskDetached, err = e2eVSphere.waitForVolumeDetachedFromNode(client,
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+			fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 
 	})
 
-	/*
-		PV with reclaim policy retain can be resized when used in a fresh GC
-		Steps:
-		1. Create a SC with allowVolumeExpansion set to 'true' in GC1
-		2. create a GC1 PVC using the SC created in step 1 and wait for binding with PV with reclaim policy set to 'Retain'
-		3. Delete GC1 PVC
-		4. verify GC1 PVC is removed but SVC PV, PVC and GC1 PV still exist
-		5. delete GC1 PV.  SVC PV, PVC still exist
-		6. Create a new GC GC2
-		7. create SC in GC1 similar to the SC created in step 1 but with reclaim policy set to delete
-		8. Create new PV in GC2 using the SVC PVC from step 5 and SC created in step 7
-		9. create new  PVC in GC2 using PV created in step 8
-		10. verify a new PVC API object is created
-		11. Resize PVC from step 9 in GC2
-		12. Wait for PVC in GC2 and SVC to reach "FilesystemResizePending" state
-		13. Check using CNS query that size has got updated to what was used in step 11
-		14. Verify size of PVs in SVC and GC to same as the one used in the step 11
-		15. delete PVC created in step 9
-		16. delete SC created in step 1 and step 7
-		17. delete GC2
-		Steps 6 and 17 need to run manually before and after this suite
-	*/
+	// PV with reclaim policy retain can be resized when used in a fresh GC.
+	// Steps:
+	// 1. Create a SC with allowVolumeExpansion set to 'true' in GC1.
+	// 2. create a GC1 PVC using the SC created in step 1 and wait for binding
+	//    with PV with reclaim policy set to 'Retain'.
+	// 3. Delete GC1 PVC.
+	// 4. verify GC1 PVC is removed but SVC PV, PVC and GC1 PV still exist.
+	// 5. delete GC1 PV.  SVC PV, PVC still exist.
+	// 6. Create a new GC GC2.
+	// 7. create SC in GC1 similar to the SC created in step 1 but with reclaim
+	//    policy set to delete.
+	// 8. Create new PV in GC2 using the SVC PVC from step 5 and SC created in
+	//    step 7.
+	// 9. create new  PVC in GC2 using PV created in step 8.
+	// 10. verify a new PVC API object is created.
+	// 11. Resize PVC from step 9 in GC2.
+	// 12. Wait for PVC in GC2 and SVC to reach "FilesystemResizePending" state.
+	// 13. Check using CNS query that size has got updated to what was used in
+	//     step 11.
+	// 14. Verify size of PVs in SVC and GC to same as the one used in the step 11.
+	// 15. delete PVC created in step 9.
+	// 16. delete SC created in step 1 and step 7.
+	// 17. delete GC2.
+	// Steps 6 and 17 need to run manually before and after this suite.
 	ginkgo.It("PV with reclaim policy retain can be resized when used in a fresh GC", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -355,7 +370,8 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 			ginkgo.Skip("Env NEW_GUEST_CLUSTER_KUBE_CONFIG is missing")
 		}
 		clientNewGc, err = k8s.CreateKubernetesClientFromConfig(newGcKubconfigPath)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Error creating k8s client with %v: %v", newGcKubconfigPath, err))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			fmt.Sprintf("Error creating k8s client with %v: %v", newGcKubconfigPath, err))
 		ginkgo.By("Creating namespace on second GC")
 		ns, err := framework.CreateTestingNS(f.BaseName, clientNewGc, map[string]string{
 			"e2e-framework": f.BaseName,
@@ -388,7 +404,8 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		scParameters := make(map[string]string)
 		scParameters[scParamFsType] = ext4FSType
 		scParameters[svStorageClassName] = storagePolicyName
-		storageclassNewGC, err := createStorageClass(clientNewGc, scParameters, nil, v1.PersistentVolumeReclaimDelete, "", true, "")
+		storageclassNewGC, err := createStorageClass(clientNewGc,
+			scParameters, nil, v1.PersistentVolumeReclaimDelete, "", true, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		pvc, err := createPVC(clientNewGc, namespaceNewGC, nil, "", storageclassNewGC, "")
@@ -401,9 +418,11 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		pvtemp := pvs[0]
 
 		defer func() {
-			err = clientNewGc.CoreV1().PersistentVolumeClaims(namespaceNewGC).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))
+			err = clientNewGc.CoreV1().PersistentVolumeClaims(namespaceNewGC).Delete(ctx,
+				pvc.Name, *metav1.NewDeleteOptions(0))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = clientNewGc.StorageV1().StorageClasses().Delete(ctx, storageclassNewGC.Name, *metav1.NewDeleteOptions(0))
+			err = clientNewGc.StorageV1().StorageClasses().Delete(ctx,
+				storageclassNewGC.Name, *metav1.NewDeleteOptions(0))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pvtemp.Spec.CSI.VolumeHandle)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -427,11 +446,13 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		ginkgo.By("Creating the PVC")
 		pvcNew := getPersistentVolumeClaimSpec(namespaceNewGC, nil, pvNew.Name)
 		pvcNew.Spec.StorageClassName = &pvtemp.Spec.StorageClassName
-		pvcNew, err = clientNewGc.CoreV1().PersistentVolumeClaims(namespaceNewGC).Create(ctx, pvcNew, metav1.CreateOptions{})
+		pvcNew, err = clientNewGc.CoreV1().PersistentVolumeClaims(namespaceNewGC).Create(ctx,
+			pvcNew, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Wait for PV and PVC to Bind
-		framework.ExpectNoError(fpv.WaitOnPVandPVC(clientNewGc, framework.NewTimeoutContextWithDefaults(), namespaceNewGC, pvNew, pvcNew))
+		// Wait for PV and PVC to Bind.
+		framework.ExpectNoError(fpv.WaitOnPVandPVC(clientNewGc,
+			framework.NewTimeoutContextWithDefaults(), namespaceNewGC, pvNew, pvcNew))
 
 		ginkgo.By("Expanding current pvc")
 		currentPvcSize := pvcNew.Spec.Resources.Requests[v1.ResourceStorage]
@@ -459,7 +480,8 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		verifyPVSizeinSupervisor(svcPVCName, newSize)
 
 		ginkgo.By("Checking for conditions on pvc")
-		pvcNew, err = waitForPVCToReachFileSystemResizePendingCondition(clientNewGc, namespaceNewGC, pvcNew.Name, pollTimeout)
+		pvcNew, err = waitForPVCToReachFileSystemResizePendingCondition(clientNewGc,
+			namespaceNewGC, pvcNew.Name, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
@@ -481,12 +503,13 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Create a new POD to use this PVC, and verify volume has been attached
+		// Create a new POD to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating a pod to attach PV again to the node")
 		pod, err := createPod(clientNewGc, namespaceNewGC, nil, []*v1.PersistentVolumeClaim{pvcNew}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Verify volume after expansion: %s is attached to the node: %s", pvNew.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		ginkgo.By(fmt.Sprintf("Verify volume after expansion: %s is attached to the node: %s",
+			pvNew.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 		vmUUID, err := getVMUUIDFromNodeName(pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -501,7 +524,8 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 			framework.TestContext.KubeConfig = oldKubeConfig
 		}()
 
-		cmd2 = []string{"exec", pod.Name, fmt.Sprintf("--namespace=%v", namespaceNewGC), "--", "/bin/sh", "-c", "df -Tkm | grep /mnt/volume1"}
+		cmd2 = []string{"exec", pod.Name, fmt.Sprintf("--namespace=%v", namespaceNewGC),
+			"--", "/bin/sh", "-c", "df -Tkm | grep /mnt/volume1"}
 		lastOutput := framework.RunKubectlOrDie(namespaceNewGC, cmd2...)
 		gomega.Expect(strings.Contains(lastOutput, ext4FSType)).NotTo(gomega.BeFalse())
 
@@ -516,18 +540,21 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		ginkgo.By("Checking for PVC resize completion on SVC PVC")
 		gomega.Expect(verifyResizeCompletedInSupervisor(svcPVCName)).To(gomega.BeTrue())
 
-		// Delete POD
+		// Delete POD.
 		ginkgo.By(fmt.Sprintf("Deleting the new pod %s in namespace %s after expansion", pod.Name, namespaceNewGC))
 		err = fpod.DeletePodWithWait(clientNewGc, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify volume is detached from the node after expansion")
-		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(clientNewGc, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(clientNewGc,
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+			fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 
 		ginkgo.By("Deleting the PV Claim")
-		framework.ExpectNoError(fpv.DeletePersistentVolumeClaim(clientNewGc, pvcNew.Name, namespaceNewGC), "Failed to delete PVC ", pvcNew.Name)
+		framework.ExpectNoError(fpv.DeletePersistentVolumeClaim(clientNewGc, pvcNew.Name, namespaceNewGC),
+			"Failed to delete PVC ", pvcNew.Name)
 		pvcNew = nil
 
 		ginkgo.By("Verify PV should be deleted automatically")
@@ -543,7 +570,8 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 
 })
 
-func waitForPvToBeReleased(ctx context.Context, client clientset.Interface, pvName string) (*v1.PersistentVolume, error) {
+func waitForPvToBeReleased(ctx context.Context, client clientset.Interface,
+	pvName string) (*v1.PersistentVolume, error) {
 	var pv *v1.PersistentVolume
 	var err error
 	waitErr := wait.PollImmediate(resizePollInterval, pollTimeoutShort, func() (bool, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles e2e test gc_block_resize_retain_policy.

**Testing done**:
Local build, check.