### PR TITLE
GC online volume expansion

### DIFF
--- a/tests/e2e/docs/guest_cluster_setup.md
+++ b/tests/e2e/docs/guest_cluster_setup.md
@@ -92,6 +92,12 @@ The section outlines how to set the env variable for running e2e test.
     export STORAGE_POLICY_WITH_THICK_PROVISIONING="<policy-name>"
     export COMPUTE_CLUSTER_NAME="<your_cluster_name>"
     export RAID_0_STORAGE_POLICY="raid-0-policy"
+    #shared VVOL datastore url
+    export SHARED_VVOL_DATASTORE_URL="<shared-VVOL-datastore-url>"
+    #shared NFS datastore url
+    export SHARED_NFS_DATASTORE_URL="<shared-NFS-datastore-url>"
+    #shared VMFS datastore url
+    export SHARED_VMFS_DATASTORE_URL="<shared-VMFS-datastore-url>"
 
     # `STORAGE_POLICY_FOR_SHARED_DATASTORES` and `STORAGE_POLICY_FOR_NONSHARED_DATASTORES` need to be
     # added to `SVC_NAMESPACE` with storage limit >=20GiB each

--- a/tests/e2e/docs/supervisor_cluster_setup.md
+++ b/tests/e2e/docs/supervisor_cluster_setup.md
@@ -91,11 +91,11 @@ datacenters should be comma separated if deployed on multi-datacenters
     export DISK_URL_PATH="https://<VC_IP>/folder/<vmName>/<vmName_1.vmdk>?dcPath=<DatacenterPath>&dsName=<dataStoreName>"
     export COMPUTE_CLUSTER_NAME="<your_cluster_name>"
     #shared VVOL datastore url
-    export SHARED_VVOL_DATASTORE_URL="ds:///vmfs/volumes/vvol:5c5ddeccfb2f476c-ac17f22d228af0f1/"
+    export SHARED_VVOL_DATASTORE_URL="<shared-VVOL-datastore-url>"
     #shared NFS datastore url
-    export SHARED_NFS_DATASTORE_URL="ds:///vmfs/volumes/fb4efbd8-6e969410/"
+    export SHARED_NFS_DATASTORE_URL="<shared-NFS-datastore-url>"
     #shared VMFS datastore url
-    export SHARED_VMFS_DATASTORE_URL="ds:///vmfs/volumes/6009698f-424076e2-c60d-02008c6fa7e4/"
+    export SHARED_VMFS_DATASTORE_URL="<shared-VMFS-datastore-url>"
 
 ### To run full sync test, need do extra following steps
 

--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -357,6 +357,8 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	// 14. delete the pod created in step 11.
 	// 15. delete PVC created in step 2.
 	// 16. delete SC created in step 1.
+
+	//TODO: need to add this test under destuctive test [csi-guest-destructive]
 	ginkgo.It("verify offline block volume expansion triggered when SVC CSI pod is down "+
 		"succeeds once SVC CSI pod comes up", func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -618,6 +620,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	// 9. Verify size of PVs in SVC and GC to same as the one used in the step 4.
 	// 10. delete PVC created in step 2.
 	// 11. delete SC created in step 1.
+	//TODO: need to add this test under destuctive test [csi-guest-destructive]
 	ginkgo.It("Verify volume expansion eventually succeeds when CNS is unavailable during initial expansion", func() {
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
@@ -726,6 +729,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	// TODO: There is an upstream work going on to prevent PVC deletion when
 	//       resize is in progress. This test needs to be re-evaluated in the
 	//       future when the upstream happens.
+	//TODO: need to add this test under destuctive test [csi-guest-destructive]
 	ginkgo.It("Verify while CNS is down the volume expansion can be triggered and "+
 		"the volume can deleted with pending resize operation", func() {
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
@@ -1351,6 +1355,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		defer cancel()
 
 		ginkgo.By("Creating Storage Class and PVC with allowVolumeExpansion = true")
+		setResourceQuota(client, namespace, rqLimit)
 		scParameters := make(map[string]string)
 		scParameters[scParamFsType] = ext4FSType
 		scParameters[svStorageClassName] = thickProvPolicy
@@ -2000,6 +2005,159 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		framework.Logf("Volume Handle :%s", volHandle)
 
 		onlineVolumeResizeCheck(f, client, namespace, svcPVCName, volHandle, gcPVC, pod)
+
+	})
+
+	//  Verify Online block volume expansion triggered when SVC CSI pod is down succeeds once SVC CSI pod comes up.
+	//    Steps:
+	// 	   1. Create a SC with allowVolumeExpansion set to 'true' in GC.
+	// 	   2. create a PVC using the SC created in step 1 in GC and wait for binding
+	// 	      with PV.
+	// 	   3. create a pod using the pvc created in step 2 in GC and wait FS init.
+	//     4. bring CSI-controller pod down in SVC.
+	//     5. Resize PVC with new size in GC.
+	//     6. check for retries in GC.
+	//     7. PVC in GC is in "Resizing" state and PVC in SVC has no state related
+	// 	      to expansion.
+	// 	   8. bring the CSI-controller pod up in SVC.
+	//     9. wait for PVC Status Condition changed to "FilesystemResizePending"
+	//        in GC.
+	//     10. Check Size from CNS query is same as what was used in step 7.
+	//     11. wait for new size of PVC in GC and compare with SVC PVC size for
+	//         equality.
+	//     12. delete the pod, pvc,sc
+
+	ginkgo.It("verify online block volume expansion triggered when SVC CSI pod is down"+
+		"succeeds once SVC CSI pod comes up", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Create a POD to use this PVC, and verify volume has been attached.
+		ginkgo.By("Creating pod to attach PV to the node")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		vmUUID, err := getVMUUIDFromNodeName(pod.Spec.NodeName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+
+		ginkgo.By("Verify the volume is accessible and filesystem type is as expected")
+		cmd[1] = pod.Name
+		lastOutput := framework.RunKubectlOrDie(namespace, cmd...)
+		gomega.Expect(strings.Contains(lastOutput, ext4FSType)).NotTo(gomega.BeFalse())
+
+		ginkgo.By("Check filesystem size for mount point /mnt/volume1 before expansion")
+		originalFsSize, err := getFSSizeMb(f, pod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify volume is detached from the node after expansion")
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q",
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		}()
+
+		ginkgo.By("Bringing SVC CSI controller down...")
+		svcCsiDeployment := updateDeploymentReplica(svcClient, 0, vSphereCSIControllerPodNamePrefix, csiSystemNamespace)
+		defer func() {
+			if *svcCsiDeployment.Spec.Replicas == 0 {
+				ginkgo.By("Bringing SVC CSI controller up (cleanup)...")
+				updateDeploymentReplica(svcClient, 1, vSphereCSIControllerPodNamePrefix, csiSystemNamespace)
+			}
+		}()
+
+		ginkgo.By("Expanding current pvc")
+		currentPvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
+		newSize := currentPvcSize.DeepCopy()
+		newSize.Add(resource.MustParse("1Gi"))
+		framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
+		pvclaim, err = expandPVCSize(pvclaim, newSize, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+
+		pvclaim, err = client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvclaim.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+		pvclaim, err = checkPvcHasGivenStatusCondition(client,
+			namespace, pvclaim.Name, true, v1.PersistentVolumeClaimResizing)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+		_, err = checkSvcPvcHasGivenStatusCondition(svcPVCName, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Bringing SVC CSI controller up...")
+		svcCsiDeployment = updateDeploymentReplica(svcClient, 1, vSphereCSIControllerPodNamePrefix, csiSystemNamespace)
+
+		ginkgo.By("Waiting for controller volume resize to finish")
+		err = waitForPvResizeForGivenPvc(pvclaim, client, totalResizeWaitPeriod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Checking for PVC request size change on SVC PVC")
+		b, err := verifyPvcRequestedSizeUpdateInSupervisorWithWait(svcPVCName, newSize)
+		gomega.Expect(b).To(gomega.BeTrue())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Checking for resize on SVC PV")
+		verifyPVSizeinSupervisor(svcPVCName, newSize)
+
+		ginkgo.By("Checking for conditions on pvc")
+		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
+		_, err = checkSvcPvcHasGivenStatusCondition(svcPVCName, true, v1.PersistentVolumeClaimFileSystemResizePending)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
+		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if len(queryResult.Volumes) == 0 {
+			err = fmt.Errorf("QueryCNSVolumeWithResult returned no volume")
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Verifying disk size requested in volume expansion is honored")
+		newSizeInMb := convertGiStrToMibInt64(newSize)
+		if queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).CapacityInMb != newSizeInMb {
+			err = fmt.Errorf("got wrong disk size after volume expansion")
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify after expansion the filesystem type is as expected")
+		cmd[1] = pod.Name
+		lastOutput = framework.RunKubectlOrDie(namespace, cmd...)
+		gomega.Expect(strings.Contains(lastOutput, ext4FSType)).NotTo(gomega.BeFalse())
+
+		ginkgo.By("Waiting for file system resize to finish")
+		pvclaim, err = waitForFSResize(pvclaim, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pvcConditions := pvclaim.Status.Conditions
+		expectEqual(len(pvcConditions), 0, "pvc should not have conditions")
+
+		ginkgo.By("Verify filesystem size for mount point /mnt/volume1 after expansion")
+		fsSize, err := getFSSizeMb(f, pod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Filesystem size may be smaller than the size of the block volume.
+		// Here since filesystem was already formatted on the original volume,
+		// we can compare the new filesystem size with the original filesystem size.
+		if fsSize < originalFsSize {
+			framework.Failf("error updating filesystem size for %q. Resulting filesystem size is %d", pvclaim.Name, fsSize)
+		}
+
+		ginkgo.By("File system resize finished successfully in GC")
+		ginkgo.By("Checking for PVC resize completion on SVC PVC")
+		_, err = waitForFSResizeInSvc(svcPVCName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	})
 

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -879,7 +879,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		9. Make sure data is intact on the PV mounted on the pod
 		10.  Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] Volume expansion on shared VVOL datastore", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] Volume expansion on shared VVOL datastore", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -893,6 +893,10 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running on SVC setup - " +
 				"This test covers Offline and Online expansion on PVC created on VVOL datastore")
+		}
+		if guestCluster {
+			ginkgo.By("CNS_TEST: Running on GC setup - This test covers Offline" +
+				"and Online expansion on PVC created on VVOL datastore")
 		}
 
 		sharedVVOLdatastoreURL := os.Getenv(envSharedVVOLDatastoreURL)
@@ -918,8 +922,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			pvclaim, pod, vmUUID = offlineVolumeExpansionOnSupervisorPVC(client, f, namespace, volHandle, pvclaim)
 		}
 
-		if vanillaCluster {
-			ginkgo.By("Create Pod using the above PVC")
+		if vanillaCluster || guestCluster {
+			ginkgo.By("Create POD using the above PVC")
 			pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 		}
 
@@ -962,7 +966,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		9. Make sure data is intact on the PV mounted on the pod
 		10.  Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] Volume expansion on shared NFS datastore", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] Volume expansion on shared NFS datastore", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -976,6 +980,10 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running on SVC setup - " +
 				"This test covers Offline and Online expansion on PVC created on NFS datastore")
+		}
+		if guestCluster {
+			ginkgo.By("CNS_TEST: Running on GC setup - This test covers Offline and" +
+				"Online expansion on PVC created on NFS datastore")
 		}
 
 		sharedNFSdatastoreURL := os.Getenv(envSharedNFSDatastoreURL)
@@ -997,12 +1005,12 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}()
 
 		if supervisorCluster {
-			ginkgo.By("Trigger offline volume expansion on PVC on shared VMFS datastore")
+			ginkgo.By("Trigger offline volume expansion on PVC on shared NFS datastore")
 			pvclaim, pod, vmUUID = offlineVolumeExpansionOnSupervisorPVC(client, f, namespace, volHandle, pvclaim)
 		}
 
-		if vanillaCluster {
-			ginkgo.By("Create Pod using the above PVC")
+		if vanillaCluster || guestCluster {
+			ginkgo.By("Create POD using the above PVC")
 			pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 		}
 
@@ -1046,7 +1054,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		9. Make sure data is intact on the PV mounted on the pod
 		10.  Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] Volume expansion on shared VMFS datastore", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] Volume expansion on shared VMFS datastore", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1060,6 +1068,10 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running on SVC setup - " +
 				"This test covers Offline and Online expansion on PVC created on NFS datastore")
+		}
+		if guestCluster {
+			ginkgo.By("CNS_TEST: Running on GC setup - This test covers Offline " +
+				"and Online expansion on PVC created on NFS datastore")
 		}
 
 		sharedVMFSdatastoreURL := os.Getenv(envSharedVMFSDatastoreURL)
@@ -1085,8 +1097,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			pvclaim, pod, vmUUID = offlineVolumeExpansionOnSupervisorPVC(client, f, namespace, volHandle, pvclaim)
 		}
 
-		if vanillaCluster {
-			ginkgo.By("Create Pod using the above PVC")
+		if vanillaCluster || guestCluster {
+			ginkgo.By("Create POD using the above PVC")
 			pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
 		}
 
@@ -1701,8 +1713,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		11.  Make sure file system has increased
 
 	*/
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] "+
-		"Verify online volume expansion when Pod is deleted and re-created", func() {
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-guest] "+
+		"Verify online volume expansion when POD is deleted and re-created", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1822,7 +1834,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		7. Delete Pod and PVC
 		8. Verify there should not be any PVC entry in CNS
 	*/
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] Verify online volume expansion when PVC is deleted", func() {
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-guest] "+
+		"Verify online volume expansion when PVC is deleted", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2230,7 +2243,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		11. Scale down deployment set to 0 replicas and delete all pods, PVC and SC
 
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] Verify online volume expansion on deployment", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] Verify online volume expansion on deployment", func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()


### PR DESCRIPTION
What this PR does / why we need it: GC Online volume expansion - set4

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

Release notes:
Online volume expansion test cases for GC
Special notes for your reviewer:

1.Verify online volume expansion when PV with reclaim policy is reused to create PVC
2.verify online block volume expansion triggered when SVC CSI pod is down succeeds once SVC CSI pod comes up
3.Verify online volume expansion when POD is deleted and re-created
4.Verify online volume expansion when PVC is deleted
5.Volume expansion on shared VVOL, shared NFS  and shared VMFS datastores
6.Verify online volume expansion on deployments

Logs : https://gist.github.com/kavyashree-r/bf25b80ed6dc02497721a367e485b961#file-gc-onlineresize-logs
https://gist.github.com/kavyashree-r/4ccaca23b858a2ae67ebc462cbf74ef1
