### PR TITLE
Clean up long lines in syncer_test

### DIFF
--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -384,7 +384,8 @@ func runTestMetadataSyncInformer(t *testing.T) {
 	newPVCLabel[testPVCLabelName] = testPVCLabelValue
 	pvcName = testPVCName + "-" + uuid.New().String()
 	pvc := getPersistentVolumeClaimSpec(pvcName, namespace, oldPVCLabel, pv.Name, "")
-	if pvc, err = k8sclient.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{}); err != nil {
+	if pvc, err = k8sclient.CoreV1().PersistentVolumeClaims(namespace).Create(
+		ctx, pvc, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -713,7 +714,8 @@ func runTestFullSyncWorkflows(t *testing.T) {
 	pvcLabel[testPVCLabelName] = testPVCLabelValue
 	pvcName := testPVCName + "-" + uuid.New().String()
 	pvc := getPersistentVolumeClaimSpec(pvcName, namespace, pvcLabel, pv.Name, "")
-	if pvc, err = k8sclient.CoreV1().PersistentVolumeClaims(testNamespace).Create(ctx, pvc, metav1.CreateOptions{}); err != nil {
+	if pvc, err = k8sclient.CoreV1().PersistentVolumeClaims(testNamespace).Create(
+		ctx, pvc, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -774,7 +776,8 @@ func runTestFullSyncWorkflows(t *testing.T) {
 	newPVCLabel := make(map[string]string)
 	newPVCLabel[testPVCLabelName] = newTestPVCLabelValue
 	pvc.Labels = newPVCLabel
-	if pvc, err = k8sclient.CoreV1().PersistentVolumeClaims(testNamespace).Update(ctx, pvc, metav1.UpdateOptions{}); err != nil {
+	if pvc, err = k8sclient.CoreV1().PersistentVolumeClaims(testNamespace).Update(
+		ctx, pvc, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	waitForListerSync()
@@ -818,7 +821,8 @@ func runTestFullSyncWorkflows(t *testing.T) {
 	if err = k8sclient.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0)); err != nil {
 		t.Fatal(err)
 	}
-	if err = k8sclient.CoreV1().PersistentVolumeClaims(testNamespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0)); err != nil {
+	if err = k8sclient.CoreV1().PersistentVolumeClaims(testNamespace).Delete(
+		ctx, pvc.Name, *metav1.NewDeleteOptions(0)); err != nil {
 		t.Fatal(err)
 	}
 	if err = k8sclient.CoreV1().Pods(testNamespace).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0)); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
We should make comments more readable, to document what is not trivial from the source code.
The comments are treated as English text (document), following its grammar. Sentences should
end with periods. In addition, I tried to make the text shorter than 80 columns.

Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles syncer_test.

**Testing done**:
Local build, check, test.