### PR TITLE
Clean up long lines a few e2e tests

### DIFF
--- a/tests/e2e/vcp_utils.go
+++ b/tests/e2e/vcp_utils.go
@@ -32,7 +32,9 @@ import (
 )
 
 // getVcpVSphereStorageClassSpec to get VCP storage class spec
-func getVcpVSphereStorageClassSpec(name string, scParameters map[string]string, zones []string, ReclaimPolicy v1.PersistentVolumeReclaimPolicy, bindingMode storagev1.VolumeBindingMode, allowVolumeExpansion bool) *storagev1.StorageClass {
+func getVcpVSphereStorageClassSpec(name string, scParameters map[string]string, zones []string,
+	ReclaimPolicy v1.PersistentVolumeReclaimPolicy, bindingMode storagev1.VolumeBindingMode,
+	allowVolumeExpansion bool) *storagev1.StorageClass {
 	if bindingMode == "" {
 		bindingMode = storagev1.VolumeBindingImmediate
 	}
@@ -74,17 +76,23 @@ func getVcpVSphereStorageClassSpec(name string, scParameters map[string]string, 
 
 // createVcpStorageClass helps creates a VCP storage class with specified name, storageclass parameters
 func createVcpStorageClass(client clientset.Interface, scParameters map[string]string, zones []string,
-	scReclaimPolicy v1.PersistentVolumeReclaimPolicy, bindingMode storagev1.VolumeBindingMode, allowVolumeExpansion bool, scName string) (*storagev1.StorageClass, error) {
+	scReclaimPolicy v1.PersistentVolumeReclaimPolicy, bindingMode storagev1.VolumeBindingMode,
+	allowVolumeExpansion bool, scName string) (*storagev1.StorageClass, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ginkgo.By(fmt.Sprintf("Creating StorageClass %s with scParameters: %+v and zones: %+v and ReclaimPolicy: %+v and allowVolumeExpansion: %t", scName, scParameters, zones, scReclaimPolicy, allowVolumeExpansion))
-	storageclass, err := client.StorageV1().StorageClasses().Create(ctx, getVcpVSphereStorageClassSpec(scName, scParameters, zones, scReclaimPolicy, bindingMode, allowVolumeExpansion), metav1.CreateOptions{})
+	ginkgo.By(fmt.Sprintf("Creating StorageClass %s with scParameters: %+v and zones: %+v and "+
+		"ReclaimPolicy: %+v and allowVolumeExpansion: %t",
+		scName, scParameters, zones, scReclaimPolicy, allowVolumeExpansion))
+	storageclass, err := client.StorageV1().StorageClasses().Create(ctx,
+		getVcpVSphereStorageClassSpec(scName, scParameters, zones, scReclaimPolicy, bindingMode, allowVolumeExpansion),
+		metav1.CreateOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to create storage class with err: %v", err))
 	return storageclass, err
 }
 
 // getvSphereVolumePathFromClaim fetches vSphere Volume Path from PVC which used VCP PV
-func getvSphereVolumePathFromClaim(ctx context.Context, client clientset.Interface, namespace string, claimName string) string {
+func getvSphereVolumePathFromClaim(ctx context.Context, client clientset.Interface,
+	namespace string, claimName string) string {
 	pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, claimName, metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	pv, err := client.CoreV1().PersistentVolumes().Get(ctx, pvclaim.Spec.VolumeName, metav1.GetOptions{})
@@ -98,8 +106,10 @@ func getUUIDFromProviderID(providerID string) string {
 	return strings.TrimPrefix(providerID, providerPrefix)
 }
 
-// getVcpPersistentVolumeSpec function to create vsphere volume spec with given VMDK volume path, Reclaim Policy and labels
-func getVcpPersistentVolumeSpec(volumePath string, persistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy, labels map[string]string) *v1.PersistentVolume {
+// getVcpPersistentVolumeSpec function to create vsphere volume spec with
+// given VMDK volume path, Reclaim Policy and labels.
+func getVcpPersistentVolumeSpec(volumePath string, persistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy,
+	labels map[string]string) *v1.PersistentVolume {
 	annotations := make(map[string]string)
 	annotations[pvAnnotationProvisionedBy] = vcpProvisionerName
 	pv := fpv.MakePersistentVolume(fpv.PersistentVolumeConfig{
@@ -122,7 +132,8 @@ func getVcpPersistentVolumeSpec(volumePath string, persistentVolumeReclaimPolicy
 }
 
 // getVcpPersistentVolumeClaimSpec function to get vsphere persistent volume spec with given selector labels.
-func getVcpPersistentVolumeClaimSpec(namespace string, size string, storageclass *storagev1.StorageClass, pvclaimlabels map[string]string, accessMode v1.PersistentVolumeAccessMode) *v1.PersistentVolumeClaim {
+func getVcpPersistentVolumeClaimSpec(namespace string, size string, storageclass *storagev1.StorageClass,
+	pvclaimlabels map[string]string, accessMode v1.PersistentVolumeAccessMode) *v1.PersistentVolumeClaim {
 	pvc := getPersistentVolumeClaimSpecWithStorageClass(namespace, size, storageclass, pvclaimlabels, accessMode)
 	annotations := make(map[string]string)
 	annotations[pvcAnnotationStorageProvisioner] = vcpProvisionerName

--- a/tests/e2e/vsphere_file_volume_basic_without_datacenter.go
+++ b/tests/e2e/vsphere_file_volume_basic_without_datacenter.go
@@ -71,22 +71,24 @@ var _ = ginkgo.Describe("[csi-file-vanilla] Basic Testing without datacenter", f
 		cancel()
 	})
 
-	/*
-		Test to verify dynamic provisioning with ReadWriteMany access mode, when no storage policy and datacenter is offered
-		1. Remove the datacenters in vsphere.conf secret
-		2. Bootstrap with config containing no datacenter.
-		3. Create StorageClass with fsType as "nfs4"
-		4. Create a PVC with "ReadWriteMany" using the SC from above
-		5. Wait for PVC to be Bound
-		6. Get the VolumeID from PV
-		7. Verify using CNS Query API if VolumeID retrieved from PV is present. Also verify Name, Capacity, VolumeType, Health matches
-		8. Verify if VolumeID is created on one of the VSAN datastores from list of datacenters provided in vsphere.conf
-		9. Delete PVC
-		10. Delete Storage class
-		11. Change back the datacenters back to normal in vsphere.conf secret.
-	*/
+	// Test to verify dynamic provisioning with ReadWriteMany access mode, when
+	// no storage policy and datacenter is offered.
+	// 1. Remove the datacenters in vsphere.conf secret.
+	// 2. Bootstrap with config containing no datacenter.
+	// 3. Create StorageClass with fsType as "nfs4".
+	// 4. Create a PVC with "ReadWriteMany" using the SC from above.
+	// 5. Wait for PVC to be Bound.
+	// 6. Get the VolumeID from PV.
+	// 7. Verify using CNS Query API if VolumeID retrieved from PV is present.
+	//    Also verify Name, Capacity, VolumeType, Health matches.
+	// 8. Verify if VolumeID is created on one of the VSAN datastores from list
+	//    of datacenters provided in vsphere.conf.
+	// 9. Delete PVC.
+	// 10. Delete Storage class.
+	// 11. Change back the datacenters back to normal in vsphere.conf secret.
 
-	ginkgo.It("verify dynamic provisioning with ReadWriteMany access mode with datastoreURL is set in storage class, when no storage policy and datacenter is offered", func() {
+	ginkgo.It("verify dynamic provisioning with ReadWriteMany access mode with datastoreURL is set in storage class, "+
+		"when no storage policy and datacenter is offered", func() {
 		datastoreURL := GetAndExpectStringEnvVar(envSharedDatastoreURL)
 
 		ctx, cancel = context.WithCancel(context.Background())

--- a/tests/e2e/vsphere_volume_disksize.go
+++ b/tests/e2e/vsphere_volume_disksize.go
@@ -43,7 +43,8 @@ import (
 	4. Verify disk size specified is being honored
 */
 
-var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor] [csi-guest] Volume Disk Size ", func() {
+var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor] [csi-guest] "+
+	"Volume Disk Size ", func() {
 	f := framework.NewDefaultFramework("volume-disksize")
 	var (
 		client            clientset.Interface
@@ -94,18 +95,21 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor]
 		if vanillaCluster {
 			ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
 			scParameters[scParamDatastoreURL] = datastoreURL
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client,
+				namespace, nil, scParameters, diskSize, nil, "", false, "")
 		} else if supervisorCluster {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
 			// create resource quota
 			createResourceQuota(client, namespace, rqLimit, storagePolicyName)
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
+			storageclass, pvclaim, err = createPVCAndStorageClass(client,
+				namespace, nil, scParameters, diskSize, nil, "", false, "", storagePolicyName)
 		} else {
 			ginkgo.By("CNS_TEST: Running for GC setup")
 			scParameters[svStorageClassName] = storagePolicyName
-			storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, diskSize, nil, "", false, "")
+			storageclass, pvclaim, err = createPVCAndStorageClass(client,
+				namespace, nil, scParameters, diskSize, nil, "", false, "")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -115,7 +119,8 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor]
 		}()
 
 		ginkgo.By("Expect claim to provision volume successfully")
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume")
 
 		pvclaims = append(pvclaims, pvclaim)

--- a/tests/e2e/vsphere_volume_fstype.go
+++ b/tests/e2e/vsphere_volume_fstype.go
@@ -33,32 +33,32 @@ import (
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 )
 
-/*
-
-Test to verify fstype specified in storage-class is being honored after volume creation.
-
-Steps
-1. Create StorageClass with fstype set to valid type (default case included).
-2. Create PVC which uses the StorageClass created in step 1.
-3. Wait for PV to be provisioned.
-4. Wait for PVC's status to become Bound.
-5. Create pod using PVC on specific node.
-6. Wait for Disk to be attached to the node.
-7. Execute command in the pod to get fstype.
-8. Delete pod and Wait for Volume Disk to be detached from the Node.
-9. Delete PVC, PV and Storage Class.
-
-Test to verify if an invalid fstype specified in storage class fails pod creation.
-
- Steps
- 1. Create StorageClass with inavlid.
- 2. Create PVC which uses the StorageClass created in step 1.
- 3. Wait for PV to be provisioned.
- 4. Wait for PVC's status to become Bound.
- 5. Create pod using PVC.
- 6. Verify if the pod creation fails.
- 7. Verify if the MountVolume.MountDevice fails because it is unable to find the file system executable file on the node.
-*/
+// Test to verify fstype specified in storage-class is being honored after
+// volume creation.
+//
+// Steps
+// 1. Create StorageClass with fstype set to valid type (default case included).
+// 2. Create PVC which uses the StorageClass created in step 1.
+// 3. Wait for PV to be provisioned.
+// 4. Wait for PVC's status to become Bound.
+// 5. Create pod using PVC on specific node.
+// 6. Wait for Disk to be attached to the node.
+// 7. Execute command in the pod to get fstype.
+// 8. Delete pod and Wait for Volume Disk to be detached from the Node.
+// 9. Delete PVC, PV and Storage Class.
+//
+// Test to verify if an invalid fstype specified in storage class fails pod
+// creation.
+//
+// Steps
+// 1. Create StorageClass with inavlid.
+// 2. Create PVC which uses the StorageClass created in step 1.
+// 3. Wait for PV to be provisioned.
+// 4. Wait for PVC's status to become Bound.
+// 5. Create pod using PVC.
+// 6. Verify if the pod creation fails.
+// 7. Verify if the MountVolume.MountDevice fails because it is unable to find
+//    the file system executable file on the node.
 
 var _ = ginkgo.Describe("[csi-block-vanilla] Volume Filesystem Type Test", func() {
 	f := framework.NewDefaultFramework("volume-fstype")
@@ -92,7 +92,8 @@ var _ = ginkgo.Describe("[csi-block-vanilla] Volume Filesystem Type Test", func(
 	})
 })
 
-func invokeTestForFstype(f *framework.Framework, client clientset.Interface, namespace string, fstype string, expectedContent string, storagePolicyName string, profileID string) {
+func invokeTestForFstype(f *framework.Framework, client clientset.Interface,
+	namespace string, fstype string, expectedContent string, storagePolicyName string, profileID string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ginkgo.By(fmt.Sprintf("Invoking Test for fstype: %s", fstype))
@@ -137,7 +138,8 @@ func invokeTestForFstype(f *framework.Framework, client clientset.Interface, nam
 	gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
 
 	ginkgo.By("Verify the volume is accessible and filesystem type is as expected")
-	_, err = framework.LookForStringInPodExec(namespace, pod.Name, []string{"/bin/cat", "/mnt/volume1/fstype"}, expectedContent, time.Minute)
+	_, err = framework.LookForStringInPodExec(namespace, pod.Name, []string{"/bin/cat", "/mnt/volume1/fstype"},
+		expectedContent, time.Minute)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	// Delete POD
@@ -148,10 +150,12 @@ func invokeTestForFstype(f *framework.Framework, client clientset.Interface, nam
 	ginkgo.By("Verify volume is detached from the node")
 	isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+	gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+		fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 }
 
-func invokeTestForInvalidFstype(f *framework.Framework, client clientset.Interface, namespace string, fstype string, storagePolicyName string, profileID string) {
+func invokeTestForInvalidFstype(f *framework.Framework, client clientset.Interface,
+	namespace string, fstype string, storagePolicyName string, profileID string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	scParameters := make(map[string]string)
@@ -189,7 +193,8 @@ func invokeTestForInvalidFstype(f *framework.Framework, client clientset.Interfa
 
 	pv := persistentvolumes[0]
 	expectedErrorMsg := `MountVolume.MountDevice failed for volume "` + pv.Name
-	isFailureFound := checkEventsforError(client, namespace, metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pod.Name)}, expectedErrorMsg)
+	isFailureFound := checkEventsforError(client, namespace,
+		metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pod.Name)}, expectedErrorMsg)
 	gomega.Expect(isFailureFound).To(gomega.BeTrue(), "Unable to verify MountVolume.MountDevice failure")
 
 	// pod.Spec.NodeName may not be set yet when pod just created
@@ -209,5 +214,6 @@ func invokeTestForInvalidFstype(f *framework.Framework, client clientset.Interfa
 	ginkgo.By("Verify volume is detached from the node")
 	isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, podNodeName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(isDiskDetached).To(gomega.BeTrue(), fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, podNodeName))
+	gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+		fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, podNodeName))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles a few more e2e test files.

**Testing done**:
Local build, check