### PR TITLE
Clean up long lines in syncer_test

### DIFF
--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -457,7 +457,8 @@ func runTestMetadataSyncInformer(t *testing.T) {
 	if err = k8sclient.CoreV1().Pods(namespace).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0)); err != nil {
 		t.Fatal(err)
 	}
-	if err = k8sclient.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0)); err != nil {
+	if err = k8sclient.CoreV1().PersistentVolumeClaims(namespace).
+		Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0)); err != nil {
 		t.Fatal(err)
 	}
 	if err = k8sclient.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0)); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Long lines are hard to read, especially if you have a small screen. Golang recommends the max
size of a line of 120 characters. So is the default rule in golangci-lint. (In C/C++, I typically limit
the line within 80 characters, for a reference.) To wrap a long line, we need to pay attention to
Golang's special grammar that it automatically inserts a semicolon immediately after a line's
final token if that token is
- an identifier
- an integer, floating-point, imaginary, rune, or string literal
- one of the keywords break, continue, fallthrough, or return
- one of the operators and delimiters ++, --, ), ], or }

Therefore, I break lines after comma, opening parenthesis e.g. (, [, {, and dot, binary operators.
The new line should be properly indented with tabs.

This change handles syncer_test.

**Testing done**:
Local build, check and test