### PR TITLE
Update govmomi to use latest updates for CnsQueryAsync API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.3
-	github.com/vmware/govmomi v0.26.1-0.20210616182200-66b9538af589
+	github.com/vmware/govmomi v0.26.2-0.20210907233321-5196d831d88e
 	go.uber.org/zap v1.17.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect

--- a/go.sum
+++ b/go.sum
@@ -684,6 +684,8 @@ github.com/vmware-tanzu/vm-operator-api v0.1.3/go.mod h1:mubK0QMyaA2TbeAmGsu2GVf
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.26.1-0.20210616182200-66b9538af589 h1:3zexZbYzLhWvG92k4xUWu2pdb05LOFrpsGA3/2Oc4T4=
 github.com/vmware/govmomi v0.26.1-0.20210616182200-66b9538af589/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
+github.com/vmware/govmomi v0.26.2-0.20210907233321-5196d831d88e h1:irZ+ONb0L2RGUxFkwt/5BAKxb2nvnP+w+U+6/asl4Qg=
+github.com/vmware/govmomi v0.26.2-0.20210907233321-5196d831d88e/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
@@ -776,8 +778,8 @@ golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181005035420-146acd28ed58/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -527,7 +527,7 @@ func (volumeMigration *volumeMigration) cleanupStaleCRDInstances() {
 			},
 		}
 		queryAllResult, err := utils.QueryAllVolumeUtil(ctx, *volumeMigrationInstance.volumeManager, queryFilter,
-			cnstypes.CnsQuerySelection{}, commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+			nil, commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 		if err != nil {
 			log.Warnf("failed to queryAllVolume with err %+v", err)
 			continue

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -81,7 +81,7 @@ type Manager interface {
 	// volume fields would be returned as part of the CnsQueryResult, if the
 	// querySelection parameters are not specified.
 	QueryVolumeAsync(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
-		querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error)
+		querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error)
 	// QueryVolume returns volumes matching the given filter.
 	QueryVolume(ctx context.Context, queryFilter cnstypes.CnsQueryFilter) (*cnstypes.CnsQueryResult, error)
 	// RelocateVolume migrates volumes to their target datastore as specified in relocateSpecList.
@@ -1438,7 +1438,7 @@ func (m *defaultManager) RetrieveVStorageObject(ctx context.Context,
 // fields would be returned as part of the CnsQueryResult if the querySelection
 // parameters are not specified.
 func (m *defaultManager) QueryVolumeAsync(ctx context.Context, queryFilter cnstypes.CnsQueryFilter,
-	querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
+	querySelection *cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
 	log := logger.GetLogger(ctx)
 	err := validateManager(ctx, m)
 	if err != nil {

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -42,7 +42,7 @@ const DefaultQuerySnapshotLimit = int64(128)
 // query filters, query selection as params. Returns queryResult when query
 // volume succeeds, otherwise returns appropriate errors.
 func QueryVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cnstypes.CnsQueryFilter,
-	querySelection cnstypes.CnsQuerySelection, useQueryVolumeAsync bool) (*cnstypes.CnsQueryResult, error) {
+	querySelection *cnstypes.CnsQuerySelection, useQueryVolumeAsync bool) (*cnstypes.CnsQueryResult, error) {
 	log := logger.GetLogger(ctx)
 	var queryAsyncNotSupported bool
 	var queryResult *cnstypes.CnsQueryResult
@@ -77,7 +77,7 @@ func QueryVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cnsty
 // instance, query filters, query selection as params. Returns queryResult
 // when query volume succeeds, otherwise returns appropriate errors.
 func QueryAllVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cnstypes.CnsQueryFilter,
-	querySelection cnstypes.CnsQuerySelection, useQueryVolumeAsync bool) (*cnstypes.CnsQueryResult, error) {
+	querySelection *cnstypes.CnsQuerySelection, useQueryVolumeAsync bool) (*cnstypes.CnsQueryResult, error) {
 	log := logger.GetLogger(ctx)
 	var queryAsyncNotSupported bool
 	var queryResult *cnstypes.CnsQueryResult
@@ -96,7 +96,10 @@ func QueryAllVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cn
 		}
 	}
 	if !useQueryVolumeAsync || queryAsyncNotSupported {
-		queryResult, err = m.QueryAllVolume(ctx, queryFilter, querySelection)
+		if querySelection == nil {
+			querySelection = &cnstypes.CnsQuerySelection{}
+		}
+		queryResult, err = m.QueryAllVolume(ctx, queryFilter, *querySelection)
 		if err != nil {
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"queryAllVolume failed for queryFilter: %+v. Err=%+v", queryFilter, err.Error())

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -827,7 +827,7 @@ func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int
 	}
 	// Query only the backing object details.
 	queryResult, err := utils.QueryAllVolumeUtil(ctx, manager.VolumeManager,
-		queryFilter, querySelection, useAsyncQueryVolume)
+		queryFilter, &querySelection, useAsyncQueryVolume)
 	if err != nil {
 		log.Errorf("QueryVolume failed with err=%+v", err.Error())
 		return false, err

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -865,7 +865,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 				},
 			}
 			// Select only the backing object details.
-			queryResult, err := utils.QueryAllVolumeUtil(ctx, c.manager.VolumeManager, queryFilter, querySelection,
+			queryResult, err := utils.QueryAllVolumeUtil(ctx, c.manager.VolumeManager, queryFilter, &querySelection,
 				commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 			if err != nil {
 				return nil, logger.LogNewErrorCodef(log, codes.Internal,
@@ -976,7 +976,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 				},
 			}
 			// Select only the volume type.
-			queryResult, err := utils.QueryAllVolumeUtil(ctx, c.manager.VolumeManager, queryFilter, querySelection,
+			queryResult, err := utils.QueryAllVolumeUtil(ctx, c.manager.VolumeManager, queryFilter, &querySelection,
 				commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 			if err != nil {
 				return nil, logger.LogNewErrorCodef(log, codes.Internal,

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -100,7 +100,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) erro
 		},
 	}
 	queryResult, err := utils.QueryAllVolumeUtil(ctx, metadataSyncer.volumeManager, queryFilter,
-		cnstypes.CnsQuerySelection{}, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+		nil, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 	if err != nil {
 		log.Errorf("PVCUpdated: QueryVolume failed with err=%+v", err.Error())
 		return err

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -900,7 +900,7 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 			// Query with empty selection. CNS returns only the volume ID from
 			// its cache.
 			queryResult, err := utils.QueryAllVolumeUtil(ctx, metadataSyncer.volumeManager, queryFilter,
-				cnstypes.CnsQuerySelection{}, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+				nil, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 			if err != nil {
 				log.Errorf("PVCUpdated: QueryVolume failed with err=%+v", err.Error())
 				return false, err
@@ -1077,7 +1077,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 		defer volumeOperationsLock.Unlock()
 		// QueryAll with no selection will return only the volume ID.
 		queryResult, err := utils.QueryAllVolumeUtil(ctx, metadataSyncer.volumeManager, queryFilter,
-			cnstypes.CnsQuerySelection{}, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+			nil, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 		if err != nil {
 			log.Errorf("PVUpdated: QueryVolume failed with err=%+v", err.Error())
 			return
@@ -1202,7 +1202,7 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 			},
 		}
 		queryResult, err := utils.QueryVolumeUtil(ctx, metadataSyncer.volumeManager, queryFilter,
-			cnstypes.CnsQuerySelection{}, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+			nil, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 		if err != nil {
 			log.Error("PVDeleted: QueryVolume failed with err=%+v", err.Error())
 			return

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -169,7 +169,7 @@ func fullSyncGetQueryResults(ctx context.Context, volumeIds []cnstypes.CnsVolume
 	var allQueryResults []*cnstypes.CnsQueryResult
 	for {
 		log.Debugf("Query volumes with offset: %v and limit: %v", queryFilter.Cursor.Offset, queryFilter.Cursor.Limit)
-		queryResult, err := utils.QueryVolumeUtil(ctx, volumeManager, queryFilter, cnstypes.CnsQuerySelection{},
+		queryResult, err := utils.QueryVolumeUtil(ctx, volumeManager, queryFilter, nil,
 			metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 		if err != nil {
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,

--- a/pkg/syncer/volume_health.go
+++ b/pkg/syncer/volume_health.go
@@ -49,7 +49,7 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 		},
 	}
 	queryResult, err := utils.QueryAllVolumeUtil(ctx, metadataSyncer.volumeManager, queryFilter,
-		querySelection, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+		&querySelection, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 	if err != nil {
 		log.Errorf("csiGetVolumeHealthStatus: QueryVolume failed with err=%+v", err.Error())
 		return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is updating the govmomi version to consume recent updates in CnsQueryAsync API request parameters to handle empty values for QuerySelection. Without this change the API will return "VolumeId" field only, when empty QuerySelection is passed. Instead, the API is expected to return entire Volume{} struct with all the fields(not just volumeId) when empty QuerySelection is passed. 

The fix in govmomi has essentially changed the API to consume pointer to QuerySelection which can be set to nil when clients choose to pass empty QuerySelection in order to fetch all fields from QueryAsync API.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running e2e pipelines

**Special notes for your reviewer**:
Before the change:
```
CnsVolumeOperationResult: types.CnsVolumeOperationResult{},
            QueryResult:              types.CnsQueryResult{
                Volumes: []types.CnsVolume{
                    {
                        VolumeId: types.CnsVolumeId{
                            Id: "5235f91b-fece-4c71-b948-9397d87fd8c5",
                        },
                        DatastoreUrl:                 "",
                        Name:                         "",
                        VolumeType:                   "",
                        StoragePolicyId:              "",
                        Metadata:                     types.CnsVolumeMetadata{},
                        BackingObjectDetails:         nil,
                        ComplianceStatus:             "",
                        DatastoreAccessibilityStatus: "",
                        HealthStatus:                 "",
                    },
                },
                Cursor: types.CnsCursor{
                    Offset:       1,
                    Limit:        100,
                    TotalRecords: 1,
                },
            },
        }
```

After the change:
```
CnsVolumeOperationResult: types.CnsVolumeOperationResult{},
            QueryResult:              types.CnsQueryResult{
                Volumes: []types.CnsVolume{
                    {
                        VolumeId: types.CnsVolumeId{
                            Id: "463f30aa-b698-4cab-8577-205f2a06bee0",
                        },
                        DatastoreUrl:    "ds:///vmfs/volumes/vsan:520e5afe58336876-6d9b508e67d14272/",
                        Name:            "pvc-901e87eb-c2bd-11e9-806f-005056a0c9a0",
                        VolumeType:      "BLOCK",
                        StoragePolicyId: "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
                        Metadata:        types.CnsVolumeMetadata{
                            ContainerCluster: types.CnsContainerCluster{
                                ClusterType:         "KUBERNETES",
                                ClusterId:           "demo-cluster-id",
                                VSphereUser:         "Administrator@vsphere.local",
                                ClusterFlavor:       "VANILLA",
                                ClusterDistribution: "OpenShift",
                            },
                            EntityMetadata: []types.BaseCnsEntityMetadata{
                                &types.CnsKubernetesEntityMetadata{
                                    CnsEntityMetadata: types.CnsEntityMetadata{
                                        EntityName: "example-pod",
                                        Labels:     nil,
                                        Delete:     false,
                                        ClusterID:  "demo-cluster-id",
                                    },
                                    EntityType:     "POD",
                                    Namespace:      "default",
                                    ReferredEntity: []types.CnsKubernetesEntityReference{
                                        {EntityType:"PERSISTENT_VOLUME_CLAIM", EntityName:"example-vanilla-block-pvc", Namespace:"default", ClusterID:"demo-cluster-id"},
                                    },
                                },
                                &types.CnsKubernetesEntityMetadata{
                                    CnsEntityMetadata: types.CnsEntityMetadata{
                                        EntityName: "example-vanilla-block-pvc",
                                        Labels:     []types.KeyValue{
                                            {
                                                Key:   "testLabel",
                                                Value: "testValue",
                                            },
                                        },
                                        Delete:    false,
                                        ClusterID: "demo-cluster-id",
                                    },
                                    EntityType:     "PERSISTENT_VOLUME_CLAIM",
                                    Namespace:      "default",
                                    ReferredEntity: []types.CnsKubernetesEntityReference{
                                        {EntityType:"PERSISTENT_VOLUME", EntityName:"pvc-53465372-5c12-4818-96f8-0ace4f4fd116", Namespace:"", ClusterID:"demo-cluster-id"},
                                    },
                                },
                                &types.CnsKubernetesEntityMetadata{
                                    CnsEntityMetadata: types.CnsEntityMetadata{
                                        EntityName: "pvc-53465372-5c12-4818-96f8-0ace4f4fd116",
                                        Labels:     []types.KeyValue{
                                            {
                                                Key:   "testLabel",
                                                Value: "testValue",
                                            },
                                        },
                                        Delete:    false,
                                        ClusterID: "demo-cluster-id",
                                    },
                                    EntityType:     "PERSISTENT_VOLUME",
                                    Namespace:      "",
                                    ReferredEntity: nil,
                                },
                            },
                            ContainerClusterArray: []types.CnsContainerCluster{
                                {
                                    ClusterType:         "KUBERNETES",
                                    ClusterId:           "demo-cluster-id",
                                    VSphereUser:         "Administrator@vsphere.local",
                                    ClusterFlavor:       "VANILLA",
                                    ClusterDistribution: "OpenShift",
                                },
                            },
                        },
                        BackingObjectDetails: &types.CnsBlockBackingDetails{
                            CnsBackingObjectDetails: types.CnsBackingObjectDetails{
                                CapacityInMb: 10240,
                            },
                            BackingDiskId:      "463f30aa-b698-4cab-8577-205f2a06bee0",
                            BackingDiskUrlPath: "",
                        },
                        ComplianceStatus:             "compliant",
                        DatastoreAccessibilityStatus: "accessible",
                        HealthStatus:                 "green",
                    },
                },
                Cursor: types.CnsCursor{
                    Offset:       1,
                    Limit:        100,
                    TotalRecords: 1,
                },
            },
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update govmomi to use latest updates fro CnsQueryAsync API
```
