### PR TITLE
Discover existing topology labels on nodes in NodeGetInfo call

### DIFF
--- a/pkg/syncer/cnsoperator/controller/csinodetopology/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/controller_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csinodetopology
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
+)
+
+func TestFindExistingTopologyLabels(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name                string
+		nodeList            []corev1.Node
+		expectedZoneLabel   string
+		expectedRegionLabel string
+		expectedErr         bool
+	}{
+		{
+			name: "ExpectedGALabels",
+			nodeList: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelTopologyZone:   "zone1",
+							corev1.LabelTopologyRegion: "regionA",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelTopologyZone:   "zone2",
+							corev1.LabelTopologyRegion: "regionB",
+						},
+					},
+				},
+			},
+			expectedZoneLabel:   corev1.LabelTopologyZone,
+			expectedRegionLabel: corev1.LabelTopologyRegion,
+			expectedErr:         false,
+		},
+		{
+			name: "ExpectedPartialGALabels",
+			nodeList: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							common.TopologyLabelsDomain + "/zone":   "zone1",
+							common.TopologyLabelsDomain + "/region": "regionA",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelTopologyZone: "zone2",
+						},
+					},
+				},
+			},
+			expectedZoneLabel:   corev1.LabelTopologyZone,
+			expectedRegionLabel: corev1.LabelTopologyRegion,
+			expectedErr:         false,
+		},
+		{
+			name: "ExpectedBetaLabels",
+			nodeList: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelFailureDomainBetaZone:   "zone1",
+							corev1.LabelFailureDomainBetaRegion: "regionA",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelFailureDomainBetaZone:   "zone2",
+							corev1.LabelFailureDomainBetaRegion: "regionB",
+						},
+					},
+				},
+			},
+			expectedZoneLabel:   corev1.LabelFailureDomainBetaZone,
+			expectedRegionLabel: corev1.LabelFailureDomainBetaRegion,
+			expectedErr:         false,
+		},
+		{
+			name: "ExpectedPartialBetaLabels",
+			nodeList: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelFailureDomainBetaZone:   "zone1",
+							corev1.LabelFailureDomainBetaRegion: "regionA",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							common.TopologyLabelsDomain + "/zone":   "zone2",
+							common.TopologyLabelsDomain + "/region": "regionB",
+						},
+					},
+				},
+			},
+			expectedZoneLabel:   corev1.LabelFailureDomainBetaZone,
+			expectedRegionLabel: corev1.LabelFailureDomainBetaRegion,
+			expectedErr:         false,
+		},
+		{
+			name: "MixedLabelsOnNodes",
+			nodeList: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelFailureDomainBetaZone:   "zone1",
+							corev1.LabelFailureDomainBetaRegion: "regionA",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelTopologyZone:   "zone2",
+							corev1.LabelTopologyRegion: "regionB",
+						},
+					},
+				},
+			},
+			expectedZoneLabel:   "",
+			expectedRegionLabel: "",
+			expectedErr:         true,
+		},
+		{
+			name: "NoStandardLabelsOnNodes",
+			nodeList: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							common.TopologyLabelsDomain + "/zone":   "zone1",
+							common.TopologyLabelsDomain + "/region": "regionA",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							common.TopologyLabelsDomain + "/zone":   "zone2",
+							common.TopologyLabelsDomain + "/region": "regionB",
+						},
+					},
+				},
+			},
+			expectedZoneLabel:   "",
+			expectedRegionLabel: "",
+			expectedErr:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualZoneLabel, actualRegionLabel, actualErr := findExistingTopologyLabels(ctx, tt.nodeList)
+			assert.Equal(t, tt.expectedErr, actualErr != nil)
+			assert.Equal(t, tt.expectedZoneLabel, actualZoneLabel)
+			assert.Equal(t, tt.expectedRegionLabel, actualRegionLabel)
+		})
+	}
+}

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -234,8 +234,9 @@ func (r *ReconcileCSINodeTopology) Reconcile(ctx context.Context, request reconc
 		// Fetch topology labels for nodeVM.
 		topologyLabels, err := getNodeTopologyInfo(ctx, nodeVM, r.configInfo.Cfg)
 		if err != nil {
-			msg := fmt.Sprintf("failed to fetch topology information for the nodeVM with ID %q", nodeID)
-			log.Errorf("%s. Error: %v", msg, err)
+			msg := fmt.Sprintf("failed to fetch topology information for the nodeVM with ID %q. Error: %v",
+				nodeID, err)
+			log.Error(msg)
 			_ = updateCRStatus(ctx, r, instance, csinodetopologyv1alpha1.CSINodeTopologyError, msg)
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: While upgrading the CSI driver in an existing topology aware environment, the customer will face a backward compatibility issue as the new topology improvements use a different topology label from the ones used in the beta versions. To avoid this breakage, this PR will discover any existing topology beta or GA labels already present on the nodes in the cluster and use these to register the node. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
E2E tests - TBD


Manual testing for zone and region labels - 
1. Discovering existing beta labels on the nodes:
Node labels prior to upgrade:
```
Name:               k8s-node-0159
Roles:              <none>
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu
                    beta.kubernetes.io/os=linux
                    failure-domain.beta.kubernetes.io/region=region-1
                    failure-domain.beta.kubernetes.io/zone=zone-a
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=k8s-node-0159
                    kubernetes.io/os=linux
```

Syncer logs
```
2021-09-12T22:52:31.581Z	INFO	csinodetopology/csinodetopology_controller.go:232	Detected a topology aware cluster
2021-09-12T22:52:31.858Z	DEBUG	vsphere/virtualmachine.go:217	Host owning node vm: VirtualMachine:vm-74 [VirtualCenterHost: 10.182.49.224, UUID: 4223c699-4b13-913e-0be7-3dd866ff7a13, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] is 10.182.63.85
2021-09-12T22:52:31.866Z	DEBUG	vsphere/virtualmachine.go:249	Ancestors of node vm: VirtualMachine:vm-74 [VirtualCenterHost: 10.182.49.224, UUID: 4223c699-4b13-913e-0be7-3dd866ff7a13, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] are : [[{ExtensibleManagedObject:{Self:Folder:group-d1 Value:[] AvailableField:[]} Parent:<nil> CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:Datacenters DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Datacenter:datacenter-3 Value:[] AvailableField:[]} Parent:Folder:group-d1 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:test-vpx-1627675815-863-hostpool DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Folder:group-h5 Value:[] AvailableField:[]} Parent:Datacenter:datacenter-3 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:host DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:ClusterComputeResource:domain-c53 Value:[] AvailableField:[]} Parent:Folder:group-h5 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:vSAN-FVT-Cluster1627677231.92674 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:HostSystem:host-31 Value:[] AvailableField:[]} Parent:ClusterComputeResource:domain-c53 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:10.182.63.85 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]}]]
2021-09-12T22:52:31.866Z	DEBUG	vsphere/virtualmachine.go:391	Name: host-31, Type: HostSystem
2021-09-12T22:52:32.093Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{HostSystem:host-31 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.85 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:a9cb10e4-29ad-4cbf-a261-266e57b2b186:GLOBAL]]
2021-09-12T22:52:32.119Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: rack-4 for object {{HostSystem:host-31 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.85 [] [] [] [] <nil> []}
2021-09-12T22:52:32.138Z	INFO	vsphere/virtualmachine.go:415	Found category: rack for object {{HostSystem:host-31 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.85 [] [] [] [] <nil> []} with tag: rack-4
2021-09-12T22:52:32.139Z	DEBUG	vsphere/virtualmachine.go:391	Name: domain-c53, Type: ClusterComputeResource
2021-09-12T22:52:32.160Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:fbd31147-bf8e-454e-92f7-1127d3d06359:GLOBAL]]
2021-09-12T22:52:32.174Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: zone-a for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}
2021-09-12T22:52:32.184Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-zone for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []} with tag: zone-a
2021-09-12T22:52:32.184Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-h5, Type: Folder
2021-09-12T22:52:32.219Z	DEBUG	vsphere/virtualmachine.go:391	Name: datacenter-3, Type: Datacenter
2021-09-12T22:52:32.253Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-d1, Type: Folder
2021-09-12T22:52:32.291Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:56f47201-30bb-404b-a247-b857ab9541cb:GLOBAL]]
2021-09-12T22:52:32.311Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: region-1 for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}
2021-09-12T22:52:32.330Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-region for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []} with tag: region-1
2021-09-12T22:52:32.330Z	INFO	vsphere/virtualmachine.go:431	Tags related to all topology categories found. Skipping tag check on following entities: []
2021-09-12T22:52:32.330Z	INFO	csinodetopology/csinodetopology_controller.go:344	NodeVM "VirtualMachine:vm-74" belongs to topology: map[k8s-region:region-1 k8s-zone:zone-a]
2021-09-12T22:52:32.331Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config
2021-09-12T22:52:32.331Z	INFO	kubernetes/kubernetes.go:341	Setting client QPS to 100.000000 and Burst to 100.
2021-09-12T22:52:32.347Z	INFO	csinodetopology/csinodetopology_controller.go:421	Found standard topology beta labels on the existing nodes in the cluster.
2021-09-12T22:52:32.389Z	DEBUG	csinodetopology/csinodetopology_controller.go:139	Ignoring CSINodeTopology reconciliation on update event
2021-09-12T22:52:32.391Z	INFO	csinodetopology/csinodetopology_controller.go:261	Successfully updated topology labels for nodeVM with ID "k8s-node-0159"
2021-09-12T22:52:32.391Z	DEBUG	node/manager.go:183	Renewing virtual machine VirtualMachine:vm-73 [VirtualCenterHost: 10.182.49.224, UUID: 42230e5a-8a23-94dd-935e-08c5ef912d93, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /test-vpx-1627675815-863-hostpool, VirtualCenterHost: 10.182.49.224]] with nodeUUID "42230e5a-8a23-94dd-935e-08c5ef912d93"
2021-09-12T22:52:32.398Z	DEBUG	node/manager.go:190	VM VirtualMachine:vm-73 [VirtualCenterHost: 10.182.49.224, UUID: 42230e5a-8a23-94dd-935e-08c5ef912d93, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] was successfully renewed with nodeUUID "42230e5a-8a23-94dd-935e-08c5ef912d93"
2021-09-12T22:52:32.398Z	INFO	csinodetopology/csinodetopology_controller.go:232	Detected a topology aware cluster
2021-09-12T22:52:32.662Z	DEBUG	vsphere/virtualmachine.go:217	Host owning node vm: VirtualMachine:vm-73 [VirtualCenterHost: 10.182.49.224, UUID: 42230e5a-8a23-94dd-935e-08c5ef912d93, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] is 10.182.60.155
2021-09-12T22:52:32.670Z	DEBUG	vsphere/virtualmachine.go:249	Ancestors of node vm: VirtualMachine:vm-73 [VirtualCenterHost: 10.182.49.224, UUID: 42230e5a-8a23-94dd-935e-08c5ef912d93, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] are : [[{ExtensibleManagedObject:{Self:Folder:group-d1 Value:[] AvailableField:[]} Parent:<nil> CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:Datacenters DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Datacenter:datacenter-3 Value:[] AvailableField:[]} Parent:Folder:group-d1 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:test-vpx-1627675815-863-hostpool DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Folder:group-h5 Value:[] AvailableField:[]} Parent:Datacenter:datacenter-3 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:host DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:ClusterComputeResource:domain-c53 Value:[] AvailableField:[]} Parent:Folder:group-h5 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:vSAN-FVT-Cluster1627677231.92674 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:HostSystem:host-22 Value:[] AvailableField:[]} Parent:ClusterComputeResource:domain-c53 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:10.182.60.155 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]}]]
2021-09-12T22:52:32.670Z	DEBUG	vsphere/virtualmachine.go:391	Name: host-22, Type: HostSystem
2021-09-12T22:52:32.858Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{HostSystem:host-22 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.60.155 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:449736f3-8b82-454e-bac1-b3c2c61059f3:GLOBAL]]
2021-09-12T22:52:32.879Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: rack-2 for object {{HostSystem:host-22 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.60.155 [] [] [] [] <nil> []}
2021-09-12T22:52:32.900Z	INFO	vsphere/virtualmachine.go:415	Found category: rack for object {{HostSystem:host-22 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.60.155 [] [] [] [] <nil> []} with tag: rack-2
2021-09-12T22:52:32.901Z	DEBUG	vsphere/virtualmachine.go:391	Name: domain-c53, Type: ClusterComputeResource
2021-09-12T22:52:32.949Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:fbd31147-bf8e-454e-92f7-1127d3d06359:GLOBAL]]
2021-09-12T22:52:32.971Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: zone-a for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}
2021-09-12T22:52:32.995Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-zone for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []} with tag: zone-a
2021-09-12T22:52:32.997Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-h5, Type: Folder
2021-09-12T22:52:33.035Z	DEBUG	vsphere/virtualmachine.go:391	Name: datacenter-3, Type: Datacenter
2021-09-12T22:52:33.065Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-d1, Type: Folder
2021-09-12T22:52:33.094Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:56f47201-30bb-404b-a247-b857ab9541cb:GLOBAL]]
2021-09-12T22:52:33.111Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: region-1 for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}
2021-09-12T22:52:33.131Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-region for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []} with tag: region-1
2021-09-12T22:52:33.131Z	INFO	vsphere/virtualmachine.go:431	Tags related to all topology categories found. Skipping tag check on following entities: []
2021-09-12T22:52:33.131Z	INFO	csinodetopology/csinodetopology_controller.go:344	NodeVM "VirtualMachine:vm-73" belongs to topology: map[k8s-region:region-1 k8s-zone:zone-a]
2021-09-12T22:52:33.131Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config
2021-09-12T22:52:33.132Z	INFO	kubernetes/kubernetes.go:341	Setting client QPS to 100.000000 and Burst to 100.
2021-09-12T22:52:33.147Z	INFO	csinodetopology/csinodetopology_controller.go:421	Found standard topology beta labels on the existing nodes in the cluster.
2021-09-12T22:52:33.171Z	INFO	csinodetopology/csinodetopology_controller.go:261	Successfully updated topology labels for nodeVM with ID "k8s-node-0935"
2021-09-12T22:52:33.172Z	DEBUG	csinodetopology/csinodetopology_controller.go:139	Ignoring CSINodeTopology reconciliation on update event
2021-09-12T22:52:33.173Z	DEBUG	node/manager.go:183	Renewing virtual machine VirtualMachine:vm-72 [VirtualCenterHost: 10.182.49.224, UUID: 4223907b-7643-1971-a615-1226b7c7016e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /test-vpx-1627675815-863-hostpool, VirtualCenterHost: 10.182.49.224]] with nodeUUID "4223907b-7643-1971-a615-1226b7c7016e"
2021-09-12T22:52:33.179Z	DEBUG	node/manager.go:190	VM VirtualMachine:vm-72 [VirtualCenterHost: 10.182.49.224, UUID: 4223907b-7643-1971-a615-1226b7c7016e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] was successfully renewed with nodeUUID "4223907b-7643-1971-a615-1226b7c7016e"
2021-09-12T22:52:33.179Z	INFO	csinodetopology/csinodetopology_controller.go:232	Detected a topology aware cluster
2021-09-12T22:52:33.397Z	DEBUG	vsphere/virtualmachine.go:217	Host owning node vm: VirtualMachine:vm-72 [VirtualCenterHost: 10.182.49.224, UUID: 4223907b-7643-1971-a615-1226b7c7016e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] is 10.182.52.33
2021-09-12T22:52:33.403Z	DEBUG	vsphere/virtualmachine.go:249	Ancestors of node vm: VirtualMachine:vm-72 [VirtualCenterHost: 10.182.49.224, UUID: 4223907b-7643-1971-a615-1226b7c7016e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] are : [[{ExtensibleManagedObject:{Self:Folder:group-d1 Value:[] AvailableField:[]} Parent:<nil> CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:Datacenters DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Datacenter:datacenter-3 Value:[] AvailableField:[]} Parent:Folder:group-d1 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:test-vpx-1627675815-863-hostpool DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Folder:group-h5 Value:[] AvailableField:[]} Parent:Datacenter:datacenter-3 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:host DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:ClusterComputeResource:domain-c53 Value:[] AvailableField:[]} Parent:Folder:group-h5 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:vSAN-FVT-Cluster1627677231.92674 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:HostSystem:host-28 Value:[] AvailableField:[]} Parent:ClusterComputeResource:domain-c53 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:10.182.52.33 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]}]]
2021-09-12T22:52:33.403Z	DEBUG	vsphere/virtualmachine.go:391	Name: host-28, Type: HostSystem
2021-09-12T22:52:33.591Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{HostSystem:host-28 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.52.33 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:123b7a5e-2512-451f-983d-4bc4053462ae:GLOBAL]]
2021-09-12T22:52:33.609Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: rack-1 for object {{HostSystem:host-28 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.52.33 [] [] [] [] <nil> []}
2021-09-12T22:52:33.625Z	INFO	vsphere/virtualmachine.go:415	Found category: rack for object {{HostSystem:host-28 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.52.33 [] [] [] [] <nil> []} with tag: rack-1
2021-09-12T22:52:33.625Z	DEBUG	vsphere/virtualmachine.go:391	Name: domain-c53, Type: ClusterComputeResource
2021-09-12T22:52:33.654Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:fbd31147-bf8e-454e-92f7-1127d3d06359:GLOBAL]]
2021-09-12T22:52:33.671Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: zone-a for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}
2021-09-12T22:52:33.689Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-zone for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []} with tag: zone-a
2021-09-12T22:52:33.689Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-h5, Type: Folder
2021-09-12T22:52:33.719Z	DEBUG	vsphere/virtualmachine.go:391	Name: datacenter-3, Type: Datacenter
2021-09-12T22:52:33.754Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-d1, Type: Folder
2021-09-12T22:52:33.780Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:56f47201-30bb-404b-a247-b857ab9541cb:GLOBAL]]
2021-09-12T22:52:33.803Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: region-1 for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}
2021-09-12T22:52:33.822Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-region for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []} with tag: region-1
2021-09-12T22:52:33.822Z	INFO	vsphere/virtualmachine.go:431	Tags related to all topology categories found. Skipping tag check on following entities: []
2021-09-12T22:52:33.823Z	INFO	csinodetopology/csinodetopology_controller.go:344	NodeVM "VirtualMachine:vm-72" belongs to topology: map[k8s-region:region-1 k8s-zone:zone-a]
2021-09-12T22:52:33.824Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config
2021-09-12T22:52:33.824Z	INFO	kubernetes/kubernetes.go:341	Setting client QPS to 100.000000 and Burst to 100.
2021-09-12T22:52:33.844Z	INFO	csinodetopology/csinodetopology_controller.go:421	Found standard topology beta labels on the existing nodes in the cluster.
2021-09-12T22:52:33.891Z	DEBUG	csinodetopology/csinodetopology_controller.go:139	Ignoring CSINodeTopology reconciliation on update event
2021-09-12T22:52:33.892Z	INFO	csinodetopology/csinodetopology_controller.go:261	Successfully updated topology labels for nodeVM with ID "k8s-master-917"
2021-09-12T22:52:33.893Z	DEBUG	node/manager.go:183	Renewing virtual machine VirtualMachine:vm-75 [VirtualCenterHost: 10.182.49.224, UUID: 4223d6fd-748d-219c-9232-f4d0ef434d49, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /test-vpx-1627675815-863-hostpool, VirtualCenterHost: 10.182.49.224]] with nodeUUID "4223d6fd-748d-219c-9232-f4d0ef434d49"
2021-09-12T22:52:33.900Z	DEBUG	node/manager.go:190	VM VirtualMachine:vm-75 [VirtualCenterHost: 10.182.49.224, UUID: 4223d6fd-748d-219c-9232-f4d0ef434d49, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] was successfully renewed with nodeUUID "4223d6fd-748d-219c-9232-f4d0ef434d49"
2021-09-12T22:52:33.901Z	INFO	csinodetopology/csinodetopology_controller.go:232	Detected a topology aware cluster
2021-09-12T22:52:34.182Z	DEBUG	vsphere/virtualmachine.go:217	Host owning node vm: VirtualMachine:vm-75 [VirtualCenterHost: 10.182.49.224, UUID: 4223d6fd-748d-219c-9232-f4d0ef434d49, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] is 10.182.63.184
2021-09-12T22:52:34.192Z	DEBUG	vsphere/virtualmachine.go:249	Ancestors of node vm: VirtualMachine:vm-75 [VirtualCenterHost: 10.182.49.224, UUID: 4223d6fd-748d-219c-9232-f4d0ef434d49, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] are : [[{ExtensibleManagedObject:{Self:Folder:group-d1 Value:[] AvailableField:[]} Parent:<nil> CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:Datacenters DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Datacenter:datacenter-3 Value:[] AvailableField:[]} Parent:Folder:group-d1 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:test-vpx-1627675815-863-hostpool DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Folder:group-h5 Value:[] AvailableField:[]} Parent:Datacenter:datacenter-3 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:host DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:ClusterComputeResource:domain-c53 Value:[] AvailableField:[]} Parent:Folder:group-h5 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:vSAN-FVT-Cluster1627677231.92674 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:HostSystem:host-25 Value:[] AvailableField:[]} Parent:ClusterComputeResource:domain-c53 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:10.182.63.184 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]}]]
2021-09-12T22:52:34.193Z	DEBUG	vsphere/virtualmachine.go:391	Name: host-25, Type: HostSystem
2021-09-12T22:52:34.395Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{HostSystem:host-25 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.184 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:469660c0-f733-4d52-924c-2347161c3632:GLOBAL]]
2021-09-12T22:52:34.414Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: rack-3 for object {{HostSystem:host-25 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.184 [] [] [] [] <nil> []}
2021-09-12T22:52:34.434Z	INFO	vsphere/virtualmachine.go:415	Found category: rack for object {{HostSystem:host-25 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.184 [] [] [] [] <nil> []} with tag: rack-3
2021-09-12T22:52:34.434Z	DEBUG	vsphere/virtualmachine.go:391	Name: domain-c53, Type: ClusterComputeResource
2021-09-12T22:52:34.463Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:fbd31147-bf8e-454e-92f7-1127d3d06359:GLOBAL]]
2021-09-12T22:52:34.482Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: zone-a for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}
2021-09-12T22:52:34.505Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-zone for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []} with tag: zone-a
2021-09-12T22:52:34.505Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-h5, Type: Folder
2021-09-12T22:52:34.535Z	DEBUG	vsphere/virtualmachine.go:391	Name: datacenter-3, Type: Datacenter
2021-09-12T22:52:34.572Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-d1, Type: Folder
2021-09-12T22:52:34.602Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:56f47201-30bb-404b-a247-b857ab9541cb:GLOBAL]]
2021-09-12T22:52:34.622Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: region-1 for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}
2021-09-12T22:52:34.645Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-region for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []} with tag: region-1
2021-09-12T22:52:34.645Z	INFO	vsphere/virtualmachine.go:431	Tags related to all topology categories found. Skipping tag check on following entities: []
2021-09-12T22:52:34.645Z	INFO	csinodetopology/csinodetopology_controller.go:344	NodeVM "VirtualMachine:vm-75" belongs to topology: map[k8s-region:region-1 k8s-zone:zone-a]
2021-09-12T22:52:34.645Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config
2021-09-12T22:52:34.645Z	INFO	kubernetes/kubernetes.go:341	Setting client QPS to 100.000000 and Burst to 100.
2021-09-12T22:52:34.678Z	INFO	csinodetopology/csinodetopology_controller.go:421	Found standard topology beta labels on the existing nodes in the cluster.
2021-09-12T22:52:34.715Z	DEBUG	csinodetopology/csinodetopology_controller.go:139	Ignoring CSINodeTopology reconciliation on update event
2021-09-12T22:52:34.717Z	INFO	csinodetopology/csinodetopology_controller.go:261	Successfully updated topology labels for nodeVM with ID "k8s-node-0573"
```

2. NodeGetInfo fails if node has a mix of beta and GA labels:
Node labels prior to upgrade:
```
Name:               k8s-node-0159
Roles:              <none>
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu
                    beta.kubernetes.io/os=linux
                    failure-domain.beta.kubernetes.io/region=region-1
                    failure-domain.beta.kubernetes.io/zone=zone-a
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=k8s-node-0159
                    kubernetes.io/os=linux
                    topology.kubernetes.io/region=region-1
                    topology.kubernetes.io/zone=zone-a
```

Syncer logs - 
```
2021-09-12T22:45:38.216Z	INFO	csinodetopology/csinodetopology_controller.go:232	Detected a topology aware cluster
2021-09-12T22:45:38.447Z	DEBUG	vsphere/virtualmachine.go:217	Host owning node vm: VirtualMachine:vm-74 [VirtualCenterHost: 10.182.49.224, UUID: 4223c699-4b13-913e-0be7-3dd866ff7a13, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] is 10.182.63.85
2021-09-12T22:45:38.454Z	DEBUG	vsphere/virtualmachine.go:249	Ancestors of node vm: VirtualMachine:vm-74 [VirtualCenterHost: 10.182.49.224, UUID: 4223c699-4b13-913e-0be7-3dd866ff7a13, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] are : [[{ExtensibleManagedObject:{Self:Folder:group-d1 Value:[] AvailableField:[]} Parent:<nil> CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:Datacenters DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Datacenter:datacenter-3 Value:[] AvailableField:[]} Parent:Folder:group-d1 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:test-vpx-1627675815-863-hostpool DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Folder:group-h5 Value:[] AvailableField:[]} Parent:Datacenter:datacenter-3 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:host DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:ClusterComputeResource:domain-c53 Value:[] AvailableField:[]} Parent:Folder:group-h5 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:vSAN-FVT-Cluster1627677231.92674 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:HostSystem:host-31 Value:[] AvailableField:[]} Parent:ClusterComputeResource:domain-c53 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:10.182.63.85 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]}]]
2021-09-12T22:45:38.454Z	DEBUG	vsphere/virtualmachine.go:391	Name: host-31, Type: HostSystem
2021-09-12T22:45:38.659Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{HostSystem:host-31 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.85 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:a9cb10e4-29ad-4cbf-a261-266e57b2b186:GLOBAL]]
2021-09-12T22:45:38.680Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: rack-4 for object {{HostSystem:host-31 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.85 [] [] [] [] <nil> []}
2021-09-12T22:45:38.697Z	INFO	vsphere/virtualmachine.go:415	Found category: rack for object {{HostSystem:host-31 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.85 [] [] [] [] <nil> []} with tag: rack-4
2021-09-12T22:45:38.697Z	DEBUG	vsphere/virtualmachine.go:391	Name: domain-c53, Type: ClusterComputeResource
2021-09-12T22:45:38.722Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:fbd31147-bf8e-454e-92f7-1127d3d06359:GLOBAL]]
2021-09-12T22:45:38.738Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: zone-a for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}
2021-09-12T22:45:38.756Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-zone for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []} with tag: zone-a
2021-09-12T22:45:38.757Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-h5, Type: Folder
2021-09-12T22:45:38.788Z	DEBUG	vsphere/virtualmachine.go:391	Name: datacenter-3, Type: Datacenter
2021-09-12T22:45:38.820Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-d1, Type: Folder
2021-09-12T22:45:38.850Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:56f47201-30bb-404b-a247-b857ab9541cb:GLOBAL]]
2021-09-12T22:45:38.869Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: region-1 for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}
2021-09-12T22:45:38.888Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-region for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []} with tag: region-1
2021-09-12T22:45:38.889Z	INFO	vsphere/virtualmachine.go:431	Tags related to all topology categories found. Skipping tag check on following entities: []
2021-09-12T22:45:38.889Z	INFO	csinodetopology/csinodetopology_controller.go:344	NodeVM "VirtualMachine:vm-74" belongs to topology: map[k8s-region:region-1 k8s-zone:zone-a]
2021-09-12T22:45:38.889Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config
2021-09-12T22:45:38.890Z	INFO	kubernetes/kubernetes.go:341	Setting client QPS to 100.000000 and Burst to 100.
2021-09-12T22:45:38.907Z	ERROR	csinodetopology/csinodetopology_controller.go:410	found conflicting topology labels on certain node(s) in the cluster. Nodes in the cluster should either have the standard topology beta labels starting with "failure-domain.beta.kubernetes.io" or standard topology GA labels starting with "topology.kubernetes.io".
sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology.findExistingTopologyLabels
	/build/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go:410
sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology.getNodeTopologyInfo
	/build/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go:361
sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology.(*ReconcileCSINodeTopology).Reconcile
	/build/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go:235
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:298
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:253
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:214
2021-09-12T22:45:38.907Z	ERROR	csinodetopology/csinodetopology_controller.go:363	failed to discover existing topology labels on the nodes in the cluster. Error: found conflicting topology labels on certain node(s) in the cluster. Nodes in the cluster should either have the standard topology beta labels starting with "failure-domain.beta.kubernetes.io" or standard topology GA labels starting with "topology.kubernetes.io".
sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology.getNodeTopologyInfo
	/build/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go:363
sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology.(*ReconcileCSINodeTopology).Reconcile
	/build/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go:235
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:298
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:253
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:214
2021-09-12T22:45:38.924Z	ERROR	csinodetopology/csinodetopology_controller.go:238	failed to fetch topology information for the nodeVM with ID "k8s-node-0159". Error: failed to discover existing topology labels on the nodes in the cluster. Error: found conflicting topology labels on certain node(s) in the cluster. Nodes in the cluster should either have the standard topology beta labels starting with "failure-domain.beta.kubernetes.io" or standard topology GA labels starting with "topology.kubernetes.io".
sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology.(*ReconcileCSINodeTopology).Reconcile
	/build/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go:238
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:298
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:253
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:214
```

3. No prior labels found on node:
Syncer logs - 
```
2021-09-12T23:08:58.691Z	INFO	csinodetopology/csinodetopology_controller.go:232	Detected a topology aware cluster
2021-09-12T23:08:58.948Z	DEBUG	vsphere/virtualmachine.go:217	Host owning node vm: VirtualMachine:vm-75 [VirtualCenterHost: 10.182.49.224, UUID: 4223d6fd-748d-219c-9232-f4d0ef434d49, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] is 10.182.63.184
2021-09-12T23:08:58.955Z	DEBUG	vsphere/virtualmachine.go:249	Ancestors of node vm: VirtualMachine:vm-75 [VirtualCenterHost: 10.182.49.224, UUID: 4223d6fd-748d-219c-9232-f4d0ef434d49, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] are : [[{ExtensibleManagedObject:{Self:Folder:group-d1 Value:[] AvailableField:[]} Parent:<nil> CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:Datacenters DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Datacenter:datacenter-3 Value:[] AvailableField:[]} Parent:Folder:group-d1 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:test-vpx-1627675815-863-hostpool DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Folder:group-h5 Value:[] AvailableField:[]} Parent:Datacenter:datacenter-3 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:host DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:ClusterComputeResource:domain-c53 Value:[] AvailableField:[]} Parent:Folder:group-h5 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:vSAN-FVT-Cluster1627677231.92674 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:HostSystem:host-25 Value:[] AvailableField:[]} Parent:ClusterComputeResource:domain-c53 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:10.182.63.184 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]}]]
2021-09-12T23:08:58.955Z	DEBUG	vsphere/virtualmachine.go:391	Name: host-25, Type: HostSystem
2021-09-12T23:08:59.137Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{HostSystem:host-25 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.184 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:469660c0-f733-4d52-924c-2347161c3632:GLOBAL]]
2021-09-12T23:08:59.160Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: rack-3 for object {{HostSystem:host-25 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.184 [] [] [] [] <nil> []}
2021-09-12T23:08:59.182Z	INFO	vsphere/virtualmachine.go:415	Found category: rack for object {{HostSystem:host-25 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.184 [] [] [] [] <nil> []} with tag: rack-3
2021-09-12T23:08:59.182Z	DEBUG	vsphere/virtualmachine.go:391	Name: domain-c53, Type: ClusterComputeResource
2021-09-12T23:08:59.218Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:fbd31147-bf8e-454e-92f7-1127d3d06359:GLOBAL]]
2021-09-12T23:08:59.244Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: zone-a for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}
2021-09-12T23:08:59.268Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-zone for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []} with tag: zone-a
2021-09-12T23:08:59.269Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-h5, Type: Folder
2021-09-12T23:08:59.304Z	DEBUG	vsphere/virtualmachine.go:391	Name: datacenter-3, Type: Datacenter
2021-09-12T23:08:59.347Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-d1, Type: Folder
2021-09-12T23:08:59.390Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:56f47201-30bb-404b-a247-b857ab9541cb:GLOBAL]]
2021-09-12T23:08:59.403Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: region-1 for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}
2021-09-12T23:08:59.427Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-region for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []} with tag: region-1
2021-09-12T23:08:59.427Z	INFO	vsphere/virtualmachine.go:431	Tags related to all topology categories found. Skipping tag check on following entities: []
2021-09-12T23:08:59.427Z	INFO	csinodetopology/csinodetopology_controller.go:344	NodeVM "VirtualMachine:vm-75" belongs to topology: map[k8s-region:region-1 k8s-zone:zone-a]
2021-09-12T23:08:59.427Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config
2021-09-12T23:08:59.428Z	INFO	kubernetes/kubernetes.go:341	Setting client QPS to 100.000000 and Burst to 100.
2021-09-12T23:08:59.459Z	INFO	csinodetopology/csinodetopology_controller.go:367	Did not find any existing standard topology labels on the nodes in the cluster, using VMware CSI topology labels instead.
2021-09-12T23:08:59.520Z	INFO	csinodetopology/csinodetopology_controller.go:261	Successfully updated topology labels for nodeVM with ID "k8s-node-0573"
2021-09-12T23:08:59.520Z	DEBUG	node/manager.go:183	Renewing virtual machine VirtualMachine:vm-74 [VirtualCenterHost: 10.182.49.224, UUID: 4223c699-4b13-913e-0be7-3dd866ff7a13, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /test-vpx-1627675815-863-hostpool, VirtualCenterHost: 10.182.49.224]] with nodeUUID "4223c699-4b13-913e-0be7-3dd866ff7a13"
2021-09-12T23:08:59.524Z	DEBUG	csinodetopology/csinodetopology_controller.go:139	Ignoring CSINodeTopology reconciliation on update event
2021-09-12T23:08:59.527Z	DEBUG	node/manager.go:190	VM VirtualMachine:vm-74 [VirtualCenterHost: 10.182.49.224, UUID: 4223c699-4b13-913e-0be7-3dd866ff7a13, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] was successfully renewed with nodeUUID "4223c699-4b13-913e-0be7-3dd866ff7a13"
2021-09-12T23:08:59.527Z	INFO	csinodetopology/csinodetopology_controller.go:232	Detected a topology aware cluster
2021-09-12T23:08:59.801Z	DEBUG	vsphere/virtualmachine.go:217	Host owning node vm: VirtualMachine:vm-74 [VirtualCenterHost: 10.182.49.224, UUID: 4223c699-4b13-913e-0be7-3dd866ff7a13, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] is 10.182.63.85
2021-09-12T23:08:59.807Z	DEBUG	vsphere/virtualmachine.go:249	Ancestors of node vm: VirtualMachine:vm-74 [VirtualCenterHost: 10.182.49.224, UUID: 4223c699-4b13-913e-0be7-3dd866ff7a13, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] are : [[{ExtensibleManagedObject:{Self:Folder:group-d1 Value:[] AvailableField:[]} Parent:<nil> CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:Datacenters DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Datacenter:datacenter-3 Value:[] AvailableField:[]} Parent:Folder:group-d1 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:test-vpx-1627675815-863-hostpool DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Folder:group-h5 Value:[] AvailableField:[]} Parent:Datacenter:datacenter-3 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:host DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:ClusterComputeResource:domain-c53 Value:[] AvailableField:[]} Parent:Folder:group-h5 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:vSAN-FVT-Cluster1627677231.92674 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:HostSystem:host-31 Value:[] AvailableField:[]} Parent:ClusterComputeResource:domain-c53 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:10.182.63.85 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]}]]
2021-09-12T23:08:59.807Z	DEBUG	vsphere/virtualmachine.go:391	Name: host-31, Type: HostSystem
2021-09-12T23:09:00.033Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{HostSystem:host-31 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.85 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:a9cb10e4-29ad-4cbf-a261-266e57b2b186:GLOBAL]]
2021-09-12T23:09:00.058Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: rack-4 for object {{HostSystem:host-31 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.85 [] [] [] [] <nil> []}
2021-09-12T23:09:00.080Z	INFO	vsphere/virtualmachine.go:415	Found category: rack for object {{HostSystem:host-31 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.63.85 [] [] [] [] <nil> []} with tag: rack-4
2021-09-12T23:09:00.080Z	DEBUG	vsphere/virtualmachine.go:391	Name: domain-c53, Type: ClusterComputeResource
2021-09-12T23:09:00.118Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:fbd31147-bf8e-454e-92f7-1127d3d06359:GLOBAL]]
2021-09-12T23:09:00.129Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: zone-a for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}
2021-09-12T23:09:00.148Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-zone for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []} with tag: zone-a
2021-09-12T23:09:00.149Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-h5, Type: Folder
2021-09-12T23:09:00.183Z	DEBUG	vsphere/virtualmachine.go:391	Name: datacenter-3, Type: Datacenter
2021-09-12T23:09:00.214Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-d1, Type: Folder
2021-09-12T23:09:00.245Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:56f47201-30bb-404b-a247-b857ab9541cb:GLOBAL]]
2021-09-12T23:09:00.263Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: region-1 for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}
2021-09-12T23:09:00.286Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-region for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []} with tag: region-1
2021-09-12T23:09:00.287Z	INFO	vsphere/virtualmachine.go:431	Tags related to all topology categories found. Skipping tag check on following entities: []
2021-09-12T23:09:00.287Z	INFO	csinodetopology/csinodetopology_controller.go:344	NodeVM "VirtualMachine:vm-74" belongs to topology: map[k8s-region:region-1 k8s-zone:zone-a]
2021-09-12T23:09:00.287Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config
2021-09-12T23:09:00.288Z	INFO	kubernetes/kubernetes.go:341	Setting client QPS to 100.000000 and Burst to 100.
2021-09-12T23:09:00.304Z	INFO	csinodetopology/csinodetopology_controller.go:367	Did not find any existing standard topology labels on the nodes in the cluster, using VMware CSI topology labels instead.
2021-09-12T23:09:00.352Z	INFO	csinodetopology/csinodetopology_controller.go:261	Successfully updated topology labels for nodeVM with ID "k8s-node-0159"
2021-09-12T23:09:00.352Z	DEBUG	node/manager.go:183	Renewing virtual machine VirtualMachine:vm-72 [VirtualCenterHost: 10.182.49.224, UUID: 4223907b-7643-1971-a615-1226b7c7016e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /test-vpx-1627675815-863-hostpool, VirtualCenterHost: 10.182.49.224]] with nodeUUID "4223907b-7643-1971-a615-1226b7c7016e"
2021-09-12T23:09:00.352Z	DEBUG	csinodetopology/csinodetopology_controller.go:139	Ignoring CSINodeTopology reconciliation on update event
2021-09-12T23:09:00.358Z	DEBUG	node/manager.go:190	VM VirtualMachine:vm-72 [VirtualCenterHost: 10.182.49.224, UUID: 4223907b-7643-1971-a615-1226b7c7016e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] was successfully renewed with nodeUUID "4223907b-7643-1971-a615-1226b7c7016e"
2021-09-12T23:09:00.358Z	INFO	csinodetopology/csinodetopology_controller.go:232	Detected a topology aware cluster
2021-09-12T23:09:00.595Z	DEBUG	vsphere/virtualmachine.go:217	Host owning node vm: VirtualMachine:vm-72 [VirtualCenterHost: 10.182.49.224, UUID: 4223907b-7643-1971-a615-1226b7c7016e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] is 10.182.52.33
2021-09-12T23:09:00.608Z	DEBUG	vsphere/virtualmachine.go:249	Ancestors of node vm: VirtualMachine:vm-72 [VirtualCenterHost: 10.182.49.224, UUID: 4223907b-7643-1971-a615-1226b7c7016e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] are : [[{ExtensibleManagedObject:{Self:Folder:group-d1 Value:[] AvailableField:[]} Parent:<nil> CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:Datacenters DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Datacenter:datacenter-3 Value:[] AvailableField:[]} Parent:Folder:group-d1 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:test-vpx-1627675815-863-hostpool DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Folder:group-h5 Value:[] AvailableField:[]} Parent:Datacenter:datacenter-3 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:host DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:ClusterComputeResource:domain-c53 Value:[] AvailableField:[]} Parent:Folder:group-h5 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:vSAN-FVT-Cluster1627677231.92674 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:HostSystem:host-28 Value:[] AvailableField:[]} Parent:ClusterComputeResource:domain-c53 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:10.182.52.33 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]}]]
2021-09-12T23:09:00.608Z	DEBUG	vsphere/virtualmachine.go:391	Name: host-28, Type: HostSystem
2021-09-12T23:09:00.835Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{HostSystem:host-28 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.52.33 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:123b7a5e-2512-451f-983d-4bc4053462ae:GLOBAL]]
2021-09-12T23:09:00.857Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: rack-1 for object {{HostSystem:host-28 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.52.33 [] [] [] [] <nil> []}
2021-09-12T23:09:00.883Z	INFO	vsphere/virtualmachine.go:415	Found category: rack for object {{HostSystem:host-28 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.52.33 [] [] [] [] <nil> []} with tag: rack-1
2021-09-12T23:09:00.883Z	DEBUG	vsphere/virtualmachine.go:391	Name: domain-c53, Type: ClusterComputeResource
2021-09-12T23:09:00.903Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:fbd31147-bf8e-454e-92f7-1127d3d06359:GLOBAL]]
2021-09-12T23:09:00.932Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: zone-a for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}
2021-09-12T23:09:00.953Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-zone for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []} with tag: zone-a
2021-09-12T23:09:00.953Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-h5, Type: Folder
2021-09-12T23:09:00.973Z	DEBUG	vsphere/virtualmachine.go:391	Name: datacenter-3, Type: Datacenter
2021-09-12T23:09:01.004Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-d1, Type: Folder
2021-09-12T23:09:01.038Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:56f47201-30bb-404b-a247-b857ab9541cb:GLOBAL]]
2021-09-12T23:09:01.058Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: region-1 for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}
2021-09-12T23:09:01.093Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-region for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []} with tag: region-1
2021-09-12T23:09:01.093Z	INFO	vsphere/virtualmachine.go:431	Tags related to all topology categories found. Skipping tag check on following entities: []
2021-09-12T23:09:01.093Z	INFO	csinodetopology/csinodetopology_controller.go:344	NodeVM "VirtualMachine:vm-72" belongs to topology: map[k8s-region:region-1 k8s-zone:zone-a]
2021-09-12T23:09:01.094Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config
2021-09-12T23:09:01.095Z	INFO	kubernetes/kubernetes.go:341	Setting client QPS to 100.000000 and Burst to 100.
2021-09-12T23:09:01.129Z	INFO	csinodetopology/csinodetopology_controller.go:367	Did not find any existing standard topology labels on the nodes in the cluster, using VMware CSI topology labels instead.
2021-09-12T23:09:01.166Z	DEBUG	csinodetopology/csinodetopology_controller.go:139	Ignoring CSINodeTopology reconciliation on update event
2021-09-12T23:09:01.166Z	INFO	csinodetopology/csinodetopology_controller.go:261	Successfully updated topology labels for nodeVM with ID "k8s-master-917"
2021-09-12T23:09:01.169Z	DEBUG	node/manager.go:183	Renewing virtual machine VirtualMachine:vm-73 [VirtualCenterHost: 10.182.49.224, UUID: 42230e5a-8a23-94dd-935e-08c5ef912d93, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /test-vpx-1627675815-863-hostpool, VirtualCenterHost: 10.182.49.224]] with nodeUUID "42230e5a-8a23-94dd-935e-08c5ef912d93"
2021-09-12T23:09:01.175Z	DEBUG	node/manager.go:190	VM VirtualMachine:vm-73 [VirtualCenterHost: 10.182.49.224, UUID: 42230e5a-8a23-94dd-935e-08c5ef912d93, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] was successfully renewed with nodeUUID "42230e5a-8a23-94dd-935e-08c5ef912d93"
2021-09-12T23:09:01.176Z	INFO	csinodetopology/csinodetopology_controller.go:232	Detected a topology aware cluster
2021-09-12T23:09:01.428Z	DEBUG	vsphere/virtualmachine.go:217	Host owning node vm: VirtualMachine:vm-73 [VirtualCenterHost: 10.182.49.224, UUID: 42230e5a-8a23-94dd-935e-08c5ef912d93, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] is 10.182.60.155
2021-09-12T23:09:01.436Z	DEBUG	vsphere/virtualmachine.go:249	Ancestors of node vm: VirtualMachine:vm-73 [VirtualCenterHost: 10.182.49.224, UUID: 42230e5a-8a23-94dd-935e-08c5ef912d93, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.49.224]] are : [[{ExtensibleManagedObject:{Self:Folder:group-d1 Value:[] AvailableField:[]} Parent:<nil> CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:Datacenters DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Datacenter:datacenter-3 Value:[] AvailableField:[]} Parent:Folder:group-d1 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:test-vpx-1627675815-863-hostpool DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Folder:group-h5 Value:[] AvailableField:[]} Parent:Datacenter:datacenter-3 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:host DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:ClusterComputeResource:domain-c53 Value:[] AvailableField:[]} Parent:Folder:group-h5 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:vSAN-FVT-Cluster1627677231.92674 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:HostSystem:host-22 Value:[] AvailableField:[]} Parent:ClusterComputeResource:domain-c53 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:10.182.60.155 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]}]]
2021-09-12T23:09:01.437Z	DEBUG	vsphere/virtualmachine.go:391	Name: host-22, Type: HostSystem
2021-09-12T23:09:01.662Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{HostSystem:host-22 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.60.155 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:449736f3-8b82-454e-bac1-b3c2c61059f3:GLOBAL]]
2021-09-12T23:09:01.683Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: rack-2 for object {{HostSystem:host-22 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.60.155 [] [] [] [] <nil> []}
2021-09-12T23:09:01.705Z	INFO	vsphere/virtualmachine.go:415	Found category: rack for object {{HostSystem:host-22 [] []} ClusterComputeResource:domain-c53 []   [] [] [] 10.182.60.155 [] [] [] [] <nil> []} with tag: rack-2
2021-09-12T23:09:01.706Z	DEBUG	vsphere/virtualmachine.go:391	Name: domain-c53, Type: ClusterComputeResource
2021-09-12T23:09:01.753Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:fbd31147-bf8e-454e-92f7-1127d3d06359:GLOBAL]]
2021-09-12T23:09:01.777Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: zone-a for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []}
2021-09-12T23:09:01.803Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-zone for object {{ClusterComputeResource:domain-c53 [] []} Folder:group-h5 []   [] [] [] vSAN-FVT-Cluster1627677231.92674 [] [] [] [] <nil> []} with tag: zone-a
2021-09-12T23:09:01.803Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-h5, Type: Folder
2021-09-12T23:09:01.834Z	DEBUG	vsphere/virtualmachine.go:391	Name: datacenter-3, Type: Datacenter
2021-09-12T23:09:01.865Z	DEBUG	vsphere/virtualmachine.go:391	Name: group-d1, Type: Folder
2021-09-12T23:09:01.911Z	DEBUG	vsphere/virtualmachine.go:399	Object [{{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}] has attached Tags [[urn:vmomi:InventoryServiceTag:56f47201-30bb-404b-a247-b857ab9541cb:GLOBAL]]
2021-09-12T23:09:01.930Z	DEBUG	vsphere/virtualmachine.go:408	Found tag: region-1 for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []}
2021-09-12T23:09:01.951Z	INFO	vsphere/virtualmachine.go:415	Found category: k8s-region for object {{Folder:group-d1 [] []} <nil> []   [] [] [] Datacenters [] [] [] [] <nil> []} with tag: region-1
2021-09-12T23:09:01.951Z	INFO	vsphere/virtualmachine.go:431	Tags related to all topology categories found. Skipping tag check on following entities: []
2021-09-12T23:09:01.951Z	INFO	csinodetopology/csinodetopology_controller.go:344	NodeVM "VirtualMachine:vm-73" belongs to topology: map[k8s-region:region-1 k8s-zone:zone-a]
2021-09-12T23:09:01.951Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config
2021-09-12T23:09:01.952Z	INFO	kubernetes/kubernetes.go:341	Setting client QPS to 100.000000 and Burst to 100.
2021-09-12T23:09:01.972Z	INFO	csinodetopology/csinodetopology_controller.go:367	Did not find any existing standard topology labels on the nodes in the cluster, using VMware CSI topology labels instead.
2021-09-12T23:09:01.995Z	INFO	csinodetopology/csinodetopology_controller.go:261	Successfully updated topology labels for nodeVM with ID "k8s-node-0935"
2021-09-12T23:09:01.995Z	DEBUG	csinodetopology/csinodetopology_controller.go:139	Ignoring CSINodeTopology reconciliation on update event
```

Sample node labels:
```
Name:               k8s-node-0935
Roles:              <none>
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu
                    beta.kubernetes.io/os=linux
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=k8s-node-0935
                    kubernetes.io/os=linux
                    topology.csi.vmware.com/k8s-region=region-1
                    topology.csi.vmware.com/k8s-zone=zone-a
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Discover existing topology labels on nodes in NodeGetInfo call
```
