### PR TITLE
Cherry-pick PR (#1043) to 2.3 release

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -180,11 +180,8 @@ func (m *defaultManager) ResetManager(ctx context.Context, vcenter *cnsvsphere.V
 	log := logger.GetLogger(ctx)
 	managerInstanceLock.Lock()
 	defer managerInstanceLock.Unlock()
-	if vcenter.Config.Host != managerInstance.virtualCenter.Config.Host {
-		log.Infof("Re-initializing defaultManager.virtualCenter")
-		managerInstance.virtualCenter = vcenter
-	}
-	m.virtualCenter.Config = vcenter.Config
+	log.Infof("Re-initializing defaultManager.virtualCenter")
+	managerInstance.virtualCenter = vcenter
 	if m.virtualCenter.Client != nil {
 		m.virtualCenter.Client.Timeout = time.Duration(vcenter.Config.VCClientTimeout) * time.Minute
 		log.Infof("VC client timeout is set to %v", m.virtualCenter.Client.Timeout)


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR cherry-picks https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1043 which fixes the reset Volume Manager method during reload config & ca file rotation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Please find the testing details in the original PR from above

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherry-pick reset volume manager fix to 2.3 release
```
