### PR TITLE
set maxSurge zero for vsphere-csi-controller pod

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -180,6 +180,11 @@ metadata:
   namespace: vmware-system-csi
 spec:
   replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
   selector:
     matchLabels:
       app: vsphere-csi-controller


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is required to allow upgrading or patching vsphere-csi-controller pod using rolling upgrade while honoring podAntiAffinity rules.

Without this change, when we patch `vsphere-csi-controller` pod, we see the following error.

> Warning  FailedScheduling  52s   default-scheduler  0/6 nodes are available: 3 node(s) didn't match Pod's node affinity/selector, 3 node(s) didn't match pod affinity/anti-affinity rules, 3 node(s) didn't match pod anti-affinity rules.

This happens because the default `RollingUpdate` strategy has `maxSurge` set to `25%`, but due to `podAntiAffinity` rules, we can not create a new pod until we create a space by terminating older pod. 

In this PR after setting `maxSurge=0` means we are telling k8s to terminate older pod and create a space for newer pod while performing a rolling upgrade. This works well with existing podAntiAffinity rules we have to spread pods on all master nodes.

`maxUnavailable` is set to 1 means Pods will be upgraded one by one.


**Testing done**:
Performed rolling upgrade of vSphere CSI Controller Pod with updated YAML file and it worked fine.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
set maxSurge zero for vsphere-csi-controller pod
```
