### PR TITLE
Revert QueryAsync invocations at places where QueryAll is needed to fetch volumes in one shot 

### DIFF
--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -41,9 +41,7 @@ import (
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
@@ -526,8 +524,8 @@ func (volumeMigration *volumeMigration) cleanupStaleCRDInstances() {
 				volumeMigrationInstance.cnsConfig.Global.ClusterID,
 			},
 		}
-		queryAllResult, err := utils.QueryAllVolumeUtil(ctx, *volumeMigrationInstance.volumeManager, queryFilter,
-			nil, commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+		queryAllResult, err := (*volumeMigrationInstance.volumeManager).QueryAllVolume(ctx,
+			queryFilter, cnstypes.CnsQuerySelection{})
 		if err != nil {
 			log.Warnf("failed to queryAllVolume with err %+v", err)
 			continue

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -35,9 +35,6 @@ import (
 // top level directory.
 const DefaultQuerySnapshotLimit = int64(128)
 
-// queryVolumeLimit is the pagination size, which should be set in the cursor for CnsQueryAsync API
-const queryVolumeLimit = int64(1000)
-
 // QueryVolumeUtil helps to invoke query volume API based on the feature
 // state set for using query async volume. If useQueryVolumeAsync is set to
 // true, the function invokes CNS QueryVolumeAsync, otherwise it invokes
@@ -68,70 +65,6 @@ func QueryVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cnsty
 		if err != nil {
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"queryVolume failed for queryFilter: %+v. Err=%+v", queryFilter, err.Error())
-		}
-	}
-	return queryResult, nil
-}
-
-// QueryAllVolumeUtil helps to invoke query volume API based on the feature
-// state set for using query async volume. If useQueryVolumeAsync is set to
-// true, the function invokes CNS QueryVolumeAsync, otherwise it invokes
-// synchronous QueryAllVolume API. The function also take volume manager
-// instance, query filters, query selection as params. Returns queryResult
-// when query volume succeeds, otherwise returns appropriate errors.
-func QueryAllVolumeUtil(ctx context.Context, m cnsvolume.Manager, queryFilter cnstypes.CnsQueryFilter,
-	querySelection *cnstypes.CnsQuerySelection, useQueryVolumeAsync bool) (*cnstypes.CnsQueryResult, error) {
-	log := logger.GetLogger(ctx)
-	var queryAsyncNotSupported bool
-	var allQueryResults []*cnstypes.CnsQueryResult
-	queryResult := &cnstypes.CnsQueryResult{
-		Volumes: make([]cnstypes.CnsVolume, 0),
-	}
-	var err error
-	if useQueryVolumeAsync {
-		// AsyncQueryVolume feature switch is enabled.
-		cursor := &cnstypes.CnsCursor{
-			Offset: 0,
-			Limit:  queryVolumeLimit,
-		}
-		queryFilter.Cursor = cursor
-		// Using pagination technique to fetch the entire QueryResults
-		for {
-			queryRes, err := m.QueryVolumeAsync(ctx, queryFilter, querySelection)
-			if err != nil {
-				if err.Error() == cnsvsphere.ErrNotSupported.Error() {
-					log.Info("QueryVolumeAsync is not supported. Invoking QueryAllVolume API")
-					queryAsyncNotSupported = true
-					break
-				} else { // Return for any other failures.
-					return nil, logger.LogNewErrorCodef(log, codes.Internal,
-						"queryVolumeAsync failed for queryFilter: %v. Err=%+v", queryFilter, err.Error())
-				}
-			}
-			allQueryResults = append(allQueryResults, queryRes)
-			if queryRes.Cursor.Offset == queryRes.Cursor.TotalRecords {
-				log.Info("Results retrieved for all requested volumes")
-				break
-			}
-			queryFilter.Cursor = &queryRes.Cursor
-			log.Infof("%v more volumes to be queried", queryRes.Cursor.TotalRecords-queryRes.Cursor.Offset)
-		}
-		if !queryAsyncNotSupported {
-			for _, res := range allQueryResults {
-				if len(res.Volumes) != 0 {
-					queryResult.Volumes = append(queryResult.Volumes, res.Volumes...)
-				}
-			}
-		}
-	}
-	if !useQueryVolumeAsync || queryAsyncNotSupported {
-		if querySelection == nil {
-			querySelection = &cnstypes.CnsQuerySelection{}
-		}
-		queryResult, err = m.QueryAllVolume(ctx, queryFilter, *querySelection)
-		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
-				"queryAllVolume failed for queryFilter: %+v. Err=%+v", queryFilter, err.Error())
 		}
 	}
 	return queryResult, nil

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -870,10 +870,9 @@ func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int
 		},
 	}
 	// Query only the backing object details.
-	queryResult, err := utils.QueryAllVolumeUtil(ctx, manager.VolumeManager,
-		queryFilter, &querySelection, useAsyncQueryVolume)
+	queryResult, err := manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
 	if err != nil {
-		log.Errorf("QueryVolume failed with err=%+v", err.Error())
+		log.Errorf("queryVolume failed for volumeID: %q with err=%v", volumeID, err)
 		return false, err
 	}
 

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -889,11 +889,10 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 				},
 			}
 			// Select only the backing object details.
-			queryResult, err := utils.QueryAllVolumeUtil(ctx, c.manager.VolumeManager, queryFilter, &querySelection,
-				commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+			queryResult, err := c.manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
-					"queryVolume failed with err=%+v", err)
+					"queryVolume failed for volumeID: %q with err=%+v", req.VolumeId, err)
 			}
 			if len(queryResult.Volumes) == 0 {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
@@ -1010,14 +1009,13 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 				},
 			}
 			// Select only the volume type.
-			queryResult, err := utils.QueryAllVolumeUtil(ctx, c.manager.VolumeManager, queryFilter, &querySelection,
-				commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+			queryResult, err := c.manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
 			// TODO: QueryAllVolumeUtil need return faultType
 			//	and we should return the faultType.
 			// Currently, just return "csi.fault.Internal"
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
-					"queryVolume failed with err=%+v", err)
+					"queryVolume failed for volumeID: %q with err=%+v", req.VolumeId, err)
 			}
 
 			if len(queryResult.Volumes) == 0 {

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -899,10 +899,9 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 			}
 			// Query with empty selection. CNS returns only the volume ID from
 			// its cache.
-			queryResult, err := utils.QueryAllVolumeUtil(ctx, metadataSyncer.volumeManager, queryFilter,
-				nil, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+			queryResult, err := metadataSyncer.volumeManager.QueryAllVolume(ctx, queryFilter, cnstypes.CnsQuerySelection{})
 			if err != nil {
-				log.Errorf("PVCUpdated: QueryVolume failed with err=%+v", err.Error())
+				log.Errorf("PVCUpdated: QueryVolume failed for volume %q with err=%+v", volumeHandle, err.Error())
 				return false, err
 			}
 			if queryResult != nil && len(queryResult.Volumes) == 1 && queryResult.Volumes[0].VolumeId.Id == volumeHandle {
@@ -1076,10 +1075,9 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 		volumeOperationsLock.Lock()
 		defer volumeOperationsLock.Unlock()
 		// QueryAll with no selection will return only the volume ID.
-		queryResult, err := utils.QueryAllVolumeUtil(ctx, metadataSyncer.volumeManager, queryFilter,
-			nil, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+		queryResult, err := metadataSyncer.volumeManager.QueryAllVolume(ctx, queryFilter, cnstypes.CnsQuerySelection{})
 		if err != nil {
-			log.Errorf("PVUpdated: QueryVolume failed with err=%+v", err.Error())
+			log.Errorf("PVUpdated: QueryVolume failed for volume %q with err=%+v", oldPv.Spec.CSI.VolumeHandle, err.Error())
 			return
 		}
 		if len(queryResult.Volumes) == 0 {

--- a/pkg/syncer/volume_health.go
+++ b/pkg/syncer/volume_health.go
@@ -26,7 +26,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 )
@@ -48,10 +47,9 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 			string(cnstypes.QuerySelectionNameTypeHealthStatus),
 		},
 	}
-	queryResult, err := utils.QueryAllVolumeUtil(ctx, metadataSyncer.volumeManager, queryFilter,
-		&querySelection, metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.AsyncQueryVolume))
+	queryAllResult, err := metadataSyncer.volumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
 	if err != nil {
-		log.Errorf("csiGetVolumeHealthStatus: QueryVolume failed with err=%+v", err.Error())
+		log.Errorf("csiGetVolumeHealthStatus: failed to QueryAllVolume with err=%+v", err.Error())
 		return
 	}
 
@@ -82,9 +80,9 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 	}
 
 	// volumeIdToHealthStatusMap maps vol.VolumeId.Id to vol.HealthStatus.
-	volumeIdToHealthStatusMap := make(volumeIdHealthStatusMap, len(queryResult.Volumes))
+	volumeIdToHealthStatusMap := make(volumeIdHealthStatusMap, len(queryAllResult.Volumes))
 
-	for _, vol := range queryResult.Volumes {
+	for _, vol := range queryAllResult.Volumes {
 		volumeIdToHealthStatusMap[vol.VolumeId.Id] = vol.HealthStatus
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
It has been identified that QueryAsync API with pagination will not be ideal in cases where there are concurrent volume create/delete operations going on. Because QueryAsync does not return all volumes in one shot, the data fetched in the paginated records can contain duplicates and will have misses. CNS team is working on a new Async version of QueryAll which can return all volume data in one shot which won't need pagination, and until then CSI will continue using QueryAll Sync API. This PR is addressing this concern.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running e2e pipelines

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Revert QueryAsync invocations at places where QueryAll is needed to fetch volumes in one shot 
```
