### PR TITLE
Fixing logic for fetching volhandle and CnsVolumeMetadata verification for gc in one test

### DIFF
--- a/tests/e2e/vcp_to_csi_create_delete.go
+++ b/tests/e2e/vcp_to_csi_create_delete.go
@@ -938,14 +938,16 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim,
 				} else {
 					labels := getLabelMap(entityMetadata.Labels)
 					if !(reflect.DeepEqual(labels, pvc.Labels)) {
-						framework.Logf("Labels on pvc '%v' are not matching with labels in metadata '%v' for volume id %v",
+						framework.Logf(
+							"Labels on pvc '%v' are not matching with labels in metadata '%v' for volume id %v",
 							pvc.Labels, entityMetadata.Labels, volumeID)
 						pvcEntryFound = false
 						break
 					}
 				}
 				if entityMetadata.Namespace != pvc.Namespace {
-					framework.Logf("PVC namespace '%v' does not match PVC namespace in pvc metadata '%v', for volume id %v",
+					framework.Logf(
+						"PVC namespace '%v' does not match PVC namespace in pvc metadata '%v', for volume id %v",
 						pvc.Namespace, entityMetadata.Namespace, volumeID)
 					pvcEntryFound = false
 					break
@@ -972,8 +974,9 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim,
 				} else {
 					labels := getLabelMap(entityMetadata.Labels)
 					if !(reflect.DeepEqual(labels, pv.Labels)) {
-						framework.Logf("Labels on pv '%v' are not matching with labels in pv metadata '%v' for volume id %v",
-							entityMetadata.Labels, pv.Labels, volumeID)
+						framework.Logf(
+							"Labels on pv '%v' are not matching with labels in pv metadata '%v' for volume id %v",
+							pv.Labels, entityMetadata.Labels, volumeID)
 						pvEntryFound = false
 						break
 					}
@@ -1006,7 +1009,7 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim,
 						}
 						if entityMetadata.ReferredEntity[0].Namespace != pvc.Namespace {
 							framework.Logf("PVC namespace '%v' does not match PVC namespace in Pod metadata "+
-								"referered entitry, '%v', for volume id %v",
+								"referered entity, '%v', for volume id %v",
 								pvc.Namespace, entityMetadata.ReferredEntity[0].Namespace, volumeID)
 							podEntryFound = false
 							break
@@ -1014,7 +1017,8 @@ func verifyCnsVolumeMetadata(volumeID string, pvc *v1.PersistentVolumeClaim,
 					}
 				}
 				if entityMetadata.Namespace != pod.Namespace {
-					framework.Logf("Pod namespace '%v' does not match pod namespace in pvc metadata '%v', for volume id %v",
+					framework.Logf(
+						"Pod namespace '%v' does not match pod namespace in pvc metadata '%v', for volume id %v",
 						pod.Namespace, entityMetadata.Namespace, volumeID)
 					podEntryFound = false
 					break


### PR DESCRIPTION
**What this PR does / why we need it**: removing logic for fetching `volHandle` for GC since the one we already have is correct. Fixing CnsVolumeMetadata verification for GC.

**Testing done**:
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1273#issuecomment-922760422

**Special notes for your reviewer**:
```zsh
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver pr2839059 ⇡ ❯ make check                                                                                                                                14:38:05
hack/check-format.sh
go: found golang.org/x/tools/cmd/goimports in golang.org/x/tools v0.1.1
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go: found honnef.co/go/tools/cmd/staticcheck in honnef.co/go/tools v0.2.0
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sashrith/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sashrith/csi/vsphere-csi-driver /Users/sashrith/csi /Users/sashrith /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (exports_file|name|types_sizes|compiled_files|deps|files|imports) took 1.620042804s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 83.916184ms
INFO [linters context/goanalysis] analyzers took 6.794765817s with top 10 stages: buildir: 573.957518ms, S1038: 388.8265ms, misspell: 388.351465ms, S1039: 228.80111ms, directives: 206.588503ms, unused: 201.940922ms, SA1012: 174.093097ms, varcheck: 165.218635ms, deadcode: 162.839635ms, S1024: 154.494434ms
INFO [runner] Issues before processing: 110, after processing: 0
INFO [runner] Processors filtering stat (out/in): skip_files: 110/110, identifier_marker: 21/21, exclude: 21/21, nolint: 0/1, cgo: 110/110, path_prettifier: 110/110, skip_dirs: 110/110, autogenerated_exclude: 21/110, filename_unadjuster: 110/110, exclude-rules: 1/21
INFO [runner] processing took 13.014566ms with stages: nolint: 10.085661ms, autogenerated_exclude: 1.628346ms, path_prettifier: 652.708µs, identifier_marker: 313.982µs, skip_dirs: 168.362µs, exclude-rules: 120.158µs, filename_unadjuster: 25.707µs, cgo: 13.991µs, max_same_issues: 1.679µs, uniq_by_line: 816ns, diff: 471ns, max_from_linter: 464ns, source_code: 408ns, severity-rules: 309ns, skip_files: 302ns, max_per_file_from_linter: 278ns, exclude: 269ns, path_shortener: 257ns, sort_results: 243ns, path_prefixer: 155ns
INFO [runner] linters took 5.28768932s with stages: goanalysis_metalinter: 5.274539945s
INFO File cache stats: 62 entries of total size 1.6MiB
INFO Memory: 72 samples, avg is 231.7MB, max is 480.2MB
INFO Execution took 7.00886874s
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver pr2839059 ⇡ 46s ❯
```

