### PR TITLE
Keep VCP to CSI migration fss set to false

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -139,7 +139,7 @@ roleRef:
 ---
 apiVersion: v1
 data:
-  "csi-migration": "true"
+  "csi-migration": "false"
   "csi-auth-check": "true"
   "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is changing the Migration FSS in CSI driver to false. When there are 1000s of VCP volumes and they get migrated to CSI volumes, the migrated CNS volumes are registered without EntityMetadata(on 67u3). The Entity metadata is added only during the update volume metadata call. Because migration of 1000s of volumes takes more than 30mins, when CNS periodic FullSync gets triggered, the migrated CNS volumes will be deleted since they are created without EntityMetadata.  This is a defect on the VCenter API side and is still being addressed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Not needed

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Keep VCP to CSI migration fss set to false
```
