### PR TITLE
Make changes to pvcsi yamls to upgrade node driver registrar to v2.1.0

### DIFF
--- a/manifests/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/guestcluster/1.19/pvcsi.yaml
@@ -304,14 +304,11 @@ spec:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>
         imagePullPolicy: "IfNotPresent"
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com-reg.sock /csi/csi.sock"]
         args:
           - "--v=5"
           - "--csi-address=$(ADDRESS)"
           - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          - "--health-port=9809"
         env:
           - name: ADDRESS
             value: /csi/csi.sock
@@ -322,6 +319,15 @@ spec:
             mountPath: /csi
           - name: registration-dir
             mountPath: /registration
+        ports:
+          - containerPort: 9809
+            name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
         args:

--- a/manifests/guestcluster/1.20/pvcsi.yaml
+++ b/manifests/guestcluster/1.20/pvcsi.yaml
@@ -304,14 +304,11 @@ spec:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>
         imagePullPolicy: "IfNotPresent"
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com-reg.sock /csi/csi.sock"]
         args:
           - "--v=5"
           - "--csi-address=$(ADDRESS)"
           - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          - "--health-port=9809"
         env:
           - name: ADDRESS
             value: /csi/csi.sock
@@ -322,6 +319,15 @@ spec:
             mountPath: /csi
           - name: registration-dir
             mountPath: /registration
+        ports:
+          - containerPort: 9809
+            name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
         args:

--- a/manifests/guestcluster/1.21/pvcsi.yaml
+++ b/manifests/guestcluster/1.21/pvcsi.yaml
@@ -304,14 +304,11 @@ spec:
       - name: node-driver-registrar
         image: vmware.io/csi-node-driver-registrar:<image_tag>
         imagePullPolicy: "IfNotPresent"
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "rm -rf /registration/csi.vsphere.vmware.com-reg.sock /csi/csi.sock"]
         args:
           - "--v=5"
           - "--csi-address=$(ADDRESS)"
           - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          - "--health-port=9809"
         env:
           - name: ADDRESS
             value: /csi/csi.sock
@@ -322,6 +319,15 @@ spec:
             mountPath: /csi
           - name: registration-dir
             mountPath: /registration
+        ports:
+          - containerPort: 9809
+            name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
         args:


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry picking https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1110  as this will be needed for pvCSI 2.3 release. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Make changes to pvcsi yamls to upgrade node driver registrar to v2.1.0
```
