### PR TITLE
Log current size retrieved from QueryVolume in ExpandVolume call

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -610,14 +610,12 @@ func ExpandVolumeUtil(ctx context.Context, manager *Manager, volumeID string, ca
 			return csifault.CSIInternalFault, err
 		}
 		if expansionRequired {
-			log.Infof("Requested size %d Mb is greater than current size for volumeID: %q. Need volume expansion.",
-				capacityInMb, volumeID)
 			faultType, err = manager.VolumeManager.ExpandVolume(ctx, volumeID, capacityInMb)
 			if err != nil {
 				log.Errorf("failed to expand volume %q with error %+v", volumeID, err)
 				return faultType, err
 			}
-			log.Infof("Successfully expanded volume for volumeid %q to new size %d Mb.", volumeID, capacityInMb)
+			log.Infof("Successfully expanded volume for volumeID %q to new size %d Mb.", volumeID, capacityInMb)
 
 		} else {
 			log.Infof("Requested volume size is equal to current size %d Mb. Expansion not required.", capacityInMb)
@@ -897,6 +895,8 @@ func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int
 		return false, err
 	}
 
+	log.Infof("isExpansionRequired: Found current size of volumeID %q to be %d Mb. "+
+		"Requested size is %d Mb", volumeID, currentSize, requestedSize)
 	return currentSize < requestedSize, nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: It is difficult to debug ExpandVolume errors if the current size received from QueryVolume is not logged. This change is required for quicker debugging.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: As this is just a log change, no testing is required.

**Special notes for your reviewer**: 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Log current size retrieved from QueryVolume in ExpandVolume call
```
