### PR TITLE
Add volume type check while reconciling cnsfileaccessconfig instances

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -339,6 +339,12 @@ func (r *ReconcileCnsFileAccessConfig) Reconcile(ctx context.Context,
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
 
+		if volume.VolumeType != string(cnstypes.CnsVolumeTypeFile) {
+			msg := fmt.Sprintf("CNS Volume: %s is not FILE volume", volumeID)
+			log.Error(msg)
+			setInstanceError(ctx, r, instance, msg)
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
 		vSANFileBackingDetails := volume.BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails)
 		accessPoints := make(map[string]string)
 		for _, kv := range vSANFileBackingDetails.AccessPoints {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding extra checks in the cnsfileaccessconfig CR instance reconciler method to check if volume type is FILE in Cns. With this check the CSI driver in Supervisor won't crash because of NPE when someone tries to use Block volume ID as the volumeHandle while provisioning a static file volume
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running e2e pipelines

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add volume type check while reconciling cnsfileaccessconfig instances
```
