### PR TITLE
Update external provisioner to 2.1.0_vmware.5 for CSI in Supervisor cluster

### DIFF
--- a/manifests/supervisorcluster/1.17/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.17/cns-csi.yaml
@@ -143,7 +143,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.5
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.18/cns-csi.yaml
@@ -146,7 +146,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.5
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.19/cns-csi.yaml
@@ -158,7 +158,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.5
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -158,7 +158,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.5
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -158,7 +158,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.5
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR updates the external provisioner to 2.1.0_vmware.5 for CSI in Supervisor cluster

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running e2e pipelines

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update external provisioner to 2.1.0_vmware.5 for CSI in Supervisor cluster
```
