### PR TITLE
Replaced 'POD' with 'Pod' in test files as its not an abbreviation.

### DIFF
--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -632,7 +632,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 2. Create Resource quota.
 	// 3. create CNS register volume with above created VolumeID.
 	// 4. verify created PV, PVC and check the bidirectional reference.
-	// 5. Create POD , with above created PVC.
+	// 5. Create Pod , with above created PVC.
 	// 6. Verify volume is attached to the node and volume is accessible in the pod.
 	// 7. Delete POD.
 	// 8. Delete PVC.
@@ -721,7 +721,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 2. Create Resource quota.
 	// 3. Create CNS register volume with above created FCD.
 	// 4. verify PV, PVC got created , check the bidirectional reference.
-	// 5. Create POD , with above created PVC.
+	// 5. Create Pod , with above created PVC.
 	// 6. Verify volume is attached to the node and volume is accessible in the pod.
 	// 7. Delete POD.
 	// 8. Delete PVC.
@@ -815,7 +815,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 5. Verify  PVC creation fails.
 	// 6. Increase Resource quota.
 	// 7. verify PVC, PV got created , check the bidirectional reference.
-	// 8. Create POD , with above created PVC.
+	// 8. Create Pod , with above created PVC.
 	// 9. Verify volume is attached to the node and volume is accessible in the pod.
 	// 10. Delete POD.
 	// 11. Delete PVC.
@@ -1693,7 +1693,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	})
 
 	// Perform dynamic and static volume provisioning together and verify the
-	// PVC creation, Create POD and then delete namespace.
+	// PVC creation, Create Pod and then delete namespace.
 	// Make sure all PV, PVC, POd's and CNS register volume got deleted.
 	//
 	// Test Steps:
@@ -1702,11 +1702,11 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 3. Create CNS register volume with above created FCD.
 	// 4. Create pvc through dynamic volume provisioning.
 	// 5. verify PV, PVC got created through static volume provisioning.
-	// 6. Create POD with the PVC created in step 4 and 5.
+	// 6. Create Pod with the PVC created in step 4 and 5.
 	// 7. Delete Namespace.
 	// 8. Verify that PV's got deleted (This ensures that all PVC, CNS register
 	//    volumes and POD's are deleted).
-	ginkgo.It("[csi-supervisor] Perform static and dynamic provisioning together, Create POD and delete Namespace", func() {
+	ginkgo.It("[csi-supervisor] Perform static and dynamic provisioning together, Create Pod and delete Namespace", func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/gc_block_resize_retain_policy.go
+++ b/tests/e2e/gc_block_resize_retain_policy.go
@@ -168,7 +168,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 	ginkgo.It("PV with reclaim policy can be reused and resized with pod", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		// Create a POD to use this PVC, and verify volume has been attached.
+		// Create a Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -285,7 +285,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Create a new POD to use this PVC, and verify volume has been attached.
+		// Create a new Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating a new pod to attach PV again to the node")
 		pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -503,7 +503,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Create a new POD to use this PVC, and verify volume has been attached.
+		// Create a new Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating a pod to attach PV again to the node")
 		pod, err := createPod(clientNewGc, namespaceNewGC, nil, []*v1.PersistentVolumeClaim{pvcNew}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -167,7 +167,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	// 14. delete PVC created in step 2.
 	// 15. delete SC created in step 1.
 	ginkgo.It("Verify offline expansion triggers FS resize", func() {
-		// Create a POD to use this PVC, and verify volume has been attached.
+		// Create a Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -267,7 +267,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Create a new POD to use this PVC, and verify volume has been attached.
+		// Create a new Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating a new pod to attach PV again to the node")
 		pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -360,7 +360,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	ginkgo.It("verify offline block volume expansion triggered when SVC CSI pod is down succeeds once SVC CSI pod comes up", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		// Create a POD to use this PVC, and verify volume has been attached.
+		// Create a Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -471,7 +471,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Create a new POD to use this PVC, and verify volume has been attached.
+		// Create a new Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating a new pod to attach PV again to the node")
 		pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -897,7 +897,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	// 13. Delete PVC created in step 2.
 	// 14. Delete SC created in step 1.
 	ginkgo.It("verify resize triggered when volume was online resumes when volumes becomes offline", func() {
-		// Create a POD to use this PVC, and verify volume has been attached.
+		// Create a Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -981,7 +981,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Create a new POD to use this PVC, and verify volume has been attached.
+		// Create a new Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating a new pod to attach PV again to the node")
 		pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1177,7 +1177,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
-		// Create a POD to use this PVC, and verify volume has been attached.
+		// Create a Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvc}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1281,7 +1281,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		gomega.Expect(queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).CapacityInMb).To(
 			gomega.Equal(newSizeInMb), "Got wrong disk size after volume expansion")
 
-		// Create a new POD to use this PVC, and verify volume has been attached.
+		// Create a new Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating a new pod to attach PV again to the node")
 		pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvc}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1421,7 +1421,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	// 12. delete PVC created in step 2.
 	// 13. delete SC created in step 1.
 	ginkgo.It("Verify Online volume expansion on dynamic PVC and check FS resize", func() {
-		// Create a POD to use this PVC, and verify volume has been attached.
+		// Create a Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1502,7 +1502,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 
 		ginkgo.By("Verify online volume expansion when PVC resized concurrently " +
 			"with different sizes expands to largest size")
-		// Create a POD to use this PVC, and verify volume has been attached.
+		// Create a Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1589,7 +1589,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	// 1. Create a SC with allowVolumeExpansion set to 'true'.
 	// 2. set a quota limit on the storage policy in VC.
 	// 3. create a PVC using the SC created in step 1 and wait for binding with PV.
-	// 4. Create POD using above PVC.
+	// 4. Create Pod using above PVC.
 	// 5. resize GC PVC to size bigger than what storage policy quota allows.
 	// 6. Verify resize fails.
 	// 7. Increase quota on the storage policy to allow the exapnsion.
@@ -1606,7 +1606,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		defer cancel()
 
 		ginkgo.By("Verify online expansion when resize beyond storage policy quota fails")
-		// Create a POD to use this PVC, and verify volume has been attached.
+		// Create a Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2255,7 +2255,7 @@ func createStaticPVandPVCinGuestCluster(client clientset.Interface,
 
 	framework.Logf("PVC name in GC : %s", gcPVC.GetName())
 
-	// Create a POD to use this PVC, and verify volume has been attached.
+	// Create a Pod to use this PVC, and verify volume has been attached.
 	ginkgo.By("Creating pod to attach PV to the node")
 	pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{gcPVC}, false, execCommand)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/gc_cns_nodevm_attachment.go
+++ b/tests/e2e/gc_cns_nodevm_attachment.go
@@ -245,7 +245,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 	// Verify volume is detached from VM.
 	// Delete PVC in GC.
 
-	ginkgo.It("Verify CnsNodeVmAttachements crd and POD is created after CSI controller comes up", func() {
+	ginkgo.It("Verify CnsNodeVmAttachements crd and Pod is created after CSI controller comes up", func() {
 		var sc *storagev1.StorageClass
 		var pvc *v1.PersistentVolumeClaim
 		var err error
@@ -735,7 +735,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 		framework.ExpectNoError(fpv.WaitOnPVandPVC(clientNewGc,
 			framework.NewTimeoutContextWithDefaults(), namespaceNewGC, pvNew, pvcNew))
 
-		// Create a new POD to use this PVC, and verify volume has been attached.
+		// Create a new Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating a pod in GC2 with PVC created in GC2")
 		pod, err := createPod(clientNewGc, namespaceNewGC, nil, []*v1.PersistentVolumeClaim{pvcNew}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -749,7 +749,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
 
-		// Create a new POD to use this PVC, and verify volume has been attached.
+		// Create a new Pod to use this PVC, and verify volume has been attached.
 		ginkgo.By("Creating a pod in GC1 with PVC created in GC1")
 		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		pod1, err = client.CoreV1().Pods(namespace).Get(ctx, pod1.Name, metav1.GetOptions{})

--- a/tests/e2e/gc_rwx_basic.go
+++ b/tests/e2e/gc_rwx_basic.go
@@ -116,7 +116,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] Basic File Volume Provision Test", func
 			queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).AccessPoints),
 		)
 
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execRWXCommandPod1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -210,7 +210,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] Basic File Volume Provision Test", func
 			queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).AccessPoints),
 		)
 
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execRWXCommandPod1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -228,7 +228,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] Basic File Volume Provision Test", func
 		ginkgo.By("Verifying whether the CnsFileAccessConfig CRD is created or not for Pod1")
 		verifyCNSFileAccessConfigCRDInSupervisor(ctx, f, pod.Spec.NodeName+"-"+volHandle, crdCNSFileAccessConfig, crdVersion, crdGroup, true)
 
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod2 to attach PV to the node")
 		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execRWXCommandPod2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -334,7 +334,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] Basic File Volume Provision Test", func
 			queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).AccessPoints),
 		)
 
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execRWXCommandPod1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -367,7 +367,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] Basic File Volume Provision Test", func
 		ginkgo.By("Verifying whether the CnsFileAccessConfig CRD is Deleted or not for Pod1")
 		verifyCNSFileAccessConfigCRDInSupervisor(ctx, f, pod.Spec.NodeName+"-"+volHandle, crdCNSFileAccessConfig, crdVersion, crdGroup, false)
 
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execRWXCommandPod2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/gc_rwx_readonly.go
+++ b/tests/e2e/gc_rwx_readonly.go
@@ -119,7 +119,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] File Volume Test for ReadOnlyMany", fun
 			queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).AccessPoints),
 		)
 
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod := fpod.MakePod(namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "echo 'Hello message from Pod1' && while true ; do sleep 2 ; done")
 		pod.Spec.Volumes[0] = v1.Volume{Name: "volume1", VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: pvclaim.Name, ReadOnly: true}}}
@@ -251,7 +251,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] File Volume Test for ReadOnlyMany", fun
 			queryResult2.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).AccessPoints),
 		)
 
-		// Create a POD to use the PVC created above
+		// Create a Pod to use the PVC created above
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod := fpod.MakePod(namespace, nil, []*v1.PersistentVolumeClaim{pvclaim, pvclaim2}, false, execRWXCommandPod1)
 
@@ -371,7 +371,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] File Volume Test for ReadOnlyMany", fun
 			queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).AccessPoints),
 		)
 
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execRWXCommandPod1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -404,7 +404,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] File Volume Test for ReadOnlyMany", fun
 		ginkgo.By(fmt.Sprintf("Verifying whether the CnsFileAccessConfig CRD is Deleted or not for Pod1 %s", pod.Spec.NodeName+"-"+volHandle))
 		verifyCNSFileAccessConfigCRDInSupervisor(ctx, f, pod.Spec.NodeName+"-"+volHandle, crdCNSFileAccessConfig, crdVersion, crdGroup, false)
 
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod2 := fpod.MakePod(namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "echo 'Hello message from Pod1' && while true ; do sleep 2 ; done")
 		pod2.Spec.Volumes[0] = v1.Volume{Name: "volume1", VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: pvclaim.Name, ReadOnly: true}}}

--- a/tests/e2e/gc_rwx_static_provision.go
+++ b/tests/e2e/gc_rwx_static_provision.go
@@ -126,7 +126,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] File Volume static Provision Test", fun
 			queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).AccessPoints),
 		)
 
-		// Create a POD to use the PVC created above
+		// Create a Pod to use the PVC created above
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execRWXCommandPod1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -171,7 +171,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] File Volume static Provision Test", fun
 		// Wait for PV and PVC to Bind
 		framework.ExpectNoError(fpv.WaitOnPVandPVC(client, framework.NewTimeoutContextWithDefaults(), namespace, pv2, pvc2))
 
-		// Create a POD to use this PVC
+		// Create a Pod to use this PVC
 		ginkgo.By("Creating pod2 to attach PV to the node")
 		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvc2}, false, execRWXCommandPod2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -279,7 +279,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] File Volume static Provision Test", fun
 			queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).AccessPoints),
 		)
 
-		// Create a POD to use the PVC created above
+		// Create a Pod to use the PVC created above
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execRWXCommandPod1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -329,7 +329,7 @@ var _ = ginkgo.Describe("[rwm-csi-guest] File Volume static Provision Test", fun
 		// Wait for PV and PVC to Bind
 		framework.ExpectNoError(fpv.WaitOnPVandPVC(client, framework.NewTimeoutContextWithDefaults(), namespace, pv2, pvc2))
 
-		// Create a POD to use this PVC
+		// Create a Pod to use this PVC
 		ginkgo.By("Creating pod2 to attach PV to the node")
 		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvc2}, false, execRWXCommandPod2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -202,7 +202,7 @@ func verifyVolumeMetadataInCNS(vs *vSphere, volumeID string,
 	for _, metadata := range queryResult.Volumes[0].Metadata.EntityMetadata {
 		kubernetesMetadata := metadata.(*cnstypes.CnsKubernetesEntityMetadata)
 		if kubernetesMetadata.EntityType == "POD" && kubernetesMetadata.EntityName != PodName {
-			return fmt.Errorf("entity POD with name %s not found for volume %s", PodName, volumeID)
+			return fmt.Errorf("entity Pod with name %s not found for volume %s", PodName, volumeID)
 		} else if kubernetesMetadata.EntityType == "PERSISTENT_VOLUME" &&
 			kubernetesMetadata.EntityName != PersistentVolumeName {
 			return fmt.Errorf("entity PV with name %s not found for volume %s", PersistentVolumeName, volumeID)

--- a/tests/e2e/vcp_to_csi_create_delete.go
+++ b/tests/e2e/vcp_to_csi_create_delete.go
@@ -936,7 +936,7 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv 
 			if verifyPodEntry {
 				podEntryFound = true
 				if entityMetadata.EntityName != pod.Name {
-					framework.Logf("POD name '%v' does not match POD name in metadata '%v', for volume id %v", pod.Name, entityMetadata.EntityName, volumeID)
+					framework.Logf("POD name '%v' does not match Pod name in metadata '%v', for volume id %v", pod.Name, entityMetadata.EntityName, volumeID)
 					podEntryFound = false
 					break
 				}
@@ -953,7 +953,7 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv 
 							break
 						}
 						if entityMetadata.ReferredEntity[0].Namespace != pvc.Namespace {
-							framework.Logf("PVC namespace '%v' does not match PVC namespace in POD metadata referered entitry, '%v', for volume id %v", pvc.Namespace, entityMetadata.ReferredEntity[0].Namespace, volumeID)
+							framework.Logf("PVC namespace '%v' does not match PVC namespace in Pod metadata referered entitry, '%v', for volume id %v", pvc.Namespace, entityMetadata.ReferredEntity[0].Namespace, volumeID)
 							podEntryFound = false
 							break
 						}

--- a/tests/e2e/vcp_to_csi_syncer.go
+++ b/tests/e2e/vcp_to_csi_syncer.go
@@ -1088,9 +1088,9 @@ func getPodTryingToUsePvc(ctx context.Context, c clientset.Interface, namespace 
 	return nil
 }
 
-//createPodWithMultipleVolsVerifyVolMounts this method creates POD and verifies VolumeMount
+//createPodWithMultipleVolsVerifyVolMounts this method creates Pod and verifies VolumeMount
 func createPodWithMultipleVolsVerifyVolMounts(ctx context.Context, client clientset.Interface, namespace string, pvclaims []*v1.PersistentVolumeClaim) *v1.Pod {
-	// Create a POD to use this PVC, and verify volume has been attached
+	// Create a Pod to use this PVC, and verify volume has been attached
 	ginkgo.By("Creating pod to attach PV to the node")
 	pod, err := createPod(client, namespace, nil, pvclaims, false, execCommand)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -256,7 +256,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		2. Create PVC which uses the StorageClass created in step 1.
 		3. Wait for PV to be provisioned.
 		4. Wait for PVC's status to become Bound and note down the size
-		5. Create a POD using the above created PVC
+		5. Create a Pod using the above created PVC
 		6. Modify PVC's size to trigger online volume expansion
 		7. verify the PVC status will change to "FilesystemResizePending". Wait till the status is removed
 		8. Verify the resized PVC by doing CNS query
@@ -286,7 +286,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		ginkgo.By("Create POD using the above PVC")
+		ginkgo.By("Create Pod using the above PVC")
 		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
@@ -317,7 +317,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		2. Create PV Spec with volumeID set to FCDID created in Step-1, and PersistentVolumeReclaimPolicy is set to Delete.
 		3. Create PVC with the storage request set to PV's storage capacity.
 		4. Wait for PV and PVC to bound and note the PVC size
-		5. Create POD using above created PVC
+		5. Create Pod using above created PVC
 		6. Modify size of PVC to trigger online volume expansion.
 		7. verify the PVC status will change to "FilesystemResizePending". Wait till the status is removed
 		8. Verify the resized PVC by doing CNS query
@@ -424,7 +424,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			2. Create PVC which uses the StorageClass created in step 1.
 			3. Wait for PV to be provisioned.
 		    4. Wait for PVC's status to become Bound and note the PVC size
-			5. Create POD using the above created PVC
+			5. Create Pod using the above created PVC
 			6. In a loop of 10, modify PVC's size by adding 1 Gb at a time to trigger online volume expansion.
 			7. Wait for file system resize to complete.
 			8. Verify the PVC Size should increased by 10Gi
@@ -475,7 +475,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		1. Create StorageClass with allowVolumeExpansion set to true
 		2. Create PVC which uses the StorageClass created in step 1
 		3. Wait for PVC's status to become Bound and note down the size
-		4. Create a POD using the above created PVC
+		4. Create a Pod using the above created PVC
 		5. Bring vsan-health service down
 		6. Modify PVC's size to trigger online volume expansion
 		7. Verify that PVC has not reached "FilesystemResizePending" state even after waiting for a min
@@ -592,7 +592,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		1. Create StorageClass with allowVolumeExpansion set to true
 		2. Create PVC which uses the StorageClass created in step 1
 		3. Wait for PVC's status to become Bound and note down the size
-		4. Create a POD using the above created PVC
+		4. Create a Pod using the above created PVC
 		5. Bring SPS service down
 		6. Modify PVC's size to trigger online volume expansion
 		7. Verify that PVC has not reached "FilesystemResizePending" state even after waiting for a min
@@ -710,7 +710,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		2. Create PVC which uses the StorageClass created in step 1.
 		3. Wait for PV to be provisioned.
 		4. Wait for PVC's status to become Bound and note down the size
-		5. Create a POD using the above created PVC
+		5. Create a Pod using the above created PVC
 		6. Trigger online expansion on Same PVC multiple times, with 3Gi , 4Gi and 8Gi
 		7. verify the PVC status will change to "FilesystemResizePending". Wait till the status is removed
 		8. Verify the resized PVC by doing CNS query, size of the volume should be 8Gi
@@ -737,7 +737,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		ginkgo.By("Create POD using the above PVC")
+		ginkgo.By("Create Pod using the above PVC")
 		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 
 		//Fetch original FileSystemSize
@@ -819,7 +819,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		2. Create PVC which uses the StorageClass created in step 1.
 		3. Wait for PV to be provisioned.
 		4. Wait for PVC's status to become Bound and note down the size
-		5. Create a POD using the above created PVC
+		5. Create a Pod using the above created PVC
 		6. Modify PVC's size to trigger online volume expansion
 		7. verify the PVC status will change to "FilesystemResizePending". Wait till the status is removed
 		8. Verify the resized PVC by doing CNS query
@@ -862,7 +862,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}
 
 		if vanillaCluster {
-			ginkgo.By("Create POD using the above PVC")
+			ginkgo.By("Create Pod using the above PVC")
 			pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 		}
 
@@ -893,7 +893,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		2. Create PVC which uses the StorageClass created in step 1.
 		3. Wait for PV to be provisioned.
 		4. Wait for PVC's status to become Bound and note down the size
-		5. Create a POD using the above created PVC
+		5. Create a Pod using the above created PVC
 		6. Modify PVC's size to trigger online volume expansion
 		7. verify the PVC status will change to "FilesystemResizePending". Wait till the status is removed
 		8. Verify the resized PVC by doing CNS query
@@ -936,7 +936,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}
 
 		if vanillaCluster {
-			ginkgo.By("Create POD using the above PVC")
+			ginkgo.By("Create Pod using the above PVC")
 			pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 		}
 
@@ -968,7 +968,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		2. Create PVC which uses the StorageClass created in step 1.
 		3. Wait for PV to be provisioned.
 		4. Wait for PVC's status to become Bound and note down the size
-		5. Create a POD using the above created PVC
+		5. Create a Pod using the above created PVC
 		6. Modify PVC's size to trigger online volume expansion
 		7. verify the PVC status will change to "FilesystemResizePending". Wait till the status is removed
 		8. Verify the resized PVC by doing CNS query
@@ -1011,7 +1011,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}
 
 		if vanillaCluster {
-			ginkgo.By("Create POD using the above PVC")
+			ginkgo.By("Create Pod using the above PVC")
 			pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 		}
 
@@ -1136,7 +1136,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1211,7 +1211,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			4. Wait for PVC's status to become Bound and note down the size
 			5. Delete reource quota and  modify PVC size to trigger offline volume expansion
 			6. Editing PVC will fail saying nsufficient quota
-			7. Create a POD using the above created PVC
+			7. Create a Pod using the above created PVC
 			8. Modify PVC's size to trigger online volume expansion - this will fail saying saying nsufficient quota
 		    9. Add suffecient quota to namespace
 			10. verify the PVC status will change to "FilesystemResizePending". Wait till the status is removed
@@ -1254,7 +1254,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		_, err := expandPVCSize(pvclaim, newSize, client)
 		gomega.Expect(err).To(gomega.HaveOccurred())
 
-		ginkgo.By("Create POD using the above PVC")
+		ginkgo.By("Create Pod using the above PVC")
 		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
@@ -1300,7 +1300,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		5. Modify PVC's size to trigger online volume expansion
 		6. Verify PVC events shows error saying "failed to expand volume"
 		7. Bring up SPS-Service service
-		8. Create a POD using the above created PVC
+		8. Create a Pod using the above created PVC
 		9. Verify that PVC has not reached "FilesystemResizePending"
 		9. Verify the resized PVC by doing CNS query
 		10. Make sure data is intact on the PV mounted on the pod
@@ -1388,7 +1388,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1448,7 +1448,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		5. Modify PVC's size to trigger online volume expansion
 		6. Verify PVC events shows error saying "503 Service Unavailable"
 		7. Bring up vsan-health service
-		8. Create a POD using the above created PVC
+		8. Create a Pod using the above created PVC
 		9. Verify that PVC has not reached "FilesystemResizePending"
 		9. Verify the resized PVC by doing CNS query
 		10. Make sure data is intact on the PV mounted on the pod
@@ -1537,7 +1537,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1589,22 +1589,22 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	})
 
 	/*
-		Verify online volume expansion on PVC volume when POD is deleted and re-created
+		Verify online volume expansion on PVC volume when Pod is deleted and re-created
 
 		1. Create StorageClass with allowVolumeExpansion set to true.
 		2. Create PVC which uses the StorageClass created in step 1.
 		3. Wait for PV to be provisioned.
 		4. Wait for PVC's status to become Bound and note down the size
-		5. Create a POD using the above created PVC
+		5. Create a Pod using the above created PVC
 		6. Modify PVC's size to trigger online volume expansion
 		7. Delete POD
-		8. Re-create POD using same PVC
+		8. Re-create Pod using same PVC
 		9. Verify the resized PVC by doing CNS query
 		10. Make sure data is intact on the PV mounted on the pod
 		11.  Make sure file system has increased
 
 	*/
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] Verify online volume expansion when POD is deleted and re-created", func() {
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] Verify online volume expansion when Pod is deleted and re-created", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1628,7 +1628,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		ginkgo.By("Create POD using the above PVC")
+		ginkgo.By("Create Pod using the above PVC")
 		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
@@ -1664,7 +1664,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
 
-		ginkgo.By("Deleting POD after triggering online expansion on PVC")
+		ginkgo.By("Deleting Pod after triggering online expansion on PVC")
 		err = fpod.DeletePodWithWait(client, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		if supervisorCluster {
@@ -1677,7 +1677,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 		}
 
-		ginkgo.By("re-create POD using the same PVC")
+		ginkgo.By("re-create Pod using the same PVC")
 		pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 
 		ginkgo.By("Waiting for file system resize to finish")
@@ -1707,9 +1707,9 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		2. Create PVC which uses the StorageClass created in step 1.
 		3. Wait for PV to be provisioned.
 		4. Wait for PVC's status to become Bound and note down the size
-		5. Create a POD using the above created PVC
+		5. Create a Pod using the above created PVC
 		6. Modify PVC's size to trigger online volume expansion
-		7. Delete POD and PVC
+		7. Delete Pod and PVC
 		8. Verify there should not be any PVC entry in CNS
 	*/
 	ginkgo.It("[csi-supervisor] [csi-block-vanilla] Verify online volume expansion when PVC is deleted", func() {
@@ -1737,7 +1737,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			}
 		}()
 
-		ginkgo.By("Create POD using the above PVC")
+		ginkgo.By("Create Pod using the above PVC")
 		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
@@ -1768,7 +1768,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
 
-		ginkgo.By("Deleting POD after triggering online expansion on PVC")
+		ginkgo.By("Deleting Pod after triggering online expansion on PVC")
 		err = fpod.DeletePodWithWait(client, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		if supervisorCluster {
@@ -1795,12 +1795,12 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	})
 
 	/*
-		Verify online volume expansion  when CSI POD is down
+		Verify online volume expansion  when CSI Pod is down
 		1. Create StorageClass with allowVolumeExpansion set to true .
 		2. Create PVC which uses the StorageClass created in step 1.
 		3. Wait for PV to be provisioned.
 		4. Wait for PVC's status to become Bound and note down the size
-		5. Create a POD using the above created PVC
+		5. Create a Pod using the above created PVC
 		6. Bring down CSI controller POD
 		7. Modify PVC's size to trigger online volume expansion
 		8. verify the PVC status will change to "Resizing", but resize won't succeed until CSI pod is up
@@ -1810,7 +1810,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		9. Make sure data is intact on the PV mounted on the pod
 		10.Make sure file system has increased
 	*/
-	ginkgo.It("[csi-supervisor] Verify online volume expansion when CSI POD is down", func() {
+	ginkgo.It("[csi-supervisor] Verify online volume expansion when CSI Pod is down", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1829,7 +1829,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		ginkgo.By("Create POD using the above PVC")
+		ginkgo.By("Create Pod using the above PVC")
 		pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 		defer func() {
 			// Delete POD
@@ -1907,7 +1907,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	})
 
 	/*
-		Verify offline volume expansion  when CSI POD is down
+		Verify offline volume expansion  when CSI Pod is down
 
 		1. Create StorageClass with allowVolumeExpansion set to true .
 		2. Create PVC which uses the StorageClass created in step 1.
@@ -1924,7 +1924,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		13. Make sure file system has increased
 	*/
 	//TODO: Need to add test case for Vanilla
-	ginkgo.It("[csi-supervisor] Verify Offline volume expansion when CSI POD is down", func() {
+	ginkgo.It("[csi-supervisor] Verify Offline volume expansion when CSI Pod is down", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1970,7 +1970,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		ginkgo.By("Bringing SVC CSI controller up...")
 		svcCsiDeployment = updateDeploymentReplica(client, 1, vSphereCSIControllerPodNamePrefix, csiSystemNamespace)
 
-		ginkgo.By("Create POD using the above PVC")
+		ginkgo.By("Create Pod using the above PVC")
 		pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
@@ -2345,9 +2345,9 @@ func createSCwithVolumeExpansionTrueAndDynamicPVC(f *framework.Framework, client
 
 }
 
-//createPODandVerifyVolumeMount this method creates POD and verifies VolumeMount
+//createPODandVerifyVolumeMount this method creates Pod and verifies VolumeMount
 func createPODandVerifyVolumeMount(f *framework.Framework, client clientset.Interface, namespace string, pvclaim *v1.PersistentVolumeClaim, volHandle string) (*v1.Pod, string) {
-	// Create a POD to use this PVC, and verify volume has been attached
+	// Create a Pod to use this PVC, and verify volume has been attached
 	ginkgo.By("Creating pod to attach PV to the node")
 	pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2533,7 +2533,7 @@ func invokeTestForVolumeExpansion(f *framework.Framework, client clientset.Inter
 	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	// Create a POD to use this PVC, and verify volume has been attached
+	// Create a Pod to use this PVC, and verify volume has been attached
 	ginkgo.By("Creating pod to attach PV to the node")
 	pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2662,7 +2662,7 @@ func invokeTestForVolumeExpansionWithFilesystem(f *framework.Framework, client c
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}()
 
-	// Create a POD to use this PVC, and verify volume has been attached
+	// Create a Pod to use this PVC, and verify volume has been attached
 	ginkgo.By("Creating pod to attach PV to the node")
 	pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2752,7 +2752,7 @@ func invokeTestForVolumeExpansionWithFilesystem(f *framework.Framework, client c
 	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	// Create a new POD to use this PVC, and verify volume has been attached
+	// Create a new Pod to use this PVC, and verify volume has been attached
 	ginkgo.By("Creating a new pod to attach PV again to the node")
 	pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -3153,7 +3153,7 @@ func invokeTestForExpandVolumeMultipleTimes(f *framework.Framework, client clien
 	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	// Create a POD to use this PVC, and verify volume has been attached
+	// Create a Pod to use this PVC, and verify volume has been attached
 	ginkgo.By("Creating pod to attach PV to the node")
 	pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -3507,7 +3507,7 @@ func offlineVolumeExpansionOnSupervisorPVC(client clientset.Interface, f *framew
 	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	ginkgo.By("Create POD using the above PVC")
+	ginkgo.By("Create Pod using the above PVC")
 	pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 
 	ginkgo.By("Waiting for file system resize to finish")

--- a/tests/e2e/vsphere_volume_fsgroup.go
+++ b/tests/e2e/vsphere_volume_fsgroup.go
@@ -123,7 +123,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-guest] [csi
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		// Create a POD to use this PVC, and verify volume has been attached
+		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")
 
 		fsGroup = 1000

--- a/tests/e2e/vsphere_volume_fstype.go
+++ b/tests/e2e/vsphere_volume_fstype.go
@@ -123,7 +123,7 @@ func invokeTestForFstype(f *framework.Framework, client clientset.Interface, nam
 	persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	// Create a POD to use this PVC, and verify volume has been attached
+	// Create a Pod to use this PVC, and verify volume has been attached
 	ginkgo.By("Creating pod to attach PV to the node")
 	pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -182,7 +182,7 @@ func invokeTestForInvalidFstype(f *framework.Framework, client clientset.Interfa
 	persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	// Create a POD to use this PVC, and verify volume has been attached
+	// Create a Pod to use this PVC, and verify volume has been attached
 	ginkgo.By("Creating pod to attach PV to the node")
 	pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
 	gomega.Expect(err).To(gomega.HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We are using the term "POD" in many places and its not an abbreviation for something like PVC or PV. Replacing all the instances of the usage of "POD" in the test code with "Pod" (a noun). 

**Testing done**:
* Ran make build, make test successfully
* Ran make check successfully.
* Since this is a cosmetic change, I'm not running E2E tests.

**Special notes for your reviewer**:
See discussion in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1116#discussion_r668127532

**Release note**:
```
Cleaned up test code by replacing the usage of "POD" with "Pod".
```
