### PR TITLE
Set PV node affinity to point to all topology segments the chosen datastore is accessible from.

### DIFF
--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -110,6 +110,12 @@ func (nodes *Nodes) GetNodeByName(ctx context.Context, nodeName string) (
 	return nodes.cnsNodeManager.GetNodeByName(ctx, nodeName)
 }
 
+// GetNodeNameByUUID fetches the name of the node given the VM UUID.
+func (nodes *Nodes) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (
+	string, error) {
+	return nodes.cnsNodeManager.GetNodeNameByUUID(ctx, nodeUUID)
+}
+
 // GetAllNodes returns VirtualMachine for all registered.
 // This is called by ControllerExpandVolume to check if volume is attached to
 // a node.

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -11,10 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
-
 	"github.com/davecgh/go-spew/spew"
-
 	"github.com/vmware/govmomi/cns"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/sts"
@@ -25,6 +22,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 )
 
 const (

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -109,10 +109,16 @@ func (nodeTopology *mockNodeVolumeTopology) GetNodeTopologyLabels(ctx context.Co
 
 // GetSharedDatastoresInTopology retrieves shared datastores of nodes which satisfy a given topology requirement.
 func (cntrlTopology *mockControllerVolumeTopology) GetSharedDatastoresInTopology(ctx context.Context,
-	topologyRequirement *csi.TopologyRequirement) ([]*cnsvsphere.DatastoreInfo, map[string][]map[string]string,
-	error) {
+	topologyRequirement *csi.TopologyRequirement) ([]*cnsvsphere.DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
-	return nil, nil, logger.LogNewError(log, "GetSharedDatastoresInTopology is not yet implemented.")
+	return nil, logger.LogNewError(log, "GetSharedDatastoresInTopology is not yet implemented.")
+}
+
+// GetTopologyInfoFromNodes retrieves the topology information of the given list of node names.
+func (cntrlTopology *mockControllerVolumeTopology) GetTopologyInfoFromNodes(ctx context.Context,
+	nodeNames []string, datastoreURL string) ([]map[string]string, error) {
+	log := logger.GetLogger(ctx)
+	return nil, logger.LogNewError(log, "GetTopologyInfoFromNodes is not yet implemented.")
 }
 
 // InitTopologyServiceInController returns a singleton implementation of the

--- a/pkg/csi/service/common/commonco/types/types.go
+++ b/pkg/csi/service/common/commonco/types/types.go
@@ -39,7 +39,9 @@ type ControllerTopologyService interface {
 	// GetSharedDatastoresInTopology gets the list of shared datastores which adhere to the topology
 	// requirement given as a parameter.
 	GetSharedDatastoresInTopology(ctx context.Context, topologyRequirement *csi.TopologyRequirement) (
-		[]*cnsvsphere.DatastoreInfo, map[string][]map[string]string, error)
+		[]*cnsvsphere.DatastoreInfo, error)
+	// GetTopologyInfoFromNodes retrieves the topology information of the given list of node names.
+	GetTopologyInfoFromNodes(ctx context.Context, nodeNames []string, datastoreURL string) ([]map[string]string, error)
 }
 
 // NodeTopologyService is an interface which exposes functionality related to

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -234,6 +234,10 @@ func (f *FakeNodeManager) GetNodeByName(ctx context.Context, nodeName string) (*
 	return vm, nil
 }
 
+func (f *FakeNodeManager) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error) {
+	return "", nil
+}
+
 func (f *FakeNodeManager) GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachine, error) {
 	return nil, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Currently in a topology aware provisioning, the PV node affinity selector terms are set to any one of the topology segments from which the volume created on a datastore is accessible from. This will create an issue when the chosen datastore is a shared datastore among multiple topology segments and one of the domains shuts down, the Pod-PV in that segment will not be able to migrate to another topology domain as the node affinity will not match. This PR fixes this issue by adding all the topology domains to the PV node affinity selector terms from which the chosen datastore is accessible from.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
**E2E testing** - Complete

**Manual testing**:
StorageClass -
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: block-sc-rack-vsan
parameters:
  storagepolicyname: vSAN Default Storage Policy
provisioner: csi.vsphere.vmware.com
allowedTopologies:
  - matchLabelExpressions:
      - key: topology.csi.vmware.com/k8s-zone
        values:
          - zone-a
      - key: topology.csi.vmware.com/k8s-region
        values:
          - region-1
      - key: topology.csi.vmware.com/rack
        values:
          - rack-1
```

CreateVolume logs - 
```
2021-09-29T22:38:23.215Z	INFO	vanilla/controller.go:792	CreateVolume: called with args {Name:pvc-3021d38e-f048-4674-9435-0a88b8f052aa CapacityRange:required_bytes:104857600  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[storagepolicyname:vSAN Default Storage Policy] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-a" > segments:<key:"topology.csi.vmware.com/rack" value:"rack-1" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-a" > segments:<key:"topology.csi.vmware.com/rack" value:"rack-1" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.219Z	DEBUG	k8sorchestrator/topology.go:490	Get shared datastores with topologyRequirement: requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-a" > segments:<key:"topology.csi.vmware.com/rack" value:"rack-1" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-a" > segments:<key:"topology.csi.vmware.com/rack" value:"rack-1" > > 	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.220Z	DEBUG	k8sorchestrator/topology.go:498	Using preferred topology	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.220Z	DEBUG	k8sorchestrator/topology.go:531	Getting list of nodeVMs for topology segments map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-1]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.227Z	DEBUG	node/manager.go:203	Renewing virtual machine VirtualMachine:vm-50 [VirtualCenterHost: 10.182.136.185, UUID: 42190a90-9478-61d7-5b25-f183f114f769, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.182.136.185]] with nodeUUID "42190a90-9478-61d7-5b25-f183f114f769"	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.253Z	DEBUG	node/manager.go:210	VM VirtualMachine:vm-50 [VirtualCenterHost: 10.182.136.185, UUID: 42190a90-9478-61d7-5b25-f183f114f769, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.136.185]] was successfully renewed with nodeUUID "42190a90-9478-61d7-5b25-f183f114f769"	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.254Z	DEBUG	k8sorchestrator/topology.go:588	Node "k8s-control-343-1632518194" with topology map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-2] did not match the topology requirement - "topology.csi.vmware.com/rack": "rack-1" 	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.255Z	DEBUG	k8sorchestrator/topology.go:588	Node "k8s-node-599-1632518223" with topology map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-4] did not match the topology requirement - "topology.csi.vmware.com/rack": "rack-1" 	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.257Z	DEBUG	k8sorchestrator/topology.go:588	Node "k8s-node-637-1632518213" with topology map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-3] did not match the topology requirement - "topology.csi.vmware.com/rack": "rack-1" 	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.258Z	DEBUG	k8sorchestrator/topology.go:588	Node "k8s-control-482-1632518184" with topology map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-3] did not match the topology requirement - "topology.csi.vmware.com/rack": "rack-1" 	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.259Z	DEBUG	k8sorchestrator/topology.go:588	Node "k8s-node-235-1632518204" with topology map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-2] did not match the topology requirement - "topology.csi.vmware.com/rack": "rack-1" 	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.260Z	INFO	k8sorchestrator/topology.go:539	Obtained list of nodeVMs [VirtualMachine:vm-50 [VirtualCenterHost: 10.182.136.185, UUID: 42190a90-9478-61d7-5b25-f183f114f769, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.136.185]]]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.260Z	DEBUG	vsphere/virtualmachine.go:364	Getting accessible datastores for node VirtualMachine:vm-50	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.282Z	INFO	k8sorchestrator/topology.go:550	Obtained shared datastores: [Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/0020d2e4-e441fdba/ Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/614e3534-261f3caa-1f6e-0200af33ab16/ Datastore: Datastore:datastore-38, datastore URL: ds:///vmfs/volumes/614e3535-9831f55a-719e-0200af33ab16/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:5288ea30d2fbef61-ab1e469e984f16de/]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.283Z	DEBUG	vanilla/controller.go:484	Shared datastores [[Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/0020d2e4-e441fdba/ Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/614e3534-261f3caa-1f6e-0200af33ab16/ Datastore: Datastore:datastore-38, datastore URL: ds:///vmfs/volumes/614e3535-9831f55a-719e-0200af33ab16/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:5288ea30d2fbef61-ab1e469e984f16de/]] retrieved for topologyRequirement [requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-a" > segments:<key:"topology.csi.vmware.com/rack" value:"rack-1" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-a" > segments:<key:"topology.csi.vmware.com/rack" value:"rack-1" > > ]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.284Z	DEBUG	vanilla/controller.go:342	filterDatastores: dsMap map[ds:///vmfs/volumes/0020d2e4-e441fdba/:Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/0020d2e4-e441fdba/ ds:///vmfs/volumes/614e3534-261f3caa-1f6e-0200af33ab16/:Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/614e3534-261f3caa-1f6e-0200af33ab16/ ds:///vmfs/volumes/614e3535-9831f55a-719e-0200af33ab16/:Datastore: Datastore:datastore-38, datastore URL: ds:///vmfs/volumes/614e3535-9831f55a-719e-0200af33ab16/ ds:///vmfs/volumes/614e3536-e4a0417c-b99a-0200af1ccf2e/:Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/614e3536-e4a0417c-b99a-0200af1ccf2e/ ds:///vmfs/volumes/614e3537-540d7b22-f332-0200af1ccf2e/:Datastore: Datastore:datastore-40, datastore URL: ds:///vmfs/volumes/614e3537-540d7b22-f332-0200af1ccf2e/ ds:///vmfs/volumes/614e3538-fe8a092a-c776-0200af14168d/:Datastore: Datastore:datastore-44, datastore URL: ds:///vmfs/volumes/614e3538-fe8a092a-c776-0200af14168d/ ds:///vmfs/volumes/614e3539-7b9e564a-53f0-0200af14168d/:Datastore: Datastore:datastore-45, datastore URL: ds:///vmfs/volumes/614e3539-7b9e564a-53f0-0200af14168d/ ds:///vmfs/volumes/614e353a-ee4dcefa-c37b-0200af30da2a/:Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/614e353a-ee4dcefa-c37b-0200af30da2a/ ds:///vmfs/volumes/614e353b-6ad2465a-0f2d-0200af30da2a/:Datastore: Datastore:datastore-43, datastore URL: ds:///vmfs/volumes/614e353b-6ad2465a-0f2d-0200af30da2a/ ds:///vmfs/volumes/vsan:5288ea30d2fbef61-ab1e469e984f16de/:Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:5288ea30d2fbef61-ab1e469e984f16de/] sharedDatastores [Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/0020d2e4-e441fdba/ Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/614e3534-261f3caa-1f6e-0200af33ab16/ Datastore: Datastore:datastore-38, datastore URL: ds:///vmfs/volumes/614e3535-9831f55a-719e-0200af33ab16/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:5288ea30d2fbef61-ab1e469e984f16de/]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.284Z	DEBUG	vanilla/controller.go:351	filterDatastores: filteredDatastores [Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/0020d2e4-e441fdba/ Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/614e3534-261f3caa-1f6e-0200af33ab16/ Datastore: Datastore:datastore-38, datastore URL: ds:///vmfs/volumes/614e3535-9831f55a-719e-0200af33ab16/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:5288ea30d2fbef61-ab1e469e984f16de/]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.386Z	DEBUG	common/vsphereutil.go:241	vSphere CSI driver creating volume pvc-3021d38e-f048-4674-9435-0a88b8f052aa with create spec (*types.CnsVolumeCreateSpec)(0xc0008b4400)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-3021d38e-f048-4674-9435-0a88b8f052aa",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=4 cap=4) {
  (types.ManagedObjectReference) Datastore:datastore-36,
  (types.ManagedObjectReference) Datastore:datastore-37,
  (types.ManagedObjectReference) Datastore:datastore-38,
  (types.ManagedObjectReference) Datastore:datastore-47
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=8) "cluster1",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA",
   ClusterDistribution: (string) (len=11) "CSI-Vanilla"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=8) "cluster1",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA",
    ClusterDistribution: (string) (len=11) "CSI-Vanilla"
   }
  }
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc0008aa1e0)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 100
  },
  BackingDiskId: (string) "",
  BackingDiskUrlPath: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) (len=1 cap=1) {
  (*types.VirtualMachineDefinedProfileSpec)(0xc0009796c0)({
   VirtualMachineProfileSpec: (types.VirtualMachineProfileSpec) {
    DynamicData: (types.DynamicData) {
    }
   },
   ProfileId: (string) (len=36) "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
   ReplicationSpec: (*types.ReplicationSpec)(<nil>),
   ProfileData: (*types.VirtualMachineProfileRawData)(<nil>),
   ProfileParams: ([]types.KeyValue) <nil>
  })
 },
 CreateSpec: (types.BaseCnsBaseCreateSpec) <nil>,
 VolumeSource: (types.BaseCnsVolumeSource) <nil>
})
	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:23.394Z	DEBUG	volume/util.go:198	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.899Z	INFO	volume/manager.go:428	CreateVolume: VolumeName: "pvc-3021d38e-f048-4674-9435-0a88b8f052aa", opId: "94e1e0b0"	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.903Z	INFO	volume/util.go:327	Volume created successfully. VolumeName: "pvc-3021d38e-f048-4674-9435-0a88b8f052aa", volumeID: "a267a32b-d2b5-466f-9e83-ef35fe14005f"	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.903Z	DEBUG	volume/util.go:329	CreateVolume volumeId {{} "a267a32b-d2b5-466f-9e83-ef35fe14005f"} is placed on datastore "ds:///vmfs/volumes/vsan:5288ea30d2fbef61-ab1e469e984f16de/"	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.904Z	DEBUG	volume/manager.go:496	internalCreateVolume: returns fault ""	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.905Z	DEBUG	node/manager.go:258	Renewing VM VirtualMachine:vm-55 [VirtualCenterHost: 10.182.136.185, UUID: 4219cfe4-35cb-ab3d-bedb-16da892d0e67, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.182.136.185]] with new connection: nodeUUID 4219cfe4-35cb-ab3d-bedb-16da892d0e67	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.908Z	DEBUG	node/manager.go:268	Updated VM VirtualMachine:vm-55 [VirtualCenterHost: 10.182.136.185, UUID: 4219cfe4-35cb-ab3d-bedb-16da892d0e67, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.136.185]] for node with nodeUUID 4219cfe4-35cb-ab3d-bedb-16da892d0e67	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.909Z	DEBUG	node/manager.go:255	Renewing VM VirtualMachine:vm-54 [VirtualCenterHost: 10.182.136.185, UUID: 4219afcc-a746-5464-a0b9-6c27c7edba44, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.182.136.185]], no new connection needed: nodeUUID 4219afcc-a746-5464-a0b9-6c27c7edba44	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.909Z	DEBUG	node/manager.go:268	Updated VM VirtualMachine:vm-54 [VirtualCenterHost: 10.182.136.185, UUID: 4219afcc-a746-5464-a0b9-6c27c7edba44, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.136.185]] for node with nodeUUID 4219afcc-a746-5464-a0b9-6c27c7edba44	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.909Z	DEBUG	node/manager.go:255	Renewing VM VirtualMachine:vm-51 [VirtualCenterHost: 10.182.136.185, UUID: 4219a3b9-d32d-5197-c032-e0e0af3287e8, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.182.136.185]], no new connection needed: nodeUUID 4219a3b9-d32d-5197-c032-e0e0af3287e8	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.909Z	DEBUG	node/manager.go:268	Updated VM VirtualMachine:vm-51 [VirtualCenterHost: 10.182.136.185, UUID: 4219a3b9-d32d-5197-c032-e0e0af3287e8, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.136.185]] for node with nodeUUID 4219a3b9-d32d-5197-c032-e0e0af3287e8	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.909Z	DEBUG	node/manager.go:255	Renewing VM VirtualMachine:vm-52 [VirtualCenterHost: 10.182.136.185, UUID: 4219791e-a711-3257-6043-15e78846a951, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.182.136.185]], no new connection needed: nodeUUID 4219791e-a711-3257-6043-15e78846a951	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.909Z	DEBUG	node/manager.go:268	Updated VM VirtualMachine:vm-52 [VirtualCenterHost: 10.182.136.185, UUID: 4219791e-a711-3257-6043-15e78846a951, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.136.185]] for node with nodeUUID 4219791e-a711-3257-6043-15e78846a951	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.909Z	DEBUG	node/manager.go:255	Renewing VM VirtualMachine:vm-53 [VirtualCenterHost: 10.182.136.185, UUID: 421998a0-7527-d17d-0985-8dd0c993a70e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.182.136.185]], no new connection needed: nodeUUID 421998a0-7527-d17d-0985-8dd0c993a70e	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.909Z	DEBUG	node/manager.go:268	Updated VM VirtualMachine:vm-53 [VirtualCenterHost: 10.182.136.185, UUID: 421998a0-7527-d17d-0985-8dd0c993a70e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.136.185]] for node with nodeUUID 421998a0-7527-d17d-0985-8dd0c993a70e	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.909Z	DEBUG	node/manager.go:255	Renewing VM VirtualMachine:vm-50 [VirtualCenterHost: 10.182.136.185, UUID: 42190a90-9478-61d7-5b25-f183f114f769, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.136.185]], no new connection needed: nodeUUID 42190a90-9478-61d7-5b25-f183f114f769	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.909Z	DEBUG	node/manager.go:268	Updated VM VirtualMachine:vm-50 [VirtualCenterHost: 10.182.136.185, UUID: 42190a90-9478-61d7-5b25-f183f114f769, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.182.136.185]] for node with nodeUUID 42190a90-9478-61d7-5b25-f183f114f769	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.952Z	INFO	common/vsphereutil.go:998	Nodes that have access to datastore "ds:///vmfs/volumes/vsan:5288ea30d2fbef61-ab1e469e984f16de/" are [VirtualMachine:vm-55 VirtualMachine:vm-51 VirtualMachine:vm-52 VirtualMachine:vm-50 VirtualMachine:vm-54 VirtualMachine:vm-53]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.955Z	DEBUG	node/manager.go:161	Retrieved node name "k8s-control-343-1632518194" for node UUID "4219cfe4-35cb-ab3d-bedb-16da892d0e67"	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.959Z	DEBUG	node/manager.go:161	Retrieved node name "k8s-node-235-1632518204" for node UUID "4219a3b9-d32d-5197-c032-e0e0af3287e8"	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.963Z	DEBUG	node/manager.go:161	Retrieved node name "k8s-node-599-1632518223" for node UUID "4219791e-a711-3257-6043-15e78846a951"	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.966Z	DEBUG	node/manager.go:161	Retrieved node name "k8s-control-108-1632518174" for node UUID "42190a90-9478-61d7-5b25-f183f114f769"	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.970Z	DEBUG	node/manager.go:161	Retrieved node name "k8s-control-482-1632518184" for node UUID "4219afcc-a746-5464-a0b9-6c27c7edba44"	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.983Z	DEBUG	node/manager.go:161	Retrieved node name "k8s-node-637-1632518213" for node UUID "421998a0-7527-d17d-0985-8dd0c993a70e"	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.985Z	INFO	k8sorchestrator/topology.go:661	Topology segments retrieved from nodes accessible to datastore "ds:///vmfs/volumes/vsan:5288ea30d2fbef61-ab1e469e984f16de/" are: [map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-2] map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-4] map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-1] map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-3]]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.985Z	DEBUG	k8sorchestrator/topology.go:709	Nodes [k8s-control-343-1632518194 k8s-node-235-1632518204] belong to topology segment map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-2]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.986Z	DEBUG	k8sorchestrator/topology.go:709	Nodes [k8s-node-599-1632518223] belong to topology segment map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-4]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.986Z	DEBUG	k8sorchestrator/topology.go:709	Nodes [k8s-control-108-1632518174] belong to topology segment map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-1]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.986Z	DEBUG	k8sorchestrator/topology.go:709	Nodes [k8s-node-637-1632518213 k8s-control-482-1632518184] belong to topology segment map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-3]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.986Z	INFO	k8sorchestrator/topology.go:670	Accessible topology calculated for datastore "ds:///vmfs/volumes/vsan:5288ea30d2fbef61-ab1e469e984f16de/" is [map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-2] map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-4] map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-1] map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-a topology.csi.vmware.com/rack:rack-3]]	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
2021-09-29T22:38:30.986Z	DEBUG	vanilla/controller.go:823	createVolumeInternal: returns fault ""	{"TraceId": "44a611df-d82c-4548-bbd9-56cc35767e45"}
```

PV describe output -
```
Name:              pvc-3021d38e-f048-4674-9435-0a88b8f052aa
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      block-sc-rack-vsan
Status:            Bound
Claim:             default/rack-pvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          100Mi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.csi.vmware.com/k8s-region in [region-1]
                   topology.csi.vmware.com/k8s-zone in [zone-a]
                   topology.csi.vmware.com/rack in [rack-2]
    Term 1:        topology.csi.vmware.com/k8s-region in [region-1]
                   topology.csi.vmware.com/k8s-zone in [zone-a]
                   topology.csi.vmware.com/rack in [rack-4]
    Term 2:        topology.csi.vmware.com/k8s-region in [region-1]
                   topology.csi.vmware.com/k8s-zone in [zone-a]
                   topology.csi.vmware.com/rack in [rack-1]
    Term 3:        topology.csi.vmware.com/rack in [rack-3]
                   topology.csi.vmware.com/k8s-region in [region-1]
                   topology.csi.vmware.com/k8s-zone in [zone-a]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      a267a32b-d2b5-466f-9e83-ef35fe14005f
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1632954951932-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Set PV node affinity to point to all topology segments the chosen datastore is accessible from.
```
