### PR TITLE
Clean up long lines in vcp_to_csi_create_delete

### DIFF
--- a/tests/e2e/vcp_to_csi_create_delete.go
+++ b/tests/e2e/vcp_to_csi_create_delete.go
@@ -98,7 +98,8 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 			ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
 			err = invokeVCenterServiceControl("start", vsanhealthServiceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again", vsanHealthServiceWaitTime))
+			ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again",
+				vsanHealthServiceWaitTime))
 			time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 		}
 
@@ -146,41 +147,47 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		}
 	})
 
-	/*
-		Migrate in-tree volumes located on different types of datastores with SC parameters supported by CSI
-		Steps:
-		1.	Create a SCs compatible with VCP and with parameters supported by CSI with different types of datastores VSAN, VVOL, VMFS, NFS, ISCSI
-			a.	SPBM policy name
-			b.	datastore
-			c.	fstype
-		2.	Create 5 PVCs using SCs created in step 1
-		3.	Enable CSIMigration and CSIMigrationvSphere feature gates on kube-controller-manager (& restart)
-		4.	Verify all the PVCs and PVs provisioned in step 2 have the following annotation -  "pv.kubernetes.io/migrated-to": "csi.vsphere.vmware.com"
-		5.	Verify cnsvspherevolumemigrations crd is created for the migrated volumes
-		6.	Verify CNS entries for the PV/PVCs
-		7.	Delete the PVCs created in step 2
-		8.	Verify cnsvspherevolumemigrations crds are deleted
-		9.	Verify the CNS volumes(vmdks) are also removed.
-		10.	Delete the SCs created in step 1
-		11.	Disable CSIMigration and CSIMigrationvSphere feature gates on kube-controller-manager (& restart)
-
-		create PVCs from CSI using VCP SC with SC parameters supported by CSI
-		Steps:
-		1.	Create a SCs compatible with VCP and with parameters supported by CSI with different types of datastores VSAN, VVOL, VMFS, NFS, ISCSI
-			a.	SPBM policy name
-			b.	datastore
-			c.	fstype
-		2.	Enable feature gates on kube-controller-manager (& restart)
-		3.	Create 5 PVCs using SC created in step 1
-		4.	Verify all the 5 PVCs are bound
-		5.	Verify that the PVCs and PVs have the following annotation -  "pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com"
-		6.	Verify cnsvspherevolumemigrations crds are created
-		7.	Verify CNS entries for the PV/PVCs
-		8.	Delete the PVCs created in step 3
-		9.	Verify the CNS volumes(fcds) are also removed.
-		10.	Delete the SC created in step 1
-		11.	Disable CSIMigration and CSIMigrationvSphere feature gates on kube-controller-manager (& restart)
-	*/
+	// Migrate in-tree volumes located on different types of datastores with SC
+	// parameters supported by CSI.
+	// Steps:
+	// 1. Create a SCs compatible with VCP and with parameters supported by CSI
+	//    with different types of datastores VSAN, VVOL, VMFS, NFS, ISCSI.
+	//    a. SPBM policy name.
+	//    b. datastore.
+	//    c. fstype.
+	// 2. Create 5 PVCs using SCs created in step 1.
+	// 3. Enable CSIMigration and CSIMigrationvSphere feature gates on
+	//    kube-controller-manager (& restart).
+	// 4. Verify all the PVCs and PVs provisioned in step 2 have the following
+	//    annotation - "pv.kubernetes.io/migrated-to": "csi.vsphere.vmware.com".
+	// 5. Verify cnsvspherevolumemigrations crd is created for the migrated volumes.
+	// 6. Verify CNS entries for the PV/PVCs.
+	// 7. Delete the PVCs created in step 2.
+	// 8. Verify cnsvspherevolumemigrations crds are deleted.
+	// 9. Verify the CNS volumes(vmdks) are also removed.
+	// 10. Delete the SCs created in step 1.
+	// 11. Disable CSIMigration and CSIMigrationvSphere feature gates on
+	//     kube-controller-manager (& restart).
+	//
+	// create PVCs from CSI using VCP SC with SC parameters supported by CSI.
+	// Steps:
+	// 1. Create a SCs compatible with VCP and with parameters supported by CSI
+	//    with different types of datastores VSAN, VVOL, VMFS, NFS, ISCSI.
+	//    a. SPBM policy name.
+	//    b. datastore.
+	//    c. fstype.
+	// 2. Enable feature gates on kube-controller-manager (& restart).
+	// 3. Create 5 PVCs using SC created in step 1.
+	// 4. Verify all the 5 PVCs are bound.
+	// 5. Verify that the PVCs and PVs have the following annotation -
+	//    "pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com".
+	// 6. Verify cnsvspherevolumemigrations crds are created.
+	// 7. Verify CNS entries for the PV/PVCs.
+	// 8. Delete the PVCs created in step 3.
+	// 9. Verify the CNS volumes(fcds) are also removed.
+	// 10. Delete the SC created in step 1.
+	// 11. Disable CSIMigration and CSIMigrationvSphere feature gates on
+	//     kube-controller-manager (& restart).
 	ginkgo.It("Create volumes using VCP SC with parameters supported by CSI before and after migration", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -233,7 +240,8 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		ginkgo.By("Verify annotations on PV/PVCs created after migration")
 		waitForMigAnnotationsPvcPvLists(ctx, client, namespace, vcpPvcsPostMig, vcpPvsPostMig, false)
 
-		ginkgo.By("Verify CnsVSphereVolumeMigration crds and CNS volume metadata for all volumes created before and after migration")
+		ginkgo.By("Verify CnsVSphereVolumeMigration crds and CNS volume metadata for all volumes created " +
+			"before and after migration")
 		for _, pvc := range append(vcpPvcsPreMig, vcpPvcsPostMig...) {
 			vpath := getvSphereVolumePathFromClaim(ctx, client, namespace, pvc.Name)
 			pv := getPvFromClaim(client, namespace, pvc.Name)
@@ -245,32 +253,32 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		}
 	})
 
-	/*
-	   migrate in-tree volumes with SC parameters not supported by CSI
-	   Steps:
-	   1. Create a VCP SC with parameters not supported by CSI
-	   2. Create 5 PVCs using SC created in step 1
-	   3. Enable feature gates on kube-controller-manager (& restart)
-	   4. Verify all the PVCs and PVs provisioned in step 2 have the following annotation -  "pv.kubernetes.io/migrated-to": "csi.vsphere.vmware.com"
-	   5. Verify cnsvspherevolumemigrations crds are created for migrated volumes
-	   6. Verify CNS entries for the PV/PVCs
-	   7. Delete the PVCs created in step 2
-	   8. Verify cnsvspherevolumemigrations crds are deleted
-	   9. Verify the CNS volumes(vmdks) are also removed.
-	   10. Delete the SC created in step 1
-	   11. Disable CSIMigration and CSIMigrationvSphere feature gates on kube-controller-manager (& restart)
-
-	   create PVCs from CSI using VCP SC with SC parameters not supported by CSI
-	   Steps:
-	   1.  Create a VCP SC and with parameters not supported by CSI
-	   2.  Enable feature gates on kube-controller-manager (& restart)
-	   3.  Create PVC1 using SC created in step 1
-	   4.  Verify PVC1 is stuck in pending state and verify the error in the events
-	   5.  Delete the PVC1
-	   6.  Delete the SC created in step 1
-	   7.  Disable CSIMigration and CSIMigrationvSphere feature gates on kube-controller-manager (& restart)
-
-	*/
+	// Migrate in-tree volumes with SC parameters not supported by CSI.
+	// Steps:
+	// 1. Create a VCP SC with parameters not supported by CSI.
+	// 2. Create 5 PVCs using SC created in step 1.
+	// 3. Enable feature gates on kube-controller-manager (& restart).
+	// 4. Verify all the PVCs and PVs provisioned in step 2 have the following
+	//    annotation -  "pv.kubernetes.io/migrated-to": "csi.vsphere.vmware.com".
+	// 5. Verify cnsvspherevolumemigrations crds are created for migrated volumes.
+	// 6. Verify CNS entries for the PV/PVCs.
+	// 7. Delete the PVCs created in step 2.
+	// 8. Verify cnsvspherevolumemigrations crds are deleted.
+	// 9. Verify the CNS volumes(vmdks) are also removed.
+	// 10. Delete the SC created in step 1.
+	// 11. Disable CSIMigration and CSIMigrationvSphere feature gates on
+	//     kube-controller-manager (& restart).
+	//
+	// create PVCs from CSI using VCP SC with SC parameters not supported by CSI.
+	// Steps:
+	// 1. Create a VCP SC and with parameters not supported by CSI.
+	// 2. Enable feature gates on kube-controller-manager (& restart).
+	// 3. Create PVC1 using SC created in step 1.
+	// 4. Verify PVC1 is stuck in pending state and verify the error in the events.
+	// 5. Delete the PVC1.
+	// 6. Delete the SC created in step 1.
+	// 7. Disable CSIMigration and CSIMigrationvSphere feature gates on
+	//    kube-controller-manager (& restart).
 	ginkgo.It("Create volumes using VCP SC with parameters not supported by CSI before and after migration", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -308,9 +316,14 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		time.Sleep(30 * time.Second)
 		ginkgo.By("Checking for error in events related to pvc " + pvc.Name)
 		expectedErrorMsg := "InvalidArgument"
-		// error looks like this:
-		//     failed to provision volume with StorageClass "vcp-unsup-sc": rpc error: code = InvalidArgument desc = Parsing storage class parameters failed with error: vSphere CSI driver does not support creating volume using in-tree vSphere volume plugin parameter key:hostfailurestotolerate-migrationparam, value:1
-		isFailureFound := checkEventsforError(client, namespace, metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvc.Name)}, expectedErrorMsg)
+		// Error looks like this:
+		//     failed to provision volume with StorageClass "vcp-unsup-sc":
+		//     rpc error: code = InvalidArgument desc = Parsing storage class
+		//     parameters failed with error: vSphere CSI driver does not support
+		//     creating volume using in-tree vSphere volume plugin parameter
+		//     key:hostfailurestotolerate-migrationparam, value:1
+		isFailureFound := checkEventsforError(client, namespace,
+			metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvc.Name)}, expectedErrorMsg)
 		gomega.Expect(isFailureFound).To(gomega.BeTrue())
 
 		ginkgo.By("Verify CnsVSphereVolumeMigration crds and CNS volume metadata for all volumes created before migration")
@@ -325,53 +338,60 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		}
 	})
 
-	/*
-		create a PV from CSI using VCP SC with SC parameters supported by CSI when SPS service is down
-		1. Create a VCP SC with parameters supported by CSI
-		2. Enable feature gates on kube-controller-manager (& restart)
-		3. Bring down SPS service
-		4. Create 5 PVCs using SC created in step 1
-		5. verify PVC is in pending state for a while (say 2mins)
-		6. Bring up SPS service
-		7. Wait and verify all the 5 PVCs are bound
-		8. Verify that PVCs and PVs have the following annotation -  "pv. kubernetes. io/provisioned-by: csi. vsphere. vmware. com"
-		9. Verify cnsvspherevolumemigrations crds are created
-		10. Verify CNS entries for the PV/PVCs
-		11. Delete the PVCs created in step 4
-		12. Verify cnsvspherevolumemigrations crds are removed
-		13. Verify the CNS volumes(fcds) are also removed.
-		14. Delete the SC created in step 1
-		15. Disable CSIMigration and CSIMigrationvSphere feature gates on kube-controller-manager (& restart)
-
-		Verify volume entry is deleted from CNS when PV is deleted from K8s (when CNS was down)
-		1. Enable CSIMigration and CSIMigrationvSphere feature gates on kube-controller-manager (& restart)
-		2. Create SC1 VCP SC
-		3. Create PVC1 using SC1 and binding with PV (say PV1)
-		4. Wait for PVC to be in Bound phase
-		5. Verify CNS entries for PVC1 and PV1
-		6. Stop vsan-health on VC
-		7. Delete PVC1
-		8. Start vsan-health on VC
-		9. Verify PVC1, PV1 and underlying vmdk are deleted
-		10. Verify CNS entries are removed for PVC1 and PV1
-		11. Delete SC1
-		12. Disable CSIMigration and CSIMigrationvSphere feature gates on kube-controller-manager (& restart)
-
-		Verify volume entry is created in CNS when PV is created in K8s (when CNS was down)
-		1. Enable CSIMigration and CSIMigrationvSphere feature gates on kube-controller-manager (& restart)
-		2. Create SC1 VCP SC
-		3. Bring down vsan health service
-		4. Create PVC1 using SC1
-		5. Bring up vsan health service
-		6. Check PVC1 is be bound to a PV (say PV1)
-		7. Verify CNS entries for PVC1 and PV1
-		8. Verify cnsvspherevolumemigrations crds are created for PVC1 and PV1
-		9. Delete the PVC1
-		10. Verify PV1 and underlying vmdk are deleted
-		11. Verify cnsvspherevolumemigrations crds are removed for PVC1 and PV1
-		12. Delete the SC1
-		13. Disable CSIMigration and CSIMigrationvSphere feature gates on kube-controller-manager (& restart)
-	*/
+	// Create a PV from CSI using VCP SC with SC parameters supported by CSI
+	// when SPS service is down.
+	// 1. Create a VCP SC with parameters supported by CSI.
+	// 2. Enable feature gates on kube-controller-manager (& restart).
+	// 3. Bring down SPS service.
+	// 4. Create 5 PVCs using SC created in step 1.
+	// 5. verify PVC is in pending state for a while (say 2mins).
+	// 6. Bring up SPS service.
+	// 7. Wait and verify all the 5 PVCs are bound.
+	// 8. Verify that PVCs and PVs have the following annotation -
+	//    "pv. kubernetes. io/provisioned-by: csi. vsphere. vmware. com".
+	// 9. Verify cnsvspherevolumemigrations crds are created.
+	// 10. Verify CNS entries for the PV/PVCs.
+	// 11. Delete the PVCs created in step 4.
+	// 12. Verify cnsvspherevolumemigrations crds are removed.
+	// 13. Verify the CNS volumes(fcds) are also removed.
+	// 14. Delete the SC created in step 1.
+	// 15. Disable CSIMigration and CSIMigrationvSphere feature gates on
+	//     kube-controller-manager (& restart).
+	//
+	// Verify volume entry is deleted from CNS when PV is deleted from K8s (when
+	// CNS was down).
+	// 1. Enable CSIMigration and CSIMigrationvSphere feature gates on
+	//    kube-controller-manager (& restart).
+	// 2. Create SC1 VCP SC.
+	// 3. Create PVC1 using SC1 and binding with PV (say PV1).
+	// 4. Wait for PVC to be in Bound phase.
+	// 5. Verify CNS entries for PVC1 and PV1.
+	// 6. Stop vsan-health on VC.
+	// 7. Delete PVC1.
+	// 8. Start vsan-health on VC.
+	// 9. Verify PVC1, PV1 and underlying vmdk are deleted.
+	// 10. Verify CNS entries are removed for PVC1 and PV1.
+	// 11. Delete SC1.
+	// 12. Disable CSIMigration and CSIMigrationvSphere feature gates on
+	//     kube-controller-manager (& restart).
+	//
+	// Verify volume entry is created in CNS when PV is created in K8s (when CNS
+	// was down).
+	// 1. Enable CSIMigration and CSIMigrationvSphere feature gates on
+	//    kube-controller-manager (& restart).
+	// 2. Create SC1 VCP SC.
+	// 3. Bring down vsan health service.
+	// 4. Create PVC1 using SC1.
+	// 5. Bring up vsan health service.
+	// 6. Check PVC1 is be bound to a PV (say PV1).
+	// 7. Verify CNS entries for PVC1 and PV1.
+	// 8. Verify cnsvspherevolumemigrations crds are created for PVC1 and PV1.
+	// 9. Delete the PVC1.
+	// 10. Verify PV1 and underlying vmdk are deleted.
+	// 11. Verify cnsvspherevolumemigrations crds are removed for PVC1 and PV1.
+	// 12. Delete the SC1.
+	// 13. Disable CSIMigration and CSIMigrationvSphere feature gates on
+	//     kube-controller-manager (& restart).
 	ginkgo.It("Create/delete volumes using VCP SC via CSI when SPS/CNS service is down", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -446,7 +466,8 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl("stop", vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown", vsanHealthServiceWaitTime))
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",
+			vsanHealthServiceWaitTime))
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
 
 		ginkgo.By("Creating PVC3...")
@@ -503,27 +524,29 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		}
 	})
 
-	/*
-		Statically provision VMDK used by a PV provisioned by VCP using CSI
-		Steps:
-		1. Create a VCP SC SC1 and with parameters supported by CSI with reclaim policy retain
-		2. Create PVC1 using SC1
-		3. verify PVC1 is bound
-		4. Enable CSIMigration and CSIMigrationvSphere feature gates on kube-controller-manager (& restart)
-		5. Verify PVC1 and PV bound to PVC1(say PV1) have the following annotation -  "pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com"
-		6. Verify cnsvspherevolumemigrations crd is created
-		7. Verify CNS entries for the PV/PVCs
-		8. Note FCD ID of the CNS volume used by PV1
-		9. Delete PVC1 and PV1
-		10. Verify cnsvspherevolumemigrations crd are deleted
-		11. Create CSI SC SC2
-		12. Create PV2 statically via CSI with the vmdk leftover by PV1 using FCD ID noted in step 8 and SC2
-		13. Create PVC2 using PV2 and SC2
-		14. Verify CNS entries for PVC2 and PV2
-		15. Delete PVC2
-		16. verify PVC2, PV2 and the cns volume(vmdk) get deleted
-		17. Delete SC1 and SC2
-	*/
+	// Statically provision VMDK used by a PV provisioned by VCP using CSI.
+	// Steps:
+	// 1. Create a VCP SC SC1 and with parameters supported by CSI with reclaim
+	//    policy retain.
+	// 2. Create PVC1 using SC1.
+	// 3. verify PVC1 is bound.
+	// 4. Enable CSIMigration and CSIMigrationvSphere feature gates on
+	//    kube-controller-manager (& restart).
+	// 5. Verify PVC1 and PV bound to PVC1(say PV1) have the following
+	//    annotation - "pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com".
+	// 6. Verify cnsvspherevolumemigrations crd is created.
+	// 7. Verify CNS entries for the PV/PVCs.
+	// 8. Note FCD ID of the CNS volume used by PV1.
+	// 9. Delete PVC1 and PV1.
+	// 10. Verify cnsvspherevolumemigrations crd are deleted.
+	// 11. Create CSI SC SC2.
+	// 12. Create PV2 statically via CSI with the vmdk leftover by PV1 using
+	//     FCD ID noted in step 8 and SC2.
+	// 13. Create PVC2 using PV2 and SC2.
+	// 14. Verify CNS entries for PVC2 and PV2.
+	// 15. Delete PVC2.
+	// 16. verify PVC2, PV2 and the cns volume(vmdk) get deleted.
+	// 17. Delete SC1 and SC2.
 	ginkgo.It("Statically provision VMDK used by a PV provisioned by VCP using CSI", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -572,7 +595,8 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Create CSI SC SC2")
-		csiSC, err := createStorageClass(client, nil, nil, v1.PersistentVolumeReclaimDelete, storagev1.VolumeBindingImmediate, false, "")
+		csiSC, err := createStorageClass(client, nil, nil, v1.PersistentVolumeReclaimDelete,
+			storagev1.VolumeBindingImmediate, false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Create PV2 statically via CSI with fcd leftover by PV1 using FCD ID noted earlier and SC2")
@@ -629,7 +653,8 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 })
 
 // waitForMigAnnotationsPvcPvLists waits for the list PVs and PVCs to have migration related annotatations
-func waitForMigAnnotationsPvcPvLists(ctx context.Context, c clientset.Interface, namespace string, pvcs []*v1.PersistentVolumeClaim, pvs []*v1.PersistentVolume, isMigratedVol bool) {
+func waitForMigAnnotationsPvcPvLists(ctx context.Context, c clientset.Interface,
+	namespace string, pvcs []*v1.PersistentVolumeClaim, pvs []*v1.PersistentVolume, isMigratedVol bool) {
 	for i := 0; i < len(pvcs); i++ {
 		pvc := pvcs[i]
 		pvc, err := waitForPvcMigAnnotations(ctx, c, pvc.Name, namespace, isMigratedVol)
@@ -645,7 +670,8 @@ func waitForMigAnnotationsPvcPvLists(ctx context.Context, c clientset.Interface,
 }
 
 // waitForPvcMigAnnotations waits for the PVC to have migration related annotatations
-func waitForPvcMigAnnotations(ctx context.Context, c clientset.Interface, pvcName string, namespace string, isMigratedVol bool) (*v1.PersistentVolumeClaim, error) {
+func waitForPvcMigAnnotations(ctx context.Context, c clientset.Interface, pvcName string,
+	namespace string, isMigratedVol bool) (*v1.PersistentVolumeClaim, error) {
 	var pvc *v1.PersistentVolumeClaim
 	var hasMigAnnotations bool
 	waitErr := wait.PollImmediate(poll, pollTimeout, func() (bool, error) {
@@ -656,7 +682,8 @@ func waitForPvcMigAnnotations(ctx context.Context, c clientset.Interface, pvcNam
 }
 
 // waitForPvMigAnnotations waits for the PV to have migration related annotatations
-func waitForPvMigAnnotations(ctx context.Context, c clientset.Interface, pvName string, isMigratedVol bool) (*v1.PersistentVolume, error) {
+func waitForPvMigAnnotations(ctx context.Context, c clientset.Interface, pvName string,
+	isMigratedVol bool) (*v1.PersistentVolume, error) {
 	var pv *v1.PersistentVolume
 	var hasMigAnnotations bool
 	waitErr := wait.PollImmediate(poll, pollTimeout, func() (bool, error) {
@@ -667,7 +694,8 @@ func waitForPvMigAnnotations(ctx context.Context, c clientset.Interface, pvName 
 }
 
 // pvcHasMigAnnotations checks whether specified PVC has migartion related annotatations
-func pvcHasMigAnnotations(ctx context.Context, c clientset.Interface, pvcName string, namespace string, isMigratedVol bool) (bool, *v1.PersistentVolumeClaim) {
+func pvcHasMigAnnotations(ctx context.Context, c clientset.Interface, pvcName string,
+	namespace string, isMigratedVol bool) (bool, *v1.PersistentVolumeClaim) {
 	pvc, err := c.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	annotations := pvc.Annotations
@@ -698,7 +726,8 @@ func pvcHasMigAnnotations(ctx context.Context, c clientset.Interface, pvcName st
 			return true, pvc
 		}
 	} else {
-		gomega.Expect(isMigratedToCsi).NotTo(gomega.BeTrue(), migratedToAnnotation+" annotation was not expected on PVC "+pvcName)
+		gomega.Expect(isMigratedToCsi).NotTo(gomega.BeTrue(),
+			migratedToAnnotation+" annotation was not expected on PVC "+pvcName)
 		if isStorageProvisionerMatching {
 			return true, pvc
 		}
@@ -707,7 +736,8 @@ func pvcHasMigAnnotations(ctx context.Context, c clientset.Interface, pvcName st
 }
 
 // pvHasMigAnnotations checks whether specified PV has migartion related annotatations
-func pvHasMigAnnotations(ctx context.Context, c clientset.Interface, pvName string, isMigratedVol bool) (bool, *v1.PersistentVolume) {
+func pvHasMigAnnotations(ctx context.Context, c clientset.Interface,
+	pvName string, isMigratedVol bool) (bool, *v1.PersistentVolume) {
 	pv, err := c.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	annotations := pv.Annotations
@@ -738,7 +768,8 @@ func pvHasMigAnnotations(ctx context.Context, c clientset.Interface, pvName stri
 			return true, pv
 		}
 	} else {
-		gomega.Expect(isMigratedToCsi).NotTo(gomega.BeTrue(), migratedToAnnotation+" annotation was not expected on PV "+pvName)
+		gomega.Expect(isMigratedToCsi).NotTo(gomega.BeTrue(),
+			migratedToAnnotation+" annotation was not expected on PV "+pvName)
 		if isProvisionedByMatching {
 			return true, pv
 		}
@@ -763,7 +794,8 @@ func getAllCnsVSphereVolumeMigrationCrds(ctx context.Context) *migrationv1alpha1
 }
 
 // getCnsVSphereVolumeMigrationCrd fetches CnsVSphereVolumeMigration crd for given volume path
-func getCnsVSphereVolumeMigrationCrd(ctx context.Context, volPath string) (bool, *migrationv1alpha1.CnsVSphereVolumeMigration) {
+func getCnsVSphereVolumeMigrationCrd(ctx context.Context, volPath string) (bool,
+	*migrationv1alpha1.CnsVSphereVolumeMigration) {
 	found := false
 	var crdP *migrationv1alpha1.CnsVSphereVolumeMigration
 	crds := getAllCnsVSphereVolumeMigrationCrds(ctx)
@@ -823,7 +855,8 @@ func waitForVmdkDeletion(ctx context.Context, volPath string) error {
 }
 
 // waitForCnsVSphereVolumeMigrationCrdToBeDeleted waits for the given CnsVSphereVolumeMigration crd to get deleted
-func waitForCnsVSphereVolumeMigrationCrdToBeDeleted(ctx context.Context, crd *migrationv1alpha1.CnsVSphereVolumeMigration) error {
+func waitForCnsVSphereVolumeMigrationCrdToBeDeleted(ctx context.Context,
+	crd *migrationv1alpha1.CnsVSphereVolumeMigration) error {
 	waitErr := wait.PollImmediate(poll, pollTimeoutShort, func() (bool, error) {
 		exists, _ := getCnsVSphereVolumeMigrationCrd(ctx, crd.Spec.VolumePath)
 		return !exists, nil
@@ -832,7 +865,8 @@ func waitForCnsVSphereVolumeMigrationCrdToBeDeleted(ctx context.Context, crd *mi
 }
 
 // verifyCnsVolumeMetadata verify the pv, pvc, pod information on given cns volume
-func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume, pod *v1.Pod) bool {
+func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim,
+	pv *v1.PersistentVolume, pod *v1.Pod) bool {
 	refferedEntityCheck := true
 	if e2eVSphere.Client.Version == cns.ReleaseVSAN67u3 {
 		refferedEntityCheck = false
@@ -867,7 +901,8 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv 
 			if verifyPvcEntry {
 				pvcEntryFound = true
 				if entityMetadata.EntityName != pvc.Name {
-					framework.Logf("PVC name '%v' does not match PVC name in metadata '%v', for volume id %v", pvc.Name, entityMetadata.EntityName, volumeID)
+					framework.Logf("PVC name '%v' does not match PVC name in metadata '%v', for volume id %v",
+						pvc.Name, entityMetadata.EntityName, volumeID)
 					pvcEntryFound = false
 					break
 				}
@@ -879,7 +914,9 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv 
 							break
 						}
 						if entityMetadata.ReferredEntity[0].EntityName != pv.Name {
-							framework.Logf("PV name '%v' in referred entity does not match PV name '%v', in PVC metadata for volume id %v", entityMetadata.ReferredEntity[0].EntityName, pv.Name, volumeID)
+							framework.Logf("PV name '%v' in referred entity does not match PV name '%v', "+
+								"in PVC metadata for volume id %v", entityMetadata.ReferredEntity[0].EntityName,
+								pv.Name, volumeID)
 							pvcEntryFound = false
 							break
 						}
@@ -887,20 +924,23 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv 
 				}
 				if pvc.Labels == nil {
 					if entityMetadata.Labels != nil {
-						framework.Logf("PVC labels '%v' does not match PVC labels in metadata '%v', for volume id %v", pvc.Labels, entityMetadata.Labels, volumeID)
+						framework.Logf("PVC labels '%v' does not match PVC labels in metadata '%v', for volume id %v",
+							pvc.Labels, entityMetadata.Labels, volumeID)
 						pvcEntryFound = false
 						break
 					}
 				} else {
 					labels := getLabelMap(entityMetadata.Labels)
 					if !(reflect.DeepEqual(labels, pvc.Labels)) {
-						framework.Logf("Labels on pvc '%v' are not matching with labels in metadata '%v' for volume id %v", pvc.Labels, entityMetadata.Labels, volumeID)
+						framework.Logf("Labels on pvc '%v' are not matching with labels in metadata '%v' for volume id %v",
+							pvc.Labels, entityMetadata.Labels, volumeID)
 						pvcEntryFound = false
 						break
 					}
 				}
 				if entityMetadata.Namespace != pvc.Namespace {
-					framework.Logf("PVC namespace '%v' does not match PVC namespace in pvc metadata '%v', for volume id %v", pvc.Namespace, entityMetadata.Namespace, volumeID)
+					framework.Logf("PVC namespace '%v' does not match PVC namespace in pvc metadata '%v', for volume id %v",
+						pvc.Namespace, entityMetadata.Namespace, volumeID)
 					pvcEntryFound = false
 					break
 				}
@@ -911,20 +951,23 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv 
 			if verifyPvEntry {
 				pvEntryFound = true
 				if entityMetadata.EntityName != pv.Name {
-					framework.Logf("PV name '%v' does not match PV name in metadata '%v', for volume id %v", pv.Name, entityMetadata.EntityName, volumeID)
+					framework.Logf("PV name '%v' does not match PV name in metadata '%v', for volume id %v",
+						pv.Name, entityMetadata.EntityName, volumeID)
 					pvEntryFound = false
 					break
 				}
 				if pv.Labels == nil {
 					if entityMetadata.Labels != nil {
-						framework.Logf("PV labels '%v' does not match PV labels in metadata '%v', for volume id %v", pv.Labels, entityMetadata.Labels, volumeID)
+						framework.Logf("PV labels '%v' does not match PV labels in metadata '%v', for volume id %v",
+							pv.Labels, entityMetadata.Labels, volumeID)
 						pvEntryFound = false
 						break
 					}
 				} else {
 					labels := getLabelMap(entityMetadata.Labels)
 					if !(reflect.DeepEqual(labels, pv.Labels)) {
-						framework.Logf("Labels on pv '%v' are not matching with labels in pv metadata '%v' for volume id %v", entityMetadata.Labels, pv.Labels, volumeID)
+						framework.Logf("Labels on pv '%v' are not matching with labels in pv metadata '%v' for volume id %v",
+							entityMetadata.Labels, pv.Labels, volumeID)
 						pvEntryFound = false
 						break
 					}
@@ -936,7 +979,8 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv 
 			if verifyPodEntry {
 				podEntryFound = true
 				if entityMetadata.EntityName != pod.Name {
-					framework.Logf("POD name '%v' does not match Pod name in metadata '%v', for volume id %v", pod.Name, entityMetadata.EntityName, volumeID)
+					framework.Logf("POD name '%v' does not match Pod name in metadata '%v', for volume id %v",
+						pod.Name, entityMetadata.EntityName, volumeID)
 					podEntryFound = false
 					break
 				}
@@ -948,31 +992,39 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv 
 							break
 						}
 						if entityMetadata.ReferredEntity[0].EntityName != pvc.Name {
-							framework.Logf("PVC name '%v' in referred entity does not match PVC name '%v', in PVC metadata for volume id %v", entityMetadata.ReferredEntity[0].EntityName, pvc.Name, volumeID)
+							framework.Logf("PVC name '%v' in referred entity does not match PVC name '%v', "+
+								"in PVC metadata for volume id %v", entityMetadata.ReferredEntity[0].EntityName,
+								pvc.Name, volumeID)
 							podEntryFound = false
 							break
 						}
 						if entityMetadata.ReferredEntity[0].Namespace != pvc.Namespace {
-							framework.Logf("PVC namespace '%v' does not match PVC namespace in Pod metadata referered entitry, '%v', for volume id %v", pvc.Namespace, entityMetadata.ReferredEntity[0].Namespace, volumeID)
+							framework.Logf("PVC namespace '%v' does not match PVC namespace in Pod metadata "+
+								"referered entitry, '%v', for volume id %v",
+								pvc.Namespace, entityMetadata.ReferredEntity[0].Namespace, volumeID)
 							podEntryFound = false
 							break
 						}
 					}
 				}
 				if entityMetadata.Namespace != pod.Namespace {
-					framework.Logf("Pod namespace '%v' does not match pod namespace in pvc metadata '%v', for volume id %v", pod.Namespace, entityMetadata.Namespace, volumeID)
+					framework.Logf("Pod namespace '%v' does not match pod namespace in pvc metadata '%v', for volume id %v",
+						pod.Namespace, entityMetadata.Namespace, volumeID)
 					podEntryFound = false
 					break
 				}
 			}
 		}
 	}
-	framework.Logf("pvEntryFound:%v, verifyPvEntry:%v, pvcEntryFound:%v, verifyPvcEntry:%v, podEntryFound:%v, verifyPodEntry:%v", pvEntryFound, verifyPvEntry, pvcEntryFound, verifyPvcEntry, podEntryFound, verifyPodEntry)
+	framework.Logf("pvEntryFound:%v, verifyPvEntry:%v, pvcEntryFound:%v, verifyPvcEntry:%v, "+
+		"podEntryFound:%v, verifyPodEntry:%v", pvEntryFound, verifyPvEntry, pvcEntryFound, verifyPvcEntry,
+		podEntryFound, verifyPodEntry)
 	return pvEntryFound == verifyPvEntry && pvcEntryFound == verifyPvcEntry && podEntryFound == verifyPodEntry
 }
 
 // waitAndVerifyCnsVolumeMetadata verify the pv, pvc, pod information on given cns volume
-func waitAndVerifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume, pod *v1.Pod) error {
+func waitAndVerifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim,
+	pv *v1.PersistentVolume, pod *v1.Pod) error {
 	waitErr := wait.PollImmediate(poll*5, pollTimeout, func() (bool, error) {
 		matches := verifyCnsVolumeMetadata(volumeID, pvc, pv, pod)
 		return matches, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles vcp_to_csi_create_delete.

**Testing done**:
Local build, check