### PR TITLE
Revert "move service before deployment (#1185)"

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -152,26 +152,6 @@ metadata:
   name: internal-feature-states.csi.vsphere.vmware.com
   namespace: vmware-system-csi
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: vsphere-csi-controller
-  namespace: vmware-system-csi
-  labels:
-    app: vsphere-csi-controller
-spec:
-  ports:
-    - name: ctlr
-      port: 2112
-      targetPort: 2112
-      protocol: TCP
-    - name: syncer
-      port: 2113
-      targetPort: 2113
-      protocol: TCP
-  selector:
-    app: vsphere-csi-controller
----
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -504,3 +484,23 @@ spec:
           operator: Exists
         - effect: NoSchedule
           operator: Exists
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller


### PR DESCRIPTION
This reverts commit 20d6188326c4fbde503414ecce49538438eda75b.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR reverts https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1185

Pipelines are failing to deploy the CSI driver after this change due to the below error:

```
error parsing vsphere-csi-driver.yaml: error converting YAML to JSON: yaml: line 20: mapping values are not allowed in this context\n"
```
We'll revert this change first and then determine the issue. 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Revert "move service before deployment (#1185)"
```
