### PR TITLE
GC online volume resize set5

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1174,17 +1174,19 @@ func setResourceQuota(client clientset.Interface, namespace string, size string)
 	deleteResourceQuota(client, namespace)
 
 	existingResourceQuota, err := client.CoreV1().ResourceQuotas(namespace).Get(ctx, namespace, metav1.GetOptions{})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	framework.Logf("existingResourceQuota name %s", existingResourceQuota.GetName())
-	requestStorageQuota := updatedSpec4ExistingResourceQuota(existingResourceQuota.GetName(), size)
-	testResourceQuota, err := client.CoreV1().ResourceQuotas(namespace).Update(
-		ctx, requestStorageQuota, metav1.UpdateOptions{})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	ginkgo.By(fmt.Sprintf("ResourceQuota details: %+v", testResourceQuota))
-	// TODO: Add polling instead of static wait time and assert against the
-	// updated quota.
-	ginkgo.By(fmt.Sprintf("Sleeping for %v seconds", sleepTimeOut))
-	time.Sleep(sleepTimeOut * time.Second)
+	if !apierrors.IsNotFound(err) {
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		framework.Logf("existingResourceQuota name %s", existingResourceQuota.GetName())
+		requestStorageQuota := updatedSpec4ExistingResourceQuota(existingResourceQuota.GetName(), size)
+		testResourceQuota, err := client.CoreV1().ResourceQuotas(namespace).Update(
+			ctx, requestStorageQuota, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By(fmt.Sprintf("ResourceQuota details: %+v", testResourceQuota))
+		// TODO: Add polling instead of static wait time and assert against the
+		// updated quota.
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds", sleepTimeOut))
+		time.Sleep(sleepTimeOut * time.Second)
+	}
 
 }
 


### PR DESCRIPTION
What this PR does / why we need it: GC Online volume expansion 

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

Release notes:
Online volume expansion test cases for GC
Special notes for your reviewer:

1.online volume expansion-PV with reclaim policy retain can be resized when used in a fresh GC
2.Offline resize of PVC in GC1, Delete PVC and PV in GC1. Statically prov same PVC and PV in GC1 and deploy a Pod and trigget online volume expansion
3.verify Online block volume expansion succeeds when GC CSI pod is down when SVC PVC reaches FilesystemResizePending state and GC CSI comes up


Logs: https://gist.github.com/kavyashree-r/8cc82277ff595e67ceabca18e0948105
https://gist.github.com/kavyashree-r/65f4b9b5163578149ef8a45006aae09c