### PR TITLE
Prevent volume expansion if snapshots are present

### DIFF
--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -1675,3 +1675,115 @@ func TestListSnapshotsWithToken(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestExpandVolumeWithSnapshots(t *testing.T) {
+	ct := getControllerTest(t)
+
+	// Create.
+	params := make(map[string]string)
+	if v := os.Getenv("VSPHERE_DATASTORE_URL"); v != "" {
+		params[common.AttributeDatastoreURL] = v
+	}
+	capabilities := []*csi.VolumeCapability{
+		{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters:         params,
+		VolumeCapabilities: capabilities,
+	}
+
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	volID := respCreate.Volume.VolumeId
+
+	// Verify the volume has been created.
+	queryFilter := cnstypes.CnsQueryFilter{
+		VolumeIds: []cnstypes.CnsVolumeId{
+			{
+				Id: volID,
+			},
+		},
+	}
+	queryResult, err := ct.vcenter.CnsClient.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(queryResult.Volumes) != 1 && queryResult.Volumes[0].VolumeId.Id != volID {
+		t.Fatalf("failed to find the newly created volume with ID: %s", volID)
+	}
+
+	// Snapshot a volume
+	reqCreateSnapshot := &csi.CreateSnapshotRequest{
+		SourceVolumeId: volID,
+		Name:           "snapshot-" + uuid.New().String(),
+	}
+
+	respCreateSnapshot, err := ct.controller.CreateSnapshot(ctx, reqCreateSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapID := respCreateSnapshot.Snapshot.SnapshotId
+
+	// Attempt to expand the volume
+	reqExpand := &csi.ControllerExpandVolumeRequest{
+		VolumeId: volID,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 2 * common.GbInBytes,
+		},
+		VolumeCapability: capabilities[0],
+	}
+	_, err = ct.controller.ControllerExpandVolume(ctx, reqExpand)
+	if err != nil {
+		expandErr, ok := status.FromError(err)
+		if !ok {
+			t.Fatalf("unable to convert the error: %+v into a grpc status error type", err)
+		}
+		if expandErr.Code() == codes.FailedPrecondition {
+			t.Logf("received error as expected when attempting to expand volume with snapshot, error: %+v", err)
+		} else {
+			t.Fatalf("unexpected error code received, expected: %s received: %s",
+				codes.FailedPrecondition.String(), expandErr.Code().String())
+		}
+	} else {
+		t.Fatal("expected error was not received when expanding volume with snapshot")
+	}
+	// Delete the snapshot
+	reqDeleteSnapshot := &csi.DeleteSnapshotRequest{
+		SnapshotId: snapID,
+	}
+	_, err = ct.controller.DeleteSnapshot(ctx, reqDeleteSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the volume
+	reqDelete := &csi.DeleteVolumeRequest{
+		VolumeId: volID,
+	}
+	_, err = ct.controller.DeleteVolume(ctx, reqDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the volume has been deleted.
+	queryResult, err = ct.vcenter.CnsClient.QueryVolume(ctx, queryFilter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(queryResult.Volumes) != 0 {
+		t.Fatalf("Volume should not exist after deletion with ID: %s", volID)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 The PR prevents volume expansion pre-emptively if there are CNS snapshots present for the volume.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
controller_test.go:1754: received error as expected when attempting to expand volume with snapshot, error: rpc error: code = FailedPrecondition desc = volume: 247f9e0f-d573-44b3-b129-7d8672eeb0d1 with existing snapshots [snapshot_id:"247f9e0f-d573-44b3-b129-7d8672eeb0d1+b983c708-c61c-481e-ac7b-7034a15aafc0" source_volume_id:"247f9e0f-d573-44b3-b129-7d8672eeb0d1" creation_time:<seconds:1628192934 nanos:914000000 > ready_to_use:true ] cannot be expanded, please delete snapshots before expanding the volume
--- PASS: TestExpandVolumeWithSnapshots (21.49s)
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Explicit error when attempting to expand a volume containing CNS snapshots.
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>