### PR TITLE
Clean up white spaces in volume_health_test

### DIFF
--- a/tests/e2e/volume_health_test.go
+++ b/tests/e2e/volume_health_test.go
@@ -104,7 +104,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
 			err := invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again", vsanHealthServiceWaitTime))
+			ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again",
+				vsanHealthServiceWaitTime))
 			time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 		}
 		if isSPSserviceStopped {
@@ -121,19 +122,18 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		waitForAllHostsToBeUp(ctx, &e2eVSphere)
 	})
 
-	/*
-		Test to verify health annotation status is accessible on the pvc .
-		(Combined test for TC1 and TC2)
-		Steps
-			1.	Create a Storage Class
-			2.	Create a PVC using above SC
-			3.	Wait for PVC to be in Bound phase
-			4.	Verify health annotation is added on the PVC is accessible
-			5.	Wait for the CNS health api to be called again (No changes made to PV/PVC, expecting it to be accessible)
-			6.	Delete PVC
-			7.	Verify PV entry is deleted from CNS
-			8.	Delete the SC
-	*/
+	// Test to verify health annotation status is accessible on the pvc.
+	// (Combined test for TC1 and TC2)
+	// Steps:
+	//    1.	Create a Storage Class.
+	//    2.	Create a PVC using above SC.
+	//    3.	Wait for PVC to be in Bound phase.
+	//    4.	Verify health annotation is added on the PVC is accessible.
+	//    5.	Wait for the CNS health api to be called again (No changes made to
+	//       PV/PVC, expecting it to be accessible).
+	//    6.	Delete PVC.
+	//    7.	Verify PV entry is deleted from CNS.
+	//    8.	Delete the SC.
 
 	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation added on the pvc is accessible", func() {
 
@@ -146,18 +146,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		defer cancel()
 
 		ginkgo.By("Invoking Test for validating health status")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, storagePolicyName)
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
 		} else if guestCluster {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = storagePolicyName
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -167,7 +169,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By("Expect claim to provision volume successfully")
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume")
 
 		pvclaims = append(pvclaims, pvclaim)
@@ -177,7 +180,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
 		svPVCName := volHandle
 		if guestCluster {
-			// svcPVCName refers to PVC Name in the supervisor cluster
+			// svcPVCName refers to PVC Name in the supervisor cluster.
 			svcPVCName := volHandle
 			volHandle = getVolumeIDFromSupervisorCluster(svcPVCName)
 		}
@@ -192,19 +195,22 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		for counter := 0; counter < 2; counter++ {
-			ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+			ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+				healthStatusWaitTime))
 			time.Sleep(healthStatusWaitTime)
 
 			ginkgo.By("Expect health status of the pvc to be accessible")
-			pvc, err := client.CoreV1().PersistentVolumeClaims(pvclaim.Namespace).Get(ctx, pvclaim.Name, metav1.GetOptions{})
+			pvc, err := client.CoreV1().PersistentVolumeClaims(pvclaim.Namespace).Get(ctx,
+				pvclaim.Name, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 			if guestCluster {
-				//verifying svc pvc health status
+				// Verifying svc pvc health status.
 				ginkgo.By("Expect health annotation is added on the SV pvc")
 				svPVC := getPVCFromSupervisorCluster(svPVCName)
-				gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
+				gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(
+					gomega.BeEquivalentTo(healthStatusAccessible))
 			}
 
 		}
@@ -224,19 +230,19 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 	})
 
-	/*
-		Test to verify health annotation status is not added on the pvc which is on pending state .
+	// Test to verify health annotation status is not added on the pvc which
+	// is on pending state.
+	//
+	// Steps
+	// 1.	Create a Storage Class with non shared datastore.
+	// 2.	Create a PVC using above SC.
+	// 3.	PVC will be created and it will be in pending state.
+	// 4.	Verify health annotation is not added on the PVC.
+	// 5.	Delete PVC.
+	// 7.	Delete the SC.
 
-		Steps
-		1.	Create a Storage Class with non shared datastore
-		2.	Create a PVC using above SC
-		3.	PVC will be created and it will be in pending state
-		4.	Verify health annotation is not added on the PVC
-		5.	Delete PVC
-		7.	Delete the SC
-	*/
-
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is not added on the pvc which is on pending state", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] "+
+		"Verify health annotation is not added on the pvc which is on pending state", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		nonShareadstoragePolicyName := GetAndExpectStringEnvVar(envStoragePolicyNameForNonSharedDatastores)
@@ -244,18 +250,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var pvclaim *v1.PersistentVolumeClaim
 		var err error
 		ginkgo.By("Invoking Test for validating health annotation is not added to PVC on Pending state")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(nonShareadstoragePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, nonShareadstoragePolicyName)
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", nonShareadstoragePolicyName)
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "", nonShareadstoragePolicyName)
 		} else if guestCluster {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = nonShareadstoragePolicyName
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -264,7 +272,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		ginkgo.By("Verify health status annotation is not added to the pvc in pending state")
@@ -283,23 +292,22 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 	})
 
-	/*
-		Validate the health status is updated from "unknown" status to accessible .
+	// Validate the health status is updated from "unknown" status to accessible.
+	//
+	// Steps
+	// 1. Create a Storage Class.
+	// 2. Create a PVC using above SC.
+	// 3. Wait for PVC to be in Bound phase.
+	// 4. Bring vSAN-health down.
+	// 5. Verify no health annotation is added on the PVC.
+	// 6. Bring vSAN-health up.
+	// 7. Verify health annotation which is added on the PVC is accessible.
+	// 8. Delete PVC.
+	// 9. Verify PV entry is deleted from CNS.
+	// 10. Delete the SC.
 
-		Steps
-		1. Create a Storage Class
-		2. Create a PVC using above SC
-		3. Wait for PVC to be in Bound phase
-		4. Bring vSAN-health down
-		5. Verify no health annotation is added on the PVC
-		6. Bring vSAN-health up
-		7. Verify health annotation which is added on the PVC is accessible
-		8. Delete PVC
-		9. Verify PV entry is deleted from CNS
-		10. Delete the SC
-	*/
-
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is updated from unknown status to accessible", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] "+
+		"Verify health annotation is updated from unknown status to accessible", func() {
 		var storageclass *storagev1.StorageClass
 		var pvclaim *v1.PersistentVolumeClaim
 		var err error
@@ -308,18 +316,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		log := logger.GetLogger(ctx)
 		defer cancel()
 		ginkgo.By("Invoking Test for validating health status")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, storagePolicyName)
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
 		} else if guestCluster {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = storagePolicyName
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client,
+				namespace, nil, scParameters, diskSize, nil, "", false, "")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -329,7 +339,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By("Expect claim to provision volume successfully")
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionShortTimeout)
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionShortTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume")
 
 		pvclaims = append(pvclaims, pvclaim)
@@ -339,7 +350,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
 		svPVCName := volHandle
 		if guestCluster {
-			// svcPVCName refers to PVC Name in the supervisor cluster
+			// svcPVCName refers to PVC Name in the supervisor cluster.
 			svcPVCName := volHandle
 			volHandle = getVolumeIDFromSupervisorCluster(svcPVCName)
 		}
@@ -350,10 +361,12 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown", vsanHealthServiceWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",
+			vsanHealthServiceWaitTime))
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		ginkgo.By("Expect health annotation is not added on the pvc")
@@ -379,7 +392,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 		isVsanhealthServiceStopped = false
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		ginkgo.By("Expect health annotation is added on the pvc and its accessible")
@@ -388,7 +402,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// Verifying svc pvc health status.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -422,24 +436,24 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	/*
-		Validate the health status is not updated to "unknown" status from accessible
+	// Validate the health status is not updated to "unknown" status from
+	// accessible.
+	//
+	// Steps
+	// 1. Create a Storage Class.
+	// 2. Create a PVC using above SC.
+	// 3. Wait for PVC to be in Bound phase.
+	// 4. Verify health annotation which is added on the PVC is accessible.
+	// 5. Bring VSAN down.
+	// 6. Verify the health annotation of the PVC remains accessible.
+	// 7. Bring VSAN up.
+	// 8. Verify health annotation which is added on the PVC is accessible.
+	// 9. Delete PVC.
+	// 10. Verify PV entry is deleted from CNS.
+	// 11. Delete the SC.
 
-		Steps
-		1. Create a Storage Class
-		2. Create a PVC using above SC
-		3. Wait for PVC to be in Bound phase
-		4. Verify health annotation which is added on the PVC is accessible
-		5. Bring VSAN down
-		6. Verify the health annotation of the PVC remains accessible
-		7. Bring VSAN up
-		8. Verify health annotation which is added on the PVC is accessible
-		9. Delete PVC
-		10. Verify PV entry is deleted from CNS
-		11. Delete the SC
-	*/
-
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is not updated to unknown status from accessible", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] "+
+		"Verify health annotation is not updated to unknown status from accessible", func() {
 		var storageclass *storagev1.StorageClass
 		var pvclaim *v1.PersistentVolumeClaim
 		var err error
@@ -448,18 +462,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		log := logger.GetLogger(ctx)
 		defer cancel()
 		ginkgo.By("Invoking Test for validating health status")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, storagePolicyName)
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
 		} else if guestCluster {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = storagePolicyName
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -469,7 +485,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By("Expect claim to provision volume successfully")
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume")
 
 		pvclaims = append(pvclaims, pvclaim)
@@ -479,13 +496,14 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
 		svPVCName := volHandle
 		if guestCluster {
-			// svcPVCName refers to PVC Name in the supervisor cluster
+			// svcPVCName refers to PVC Name in the supervisor cluster.
 			svcPVCName := volHandle
 			volHandle = getVolumeIDFromSupervisorCluster(svcPVCName)
 		}
 		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		ginkgo.By("Expect health annotation is added on the pvc and its accessible")
@@ -494,7 +512,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// Verifying svc pvc health status.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -514,10 +532,12 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		isVsanhealthServiceStopped = true
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown", vsanHealthServiceWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",
+			vsanHealthServiceWaitTime))
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		ginkgo.By("Expect health annotation is added on the pvc and its accessible after the vsan health is down")
@@ -526,7 +546,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// Verifying svc pvc health status.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -539,7 +559,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 		isVsanhealthServiceStopped = false
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		ginkgo.By("Expect health annotation is added on the pvc and its accessible")
@@ -563,21 +584,19 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}
 	})
 
-	/*
-		Validate the health status is not updated when SPS is down .
-
-		Steps
-		1. Create a Storage Class
-		2. Create a PVC using above SC
-		3. Wait for PVC to be in Bound phase
-		4. Bring SPS down
-		5. Verify no annotation is added on the PVC
-		6. Bring SPS up
-		7. Verify annotation is added on the PVC is accessible
-		8. Delete PVC
-		9. Verify PV entry is deleted from CNS
-		10. Delete the SC
-	*/
+	// Validate the health status is not updated when SPS is down.
+	//
+	// Steps
+	// 1. Create a Storage Class.
+	// 2. Create a PVC using above SC.
+	// 3. Wait for PVC to be in Bound phase.
+	// 4. Bring SPS down.
+	// 5. Verify no annotation is added on the PVC.
+	// 6. Bring SPS up.
+	// 7. Verify annotation is added on the PVC is accessible.
+	// 8. Delete PVC.
+	// 9. Verify PV entry is deleted from CNS.
+	// 10. Delete the SC.
 
 	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is not updated when SPS is down", func() {
 		var storageclass *storagev1.StorageClass
@@ -588,18 +607,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		log := logger.GetLogger(ctx)
 		defer cancel()
 		ginkgo.By("Invoking Test for validating health status")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, storagePolicyName)
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
 		} else if guestCluster {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = storagePolicyName
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -609,7 +630,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By("Expect claim to provision volume successfully")
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume")
 
 		pvclaims = append(pvclaims, pvclaim)
@@ -620,7 +642,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		svPVCName := volHandle
 
 		if guestCluster {
-			// svcPVCName refers to PVC Name in the supervisor cluster
+			// svcPVCName refers to PVC Name in the supervisor cluster.
 			svcPVCName := volHandle
 			volHandle = getVolumeIDFromSupervisorCluster(svcPVCName)
 		}
@@ -634,7 +656,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow sps to completely shutdown", vsanHealthServiceWaitTime))
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		ginkgo.By("Expect health annotation is not added on the pvc")
@@ -660,7 +683,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 		isSPSserviceStopped = false
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		ginkgo.By("Expect health annotation is added on the pvc and its accessible")
@@ -669,7 +693,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// Verifying svc pvc health status.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -698,21 +722,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 	})
 
-	/*
-		Verify changing the annotated values on the PVC to random value
-
-		Steps
-		1. Create a Storage Class
-		2.	Create a PVC using above SC
-		3.	Wait for PVC to be in Bound phase
-		4.	Verify annotation added on the PVC in accessible
-		5.	Kubectl edit on the annotation of the PVC and change the annotation to inaccessible state
-		6.	Wait for the default time interval
-		7.	Verify health annotation is added on the PVC is accessible
-		8.	Delete PVC
-		9.	Verify PV entry is deleted from CNS
-		10.	Delete the SC
-	*/
+	// Verify changing the annotated values on the PVC to random value.
+	//
+	// Steps
+	// 1. Create a Storage Class.
+	// 2.	Create a PVC using above SC.
+	// 3.	Wait for PVC to be in Bound phase.
+	// 4.	Verify annotation added on the PVC in accessible.
+	// 5.	Kubectl edit on the annotation of the PVC and change the annotation
+	//    to inaccessible state.
+	// 6.	Wait for the default time interval.
+	// 7.	Verify health annotation is added on the PVC is accessible.
+	// 8.	Delete PVC.
+	// 9.	Verify PV entry is deleted from CNS.
+	// 10. Delete the SC.
 
 	ginkgo.It("[csi-supervisor] Verify changing the annotated values on the PVC to random value", func() {
 		var storageclass *storagev1.StorageClass
@@ -723,18 +746,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		log := logger.GetLogger(ctx)
 		defer cancel()
 		ginkgo.By("Invoking Test for validating health status")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, storagePolicyName)
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
 		} else if guestCluster {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = storagePolicyName
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -744,7 +769,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By("Expect claim to provision volume successfully")
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume")
 
 		pvclaims = append(pvclaims, pvclaim)
@@ -753,12 +779,13 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
 		if guestCluster {
-			// svcPVCName refers to PVC Name in the supervisor cluster
+			// svcPVCName refers to PVC Name in the supervisor cluster.
 			svcPVCName := volHandle
 			volHandle = getVolumeIDFromSupervisorCluster(svcPVCName)
 		}
 		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		ginkgo.By("Expect health status of the pvc to be accessible")
@@ -778,7 +805,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusInAccessible))
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		pvc, err = client.CoreV1().PersistentVolumeClaims(pvclaim.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
@@ -796,7 +824,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo("vmware"))
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 		ginkgo.By("Verify if health status of the pvc is changed to accessible")
 		pvc, err = client.CoreV1().PersistentVolumeClaims(pvclaim.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
@@ -823,31 +852,28 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}
 	})
 
-	/*
-		Verify health annotation is added on the volume created by statefulset
-
-		steps
-		1. Create a storage class.
-		2. Create nginx service.
-		3. Create nginx statefulset
-		4. Wait until all Pods are ready and PVCs are bounded with PV.
-		5. Verify health annotation added on the PVC is accessible
-		6. Delete the pod(make the replicas to 0)
-		7. Delete PVC from the tests namespace
-		8. Delete the storage class.
-
-	*/
+	// Verify health annotation is added on the volume created by statefulset.
+	//
+	// Steps
+	// 1. Create a storage class.
+	// 2. Create nginx service.
+	// 3. Create nginx statefulset.
+	// 4. Wait until all Pods are ready and PVCs are bounded with PV.
+	// 5. Verify health annotation added on the PVC is accessible.
+	// 6. Delete the pod(make the replicas to 0).
+	// 7. Delete PVC from the tests namespace.
+	// 8. Delete the storage class.
 
 	ginkgo.It("[csi-supervisor] Verify Volume health on Statefulset", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, storageclassname)
 		}
 
@@ -868,31 +894,37 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		ginkgo.By("Creating statefulset")
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
-		// Waiting for pods status to be Ready
+		// Waiting for pods status to be Ready.
 		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
 		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
 		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
-		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(), fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
-		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(), "Number of Pods in the statefulset should match with number of replicas")
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
 
-		// Verify the health status is accessible on the volume created
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		// Verify the health status is accessible on the volume created.
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
-		// Get the list of Volumes attached to Pods before scale dow
+		// Get the list of Volumes attached to Pods before scale dow.
 		for _, sspod := range ssPodsBeforeScaleDown.Items {
 			// _, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
 			// gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			for _, volumespec := range sspod.Spec.Volumes {
 				if volumespec.PersistentVolumeClaim != nil {
 					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
-					// Verify the attached volume match the one in CNS cache
-					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle, volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					// Verify the attached volume match the one in CNS cache.
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					ginkgo.By("Expect health status of the pvc to be accessible")
-					pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, volumespec.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+					pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
+						volumespec.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
+					gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(
+						gomega.BeEquivalentTo(healthStatusAccessible))
 				}
 			}
 		}
@@ -903,18 +935,16 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 	})
 
-	/*
-		Verify health annotaiton is not added on the PV
-
-		Steps
-		1. Create a Storage Class
-		2. Create a PVC using above SC
-		3. Wait for PVC to be in Bound phase
-		4. Verify health annotation is not added on the PV
-		5. Delete PVC
-		6. Verify PV entry is deleted from CNS
-		7. Delete the SC
-	*/
+	// Verify health annotaiton is not added on the PV.
+	//
+	// Steps
+	// 1. Create a Storage Class.
+	// 2. Create a PVC using above SC.
+	// 3. Wait for PVC to be in Bound phase.
+	// 4. Verify health annotation is not added on the PV.
+	// 5. Delete PVC.
+	// 6. Verify PV entry is deleted from CNS.
+	// 7. Delete the SC.
 
 	ginkgo.It("[csi-supervisor] Verify health annotaiton is not added on the PV ", func() {
 		var storageclass *storagev1.StorageClass
@@ -925,14 +955,15 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		log := logger.GetLogger(ctx)
 		defer cancel()
 		ginkgo.By("Invoking Test for validating health status")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, storagePolicyName)
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -942,7 +973,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By("Expect volume to be provisioned successfully")
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name,
+			framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume")
 
 		pvclaims = append(pvclaims, pvclaim)
@@ -952,7 +984,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
 
 		ginkgo.By("Verify health annotation is not added on PV")
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 		pv, err := client.CoreV1().PersistentVolumes().Get(ctx, persistentvolumes[0].Name, metav1.GetOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -983,21 +1016,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 	})
 
-	/*
-		Verify removing the health annotation on the PVC
-
-		Steps
-		1. Create a Storage Class
-		2. Create a PVC using above SC
-		3. Wait for PVC to be in Bound phase
-		4. Verify annotation added on the PVC in accessible
-		5. Kubectl edit on the annotation of the PVC and remove the entire health annotation
-		6. Wait for the default time interval
-		7. Verify health annotation is added on the PVC is accessible
-		8. Delete PVC
-		9. Verify PV entry is deleted from CNS
-		10. Delete the SC
-	*/
+	// Verify removing the health annotation on the PVC.
+	//
+	// Steps
+	// 1. Create a Storage Class.
+	// 2. Create a PVC using above SC.
+	// 3. Wait for PVC to be in Bound phase.
+	// 4. Verify annotation added on the PVC in accessible.
+	// 5. Kubectl edit on the annotation of the PVC and remove the entire health
+	//    annotation.
+	// 6. Wait for the default time interval.
+	// 7. Verify health annotation is added on the PVC is accessible.
+	// 8. Delete PVC.
+	// 9. Verify PV entry is deleted from CNS.
+	// 10. Delete the SC.
 	ginkgo.It("[csi-supervisor] Verify removing the health annotation on the PVC", func() {
 		var storageclass *storagev1.StorageClass
 		var pvclaim *v1.PersistentVolumeClaim
@@ -1011,9 +1043,10 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		ginkgo.By("CNS_TEST: Running for WCP setup")
 		profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 		scParameters[scParamStoragePolicyID] = profileID
-		// create resource quota
+		// Create resource quota.
 		createResourceQuota(client, namespace, rqLimit, storagePolicyName)
-		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
+		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+			nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
@@ -1022,7 +1055,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By("Expect volume to be provisioned successfully")
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name,
+			framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume")
 
 		pvclaims = append(pvclaims, pvclaim)
@@ -1032,7 +1066,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
 		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		ginkgo.By("Expect health status of the pvc to be accessible")
@@ -1056,7 +1091,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			gomega.Expect(describe).ShouldNot(gomega.BeEquivalentTo(volumeHealthAnnotation))
 		}
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		ginkgo.By("Expect health status of the pvc to be accessible")
@@ -1085,19 +1121,16 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 	})
 
-	/*
-		Verify health annotation is added on the volume created by statefulset
-
-		1. Create a storage class.
-		2. Create nginx service.
-		3. Create nginx statefulset
-		4. Wait until all Pods are ready and PVCs are bounded with PV.
-		5. Verify health annotation added on the PVC is accessible
-		6. Delete the pod
-		7. Delete PVC from the tests namespace
-		8. Delete the storage class.
-
-	*/
+	// Verify health annotation is added on the volume created by statefulset.
+	//
+	// 1. Create a storage class.
+	// 2. Create nginx service.
+	// 3. Create nginx statefulset.
+	// 4. Wait until all Pods are ready and PVCs are bounded with PV.
+	// 5. Verify health annotation added on the PVC is accessible.
+	// 6. Delete the pod.
+	// 7. Delete PVC from the tests namespace.
+	// 8. Delete the storage class.
 
 	ginkgo.It("[csi-guest] In Guest Cluster Verify Volume health on Statefulset", func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1122,18 +1155,21 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 
-		// Waiting for pods status to be Ready
+		// Waiting for pods status to be Ready.
 		ginkgo.By("Wait for all Pods are Running state")
 		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
 		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
 		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
-		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(), fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
-		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(), "Number of Pods in the statefulset should match with number of replicas")
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
-		// Get the list of Volumes attached to Pods before scale down
+		// Get the list of Volumes attached to Pods before scale down.
 		for _, sspod := range ssPodsBeforeScaleDown.Items {
 			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1142,25 +1178,30 @@ var _ = ginkgo.Describe("Volume health check", func() {
 					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
 					ginkgo.By("Verify CnsNodeVmAttachment CRD is created")
 					volumeID := pv.Spec.CSI.VolumeHandle
-					// svcPVCName refers to PVC Name in the supervisor cluster
+					// svcPVCName refers to PVC Name in the supervisor cluster.
 					svcPVCName := volumeID
 					volumeID = getVolumeIDFromSupervisorCluster(svcPVCName)
 					gomega.Expect(volumeID).NotTo(gomega.BeEmpty())
-					verifyCRDInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+svcPVCName, crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
+					verifyCRDInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+svcPVCName,
+						crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
 
-					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
 					var vmUUID string
 					vmUUID, err = getVMUUIDFromNodeName(sspod.Spec.NodeName)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volumeID, vmUUID)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Expect(isDiskAttached).To(gomega.BeTrue(), fmt.Sprintf("Volume is not attached to the node, %s", vmUUID))
+					gomega.Expect(isDiskAttached).To(gomega.BeTrue(),
+						fmt.Sprintf("Volume is not attached to the node, %s", vmUUID))
 
-					// Verify the health status is accessible on the volume created
+					// Verify the health status is accessible on the volume created.
 					ginkgo.By("Expect health status of the pvc to be accessible")
-					pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, volumespec.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+					pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
+						volumespec.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
+					gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(
+						gomega.BeEquivalentTo(healthStatusAccessible))
 				}
 			}
 		}
@@ -1171,22 +1212,21 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 	})
 
-	/*
-		Verify Volume health when GC CSI is down
-
-		1. Create a Storage Class
-		2. Create a GC PVC using above SC
-		3. Wait for PVC to be in Bound phase
-		4. Verify annotation in the GC PVC is accessible
-		5. Bring GC CSI controller down
-		6. Verify SV PVC and GC PVC have same health annotation
-		7. Bring GC CSI controller up
-		8. Verify the existing annotation in the GC PVC is not affected(remains accessible)
-		9. Verify SV PVC and GC PVC have same health annotation
-		10. Delete GC PVC
-		11. Verify PV entry is deleted from CNS
-		12. Delete the SC
-	*/
+	// Verify Volume health when GC CSI is down.
+	//
+	// 1. Create a Storage Class.
+	// 2. Create a GC PVC using above SC.
+	// 3. Wait for PVC to be in Bound phase.
+	// 4. Verify annotation in the GC PVC is accessible.
+	// 5. Bring GC CSI controller down.
+	// 6. Verify SV PVC and GC PVC have same health annotation.
+	// 7. Bring GC CSI controller up.
+	// 8. Verify the existing annotation in the GC PVC is not affected,
+	//    remaining accessible.
+	// 9. Verify SV PVC and GC PVC have same health annotation.
+	// 10. Delete GC PVC.
+	// 11. Verify PV entry is deleted from CNS.
+	// 12. Delete the SC.
 
 	ginkgo.It("[csi-guest] Verify Volume health when GC CSI is down", func() {
 
@@ -1210,12 +1250,13 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By(fmt.Sprintf("Waiting for claim %s to be in bound phase", pvc.Name))
-		pvs, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
+		pvs, err := fpv.WaitForPVClaimBoundPhase(client,
+			[]*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
 		pv := pvs[0]
 		volumeID := pv.Spec.CSI.VolumeHandle
-		//svPVCName refers to PVC Name in the supervisor cluster
+		// svPVCName refers to PVC Name in the supervisor cluster.
 		svPVCName := volumeID
 		volumeID = getVolumeIDFromSupervisorCluster(svPVCName)
 		gomega.Expect(volumeID).NotTo(gomega.BeEmpty())
@@ -1228,7 +1269,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 		ginkgo.By("Expect health status of the pvc to be accessible")
 		pvclaim, err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
@@ -1254,7 +1296,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			}
 		}()
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 		ginkgo.By("Expect health status of the pvc to be accessible")
 		pvclaim, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
@@ -1271,7 +1314,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		isControllerUP = true
 
 		ginkgo.By("Verify health status of GC PVC after GC csi is up")
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 		pvclaim, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1295,17 +1339,15 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 	})
 
-	/*
-		Verify Volume health after password rotation
-
-		1. Create StorageClass and PVC
-		2. Wait for PVC to be Bound
-		3. verify health annotation on PVC
-		4. Modify the password rotation time in storage user file to 0.
-		5. verify health annotation on PVC
-		6. Delete PVC
-		7. Delete Storage class
-	*/
+	// Verify Volume health after password rotation.
+	//
+	// 1. Create StorageClass and PVC.
+	// 2. Wait for PVC to be Bound.
+	// 3. verify health annotation on PVC.
+	// 4. Modify the password rotation time in storage user file to 0.
+	// 5. verify health annotation on PVC.
+	// 6. Delete PVC.
+	// 7. Delete Storage class.
 
 	ginkgo.It("[csi-supervisor] [csi-guest] Verify Volume health after password rotation", func() {
 		var sc *storagev1.StorageClass
@@ -1319,9 +1361,10 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, storagePolicyName)
-			sc, pvc, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
+			sc, pvc, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
 		} else if guestCluster {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = storagePolicyName
@@ -1335,14 +1378,15 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By(fmt.Sprintf("Waiting for claim %s to be in bound phase", pvc.Name))
-		pvs, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
+		pvs, err := fpv.WaitForPVClaimBoundPhase(client,
+			[]*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
 		pv := pvs[0]
 		volumeID := pv.Spec.CSI.VolumeHandle
 		svPVCName := volumeID
 		if guestCluster {
-			// svcPVCName refers to PVC Name in the supervisor cluster
+			// svcPVCName refers to PVC Name in the supervisor cluster.
 			svPVCName := volumeID
 			volumeID = getVolumeIDFromSupervisorCluster(svPVCName)
 		}
@@ -1357,7 +1401,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 		ginkgo.By("Expect health status of the pvc to be accessible")
 		pvclaim, err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
@@ -1365,7 +1410,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvclaim.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// Verifying svc pvc health status.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -1377,14 +1422,15 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify health annotation on the PVC after password rotation")
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 		pvclaim, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvclaim.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// Verifying svc pvc health status.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -1403,24 +1449,23 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}
 
 	})
-	/*
-		Verify Volume health when SV CSI is down
 
-		Create a Storage Class
-		Create a PVC using above SC
-		Wait for PVC to be in Bound phase
-		Verify health annotation which is added on the PVC is accessible
-		Bring CSI controller down
-		Bring down link between all the hosts and datastore
-		Existing PVC annotation should remain same
-		Bring CSI controller up
-		Verify health annotation which is added on the PVC is inaccessible
-		Restore link between all the hosts and datastore
-		Verify health annotation which is added on the PVC is accessible
-		Delete PVC
-		Verify PV entry is deleted from CNS
-		Delete the SC
-	*/
+	// Verify Volume health when SV CSI is down.
+	//
+	// Create a Storage Class.
+	// Create a PVC using above SC.
+	// Wait for PVC to be in Bound phase.
+	// Verify health annotation which is added on the PVC is accessible.
+	// Bring CSI controller down.
+	// Bring down link between all the hosts and datastore.
+	// Existing PVC annotation should remain same.
+	// Bring CSI controller up.
+	// Verify health annotation which is added on the PVC is inaccessible.
+	// Restore link between all the hosts and datastore.
+	// Verify health annotation which is added on the PVC is accessible.
+	// Delete PVC.
+	// Verify PV entry is deleted from CNS.
+	// Delete the SC.
 
 	ginkgo.It("[csi-supervisor] Verify Volume health when SVC CSI is down", func() {
 		var sc *storagev1.StorageClass
@@ -1438,9 +1483,10 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		ginkgo.By("CNS_TEST: Running for WCP setup")
 		profileID := e2eVSphere.GetSpbmPolicyID(raid0StoragePolicyName)
 		scParameters[scParamStoragePolicyID] = profileID
-		// create resource quota
+		// Create resource quota.
 		createResourceQuota(client, namespace, rqLimit, raid0StoragePolicyName)
-		sc, pvc, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", raid0StoragePolicyName)
+		sc, pvc, err = createPVCAndStorageClass(client, namespace,
+			nil, scParameters, diskSize, nil, "", false, "", raid0StoragePolicyName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
@@ -1449,7 +1495,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By(fmt.Sprintf("Waiting for claim %s to be in bound phase", pvc.Name))
-		pvs, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
+		pvs, err := fpv.WaitForPVClaimBoundPhase(client,
+			[]*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
 		volHandle := pvs[0].Spec.CSI.VolumeHandle
@@ -1537,24 +1584,25 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}
 	})
 
-	/*
-		Verify health annotation added on the pvc is changed from accessible to inaccessible
+	// Verify health annotation added on the pvc is changed from accessible to
+	// inaccessible.
+	//
+	// Steps
+	// 1. Create a Storage Class.
+	// 2. Create a PVC using above SC.
+	// 3. Wait for PVC to be in Bound phase.
+	// 4. Verify health annotation is added on the PVC is accessible.
+	// 5. Bring down link between all the hosts and datastore. (Health status
+	//    should return in-accessible status).
+	// 6. Verify health annotation on the PVC is updated to in-accessible.
+	// 7. Restore link between all the hosts and datastore.
+	// 8. Verify health annotation on the PVC is updated to accessible.
+	// 9. Delete PVC.
+	// 10.Verify PV entry is deleted from CNS.
+	// 11.Delete the SC.
 
-		Steps
-		1. Create a Storage Class
-		2. Create a PVC using above SC
-		3. Wait for PVC to be in Bound phase
-		4. Verify health annotation is added on the PVC is accessible
-		5. Bring down link between all the hosts and datastore. (Health status should return in-accessible status)
-		6. Verify health annotation on the PVC is updated to in-accessible
-		7. Restore link between all the hosts and datastore
-		8. Verify health annotation on the PVC is updated to accessible
-		9. Delete PVC
-		10.Verify PV entry is deleted from CNS
-		11.Delete the SC
-	*/
-
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation added on the pvc is changed from accessible to inaccessible", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] "+
+		"Verify health annotation added on the pvc is changed from accessible to inaccessible", func() {
 		var storageclass *storagev1.StorageClass
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
@@ -1569,18 +1617,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}
 
 		ginkgo.By("Invoking Test for validating health status")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(raid0StoragePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, raid0StoragePolicyName)
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", raid0StoragePolicyName)
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "", raid0StoragePolicyName)
 		} else if guestCluster {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = raid0StoragePolicyName
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1600,7 +1650,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			framework.Logf("volume name %v", pv.Name)
 		}
 		if guestCluster {
-			// svcPVCName refers to PVC Name in the supervisor cluster
+			// svcPVCName refers to PVC Name in the supervisor cluster.
 			svcPVCName := volHandle
 			volHandle = getVolumeIDFromSupervisorCluster(svcPVCName)
 			ginkgo.By("Get svcClient and svNamespace")
@@ -1620,13 +1670,13 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status also to be inaccessible
+			// Verifying svc pvc health status also to be inaccessible.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
 		}
 
-		//PSOD the host
+		// PSOD the host.
 		ginkgo.By("PSOD the host")
 		framework.Logf("pvName %v", pv.Name)
 		hostIP = psodHostWithPv(ctx, &e2eVSphere, pv.Name)
@@ -1646,10 +1696,11 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		if guestCluster {
-			//verifying svc pvc health status also to be inaccessible
+			// Verifying svc pvc health status also to be inaccessible.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
-			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusInAccessible))
+			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(
+				gomega.BeEquivalentTo(healthStatusInAccessible))
 		}
 
 		ginkgo.By("Expect health status of the pvc to be inaccessible")
@@ -1657,13 +1708,13 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusInAccessible))
 
-		//CNS should return the health status as red when its inaccessible
+		// CNS should return the health status as red when its inaccessible.
 		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
 		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volHandle)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(len(queryResult.Volumes) > 0)
 
-		//It checks the colour code returned by cns for pv
+		// It checks the colour code returned by cns for pv.
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red)")
 		for _, vol := range queryResult.Volumes {
 			log.Infof("Volume health status: %s", vol.HealthStatus)
@@ -1679,7 +1730,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			err = pvcHealthAnnotationWatcher(ctx, client, pvclaim, healthStatusAccessible)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			//verifying svc pvc health status
+			// Verifying svc pvc health status.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -1702,20 +1753,21 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}
 	})
 
-	/*
-		Verify health status of pvc after bringing SV API server down
-
-		Steps
-		1. Create a Storage Class
-		2. Create a PVC using above SC
-		3. Wait for PVC to be in Bound phase
-		4. Verify that the volume health is accessible.
-		5. Bring down the SV API server completely.
-		6. Bring down link between the host and the datastore to make volume health inaccessible.
-		7. CNS should return the health status when API server is down (health status should be inaccessible).
-		8. Bring up SV API server.
-		9. validate that volume health on PVC changes from inaccessible to accessible after default time interval.
-	*/
+	// Verify health status of pvc after bringing SV API server down.
+	//
+	// Steps
+	// 1. Create a Storage Class.
+	// 2. Create a PVC using above SC.
+	// 3. Wait for PVC to be in Bound phase.
+	// 4. Verify that the volume health is accessible.
+	// 5. Bring down the SV API server completely.
+	// 6. Bring down link between the host and the datastore to make volume
+	//    health inaccessible.
+	// 7. CNS should return the health status when API server is down (health
+	//    status should be inaccessible).
+	// 8. Bring up SV API server.
+	// 9. validate that volume health on PVC changes from inaccessible to
+	//    accessible after default time interval.
 
 	ginkgo.It("[csi-supervisor] Verify health status of pvc after bringing SV API server down", func() {
 		var storageclass *storagev1.StorageClass
@@ -1736,9 +1788,10 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		ginkgo.By("CNS_TEST: Running for WCP setup")
 		profileID := e2eVSphere.GetSpbmPolicyID(raid0StoragePolicyName)
 		scParameters[scParamStoragePolicyID] = profileID
-		// create resource quota
+		// Create resource quota.
 		createResourceQuota(client, namespace, rqLimit, raid0StoragePolicyName)
-		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", raid0StoragePolicyName)
+		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+			nil, scParameters, diskSize, nil, "", false, "", raid0StoragePolicyName)
 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1793,7 +1846,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			}
 		}()
 
-		//PSOD the host
+		// PSOD the host.
 		ginkgo.By("PSOD the host")
 		hostIP = psodHostWithPv(ctx, &e2eVSphere, pv.Name)
 
@@ -1813,25 +1866,24 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 	})
 
-	/*
-		Validate the health status is updated from "unknown" status to inaccessible .
+	// Validate the health status is updated from "unknown" status to inaccessible.
+	//
+	// Steps:
+	// Create a Storage Class.
+	// Create a PVC using above SC.
+	// Wait for PVC to be in Bound phase.
+	// Bring VSAN down.
+	// Verify no health annotation is added on the PVC.
+	// Bring VSAN up.
+	// Bring down link between all the hosts and datastore.
+	// Verify health annotation which is added on the PVC is inaccessible.
+	// Restore link between all the hosts and datastore.
+	// Delete PVCs.
+	// Verify PV entry is deleted from CNS.
+	// Delete the SC.
 
-		Steps
-		Create a Storage Class
-		Create a PVC using above SC
-		Wait for PVC to be in Bound phase
-		Bring VSAN down
-		Verify no health annotation is added on the PVC
-		Bring VSAN up
-		Bring down link between all the hosts and datastore.
-		Verify health annotation which is added on the PVC is inaccessible
-		Restore link between all the hosts and datastore.
-		Delete PVCs
-		Verify PV entry is deleted from CNS
-		Delete the SC
-	*/
-
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is updated from unknown status to inaccessible", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] "+
+		"Verify health annotation is updated from unknown status to inaccessible", func() {
 		var storageclass *storagev1.StorageClass
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
@@ -1844,18 +1896,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			ginkgo.Skip("Env RAID_0_STORAGE_POLICY is missing")
 		}
 		ginkgo.By("Invoking Test for validating health status")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(raid0StoragePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, raid0StoragePolicyName)
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", raid0StoragePolicyName)
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "", raid0StoragePolicyName)
 		} else if guestCluster {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = raid0StoragePolicyName
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1872,7 +1926,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		svPVCName := volHandle
 
 		if guestCluster {
-			// svcPVCName refers to PVC Name in the supervisor cluster
+			// svcPVCName refers to PVC Name in the supervisor cluster.
 			svcPVCName := volHandle
 			volHandle = getVolumeIDFromSupervisorCluster(svcPVCName)
 		}
@@ -1883,10 +1937,12 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		isVsanhealthServiceStopped = true
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown", vsanHealthServiceWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",
+			vsanHealthServiceWaitTime))
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 
-		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered", healthStatusWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes to allow volume health check to be triggered",
+			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
 		ginkgo.By("Expect health annotation is not added on the pvc")
@@ -1919,7 +1975,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 		isVsanhealthServiceStopped = false
 
-		//PSOD the host
+		// PSOD the host.
 		ginkgo.By("PSOD the host")
 		hostIP = psodHostWithPv(ctx, &e2eVSphere, pv.Name)
 
@@ -1944,10 +2000,11 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusInAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status also to be inaccessible
+			// Verifying svc pvc health status also to be inaccessible.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
-			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusInAccessible))
+			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(
+				gomega.BeEquivalentTo(healthStatusInAccessible))
 		}
 
 		ginkgo.By("poll for health status annotation")
@@ -1959,7 +2016,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			err = pvcHealthAnnotationWatcher(ctx, client, pvclaim, healthStatusAccessible)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			//verifying svc pvc health status
+			// Verifying svc pvc health status.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -1981,25 +2038,27 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 		}
 	})
-	/*
-		Bring the CSI controller down when there is change in health status
 
-		Create a Storage Class
-		Create a GC PVC using above SC
-		Wait for PVC to be in Bound phase
-		Verify health annotation format which is added on the SV PVC and GC PVC is accessible
-		Bring down link between all the hosts and datastore
-		Bring GC CSI down
-		Verify health annotation which is added on the GC PVC is not changed to inaccessible
-		Bring GC CSI controller Up
-		wait for healthStatusWaitTime to make sure the GC PVC is updated with the health annotation
-		Verify health annotation which is added on the SV PVC and GC PVC is changed to inaccessible
-		Restore link between all the hosts and datastore
-		Delete GC PVC
-		Verify PV entry is deleted from CNS
-		Delete the SC
-
-	*/
+	// Bring the CSI controller down when there is change in health status.
+	//
+	// 1. Create a Storage Class.
+	// 2. Create a GC PVC using above SC.
+	// 3. Wait for PVC to be in Bound phase.
+	// 4. Verify health annotation format which is added on the SV PVC and GC
+	//    PVC is accessible.
+	// 5. Bring down link between all the hosts and datastore.
+	// 6. Bring GC CSI down.
+	// 7. Verify health annotation which is added on the GC PVC is not changed
+	//    to inaccessible.
+	// 8. Bring GC CSI controller Up.
+	// 9. wait for healthStatusWaitTime to make sure the GC PVC is updated with
+	//    the health annotation.
+	// 10. Verify health annotation which is added on the SV PVC and GC PVC is
+	//     changed to inaccessible.
+	// 11. Restore link between all the hosts and datastore.
+	// 12. Delete GC PVC.
+	// 13. Verify PV entry is deleted from CNS.
+	// 14. Delete the SC.
 	ginkgo.It("[csi-guest] Verify Inaccesssible Volume health when GC CSI is down", func() {
 		var sc *storagev1.StorageClass
 		var err error
@@ -2024,12 +2083,13 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By(fmt.Sprintf("Waiting for claim %s to be in bound phase", pvc.Name))
-		pvs, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
+		pvs, err := fpv.WaitForPVClaimBoundPhase(client,
+			[]*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvs).NotTo(gomega.BeEmpty())
 		pv := pvs[0]
 		volumeID := pv.Spec.CSI.VolumeHandle
-		//svPVCName refers to PVC Name in the supervisor cluster
+		// svPVCName refers to PVC Name in the supervisor cluster.
 		svPVCName := volumeID
 		volumeID = getVolumeIDFromSupervisorCluster(svPVCName)
 		framework.Logf("volume ID from SVC %v", volumeID)
@@ -2073,14 +2133,14 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		bringDownCsiController(gcClient)
 		isControllerUP = false
 
-		//Get SV PVC before PSOD
+		// Get SV PVC before PSOD.
 		svPVC := getPVCFromSupervisorCluster(svPVCName)
 
-		//PSOD the host
+		// PSOD the host.
 		ginkgo.By("PSOD the host")
 		hostIP = psodHostWithPv(ctx, &e2eVSphere, svcPV.Name)
 
-		//Health status in gc pvc should be still accessible
+		// Health status in gc pvc should be still accessible.
 		ginkgo.By("Expect health status of the GC PVC to be accessible")
 		err = pvcHealthAnnotationWatcher(ctx, client, pvc, healthStatusAccessible)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2118,23 +2178,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}
 	})
 
-	/*
-		Verify health annotation is added on the volume created by statefulset
-
-		steps
-		Create a storage class.
-		Create nginx service.
-		Create nginx statefulset
-		Wait until all Pods are ready and PVCs are bounded with PV.
-		Verify health annotation added on the PVC is accessible
-		Bring down link between all the hosts and datastore.
-		Verify health annotation on the PVC is updated to inaccessible
-		Restore the link between all the hosts and datastore.
-		Delete the pod(make the replicas to 0)
-		Delete PVC from the tests namespace
-		Delete the storage class.
-
-	*/
+	// Verify health annotation is added on the volume created by statefulset.
+	//
+	// Steps
+	// Create a storage class.
+	// Create nginx service.
+	// Create nginx statefulset.
+	// Wait until all Pods are ready and PVCs are bounded with PV.
+	// Verify health annotation added on the PVC is accessible.
+	// Bring down link between all the hosts and datastore.
+	// Verify health annotation on the PVC is updated to inaccessible.
+	// Restore the link between all the hosts and datastore.
+	// Delete the pod(make the replicas to 0).
+	// Delete PVC from the tests namespace.
+	// Delete the storage class.
 
 	ginkgo.It("[csi-supervisor] [csi-guest] Verify Volume health Inaccessible on Statefulset", func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -2147,12 +2204,12 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}
 
 		ginkgo.By("Creating StorageClass for Statefulset")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(raid0StoragePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, storageclassname)
 			scSpec := getVSphereStorageClassSpec(storageclassname, scParameters, nil, "", "", false)
 			sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
@@ -2184,24 +2241,28 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		ginkgo.By("Creating statefulset")
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
-		// Waiting for pods status to be Ready
+		// Waiting for pods status to be Ready.
 		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
 		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
 		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
-		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(), fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
-		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(), "Number of Pods in the statefulset should match with number of replicas")
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
 
 		if supervisorCluster {
-			// Get the list of Volumes attached to Pods
+			// Get the list of Volumes attached to Pods.
 			for _, sspod := range ssPodsBeforeScaleDown.Items {
 				for _, volumespec := range sspod.Spec.Volumes {
 					if volumespec.PersistentVolumeClaim != nil {
 						pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
-						// Verify the attached volume match the one in CNS cache
-						err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle, volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+						// Verify the attached volume match the one in CNS cache.
+						err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+							volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						ginkgo.By("Expect health status of the pvc to be accessible")
-						pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, volumespec.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+						pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
+							volumespec.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						ginkgo.By("poll for health status annotation")
 						err = pvcHealthAnnotationWatcher(ctx, client, pvc, healthStatusAccessible)
@@ -2222,14 +2283,16 @@ var _ = ginkgo.Describe("Volume health check", func() {
 						pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
 						ginkgo.By("Verify CnsNodeVmAttachment CRD is created")
 						volumeID := pv.Spec.CSI.VolumeHandle
-						// svcPVCName refers to PVC Name in the supervisor cluster
+						// svcPVCName refers to PVC Name in the supervisor cluster.
 						svcPVCName := volumeID
 						volumeID = getVolumeIDFromSupervisorCluster(svcPVCName)
 						gomega.Expect(volumeID).NotTo(gomega.BeEmpty())
-						verifyCRDInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+svcPVCName, crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
+						verifyCRDInSupervisor(ctx, f, sspod.Spec.NodeName+"-"+svcPVCName,
+							crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
 
 						ginkgo.By("Expect health status of the pvc to be accessible")
-						pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, volumespec.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+						pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
+							volumespec.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 						ginkgo.By("poll for health status annotation")
@@ -2255,7 +2318,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			}
 		}
 
-		//PSOD the host
+		// PSOD the host.
 		ginkgo.By("PSOD the host")
 		framework.Logf("pv.Name %v", pvSVC.Name)
 		hostIP = psodHostWithPv(ctx, &e2eVSphere, pvSVC.Name)
@@ -2272,17 +2335,19 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		time.Sleep(svOperationTimeout)
 
 		ginkgo.By("Expect health status of a pvc to be inaccessible")
-		// Get the list of Volumes attached to Pods
+		// Get the list of Volumes attached to Pods.
 		for _, sspod := range ssPodsBeforeScaleDown.Items {
 			for _, volumespec := range sspod.Spec.Volumes {
 				if volumespec.PersistentVolumeClaim != nil {
 					if supervisorCluster {
 						pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
-						// Verify the attached volume match the one in CNS cache
-						err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle, volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+						// Verify the attached volume match the one in CNS cache.
+						err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+							volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					}
-					pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, volumespec.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+					pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
+						volumespec.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					if pvc.Annotations[volumeHealthAnnotation] == healthStatusInAccessible {
 						statusFlag = true
@@ -2312,20 +2377,22 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			}
 		}
 
-		//Expecting the status Flag to be true
+		// Expecting the status Flag to be true.
 		gomega.Expect(statusFlag).NotTo(gomega.BeFalse(), "Volume health status is not as expected")
 
 		if supervisorCluster {
-			// Get the list of Volumes attached to Pods
+			// Get the list of Volumes attached to Pods.
 			for _, sspod := range ssPodsBeforeScaleDown.Items {
 				for _, volumespec := range sspod.Spec.Volumes {
 					if volumespec.PersistentVolumeClaim != nil {
 						pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
-						// Verify the attached volume match the one in CNS cache
-						err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle, volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+						// Verify the attached volume match the one in CNS cache.
+						err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+							volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						ginkgo.By("Expect health status of the pvc to be accessible")
-						pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, volumespec.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+						pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
+							volumespec.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						ginkgo.By("poll for health status annotation")
 						err = pvcHealthAnnotationWatcher(ctx, client, pvc, healthStatusAccessible)
@@ -2337,25 +2404,25 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 	})
 
-	/*
-		Validate the health status is not updated to "unknown" status from inaccessible
+	// Validate the health status is not updated to "unknown" status from
+	// inaccessible.
+	//
+	// Steps
+	// Create a Storage Class.
+	// Create a PVC using above SC.
+	// Wait for PVC to be in Bound phase.
+	// Bring down link between all the hosts and datastore.
+	// Verify health annotation which is added on the PVC is inaccessible.
+	// Bring VSAN down.
+	// Verify the health annotation of the PVC remains inaccessible.
+	// Bring VSAN up.
+	// Restore link between all the hosts and datastore.
+	// Delete PVC.
+	// Verify PV entry is deleted from CNS.
+	// Delete the SC.
 
-		Steps
-		Create a Storage Class
-		Create a PVC using above SC
-		Wait for PVC to be in Bound phase
-		Bring down link between all the hosts and datastore.
-		Verify health annotation which is added on the PVC is inaccessible
-		Bring VSAN down
-		Verify the health annotation of the PVC remains inaccessible
-		Bring VSAN up
-		Restore link between all the hosts and datastore.
-		Delete PVC
-		Verify PV entry is deleted from CNS
-		Delete the SC
-	*/
-
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is not updated to unknown status from inaccessible", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] "+
+		"Verify health annotation is not updated to unknown status from inaccessible", func() {
 		var storageclass *storagev1.StorageClass
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
@@ -2367,18 +2434,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			ginkgo.Skip("Env RAID_0_STORAGE_POLICY is missing")
 		}
 		ginkgo.By("Invoking Test for validating health status")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(raid0StoragePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, raid0StoragePolicyName)
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", raid0StoragePolicyName)
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "", raid0StoragePolicyName)
 		} else if guestCluster {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = raid0StoragePolicyName
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -2396,7 +2465,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		pv := getPvFromClaim(client, namespace, pvclaim.Name)
 		framework.Logf("volume name %v", pv.Name)
 		if guestCluster {
-			// svcPVCName refers to PVC Name in the supervisor cluster
+			// svcPVCName refers to PVC Name in the supervisor cluster.
 			svcPVCName := volHandle
 			volHandle = getVolumeIDFromSupervisorCluster(svcPVCName)
 			svcClient, svNamespace := getSvcClientAndNamespace()
@@ -2405,7 +2474,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}
 		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
 
-		//PSOD the host
+		// PSOD the host.
 		ginkgo.By("PSOD the host")
 		hostIP = psodHostWithPv(ctx, &e2eVSphere, pv.Name)
 
@@ -2430,10 +2499,11 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusInAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// Verifying svc pvc health status.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
-			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusInAccessible))
+			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(
+				gomega.BeEquivalentTo(healthStatusInAccessible))
 		}
 
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
@@ -2449,7 +2519,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown", vsanHealthServiceWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",
+			vsanHealthServiceWaitTime))
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 
 		ginkgo.By("poll for health status annotation")
@@ -2462,10 +2533,11 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(pvc.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusInAccessible))
 
 		if guestCluster {
-			//verifying svc pvc health status
+			// Verifying svc pvc health status.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
-			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusInAccessible))
+			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(
+				gomega.BeEquivalentTo(healthStatusInAccessible))
 		}
 
 		ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
@@ -2484,7 +2556,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			err = pvcHealthAnnotationWatcher(ctx, client, pvclaim, healthStatusAccessible)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			//verifying svc pvc health status
+			// Verifying svc pvc health status.
 			ginkgo.By("Expect health annotation is added on the SV pvc")
 			svPVC := getPVCFromSupervisorCluster(svPVCName)
 			gomega.Expect(svPVC.Annotations[volumeHealthAnnotation]).Should(gomega.BeEquivalentTo(healthStatusAccessible))
@@ -2508,17 +2580,15 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}
 	})
 
-	/*
-		Verify pvc is not annotated with health status in block vanilla setup.
-		Steps
-		Create a Storage Class
-		Create a PVC using above SC
-		Wait for PVC to be in Bound phase
-		Verify health annotation is not added on the PVC
-		Delete PVC
-		Verify PV entry is deleted from CNS
-		Delete the SC
-	*/
+	// Verify pvc is not annotated with health status in block vanilla setup.
+	// Steps
+	// Create a Storage Class.
+	// Create a PVC using above SC.
+	// Wait for PVC to be in Bound phase.
+	// Verify health annotation is not added on the PVC.
+	// Delete PVC.
+	// Verify PV entry is deleted from CNS.
+	// Delete the SC.
 
 	ginkgo.It("[csi-block-vanilla] Verify pvc is not annotated with health status in vanilla setup", func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -2531,7 +2601,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
 		scParameters[scParamDatastoreURL] = datastoreURL
-		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+			nil, scParameters, diskSize, nil, "", false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
@@ -2573,17 +2644,15 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	/*
-		Verify pvc is not annotated with health status in file vanilla setup .
-		Steps
-		Create a Storage Class
-		Create a PVC using above SC
-		Wait for PVC to be in Bound phase
-		Verify health annotation is not added on the PVC
-		Delete PVC
-		Verify PV entry is deleted from CNS
-		Delete the SC
-	*/
+	// Verify pvc is not annotated with health status in file vanilla setup.
+	// Steps
+	// Create a Storage Class.
+	// Create a PVC using above SC.
+	// Wait for PVC to be in Bound phase.
+	// Verify health annotation is not added on the PVC.
+	// Delete PVC.
+	// Verify PV entry is deleted from CNS.
+	// Delete the SC.
 
 	ginkgo.It("[csi-file-vanilla] File Vanilla Verify pvc is not annotated with health status", func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -2591,20 +2660,21 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		scParameters := make(map[string]string)
 		scParameters[scParamFsType] = nfs4FSType
 		accessMode := v1.ReadWriteMany
-		// Create Storage class and PVC
+		// Create Storage class and PVC.
 		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q", accessMode, nfs4FSType))
 		var storageclass *storagev1.StorageClass
 		var pvclaim *v1.PersistentVolumeClaim
 		var err error
 
-		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "", false, accessMode)
+		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+			nil, scParameters, "", nil, "", false, accessMode)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		// Waiting for PVC to be bound
+		// Waiting for PVC to be bound.
 		var pvclaims []*v1.PersistentVolumeClaim
 		pvclaims = append(pvclaims, pvclaim)
 		ginkgo.By("Waiting for all claims to be in bound state")
@@ -2635,7 +2705,9 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(queryResult.Volumes).ShouldNot(gomega.BeEmpty())
 
-		ginkgo.By(fmt.Sprintf("volume Name:%s , capacity:%d volumeType:%s health:%s", queryResult.Volumes[0].Name, queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb, queryResult.Volumes[0].VolumeType, queryResult.Volumes[0].HealthStatus))
+		ginkgo.By(fmt.Sprintf("volume Name:%s , capacity:%d volumeType:%s health:%s", queryResult.Volumes[0].Name,
+			queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb,
+			queryResult.Volumes[0].VolumeType, queryResult.Volumes[0].HealthStatus))
 
 		ginkgo.By("Verifying volume type specified in PVC is honored")
 		if queryResult.Volumes[0].VolumeType != testVolumeType {
@@ -2644,18 +2716,17 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}
 
 	})
-	/*
-		Test to verify health annotation timestamp is added on the pvc .
-		Steps
-			1.	Create a Storage Class
-			2.	Create a PVC using above SC
-			3.	Wait for PVC to be in Bound phase
-			4.	Verify health annotation is added on the PVC
-			5.	Verify volume health timestamp is added on the PVC
-			6.	Delete PVC
-			7.	Verify PV entry is deleted from CNS
-			8.	Delete the SC
-	*/
+
+	// Test to verify health annotation timestamp is added on the pvc.
+	// Steps
+	//    1. Create a Storage Class.
+	//    2. Create a PVC using above SC.
+	//    3. Wait for PVC to be in Bound phase.
+	//    4. Verify health annotation is added on the PVC.
+	//    5. Verify volume health timestamp is added on the PVC.
+	//    6. Delete PVC.
+	//    7. Verify PV entry is deleted from CNS.
+	//    8. Delete the SC.
 
 	ginkgo.It("[csi-supervisor] [csi-guest] Verify health timestamp annotation is added on the pvc", func() {
 
@@ -2667,18 +2738,20 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		defer cancel()
 
 		ginkgo.By("Invoking Test for validating health status")
-		// decide which test setup is available to run
+		// Decide which test setup is available to run.
 		if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
-			// create resource quota
+			// Create resource quota.
 			createResourceQuota(client, namespace, rqLimit, storagePolicyName)
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
 		} else if guestCluster {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = storagePolicyName
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+				nil, scParameters, diskSize, nil, "", false, "")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -2688,7 +2761,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		}()
 
 		ginkgo.By("Expect claim to provision volume successfully")
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume")
 
 		pvclaims = append(pvclaims, pvclaim)
@@ -2698,7 +2772,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
 		svcPVCName = volHandle
 		if guestCluster {
-			// svcPVCName refers to PVC Name in the supervisor cluster
+			// svcPVCName refers to PVC Name in the supervisor cluster.
 			volHandle = getVolumeIDFromSupervisorCluster(svcPVCName)
 		}
 		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())

--- a/tests/e2e/volume_health_test.go
+++ b/tests/e2e/volume_health_test.go
@@ -726,15 +726,15 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	//
 	// Steps
 	// 1. Create a Storage Class.
-	// 2.	Create a PVC using above SC.
-	// 3.	Wait for PVC to be in Bound phase.
-	// 4.	Verify annotation added on the PVC in accessible.
-	// 5.	Kubectl edit on the annotation of the PVC and change the annotation
+	// 2. Create a PVC using above SC.
+	// 3. Wait for PVC to be in Bound phase.
+	// 4. Verify annotation added on the PVC in accessible.
+	// 5. Kubectl edit on the annotation of the PVC and change the annotation
 	//    to inaccessible state.
-	// 6.	Wait for the default time interval.
-	// 7.	Verify health annotation is added on the PVC is accessible.
-	// 8.	Delete PVC.
-	// 9.	Verify PV entry is deleted from CNS.
+	// 6. Wait for the default time interval.
+	// 7. Verify health annotation is added on the PVC is accessible.
+	// 8. Delete PVC.
+	// 9. Verify PV entry is deleted from CNS.
 	// 10. Delete the SC.
 
 	ginkgo.It("[csi-supervisor] Verify changing the annotated values on the PVC to random value", func() {
@@ -908,7 +908,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			healthStatusWaitTime))
 		time.Sleep(healthStatusWaitTime)
 
-		// Get the list of Volumes attached to Pods before scale dow.
+		// Get the list of Volumes attached to Pods before scale down.
 		for _, sspod := range ssPodsBeforeScaleDown.Items {
 			// _, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
 			// gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles volume_health_test.

**Testing done**:
Local build, check, test.