### PR TITLE
[WIP]Add fault type to CsiControlOpsHistVec for WCP, PVCSI and Vanilla CSI

### DIFF
--- a/pkg/common/prometheus/metrics.go
+++ b/pkg/common/prometheus/metrics.go
@@ -42,6 +42,24 @@ const (
 	// PrometheusExpandVolumeOpType represents the ExpandVolume operation.
 	PrometheusExpandVolumeOpType = "expand-volume"
 
+	// CSI operation fault types
+
+	// PrometheusFaultInvalidArgumentType represents the InvalidArgument fault
+	// that CSI operation may failed with
+	PrometheusFaultInvalidArgumentType = "InvalidArgument"
+	// PrometheusFaultNotFoundType represents the NotFound fault
+	// that CSI operation may failed with
+	PrometheusFaultNotFoundType = "NotFound"
+	// PrometheusFaultResourceInUseType represents the ResourceInUse fault
+	// that CSI operation may failed with
+	PrometheusFaultResourceInUseType = "ResourceInUse"
+	// PrometheusFaultManagedObjectNotFoundType represents the ManagedObjectNotFound fault
+	// that CSI operation may failed with
+	PrometheusFaultManagedObjectNotFoundType = "ManagedObjectNotFound"
+	// PrometheusFaultOtherFaultType represents the fault
+	// that CSI operation may failed with other than the fault listed above
+	PrometheusFaultOtherFaultType = "OtherFault"
+
 	// CNS operation types
 
 	// PrometheusCnsCreateVolumeOpType represents the CreateVolume operation.
@@ -101,7 +119,8 @@ var (
 		// Possible voltype - "unknown", "block", "file"
 		// Possible optype - "create-volume", "delete-volume", "attach-volume", "detach-volume", "expand-volume"
 		// Possible status - "pass", "fail"
-		[]string{"voltype", "optype", "status"})
+		// Possible fault - "InvalidArgument", "NotFound", "ResourceInUse", "ManagedObjectNotFound", "CnsFault", "OtherFault"
+		[]string{"voltype", "optype", "status", "fault"})
 
 	// CnsControlOpsHistVec is a histogram vector metric to observe various control
 	// operations on CNS. Note that this captures the time taken by CNS into a bucket

--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/codes"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/pkg/common/prometheus"
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
@@ -262,4 +263,22 @@ func IsOnlineExpansion(ctx context.Context, volumeID string, nodes []*cnsvsphere
 	}
 
 	return nil
+}
+
+// ExtractCsiControlOpFaultFromError extracts the fault type from the error of
+// CsiControlOp
+func ExtractCsiControlOpFaultFromError(ctx context.Context, err error) string {
+	log := logger.GetLogger(ctx)
+	log.Infof("ExtractCsiControlOpFaultFromError called with err %v", err)
+	if strings.Contains(err.Error(), prometheus.PrometheusFaultInvalidArgumentType) {
+		return prometheus.PrometheusFaultInvalidArgumentType
+	} else if strings.Contains(err.Error(), prometheus.PrometheusFaultNotFoundType) {
+		return prometheus.PrometheusFaultNotFoundType
+	} else if strings.Contains(err.Error(), prometheus.PrometheusFaultResourceInUseType) {
+		return prometheus.PrometheusFaultResourceInUseType
+	} else if strings.Contains(err.Error(), prometheus.PrometheusFaultManagedObjectNotFoundType) {
+		return prometheus.PrometheusFaultManagedObjectNotFoundType
+	} else {
+		return prometheus.PrometheusFaultOtherFaultType
+	}
 }

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -663,12 +663,14 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return c.createBlockVolume(ctx, req)
 	}
 	resp, err := createVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -731,12 +733,14 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 	resp, err := deleteVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -846,12 +850,14 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 		}, nil
 	}
 	resp, err := controllerPublishVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -947,12 +953,14 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 	resp, err := controllerUnpublishVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -207,7 +207,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	go func() {
 		prometheus.CsiInfo.WithLabelValues(version).Set(1)
 		for {
-			log.Info("Starting the http server to expose Prometheus metrics..")
+			log.Info("Starting the http server to expose Prometheus metrics..Liping")
 			http.Handle("/metrics", promhttp.Handler())
 			err = http.ListenAndServe(":2112", nil)
 			if err != nil {
@@ -537,12 +537,14 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return c.createBlockVolume(ctx, req)
 	}
 	resp, err := createVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -576,12 +578,14 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 	resp, err := deleteVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -696,12 +700,14 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 		return resp, nil
 	}
 	resp, err := controllerPublishVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -737,12 +743,14 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 	resp, err := controllerUnpublishVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -878,12 +886,14 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		return resp, nil
 	}
 	resp, err := controllerExpandVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -312,12 +312,14 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		return resp, nil
 	}
 	resp, err := createVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -372,12 +374,14 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 	resp, err := deleteVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -419,12 +423,14 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 		return controllerPublishForBlockVolume(ctx, req, c)
 	}
 	resp, err := controllerPublishVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -733,12 +739,14 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		return controllerUnpublishForBlockVolume(ctx, req, c)
 	}
 	resp, err := controllerUnpublishVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1067,12 +1075,14 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		return resp, nil
 	}
 	resp, err := controllerExpandVolumeInternal()
+	fault := ""
 	if err != nil {
+		fault = common.ExtractCsiControlOpFaultFromError(ctx, err)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusFailStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, fault).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, fault).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is to add fault type to CsiControlOpsHistVec for CSI Control Ops.
According to the CNS API definition, the following are possible faults that will be returned by CNS
CreateVolume: NotFound, InvalidArgument, CnsFault
DeleteVolume: NotFound, InvalidArgument, ResourceInUse, CnsFault
AttachVolume: NotFound, InvalidArgument, ResourceInUse, ManagedObjectNotFound
, CnsFault
DetachVolume: NotFound, InvalidArgument, ManagedObjectNotFound
, CnsFault

ExtendVolume: NotFound, InvalidArgument, CnsFault

With this change, Prometheus metrics `CsiControlOpsHistVec` will have a label "fault" to indicate the CSI control op is failed with which fault and we can build dashboard based on the fault type for CSI control ops.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Test 1: Attach Volume failed with NotFound
1. create a pvc, and make sure the pvc is bound
2. delete the fcd disk corresponding to the pv
3. create a pod to use this pvc
4. observed Attach Volume failed with NotFound
See the following Prometheus metrics
```
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="1"} 0
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="2"} 0
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="3"} 5
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="4"} 5
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="5"} 5
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="7"} 6
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="10"} 6
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="12"} 6
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="15"} 6
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="18"} 6
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="20"} 6
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="25"} 6
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="30"} 6
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="60"} 6
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="120"} 6
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="180"} 6
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="300"} 6
vsphere_csi_volume_ops_histogram_bucket{fault="NotFound",optype="attach-volume",status="fail",voltype="block",le="+Inf"} 6
vsphere_csi_volume_ops_histogram_sum{fault="NotFound",optype="attach-volume",status="fail",voltype="block"} 17.049341924
vsphere_csi_volume_ops_histogram_count{fault="NotFound",optype="attach-volume",status="fail",voltype="block"} 6
```
Test 2: Delete Volume failed with ResourceInUse
1. create a pvc and wait for pvc bound
2. Use VC UI to attach the volume to a dummy VM
3. delete the pvc
4. observed pvc delete failed with ResourceInUse
See the following Prometheus metrics:
```
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="1"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="2"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="3"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="4"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="5"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="7"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="10"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="12"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="15"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="18"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="20"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="25"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="30"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="60"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="120"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="180"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="300"} 7
vsphere_csi_volume_ops_histogram_bucket{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown",le="+Inf"} 7
vsphere_csi_volume_ops_histogram_sum{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown"} 3.53394825
vsphere_csi_volume_ops_histogram_count{fault="ResourceInUse",optype="delete-volume",status="fail",voltype="unknown"} 7
```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
