### PR TITLE
document workaround for node shutdown issue

### DIFF
--- a/docs/book/known_issues.md
+++ b/docs/book/known_issues.md
@@ -8,6 +8,24 @@ Please refer to release notes to learn known issues in each release.
 
 Following listing is for issues observed in the Kubernetes.
 
+## Multi-Attach error for RWO (Block) volume when Node VM is shutdown before Pods are evicted and Volumes are detached from Node VM
+
+Note: This Issue is present in all Kubernetes Releases
+
+- Impact: After Node is shutdown, Pod running on that Node does not come up on the new Node. Events on the Pod will have a warning message for "FailedAttachVolume". Error Message: `Multi-Attach error for volume "pvc-uuid" Volume is already exclusively attached to one node and can't be attached to another.`
+- Upstream Issue:  Kubernetes is being enhanced to fix this issue. Here is the Kubernetes Enhancement Proposals (KEP) PR you can refer for more detail - https://github.com/kubernetes/enhancements/pull/1116
+- Workaround:
+  - Pods stuck in this state can be recovered by following steps.
+    1. Find the Node VM in the vCenter Inventory. Make sure the correct VM associated with the Node is used for further instructions.
+    2. Detach all Persistent Volumes Disk attached to this Node VM. Note: Do not detach Primary disks used by the Guest OS.
+        1. Right-click a virtual machine in the inventory and select Edit Settings.
+        2. From Virtual Hardware find all Hard Disks for Persistent Volumes and remove them. (Do not select - Delete files from datastore)
+        3. Click on OK to reconfigure VM to detach all Persistent Volumes disks from shutdown/powered off Node VM.
+    3. Execute `kubectl get volumeattachments` and find all volumeattachments objects associated with shutdown Node VM.
+    4. Edit `volumeattachment` object with `kubectl edit volumeattachments <volumeattachments-object-name>` and remove finalizers.
+    5. Check if the `volumeattachment` object is deleted by Kubernetes. If this object remains on the system, you can safely delete this with `kubectl delete volumeattachments <volumeattachments-object-name>`.
+    6. Wait for some time for Pod to come up on a new Node.
+
 ## Kubernetes 1.17 and 1.18 issues
 
 1. Performance regression in Kubernetes 1.17 and 1.18


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is documenting the workaround for node shutdown issue



**Special notes for your reviewer**:

Preview link - https://deploy-preview-1249--kubernetes-sigs-vsphere-csi-driver.netlify.app/known_issues.html#multi-attach-error-for-rwo-volume-when-node-vm-is-shutdown-before-pods-are-evicted-and-volumes-are-detached-from-node-vm

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
document workaround for node shutdown issue
```
