### PR TITLE
running vSphere CSI node daemonset pods with hostNetwork true

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -350,7 +350,8 @@ spec:
         role: vsphere-csi
     spec:
       serviceAccountName: vsphere-csi-node
-      dnsPolicy: "Default"
+      hostNetwork: true
+      dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
           image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is configuring vSphere CSI Node DaemonSet Pod with `hostNetwork` true and `dnsPolicy` ClusterFirstWithHostNet.

This change is required to prevent vSAN file share volume (vSphere CSI `RWM` volume) from becoming inaccessible when vSphere CSI Node Daemon set pod restarts.



**Which issue this PR fixes**
fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/1216

**Testing done**:
Deployed vSphere CSI Driver node Daemonset Pod with this change, and confirmed volumes on the node are accessible after multiple restarts of the vSphere CSI Driver node Daemonset

**Special notes for your reviewer**:
- We need to patch all prior releases which support RWM volume with this change.
- We need to provide a workaround to the customers to recover frozen volumes If they have restarted vSphere CSI Node Deamonset Pod.
- We need to provide steps to customers they can execute before they upgrade the vSphere CSI Driver. Upgrading the vSphere CSI Driver also restarts the vSphere CSI Driver node Deamonset Pods, which can result in frozen volumes.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
running vSphere CSI node Daemonset pods with hostNetwork true
```
