### PR TITLE
Use git commit for binary version, image tags and image labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ deps:
 ##                                VERSIONS                                    ##
 ################################################################################
 # Ensure the version is injected into the binaries via a linker flag.
-export VERSION ?= $(shell git describe --always --dirty)
+export VERSION ?= $(shell git log -1 --format=%h)
 
 .PHONY: version
 version:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -41,7 +41,7 @@ PUSH=
 LATEST=
 CSI_IMAGE_NAME=
 SYNCER_IMAGE_NAME=
-VERSION=$(git describe --dirty --always 2>/dev/null)
+VERSION=$(git log -1 --format=%h)
 GCR_KEY_FILE="${GCR_KEY_FILE:-}"
 GOPROXY="${GOPROXY:-https://proxy.golang.org}"
 BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
@@ -117,6 +117,7 @@ function build_images() {
     -t "${CSI_IMAGE_NAME}":"${VERSION}" \
     --build-arg "VERSION=${VERSION}" \
     --build-arg "GOPROXY=${GOPROXY}" \
+    --build-arg "GIT_COMMIT=${VERSION}" \
     .
 
   echo "building ${SYNCER_IMAGE_NAME}:${VERSION}"
@@ -125,6 +126,7 @@ function build_images() {
       -t "${SYNCER_IMAGE_NAME}":"${VERSION}" \
       --build-arg "VERSION=${VERSION}" \
       --build-arg "GOPROXY=${GOPROXY}" \
+      --build-arg "GIT_COMMIT=${VERSION}" \
       .
   if [ "${LATEST}" ]; then
     echo "tagging image ${CSI_IMAGE_NAME}:${VERSION} as latest"

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -46,6 +46,12 @@ RUN go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-dr
 ##                               MAIN STAGE                                   ##
 ################################################################################
 FROM ${BASE_IMAGE}
+
+# This build arg is the git commit to embed in the CSI binary
+ARG GIT_COMMIT
+
+# This label will be overridden from driver base image
+LABEL git_commit=$GIT_COMMIT
 LABEL "maintainers"="Divyen Patel <divyenp@vmware.com>, Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>, Xing Yang <yangxi@vmware.com>"
 
 # install nfs-utils, util-linux and e2fsprogs

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -48,6 +48,12 @@ RUN go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-dr
 ################################################################################
 FROM ${BASE_IMAGE}
 
+# This build arg is the git commit to embed in the CSI binary
+ARG GIT_COMMIT
+
+# This label will be overridden from driver base image
+LABEL git_commit=$GIT_COMMIT
+
 COPY --from=builder /build/vsphere-syncer /bin/vsphere-syncer
 
 RUN mkdir -p config


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing driver and syncer images tags with git commit ID and adds git commit ID to image labels.
This PR is an extension of https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1255 that enhances changes for driver and syncer images

Before this PR, base image tags were created using $(shell git describe --always --dirty), which is incorrect.
```
❯ git describe --always --dirty
v2.1.0-rc.1-1020-g7d02392
```

All of the driver and syncer images are tagged with 2.1 which is incorrect for images built from master branch.
![image](https://user-images.githubusercontent.com/41256307/133991613-c8902b00-a276-4b88-9812-1650c809a390.png)

When we create new binaries of driver/syncer or create new docker images of driver/syncer, it will create with 2.1rc tag or version.
With this PR, I am correcting the version used for CSI binaries and tags used for driver/syncer docker images with git commit id.

After this PR:
Building binaries will show git commit as version
```
❯ make build
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service.Version=7d02392"' -o /Users/pghegde/Documents/github/vsphere-csi-driver/.build/bin/vsphere-csi.linux_amd64 cmd/vsphere-csi/main.go
go: creating new go.mod: module tmp
go get: added sigs.k8s.io/controller-tools v0.2.5
/Users/pghegde/go/bin/controller-gen crd:trivialVersions=true paths=./pkg/apis/storagepool/... output:crd:dir=pkg/apis/storagepool/config
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer.Version=7d02392"' -o /Users/pghegde/Documents/github/vsphere-csi-driver/.build/bin/syncer.linux_amd64 cmd/syncer/main.go
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "main.Version=7d02392"' -o /Users/pghegde/Documents/github/vsphere-csi-driver/.build/bin/cnsctl.linux_amd64 cnsctl/main.go
```

Building docker images will show git commit as tag
```
❯ make images
hack/release.sh
..
..
tagging image gcr.io/cloud-provider-vsphere/csi/ci/driver:7d02392 as latest
tagging image gcr.io/cloud-provider-vsphere/csi/ci/syncer:7d02392 as latest
```

Docker images built with after git commit will show images with following tags
```
❯ docker images | grep 'driver\|syncer'
gcr.io/cloud-provider-vsphere/csi/ci/syncer            7d02392      a0fa0a6e7e21   23 minutes ago   92.8MB
gcr.io/cloud-provider-vsphere/csi/ci/syncer            latest       a0fa0a6e7e21   23 minutes ago   92.8MB
gcr.io/cloud-provider-vsphere/csi/ci/driver            7d02392      e4440953c22d   26 minutes ago   269MB
gcr.io/cloud-provider-vsphere/csi/ci/driver            latest       e4440953c22d   26 minutes ago   269MB
```

After this PR, we will also be able to inspect the git commit ID for the generated image along with the tag
```
❯ docker inspect gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest | grep -i commit
                "git_commit": "7d02392",
```

**Testing done**:
Yes generated image locally with this change and inspected git commit from the image.

**Special notes for your reviewer**:
Git commit ID added as labels will override earlier set labels on the image. This applies to labels assigned to any layer in the docker image i.e. labels assigned in the base image.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Use git commit for binary version, image tags and image labels
```
