### PR TITLE
Clean up white spaces in tests - long strings

### DIFF
--- a/tests/e2e/csi_cns_telemetry_statefulsets.go
+++ b/tests/e2e/csi_cns_telemetry_statefulsets.go
@@ -41,7 +41,8 @@ import (
 // 7. Delete all PVCs from the tests namespace.
 // 8. Delete the storage class.
 
-var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor] [csi-guest] CNS-CSI Cluster Distribution for StatefulSets", func() {
+var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor] [csi-guest] "+
+	"CNS-CSI Cluster Distribution for StatefulSets", func() {
 	f := framework.NewDefaultFramework("csi-cns-telemetry")
 	var (
 		namespace         string

--- a/tests/e2e/csi_cns_telemetry_vc_reboot.go
+++ b/tests/e2e/csi_cns_telemetry_vc_reboot.go
@@ -35,7 +35,8 @@ import (
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 )
 
-var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] CNS-CSI Cluster Distribution Operations during VC reboot", func() {
+var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
+	"CNS-CSI Cluster Distribution Operations during VC reboot", func() {
 	f := framework.NewDefaultFramework("csi-cns-telemetry")
 	var (
 		client           clientset.Interface

--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -822,7 +822,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 12. Verify PV is deleted automatically.
 	// 13. Verify Volume id deleted automatically.
 	// 14. Verify CRD deleted automatically.
-	ginkgo.It("[csi-supervisor] Verify static provisioning workflow on svc - when there is no resourcequota available", func() {
+	ginkgo.It("[csi-supervisor] Verify static provisioning workflow on svc - "+
+		"when there is no resourcequota available", func() {
 
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1189,7 +1190,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 8. Delete PVC.
 	// 9. PV and CRD gets auto deleted.
 	// 10. Delete Resource quota.
-	ginkgo.It("[csi-supervisor] Verifies static provisioning workflow on supervisor cluster - When vsanhealthService is down", func() {
+	ginkgo.It("[csi-supervisor] Verifies static provisioning workflow on supervisor cluster - "+
+		"When vsanhealthService is down", func() {
 
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1496,7 +1498,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 2. Create a storage policy.
 	// 3. Create FCD with the above created storage policy.
 	// 4. Import the volume created in step 3 to namespace created in step 1.
-	ginkgo.It("[csi-supervisor] static provisioning workflow - when tried to import volume with a storage policy that doesn't belong to the namespace", func() {
+	ginkgo.It("[csi-supervisor] static provisioning workflow - "+
+		"when tried to import volume with a storage policy that doesn't belong to the namespace", func() {
 
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1706,7 +1709,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 7. Delete Namespace.
 	// 8. Verify that PV's got deleted (This ensures that all PVC, CNS register
 	//    volumes and POD's are deleted).
-	ginkgo.It("[csi-supervisor] Perform static and dynamic provisioning together, Create Pod and delete Namespace", func() {
+	ginkgo.It("[csi-supervisor] Perform static and dynamic provisioning together, "+
+		"Create Pod and delete Namespace", func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/data_persistence.go
+++ b/tests/e2e/data_persistence.go
@@ -112,7 +112,8 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		}
 	})
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] Should create and delete pod with the same volume source", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] "+
+		"Should create and delete pod with the same volume source", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var sc *storagev1.StorageClass

--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -210,7 +210,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 
 	})
 
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] Verify labels are created in CNS after updating pvc and/or pv with new labels", func() {
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] "+
+		"Verify labels are created in CNS after updating pvc and/or pv with new labels", func() {
 		ginkgo.By("Invoking test to verify labels creation")
 		var sc *storagev1.StorageClass
 		var pvc *v1.PersistentVolumeClaim
@@ -298,7 +299,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 
 	})
 
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] Verify CNS volume is deleted after full sync when pv entry is delete", func() {
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] "+
+		"Verify CNS volume is deleted after full sync when pv entry is delete", func() {
 		ginkgo.By("Invoking test to verify CNS volume creation")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -694,7 +696,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 
 	})
 
-	ginkgo.It("[csi-block-vanilla-destructive] Scale down driver deployment to zero replica and verify PV metadata is created in CNS", func() {
+	ginkgo.It("[csi-block-vanilla-destructive] "+
+		"Scale down driver deployment to zero replica and verify PV metadata is created in CNS", func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -357,7 +357,8 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	// 14. delete the pod created in step 11.
 	// 15. delete PVC created in step 2.
 	// 16. delete SC created in step 1.
-	ginkgo.It("verify offline block volume expansion triggered when SVC CSI pod is down succeeds once SVC CSI pod comes up", func() {
+	ginkgo.It("verify offline block volume expansion triggered when SVC CSI pod is down "+
+		"succeeds once SVC CSI pod comes up", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		// Create a Pod to use this PVC, and verify volume has been attached.
@@ -725,7 +726,8 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	// TODO: There is an upstream work going on to prevent PVC deletion when
 	//       resize is in progress. This test needs to be re-evaluated in the
 	//       future when the upstream happens.
-	ginkgo.It("Verify while CNS is down the volume expansion can be triggered and the volume can deleted with pending resize operation", func() {
+	ginkgo.It("Verify while CNS is down the volume expansion can be triggered and "+
+		"the volume can deleted with pending resize operation", func() {
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
@@ -1142,7 +1144,8 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	// 14. Delete the pod created in step 11.
 	// 15. Delete PVC created in step 2.
 	// 16. Delete SC created in step 1.
-	ginkgo.It("verify offline block volume expansion succeeds when GC CSI pod is down when SVC PVC reaches FilesystemResizePending state and GC CSI comes up", func() {
+	ginkgo.It("verify offline block volume expansion succeeds when GC CSI pod is down "+
+		"when SVC PVC reaches FilesystemResizePending state and GC CSI comes up", func() {
 		thickProvPolicy := os.Getenv(envStoragePolicyNameWithThickProvision)
 		if thickProvPolicy == "" {
 			ginkgo.Skip(envStoragePolicyNameWithThickProvision + " env variable not set")


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles a few long strings in e2e tests.

**Testing done**:
Local build, check, test.