### PR TITLE
Clean white spaces in vsphere_volume_mount

### DIFF
--- a/tests/e2e/vsphere_volume_mount.go
+++ b/tests/e2e/vsphere_volume_mount.go
@@ -52,33 +52,38 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume Attach Test", func() {
 
 	})
 
-	/*
-		Steps:
-		Test to Verify Pod can be created with PVC (dynamically provisioned) with access mode "ReadWriteMany"
-		1.Create a storage policy having "targetDatastoreUrls" as the compliant datastores
-		2.Create StorageClass with fsType as "nfs4" and storagePolicy created in Step 1
-		3.Create a PVC with "ReadWriteMany" using the SC from above
-		4.Wait for PVC to be Bound
-		5.Get the VolumeID from PV
-		6.Verify using CNS Query API if VolumeID retrieved from PV is present.
-		  Also verify Name, Capacity, VolumeType, Health matches
-		7.Verify if VolumeID is created on one of the VSAN datastores from list of datacenters provided in vsphere.conf
-		8.Create Pod1 using PVC created above at a mount path specified in PodSpec
-		9.Wait for Pod1 to be Running
-		10.Create a file (file1.txt) at the mount path. Check if the creation is successful
-		11.Delete Pod1
-		12.Verify if Pod1 is successfully deleted
-		13.Create Pod2 using PVC created above
-		14.Wait for Pod2 to be Running
-		15.Read the file (file1.txt) created in Step 8. Check if reading is successful
-		16.Create a new file (file2.txt) at the mount path. Check if the creation is successful
-		17.Delete Pod2
-		18.Verify if Pod2 is successfully deleted
-		19.Delete PVC
-		20.Check if the VolumeID is deleted from CNS by using CNSQuery API
-		21.Delete Storage Class
-		22.Delete storage policy
-	*/
+	// Steps:
+	// Test to Verify Pod can be created with PVC (dynamically provisioned) with
+	// access mode "ReadWriteMany".
+	// 1.Create a storage policy having "targetDatastoreUrls" as the compliant
+	//   datastores.
+	// 2.Create StorageClass with fsType as "nfs4" and storagePolicy created in
+	//   Step 1.
+	// 3.Create a PVC with "ReadWriteMany" using the SC from above.
+	// 4.Wait for PVC to be Bound.
+	// 5.Get the VolumeID from PV.
+	// 6.Verify using CNS Query API if VolumeID retrieved from PV is present.
+	//   Also verify Name, Capacity, VolumeType, Health matches.
+	// 7.Verify if VolumeID is created on one of the VSAN datastores from list
+	//   of datacenters provided in vsphere.conf.
+	// 8.Create Pod1 using PVC created above at a mount path specified in PodSpec.
+	// 9.Wait for Pod1 to be Running.
+	// 10.Create a file (file1.txt) at the mount path. Check if the creation is
+	//    successful.
+	// 11.Delete Pod1.
+	// 12.Verify if Pod1 is successfully deleted.
+	// 13.Create Pod2 using PVC created above.
+	// 14.Wait for Pod2 to be Running.
+	// 15.Read the file (file1.txt) created in Step 8. Check if reading is
+	//    successful.
+	// 16.Create a new file (file2.txt) at the mount path. Check if the creation
+	//    is successful.
+	// 17.Delete Pod2.
+	// 18.Verify if Pod2 is successfully deleted.
+	// 19.Delete PVC.
+	// 20.Check if the VolumeID is deleted from CNS by using CNSQuery API.
+	// 21.Delete Storage Class.
+	// 22.Delete storage policy.
 	ginkgo.It("[csi-file-vanilla] Verify Pod can be created with PVC (dynamically provisioned) with access mode ReadWriteMany", func() {
 		createFileVolumeAndMount(f, client, namespace)
 	})
@@ -92,9 +97,10 @@ func createFileVolumeAndMount(f *framework.Framework, client clientset.Interface
 	scParameters := make(map[string]string)
 	scParameters[scParamDatastoreURL] = sharedatastoreURL
 	const mntPath = "/mnt/volume1/"
-	// Create Storage class and PVC
+	// Create Storage class and PVC.
 	ginkgo.By("Creating Storage Class")
-	storageclass, pvclaim, err := createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "", false, v1.ReadWriteMany)
+	storageclass, pvclaim, err := createPVCAndStorageClass(client,
+		namespace, nil, scParameters, "", nil, "", false, v1.ReadWriteMany)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	defer func() {
 		err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
@@ -103,7 +109,7 @@ func createFileVolumeAndMount(f *framework.Framework, client clientset.Interface
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}()
 
-	// Waiting for PVC to be bound
+	// Waiting for PVC to be bound.
 	var pvclaims []*v1.PersistentVolumeClaim
 	pvclaims = append(pvclaims, pvclaim)
 	ginkgo.By("Waiting for all claims to be in bound state")
@@ -124,7 +130,8 @@ func createFileVolumeAndMount(f *framework.Framework, client clientset.Interface
 	queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volHandle)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	gomega.Expect(queryResult.Volumes).ShouldNot(gomega.BeEmpty())
-	ginkgo.By(fmt.Sprintf("volume Name:%s, capacity:%d volumeType:%s health:%s accesspoint: %s", queryResult.Volumes[0].Name,
+	ginkgo.By(fmt.Sprintf("volume Name:%s, capacity:%d volumeType:%s health:%s accesspoint: %s",
+		queryResult.Volumes[0].Name,
 		queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb,
 		queryResult.Volumes[0].VolumeType, queryResult.Volumes[0].HealthStatus,
 		queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).AccessPoints),
@@ -132,52 +139,58 @@ func createFileVolumeAndMount(f *framework.Framework, client clientset.Interface
 
 	// Verify if Volume capacity, name, type, health matches.
 	ginkgo.By("Verifying disk size specified in PVC is honored")
-	gomega.Expect(queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb == diskSizeInMb).To(gomega.BeTrue(), "Wrong disk size provisioned")
+	gomega.Expect(queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb ==
+		diskSizeInMb).To(gomega.BeTrue(), "Wrong disk size provisioned")
 
 	ginkgo.By("Verifying volume type specified in PVC is honored")
 	gomega.Expect(queryResult.Volumes[0].VolumeType == testVolumeType).To(gomega.BeTrue(), "Volume type is not FILE")
 
-	// Verify if VolumeID is created on the VSAN datastores
+	// Verify if VolumeID is created on the VSAN datastores.
 	ginkgo.By("Verify if VolumeID is created on the VSAN datastores")
-	gomega.Expect(strings.HasPrefix(queryResult.Volumes[0].DatastoreUrl, "ds:///vmfs/volumes/vsan:")).To(gomega.BeTrue(), "Volume is not provisioned on vSan datastore")
+	gomega.Expect(strings.HasPrefix(queryResult.Volumes[0].DatastoreUrl, "ds:///vmfs/volumes/vsan:")).To(
+		gomega.BeTrue(), "Volume is not provisioned on vSan datastore")
 
-	// Verify if VolumeID is created on the datastore from list of datacenters provided in vsphere.conf
+	// Verify if VolumeID is created on the datastore from list of datacenters
+	// provided in vsphere.conf.
 	ginkgo.By("Verify if VolumeID is created on the datastore from list of datacenters provided in vsphere.conf")
-	gomega.Expect(isDatastoreBelongsToDatacenterSpecifiedInConfig(queryResult.Volumes[0].DatastoreUrl)).To(gomega.BeTrue(), "Volume is not provisioned on the datastore specified on config file")
+	gomega.Expect(isDatastoreBelongsToDatacenterSpecifiedInConfig(queryResult.Volumes[0].DatastoreUrl)).To(
+		gomega.BeTrue(), "Volume is not provisioned on the datastore specified on config file")
 
-	//Create Pod1 with pvc created above
+	// Create Pod1 with pvc created above.
 	ginkgo.By("Create Pod1 with pvc created above")
 	pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//cleanup for Pod1
+	// Cleanup for Pod1.
 	defer func() {
 		ginkgo.By(fmt.Sprintf("Deleting the pod : %s in namespace %s", pod1.Name, namespace))
 		err = fpod.DeletePodWithWait(client, pod1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}()
 
-	//Create file1.txt on Pod1
+	// Create file1.txt on Pod1.
 	filePath := mntPath + "file1.txt"
 	ginkgo.By("Create file1.txt on Pod1")
 	err = framework.CreateEmptyFileOnPod(namespace, pod1.Name, filePath)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//Write data on file1.txt on Pod1
+	// Write data on file1.txt on Pod1.
 	data := filePath
 	ginkgo.By("Writing the file file1.txt from Pod1")
 
-	_, err = framework.RunKubectl(namespace, "exec", fmt.Sprintf("--namespace=%s", namespace), pod1.Name, "--", "/bin/sh", "-c", fmt.Sprintf(" echo %s >  %s ", data, filePath))
+	_, err = framework.RunKubectl(namespace, "exec", fmt.Sprintf("--namespace=%s", namespace), pod1.Name,
+		"--", "/bin/sh", "-c", fmt.Sprintf(" echo %s >  %s ", data, filePath))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//Read file1.txt created from Pod1
+	// Read file1.txt created from Pod1.
 	ginkgo.By("Read file1.txt from Pod1 created by Pod1")
-	output, err := framework.RunKubectl(namespace, "exec", fmt.Sprintf("--namespace=%s", namespace), pod1.Name, "--", "/bin/sh", "-c", fmt.Sprintf("less %s", filePath))
+	output, err := framework.RunKubectl(namespace, "exec", fmt.Sprintf("--namespace=%s", namespace), pod1.Name,
+		"--", "/bin/sh", "-c", fmt.Sprintf("less %s", filePath))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	ginkgo.By(fmt.Sprintf("File contents from file1.txt are: %s", output))
 	gomega.Expect(output == data+"\n").To(gomega.BeTrue(), "Pod1 is able to read file1 written by Pod1")
 
-	//cleanup for Pod1
+	// Cleanup for Pod1.
 	ginkgo.By(fmt.Sprintf("Deleting the pod : %s in namespace %s", pod1.Name, namespace))
 	err = fpod.DeletePodWithWait(client, pod1)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -186,41 +199,45 @@ func createFileVolumeAndMount(f *framework.Framework, client clientset.Interface
 	ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from the node: %s", volHandle, nodeName))
 	isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, volHandle, nodeName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, nodeName))
+	gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+		fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, nodeName))
 
-	//Create Pod2 using the same pvc
+	// Create Pod2 using the same pvc.
 	ginkgo.By("Create Pod2 with pvc created above")
 	pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//cleanup for Pod2
+	// Cleanup for Pod2.
 	defer func() {
 		ginkgo.By(fmt.Sprintf("Deleting the pod : %s in namespace %s", pod2.Name, namespace))
 		err = fpod.DeletePodWithWait(client, pod2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}()
 
-	//Read file1.txt created from Pod2
+	// Read file1.txt created from Pod2.
 	ginkgo.By("Read file1.txt from Pod2 created by Pod1")
-	output, err = framework.RunKubectl(namespace, "exec", fmt.Sprintf("--namespace=%s", namespace), pod2.Name, "--", "/bin/sh", "-c", fmt.Sprintf("less %s", filePath))
+	output, err = framework.RunKubectl(namespace, "exec", fmt.Sprintf("--namespace=%s", namespace), pod2.Name,
+		"--", "/bin/sh", "-c", fmt.Sprintf("less %s", filePath))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	ginkgo.By(fmt.Sprintf("File contents from file1.txt are: %s", output))
 	gomega.Expect(output == data+"\n").To(gomega.BeTrue(), "Pod2 is able to read file1 written by Pod1")
 
-	//Create a file file2.txt from Pod2
+	// Create a file file2.txt from Pod2.
 	filePath = mntPath + "file2.txt"
 	err = framework.CreateEmptyFileOnPod(namespace, pod2.Name, filePath)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	ginkgo.By("Write on file2.txt from Pod2")
-	//Writing to the file
+	// Writing to the file.
 	data = filePath
-	_, err = framework.RunKubectl(namespace, "exec", fmt.Sprintf("--namespace=%s", namespace), pod2.Name, "--", "/bin/sh", "-c", fmt.Sprintf("echo %s >   %s", data, filePath))
+	_, err = framework.RunKubectl(namespace, "exec", fmt.Sprintf("--namespace=%s", namespace), pod2.Name,
+		"--", "/bin/sh", "-c", fmt.Sprintf("echo %s >   %s", data, filePath))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	//Read file2.txt created from Pod2
+	// Read file2.txt created from Pod2.
 	ginkgo.By("Read file2.txt from Pod2 created by Pod2")
-	output, err = framework.RunKubectl(namespace, "exec", fmt.Sprintf("--namespace=%s", namespace), pod2.Name, "--", "/bin/sh", "-c", fmt.Sprintf("less %s", filePath))
+	output, err = framework.RunKubectl(namespace, "exec", fmt.Sprintf("--namespace=%s", namespace), pod2.Name,
+		"--", "/bin/sh", "-c", fmt.Sprintf("less %s", filePath))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	ginkgo.By(fmt.Sprintf("File contents from file2.txt are: %s", output))
 	gomega.Expect(output == data+"\n").To(gomega.BeTrue(), "Pod2 is able to read file2 written by Pod2")
@@ -233,6 +250,7 @@ func createFileVolumeAndMount(f *framework.Framework, client clientset.Interface
 	ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from the node: %s", volHandle, nodeName))
 	isDiskDetached, err = e2eVSphere.waitForVolumeDetachedFromNode(client, volHandle, nodeName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, nodeName))
+	gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+		fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, nodeName))
 
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles e2e test vsphere_volume_mount.

**Testing done**:
Local build, check.