### PR TITLE
add kubelet-registration-probe for node-driver-registrar

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -390,7 +390,6 @@ spec:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
-            - "--health-port=9809"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -401,15 +400,13 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
-          ports:
-            - containerPort: 9809
-              name: healthz
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: healthz
-            initialDelaySeconds: 5
-            timeoutSeconds: 5
+            exec:
+              command:
+              - /csi-node-driver-registrar
+              - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+              - --mode=kubelet-registration-probe
+            initialDelaySeconds: 3
         - name: vsphere-csi-node
           image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
           args:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
livenessprobe check is added in the node-driver-registrar container to check if the registration is complete. If not, it'll fail the livenessprobe check and restart the node-driver-registrar until it succeeds. This was introduced in node-driver-registrar release v2.3.0. 

We have recently observed Pods are getting stuck with the following error.

```
  Warning  FailedMount             3m21s (x5 over 3m29s)  kubelet                  MountVolume.MountDevice failed for volume "pvc-7aacbd1a-2a83-45e0-b0d0-872e46a2f79a" : kubernetes.io/csi: attacher.MountDevice failed to create newCsiDriverClient: driver name csi.vsphere.vmware.com not found in the list of registered CSI drivers
```

This change might help fix this registration issue.

For more detail refer to - https://github.com/kubernetes-csi/node-driver-registrar#health-check-with-an-exec-probe

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified deploying driver with this YAML change.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add kubelet-registration-probe for node-driver-registrar
```
