### PR TITLE
enable lll linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,3 +12,11 @@ linters:
     - unused
     - varcheck
     - misspell
+    - lll
+linters-settings:
+  lll:
+    # max line length, lines longer will be reported. Default is 120.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+    line-length: 120
+    # tab width in spaces. Default to 1.
+    tab-width: 1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding `lll` linter of `golangci-lint` to prevent adding code with more than 120 characters in a single line.


**Testing done**:
```
% make check
hack/check-format.sh
go: found golang.org/x/tools/cmd/goimports in golang.org/x/tools v0.1.1
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go: found honnef.co/go/tools/cmd/staticcheck in honnef.co/go/tools v0.2.0
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/divyenp/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver /Users/divyenp/go/src/github.com/divyenpatel /Users/divyenp/go/src/github.com /Users/divyenp/go/src /Users/divyenp/go /Users/divyenp /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|files|imports|name|types_sizes|exports_file) took 1.67171996s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 60.399388ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 108, after processing: 0 
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 19/108, skip_dirs: 108/108, identifier_marker: 19/19, exclude: 19/19, exclude-rules: 1/19, nolint: 0/1, filename_unadjuster: 108/108, path_prettifier: 108/108, cgo: 108/108, skip_files: 108/108 
INFO [runner] processing took 8.491001ms with stages: nolint: 6.534863ms, autogenerated_exclude: 890.229µs, path_prettifier: 616.853µs, identifier_marker: 228.447µs, skip_dirs: 114.889µs, exclude-rules: 87.113µs, cgo: 8.449µs, filename_unadjuster: 5.652µs, max_same_issues: 1.287µs, uniq_by_line: 484ns, source_code: 414ns, exclude: 375ns, path_shortener: 313ns, max_from_linter: 301ns, diff: 270ns, skip_files: 245ns, path_prefixer: 242ns, max_per_file_from_linter: 197ns, severity-rules: 194ns, sort_results: 184ns 
INFO [runner] linters took 1.986510906s with stages: goanalysis_metalinter: 1.977931594s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 39 samples, avg is 111.0MB, max is 141.1MB 
INFO Execution took 3.730820923s 
```

**Special notes for your reviewer**:
`lll` check passed for this PR - https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_vsphere-csi-driver/1182/pull-vsphere-csi-driver-verify-golangci-lint/1417558565685563392/build-log.txt

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
enable lll linter
```
cc: @zhelongp 