### PR TITLE
Fix sleep time in cns csi telemetry test case to wait for secret to be updated in the CSI containers

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -2808,9 +2808,10 @@ func setClusterDistribution(ctx context.Context, client clientset.Interface, clu
 		_, err := client.CoreV1().Secrets(csiSystemNamespace).Update(ctx, currentSecret, metav1.UpdateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Adding a explicit wait of one min for the Cluster-distribution to
-		// reflect latest value.
-		time.Sleep(time.Duration(pollTimeoutShort))
+		// TODO: Adding a explicit wait of two min for the Cluster-distribution to
+		// reflect latest value. This should be replaced with a polling mechanism
+		// to watch on csi-vsphere.conf inside the CSI containers.
+		time.Sleep(time.Duration(2 * time.Minute))
 
 		framework.Logf("Cluster distribution value is now set to = %s", clusterDistribution)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix wait time in cns csi telemetry test case to wait for secret to be updated in the CSI containers. Ideally the wait should be handled by polling on csi-vsphere.conf inside the CSI containers(vsphere-csi-controller & syncer), but for now this is handled with a wait time of 2 minutes which is enough to make sure that secret is updated through fsnotify

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
**Before:**
Was able to reproduce the issue before the fix with 50% strike rate, test case failed 2 times in 4 attempts.

**After:**
Ran e2e pipelines with ginkgo_focus set to this test case 4 times and succeeded every time.
Also ran the pipeline manually to confirm the additional wait time is working.  

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix wait time in cns csi telemetry test case to wait for secret to be updated in the CSI containers
```
