### PR TITLE
Add locking to prevent concurrent write to volumeTaskMap

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -136,13 +136,14 @@ var (
 	// read/write on manager instance.
 	managerInstanceLock sync.Mutex
 	volumeTaskMap       = make(map[string]*createVolumeTaskDetails)
+	// volumeTaskMapLock is used to serialize writes to volumeTaskMap.
+	volumeTaskMapLock sync.Mutex
 	// Alias for CreateVolumeOperationRequestDetails function declaration.
 	createRequestDetails = cnsvolumeoperationrequest.CreateVolumeOperationRequestDetails
 )
 
 // createVolumeTaskDetails contains taskInfo object and expiration time.
 type createVolumeTaskDetails struct {
-	sync.Mutex
 	task           *object.Task
 	expirationTime time.Time
 }
@@ -192,9 +193,9 @@ func ClearTaskInfoObjects() {
 				// the entry has to be deleted.
 				log.Debugf("Found an expired taskInfo: %+v for volume %q. Deleting it from task map",
 					volumeTaskMap[pvc].task, pvc)
-				taskDetails.Lock()
+				volumeTaskMapLock.Lock()
 				delete(volumeTaskMap, pvc)
-				taskDetails.Unlock()
+				volumeTaskMapLock.Unlock()
 			}
 		}
 	}
@@ -400,7 +401,9 @@ func (m *defaultManager) createVolume(ctx context.Context, spec *cnstypes.CnsVol
 			taskDetails.task = task
 			taskDetails.expirationTime = time.Now().Add(time.Hour * time.Duration(
 				defaultOpsExpirationTimeInHours))
+			volumeTaskMapLock.Lock()
 			volumeTaskMap[volNameFromInputSpec] = &taskDetails
+			volumeTaskMapLock.Unlock()
 		}
 	} else {
 		// Create new task object with latest vCenter Client to avoid
@@ -442,13 +445,13 @@ func (m *defaultManager) createVolume(ctx context.Context, spec *cnstypes.CnsVol
 			// Remove the taskInfo object associated with the volume name when the
 			// current task fails. This is needed to ensure the sub-sequent create
 			// volume call from the external provisioner invokes Create Volume.
-			taskDetailsInMap, ok := volumeTaskMap[volNameFromInputSpec]
+			_, ok := volumeTaskMap[volNameFromInputSpec]
 			if ok {
-				taskDetailsInMap.Lock()
+				volumeTaskMapLock.Lock()
 				log.Debugf("Deleted task for %s from volumeTaskMap because the task has failed",
 					volNameFromInputSpec)
 				delete(volumeTaskMap, volNameFromInputSpec)
-				taskDetailsInMap.Unlock()
+				volumeTaskMapLock.Unlock()
 			}
 			log.Errorf("failed to create cns volume %s. createSpec: %q, fault: %q",
 				volNameFromInputSpec, spew.Sdump(spec), spew.Sdump(volumeOperationRes.Fault))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In recent test environments, we have seen that when concurrent calls to create volumes are made, CSI controller crashes due to a panic due to "concurrent map writes"

```
container_name":"vsphere-csi-controller","docker_id":"0f5415611ec55b3117cc7d72ebe6ec61c185832f81abfe69ebd462bcf9fcfca6","host":"42013e642fb4503884979d29912e1452","labels":{"app":"vsphere-csi-controller","pod-template-hash":"85f97b549c","role":"vsphere-csi"},"namespace_name":"vmware-system-csi","pod_id":"5c4d5514-e201-42b2-92df-38a174a5491d","pod_name":"vsphere-csi-controller-85f97b549c-lfq58"},"log":"2021-09-12T10:32:28.825124025Z stderr F fatal error: concurrent map writes"}

```

On further inspection, this seems to be due to writes to the `volumeTaskInfo` map that stores create volume task information. 

This PR adds a locking to prevent concurrent writes to that map.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Vanilla and GC pipelines passed.
WCP pipeline :

```
FAIL! -- 10 Passed | 3 Failed | 0 Pending | 216 Skipped
--- FAIL: TestE2E (1994.97s)
FAIL
```

3 failures were due to pipeline configuration issues in volume health tests:

```
 Expected
      <[]*object.HostSystem | len:0, cap:0>: nil
  not to be nil
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add locking to prevent concurrent write to volumeTaskMap
```
