### PR TITLE
Adding a feature switch to use service for placement engine prov and spec bump up

### DIFF
--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -10,7 +10,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces"]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
@@ -158,7 +158,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.5
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -170,6 +170,7 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--default-fstype=ext4"
+            - "--use-service-for-placement-engine=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -179,6 +180,10 @@ spec:
               value: "6443"
             - name: VSPHERE_CLOUD_OPERATOR_SERVICE_PORT
               value: "29000"
+            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAME # service name to be used by csi-provisioner to connect to placement engine
+              value: vmware-system-psp-operator-k8s-cloud-operator-service
+            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAMESPACE # namespace for service name to be used by csi-provisioner to connect to placement engine
+              value: vmware-system-appplatform-operator-system                        
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -10,7 +10,7 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces"]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
@@ -158,7 +158,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.5
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -170,6 +170,7 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--default-fstype=ext4"
+            - "--use-service-for-placement-engine=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -179,6 +180,10 @@ spec:
               value: "6443"
             - name: VSPHERE_CLOUD_OPERATOR_SERVICE_PORT
               value: "29000"
+            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAME # service name to be used by csi-provisioner to connect to placement engine
+              value: vmware-system-psp-operator-k8s-cloud-operator-service
+            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAMESPACE # namespace for service name to be used by csi-provisioner to connect to placement engine
+              value: vmware-system-appplatform-operator-system                
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir


### PR DESCRIPTION
Adding a feature switch to use service for placement engine in external provisioner and changing the image of provisioner to be used 

This was earlier removed in commit d5d0ed48b9df3cc0f7ffd3cc9be5936cc202928b.


**What this PR does / why we need it**:
Without this fix spec bump up of csi in cayman_photon will fail.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
make build and make images.
Cant run pipelines as this changes deployment.yaml which is not tested by pipelines.
Have manually verified the changes
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
