### PR TITLE
Clean up white spaces in common utils

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -96,7 +96,8 @@ func QueryAllVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cn
 	return queryResult, nil
 }
 
-func QuerySnapshotsUtil(ctx context.Context, m cnsvolume.Manager, snapshotQueryFilter cnstypes.CnsSnapshotQueryFilter) ([]cnstypes.CnsSnapshotQueryResultEntry, error) {
+func QuerySnapshotsUtil(ctx context.Context, m cnsvolume.Manager,
+	snapshotQueryFilter cnstypes.CnsSnapshotQueryFilter) ([]cnstypes.CnsSnapshotQueryResultEntry, error) {
 	log := logger.GetLogger(ctx)
 	var allQuerySnapshotResults []cnstypes.CnsSnapshotQueryResultEntry
 	var snapshotQuerySpec cnstypes.CnsSnapshotQuerySpec
@@ -121,7 +122,8 @@ func QuerySnapshotsUtil(ctx context.Context, m cnsvolume.Manager, snapshotQueryF
 			log.Infof("QuerySnapshots retrieved no results for the spec: %+v", snapshotQuerySpec)
 		}
 		allQuerySnapshotResults = append(allQuerySnapshotResults, snapshotQueryResult.Entries...)
-		log.Infof("%v more snapshots to be queried", snapshotQueryResult.Cursor.TotalRecords-snapshotQueryResult.Cursor.Offset)
+		log.Infof("%v more snapshots to be queried",
+			snapshotQueryResult.Cursor.TotalRecords-snapshotQueryResult.Cursor.Offset)
 		if snapshotQueryResult.Cursor.Offset == snapshotQueryResult.Cursor.TotalRecords {
 			log.Infof("QuerySnapshots retrieved all records (%d) for the SnapshotQuerySpec: %+v in %d iterations",
 				snapshotQueryResult.Cursor.TotalRecords, snapshotQuerySpec, iteration)

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -67,8 +67,10 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*cnsconf
 
 	// Write values to test_vsphere.conf
 	os.Setenv("VSPHERE_CSI_CONFIG", "test_vsphere.conf")
-	conf := []byte(fmt.Sprintf("[Global]\ninsecure-flag = \"%t\"\n[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"",
-		cfg.Global.InsecureFlag, cfg.Global.VCenterIP, cfg.Global.User, cfg.Global.Password, cfg.Global.Datacenters, cfg.Global.VCenterPort))
+	conf := []byte(fmt.Sprintf("[Global]\ninsecure-flag = \"%t\"\n"+
+		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"",
+		cfg.Global.InsecureFlag, cfg.Global.VCenterIP, cfg.Global.User, cfg.Global.Password,
+		cfg.Global.Datacenters, cfg.Global.VCenterPort))
 	err = ioutil.WriteFile("test_vsphere.conf", conf, 0644)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles common utils.

**Testing done**:
Local build, check.