### PR TITLE
Fix panic in WCP Init due to cleanup interval

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -94,7 +94,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	if idempotencyHandlingEnabled {
 		log.Info("CSI Volume manager idempotency handling feature flag is enabled.")
 		operationStore, err = cnsvolumeoperationrequest.InitVolumeOperationRequestInterface(ctx,
-			c.manager.CnsConfig.Global.CnsVolumeOperationRequestCleanupIntervalInMin)
+			config.Global.CnsVolumeOperationRequestCleanupIntervalInMin)
 		if err != nil {
 			log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
 			return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR fixes a panic in WCP controller during Init due to the addition of cleanup interval variable introduced in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/951

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

CSI controller is running:

```
# kubectl get pod  -n vmware-system-csi -o wide
NAME                                      READY   STATUS    RESTARTS   AGE   IP           NODE                               NOMINATED NODE   READINESS GATES
vsphere-csi-controller-5446f66968-8zkmq   6/6     Running   0          44s   172.26.0.2   422d75bd9bc3b1c4a97c8e22d9c36775   <none>           <none>
```

Logs to show it gets passed the panic:
```
# kubectl logs vsphere-csi-controller-5446f66968-8zkmq -n vmware-system-csi -c vsphere-csi-controller
{"level":"info","time":"2021-07-17T15:26:03.448706398Z","caller":"logger/logger.go:41","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2021-07-17T15:26:03.498368842Z","caller":"vsphere-csi/main.go:57","msg":"Version : v2.1.0-rc.1-946-g76d5de6-dirty","TraceId":"868fbfc1-20b8-488c-9d3d-9a6b983973c9"}
{"level":"info","time":"2021-07-17T15:26:03.49865906Z","caller":"commonco/utils.go:40","msg":"Defaulting feature states configmap name to \"csi-feature-states\"","TraceId":"868fbfc1-20b8-488c-9d3d-9a6b983973c9"}
{"level":"info","time":"2021-07-17T15:26:03.498937691Z","caller":"commonco/utils.go:44","msg":"Defaulting feature states configmap namespace to \"vmware-system-csi\"","TraceId":"868fbfc1-20b8-488c-9d3d-9a6b983973c9"}
{"level":"info","time":"2021-07-17T15:26:03.566487875Z","caller":"logger/logger.go:41","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2021-07-17T15:26:03.566717424Z","caller":"k8sorchestrator/k8sorchestrator.go:152","msg":"Initializing k8sOrchestratorInstance","TraceId":"ffb499e3-35f1-4a3c-970c-39991b706bfc"}
{"level":"info","time":"2021-07-17T15:26:03.568542422Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config","TraceId":"ffb499e3-35f1-4a3c-970c-39991b706bfc"}
{"level":"info","time":"2021-07-17T15:26:03.583012057Z","caller":"kubernetes/kubernetes.go:341","msg":"Setting client QPS to 50.000000 and Burst to 50.","TraceId":"ffb499e3-35f1-4a3c-970c-39991b706bfc"}
{"level":"info","time":"2021-07-17T15:26:03.696406336Z","caller":"k8sorchestrator/k8sorchestrator.go:390","msg":"New supervisor feature states values stored successfully: map[async-query-volume:false block-volume-snapshot:false csi-auth-check:true csi-sv-feature-states-replication:true fake-attach:true file-volume:true improved-csi-idempotency:false online-volume-extend:true sibling-replica-bound-pvc-check:false trigger-csi-fullsync:false volume-extend:true volume-health:true vsan-direct-disk-decommission:true]","TraceId":"ffb499e3-35f1-4a3c-970c-39991b706bfc"}
{"level":"info","time":"2021-07-17T15:26:03.709054994Z","caller":"k8sorchestrator/k8sorchestrator.go:178","msg":"k8sOrchestratorInstance initialized","TraceId":"ffb499e3-35f1-4a3c-970c-39991b706bfc"}
{"level":"info","time":"2021-07-17T15:26:03.716688499Z","caller":"k8sorchestrator/k8sorchestrator.go:478","msg":"configMapAdded: Supervisor feature state values from \"csi-feature-states\" stored successfully: map[async-query-volume:false block-volume-snapshot:false csi-auth-check:true csi-sv-feature-states-replication:true fake-attach:true file-volume:true improved-csi-idempotency:false online-volume-extend:true sibling-replica-bound-pvc-check:false trigger-csi-fullsync:false volume-extend:true volume-health:true vsan-direct-disk-decommission:true]","TraceId":"24e64f24-b81d-4d1c-83d3-d1d942bcde9c"}
{"level":"info","time":"2021-07-17T15:26:03.722835711Z","caller":"config/config.go:321","msg":"No Net Permissions given in Config. Using default permissions.","TraceId":"ffb499e3-35f1-4a3c-970c-39991b706bfc"}
{"level":"info","time":"2021-07-17T15:26:03.746843779Z","caller":"wcp/controller.go:77","msg":"Initializing WCP CSI controller","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:03.748039736Z","caller":"vsphere/utils.go:165","msg":"Defaulting timeout for vCenter Client to 5 minutes","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:03.749571067Z","caller":"vsphere/virtualcentermanager.go:73","msg":"Initializing defaultVirtualCenterManager...","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:03.750145707Z","caller":"vsphere/virtualcentermanager.go:75","msg":"Successfully initialized defaultVirtualCenterManager","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:03.750375383Z","caller":"vsphere/virtualcentermanager.go:121","msg":"Successfully registered VC \"sc1-10-182-5-182.eng.vmware.com\"","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:03.75092811Z","caller":"volume/manager.go:139","msg":"Initializing new defaultManager...","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:03.90195242Z","caller":"vsphere/virtualcenter.go:177","msg":"New session ID for 'VSPHERE.LOCAL\\workload_storage_management-a7fc6350-5b5d-4bf8-a36a-12e4678cef7a' = 52fc4057-67c1-556f-bdd7-d9276d213634","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:03.902497872Z","caller":"wcp/controller.go:130","msg":"CSIAuthCheck feature is enabled, loading AuthorizationService","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:03.903117439Z","caller":"common/authmanager.go:83","msg":"Initializing authorization service...","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:03.903246536Z","caller":"common/authmanager.go:93","msg":"authorization service initialized","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:03.903814399Z","caller":"wcp/controller.go:193","msg":"Adding watch on path: \"/etc/vmware/wcp\"","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:03.903965902Z","caller":"wcp/controller.go:200","msg":"Adding watch on path: \"/etc/vmware/wcp/tls\"","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:03.904158713Z","caller":"service/driver.go:107","msg":"Configured: \"csi.vsphere.vmware.com\" with clusterFlavor: \"WORKLOAD\" and mode: \"controller\"","TraceId":"ffb499e3-35f1-4a3c-970c-39991b706bfc"}
time="2021-07-17T15:26:03Z" level=info msg="identity service registered"
{"level":"info","time":"2021-07-17T15:26:03.905323611Z","caller":"common/authmanager.go:179","msg":"auth manager: ComputeFSEnabledClustersToDsMap enter"}
time="2021-07-17T15:26:03Z" level=info msg="controller service registered"
time="2021-07-17T15:26:03Z" level=info msg=serving endpoint="unix:///csi/csi.sock"
{"level":"info","time":"2021-07-17T15:26:03.908663393Z","caller":"wcp/controller.go:210","msg":"Starting the http server to expose Prometheus metrics..","TraceId":"526f5925-f583-4dd8-b97d-1cc950257a21"}
{"level":"info","time":"2021-07-17T15:26:04.117182752Z","caller":"wcp/controller.go:787","msg":"ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"6b8973d0-e036-4873-9b35-916ab7a6d961"}
{"level":"info","time":"2021-07-17T15:26:04.538621822Z","caller":"wcp/controller.go:787","msg":"ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"44cfbacb-f1fd-4414-a3b6-0ea85ec20bce"}
{"level":"info","time":"2021-07-17T15:26:04.612329546Z","caller":"wcp/controller.go:787","msg":"ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"890041b6-752b-461a-8659-8e4b0251b4fd"}
{"level":"info","time":"2021-07-17T15:26:04.621904064Z","caller":"wcp/controller.go:787","msg":"ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"2413e72f-4698-4f99-ab8a-51e25fb9b2db"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix panic in WCP Init due to cleanup interval
```
