### PR TITLE
Fix linter errors

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -566,7 +566,7 @@ func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int
 	}
 	var currentSize int64
 	if len(queryResult.Volumes) > 0 {
-		currentSize = queryResult.Volumes[0].BackingObjectDetails.(cnstypes.BaseCnsBackingObjectDetails).GetCnsBackingObjectDetails().CapacityInMb
+		currentSize = queryResult.Volumes[0].BackingObjectDetails.GetCnsBackingObjectDetails().CapacityInMb
 	} else {
 		msg := fmt.Sprintf("failed to find volume by querying volumeID: %q", volumeID)
 		log.Error(msg)

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 	"time"
 
-	cnstypes "github.com/vmware/govmomi/cns/types"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -271,7 +270,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(request reconcile.Request) (recon
 	}
 	log.Infof("Volume with storagepolicyId: %s is mapping to K8S storage class: %s and assigned to namespace: %s", volume.StoragePolicyId, storageClassName, request.Namespace)
 
-	capacityInMb := volume.BackingObjectDetails.(cnstypes.BaseCnsBackingObjectDetails).GetCnsBackingObjectDetails().CapacityInMb
+	capacityInMb := volume.BackingObjectDetails.GetCnsBackingObjectDetails().CapacityInMb
 	accessMode := instance.Spec.AccessMode
 	// Set accessMode to ReadWriteOnce if DiskURLPath is used for import
 	if accessMode == "" && instance.Spec.DiskURLPath != "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix linter errors in release-2.2 branch

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
make check succeeded
```
make check
hack/check-format.sh
go: found golang.org/x/tools/cmd/goimports in golang.org/x/tools v0.1.5
hack/check-lint.sh
go: found golang.org/x/lint/golint in golang.org/x/lint v0.0.0-20210508222113-6edffad5e616

hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go: found honnef.co/go/tools/cmd/staticcheck in honnef.co/go/tools v0.2.0
hack/check-vet.sh
hack/check-golangci-lint.sh
INFO [config_reader] Config search paths: [./ /Users/chethanv/Downloads/csi-external/vsphere-csi-driver /Users/chethanv/Downloads/csi-external /Users/chethanv/Downloads /Users/chethanv /Users /] 
INFO [lintersdb] Active 10 linters: [deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (files|imports|types_sizes|deps|exports_file|name|compiled_files) took 3.433022969s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 86.382114ms 
INFO [linters context/goanalysis] analyzers took 4m46.278277269s with top 10 stages: buildir: 4m2.541544036s, ctrlflow: 8.358648069s, printf: 8.214199872s, fact_deprecated: 7.907882321s, fact_purity: 5.014944741s, inspect: 3.975329076s, ineffassign: 1.31164675s, S1038: 521.503428ms, isgenerated: 502.761629ms, S1039: 386.854574ms 
INFO [linters context/goanalysis] analyzers took 21.990204421s with top 10 stages: buildir: 20.55370581s, U1000: 1.436498611s 
INFO [runner] Issues before processing: 73, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 73/73, exclude: 0/15, cgo: 73/73, autogenerated_exclude: 15/73, identifier_marker: 15/15, filename_unadjuster: 73/73, skip_dirs: 73/73, skip_files: 73/73 
INFO [runner] processing took 6.073748ms with stages: autogenerated_exclude: 3.090238ms, path_prettifier: 1.314824ms, exclude: 885.591µs, identifier_marker: 431.981µs, skip_dirs: 311.103µs, cgo: 18.755µs, filename_unadjuster: 7.652µs, nolint: 6.775µs, max_same_issues: 1.258µs, uniq_by_line: 855ns, diff: 623ns, skip_files: 562ns, max_from_linter: 552ns, source_code: 530ns, exclude-rules: 522ns, severity-rules: 474ns, sort_results: 416ns, path_shortener: 399ns, max_per_file_from_linter: 332ns, path_prefixer: 306ns 
INFO [runner] linters took 45.003061001s with stages: goanalysis_metalinter: 38.428568714s, unused: 6.568246695s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 429 samples, avg is 1113.5MB, max is 1493.7MB 
INFO Execution took 48.548260837s 
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix linter errors in release-2.2 branch
```
