### PR TITLE
Block file volume provisioning when topology requirement is provided.

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -452,7 +452,8 @@ func (volTopology *controllerVolumeTopology) getNodesMatchingTopologySegment(ctx
 
 		// Check CSINodeTopology instance `Status` field for success.
 		if nodeTopologyInstance.Status.Status != csinodetopologyv1alpha1.CSINodeTopologySuccess {
-			log.Errorf("node %q not yet ready", nodeTopologyInstance.Name)
+			log.Errorf("node %q not yet ready. Status of CSINodeTopology instance: %q",
+				nodeTopologyInstance.Name, nodeTopologyInstance.Status.Status)
 			return nil, err
 		}
 		// Convert array of labels to map.
@@ -464,8 +465,8 @@ func (volTopology *controllerVolumeTopology) getNodesMatchingTopologySegment(ctx
 		isMatch := true
 		for key, value := range segments {
 			if topoLabels[key] != value {
-				log.Debugf("Node %q (ID: %q) did not match the topology requirement - %q: %q ",
-					nodeTopologyInstance.Name, nodeTopologyInstance.Spec.NodeID, key, value)
+				log.Debugf("Node %q did not match the topology requirement - %q: %q ",
+					nodeTopologyInstance.Name, key, value)
 				isMatch = false
 				break
 			}
@@ -474,8 +475,8 @@ func (volTopology *controllerVolumeTopology) getNodesMatchingTopologySegment(ctx
 			// NOTE: NodeID is set to NodeName for now. Will be changed to NodeUUID in future.
 			nodeVM, err := volTopology.nodeMgr.GetNodeByName(ctx, nodeTopologyInstance.Spec.NodeID)
 			if err != nil {
-				log.Errorf("failed to retrieve NodeVM %q with ID %q. Error - %+v",
-					nodeTopologyInstance.Name, nodeTopologyInstance.Spec.NodeID, err)
+				log.Errorf("failed to retrieve NodeVM %q. Error - %+v",
+					nodeTopologyInstance.Name, err)
 				return nil, err
 			}
 			matchingNodeVMs = append(matchingNodeVMs, nodeVM)

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -243,11 +243,14 @@ func (volTopology *nodeVolumeTopology) GetNodeTopologyLabels(ctx context.Context
 		if !apierrors.IsAlreadyExists(err) {
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to create CSINodeTopology CR. Error: %+v", err)
+		} else {
+			log.Infof("CSINodeTopology instance already exists for NodeName: %q", nodeInfo.NodeName)
 		}
 	} else {
 		log.Infof("Successfully created a CSINodeTopology instance for NodeName: %q", nodeInfo.NodeName)
 	}
 
+	// Create a watcher for CSINodeTopology CRs.
 	timeoutSeconds := int64((time.Duration(getCSINodeTopologyWatchTimeoutInMin(ctx)) * time.Minute).Seconds())
 	watchCSINodeTopology, err := volTopology.csiNodeTopologyWatcher.Watch(metav1.ListOptions{
 		FieldSelector:  fields.OneTermEqualSelector("metadata.name", nodeInfo.NodeName).String(),
@@ -446,19 +449,23 @@ func (volTopology *controllerVolumeTopology) getNodesMatchingTopologySegment(ctx
 			log.Warnf("received a non-CSINodeTopology instance: %+v", val)
 			continue
 		}
+
+		// Check CSINodeTopology instance `Status` field for success.
+		if nodeTopologyInstance.Status.Status != csinodetopologyv1alpha1.CSINodeTopologySuccess {
+			log.Errorf("node %q not yet ready", nodeTopologyInstance.Name)
+			return nil, err
+		}
 		// Convert array of labels to map.
 		topoLabels := make(map[string]string)
-		if nodeTopologyInstance.Status.Status == csinodetopologyv1alpha1.CSINodeTopologySuccess {
-			for _, topoLabel := range nodeTopologyInstance.Status.TopologyLabels {
-				topoLabels[topoLabel.Key] = topoLabel.Value
-			}
+		for _, topoLabel := range nodeTopologyInstance.Status.TopologyLabels {
+			topoLabels[topoLabel.Key] = topoLabel.Value
 		}
 		// Check for a match of labels in every segment.
 		isMatch := true
 		for key, value := range segments {
 			if topoLabels[key] != value {
-				log.Debugf("Node %q did not match the topology requirement - %q: %q ",
-					nodeTopologyInstance.Spec.NodeID, key, value)
+				log.Debugf("Node %q (ID: %q) did not match the topology requirement - %q: %q ",
+					nodeTopologyInstance.Name, nodeTopologyInstance.Spec.NodeID, key, value)
 				isMatch = false
 				break
 			}
@@ -467,8 +474,8 @@ func (volTopology *controllerVolumeTopology) getNodesMatchingTopologySegment(ctx
 			// NOTE: NodeID is set to NodeName for now. Will be changed to NodeUUID in future.
 			nodeVM, err := volTopology.nodeMgr.GetNodeByName(ctx, nodeTopologyInstance.Spec.NodeID)
 			if err != nil {
-				log.Errorf("failed to retrieve NodeVM for nodeID %q. Error - %+v",
-					nodeTopologyInstance.Spec.NodeID, err)
+				log.Errorf("failed to retrieve NodeVM %q with ID %q. Error - %+v",
+					nodeTopologyInstance.Name, nodeTopologyInstance.Spec.NodeID, err)
 				return nil, err
 			}
 			matchingNodeVMs = append(matchingNodeVMs, nodeVM)

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -81,7 +81,8 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 	if !coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeTopology) {
-		log.Infof("Not initializing the CSINodetopology Controller as %s FSS is disabled", common.ImprovedVolumeTopology)
+		log.Infof("Not initializing the CSINodetopology Controller as %s FSS is disabled",
+			common.ImprovedVolumeTopology)
 		return nil
 	}
 
@@ -186,8 +187,8 @@ func (r *ReconcileCSINodeTopology) Reconcile(ctx context.Context, request reconc
 	err := r.client.Get(ctx, request.NamespacedName, instance)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Infof("CSINodeTopology resource with name %q not found. Ignoring since object must have been deleted.",
-				request.Name)
+			log.Infof("CSINodeTopology resource with name %q not found. Ignoring since object must have "+
+				"been deleted.", request.Name)
 			return reconcile.Result{}, nil
 		}
 		log.Errorf("Failed to fetch the CSINodeTopology instance with name: %q. Error: %+v", request.Name, err)
@@ -202,8 +203,8 @@ func (r *ReconcileCSINodeTopology) Reconcile(ctx context.Context, request reconc
 	nodeVM, err := nodeManager.GetNodeByName(ctx, nodeID)
 	if err != nil {
 		// If nodeVM not found, ignore reconcile call.
-		log.Warnf("Ignoring update to CSINodeTopology CR with name %s as corresponding NodeVM seems to be deleted. "+
-			"Error: %v", nodeID, err)
+		log.Warnf("Ignoring update to CSINodeTopology CR with name %s (ID: %q) as corresponding NodeVM "+
+			"seems to be deleted. Error: %v", instance.Name, nodeID, err)
 		return reconcile.Result{}, nil
 	}
 
@@ -234,8 +235,8 @@ func (r *ReconcileCSINodeTopology) Reconcile(ctx context.Context, request reconc
 		// Fetch topology labels for nodeVM.
 		topologyLabels, err := getNodeTopologyInfo(ctx, nodeVM, r.configInfo.Cfg)
 		if err != nil {
-			msg := fmt.Sprintf("failed to fetch topology information for the nodeVM with ID %q. Error: %v",
-				nodeID, err)
+			msg := fmt.Sprintf("failed to fetch topology information for the nodeVM %q with ID %q. Error: %v",
+				instance.Name, nodeID, err)
 			log.Error(msg)
 			_ = updateCRStatus(ctx, r, instance, csinodetopologyv1alpha1.CSINodeTopologyError, msg)
 			return reconcile.Result{RequeueAfter: timeout}, nil
@@ -244,7 +245,7 @@ func (r *ReconcileCSINodeTopology) Reconcile(ctx context.Context, request reconc
 		// Update CSINodeTopology instance.
 		instance.Status.TopologyLabels = topologyLabels
 		err = updateCRStatus(ctx, r, instance, csinodetopologyv1alpha1.CSINodeTopologySuccess,
-			fmt.Sprintf("Topology labels successfully updated for nodeVM %q", nodeID))
+			fmt.Sprintf("Topology labels successfully updated for nodeVM %q with ID %q", instance.Name, nodeID))
 		if err != nil {
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
@@ -259,7 +260,7 @@ func (r *ReconcileCSINodeTopology) Reconcile(ctx context.Context, request reconc
 	backOffDurationMapMutex.Lock()
 	delete(backOffDuration, instance.Name)
 	backOffDurationMapMutex.Unlock()
-	log.Infof("Successfully updated topology labels for nodeVM with ID %q", nodeID)
+	log.Infof("Successfully updated topology labels for nodeVM %q with ID %q", instance.Name, nodeID)
 	return reconcile.Result{}, nil
 }
 
@@ -288,7 +289,8 @@ func updateCRStatus(ctx context.Context, r *ReconcileCSINodeTopology, instance *
 	// Update CSINodeTopology instance.
 	err := r.client.Update(ctx, instance)
 	if err != nil {
-		msg := fmt.Sprintf("Failed to update the CSINodeTopology instance with name %q.", instance.Spec.NodeID)
+		msg := fmt.Sprintf("Failed to update the CSINodeTopology instance with name %q and ID %q.",
+			instance.Name, instance.Spec.NodeID)
 		log.Errorf("%s. Error: %+v", msg, err)
 		r.recorder.Event(instance, corev1.EventTypeWarning, "CSINodeTopologyFailed", msg)
 		return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR removes redundant code in CreateBlockVolume function. It also errors out file volume provisioning when topology requirement is provided. Earlier we were ignoring the topology requirement if provided during file volume provisioning but we decided to change this behavior in order to avoid problems in future when we do support topology feature for file volumes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
E2E testing - 
```
Build ID: 338
Block vanilla build status: FAILURE 
Stage before exit: e2e-tests 
Jenkins E2E Test Results: 
JUnit report was created: /home/worker/workspace/csi-block-vanilla-pre-check-in/338/vsphere-csi-driver/tests/e2e/junit.xml

Ran 1 of 229 Specs in 285.033 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 228 Skipped
PASS

Ginkgo ran 1 suite in 5m25.711123272s
Test Suite Passed
--
JUnit report was created: /home/worker/workspace/csi-block-vanilla-pre-check-in/338/vsphere-csi-driver/tests/e2e/junit.xml

Ran 9 of 229 Specs in 3364.727 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 220 Skipped
PASS

Ginkgo ran 1 suite in 56m17.605229698s
Test Suite Passed
--
/home/worker/workspace/csi-block-vanilla-pre-check-in/338/vsphere-csi-driver/tests/e2e/csi_static_provisioning_basic.go:137

Ran 38 of 229 Specs in 595.994 seconds
FAIL! -- 37 Passed | 1 Failed | 0 Pending | 191 Skipped
```
Re-ran the failed test and it worked. 

Ginkgo ran 1 suite in 10m9.566832288s
Test Suite Failed

Manual testing - 
1. File volume provisioning with any storage class in a topology aware environment is blocked - 
SC:
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: block-sc-all
provisioner: csi.vsphere.vmware.com
allowVolumeExpansion: true
```

```
NAME        STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   AGE
file-pvc1   Pending                                                                            block-sc-all   2m38s
```

PVC:
```
root@k8s-master-917:~# kdsc pvc file-pvc1
Name:          file-pvc1
Namespace:     default
StorageClass:  block-sc-all
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age                From                                                                                                Message
  ----     ------                ----               ----                                                                                                -------
  Normal   ExternalProvisioning  14s (x3 over 18s)  persistentvolume-controller                                                                         waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   Provisioning          3s (x5 over 18s)   csi.vsphere.vmware.com_vsphere-csi-controller-974fb67bc-j8mhr_6e6631eb-01e2-49ea-8083-55e0399e7448  External provisioner is provisioning volume for claim "default/file-pvc1"
  Warning  ProvisioningFailed    3s (x5 over 18s)   csi.vsphere.vmware.com_vsphere-csi-controller-974fb67bc-j8mhr_6e6631eb-01e2-49ea-8083-55e0399e7448  failed to provision volume with StorageClass "block-sc-all": rpc error: code = InvalidArgument desc = volume topology feature for file volumes is not supported.
```

2. CreateVolume with datastoreURL successful:
```
2021-09-17T19:50:08.061Z	INFO	vanilla/controller.go:717	CreateVolume: called with args {Name:pvc-a4337c17-4230-428b-bba9-0cf4611bea5e CapacityRange:required_bytes:104857600  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[datastoreurl:ds:///vmfs/volumes/vsan:52795098c2fecc0c-34fe017e535f3365/] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-a" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-a" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.066Z	DEBUG	k8sorchestrator/topology.go:359	Get shared datastores with topologyRequirement: requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-a" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-a" > > 	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.068Z	DEBUG	k8sorchestrator/topology.go:369	Using preferred topology	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.070Z	DEBUG	k8sorchestrator/topology.go:406	Getting list of nodeVMs for topology segments map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a]	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.087Z	DEBUG	node/manager.go:183	Renewing virtual machine VirtualMachine:vm-75 [VirtualCenterHost: 10.182.49.224, UUID: 4223d6fd-748d-219c-9232-f4d0ef434d49, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /test-vpx-1627675815-863-hostpool, VirtualCenterHost: 10.182.49.224]] with nodeUUID "4223d6fd-748d-219c-9232-f4d0ef434d49"	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.128Z	DEBUG	node/manager.go:190	VM VirtualMachine:vm-75 [VirtualCenterHost: 10.182.49.224, UUID: 4223d6fd-748d-219c-9232-f4d0ef434d49, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] was successfully renewed with nodeUUID "4223d6fd-748d-219c-9232-f4d0ef434d49"	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.130Z	DEBUG	node/manager.go:183	Renewing virtual machine VirtualMachine:vm-74 [VirtualCenterHost: 10.182.49.224, UUID: 4223c699-4b13-913e-0be7-3dd866ff7a13, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /test-vpx-1627675815-863-hostpool, VirtualCenterHost: 10.182.49.224]] with nodeUUID "4223c699-4b13-913e-0be7-3dd866ff7a13"	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.142Z	DEBUG	node/manager.go:190	VM VirtualMachine:vm-74 [VirtualCenterHost: 10.182.49.224, UUID: 4223c699-4b13-913e-0be7-3dd866ff7a13, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] was successfully renewed with nodeUUID "4223c699-4b13-913e-0be7-3dd866ff7a13"	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.151Z	DEBUG	node/manager.go:183	Renewing virtual machine VirtualMachine:vm-72 [VirtualCenterHost: 10.182.49.224, UUID: 4223907b-7643-1971-a615-1226b7c7016e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /test-vpx-1627675815-863-hostpool, VirtualCenterHost: 10.182.49.224]] with nodeUUID "4223907b-7643-1971-a615-1226b7c7016e"	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.157Z	DEBUG	node/manager.go:190	VM VirtualMachine:vm-72 [VirtualCenterHost: 10.182.49.224, UUID: 4223907b-7643-1971-a615-1226b7c7016e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] was successfully renewed with nodeUUID "4223907b-7643-1971-a615-1226b7c7016e"	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.159Z	DEBUG	node/manager.go:183	Renewing virtual machine VirtualMachine:vm-73 [VirtualCenterHost: 10.182.49.224, UUID: 42230e5a-8a23-94dd-935e-08c5ef912d93, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /test-vpx-1627675815-863-hostpool, VirtualCenterHost: 10.182.49.224]] with nodeUUID "42230e5a-8a23-94dd-935e-08c5ef912d93"	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.169Z	DEBUG	node/manager.go:190	VM VirtualMachine:vm-73 [VirtualCenterHost: 10.182.49.224, UUID: 42230e5a-8a23-94dd-935e-08c5ef912d93, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] was successfully renewed with nodeUUID "42230e5a-8a23-94dd-935e-08c5ef912d93"	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.169Z	INFO	k8sorchestrator/topology.go:414	Obtained list of nodeVMs [VirtualMachine:vm-75 [VirtualCenterHost: 10.182.49.224, UUID: 4223d6fd-748d-219c-9232-f4d0ef434d49, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] VirtualMachine:vm-74 [VirtualCenterHost: 10.182.49.224, UUID: 4223c699-4b13-913e-0be7-3dd866ff7a13, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] VirtualMachine:vm-72 [VirtualCenterHost: 10.182.49.224, UUID: 4223907b-7643-1971-a615-1226b7c7016e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] VirtualMachine:vm-73 [VirtualCenterHost: 10.182.49.224, UUID: 42230e5a-8a23-94dd-935e-08c5ef912d93, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]]]	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.169Z	DEBUG	vsphere/virtualmachine.go:347	Getting accessible datastores for node VirtualMachine:vm-75	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.215Z	DEBUG	vsphere/virtualmachine.go:347	Getting accessible datastores for node VirtualMachine:vm-74	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.236Z	DEBUG	vsphere/virtualmachine.go:347	Getting accessible datastores for node VirtualMachine:vm-72	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.263Z	DEBUG	vsphere/virtualmachine.go:347	Getting accessible datastores for node VirtualMachine:vm-73	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.295Z	INFO	k8sorchestrator/topology.go:429	Obtained shared datastores: [Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/b2ed2a7d-d8a0ebea/ Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/276c8c8c-c4782ff4/ Datastore: Datastore:datastore-57, datastore URL: ds:///vmfs/volumes/vsan:52795098c2fecc0c-34fe017e535f3365/]	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.296Z	DEBUG	vanilla/controller.go:515	Shared datastores [[Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/b2ed2a7d-d8a0ebea/ Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/276c8c8c-c4782ff4/ Datastore: Datastore:datastore-57, datastore URL: ds:///vmfs/volumes/vsan:52795098c2fecc0c-34fe017e535f3365/]] retrieved for topologyRequirement [requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-a" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-a" > > ] with datastoreTopologyMap [+map[ds:///vmfs/volumes/276c8c8c-c4782ff4/:[map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a]] ds:///vmfs/volumes/b2ed2a7d-d8a0ebea/:[map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a]] ds:///vmfs/volumes/vsan:52795098c2fecc0c-34fe017e535f3365/:[map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a]]]]	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.297Z	DEBUG	vanilla/controller.go:342	filterDatastores: dsMap map[ds:///vmfs/volumes/276c8c8c-c4782ff4/:Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/276c8c8c-c4782ff4/ ds:///vmfs/volumes/61045c6a-85ee1e32-aa6e-02008f6bed16/:Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/61045c6a-85ee1e32-aa6e-02008f6bed16/ ds:///vmfs/volumes/61045c6b-35f80e9c-75ef-02008f6bed16/:Datastore: Datastore:datastore-38, datastore URL: ds:///vmfs/volumes/61045c6b-35f80e9c-75ef-02008f6bed16/ ds:///vmfs/volumes/61045c6d-90320c36-94b9-02008f960930/:Datastore: Datastore:datastore-32, datastore URL: ds:///vmfs/volumes/61045c6d-90320c36-94b9-02008f960930/ ds:///vmfs/volumes/61045c6e-583206fe-6ec5-02008f960930/:Datastore: Datastore:datastore-33, datastore URL: ds:///vmfs/volumes/61045c6e-583206fe-6ec5-02008f960930/ ds:///vmfs/volumes/61045c70-25b9300c-24f5-02008fa0cdf9/:Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/61045c70-25b9300c-24f5-02008fa0cdf9/ ds:///vmfs/volumes/61045c72-df562676-c207-02008fa0cdf9/:Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/61045c72-df562676-c207-02008fa0cdf9/ ds:///vmfs/volumes/61045c74-1d92cbd6-b0fd-02008f45931f/:Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/61045c74-1d92cbd6-b0fd-02008f45931f/ ds:///vmfs/volumes/61045c75-c7b46654-fb97-02008f45931f/:Datastore: Datastore:datastore-40, datastore URL: ds:///vmfs/volumes/61045c75-c7b46654-fb97-02008f45931f/ ds:///vmfs/volumes/b2ed2a7d-d8a0ebea/:Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/b2ed2a7d-d8a0ebea/ ds:///vmfs/volumes/vsan:52795098c2fecc0c-34fe017e535f3365/:Datastore: Datastore:datastore-57, datastore URL: ds:///vmfs/volumes/vsan:52795098c2fecc0c-34fe017e535f3365/] sharedDatastores [Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/b2ed2a7d-d8a0ebea/ Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/276c8c8c-c4782ff4/ Datastore: Datastore:datastore-57, datastore URL: ds:///vmfs/volumes/vsan:52795098c2fecc0c-34fe017e535f3365/]	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.299Z	DEBUG	vanilla/controller.go:351	filterDatastores: filteredDatastores [Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/b2ed2a7d-d8a0ebea/ Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/276c8c8c-c4782ff4/ Datastore: Datastore:datastore-57, datastore URL: ds:///vmfs/volumes/vsan:52795098c2fecc0c-34fe017e535f3365/]	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.372Z	DEBUG	common/vsphereutil.go:240	vSphere CSI driver creating volume pvc-a4337c17-4230-428b-bba9-0cf4611bea5e with create spec (*types.CnsVolumeCreateSpec)(0xc000922900)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-a4337c17-4230-428b-bba9-0cf4611bea5e",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=1 cap=1) {
  (types.ManagedObjectReference) Datastore:datastore-57
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=32) "vSAN-FVT-Cluster1627677231.92674",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA",
   ClusterDistribution: (string) (len=11) "CSI-Vanilla"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=32) "vSAN-FVT-Cluster1627677231.92674",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA",
    ClusterDistribution: (string) (len=11) "CSI-Vanilla"
   }
  }
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc0001885a0)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 100
  },
  BackingDiskId: (string) "",
  BackingDiskUrlPath: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) <nil>,
 CreateSpec: (types.BaseCnsBaseCreateSpec) <nil>,
 VolumeSource: (types.BaseCnsVolumeSource) <nil>
})
	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:08.389Z	DEBUG	volume/util.go:198	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:14.154Z	INFO	volume/manager.go:423	CreateVolume: VolumeName: "pvc-a4337c17-4230-428b-bba9-0cf4611bea5e", opId: "2a7bc643"	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:14.159Z	INFO	volume/util.go:327	Volume created successfully. VolumeName: "pvc-a4337c17-4230-428b-bba9-0cf4611bea5e", volumeID: "6821d4ac-2d96-4d75-a381-987c3b1fc914"	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:14.159Z	DEBUG	volume/util.go:329	CreateVolume volumeId {{} "6821d4ac-2d96-4d75-a381-987c3b1fc914"} is placed on datastore "ds:///vmfs/volumes/vsan:52795098c2fecc0c-34fe017e535f3365/"	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:14.160Z	DEBUG	volume/manager.go:491	internalCreateVolume: returns fault ""	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:14.161Z	DEBUG	vanilla/controller.go:600	Volume: 6821d4ac-2d96-4d75-a381-987c3b1fc914 is provisioned on the datastore: ds:///vmfs/volumes/vsan:52795098c2fecc0c-34fe017e535f3365/ 	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:14.162Z	DEBUG	vanilla/controller.go:605	volumeAccessibleTopology: [map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a]] is selected for datastore: ds:///vmfs/volumes/vsan:52795098c2fecc0c-34fe017e535f3365/ 	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
2021-09-17T19:50:14.162Z	DEBUG	vanilla/controller.go:748	createVolumeInternal: returns fault ""	{"TraceId": "c277d122-0281-4bee-a317-d74ab66d10dc"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove redundant code in CreateVolume call.
Block file volume provisioning when topology requirement is provided.
```
