### PR TITLE
TKGS: Run node daemon set with hostNetwork set to true

### DIFF
--- a/manifests/guestcluster/1.17/pvcsi.yaml
+++ b/manifests/guestcluster/1.17/pvcsi.yaml
@@ -298,6 +298,8 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      hostNetwork: true
+      dnsPolicy: "ClusterFirstWithHostNet"
       serviceAccountName: vsphere-csi-node
       priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:

--- a/manifests/guestcluster/1.18/pvcsi.yaml
+++ b/manifests/guestcluster/1.18/pvcsi.yaml
@@ -298,6 +298,8 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      hostNetwork: true
+      dnsPolicy: "ClusterFirstWithHostNet"
       serviceAccountName: vsphere-csi-node
       priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:

--- a/manifests/guestcluster/1.19/pvcsi.yaml
+++ b/manifests/guestcluster/1.19/pvcsi.yaml
@@ -298,6 +298,8 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      hostNetwork: true
+      dnsPolicy: "ClusterFirstWithHostNet"
       serviceAccountName: vsphere-csi-node
       priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:

--- a/manifests/guestcluster/1.20/pvcsi.yaml
+++ b/manifests/guestcluster/1.20/pvcsi.yaml
@@ -298,6 +298,8 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      hostNetwork: true
+      dnsPolicy: "ClusterFirstWithHostNet"
       serviceAccountName: vsphere-csi-node
       priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:

--- a/manifests/guestcluster/1.21/pvcsi.yaml
+++ b/manifests/guestcluster/1.21/pvcsi.yaml
@@ -298,6 +298,8 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      hostNetwork: true
+      dnsPolicy: "ClusterFirstWithHostNet"
       serviceAccountName: vsphere-csi-node
       priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR ensures we run node daemon set with hostNetwork set to true.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified that the pods get deleted successfully after restarting/upgrading CSI driver

```
kubectl get daemonset -n vmware-system-csi -o yaml | grep hostNetwork
        hostNetwork: true

kubectl create -f file-pod.yaml 
pod/example-vanilla-file-pod1 created
pod/example-vanilla-file-pod2 created
pod/example-vanilla-file-pod3 created


kubectl delete pod --all -n vmware-system-csi 
pod "vsphere-csi-controller-869fd67797-x5dw2" deleted
pod "vsphere-csi-node-8vlsr" deleted
pod "vsphere-csi-node-l9vjn" deleted
pod "vsphere-csi-node-mqxwm" deleted
pod "vsphere-csi-node-wttf4" deleted

kubectl delete -f file-pod.yaml 
pod "example-vanilla-file-pod1" deleted
pod "example-vanilla-file-pod2" deleted
pod "example-vanilla-file-pod3" deleted

kubectl get pods | grep example
No resources found
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Run node daemon set with hostNetwork set to true
```
