### PR TITLE
document vCenter restart impact/workaround for inflight PVCs

### DIFF
--- a/docs/book/releases/v2.0.0.md
+++ b/docs/book/releases/v2.0.0.md
@@ -80,13 +80,12 @@
 10. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
     - Impact: Volume lifecycle operations fail until the controller pod restarts.
     - Workaround: Restart `vsphere-csi-controller` deployment Pod.
-11. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+11. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.
     - Impact:
         - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
         - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
         - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
     - Workaround:
-        - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
         - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues

--- a/docs/book/releases/v2.0.0.md
+++ b/docs/book/releases/v2.0.0.md
@@ -80,6 +80,14 @@
 10. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
     - Impact: Volume lifecycle operations fail until the controller pod restarts.
     - Workaround: Restart `vsphere-csi-controller` deployment Pod.
+11. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+    - Impact:
+        - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
+        - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
+        - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
+    - Workaround:
+        - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
+        - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.0.1.md
+++ b/docs/book/releases/v2.0.1.md
@@ -59,6 +59,14 @@
 8. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
    - Impact: Volume lifecycle operations fail until the controller pod restarts.
    - Workaround: Restart `vsphere-csi-controller` deployment Pod.
+9. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+   - Impact:
+      - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
+      - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
+      - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
+   - Workaround:
+      - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
+      - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.0.1.md
+++ b/docs/book/releases/v2.0.1.md
@@ -59,13 +59,12 @@
 8. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
    - Impact: Volume lifecycle operations fail until the controller pod restarts.
    - Workaround: Restart `vsphere-csi-controller` deployment Pod.
-9. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+9. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.
    - Impact:
       - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
       - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
       - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
    - Workaround:
-      - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
       - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues

--- a/docs/book/releases/v2.1.0.md
+++ b/docs/book/releases/v2.1.0.md
@@ -64,6 +64,14 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
 11. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
     - Impact: Volume lifecycle operations fail until the controller pod restarts.
     - Workaround: Restart `vsphere-csi-controller` deployment Pod.
+12. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+    - Impact:
+      - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
+      - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
+      - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
+    - Workaround:
+      - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
+      - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.1.0.md
+++ b/docs/book/releases/v2.1.0.md
@@ -64,13 +64,12 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
 11. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
     - Impact: Volume lifecycle operations fail until the controller pod restarts.
     - Workaround: Restart `vsphere-csi-controller` deployment Pod.
-12. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+12. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.
     - Impact:
       - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
       - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
       - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
     - Workaround:
-      - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
       - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues

--- a/docs/book/releases/v2.1.1.md
+++ b/docs/book/releases/v2.1.1.md
@@ -65,13 +65,12 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
 10. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
     - Impact: Volume lifecycle operations fail until the controller pod restarts.
     - Workaround: Restart `vsphere-csi-controller` deployment Pod.
-11. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+11. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.
     - Impact:
       - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
       - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
       - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
     - Workaround:
-      - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
       - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues

--- a/docs/book/releases/v2.1.1.md
+++ b/docs/book/releases/v2.1.1.md
@@ -65,6 +65,14 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
 10. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
     - Impact: Volume lifecycle operations fail until the controller pod restarts.
     - Workaround: Restart `vsphere-csi-controller` deployment Pod.
+11. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+    - Impact:
+      - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
+      - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
+      - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
+    - Workaround:
+      - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
+      - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.2.0.md
+++ b/docs/book/releases/v2.2.0.md
@@ -56,6 +56,14 @@
 5. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
     - Impact: Volume lifecycle operations fail until the controller pod restarts.
     - Workaround: Restart `vsphere-csi-controller` deployment Pod.
+6. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+   - Impact:
+      - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
+      - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
+      - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
+   - Workaround:
+      - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
+      - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.2.0.md
+++ b/docs/book/releases/v2.2.0.md
@@ -56,13 +56,12 @@
 5. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
     - Impact: Volume lifecycle operations fail until the controller pod restarts.
     - Workaround: Restart `vsphere-csi-controller` deployment Pod.
-6. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+6. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.
    - Impact:
       - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
       - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
       - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
    - Workaround:
-      - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
       - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues

--- a/docs/book/releases/v2.2.1.md
+++ b/docs/book/releases/v2.2.1.md
@@ -48,6 +48,14 @@
 5. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
    - Impact: Volume lifecycle operations fail until the controller pod restarts.
    - Workaround: Restart `vsphere-csi-controller` deployment Pod.
+6. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+   - Impact:
+      - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
+      - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
+      - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
+   - Workaround:
+      - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
+      - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.2.1.md
+++ b/docs/book/releases/v2.2.1.md
@@ -48,13 +48,12 @@
 5. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
    - Impact: Volume lifecycle operations fail until the controller pod restarts.
    - Workaround: Restart `vsphere-csi-controller` deployment Pod.
-6. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+6. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.
    - Impact:
       - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
       - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
       - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
    - Workaround:
-      - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
       - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues

--- a/docs/book/releases/v2.3.0.md
+++ b/docs/book/releases/v2.3.0.md
@@ -60,13 +60,12 @@
     - Issue: https://github.com/kubernetes/kubernetes/issues/103745
     - Impact: Pod with inline, migrated vSphere volume remains in `Terminating` state in the cluster for longer duration.
     - Workaround: Wait for Pod to be garbage collected, or force delete the pod.
-5. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+5. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.
     - Impact:
       - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
       - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
       - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
     - Workaround:
-      - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
       - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues

--- a/docs/book/releases/v2.3.0.md
+++ b/docs/book/releases/v2.3.0.md
@@ -60,6 +60,14 @@
     - Issue: https://github.com/kubernetes/kubernetes/issues/103745
     - Impact: Pod with inline, migrated vSphere volume remains in `Terminating` state in the cluster for longer duration.
     - Workaround: Wait for Pod to be garbage collected, or force delete the pod.
+5. vCenter restart may leave Kubernetes persistent volume claims in the Pending state with error message - `failed to get taskInfo for CreateVolume task from vCenter "vCenter IP" with err: ServerFaultCode: The session is not authenticated`.
+    - Impact:
+      - Persistent volume claims which are being created at the time vCenter is restarting may remain in the `pending` state for 1 hour.
+      - After vSphere CSI Driver clears up pending cached tasks, new tasks to create volumes will be issued to the vCenter and then Persistent volume claims can go into `Bound` State.
+      - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
+    - Workaround:
+      - Make sure vCenter is restarted in the maintenance window when Kubernetes users are not actively provisioning new volumes.
+      - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
 
 ### Kubernetes issues
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is documenting the impact and workaround for inflight PVCs when vCenter is restarted.

This issue is present in all releases of the vCenter CSI driver. This issue is fixed on the master branch after `v2.3.0` release - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1263

After we release `improved-csi-idempotency` feature, we will not hit into this issue.

**Testing done**:
`./hack/check-mdlint.sh` has passed with these changes.

**Special notes for your reviewer**:
Preview of Doc change
https://deploy-preview-1289--kubernetes-sigs-vsphere-csi-driver.netlify.app/releases/v2.3.0.html#vsphere-csi-driver-issues

Refer to Issue-5 under Known Issue - vSphere CSI Driver issues section.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
document vCenter restart impact/workaround for inflight PVCs
```
