### PR TITLE
move service before deployment in the vsphere-csi-driver.yaml 

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -152,6 +152,26 @@ metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
   namespace: vmware-system-csi
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -484,23 +504,3 @@ spec:
           operator: Exists
         - effect: NoSchedule
           operator: Exists
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: vsphere-csi-controller
-  namespace: vmware-system-csi
-  labels:
-    app: vsphere-csi-controller
-spec:
-  ports:
-    - name: ctlr
-      port: 2112
-      targetPort: 2112
-      protocol: TCP
-    - name: syncer
-      port: 2113
-      targetPort: 2113
-      protocol: TCP
-  selector:
-    app: vsphere-csi-controller


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
As per Kubernetes Documentation and Guidelines - https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/#organizing-resource-configurations

> The resources will be created in the order they appear in the file. Therefore, it's best to specify the service first, since that will ensure the scheduler can spread the pods associated with the service as they are created by the controller(s), such as Deployment.


**Testing done**:

Order before this change

```
# kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/vanilla/vsphere-csi-driver.yaml
csidriver.storage.k8s.io/csi.vsphere.vmware.com created
serviceaccount/vsphere-csi-controller created
clusterrole.rbac.authorization.k8s.io/vsphere-csi-controller-role created
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-controller-binding created
serviceaccount/vsphere-csi-node created
clusterrole.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role created
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role-binding created
role.rbac.authorization.k8s.io/vsphere-csi-node-role created
rolebinding.rbac.authorization.k8s.io/vsphere-csi-node-binding created
configmap/internal-feature-states.csi.vsphere.vmware.com created
deployment.apps/vsphere-csi-controller created
daemonset.apps/vsphere-csi-node created
service/vsphere-csi-controller created
```

Order After this change

```
# kubectl apply -f https://raw.githubusercontent.com/divyenpatel/vsphere-csi-driver/moving-service-before-deployment/manifests/vanilla/vsphere-csi-driver.yaml
csidriver.storage.k8s.io/csi.vsphere.vmware.com created
serviceaccount/vsphere-csi-controller created
clusterrole.rbac.authorization.k8s.io/vsphere-csi-controller-role created
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-controller-binding created
serviceaccount/vsphere-csi-node created
clusterrole.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role created
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role-binding created
role.rbac.authorization.k8s.io/vsphere-csi-node-role created
rolebinding.rbac.authorization.k8s.io/vsphere-csi-node-binding created
configmap/internal-feature-states.csi.vsphere.vmware.com created
service/vsphere-csi-controller created
deployment.apps/vsphere-csi-controller created
daemonset.apps/vsphere-csi-node created
```

**Special notes for your reviewer**:
This change will be useful when we support increasing the replica count of `vsphere-csi-controller`.  It's best to specify the service first, since that will ensure the scheduler can spread the pods associated with the service as they are created by the controller(s), such as Deployment.

**Release note**:

```release-note
move service before deployment
```
