### PR TITLE
WIP: Add default mount options while publishing a file volume

### DIFF
--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -57,7 +57,11 @@ const (
 	maxAllowedBlockVolumesPerNode = 59
 )
 
-var topologyService csinodetopology.TopologyService
+var (
+	topologyService csinodetopology.TopologyService
+	// defaultFileMountOptions are the mount flag options used by default while publishing a file volume.
+	defaultFileMountOptions = []string{"hard", "sec=sys", "vers=4", "minorversion=1"}
+)
 
 type nodeStageParams struct {
 	// volID is the identifier for the underlying volume.
@@ -1176,9 +1180,8 @@ func publishFileVol(
 	if params.ro {
 		mntFlags = append(mntFlags, "ro")
 	}
-	if cnstypes.CnsClusterFlavor(os.Getenv(csitypes.EnvClusterFlavor)) == cnstypes.CnsClusterFlavorGuest {
-		mntFlags = append(mntFlags, "hard")
-	}
+	// Add defaultFileMountOptions to the mntFlags.
+	mntFlags = append(mntFlags, defaultFileMountOptions...)
 	// Retrieve the file share access point from publish context.
 	mntSrc, ok := req.GetPublishContext()[common.Nfsv4AccessPoint]
 	if !ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Adding in some default NFS mount flags to the NodePublishVolume call for vanilla and GC flavors.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add default mount options while publishing a file volume
```
