### PR TITLE
Add RPC_LIST_SNAPSHOTS capability

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1256,7 +1256,8 @@ func (c *controller) ControllerGetCapabilities(ctx context.Context, req *csi.Con
 
 	if csiSnapshotFSSEnabled && vcSnapshotSupportCheck {
 		log.Infof("ControllerGetCapabilities: reporting Snapshot capabilities as snapshot FSS is enabled.")
-		controllerCaps = append(controllerCaps, csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT)
+		controllerCaps = append(controllerCaps, csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
+			csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS)
 	}
 
 	var caps []*csi.ControllerServiceCapability


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add the ControllerServiceCapability_RPC_LIST_SNAPSHOTS capability when block volume snapshot feature is enabled.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Pre-provision with valid snapshot handle
```
csi-driver:
2021-09-27T20:22:53.147Z	INFO	vanilla/controller.go:1256	ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "9bb21565-e274-462f-8277-20edc1f24b8c"}
2021-09-27T20:22:53.154Z	INFO	common/common_controller_helper.go:118	vCenter API version: 8.0.0.0 supports CNS snapshots.	{"TraceId": "9bb21565-e274-462f-8277-20edc1f24b8c"}
2021-09-27T20:22:53.155Z	INFO	vanilla/controller.go:1273	ControllerGetCapabilities: reporting Snapshot capabilities as snapshot FSS is enabled.	{"TraceId": "9bb21565-e274-462f-8277-20edc1f24b8c"}
2021-09-27T20:22:53.166Z	INFO	vanilla/controller.go:1453	ListSnapshots: called with args {MaxEntries:0 StartingToken: SourceVolumeId: SnapshotId:683c86a7-04a8-4d44-9467-794bb873987e+3ace7644-3ca0-4485-9c7d-006169a96e79 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "6fb93d95-918c-43f5-b498-81853343b14d"}
2021-09-27T20:22:53.168Z	INFO	utils/utils.go:155	Invoking QuerySnapshots with spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:683c86a7-04a8-4d44-9467-794bb873987e} SnapshotId:0xc0007d5d50}	{"TraceId": "6fb93d95-918c-43f5-b498-81853343b14d"}
2021-09-27T20:22:53.168Z	INFO	utils/utils.go:180	invoking QuerySnapshots in iteration: 1 with offset: 0 and limit: 128, current total results: 0	{"TraceId": "6fb93d95-918c-43f5-b498-81853343b14d"}
2021-09-27T20:22:53.227Z	INFO	utils/utils.go:212	setting max iteration to 1 for total records count: 1	{"TraceId": "6fb93d95-918c-43f5-b498-81853343b14d"}
2021-09-27T20:22:53.227Z	INFO	utils/utils.go:232	0 more snapshots to be queried	{"TraceId": "6fb93d95-918c-43f5-b498-81853343b14d"}
2021-09-27T20:22:53.227Z	INFO	utils/utils.go:235	QuerySnapshots retrieved all records (1) for the SnapshotQuerySpec: {DynamicData:{} VolumeId:{DynamicData:{} Id:683c86a7-04a8-4d44-9467-794bb873987e} SnapshotId:0xc0007d5d50} in 1 iterations	{"TraceId": "6fb93d95-918c-43f5-b498-81853343b14d"}
2021-09-27T20:22:53.227Z	INFO	vanilla/controller.go:1478	ListSnapshot served 1 results, token for next set: 	{"TraceId": "6fb93d95-918c-43f5-b498-81853343b14d"}
```

Pre-provision with invalid snapshot handle
```
Pre-provision with invalid snapshot handle
csi-driver:
2021-09-27T20:26:29.570Z	INFO	vanilla/controller.go:1273	ControllerGetCapabilities: reporting Snapshot capabilities as snapshot FSS is enabled.	{"TraceId": "59e6bc29-a094-443f-a98a-0fd9d668c76a"}
2021-09-27T20:26:29.573Z	INFO	vanilla/controller.go:1453	ListSnapshots: called with args {MaxEntries:0 StartingToken: SourceVolumeId: SnapshotId:993c86a7-04a8-4d44-9467-794bb873987e+3ace7644-3ca0-4485-9c7d-006169a96e79 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "0dc8fd62-cbe7-4203-a33e-680f346ac825"}
2021-09-27T20:26:29.573Z	INFO	utils/utils.go:155	Invoking QuerySnapshots with spec: {DynamicData:{} VolumeId:{DynamicData:{} Id:993c86a7-04a8-4d44-9467-794bb873987e} SnapshotId:0xc00052e820}	{"TraceId": "0dc8fd62-cbe7-4203-a33e-680f346ac825"}
2021-09-27T20:26:29.573Z	INFO	utils/utils.go:180	invoking QuerySnapshots in iteration: 1 with offset: 0 and limit: 128, current total results: 0	{"TraceId": "0dc8fd62-cbe7-4203-a33e-680f346ac825"}
2021-09-27T20:26:29.636Z	INFO	utils/utils.go:212	setting max iteration to 0 for total records count: 0	{"TraceId": "0dc8fd62-cbe7-4203-a33e-680f346ac825"}
2021-09-27T20:26:29.636Z	INFO	utils/utils.go:232	0 more snapshots to be queried	{"TraceId": "0dc8fd62-cbe7-4203-a33e-680f346ac825"}
2021-09-27T20:26:29.636Z	INFO	utils/utils.go:235	QuerySnapshots retrieved all records (0) for the SnapshotQuerySpec: {DynamicData:{} VolumeId:{DynamicData:{} Id:993c86a7-04a8-4d44-9467-794bb873987e} SnapshotId:0xc00052e820} in 1 iterations	{"TraceId": "0dc8fd62-cbe7-4203-a33e-680f346ac825"}
2021-09-27T20:26:29.637Z	ERROR	common/vsphereutil.go:707	failed retrieve snapshot info for volume-id: 993c86a7-04a8-4d44-9467-794bb873987e snapshot-id: 3ace7644-3ca0-4485-9c7d-006169a96e79 err: &{DynamicData:{} Fault:{CnsFault:{BaseMethodFault:<nil> Reason:} VolumeId:{DynamicData:{} Id:993c86a7-04a8-4d44-9467-794bb873987e}} LocalizedMessage:Volume with ID 993c86a7-04a8-4d44-9467-794bb873987e is not found. Error message: }	{"TraceId": "0dc8fd62-cbe7-4203-a33e-680f346ac825"}
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.QueryVolumeSnapshot
	/build/pkg/csi/service/common/vsphereutil.go:707
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.ListSnapshotsUtil
	/build/pkg/csi/service/common/vsphereutil.go:640
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).ListSnapshots.func1
	/build/pkg/csi/service/vanilla/controller.go:1462
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).ListSnapshots
	/build/pkg/csi/service/vanilla/controller.go:1481
github.com/container-storage-interface/spec/lib/go/csi._Controller_ListSnapshots_Handler.func1
	/go/pkg/mod/github.com/container-storage-interface/spec@v1.4.0/lib/go/csi/csi.pb.go:5776
github.com/rexray/gocsi/middleware/serialvolume.(*interceptor).handle
	/go/pkg/mod/github.com/rexray/gocsi@v1.2.2/middleware/serialvolume/serial_volume_locker.go:99
github.com/rexray/gocsi/utils.ChainUnaryServer.func2.1.1
	/go/pkg/mod/github.com/rexray/gocsi@v1.2.2/utils/utils_middleware.go:99
github.com/rexray/gocsi/middleware/specvalidator.(*interceptor).handleServer.func1
	/go/pkg/mod/github.com/rexray/gocsi@v1.2.2/middleware/specvalidator/spec_validator.go:178
github.com/rexray/gocsi/middleware/specvalidator.(*interceptor).handle
	/go/pkg/mod/github.com/rexray/gocsi@v1.2.2/middleware/specvalidator/spec_validator.go:218
github.com/rexray/gocsi/middleware/specvalidator.(*interceptor).handleServer
.
.
.
.

kubectl get example-vanilla-block-snap-content-inavlid

apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshotContent
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: >
      {"apiVersion":"snapshot.storage.k8s.io/v1","kind":"VolumeSnapshotContent","metadata":{"annotations":{},"name":"example-vanilla-block-snap-content-inavlid"},"spec":{"deletionPolicy":"Delete","driver":"csi.vsphere.vmware.com","source":{"snapshotHandle":"993c86a7-04a8-4d44-9467-794bb873987e+3ace7644-3ca0-4485-9c7d-006169a96e79"},"volumeSnapshotRef":{"name":"example-vanilla-block-snap-vs-2","namespace":"test-ns"}}}
  creationTimestamp: '2021-09-27T20:26:29Z'
  generation: 1
status:
  error:
    message: >-
      Failed to check and update snapshot content: failed to list snapshot for
      content example-vanilla-block-snap-content-inavlid: "rpc error: code =
      Internal desc =  failed to retrieve the snapshots, err: rpc error: code =
      Internal desc = failed retrieve snapshot info for volume-id:
      993c86a7-04a8-4d44-9467-794bb873987e snapshot-id:
      3ace7644-3ca0-4485-9c7d-006169a96e79 err: &{DynamicData:{}
      Fault:{CnsFault:{BaseMethodFault:<nil> Reason:} VolumeId:{DynamicData:{}
      Id:993c86a7-04a8-4d44-9467-794bb873987e}} LocalizedMessage:Volume with ID
      993c86a7-04a8-4d44-9467-794bb873987e is not found. Error message: }"
    time: '2021-09-27T20:26:29Z'
  readyToUse: false
spec:
  deletionPolicy: Delete
  driver: csi.vsphere.vmware.com
  source:
    snapshotHandle: 993c86a7-04a8-4d44-9467-794bb873987e+3ace7644-3ca0-4485-9c7d-006169a96e79
  volumeSnapshotRef:
    name: example-vanilla-block-snap-vs-2
    namespace: test-ns
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>