### PR TITLE
Use appropriate variable names for storage class creation in e2e tests

### DIFF
--- a/tests/e2e/gc_metadata_syncer.go
+++ b/tests/e2e/gc_metadata_syncer.go
@@ -388,7 +388,7 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 
 		ginkgo.By("Creating StorageClass for Statefulset")
 		scParameters[svStorageClassName] = storagePolicyName
-		scSpec := getVSphereStorageClassSpec(storageclassname, scParameters, nil, "", "", false)
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
 		sc, err = client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {

--- a/tests/e2e/statefulset_with_topology.go
+++ b/tests/e2e/statefulset_with_topology.go
@@ -76,7 +76,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
-		scSpec := getVSphereStorageClassSpec(storageclassname, nil, allowedTopologies, "", "", false)
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {

--- a/tests/e2e/topology_aware_node_poweroff.go
+++ b/tests/e2e/topology_aware_node_poweroff.go
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 			GetAndExpectStringEnvVar(envRegionZoneWithSharedDS))
 
 		ginkgo.By("Creating StorageClass for Statefulset")
-		scSpec := getVSphereStorageClassSpec(storageclassname, nil, allowedTopologies, "", "", false)
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
@@ -213,7 +213,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		regionValues, zoneValues, allowedTopologies = topologyParameterForStorageClass(topologyValue)
 
 		ginkgo.By("Creating StorageClass for Statefulset")
-		scSpec := getVSphereStorageClassSpec(storageclassname, nil, allowedTopologies, "", "", false)
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {

--- a/tests/e2e/volume_health_test.go
+++ b/tests/e2e/volume_health_test.go
@@ -875,10 +875,10 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
 			// Create resource quota.
-			createResourceQuota(client, namespace, rqLimit, storageclassname)
+			createResourceQuota(client, namespace, rqLimit, defaultNginxStorageClassName)
 		}
 
-		scSpec := getVSphereStorageClassSpec(storageclassname, scParameters, nil, "", "", false)
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
@@ -2211,8 +2211,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 			profileID := e2eVSphere.GetSpbmPolicyID(raid0StoragePolicyName)
 			scParameters[scParamStoragePolicyID] = profileID
 			// Create resource quota.
-			createResourceQuota(client, namespace, rqLimit, storageclassname)
-			scSpec := getVSphereStorageClassSpec(storageclassname, scParameters, nil, "", "", false)
+			createResourceQuota(client, namespace, rqLimit, defaultNginxStorageClassName)
+			scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", "", false)
 			sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR ensures we use appropriate variable names for storage class creation in e2e tests for all the flavors.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran WCP & Vanilla e2e pipelines to confirm that the test cases are passing

**Special notes for your reviewer**:
Before:
```
Failed test cases:

1. Statefulset service for cluster-distribution metadata check
2. Statefulset testing with parallel podManagementPolicy
3. Verify label updates on PVC and PV attached to a stateful set.

Error snippet:

Failure [6.712 seconds]
[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized] statefulset
/home/worker/workspace/Github_WCP_BuildRecommendation/382/vsphere-csi-driver/tests/e2e/statefulsets.go:58
  Statefulset testing with parallel podManagementPolicy [It]
  /home/worker/workspace/Github_WCP_BuildRecommendation/382/vsphere-csi-driver/tests/e2e/statefulsets.go:291

  Failed to get profileID from given profileName
  Unexpected error:
      <*errors.errorString | 0xc0012cdc00>: {
          s: "no pbm profile found with name: \"nginx-sc-parallel\"",
      }
      no pbm profile found with name: "nginx-sc-parallel"
  occurred

  /home/worker/workspace/Github_WCP_BuildRecommendation/382/vsphere-csi-driver/tests/e2e/vsphere.go:269

....

Failure [277.049 seconds]
[csi-block-vanilla] [csi-block-vanilla-parallelized] label-updates
/home/worker/workspace/Github_WCP_BuildRecommendation/382/vsphere-csi-driver/tests/e2e/labelupdates.go:59
  [csi-supervisor] Verify label updates on PVC and PV attached to a stateful set. [It]
  /home/worker/workspace/Github_WCP_BuildRecommendation/382/vsphere-csi-driver/tests/e2e/labelupdates.go:628

  Unexpected error:
      <*errors.StatusError | 0xc001361680>: {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "services \"nginx\" not found",
              Reason: "NotFound",
              Details: {Name: "nginx", Group: "", Kind: "services", UID: "", Causes: nil, RetryAfterSeconds: 0},
              Code: 404,
          },
      }
      services "nginx" not found
  occurred

  /home/worker/workspace/Github_WCP_BuildRecommendation/382/vsphere-csi-driver/tests/e2e/labelupdates.go:663


These failures are seen after merging this PR 
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/958

Because of these failures, WCP BR pipeline is failing.
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use appropriate variable names for storage class creation in e2e tests
```
