### PR TITLE
set latest VC client for cached task object

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -402,6 +402,10 @@ func (m *defaultManager) createVolume(ctx context.Context, spec *cnstypes.CnsVol
 				defaultOpsExpirationTimeInHours))
 			volumeTaskMap[volNameFromInputSpec] = &taskDetails
 		}
+	} else {
+		// Create new task object with latest vCenter Client to avoid
+		// NotAuthenticated fault for cached tasks objects.
+		task = object.NewTask(m.virtualCenter.Client.Client, task.Reference())
 	}
 
 	// Get the taskInfo.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This fix is required when `improved-csi-idempotency` feature is disabled.

Before `improved-csi-idempotency` feature was added, we were caching task objects in the memory.
When vCenter restarts, the client for those cached task objects becomes unauthenticated. When CSI driver attempts to retrieve task result from those cached task objects, it fails with the following error

> 2021-07-07T17:12:46.307Z        ERROR   volume/manager.go:210   failed to get taskInfo for CreateVolume task from vCenter "10.185.33.130" with err: ServerFaultCode: The session is not authenticated.  {"TraceId": "4c3f40c2-4984-45f5-babf-e6b1ca84eb59"}


**Testing done**:
Verified creating 15 PVCs in parallel. While volumes are being created on the vCenter and tasks are in progress, restarted vCenter. After vCenter is rebooted, did not observe task monitoring stuck with unauthenticated session.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
set latest VC client for cached task object
```
