### PR TITLE
Updated to new topology labels

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -115,7 +115,7 @@ const (
 	pvcHealthAnnotation                       = "volumehealth.storage.kubernetes.io/health"
 	pvcHealthTimestampAnnotation              = "volumehealth.storage.kubernetes.io/health-timestamp"
 	quotaName                                 = "cns-test-quota"
-	regionKey                                 = "failure-domain.beta.kubernetes.io/region"
+	regionKey                                 = "topology.csi.vmware.com/region"
 	resizePollInterval                        = 2 * time.Second
 	rqLimit                                   = "200Gi"
 	rqLimitScaleTest                          = "900Gi"
@@ -157,7 +157,7 @@ const (
 	vmcWcpHost                                = "10.2.224.24" //This is the LB IP of VMC WCP and its constant
 	devopsTKG                                 = "test-cluster-e2e-script"
 	cloudadminTKG                             = "test-cluster-e2e-script-1"
-	zoneKey                                   = "failure-domain.beta.kubernetes.io/zone"
+	zoneKey                                   = "topology.csi.vmware.com/zone"
 	tkgAPI                                    = "/apis/run.tanzu.vmware.com/v1alpha1/namespaces" +
 		"/test-gc-e2e-demo-ns/tanzukubernetesclusters/"
 )

--- a/tests/e2e/gc_block_resize_retain_policy.go
+++ b/tests/e2e/gc_block_resize_retain_policy.go
@@ -954,7 +954,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		svcClient, svNamespace := getSvcClientAndNamespace()
 
 		ginkgo.By("Creating FCD (CNS Volume)")
-		fcdID, err := e2eVSphere.createFCDwithValidProfileID(ctx,
+		fcdID, err = e2eVSphere.createFCDwithValidProfileID(ctx,
 			"staticfcd"+curtimestring, profileID, diskSizeInMb, defaultDatastore.Reference())
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow newly created FCD:%s to sync with pandora",


### PR DESCRIPTION
What this PR does / why we need it:  Updated to new topology labels

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

Release notes:
1. Updated topology labels from "failure-domain.beta.kubernetes.io" to "topology.csi.vmware.com"
2. Fixed a test issue in GC 2839076

Logs: https://gist.github.com/kavyashree-r/a827f83247a67a63fb4f3fae674a1071