### PR TITLE
fix running make test on macOs

### DIFF
--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build darwin || linux
+// +build darwin linux
 
 /*
 Copyright 2021 The Kubernetes Authors.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
`make test` on macOs is failing with the following error

```
# sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils
pkg/csi/service/osutils/os_utils.go:91:15: osUtils.GetVolumeCapabilityFsType undefined (type *OsUtils has no field or method GetVolumeCapabilityFsType)
FAIL	sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service [build failed]
```

This is because `go test` is skipping files with the tag `build linux` on macOs.


**Testing done**:
Executed `make test` locally and it is passing.

**Special notes for your reviewer**:
This change will not generate darwin binary, as during build time we specify Linux as the platform.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix running make test on macOs
```
