### PR TITLE
Clean up long lines in vsphere_file_volume_storagepolicy

### DIFF
--- a/tests/e2e/vsphere_file_volume_storagepolicy.go
+++ b/tests/e2e/vsphere_file_volume_storagepolicy.go
@@ -55,112 +55,132 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume Provision Testing With S
 		}
 	})
 
-	/*
-		Verify dynamic volume provisioning works with storage policy having compliant VSAN datastores only
-		1. Create a storage policy having compliant VSAN datastores with VSANFS enabled from list of datacenters where K8s nodes are deployed on
-		2. Create StorageClass with fsType as "nfs4" and storagePolicy created in step1
-		3. Create a PVC with "ReadWriteMany" using the SC from above
-		4. Wait for PVC to be Bound
-		5. Get the VolumeID from PV
-		6. Verify using CNS Query API if VolumeID retrieved from PV is present.
-		   Also verify if Name, Capacity, VolumeType, Health, Policy matches
-		   Verify if VolumeID is created on one of the VSAN datastores (compliant with storage policy) from list of datacenters provided in vsphere.conf
-		   Also verify if VolumeID is created with expected storage policy
-		7. Delete PVC
-		8. Delete storage policy
-	*/
-	ginkgo.It("[csi-file-vanilla] verify dynamic provisioning with ReadWriteMany access mode, when storage policy is offered", func() {
+	// Verify dynamic volume provisioning works with storage policy having
+	// compliant VSAN datastores only.
+	// 1. Create a storage policy having compliant VSAN datastores with VSANFS
+	//    enabled from list of datacenters where K8s nodes are deployed on.
+	// 2. Create StorageClass with fsType as "nfs4" and storagePolicy created
+	//    in step1.
+	// 3. Create a PVC with "ReadWriteMany" using the SC from above.
+	// 4. Wait for PVC to be Bound.
+	// 5. Get the VolumeID from PV.
+	// 6. Verify using CNS Query API if VolumeID retrieved from PV is present.
+	//    Also verify if Name, Capacity, VolumeType, Health, Policy matches.
+	//    Verify if VolumeID is created on one of the VSAN datastores (compliant
+	//    with storage policy) from list of datacenters provided in vsphere.conf.
+	//    Also verify if VolumeID is created with expected storage policy.
+	// 7. Delete PVC.
+	// 8. Delete storage policy.
+	ginkgo.It("[csi-file-vanilla] verify dynamic provisioning with ReadWriteMany access mode, "+
+		"when storage policy is offered", func() {
 		storagePolicyNameForSharedDatastores := GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
-		testHelperForCreateFileVolumeWithNoDatastoreURLInSCWithStoragePolicy(f, client, namespace, v1.ReadWriteMany, storagePolicyNameForSharedDatastores, true)
+		testHelperForCreateFileVolumeWithNoDatastoreURLInSCWithStoragePolicy(f, client,
+			namespace, v1.ReadWriteMany, storagePolicyNameForSharedDatastores, true)
 	})
 
-	/*
-		Verify dynamic volume provisioning works with storage policy having compliant VSAN datastores only
-		1. Create a storage policy having compliant VSAN datastores with VSANFS enabled from list of datacenters where K8s nodes are deployed on
-		2. Create StorageClass with fsType as "nfs4" and storagePolicy created in step1
-		3. Create a PVC with "ReadWriteMany" using the SC from above
-		4. Wait for PVC to be Bound
-		5. Get the VolumeID from PV
-		6. Verify using CNS Query API if VolumeID retrieved from PV is present.
-		   Also verify if Name, Capacity, VolumeType, Health, Policy matches
-		   Also verify if VolumeID is created with expected storage policy
-		7. Delete PVC
-		8. Delete storage policy
-	*/
+	// Verify dynamic volume provisioning works with storage policy having
+	// compliant VSAN datastores only.
+	// 1. Create a storage policy having compliant VSAN datastores with VSANFS
+	//    enabled from list of datacenters where K8s nodes are deployed on.
+	// 2. Create StorageClass with fsType as "nfs4" and storagePolicy created
+	//    in step1
+	// 3. Create a PVC with "ReadWriteMany" using the SC from above.
+	// 4. Wait for PVC to be Bound.
+	// 5. Get the VolumeID from PV.
+	// 6. Verify using CNS Query API if VolumeID retrieved from PV is present.
+	//    Also verify if Name, Capacity, VolumeType, Health, Policy matches.
+	//    Also verify if VolumeID is created with expected storage policy.
+	// 7. Delete PVC.
+	// 8. Delete storage policy.
 
-	ginkgo.It("[csi-file-vanilla] verify dynamic provisioning with ReadWriteMany access mode, when storage policy is offered and datacenters is not specified in conf file", func() {
+	ginkgo.It("[csi-file-vanilla] verify dynamic provisioning with ReadWriteMany access mode, "+
+		"when storage policy is offered and datacenters is not specified in conf file", func() {
 		storagePolicyNameForSharedDatastores := GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
-		testHelperForCreateFileVolumeWithNoDatastoreURLInSCWithStoragePolicy(f, client, namespace, v1.ReadWriteMany, storagePolicyNameForSharedDatastores, false)
+		testHelperForCreateFileVolumeWithNoDatastoreURLInSCWithStoragePolicy(f, client,
+			namespace, v1.ReadWriteMany, storagePolicyNameForSharedDatastores, false)
 	})
 
-	/*
-		Verify dynamic volume provisioning works with storage policy having compliant VSAN datastores only
-		1. Create a storage policy having compliant VSAN datastores with VSANFS enabled from list of datacenters where K8s nodes are deployed on
-		2. Create StorageClass with fsType as "nfs4" and storagePolicy created in step1
-		3. Create a PVC with "ReadOnlyMany" using the SC from above
-		4. Wait for PVC to be Bound
-		5. Get the VolumeID from PV
-		6. Verify using CNS Query API if VolumeID retrieved from PV is present.
-		   Also verify if Name, Capacity, VolumeType, Health, Policy matches
-		   Verify if VolumeID is created on one of the VSAN datastores (compliant with storage policy) from list of datacenters provided in vsphere.conf
-		   Also verify if VolumeID is created with expected storage policy
-		7. Delete PVC
-		8. Delete storage policy
-	*/
+	// Verify dynamic volume provisioning works with storage policy having
+	// compliant VSAN datastores only.
+	// 1. Create a storage policy having compliant VSAN datastores with VSANFS
+	//    enabled from list of datacenters where K8s nodes are deployed on.
+	// 2. Create StorageClass with fsType as "nfs4" and storagePolicy created
+	//    in step1.
+	// 3. Create a PVC with "ReadOnlyMany" using the SC from above.
+	// 4. Wait for PVC to be Bound.
+	// 5. Get the VolumeID from PV.
+	// 6. Verify using CNS Query API if VolumeID retrieved from PV is present.
+	//    Also verify if Name, Capacity, VolumeType, Health, Policy matches.
+	//    Verify if VolumeID is created on one of the VSAN datastores (compliant
+	//    with storage policy) from list of datacenters provided in vsphere.conf.
+	//    Also verify if VolumeID is created with expected storage policy.
+	// 7. Delete PVC.
+	// 8. Delete storage policy.
 
-	ginkgo.It("[csi-file-vanilla] verify dynamic provisioning with ReadOnlyMany access mode, when storage policy is offered", func() {
+	ginkgo.It("[csi-file-vanilla] verify dynamic provisioning with ReadOnlyMany access mode, "+
+		"when storage policy is offered", func() {
 		storagePolicyNameForSharedDatastores := GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
-		testHelperForCreateFileVolumeWithNoDatastoreURLInSCWithStoragePolicy(f, client, namespace, v1.ReadOnlyMany, storagePolicyNameForSharedDatastores, true)
+		testHelperForCreateFileVolumeWithNoDatastoreURLInSCWithStoragePolicy(f, client,
+			namespace, v1.ReadOnlyMany, storagePolicyNameForSharedDatastores, true)
 	})
 
-	/*
-		Verify dynamic volume provisioning works with storage policy having compliant VSAN datastores only
-		1. Create a storage policy using targetvSANFileShareDatastoreURLs as the compliant datastores
-		2. Create StorageClass with fsType as "nfs4" and storagePolicy created in step1
-		3. Create a PVC with "ReadWriteMany" using the SC from above
-		4. Wait for PVC to be Bound
-		5. Get the VolumeID from PV
-		6. Verify using CNS Query API if VolumeID retrieved from PV is present.
-		   Verify if Name, Capacity, VolumeType, Health, Policy matches
-		   Verify if VolumeID is created on one of the VSAN datastores from list of targetvSANFileShareDatastoreURLs provided in vsphere.conf
-		   Also verify if VolumeID is created with expected storage policy
-		7. Delete PVC
-		8. Delete storage policy
-	*/
+	// Verify dynamic volume provisioning works with storage policy having
+	// compliant VSAN datastores only.
+	// 1. Create a storage policy using targetvSANFileShareDatastoreURLs as
+	//    the compliant datastores.
+	// 2. Create StorageClass with fsType as "nfs4" and storagePolicy created
+	//    in step1.
+	// 3. Create a PVC with "ReadWriteMany" using the SC from above.
+	// 4. Wait for PVC to be Bound.
+	// 5. Get the VolumeID from PV.
+	// 6. Verify using CNS Query API if VolumeID retrieved from PV is present.
+	//    Verify if Name, Capacity, VolumeType, Health, Policy matches.
+	//    Verify if VolumeID is created on one of the VSAN datastores from list
+	//    of targetvSANFileShareDatastoreURLs provided in vsphere.conf.
+	//    Also verify if VolumeID is created with expected storage policy.
+	// 7. Delete PVC.
+	// 8. Delete storage policy.
 
-	ginkgo.It("[csi-file-vanilla] verify dynamic provisioning with ReadWriteMany access mode when storage policy is offered with TargetvSANFileShareDatastoreURLs as the compliant datastores", func() {
+	ginkgo.It("[csi-file-vanilla] verify dynamic provisioning with ReadWriteMany access mode "+
+		"when storage policy is offered with TargetvSANFileShareDatastoreURLs as the compliant datastores", func() {
 		// Verify if test is valid for the given environment
 		if len(targetDsURLs) == 0 {
 			ginkgo.Skip("TargetvSANFileShareDatastoreURLs is not set in e2eTest.conf, skipping the test")
 		}
 		storagePolicyNameForSharedDatastores := GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
-		createFileVolumeWithStoragePolicyAndTargetvSANFileShareDatastoreURLs(f, client, namespace, v1.ReadWriteMany, storagePolicyNameForSharedDatastores, "")
+		createFileVolumeWithStoragePolicyAndTargetvSANFileShareDatastoreURLs(f, client,
+			namespace, v1.ReadWriteMany, storagePolicyNameForSharedDatastores, "")
 	})
 
-	/*
-		Verify dynamic volume provisioning works with storage policy having compliant VSAN datastores only
-		1. Create a storage policy using targetvSANFileShareDatastoreURLs as the compliant datastores
-		2. Create StorageClass with fsType as "nfs4" and storagePolicy created in step1 and datastoreURL set to anyone from targetvSANFileShareDatastoreURLs
-		3. Create a PVC with "ReadWriteMany" using the SC from above
-		4. Wait for PVC to be Bound
-		5. Get the VolumeID from PV
-		6. Verify using CNS Query API if VolumeID retrieved from PV is present.
-		   Verify if Name, Capacity, VolumeType, Health, Policy matches
-		   Verify if VolumeID is created on one of the VSAN datastores from list of targetvSANFileShareDatastoreURLs provided in vsphere.conf
-		   Verify if VolumeID is created on the datastoreURL mentioned in Storage class
-		   Also verify if VolumeID is created with expected storage policy
-		7. Delete PVC
-		8. Delete storage policy
-	*/
+	// Verify dynamic volume provisioning works with storage policy having
+	// compliant VSAN datastores only.
+	// 1. Create a storage policy using targetvSANFileShareDatastoreURLs as
+	//    the compliant datastores.
+	// 2. Create StorageClass with fsType as "nfs4" and storagePolicy created
+	//    in step1 and datastoreURL set to anyone from
+	//    targetvSANFileShareDatastoreURLs.
+	// 3. Create a PVC with "ReadWriteMany" using the SC from above.
+	// 4. Wait for PVC to be Bound.
+	// 5. Get the VolumeID from PV.
+	// 6. Verify using CNS Query API if VolumeID retrieved from PV is present.
+	//    Verify if Name, Capacity, VolumeType, Health, Policy matches.
+	//    Verify if VolumeID is created on one of the VSAN datastores from list
+	//    of targetvSANFileShareDatastoreURLs provided in vsphere.conf.
+	//    Verify if VolumeID is created on the datastoreURL mentioned in Storage
+	//    class. Also verify if VolumeID is created with expected storage policy.
+	// 7. Delete PVC.
+	// 8. Delete storage policy.
 
-	ginkgo.It("[csi-file-vanilla] verify dynamic provisioning with ReadWriteMany access mode when datastoreURL is mentioned in storage class and storage policy has the vSAN compliant datastores", func() {
+	ginkgo.It("[csi-file-vanilla] verify dynamic provisioning with ReadWriteMany access mode "+
+		"when datastoreURL is mentioned in storage class and storage policy has the vSAN compliant datastores", func() {
 		// Verify if test is valid for the given environment
 		if len(targetDsURLs) == 0 {
 			ginkgo.Skip("TargetvSANFileShareDatastoreURLs is not set in e2eTest.conf, skipping the test")
 		}
 		sharedDatastoreURL := GetAndExpectStringEnvVar(envSharedDatastoreURL)
 		storagePolicyNameForSharedDatastores := GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
-		createFileVolumeWithStoragePolicyAndTargetvSANFileShareDatastoreURLs(f, client, namespace, v1.ReadWriteMany, storagePolicyNameForSharedDatastores, sharedDatastoreURL)
+		createFileVolumeWithStoragePolicyAndTargetvSANFileShareDatastoreURLs(f, client,
+			namespace, v1.ReadWriteMany, storagePolicyNameForSharedDatastores, sharedDatastoreURL)
 	})
 
 	/*
@@ -174,7 +194,8 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume Provision Testing With S
 		7. Delete Storage class
 	*/
 
-	ginkgo.It("[csi-file-vanilla] verify dynamic provisioning with ReadWriteMany access mode when storage policy has non-vSAN compliant datastores", func() {
+	ginkgo.It("[csi-file-vanilla] verify dynamic provisioning with ReadWriteMany access mode "+
+		"when storage policy has non-vSAN compliant datastores", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		// Verify if test is valid for the given environment
@@ -192,8 +213,10 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume Provision Testing With S
 		scParameters[scParamStoragePolicyName] = storagePolicyNameForNonSharedDatastores
 
 		// Create Storage class and PVC
-		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q, storage policy %q and fstype %q", accessMode, storagePolicyNameForNonSharedDatastores, nfs4FSType))
-		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "", false, accessMode)
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q, storage policy %q and fstype %q",
+			accessMode, storagePolicyNameForNonSharedDatastores, nfs4FSType))
+		storageclass, pvclaim, err = createPVCAndStorageClass(client,
+			namespace, nil, scParameters, "", nil, "", false, accessMode)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
@@ -204,18 +227,22 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume Provision Testing With S
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		ginkgo.By("Expect claim to fail as the storage policy mentioned in Storage class has non-vSAN compliant datastores")
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute/2)
+		ginkgo.By("Expect claim to fail as the storage policy mentioned in Storage class " +
+			"has non-vSAN compliant datastores")
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute/2)
 		gomega.Expect(err).To(gomega.HaveOccurred())
 		expectedErrMsg := "Failed to create volume."
 		ginkgo.By(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
-		isFailureFound := checkEventsforError(client, namespace, metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvclaim.Name)}, expectedErrMsg)
+		isFailureFound := checkEventsforError(client, namespace,
+			metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvclaim.Name)}, expectedErrMsg)
 		gomega.Expect(isFailureFound).To(gomega.BeTrue(), "Unable to verify pvc create failure")
 	})
 })
 
-func testHelperForCreateFileVolumeWithNoDatastoreURLInSCWithStoragePolicy(f *framework.Framework, client clientset.Interface,
-	namespace string, accessMode v1.PersistentVolumeAccessMode, storagePolicyName string, checkDatastoreBelongToDatacenter bool) {
+func testHelperForCreateFileVolumeWithNoDatastoreURLInSCWithStoragePolicy(f *framework.Framework,
+	client clientset.Interface, namespace string, accessMode v1.PersistentVolumeAccessMode,
+	storagePolicyName string, checkDatastoreBelongToDatacenter bool) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ginkgo.By(fmt.Sprintf("Invoking Test for accessMode: %s storagePolicy %s", accessMode, storagePolicyName))
@@ -230,7 +257,8 @@ func testHelperForCreateFileVolumeWithNoDatastoreURLInSCWithStoragePolicy(f *fra
 	var pvclaim *v1.PersistentVolumeClaim
 	var err error
 
-	storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "", false, accessMode)
+	storageclass, pvclaim, err = createPVCAndStorageClass(client,
+		namespace, nil, scParameters, "", nil, "", false, accessMode)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	defer func() {
 		err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
@@ -258,11 +286,13 @@ func testHelperForCreateFileVolumeWithNoDatastoreURLInSCWithStoragePolicy(f *fra
 	gomega.Expect(queryResult.Volumes).ShouldNot(gomega.BeEmpty())
 
 	ginkgo.By(fmt.Sprintf("volume Name: %q capacity: %d volumeType: %q health: %q storagePolicy: %q",
-		queryResult.Volumes[0].Name, queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb,
+		queryResult.Volumes[0].Name,
+		queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb,
 		queryResult.Volumes[0].VolumeType, queryResult.Volumes[0].HealthStatus, queryResult.Volumes[0].StoragePolicyId))
 
 	ginkgo.By("Verifying disk size specified in PVC is honored")
-	if queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb != diskSizeInMb {
+	if queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb !=
+		diskSizeInMb {
 		err = fmt.Errorf("wrong disk size provisioned")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
@@ -278,23 +308,27 @@ func testHelperForCreateFileVolumeWithNoDatastoreURLInSCWithStoragePolicy(f *fra
 
 	// Verify if VolumeID is created on the VSAN datastores
 	gomega.Expect(strings.HasPrefix(queryResult.Volumes[0].DatastoreUrl, "ds:///vmfs/volumes/vsan:")).To(gomega.BeTrue(),
-		"Volume is not provisioned on vSan datastore. Instead volume is provisioned on %q", queryResult.Volumes[0].DatastoreUrl)
+		"Volume is not provisioned on vSan datastore. Instead volume is provisioned on %q",
+		queryResult.Volumes[0].DatastoreUrl)
 
 	if checkDatastoreBelongToDatacenter {
 		// Verify if VolumeID is created on the datastore from list of datacenters provided in vsphere.conf
-		gomega.Expect(isDatastoreBelongsToDatacenterSpecifiedInConfig(queryResult.Volumes[0].DatastoreUrl)).To(gomega.BeTrue(),
-			"Volume is not provisioned on the datastore specified on config file. Instead the volume is provisioned on : %q", queryResult.Volumes[0].DatastoreUrl)
+		gomega.Expect(isDatastoreBelongsToDatacenterSpecifiedInConfig(queryResult.Volumes[0].DatastoreUrl)).To(
+			gomega.BeTrue(), "Volume is not provisioned on the datastore specified on config file. "+
+				"Instead the volume is provisioned on : %q", queryResult.Volumes[0].DatastoreUrl)
 	}
 
 	// Verify the volume is provisioned using specified storage policy
 	storagePolicyID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 	gomega.Expect(storagePolicyID == queryResult.Volumes[0].StoragePolicyId).To(gomega.BeTrue(),
-		fmt.Sprintf("Storage policy verification failed. Actual storage policy: %q does not match with the Expected storage policy: %q", queryResult.Volumes[0].StoragePolicyId, storagePolicyID))
+		fmt.Sprintf("Storage policy verification failed. Actual storage policy: %q does not match "+
+			"with the Expected storage policy: %q", queryResult.Volumes[0].StoragePolicyId, storagePolicyID))
 
 }
 
-func createFileVolumeWithStoragePolicyAndTargetvSANFileShareDatastoreURLs(f *framework.Framework, client clientset.Interface,
-	namespace string, accessMode v1.PersistentVolumeAccessMode, storagePolicyName string, datastoreURL string) {
+func createFileVolumeWithStoragePolicyAndTargetvSANFileShareDatastoreURLs(f *framework.Framework,
+	client clientset.Interface, namespace string, accessMode v1.PersistentVolumeAccessMode,
+	storagePolicyName string, datastoreURL string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	var storageclass *storagev1.StorageClass
@@ -310,8 +344,10 @@ func createFileVolumeWithStoragePolicyAndTargetvSANFileShareDatastoreURLs(f *fra
 		scParameters[scParamDatastoreURL] = datastoreURL
 	}
 	// Create Storage class and PVC
-	ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q, storage policy %q and fstype %q", accessMode, storagePolicyName, nfs4FSType))
-	storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "", false, accessMode)
+	ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q, storage policy %q and fstype %q",
+		accessMode, storagePolicyName, nfs4FSType))
+	storageclass, pvclaim, err = createPVCAndStorageClass(client,
+		namespace, nil, scParameters, "", nil, "", false, accessMode)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	defer func() {
 		err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
@@ -340,7 +376,8 @@ func createFileVolumeWithStoragePolicyAndTargetvSANFileShareDatastoreURLs(f *fra
 
 	targetQueryVolume := queryResult.Volumes[0]
 	ginkgo.By(fmt.Sprintf("volume Name: %q capacity: %d volumeType: %q health: %q storagePolicy: %q",
-		targetQueryVolume.Name, targetQueryVolume.BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb,
+		targetQueryVolume.Name,
+		targetQueryVolume.BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb,
 		targetQueryVolume.VolumeType, targetQueryVolume.HealthStatus, targetQueryVolume.StoragePolicyId))
 
 	ginkgo.By("Verifying disk size specified in PVC is honored")
@@ -360,24 +397,29 @@ func createFileVolumeWithStoragePolicyAndTargetvSANFileShareDatastoreURLs(f *fra
 
 	// Verify if VolumeID is created on VSAN datastores
 	gomega.Expect(strings.HasPrefix(targetQueryVolume.DatastoreUrl, "ds:///vmfs/volumes/vsan:")).To(gomega.BeTrue(),
-		"Volume is not provisioned on vSan datastore. Instead volume is provisioned on %q", queryResult.Volumes[0].DatastoreUrl)
+		"Volume is not provisioned on vSan datastore. Instead volume is provisioned on %q",
+		queryResult.Volumes[0].DatastoreUrl)
 
 	if datastoreURL != "" {
 		// Verify if VolumeID is created in the datastore mentioned in the Storage class params
 		if targetQueryVolume.DatastoreUrl != datastoreURL {
-			err = fmt.Errorf("volume provisioned on datastoreURL %q which is not the datatore mentioned in the storage class", targetQueryVolume.DatastoreUrl)
+			err = fmt.Errorf("volume provisioned on datastoreURL %q which is not the datatore "+
+				"mentioned in the storage class", targetQueryVolume.DatastoreUrl)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 	}
 
-	// Verify if VolumeID is created in one of the datastores listed in TargetvSANFileShareDatastoreURLs provided in vsphere.conf
-	errorMsg := fmt.Sprintf("Volume is provisioned on %q which does not match any of the datastores specified in TargetvSANFileShareDatastoreURLs in the vSphere config file",
+	// Verify if VolumeID is created in one of the datastores listed in
+	// TargetvSANFileShareDatastoreURLs provided in vsphere.conf.
+	errorMsg := fmt.Sprintf("Volume is provisioned on %q which does not match any of the datastores "+
+		"specified in TargetvSANFileShareDatastoreURLs in the vSphere config file",
 		targetQueryVolume.DatastoreUrl)
-	gomega.Expect(isDatastorePresentinTargetvSANFileShareDatastoreURLs(targetQueryVolume.DatastoreUrl)).To(gomega.BeTrue(), errorMsg)
+	gomega.Expect(isDatastorePresentinTargetvSANFileShareDatastoreURLs(targetQueryVolume.DatastoreUrl)).To(
+		gomega.BeTrue(), errorMsg)
 
 	// Verify the volume is provisioned using specified storage policy
 	storagePolicyID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 	gomega.Expect(storagePolicyID == queryResult.Volumes[0].StoragePolicyId).To(gomega.BeTrue(),
-		fmt.Sprintf("Storage policy verification failed. Actual storage policy: %q does not match with the Expected storage policy: %q",
-			queryResult.Volumes[0].StoragePolicyId, storagePolicyID))
+		fmt.Sprintf("Storage policy verification failed. Actual storage policy: %q does not match "+
+			"with the Expected storage policy: %q", queryResult.Volumes[0].StoragePolicyId, storagePolicyID))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles vsphere_file_volume_storagepolicy. I left the long comments untouched for future changes.

**Testing done**:
Local build, check.