### PR TITLE
fix accessModes for raw block volume doc

### DIFF
--- a/docs/book/features/raw_block_volume.md
+++ b/docs/book/features/raw_block_volume.md
@@ -11,6 +11,7 @@ The ability to use a raw block device without a filesystem will allow Kubernetes
 ## Creating a new raw block PVC
 
 To request a raw block PersistentVolumeClaim, volumeMode = "Block" must be specified in the PersistentVolumeClaimSpec.
+Raw Block Volume should be created using accessModes `ReadWriteOnce`. vSphere CSI Driver does not support creating raw block volume using `ReadWriteMany` accessModes.
 
 ```yaml
 apiVersion: v1
@@ -19,7 +20,7 @@ metadata:
   name: block-pvc
 spec:
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   volumeMode: Block
   storageClassName: example-vanilla-block-sc
   resources:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix `accessModes` for raw block volume doc. `accessModes` should be `ReadWriteOnce` for raw block volume.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix accessModes for raw block volume doc
```
