### PR TITLE
Updating param name in ReloadConfig for better code readability

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -221,12 +221,12 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 
 // ReloadConfiguration reloads configuration from the secret, and update
 // controller's config cache and VolumeManager's VC Config cache.
-// The function takes a boolean reconnectToVCFromNewConfig as ainputs.
-// If reconnectToVCFromNewConfig is set to true, the function re-establishes
+// The function takes a boolean forceReconnectToVC as ainputs.
+// If forceReconnectToVC is set to true, the function re-establishes
 // connection with VC, else based on the configuration data changed during
 // reload, the function resets config, reloads VC connection when credentials
 // are changed and returns appropriate error.
-func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error {
+func (c *controller) ReloadConfiguration(forceReconnectToVC bool) error {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Info("Reloading Configuration")
 	cfg, err := common.GetConfig(ctx)
@@ -243,7 +243,7 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 		var vcenter *cnsvsphere.VirtualCenter
 		if c.manager.VcenterConfig.Host != newVCConfig.Host ||
 			c.manager.VcenterConfig.Username != newVCConfig.Username ||
-			c.manager.VcenterConfig.Password != newVCConfig.Password || reconnectToVCFromNewConfig {
+			c.manager.VcenterConfig.Password != newVCConfig.Password || forceReconnectToVC {
 
 			// Verify if new configuration has valid credentials by connecting to
 			// vCenter. Proceed only if the connection succeeds, else return error.

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -236,6 +236,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				// the expected ca file path.
 				if event.Op&fsnotify.Create == fsnotify.Create && event.Name == cnsconfig.SupervisorCAFilePath {
 					for {
+						// Invoking ReloadConfiguration with forceReconnectToVC set to true.
 						reconnectVCErr := ReloadConfiguration(metadataSyncer, true)
 						if reconnectVCErr == nil {
 							log.Infof("Successfully re-established connection with VC from: %q",
@@ -470,12 +471,12 @@ func updateTriggerCsiFullSyncInstance(ctx context.Context,
 
 // ReloadConfiguration reloads configuration from the secret, and update
 // controller's cached configs. The function takes metadatasyncerInformer and
-// reconnectToVCFromNewConfig as parameters. If reconnectToVCFromNewConfig
+// forceReconnectToVC as parameters. If forceReconnectToVC
 // is set to true, the function re-establishes connection with VC. Otherwise,
 // based on the configuration data changed during reload, the function resets
 // config, reloads VC connection when credentials are changed and returns
 // appropriate error.
-func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFromNewConfig bool) error {
+func ReloadConfiguration(metadataSyncer *metadataSyncInformer, forceReconnectToVC bool) error {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Info("Reloading Configuration")
 	cfg, err := common.GetConfig(ctx)
@@ -506,7 +507,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 			if metadataSyncer.host != newVCConfig.Host ||
 				metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User != newVCConfig.Username ||
 				metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].Password != newVCConfig.Password ||
-				reconnectToVCFromNewConfig {
+				forceReconnectToVC {
 				// Verify if new configuration has valid credentials by connecting
 				// to vCenter. Proceed only if the connection succeeds, else return
 				// error.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is updating the variable names & function parameter name for ReloadConfiguration() method.
Instead of `reconnectToVCFromNewConfig`, changing it to `forceReconnectToVC` so that it is easier to understand and define the behavior of callers of ReloadConfiguration() method.
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Not Applicable since the PR includes only variable name changes

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Updating variable names for better code readability
```
