### PR TITLE
[release-2.3] running vsphere-csi-node DaemonSet pod with hostNetwork true

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -306,7 +306,8 @@ spec:
         role: vsphere-csi
     spec:
       serviceAccountName: vsphere-csi-node
-      dnsPolicy: "Default"
+      hostNetwork: true
+      dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is configuring vSphere CSI Node DaemonSet Pod with hostNetwork true and dnsPolicy ClusterFirstWithHostNet.

For more detail refer to https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1217 and https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/1216 