### PR TITLE
Clean up white spaces in syncer unit test

### DIFF
--- a/pkg/syncer/util_test.go
+++ b/pkg/syncer/util_test.go
@@ -89,16 +89,14 @@ func TestValidMigratedAndLegacyVolume(t *testing.T) {
 	}
 }
 
-/*
-	This test verifies the correctness of GetSCNameFromPVC in following scenarios
-	where SC name is provided through:
-		1. Only Spec.StorageClassName
-		2. Only Metadata.Annotation
-		3. Both Spec.StorageClassName and Metadata.Annotation
-		4. Neither Spec.StorageClassName nor Metadata.Annotation
-*/
+// This test verifies the correctness of GetSCNameFromPVC in following scenarios
+// where SC name is provided through:
+//    1. Only Spec.StorageClassName
+//    2. Only Metadata.Annotation
+//    3. Both Spec.StorageClassName and Metadata.Annotation
+//    4. Neither Spec.StorageClassName nor Metadata.Annotation
 func TestGetSCNameFromPVC(t *testing.T) {
-	// Create context
+	// Create context.
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 
@@ -115,7 +113,7 @@ func TestGetSCNameFromPVC(t *testing.T) {
 		return nil
 	}
 
-	// scenario 1
+	// Scenario 1.
 	t.Log("Verifying GetSCNameFromPVC for case where SC name is provided through only Spec.StorageClassName")
 	pvcName := testPVCName + "-" + uuid.New().String()
 	pvc := getPersistentVolumeClaimSpec(pvcName, namespace, pvcLabel, "", specSCName)
@@ -125,7 +123,7 @@ func TestGetSCNameFromPVC(t *testing.T) {
 		t.Error(err)
 	}
 
-	// scenario 2
+	// Scenario 2.
 	t.Log("Verifying GetSCNameFromPVC for case where SC name is provided through only Metadata.Annotation")
 	pvcName = testPVCName + "-" + uuid.New().String()
 	pvc = getPersistentVolumeClaimSpec(pvcName, namespace, pvcLabel, "", "")
@@ -136,8 +134,9 @@ func TestGetSCNameFromPVC(t *testing.T) {
 		t.Error(err)
 	}
 
-	// scenario 3
-	t.Log("Verifying GetSCNameFromPVC for case where SC name is provided through both Spec.StorageClassName and Metadata.Annotation")
+	// Scenario 3.
+	t.Log("Verifying GetSCNameFromPVC for case where SC name is provided through " +
+		"both Spec.StorageClassName and Metadata.Annotation")
 	pvcName = testPVCName + "-" + uuid.New().String()
 	pvc = getPersistentVolumeClaimSpec(pvcName, namespace, pvcLabel, "", specSCName)
 	pvc.Annotations = map[string]string{k8scloudoperator.ScNameAnnotationKey: annotatedSCName}
@@ -147,8 +146,9 @@ func TestGetSCNameFromPVC(t *testing.T) {
 		t.Error(err)
 	}
 
-	// scenario 4
-	t.Log("Verifying GetSCNameFromPVC for case where SC name is provided through neither Spec.StorageClassName nor Metadata.Annotation")
+	// Scenario 4.
+	t.Log("Verifying GetSCNameFromPVC for case where SC name is provided through " +
+		"neither Spec.StorageClassName nor Metadata.Annotation")
 	pvcName = testPVCName + "-" + uuid.New().String()
 	pvc = getPersistentVolumeClaimSpec(pvcName, namespace, pvcLabel, "", "")
 	expError := fmt.Errorf("storage class name not specified in PVC %q", pvcName)


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles syncer unit test.

**Testing done**:
Local build, check, test.