### PR TITLE
Revert "Adding a feature switch to use service for placement engine i…

### DIFF
--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -10,7 +10,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
@@ -170,7 +170,6 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--default-fstype=ext4"
-            - "--use-service-for-placement-engine=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -180,10 +179,6 @@ spec:
               value: "6443"
             - name: VSPHERE_CLOUD_OPERATOR_SERVICE_PORT
               value: "29000"
-            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAME # service name to be used by csi-provisioner to connect to placement engine
-              value: vmware-system-psp-operator-k8s-cloud-operator-service
-            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAMESPACE # namespace for service name to be used by csi-provisioner to connect to placement engine
-              value: vmware-system-appplatform-operator-system                        
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -10,7 +10,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
@@ -170,7 +170,6 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--default-fstype=ext4"
-            - "--use-service-for-placement-engine=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -180,10 +179,6 @@ spec:
               value: "6443"
             - name: VSPHERE_CLOUD_OPERATOR_SERVICE_PORT
               value: "29000"
-            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAME # service name to be used by csi-provisioner to connect to placement engine
-              value: vmware-system-psp-operator-k8s-cloud-operator-service
-            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAMESPACE # namespace for service name to be used by csi-provisioner to connect to placement engine
-              value: vmware-system-appplatform-operator-system                
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir


### PR DESCRIPTION
…n external provisioner. (#1109)"

This reverts commit 7c3880768517a2fedf774bcd369ba82188972437.
Because of this change wcp pipelines are failing if replae images is set to true.


**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
