### PR TITLE
Clean up white spaces in fullsync_test_for_file_volume

### DIFF
--- a/tests/e2e/fullsync_test_for_file_volume.go
+++ b/tests/e2e/fullsync_test_for_file_volume.go
@@ -36,16 +36,15 @@ import (
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 )
 
-/*
-   Tests to verify Full Sync .
-
-   Test 1) Verify CNS volume is created after full sync when pv entry is present.
-   Test 2) Verify labels are created in CNS after updating pvc and/or pv with new labels.
-   Test 3) Verify CNS volume is deleted after full sync when pv entry is delete
-
-   Cleanup
-   - Delete PVC and StorageClass and verify volume is deleted from CNS.
-*/
+// Tests to verify Full Sync .
+//
+// Test 1) Verify CNS volume is created after full sync when pv entry is present.
+// Test 2) Verify labels are created in CNS after updating pvc and/or pv with
+//         new labels.
+// Test 3) Verify CNS volume is deleted after full sync when pv entry is delete.
+//
+// Cleanup
+// - Delete PVC and StorageClass and verify volume is deleted from CNS.
 
 var _ bool = ginkgo.Describe("[csi-file-vanilla] Full sync test for file volume", func() {
 	f := framework.NewDefaultFramework("e2e-full-sync-test-file-volume")
@@ -88,31 +87,30 @@ var _ bool = ginkgo.Describe("[csi-file-vanilla] Full sync test for file volume"
 			ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
 			err := invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again", vsanHealthServiceWaitTime))
+			ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again",
+				vsanHealthServiceWaitTime))
 			time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 		}
 	})
 
-	/*
-				Verify fullsync is able to update label of pv and pvc
-					1. Create StorageClass with fsType as "nfs4"
-		            2. Create a PVC with "ReadWriteMany" using the SC from above
-		            3. Wait for PVC to be Bound
-		            4. Get the VolumeID from PV
-		            5. stop vSan health service
-		            6. Update label for pvc
-		            7. Update label for pv
-		            8. start vSan health service
-		            9. wait for FullSync to finish
-		            10. verify pv and pvc label has been updated
-		            11. Delete PVC
-		            12. Delete Storage class
-	*/
+	// Verify fullsync is able to update label of pv and pvc.
+	// 1. Create StorageClass with fsType as "nfs4".
+	// 2. Create a PVC with "ReadWriteMany" using the SC from above.
+	// 3. Wait for PVC to be Bound.
+	// 4. Get the VolumeID from PV.
+	// 5. Stop vSan health service.
+	// 6. Update label for pvc.
+	// 7. Update label for pv.
+	// 8. Start vSan health service.
+	// 9. Wait for FullSync to finish.
+	// 10. Verify pv and pvc label has been updated.
+	// 11. Delete PVC.
+	// 12. Delete Storage class.
 	ginkgo.It("verify labels are created in CNS after updating pvc and/or pv with new labels for file volume", func() {
 		ginkgo.By("Invoking test to verify labels creation")
 		scParameters := make(map[string]string)
 		scParameters[scParamFsType] = nfs4FSType
-		// Create Storage class and PVC
+		// Create Storage class and PVC.
 		ginkgo.By(fmt.Sprintf("Creating Storage Class with %q", nfs4FSType))
 		var storageclass *storagev1.StorageClass
 		var pvc *v1.PersistentVolumeClaim
@@ -120,7 +118,8 @@ var _ bool = ginkgo.Describe("[csi-file-vanilla] Full sync test for file volume"
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		storageclass, pvc, err = createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "", false, v1.ReadWriteMany)
+		storageclass, pvc, err = createPVCAndStorageClass(client,
+			namespace, nil, scParameters, "", nil, "", false, v1.ReadWriteMany)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
@@ -128,7 +127,8 @@ var _ bool = ginkgo.Describe("[csi-file-vanilla] Full sync test for file volume"
 		}()
 
 		ginkgo.By(fmt.Sprintf("Waiting for claim %s to be in bound phase", pvc.Name))
-		pvs, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
+		pvs, err := fpv.WaitForPVClaimBoundPhase(client,
+			[]*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
 		pv := pvs[0]
@@ -152,7 +152,8 @@ var _ bool = ginkgo.Describe("[csi-file-vanilla] Full sync test for file volume"
 			}
 		}()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown", vsanHealthServiceWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",
+			vsanHealthServiceWaitTime))
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 
 		labels := make(map[string]string)
@@ -180,12 +181,15 @@ var _ bool = ginkgo.Describe("[csi-file-vanilla] Full sync test for file volume"
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow full sync finish", fullSyncWaitTime))
 		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
 
-		ginkgo.By(fmt.Sprintf("Waiting for labels %+v to be updated for pvc %s in namespace %s", labels, pvc.Name, pvc.Namespace))
-		err = e2eVSphere.waitForLabelsToBeUpdated(pv.Spec.CSI.VolumeHandle, labels, string(cnstypes.CnsKubernetesEntityTypePVC), pvc.Name, pvc.Namespace)
+		ginkgo.By(fmt.Sprintf("Waiting for labels %+v to be updated for pvc %s in namespace %s",
+			labels, pvc.Name, pvc.Namespace))
+		err = e2eVSphere.waitForLabelsToBeUpdated(pv.Spec.CSI.VolumeHandle,
+			labels, string(cnstypes.CnsKubernetesEntityTypePVC), pvc.Name, pvc.Namespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Waiting for labels %+v to be updated for pv %s", labels, pv.Name))
-		err = e2eVSphere.waitForLabelsToBeUpdated(pv.Spec.CSI.VolumeHandle, labels, string(cnstypes.CnsKubernetesEntityTypePV), pv.Name, pv.Namespace)
+		err = e2eVSphere.waitForLabelsToBeUpdated(pv.Spec.CSI.VolumeHandle,
+			labels, string(cnstypes.CnsKubernetesEntityTypePV), pv.Name, pv.Namespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles fullsync_test_for_file_volume.

**Testing done**:
Local build, check.