### PR TITLE
Added the limit check on number of snapshots per block volume when create snapshot

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -192,6 +192,22 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 			cfg.Snapshot.GlobalMaxSnapshotsPerBlockVolume = maxSnaps
 		}
 	}
+	if v := os.Getenv("GRANULAR_MAX_SNAPSHOTS_PER_BLOCK_VOLUME_VSAN"); v != "" {
+		maxSnaps, err := strconv.Atoi(v)
+		if err != nil {
+			log.Errorf("failed to parse GRANULAR_MAX_SNAPSHOTS_PER_BLOCK_VOLUME_VSAN: %s", err)
+		} else {
+			cfg.Snapshot.GranularMaxSnapshotsPerBlockVolumeInVSAN = maxSnaps
+		}
+	}
+	if v := os.Getenv("GRANULAR_MAX_SNAPSHOTS_PER_BLOCK_VOLUME_VVOL"); v != "" {
+		maxSnaps, err := strconv.Atoi(v)
+		if err != nil {
+			log.Errorf("failed to parse GRANULAR_MAX_SNAPSHOTS_PER_BLOCK_VOLUME_VVOL: %s", err)
+		} else {
+			cfg.Snapshot.GranularMaxSnapshotsPerBlockVolumeInVVOL = maxSnaps
+		}
+	}
 	// Build VirtualCenter from ENVs.
 	for _, e := range os.Environ() {
 		pair := strings.Split(e, "=")

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -142,4 +142,10 @@ type GCConfig struct {
 type SnapshotConfig struct {
 	// GlobalMaxSnapshotsPerBlockVolume specifies the maximum number of block volume snapshots per volume.
 	GlobalMaxSnapshotsPerBlockVolume int `gcfg:"global-max-snapshots-per-block-volume"`
+	// GranularMaxSnapshotsPerBlockVolumeInVSAN specifies the maximum number of block volume snapshots
+	// per volume in VSAN datastores.
+	GranularMaxSnapshotsPerBlockVolumeInVSAN int `gcfg:"granular-max-snapshots-per-block-volume-vsan"`
+	// GranularMaxSnapshotsPerBlockVolumeInVVOL specifies the maximum number of block volume snapshots
+	// per volume in VVOL datastores.
+	GranularMaxSnapshotsPerBlockVolumeInVVOL int `gcfg:"granular-max-snapshots-per-block-volume-vvol"`
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There is known performance degradation when number of snapshots per block volume increases in redo-log based snapshots in vSphere. To avoid such performance degradation, adding a global (applicable to all types of datastore) configurable parameter in vSphere CSI configuration file and a corresponding limit check to prevent from creating too many snapshots per block volume. 

Meanwhile, there is no such performance degradation for block volumes on VSAN and VVOL datastore. Users might expect to have specific limit which is different from the global one. So, adding granular configurable parameters for block volumes on VSAN and VVOL datastore, which is eligible to override the global limit from the vSphere CSI configuration file.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Unit test: Passed
Functional test: Passed
Regression test: Passed

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added the limit check on number of snapshots per block volume when create snapshot
```

Signed-off-by: Lintong Jiang <lintongj@vmware.com>
