### PR TITLE
Introduce topologyCategories in vSphere config secret

### DIFF
--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -75,10 +75,18 @@ type Config struct {
 	// Guest Cluster configurations, only used by GC
 	GC GCConfig
 
-	// Tag categories and tags which correspond to "built-in node labels: zones and region"
+	// Labels will list the topology domains the CSI driver is expected
+	// to pick up from the inventory. This info will later be used while provisioning volumes.
 	Labels struct {
-		Zone   string `gcfg:"zone"`
-		Region string `gcfg:"region"`
+		// Zone and Region correspond to the vSphere categories
+		// created to tag specific topology domains in the inventory.
+		Zone   string `gcfg:"zone"`   // Deprecated
+		Region string `gcfg:"region"` // Deprecated
+		// TopologyCategories is a comma separated string of topology domains
+		// which will correspond to the `Categories` the vSphere admin will
+		// create in the inventory using the UI.
+		// Maximum number of categories allowed is 5.
+		TopologyCategories string `gcfg:"topology-categories"`
 	}
 }
 

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -242,6 +242,10 @@ const (
 
 	// VSphereCSISnapshotIdDelimiter is the delimiter for concatenating CNS VolumeID and CNS SnapshotID
 	VSphereCSISnapshotIdDelimiter = "+"
+
+	// TopologyLabelsDomain is the domain name used to identify user-defined
+	// topology labels applied on the node by vSphere CSI driver.
+	TopologyLabelsDomain = "topology.csi.vmware.com"
 )
 
 // Supported container orchestrators.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Currently the vSphere CSI driver only supports the use of `Region` and `Zone` labels as topology domains. With this PR, we are opening it up for any category to be used as a topology domain.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
**Vanilla E2E tests** - 
```
Ran 1 of 214 Specs in 504.277 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 213 Skipped
PASS

Ran 47 of 214 Specs in 8548.147 seconds
FAIL! -- 45 Passed | 2 Failed | 0 Pending | 167 Skipped
--- FAIL: TestE2E (8548.23s)
FAIL
```
The 2 tests failed at the etcd layer. Retried these tests and they passed - 
```
Ran 2 of 214 Specs in 491.501 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 212 Skipped
PASS
```

**Manual testing** - 

Node daemonset init logs:
```
2021-08-09T18:57:06.718Z	INFO	logger/logger.go:41	Setting default log level to :"DEVELOPMENT"
2021-08-09T18:57:06.721Z	INFO	vsphere-csi/main.go:57	Version : v2.1.0-rc.1-981-gc17f7053	{"TraceId": "725da7da-09aa-401d-a095-0115e3c61916"}
2021-08-09T18:57:06.723Z	DEBUG	commonco/utils.go:102	Container orchestrator init params: {InternalFeatureStatesConfigInfo:{Name:internal-feature-states.csi.vsphere.vmware.com Namespace:vmware-system-csi} ServiceMode:node}	{"TraceId": "725da7da-09aa-401d-a095-0115e3c61916"}
2021-08-09T18:57:06.733Z	INFO	logger/logger.go:41	Setting default log level to :"DEVELOPMENT"
2021-08-09T18:57:06.733Z	INFO	k8sorchestrator/k8sorchestrator.go:152	Initializing k8sOrchestratorInstance	{"TraceId": "7eb29961-2b83-41af-b759-a6b37f1eb532"}
2021-08-09T18:57:06.733Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config	{"TraceId": "7eb29961-2b83-41af-b759-a6b37f1eb532"}
2021-08-09T18:57:06.734Z	INFO	kubernetes/kubernetes.go:341	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "7eb29961-2b83-41af-b759-a6b37f1eb532"}
2021-08-09T18:57:06.761Z	INFO	k8sorchestrator/k8sorchestrator.go:258	New internal feature states values stored successfully: map[async-query-volume:false block-volume-snapshot:false csi-auth-check:true csi-migration:false improved-csi-idempotency:false improved-volume-topology:true online-volume-extend:true trigger-csi-fullsync:false]	{"TraceId": "7eb29961-2b83-41af-b759-a6b37f1eb532"}
2021-08-09T18:57:06.762Z	INFO	k8sorchestrator/k8sorchestrator.go:178	k8sOrchestratorInstance initialized	{"TraceId": "7eb29961-2b83-41af-b759-a6b37f1eb532"}
2021-08-09T18:57:06.762Z	INFO	service/driver.go:107	Configured: "csi.vsphere.vmware.com" with clusterFlavor: "VANILLA" and mode: "node"	{"TraceId": "7eb29961-2b83-41af-b759-a6b37f1eb532"}
time="2021-08-09T18:57:06Z" level=info msg="identity service registered"
time="2021-08-09T18:57:06Z" level=info msg="node service registered"
time="2021-08-09T18:57:06Z" level=info msg=serving endpoint="unix:///csi/csi.sock"
2021-08-09T18:57:06.773Z	INFO	k8sorchestrator/k8sorchestrator.go:484	configMapAdded: Internal feature state values from "internal-feature-states.csi.vsphere.vmware.com" stored successfully: map[async-query-volume:false block-volume-snapshot:false csi-auth-check:true csi-migration:false improved-csi-idempotency:false improved-volume-topology:true online-volume-extend:true trigger-csi-fullsync:false]	{"TraceId": "88ad4ca9-09bb-4dc9-8b0b-9bb7e7a1e574"}
2021-08-09T18:57:07.109Z	INFO	service/node.go:660	NodeGetInfo: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "0941d49a-3ea8-4205-ad79-d06f56231e4a"}
2021-08-09T18:57:07.109Z	INFO	service/node.go:682	NodeGetInfo: MAX_VOLUMES_PER_NODE is set to 0	{"TraceId": "0941d49a-3ea8-4205-ad79-d06f56231e4a"}
2021-08-09T18:57:07.110Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config	{"TraceId": "0941d49a-3ea8-4205-ad79-d06f56231e4a"}
2021-08-09T18:57:07.110Z	INFO	kubernetes/kubernetes.go:341	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "0941d49a-3ea8-4205-ad79-d06f56231e4a"}
2021-08-09T18:57:07.112Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config	{"TraceId": "0941d49a-3ea8-4205-ad79-d06f56231e4a"}
2021-08-09T18:57:07.112Z	INFO	kubernetes/kubernetes.go:341	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "0941d49a-3ea8-4205-ad79-d06f56231e4a"}
2021-08-09T18:57:07.160Z	INFO	k8sorchestrator/topology.go:204	Topology service initiated successfully	{"TraceId": "0941d49a-3ea8-4205-ad79-d06f56231e4a"}
2021-08-09T18:57:07.182Z	INFO	k8sorchestrator/topology.go:248	Successfully created a CSINodeTopology instance for NodeName: "k8s-master-661"	{"TraceId": "0941d49a-3ea8-4205-ad79-d06f56231e4a"}
2021-08-09T18:57:07.182Z	INFO	k8sorchestrator/topology.go:314	Timeout is set to 1 minute(s)	{"TraceId": "0941d49a-3ea8-4205-ad79-d06f56231e4a"}
2021-08-09T18:57:07.710Z	INFO	service/node.go:753	NodeGetInfo response: node_id:"k8s-master-661" accessible_topology:<segments:<key:"topology.csi.vmware.com/building" value:"building1" > segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/rack" value:"rack1" > > 	{"TraceId": "0941d49a-3ea8-4205-ad79-d06f56231e4a"}
```

Topology of nodes:
```
$ k get nodes -L topology.csi.vmware.com/building -L topology.csi.vmware.com/rack -L topology.csi.vmware.com/k8s-region
NAME             STATUS   ROLES                  AGE   VERSION   BUILDING    RACK    K8S-REGION
k8s-master-661   Ready    control-plane,master   10d   v1.21.1   building1   rack1   region1
k8s-node-0179    Ready    <none>                 10d   v1.21.1   building1   rack2   region1
k8s-node-0486    Ready    <none>                 10d   v1.21.1   building1   rack3   region1
k8s-node-0869    Ready    <none>                 10d   v1.21.1   building1   rack1   region1
```

Sample CSINode instance:
```
Name:               k8s-node-0179
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Fri, 30 Jul 2021 00:20:58 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:        k8s-node-0179
      Topology Keys:  [topology.csi.vmware.com/building topology.csi.vmware.com/k8s-region topology.csi.vmware.com/rack]
Events:               <none>
```

Sample describe output of node:
```
Name:               k8s-node-0179
Roles:              <none>
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu
                    beta.kubernetes.io/os=linux
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=k8s-node-0179
                    kubernetes.io/os=linux
                    topology.csi.vmware.com/building=building1
                    topology.csi.vmware.com/k8s-region=region1
                    topology.csi.vmware.com/rack=rack2
Annotations:        ....
```

StorageClass definition:
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: single-zone-sc
provisioner: csi.vsphere.vmware.com
allowedTopologies:
  - matchLabelExpressions:
      - key: topology.csi.vmware.com/k8s-region
        values:
          - region1
      - key: topology.csi.vmware.com/rack
        values:
          - rack2
```

CreateVolume logs:
```
2021-07-30T21:27:54.741Z	INFO	vanilla/controller.go:716	CreateVolume: called with args {Name:pvc-d7ceac54-c163-4b99-a1be-dfa4bde4c59f CapacityRange:required_bytes:104857600  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"k8s-region" value:"region1" > segments:<key:"rack" value:"rack2" > > preferred:<segments:<key:"k8s-region" value:"region1" > segments:<key:"rack" value:"rack2" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.742Z	DEBUG	k8sorchestrator/topology.go:353	Get shared datastores with topologyRequirement: requisite:<segments:<key:"k8s-region" value:"region1" > segments:<key:"rack" value:"rack2" > > preferred:<segments:<key:"k8s-region" value:"region1" > segments:<key:"rack" value:"rack2" > > 	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.742Z	DEBUG	k8sorchestrator/topology.go:363	Using preferred topology	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.742Z	DEBUG	k8sorchestrator/topology.go:400	Getting list of nodeVMs for topology segments map[k8s-region:region1 rack:rack2]	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.746Z	DEBUG	node/manager.go:183	Renewing virtual machine VirtualMachine:vm-48 [VirtualCenterHost: 10.187.156.249, UUID: 423a99ad-fda8-d64c-6867-b7eb5e4615ec, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.187.156.249]] with nodeUUID "423a99ad-fda8-d64c-6867-b7eb5e4615ec"	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.757Z	DEBUG	node/manager.go:190	VM VirtualMachine:vm-48 [VirtualCenterHost: 10.187.156.249, UUID: 423a99ad-fda8-d64c-6867-b7eb5e4615ec, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.156.249]] was successfully renewed with nodeUUID "423a99ad-fda8-d64c-6867-b7eb5e4615ec"	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.758Z	DEBUG	k8sorchestrator/topology.go:457	Node "k8s-node-0869" did not match the topology requirement - "rack": "rack2" 	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.758Z	DEBUG	k8sorchestrator/topology.go:457	Node "k8s-node-0486" did not match the topology requirement - "rack": "rack2" 	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.758Z	DEBUG	k8sorchestrator/topology.go:457	Node "k8s-master-661" did not match the topology requirement - "rack": "rack2" 	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.758Z	INFO	k8sorchestrator/topology.go:408	Obtained list of nodeVMs [VirtualMachine:vm-48 [VirtualCenterHost: 10.187.156.249, UUID: 423a99ad-fda8-d64c-6867-b7eb5e4615ec, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.156.249]]]	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.758Z	DEBUG	vsphere/virtualmachine.go:347	Getting accessible datastores for node VirtualMachine:vm-48	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.772Z	INFO	k8sorchestrator/topology.go:423	Obtained shared datastores: [Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/61033fdf-5166805e-5884-0200a413a308/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/61033fe0-c727d92a-650e-0200a413a308/ Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/vsan:5225f61ed71ccc1e-2f1ef7605e976a38/]	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.772Z	DEBUG	vanilla/controller.go:504	Shared datastores [[Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/61033fdf-5166805e-5884-0200a413a308/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/61033fe0-c727d92a-650e-0200a413a308/ Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/vsan:5225f61ed71ccc1e-2f1ef7605e976a38/]] retrieved for topologyRequirement [requisite:<segments:<key:"k8s-region" value:"region1" > segments:<key:"rack" value:"rack2" > > preferred:<segments:<key:"k8s-region" value:"region1" > segments:<key:"rack" value:"rack2" > > ] with datastoreTopologyMap [+map[ds:///vmfs/volumes/61033fdf-5166805e-5884-0200a413a308/:[map[k8s-region:region1 rack:rack2]] ds:///vmfs/volumes/61033fe0-c727d92a-650e-0200a413a308/:[map[k8s-region:region1 rack:rack2]] ds:///vmfs/volumes/vsan:5225f61ed71ccc1e-2f1ef7605e976a38/:[map[k8s-region:region1 rack:rack2]]]]	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.773Z	DEBUG	vanilla/controller.go:340	filterDatastores: dsMap map[ds:///vmfs/volumes/61033fdb-2f501bd8-7bbe-0200a4cd2297/:Datastore: Datastore:datastore-32, datastore URL: ds:///vmfs/volumes/61033fdb-2f501bd8-7bbe-0200a4cd2297/ ds:///vmfs/volumes/61033fdc-9e3f9acc-de36-0200a4cd2297/:Datastore: Datastore:datastore-33, datastore URL: ds:///vmfs/volumes/61033fdc-9e3f9acc-de36-0200a4cd2297/ ds:///vmfs/volumes/61033fdd-22c3a6da-a011-0200a4631361/:Datastore: Datastore:datastore-29, datastore URL: ds:///vmfs/volumes/61033fdd-22c3a6da-a011-0200a4631361/ ds:///vmfs/volumes/61033fde-a5592ae6-bbda-0200a4631361/:Datastore: Datastore:datastore-30, datastore URL: ds:///vmfs/volumes/61033fde-a5592ae6-bbda-0200a4631361/ ds:///vmfs/volumes/61033fdf-5166805e-5884-0200a413a308/:Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/61033fdf-5166805e-5884-0200a413a308/ ds:///vmfs/volumes/61033fe0-c727d92a-650e-0200a413a308/:Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/61033fe0-c727d92a-650e-0200a413a308/ ds:///vmfs/volumes/vsan:5225f61ed71ccc1e-2f1ef7605e976a38/:Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/vsan:5225f61ed71ccc1e-2f1ef7605e976a38/] sharedDatastores [Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/61033fdf-5166805e-5884-0200a413a308/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/61033fe0-c727d92a-650e-0200a413a308/ Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/vsan:5225f61ed71ccc1e-2f1ef7605e976a38/]	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.773Z	DEBUG	vanilla/controller.go:349	filterDatastores: filteredDatastores [Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/61033fdf-5166805e-5884-0200a413a308/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/61033fe0-c727d92a-650e-0200a413a308/ Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/vsan:5225f61ed71ccc1e-2f1ef7605e976a38/]	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.776Z	DEBUG	common/vsphereutil.go:195	vSphere CSI driver creating volume pvc-d7ceac54-c163-4b99-a1be-dfa4bde4c59f with create spec (*types.CnsVolumeCreateSpec)(0xc00017d500)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-d7ceac54-c163-4b99-a1be-dfa4bde4c59f",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=3 cap=4) {
  (types.ManagedObjectReference) Datastore:datastore-34,
  (types.ManagedObjectReference) Datastore:datastore-35,
  (types.ManagedObjectReference) Datastore:datastore-39
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=16) "vSAN-FVT-Cluster",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA",
   ClusterDistribution: (string) (len=11) "CSI-Vanilla"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=16) "vSAN-FVT-Cluster",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA",
    ClusterDistribution: (string) (len=11) "CSI-Vanilla"
   }
  }
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc000140930)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 100
  },
  BackingDiskId: (string) "",
  BackingDiskUrlPath: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) <nil>,
 CreateSpec: (types.BaseCnsBaseCreateSpec) <nil>,
 VolumeSource: (types.BaseCnsVolumeSource) <nil>
})
	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:54.783Z	DEBUG	volume/util.go:191	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:56.266Z	INFO	volume/manager.go:380	CreateVolume: VolumeName: "pvc-d7ceac54-c163-4b99-a1be-dfa4bde4c59f", opId: "305deadf"	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:56.269Z	INFO	volume/util.go:318	Volume created successfully. VolumeName: "pvc-d7ceac54-c163-4b99-a1be-dfa4bde4c59f", volumeID: "4988c212-5ffc-4470-9a5a-da96f91c25d4"	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:56.269Z	DEBUG	volume/util.go:320	CreateVolume volumeId {{} "4988c212-5ffc-4470-9a5a-da96f91c25d4"} is placed on datastore "ds:///vmfs/volumes/61033fe0-c727d92a-650e-0200a413a308/"	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:56.270Z	DEBUG	vanilla/controller.go:603	Volume: 4988c212-5ffc-4470-9a5a-da96f91c25d4 is provisioned on the datastore: ds:///vmfs/volumes/61033fe0-c727d92a-650e-0200a413a308/ 	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
2021-07-30T21:27:56.270Z	DEBUG	vanilla/controller.go:608	volumeAccessibleTopology: [map[k8s-region:region1 rack:rack2]] is selected for datastore: ds:///vmfs/volumes/61033fe0-c727d92a-650e-0200a413a308/ 	{"TraceId": "e5d1fcfb-57f5-4c40-8a50-1a1102625a8d"}
```

Describe output of PV:
```
root@k8s-master-661:/etc/kubernetes# kdsc pv pvc-d7ceac54-c163-4b99-a1be-dfa4bde4c59f
Name:              pvc-d7ceac54-c163-4b99-a1be-dfa4bde4c59f
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      single-zone-sc
Status:            Bound
Claim:             default/single-zone-pvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          100Mi
Node Affinity:     
  Required Terms:  
    Term 0:        k8s-region in [region1]
                   rack in [rack2]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      4988c212-5ffc-4470-9a5a-da96f91c25d4
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1627677310736-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Introduce topologyCategories in vSphere config secret
```
