### PR TITLE
Handling pv annotations post migration if provisioner is not CSI but VCP and wait for pods post migration

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -3364,7 +3364,8 @@ func setClusterDistribution(ctx context.Context, client clientset.Interface, clu
 
 // toggleCSIMigrationFeatureGatesOnK8snodes to toggle CSI migration feature
 // gates on kublets for worker nodes.
-func toggleCSIMigrationFeatureGatesOnK8snodes(ctx context.Context, client clientset.Interface, shouldEnable bool) {
+func toggleCSIMigrationFeatureGatesOnK8snodes(ctx context.Context, client clientset.Interface, shouldEnable bool,
+	namespace string) {
 	var err error
 	var found bool
 	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
@@ -3401,6 +3402,10 @@ func toggleCSIMigrationFeatureGatesOnK8snodes(ctx context.Context, client client
 		err = drain.RunCordonOrUncordon(&dh, &node, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
+	pods, err := fpod.GetPodsInNamespace(client, namespace, nil)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = fpod.WaitForPodsRunningReady(client, namespace, int32(len(pods)), 0, pollTimeout*2, nil)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
 // isCSIMigrationFeatureGatesEnabledOnKubelet checks whether CSIMigration

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -3286,7 +3286,11 @@ func deleteFcdWithRetriesForSpecificErr(ctx context.Context, fcdID string,
 
 // getDefaultDatastore returns default datastore.
 func getDefaultDatastore(ctx context.Context, forceRefresh ...bool) *object.Datastore {
-	if defaultDatastore == nil || forceRefresh[0] {
+	refresh := false
+	if len(forceRefresh) > 0 {
+		refresh = forceRefresh[0]
+	}
+	if defaultDatastore == nil || refresh {
 		finder := find.NewFinder(e2eVSphere.Client.Client, false)
 		cfg, err := getConfig()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -3285,8 +3285,8 @@ func deleteFcdWithRetriesForSpecificErr(ctx context.Context, fcdID string,
 }
 
 // getDefaultDatastore returns default datastore.
-func getDefaultDatastore(ctx context.Context) *object.Datastore {
-	if defaultDatastore == nil {
+func getDefaultDatastore(ctx context.Context, forceRefresh ...bool) *object.Datastore {
+	if defaultDatastore == nil || forceRefresh[0] {
 		finder := find.NewFinder(e2eVSphere.Client.Client, false)
 		cfg, err := getConfig()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/vcp_to_csi_attach_detach.go
+++ b/tests/e2e/vcp_to_csi_attach_detach.go
@@ -74,7 +74,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 		defer cancel()
 		generateNodeMap(ctx, testConfig, &e2eVSphere, client)
 
-		toggleCSIMigrationFeatureGatesOnK8snodes(ctx, client, false)
+		toggleCSIMigrationFeatureGatesOnK8snodes(ctx, client, false, namespace)
 		kubectlMigEnabled = false
 
 		err = toggleCSIMigrationFeatureGatesOnKubeControllerManager(ctx, client, false)
@@ -151,7 +151,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 
 		if kubectlMigEnabled {
 			ginkgo.By("Disable CSI migration feature gates on kublets on k8s nodes")
-			toggleCSIMigrationFeatureGatesOnK8snodes(ctx, client, false)
+			toggleCSIMigrationFeatureGatesOnK8snodes(ctx, client, false, namespace)
 		}
 
 		crds := []*v1alpha1.CnsVSphereVolumeMigration{}
@@ -458,7 +458,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Enable CSI migration feature gates on kublets on k8s nodes")
-		toggleCSIMigrationFeatureGatesOnK8snodes(ctx, client, true)
+		toggleCSIMigrationFeatureGatesOnK8snodes(ctx, client, true, namespace)
 		kubectlMigEnabled = true
 
 		ginkgo.By("Creating VCP SC post migration")
@@ -571,7 +571,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 		vcpPvcsPostMig = []*v1.PersistentVolumeClaim{}
 
 		ginkgo.By("Disable CSI migration feature gates on kublets on k8s nodes")
-		toggleCSIMigrationFeatureGatesOnK8snodes(ctx, client, false)
+		toggleCSIMigrationFeatureGatesOnK8snodes(ctx, client, false, namespace)
 		kubectlMigEnabled = false
 
 		ginkgo.By("Disable CSI migration feature gates on kube-controller-manager")

--- a/tests/e2e/vcp_to_csi_create_delete.go
+++ b/tests/e2e/vcp_to_csi_create_delete.go
@@ -704,6 +704,8 @@ func pvcHasMigAnnotations(ctx context.Context, c clientset.Interface, pvcName st
 	isStorageProvisionerMatching := false
 	isMigratedToCsi := false
 	gomega.Expect(annotations).NotTo(gomega.BeNil(), "No annotations found on PVC "+pvcName)
+	framework.Logf(
+		"Annotations found on PVC: %v in namespace:%v are,\n%v", pvcName, pvc.Namespace, spew.Sdump(annotations))
 	for k, v := range annotations {
 		if isMigratedVol {
 			if k == pvcAnnotationStorageProvisioner && v == vcpProvisionerName {
@@ -734,8 +736,6 @@ func pvcHasMigAnnotations(ctx context.Context, c clientset.Interface, pvcName st
 			return true, pvc
 		}
 	}
-	framework.Logf(
-		"Annotations found on PVC: %v in namespace:%v are,\n%v", pvcName, pvc.Namespace, spew.Sdump(annotations))
 	return false, pvc
 }
 
@@ -748,38 +748,32 @@ func pvHasMigAnnotations(ctx context.Context, c clientset.Interface,
 	isProvisionedByMatching := false
 	isMigratedToCsi := false
 	gomega.Expect(annotations).NotTo(gomega.BeNil(), "No annotations found on PV "+pvName)
-	for k, v := range annotations {
-		if isMigratedVol {
-			if k == pvAnnotationProvisionedBy && v == vcpProvisionerName {
-				isProvisionedByMatching = true
-				continue
-			}
-			if k == migratedToAnnotation && v == e2evSphereCSIDriverName {
-				isMigratedToCsi = true
-			}
-		} else {
-			if k == pvAnnotationProvisionedBy && v == e2evSphereCSIDriverName {
-				isProvisionedByMatching = true
-				continue
-			}
-			if k == migratedToAnnotation {
-				isMigratedToCsi = true
-			}
-		}
-	}
-	if isMigratedVol {
-		if isProvisionedByMatching && isMigratedToCsi {
-			return true, pv
-		}
-	} else {
-		gomega.Expect(isMigratedToCsi).NotTo(gomega.BeTrue(),
-			migratedToAnnotation+" annotation was not expected on PV "+pvName)
-		if isProvisionedByMatching {
-			return true, pv
-		}
-	}
 	framework.Logf(
 		"Annotations found on PV: %v are,\n%v", pvName, spew.Sdump(annotations))
+	provisionedByIsCSI := false
+	migratedToFound := false
+	for k, v := range annotations {
+		if k == pvAnnotationProvisionedBy && v == vcpProvisionerName {
+			isProvisionedByMatching = true
+			continue
+		}
+		if k == pvAnnotationProvisionedBy && v == e2evSphereCSIDriverName {
+			provisionedByIsCSI = true
+			continue
+		}
+		if k == migratedToAnnotation && v == e2evSphereCSIDriverName {
+			isMigratedToCsi = true
+		}
+		if k == migratedToAnnotation {
+			migratedToFound = true
+		}
+	}
+	if provisionedByIsCSI && !migratedToFound {
+		return true, pv
+	}
+	if isProvisionedByMatching && isMigratedToCsi {
+		return true, pv
+	}
 	return false, pv
 }
 

--- a/tests/e2e/vcp_to_csi_create_delete.go
+++ b/tests/e2e/vcp_to_csi_create_delete.go
@@ -824,7 +824,7 @@ func generateNodeMap(ctx context.Context, config *e2eTestConfig, vs *vSphere, c 
 
 // fileExists checks whether the specified file exists on the shared datastore
 func fileExistsOnSharedDatastore(ctx context.Context, volPath string) (bool, error) {
-	datastore := getDefaultDatastore(ctx)
+	datastore := getDefaultDatastore(ctx, true)
 	b, err := datastore.Browser(ctx)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	spec := types.HostDatastoreBrowserSearchSpec{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Handling pv annotations post migration if provisioner is not CSI but VCP and wait for pods post migration

**Testing done**:

[vcp2csi2.log](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/7402420/vcp2csi2.log)

**Special notes for your reviewer**:
```bash
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver vcp2csi2* ⇡ 5s ❯ make check                                     12:41:05
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sashrith/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sashrith/csi/vsphere-csi-driver /Users/sashrith/csi /Users/sashrith /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (files|compiled_files|exports_file|imports|name|types_sizes|deps) took 2.591614397s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 115.747051ms
INFO [linters context/goanalysis] analyzers took 4m28.393069381s with top 10 stages: buildir: 3m11.138597592s, nilness: 19.677256348s, ctrlflow: 8.053604398s, fact_deprecated: 7.637982326s, printf: 7.142834974s, typedness: 6.589949799s, fact_purity: 6.527577379s, SA5012: 5.57448859s, inspect: 4.418250078s, misspell: 1.073065945s
INFO [runner] Issues before processing: 111, after processing: 0
INFO [runner] Processors filtering stat (out/in): path_prettifier: 111/111, nolint: 0/1, exclude-rules: 1/22, cgo: 111/111, skip_files: 111/111, skip_dirs: 111/111, filename_unadjuster: 111/111, autogenerated_exclude: 22/111, identifier_marker: 22/22, exclude: 22/22
INFO [runner] processing took 13.281703ms with stages: nolint: 9.845454ms, autogenerated_exclude: 1.938785ms, path_prettifier: 768.555µs, identifier_marker: 358.383µs, skip_dirs: 189.761µs, exclude-rules: 147.547µs, cgo: 20.62µs, filename_unadjuster: 7.98µs, max_same_issues: 975ns, uniq_by_line: 618ns, max_from_linter: 459ns, skip_files: 382ns, diff: 345ns, source_code: 315ns, path_shortener: 285ns, exclude: 280ns, max_per_file_from_linter: 273ns, severity-rules: 266ns, sort_results: 257ns, path_prefixer: 163ns
INFO [runner] linters took 35.540107452s with stages: goanalysis_metalinter: 35.526722226s
INFO File cache stats: 239 entries of total size 3.3MiB
INFO Memory: 345 samples, avg is 1452.7MB, max is 2233.7MB
INFO Execution took 38.26725529s
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver vcp2csi2* ⇡ 3m 35s ❯
```
