### PR TITLE
fixing base image tag and adding git commit to the base image

### DIFF
--- a/images/driver-base/Dockerfile
+++ b/images/driver-base/Dockerfile
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 FROM photon:4.0
+ARG GIT_COMMIT
+LABEL git_commit=$GIT_COMMIT
 LABEL "maintainers"="Divyen Patel <divyenp@vmware.com>, Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>, Xing Yang <yangxi@vmware.com>"
 
 RUN tdnf -y upgrade && tdnf clean all

--- a/images/driver-base/Makefile
+++ b/images/driver-base/Makefile
@@ -16,24 +16,23 @@ all: build
 
 include ../../hack/make/login-to-image-registry.mk
 
-VERSION ?= $(shell git describe --always --dirty)
 IMAGE_NAME ?= $(REGISTRY)/extra/csi-driver-base
-IMAGE_TAG ?= $(IMAGE_NAME):$(VERSION)
+IMAGE_NAME_WITH_TAG ?= $(IMAGE_NAME):$(shell git log -1 --format=%h)
 
 build:
-	docker build -t $(IMAGE_TAG) .
-	docker tag $(IMAGE_TAG) $(IMAGE_NAME):latest
+	docker build -t $(IMAGE_NAME_WITH_TAG) --build-arg GIT_COMMIT=$(shell git log -1 --format=%H) .
+	docker tag $(IMAGE_NAME_WITH_TAG) $(IMAGE_NAME):latest
 .PHONY: build
 
 push: login-to-image-registry
-	docker push $(IMAGE_TAG)
+	docker push $(IMAGE_NAME_WITH_TAG)
 	docker push $(IMAGE_NAME):latest
 .PHONY: push
 
 .PHONY: clean
 DOCKER_RMI_FLAGS := --no-prune
 clean:
-	docker rmi $(DOCKER_RMI_FLAGS) $(IMAGE_TAG) $(IMAGE_NAME):latest 2>/dev/null || true
+	docker rmi $(DOCKER_RMI_FLAGS) $(IMAGE_NAME_WITH_TAG) $(IMAGE_NAME):latest 2>/dev/null || true
 
 .PHONY: clobber
 clobber: DOCKER_RMI_FLAGS :=
@@ -42,4 +41,4 @@ clobber: clean
 
 .PHONY: print
 print:
-	@echo $(IMAGE_TAG)
+	@echo $(IMAGE_NAME_WITH_TAG)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing the base image tag and adding git commit to the base image.

Before this PR, base image tags were created using `$(shell git describe --always --dirty)`, which is incorrect.

```
% git describe --always --dirty
v2.1.0-rc.1-997-g910a5a18
```


Look how all of our bases images are created so far.

![base-driver-images](https://user-images.githubusercontent.com/22985595/131196632-72c51968-b7bb-4e58-9468-7cfbf1a26180.jpg)

When we create a new base driver image from the master branch it creates a tag as below which has 2.1.0 references that creates confusion.

**Before this PR**

```
% make build
docker build -t gcr.io/cloud-provider-vsphere/extra/csi-driver-base:v2.1.0-rc.1-994-g75cf820 .
[+] Building 1.2s (7/7) FINISHED                                                                                                                                                                        
 => [internal] load build definition from Dockerfile                                                                                                                                               0.0s
 => => transferring dockerfile: 826B                                                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/photon:4.0                                                                                                                                      1.1s
 => [auth] library/photon:pull token for registry-1.docker.io                                                                                                                                      0.0s
 => [1/2] FROM docker.io/library/photon:4.0@sha256:2fb54b28a0e9d58ecf18fe4b494a4a5357c41c253dd73db2ace8bf2219b4fb5d                                                                                0.0s
 => CACHED [2/2] RUN tdnf -y upgrade && tdnf clean all                                                                                                                                             0.0s
 => exporting to image                                                                                                                                                                             0.0s
 => => exporting layers                                                                                                                                                                            0.0s
 => => writing image sha256:aac02131d875d4550cd59e318e88eae613583a0726eecb4754fde4b4d9ce8752                                                                                                       0.0s
 => => naming to gcr.io/cloud-provider-vsphere/extra/csi-driver-base:v2.1.0-rc.1-994-g75cf820                                                                                                      0.0s
docker tag gcr.io/cloud-provider-vsphere/extra/csi-driver-base:v2.1.0-rc.1-994-g75cf820 gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest

```
 
With this PR, I am correcting the tag to be used for the base driver image, which will now use the master branch's latest git commit hash as the tag name. The change will also put a full commit-id in the generated docker image.



**After this PR**

```
 % make build
docker build -t gcr.io/cloud-provider-vsphere/extra/csi-driver-base:910a5a18 --build-arg GIT_COMMIT=910a5a18d44e8419da6d1b21f61bb7fc2b5d7228 .
[+] Building 6.8s (6/6) FINISHED                                                                                                                                                                                                                                                                                      
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                             0.0s
 => => transferring dockerfile: 872B                                                                                                                                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/photon:4.0                                                                                                                                                                                                                                                    0.4s
 => CACHED [1/2] FROM docker.io/library/photon:4.0@sha256:2fb54b28a0e9d58ecf18fe4b494a4a5357c41c253dd73db2ace8bf2219b4fb5d                                                                                                                                                                                       0.0s
 => [2/2] RUN tdnf -y upgrade && tdnf clean all                                                                                                                                                                                                                                                                  6.2s
 => exporting to image                                                                                                                                                                                                                                                                                           0.0s
 => => exporting layers                                                                                                                                                                                                                                                                                          0.0s
 => => writing image sha256:9e1264bc6654db6e73a5151c032c33091d3a7ba7fd48739a717a63b4130645b0                                                                                                                                                                                                                     0.0s 
 => => naming to gcr.io/cloud-provider-vsphere/extra/csi-driver-base:910a5a18                                                                                                                                                                                                                                    0.0s 
docker tag gcr.io/cloud-provider-vsphere/extra/csi-driver-base:910a5a18 gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest                                                                                                                                                                                    
```

Also with this change, we will be able to inspect the git commit id from the generated image.

```
% docker inspect gcr.io/cloud-provider-vsphere/extra/csi-driver-base:910a5a18 | grep "git_commit"
                "git_commit": "910a5a18d44e8419da6d1b21f61bb7fc2b5d7228",

```



**Testing done**:
Yes generated image locally with this change and inspected git commit from the image.

**Special notes for your reviewer**:
In the follow-up PRs, I will docker file and build file for syncer and controller container, so we can identify git commit right from the container image.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fixing base image tag and adding git commit to the base image
```
