### PR TITLE
Prevent volume deletion if snapshots are present

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -42,10 +42,11 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 	if orchestratorType == common.Kubernetes {
 		fakeCO := &FakeK8SOrchestrator{
 			featureStates: map[string]string{
-				"volume-extend": "true",
-				"volume-health": "true",
-				"csi-migration": "true",
-				"file-volume":   "true",
+				"volume-extend":         "true",
+				"volume-health":         "true",
+				"csi-migration":         "true",
+				"file-volume":           "true",
+				"block-volume-snapshot": "true",
 			},
 		}
 		return fakeCO, nil

--- a/pkg/common/utils/test_vsphere.conf
+++ b/pkg/common/utils/test_vsphere.conf
@@ -1,7 +1,0 @@
-[Global]
-insecure-flag = "true"
-[VirtualCenter "127.0.0.1"]
-user = "user"
-password = "pass"
-datacenters = "DC0"
-port = "64872"

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -110,8 +110,8 @@ func QuerySnapshotsUtil(ctx context.Context, m cnsvolume.Manager, snapshotQueryF
 	for {
 		snapshotQueryResult, err := m.QuerySnapshots(ctx, snapshotQueryFilter)
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
-				"querySnapshots failed for snapshotQueryFilter: %v. Err=%+v", snapshotQueryFilter, err.Error())
+			log.Errorf("querySnapshots failed for snapshotQueryFilter: %v. Err=%+v", snapshotQueryFilter, err)
+			return nil, err
 		}
 		if snapshotQueryResult == nil {
 			log.Infof("Observed empty SnapshotQueryResult")

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -235,6 +235,10 @@ const (
 	// TriggerCsiFullSyncCRName is the instance name of TriggerCsiFullSync
 	// All other names will be rejected by TriggerCsiFullSync controller.
 	TriggerCsiFullSyncCRName = "csifullsync"
+
+	// QuerySnapshotLimit is the maximum number of snapshots that can be retrieved per QuerySnapshot call.
+	// The 128 size limit is specified by CNS QuerySnapshot API.
+	QuerySnapshotLimit = int64(128)
 )
 
 // Supported container orchestrators.

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -532,6 +532,32 @@ func ExpandVolumeUtil(ctx context.Context, manager *Manager, volumeID string, ca
 	}
 }
 
+func QueryVolumeSnapshotsByID(ctx context.Context, volManager cnsvolume.Manager, volumeID string) ([]string, error) {
+	log := logger.GetLogger(ctx)
+	var snapshots []string
+	querySpec := cnstypes.CnsSnapshotQuerySpec{
+		VolumeId: cnstypes.CnsVolumeId{
+			Id: volumeID,
+		},
+	}
+	queryFilter := cnstypes.CnsSnapshotQueryFilter{
+		SnapshotQuerySpecs: []cnstypes.CnsSnapshotQuerySpec{querySpec},
+		Cursor: &cnstypes.CnsCursor{
+			Offset: 0,
+			Limit:  QuerySnapshotLimit,
+		},
+	}
+	queryResultEntries, err := utils.QuerySnapshotsUtil(ctx, volManager, queryFilter)
+	if err != nil {
+		log.Errorf("failed to retrieve snapshots for volume-id: %s err: %+v", volumeID, err)
+		return nil, err
+	}
+	for _, queryResult := range queryResultEntries {
+		snapshots = append(snapshots, queryResult.Snapshot.SnapshotId.Id)
+	}
+	return snapshots, nil
+}
+
 // QueryVolumeByID is the helper function to query volume by volumeID.
 func QueryVolumeByID(ctx context.Context, volManager cnsvolume.Manager, volumeID string) (*cnstypes.CnsVolume, error) {
 	log := logger.GetLogger(ctx)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The PR prevents volume deletion pre-emptively if there are CNS snapshots present for the volume.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
https://container-dp.svc.eng.vmware.com/job/Block-Vanilla/384/

Integration test to delete a volume having snapshots.

```
    controller_test.go:861: received error as expected when attempting to delete volume with snapshot, err: rpc error: code = FailedPrecondition desc = volume: 9688b135-d4d6-4c9c-8a64-9f8e6de7178f with existing snapshots [2c48418f-d7b3-4871-a4f9-feb3e3b6006a] cannot be deleted, please delete snapshots before deleting the volume
--- PASS: TestDeleteVolumeWithSnapshots (5.13s)
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Explicit error when attempting to delete a volume containing CNS snapshots.
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>