### PR TITLE
Clean up white spaces in gc_full_sync

### DIFF
--- a/tests/e2e/gc_full_sync.go
+++ b/tests/e2e/gc_full_sync.go
@@ -44,7 +44,7 @@ var _ = ginkgo.Describe("[csi-guest] Guest cluster fullsync tests", func() {
 		namespace         string
 		scParameters      map[string]string
 		storagePolicyName string
-		svcPVCName        string // PVC Name in the Supervisor Cluster
+		svcPVCName        string // PVC Name in the Supervisor Cluster.
 		labelKey          string
 		labelValue        string
 		fullSyncWaitTime  int
@@ -66,7 +66,8 @@ var _ = ginkgo.Describe("[csi-guest] Guest cluster fullsync tests", func() {
 		if os.Getenv(envFullSyncWaitTime) != "" {
 			fullSyncWaitTime, err = strconv.Atoi(os.Getenv(envFullSyncWaitTime))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			// Full sync interval can be 1 min at minimum so full sync wait time has to be more than 120s
+			// Full sync interval can be 1 min at minimum so full sync wait time
+			// has to be more than 120s.
 			if fullSyncWaitTime < 120 || fullSyncWaitTime > defaultFullSyncWaitTime {
 				framework.Failf("The FullSync Wait time %v is not set correctly", fullSyncWaitTime)
 			}
@@ -82,20 +83,18 @@ var _ = ginkgo.Describe("[csi-guest] Guest cluster fullsync tests", func() {
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
 	})
 
-	/*
-		Steps:
-		Create a PVC using any replicated storage class from the SV.
-		Wait for PVC to be in Bound phase
-		Bring down csi-controller pod in GC
-		Update PVC labels
-		Verify CnsVolumeMetadata CRD is not updated.
-		Bring up csi-controller pod in SV
-		Sleep double the Full Sync interval
-		Verify CnsVolumeMetadata CRD is updated
-		Verify entry is updated in CNS
-		Delete PVC
-	*/
-	ginkgo.It("Verify volume entry is updated in CNS when PV and PVC labels are updated in GC when csi-controller pod in GC is down", func() {
+	// Steps:
+	// Create a PVC using any replicated storage class from the SV.
+	// Wait for PVC to be in Bound phase.
+	// Bring down csi-controller pod in GC.
+	// Update PVC labels.
+	// Verify CnsVolumeMetadata CRD is not updated.
+	// Bring up csi-controller pod in SV.
+	// Sleep double the Full Sync interval.
+	// Verify CnsVolumeMetadata CRD is updated.
+	// Verify entry is updated in CNS.
+	// Delete PVC.
+	ginkgo.It("Verify CNS volume is synced with updated GC PV & PVC labels when GC csi-controller pod is down", func() {
 		var sc *storagev1.StorageClass
 		var pvc *v1.PersistentVolumeClaim
 		var err error
@@ -114,7 +113,8 @@ var _ = ginkgo.Describe("[csi-guest] Guest cluster fullsync tests", func() {
 		}()
 
 		ginkgo.By(fmt.Sprintf("Waiting for claim %s to be in bound phase", pvc.Name))
-		pvs, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
+		pvs, err := fpv.WaitForPVClaimBoundPhase(client,
+			[]*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
 		pv := pvs[0]
@@ -133,7 +133,8 @@ var _ = ginkgo.Describe("[csi-guest] Guest cluster fullsync tests", func() {
 		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 		var vmUUID string
 		ginkgo.By("Verifying CNSNodeVMAttachment in supervisor")
 		vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
@@ -170,23 +171,23 @@ var _ = ginkgo.Describe("[csi-guest] Guest cluster fullsync tests", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify volume is detached from the node")
-		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+			fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 
 	})
 
-	/*
-		Create a PVC using any replicated storage class from the SV.
-		Wait for PVC to be in Bound phase
-		Break connection to SV
-		Update PV and PVC labels
-		Re-establish connection to SV
-		Sleep double the Full Sync interval
-		Verify CnsVolumeMetadata CRD is updated
-		Verify entry is updated in CNS
-		Delete PVC
-	*/
+	// Create a PVC using any replicated storage class from the SV.
+	// Wait for PVC to be in Bound phase.
+	// Break connection to SV.
+	// Update PV and PVC labels.
+	// Re-establish connection to SV.
+	// Sleep double the Full Sync interval.
+	// Verify CnsVolumeMetadata CRD is updated.
+	// Verify entry is updated in CNS.
+	// Delete PVC.
 	ginkgo.It("Verify CNS volume is synced with updated GC PV & PVC labels after SVC connection is restored", func() {
 		var err error
 		var sc *storagev1.StorageClass
@@ -205,7 +206,8 @@ var _ = ginkgo.Describe("[csi-guest] Guest cluster fullsync tests", func() {
 		}()
 
 		ginkgo.By(fmt.Sprintf("Waiting for claim %s to be in bound phase", pvc.Name))
-		pvs, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
+		pvs, err := fpv.WaitForPVClaimBoundPhase(client,
+			[]*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
 		pv := pvs[0]
@@ -228,7 +230,7 @@ var _ = ginkgo.Describe("[csi-guest] Guest cluster fullsync tests", func() {
 			_ = updateCSIDeploymentTemplateFullSyncInterval(client, defaultFullSyncIntervalInMin, csiSystemNamespace)
 		}()
 
-		// break connection with SVC
+		// Break connection with SVC.
 		ginkgo.By("Scaling down the csi driver to zero replica")
 		deployment := updateDeploymentReplica(client, 0, vSphereCSIControllerPodNamePrefix, csiSystemNamespace)
 		ginkgo.By(fmt.Sprintf("Successfully scaled down the csi driver deployment:%s to zero replicas", deployment.Name))
@@ -253,7 +255,7 @@ var _ = ginkgo.Describe("[csi-guest] Guest cluster fullsync tests", func() {
 		pv, err = client.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// re-establish connection with SVC
+		// Re-establish connection with SVC.
 		ginkgo.By("Scaling up the csi driver to one replica")
 		deployment = updateDeploymentReplica(client, 1, vSphereCSIControllerPodNamePrefix, csiSystemNamespace)
 		ginkgo.By(fmt.Sprintf("Successfully scaled up the csi driver deployment:%s to one replica", deployment.Name))
@@ -270,18 +272,23 @@ var _ = ginkgo.Describe("[csi-guest] Guest cluster fullsync tests", func() {
 		pvUID := string(pv.UID)
 		fmt.Println("PV uuid", pvUID)
 
-		// check pvc label update in CRD
-		verifyEntityReferenceInCRDInSupervisor(ctx, f, volumeID, crdCNSVolumeMetadatas, crdVersion, crdGroup, true, volumeID, true, pvcLabels, true)
+		// Check pvc label update in CRD.
+		verifyEntityReferenceInCRDInSupervisor(ctx, f, volumeID, crdCNSVolumeMetadatas,
+			crdVersion, crdGroup, true, volumeID, true, pvcLabels, true)
 
-		// check pv label update in CRD
-		verifyEntityReferenceInCRDInSupervisor(ctx, f, gcClusterID+pvUID, crdCNSVolumeMetadatas, crdVersion, crdGroup, true, volumeID, true, pvLabels, true)
+		// Check pv label update in CRD.
+		verifyEntityReferenceInCRDInSupervisor(ctx, f, gcClusterID+pvUID, crdCNSVolumeMetadatas,
+			crdVersion, crdGroup, true, volumeID, true, pvLabels, true)
 
-		ginkgo.By(fmt.Sprintf("Waiting for labels %+v to be updated for pvc %s in namespace %s", pvcLabels, pvc.Name, pvc.Namespace))
-		err = e2eVSphere.waitForLabelsToBeUpdated(svcVolumeID, pvcLabels, string(cnstypes.CnsKubernetesEntityTypePVC), pvc.Name, pvc.Namespace)
+		ginkgo.By(fmt.Sprintf("Waiting for labels %+v to be updated for pvc %s in namespace %s",
+			pvcLabels, pvc.Name, pvc.Namespace))
+		err = e2eVSphere.waitForLabelsToBeUpdated(svcVolumeID, pvcLabels,
+			string(cnstypes.CnsKubernetesEntityTypePVC), pvc.Name, pvc.Namespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Waiting for labels %+v to be updated for pv %s", pvLabels, pv.Name))
-		err = e2eVSphere.waitForLabelsToBeUpdated(svcVolumeID, pvLabels, string(cnstypes.CnsKubernetesEntityTypePV), pv.Name, pv.Namespace)
+		err = e2eVSphere.waitForLabelsToBeUpdated(svcVolumeID, pvLabels,
+			string(cnstypes.CnsKubernetesEntityTypePV), pv.Name, pv.Namespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles gc_full_sync.

**Testing done**:
Local build, check.