### PR TITLE
Clean up white spaces in volume_health

### DIFF
--- a/pkg/syncer/volume_health.go
+++ b/pkg/syncer/volume_health.go
@@ -31,11 +31,12 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/pkg/csi/service/logger"
 )
 
-func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface, metadataSyncer *metadataSyncInformer) {
+func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface,
+	metadataSyncer *metadataSyncInformer) {
 	log := logger.GetLogger(ctx)
 	log.Infof("csiGetVolumeHealthStatus: start")
 
-	//Call CNS QueryAll to get container volumes by cluster ID
+	// Call CNS QueryAll to get container volumes by cluster ID.
 	queryFilter := cnstypes.CnsQueryFilter{
 		ContainerClusterIds: []string{
 			metadataSyncer.configInfo.Cfg.Global.ClusterID,
@@ -47,25 +48,28 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 			string(cnstypes.QuerySelectionNameTypeHealthStatus),
 		},
 	}
-	queryResult, err := utils.QueryAllVolumeUtil(ctx, metadataSyncer.volumeManager, queryFilter, querySelection, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+	queryResult, err := utils.QueryAllVolumeUtil(ctx, metadataSyncer.volumeManager, queryFilter,
+		querySelection, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 	if err != nil {
 		log.Errorf("csiGetVolumeHealthStatus: QueryVolume failed with err=%+v", err.Error())
 		return
 	}
 
-	// Get K8s PVs in State "Bound"
+	// Get K8s PVs in State "Bound".
 	k8sPVs, err := getBoundPVs(ctx, metadataSyncer)
 	if err != nil {
 		log.Errorf("csiGetVolumeHealthStatus: Failed to get PVs from kubernetes. Err: %+v", err)
 		return
 	}
 
-	// volumeHandleToPvcMap maps pv.Spec.CSI.VolumeHandle to the pvc object which bounded to the pv
+	// volumeHandleToPvcMap maps pv.Spec.CSI.VolumeHandle to the pvc object which
+	// bounded to the pv.
 	volumeHandleToPvcMap := make(volumeHandlePVCMap, len(k8sPVs))
 
 	for _, pv := range k8sPVs {
 		if pv.Spec.ClaimRef != nil && pv.Status.Phase == v1.VolumeBound {
-			pvc, err := metadataSyncer.pvcLister.PersistentVolumeClaims(pv.Spec.ClaimRef.Namespace).Get(pv.Spec.ClaimRef.Name)
+			pvc, err := metadataSyncer.pvcLister.PersistentVolumeClaims(
+				pv.Spec.ClaimRef.Namespace).Get(pv.Spec.ClaimRef.Name)
 			if err != nil {
 				log.Warnf("csiGetVolumeHealthStatus: Failed to get pvc for namespace %s and name %s. err=%+v",
 					pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name, err)
@@ -77,7 +81,7 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 		}
 	}
 
-	// volumeIdToHealthStatusMap maps vol.VolumeId.Id to vol.HealthStatus
+	// volumeIdToHealthStatusMap maps vol.VolumeId.Id to vol.HealthStatus.
 	volumeIdToHealthStatusMap := make(volumeIdHealthStatusMap, len(queryResult.Volumes))
 
 	for _, vol := range queryResult.Volumes {
@@ -86,7 +90,8 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 
 	for volID, pvc := range volumeHandleToPvcMap {
 		if volHealthStatus, ok := volumeIdToHealthStatusMap[volID]; ok {
-			// only update PVC health annotation if the HealthStatus of volume is not "unknown"
+			// Only update PVC health annotation if the HealthStatus of volume is
+			// not "unknown".
 			if volHealthStatus != string(pbmtypes.PbmHealthStatusForEntityUnknown) {
 				volHealthStatusAnn, err := common.ConvertVolumeHealthStatus(ctx, volID, volHealthStatus)
 				if err != nil {
@@ -95,27 +100,32 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 				updateVolumeHealthStatus(ctx, k8sclient, pvc, volHealthStatusAnn)
 			}
 		} else {
-			// Set volume health status as "Inaccessible" when PVC is not found in CNS.
-			// When a Datastore is removed from VC (like vSAN direct disk decommisson with noAction does), the CNS Volumes
-			// on that Datastore are eventually removed from CNS DB, but the PVCs still remain in the K8S cluster.
-			// We are making the design choice of reflecting the CNS cached status of health on the PVC's health annotation
-			// at any given point of time. The vDPp operators are advised to look at the health change timestamp and wait
-			// "long enough" (like an hour) before taking any corrective actions. So if the PVC health is getting updated
-			// every 5 mins, wait for an hour or so before taking any corrective actions. This is an acceptable level
-			// of eventual consistency.
+			// Set volume health status as "Inaccessible" when PVC is not found in
+			// CNS. When a Datastore is removed from VC (like vSAN direct disk
+			// decommisson with noAction does), the CNS Volumes on that Datastore
+			// are eventually removed from CNS DB, but the PVCs still remain in
+			// the K8S cluster. We are making the design choice of reflecting the
+			// CNS cached status of health on the PVC's health annotation at any
+			// given point of time. The vDPp operators are advised to look at the
+			// health change timestamp and wait "long enough" (like an hour) before
+			// taking any corrective actions. So if the PVC health is getting
+			// updated every 5 mins, wait for an hour or so before taking any
+			// corrective actions. This is an acceptable level of eventual
+			// consistency.
 			updateVolumeHealthStatus(ctx, k8sclient, pvc, common.VolHealthStatusInaccessible)
 		}
 	}
 	log.Infof("GetVolumeHealthStatus: end")
 }
 
-func updateVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface, pvc *v1.PersistentVolumeClaim, volHealthStatus string) {
+func updateVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface,
+	pvc *v1.PersistentVolumeClaim, volHealthStatus string) {
 	log := logger.GetLogger(ctx)
 
 	val, found := pvc.Annotations[annVolumeHealth]
 	_, foundAnnHealthTS := pvc.Annotations[annVolumeHealthTS]
 	if !found || val != volHealthStatus || !foundAnnHealthTS {
-		// VolumeHealth annotation on pvc is changed, set it to new value
+		// VolumeHealth annotation on pvc is changed, set it to new value.
 		metav1.SetMetaDataAnnotation(&pvc.ObjectMeta, annVolumeHealth, volHealthStatus)
 		timeNow := time.Now().Format(time.UnixDate)
 		metav1.SetMetaDataAnnotation(&pvc.ObjectMeta, annVolumeHealthTS, timeNow)
@@ -127,8 +137,10 @@ func updateVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 			if apierrors.IsConflict(err) {
 				log.Debugf("updateVolumeHealthStatus: Failed to update pvc %s/%s with err:%+v, will retry the update",
 					pvc.Namespace, pvc.Name, err)
-				// pvc get from pvcLister may be stale, try to get updated pvc which bound to pv from API server
-				newPvc, err := k8sclient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+				// pvc get from pvcLister may be stale, try to get updated pvc which
+				// bound to pv from API server.
+				newPvc, err := k8sclient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(
+					ctx, pvc.Name, metav1.GetOptions{})
 				if err == nil {
 					timeUpdate := time.Now().Format(time.UnixDate)
 					log.Infof("updateVolumeHealthStatus: updating volume health annotation for pvc %s/%s which "+
@@ -136,7 +148,8 @@ func updateVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 						newPvc.Namespace, newPvc.Name, val, volHealthStatus, timeUpdate)
 					metav1.SetMetaDataAnnotation(&newPvc.ObjectMeta, annVolumeHealth, volHealthStatus)
 					metav1.SetMetaDataAnnotation(&newPvc.ObjectMeta, annVolumeHealthTS, timeUpdate)
-					_, err := k8sclient.CoreV1().PersistentVolumeClaims(newPvc.Namespace).Update(ctx, newPvc, metav1.UpdateOptions{})
+					_, err := k8sclient.CoreV1().PersistentVolumeClaims(newPvc.Namespace).Update(ctx,
+						newPvc, metav1.UpdateOptions{})
 					if err != nil {
 						log.Errorf("updateVolumeHealthStatus: Failed to update pvc %s/%s with err:%+v",
 							newPvc.Namespace, newPvc.Name, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles volume_health.

**Testing done**:
Local build, check.