### PR TITLE
Vanilla k8s: Upgrade sidecar container images to latest stable releases

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -188,7 +188,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.1
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -203,7 +203,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -267,7 +267,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -305,7 +305,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -354,7 +354,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -447,7 +447,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR updates sidecar container images to latest stable releases
Here is the ChangeLog links:
https://github.com/kubernetes-csi/external-attacher/blob/release-3.3/CHANGELOG/CHANGELOG-3.3.md
https://github.com/kubernetes-csi/external-provisioner/blob/release-3.0/CHANGELOG/CHANGELOG-3.0.md
https://github.com/kubernetes-csi/livenessprobe/blob/master/CHANGELOG/CHANGELOG-2.4.md
https://github.com/kubernetes-csi/external-resizer/blob/release-1.3/CHANGELOG/CHANGELOG-1.3.md
https://github.com/kubernetes-csi/node-driver-registrar/blob/release-2.3/CHANGELOG/CHANGELOG-2.3.md

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran e2e pipelines
```
Build ID: 235
Block vanilla build status: FAILURE 
Stage before exit: e2e-tests 
Jenkins E2E Test Results: 
JUnit report was created: /home/worker/workspace/csi-block-vanilla-pre-check-in/235/vsphere-csi-driver/tests/e2e/junit.xml

Ran 1 of 216 Specs in 291.792 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 215 Skipped
PASS

Ginkgo ran 1 suite in 5m43.401764589s
Test Suite Passed
--
JUnit report was created: /home/worker/workspace/csi-block-vanilla-pre-check-in/235/vsphere-csi-driver/tests/e2e/junit.xml

Ran 8 of 216 Specs in 3118.167 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 208 Skipped
PASS

Ginkgo ran 1 suite in 52m12.612931877s
Test Suite Passed
--
/home/worker/workspace/csi-block-vanilla-pre-check-in/235/vsphere-csi-driver/tests/e2e/e2e_common.go:180

Ran 38 of 216 Specs in 466.966 seconds
```


The 4 failures are due to ENV issues in test cases
```
  Verify relocating detached volume works fine [BeforeEach]
  /home/worker/workspace/csi-block-vanilla-pre-check-in/235/vsphere-csi-driver/tests/e2e/svmotion_detached_volume.go:77

  ENV DESTINATION_VSPHERE_DATASTORE_URL is not set
  Expected
      <string>: 
  not to be empty


  Verify dynamic provisioning of PV fails with user specified non-shared datastore and no storage policy specified in the storage class [It]
  /home/worker/workspace/csi-block-vanilla-pre-check-in/235/vsphere-csi-driver/tests/e2e/vsphere_shared_datastore.go:96

  ENV NONSHARED_VSPHERE_DATASTORE_URL is not set
  Expected
      <string>: 
  not to be empty

  [csi-block-vanilla] [csi-block-vanilla-parallelized] Verify basic static provisioning workflow [BeforeEach]
  /home/worker/workspace/csi-block-vanilla-pre-check-in/235/vsphere-csi-driver/tests/e2e/csi_static_provisioning_basic.go:272

  ENV NONSHARED_VSPHERE_DATASTORE_URL is not set
  Expected
      <string>: 
  not to be empty

  [csi-block-vanilla] [csi-block-vanilla-parallelized] Verify static provisioning workflow using same PV name twice [BeforeEach]
  /home/worker/workspace/csi-block-vanilla-pre-check-in/235/vsphere-csi-driver/tests/e2e/csi_static_provisioning_basic.go:379

  ENV NONSHARED_VSPHERE_DATASTORE_URL is not set
  Expected
      <string>: 
  not to be empty
```

We can safely ignore these 4 failures.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Upgrade sidecar container images to latest stable releases
```
