### PR TITLE
Perform hard mount for file volumes in Vanilla k8s

### DIFF
--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -1176,9 +1176,7 @@ func publishFileVol(
 	if params.ro {
 		mntFlags = append(mntFlags, "ro")
 	}
-	if cnstypes.CnsClusterFlavor(os.Getenv(csitypes.EnvClusterFlavor)) == cnstypes.CnsClusterFlavorGuest {
-		mntFlags = append(mntFlags, "hard")
-	}
+	mntFlags = append(mntFlags, "hard")
 	// Retrieve the file share access point from publish context.
 	mntSrc, ok := req.GetPublishContext()[common.Nfsv4AccessPoint]
 	if !ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is appending mount flags with the option "hard" for file volumes in Vanilla Kubernetes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
In-progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Perform hard mount for file volumes in Vanilla k8s
```
