### PR TITLE
Added the functionality of CreateVolume from snapshot data source for block volumes in Vanilla cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/rexray/gocsi v1.2.2
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
+	github.com/stretchr/testify v1.7.0
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.3
 	github.com/vmware/govmomi v0.26.1-0.20210616182200-66b9538af589

--- a/pkg/csi/service/common/types.go
+++ b/pkg/csi/service/common/types.go
@@ -70,9 +70,10 @@ type CreateVolumeSpec struct {
 	StoragePolicyID string
 	CapacityMB      int64
 	// TODO: Move this StorageClassParams
-	AffineToHost           string
-	VolumeType             string
-	VsanDirectDatastoreURL string // Datastore URL from vSan direct storage pool
+	AffineToHost            string
+	VolumeType              string
+	VsanDirectDatastoreURL  string // Datastore URL from vSan direct storage pool
+	ContentSourceSnapshotID string // SnapshotID from VolumeContentSource in CreateVolumeRequest
 }
 
 // StorageClassParams represents the storage class parameterss

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -351,6 +351,37 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	}
 	volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
 
+	// Check if the feature state of block-volume-snapshot is enabled
+	isBlockVolumeSnapshotEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
+	// Check if requested volume size and source snapshot size matches
+	volumeSource := req.GetVolumeContentSource()
+	var contentSourceSnapshotID string
+	if isBlockVolumeSnapshotEnabled && volumeSource != nil {
+		sourceSnapshot := volumeSource.GetSnapshot()
+		if sourceSnapshot == nil {
+			return nil, logger.LogNewErrorCode(log, codes.InvalidArgument, "unsupported VolumeContentSource type")
+		}
+		contentSourceSnapshotID = sourceSnapshot.GetSnapshotId()
+
+		cnsVolumeID, _, err := common.ParseCSISnapshotID(contentSourceSnapshotID)
+		if err != nil {
+			return nil, logger.LogNewErrorCode(log, codes.InvalidArgument, err.Error())
+		}
+
+		snapshotSizeInMB, err := utils.QueryCapacityForBlockVolumeSnapshotUtil(
+			ctx, c.manager.VolumeManager, cnsVolumeID, common.BlockVolumeType)
+		if err != nil {
+			return nil, err
+		}
+
+		snapshotSizeInBytes := snapshotSizeInMB * common.MbInBytes
+		if volSizeBytes != snapshotSizeInBytes {
+			return nil, logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"size mismatches, requested volume size %d and source snapshot size %d",
+				volSizeBytes, snapshotSizeInBytes)
+		}
+	}
+
 	// Fetching the feature state for csi-migration before parsing storage class
 	// params.
 	csiMigrationFeatureState := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration)
@@ -400,10 +431,11 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		}
 	}
 	var createVolumeSpec = common.CreateVolumeSpec{
-		CapacityMB: volSizeMB,
-		Name:       req.Name,
-		ScParams:   scParams,
-		VolumeType: common.BlockVolumeType,
+		CapacityMB:              volSizeMB,
+		Name:                    req.Name,
+		ScParams:                scParams,
+		VolumeType:              common.BlockVolumeType,
+		ContentSourceSnapshotID: contentSourceSnapshotID,
 	}
 
 	var sharedDatastores []*cnsvsphere.DatastoreInfo
@@ -555,6 +587,18 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		}
 		resp.Volume.AccessibleTopology = append(resp.Volume.AccessibleTopology, volumeTopology)
 	}
+
+	// Set the Snapshot VolumeContentSource in the CreateVolumeResponse
+	if contentSourceSnapshotID != "" {
+		resp.Volume.ContentSource = &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Snapshot{
+				Snapshot: &csi.VolumeContentSource_SnapshotSource{
+					SnapshotId: contentSourceSnapshotID,
+				},
+			},
+		}
+	}
+
 	return resp, nil
 }
 
@@ -1160,33 +1204,13 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 				"cannot snapshot migrated vSphere volume. :%q", volumeID)
 		}
 
-		// Check if volume already exists
-		volumeIds := []cnstypes.CnsVolumeId{{Id: volumeID}}
-		queryFilter := cnstypes.CnsQueryFilter{
-			VolumeIds: volumeIds,
-		}
-		queryResult, err := c.manager.VolumeManager.QueryVolume(ctx, queryFilter)
+		// Query Capacity in MB for block volume snapshot
+		snapshotSizeInMB, err := utils.QueryCapacityForBlockVolumeSnapshotUtil(
+			ctx, c.manager.VolumeManager, volumeID, common.BlockVolumeType)
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
-				"The volume %q to be snapshotted is not available: %v", volumeID, err)
-		}
-
-		// Check if it is a block volume
-		if queryResult.Volumes[0].VolumeType != common.BlockVolumeType {
-			return nil, logger.LogNewErrorCodef(log, codes.Unimplemented,
-				"CreateSnapshot is only supported on block volume. VolumeType: %v",
-				queryResult.Volumes[0].VolumeType)
+			return nil, err
 		}
 		volumeType = prometheus.PrometheusBlockVolumeType
-
-		// Get the snapshot size by getting the volume size, which is only valid for full backup use cases
-		var snapshotSize int64
-		if len(queryResult.Volumes) > 0 {
-			snapshotSize = queryResult.Volumes[0].BackingObjectDetails.GetCnsBackingObjectDetails().CapacityInMb
-		} else {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
-				"failed to get the snapshot size by querying volume: %q", volumeID)
-		}
 
 		// the returned snapshotID below is a combination of CNS VolumeID and CNS SnapshotID concatenated by the "+"
 		// sign. That is, a string of "<UUID>+<UUID>". Because, all other CNS snapshot APIs still require both
@@ -1201,7 +1225,7 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 
 		createSnapshotResponse := &csi.CreateSnapshotResponse{
 			Snapshot: &csi.Snapshot{
-				SizeBytes:      snapshotSize * common.MbInBytes,
+				SizeBytes:      snapshotSizeInMB * common.MbInBytes,
 				SnapshotId:     snapshotID,
 				SourceVolumeId: volumeID,
 				CreationTime:   snapshotCreateTimeInProto,
@@ -1211,7 +1235,7 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 
 		log.Infof("CreateSnapshot succeeded for snapshot %s "+
 			"on volume %s size %d Time proto %d Timestamp %+v Response: %+v",
-			snapshotID, volumeID, snapshotSize*common.MbInBytes, snapshotCreateTimeInProto,
+			snapshotID, volumeID, snapshotSizeInMB*common.MbInBytes, snapshotCreateTimeInProto,
 			*snapshotCreateTimePtr, createSnapshotResponse)
 		return createSnapshotResponse, nil
 	}
@@ -1241,35 +1265,15 @@ func (c *controller) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshot
 	}
 
 	deleteSnapshotInternal := func() (*csi.DeleteSnapshotResponse, error) {
-		// Validate arguments
-		// The expected format of the SnapshotId in the DeleteSnapshotRequest is,
-		// a combination of CNS VolumeID and CNS SnapshotID concatenated by the "+" sign.
-		// That is, a string of "<UUID>+<UUID>"
 		csiSnapshotID := req.GetSnapshotId()
-		if len(csiSnapshotID) == 0 {
-			return nil, logger.LogNewErrorCode(log, codes.InvalidArgument,
-				"DeleteSnapshot Snapshot ID must be provided")
-		}
-
-		// Decompose csiSnapshotID based on the expected format mentioned above
-		IDs := strings.Split(csiSnapshotID, common.VSphereCSISnapshotIdDelimiter)
-		if len(IDs) != 2 {
-			return nil, logger.LogNewErrorCode(log, codes.InvalidArgument,
-				"DeleteSnapshot provided invalid Snapshot ID")
-		}
-
-		volumeID := IDs[0]
-		snapshotID := IDs[1]
-		log.Debugf("DeleteSnapshot: Deleting snapshot %q on volume %q", snapshotID, volumeID)
-
-		err := common.DeleteSnapshotUtil(ctx, c.manager, volumeID, snapshotID)
+		err := common.DeleteSnapshotUtil(ctx, c.manager, csiSnapshotID)
 		if err != nil {
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,
-				"Failed to delete snapshot %q on volume %q. Error: %+v",
-				snapshotID, volumeID, err)
+				"Failed to delete snapshot %q. Error: %+v",
+				csiSnapshotID, err)
 		}
 
-		log.Infof("DeleteSnapshot: successfully deleted snapshot %q on volume %q", snapshotID, volumeID)
+		log.Infof("DeleteSnapshot: successfully deleted snapshot %q", csiSnapshotID)
 		return &csi.DeleteSnapshotResponse{}, nil
 	}
 

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -973,3 +973,209 @@ func TestSnapshotVolume(t *testing.T) {
 		t.Fatalf("Volume should not exist after deletion with ID: %s", volID)
 	}
 }
+
+func TestCreateVolumeFromSnapshot(t *testing.T) {
+	ct := getControllerTest(t)
+
+	// Create.
+	params := make(map[string]string)
+	if v := os.Getenv("VSPHERE_DATASTORE_URL"); v != "" {
+		params[common.AttributeDatastoreURL] = v
+	}
+	capabilities := []*csi.VolumeCapability{
+		{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters:         params,
+		VolumeCapabilities: capabilities,
+	}
+
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	volID := respCreate.Volume.VolumeId
+
+	// Verify the volume has been created.
+	queryFilter := cnstypes.CnsQueryFilter{
+		VolumeIds: []cnstypes.CnsVolumeId{
+			{
+				Id: volID,
+			},
+		},
+	}
+	queryResult, err := ct.vcenter.CnsClient.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(queryResult.Volumes) != 1 && queryResult.Volumes[0].VolumeId.Id != volID {
+		t.Fatalf("failed to find the newly created volume with ID: %s", volID)
+	}
+
+	// QueryAll.
+	queryFilter = cnstypes.CnsQueryFilter{
+		VolumeIds: []cnstypes.CnsVolumeId{
+			{
+				Id: volID,
+			},
+		},
+	}
+	querySelection := cnstypes.CnsQuerySelection{}
+	queryResult, err = ct.vcenter.CnsClient.QueryAllVolume(ctx, queryFilter, querySelection)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(queryResult.Volumes) != 1 && queryResult.Volumes[0].VolumeId.Id != volID {
+		t.Fatalf("failed to find the newly created volume with ID: %s", volID)
+	}
+
+	defer func() {
+		// Delete.
+		reqDelete := &csi.DeleteVolumeRequest{
+			VolumeId: volID,
+		}
+		_, err = ct.controller.DeleteVolume(ctx, reqDelete)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify the volume has been deleted.
+		queryResult, err = ct.vcenter.CnsClient.QueryVolume(ctx, queryFilter)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(queryResult.Volumes) != 0 {
+			t.Fatalf("Volume should not exist after deletion with ID: %s", volID)
+		}
+	}()
+
+	// Snapshot a volume
+	reqCreateSnapshot := &csi.CreateSnapshotRequest{
+		SourceVolumeId: volID,
+		Name:           "snapshot-" + uuid.New().String(),
+	}
+
+	respCreateSnapshot, err := ct.controller.CreateSnapshot(ctx, reqCreateSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapID := respCreateSnapshot.Snapshot.SnapshotId
+
+	defer func() {
+		// Delete the snapshot
+		reqDeleteSnapshot := &csi.DeleteSnapshotRequest{
+			SnapshotId: snapID,
+		}
+
+		_, err = ct.controller.DeleteSnapshot(ctx, reqDeleteSnapshot)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Create a new volume from the snapshot with expected request
+	reqCreateFromSnapshot := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters:         params,
+		VolumeCapabilities: capabilities,
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Snapshot{
+				Snapshot: &csi.VolumeContentSource_SnapshotSource{
+					SnapshotId: snapID,
+				},
+			},
+		},
+	}
+
+	respCreateFromSnapshot, err := ct.controller.CreateVolume(ctx, reqCreateFromSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restoredVolID := respCreateFromSnapshot.Volume.VolumeId
+
+	// Verify the volume has been created.
+	queryFilter = cnstypes.CnsQueryFilter{
+		VolumeIds: []cnstypes.CnsVolumeId{
+			{
+				Id: restoredVolID,
+			},
+		},
+	}
+	queryResult, err = ct.vcenter.CnsClient.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(queryResult.Volumes) != 1 && queryResult.Volumes[0].VolumeId.Id != restoredVolID {
+		t.Fatalf("failed to find the newly created volume from snapshot with ID: %s", restoredVolID)
+	}
+
+	defer func() {
+		// Delete the restored volume
+		reqDelete := &csi.DeleteVolumeRequest{
+			VolumeId: restoredVolID,
+		}
+		_, err = ct.controller.DeleteVolume(ctx, reqDelete)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify the volume has been deleted.
+		queryResult, err = ct.vcenter.CnsClient.QueryVolume(ctx, queryFilter)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(queryResult.Volumes) != 0 {
+			t.Fatalf("Volume should not exist after deletion with ID: %s", restoredVolID)
+		}
+	}()
+
+	// Create a new volume from the snapshot with unexpected request
+	reqCreateFromSnapshot = &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 2 * common.GbInBytes,
+		},
+		Parameters:         params,
+		VolumeCapabilities: capabilities,
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Snapshot{
+				Snapshot: &csi.VolumeContentSource_SnapshotSource{
+					SnapshotId: snapID,
+				},
+			},
+		},
+	}
+
+	_, err = ct.controller.CreateVolume(ctx, reqCreateFromSnapshot)
+	if err != nil {
+		statusErr, ok := status.FromError(err)
+		if !ok {
+			t.Fatalf("unable to convert the error: %+v into a grpc status error type", err)
+		}
+		if statusErr.Code() == codes.InvalidArgument {
+			t.Logf("received error as expected when attempting to create volume from snapshot, error: %+v", err)
+		} else {
+			t.Fatalf("unexpected error code received, expected: %s received: %s",
+				codes.InvalidArgument.String(), statusErr.Code().String())
+		}
+	} else {
+		t.Fatal("expected error was not received when creating volume from snapshot")
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Added the functionality of CreateVolume from snapshot data source for block volumes in Vanilla cluster

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

- unit/integration test: added test cases that cover functionality for this change and passed all test cases by running `make test` locally.
- e2e test: TBD

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added the functionality of CreateVolume from snapshot data source for block volumes in Vanilla cluster
```

Signed-off-by: Lintong Jiang <lintongj@vmware.com>
