### PR TITLE
Added validating admission webhooks in vanilla cluster for the block volume snapshot feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/vsphere-csi-driver/v2
 go 1.16
 
 require (
+	github.com/agiledragon/gomonkey v2.0.2+incompatible
 	github.com/akutz/gofsutil v0.1.2
 	github.com/container-storage-interface/spec v1.4.0
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
+github.com/agiledragon/gomonkey v2.0.2+incompatible h1:eXKi9/piiC3cjJD1658mEE2o3NjkJ5vDLgYjCQu0Xlw=
+github.com/agiledragon/gomonkey v2.0.2+incompatible/go.mod h1:2NGfXu1a80LLr2cmWXGBDaHEjb1idR6+FVlX5T3D9hw=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/akutz/gofsutil v0.1.2 h1:aCdWrZdxajx8kllNQSKaMDpRJWSE2wcyKNy7eDMXkrI=

--- a/manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh
+++ b/manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh
@@ -107,8 +107,10 @@ CA_BUNDLE="$(openssl base64 -A <"${tmpdir}/ca.crt")"
 kubectl delete service vsphere-webhook-svc --namespace "${namespace}" 2>/dev/null || true
 kubectl delete validatingwebhookconfiguration.admissionregistration.k8s.io validation.csi.vsphere.vmware.com --namespace "${namespace}" 2>/dev/null || true
 kubectl delete serviceaccount vsphere-csi-webhook --namespace "${namespace}" 2>/dev/null || true
-kubectl delete clusterrole.rbac.authorization.k8s.io vsphere-csi-webhook-role 2>/dev/null || true
-kubectl delete clusterrolebinding.rbac.authorization.k8s.io vsphere-csi-webhook-role-binding --namespace "${namespace}" 2>/dev/null || true
+kubectl delete role.rbac.authorization.k8s.io vsphere-csi-webhook-role --namespace "${namespace}" 2>/dev/null || true
+kubectl delete rolebinding.rbac.authorization.k8s.io vsphere-csi-webhook-role-binding --namespace "${namespace}" 2>/dev/null || true
+kubectl delete clusterrole.rbac.authorization.k8s.io vsphere-csi-webhook-cluster-role 2>/dev/null || true
+kubectl delete clusterrolebinding.rbac.authorization.k8s.io vsphere-csi-webhook-cluster-role-binding 2>/dev/null || true
 kubectl delete deployment vsphere-csi-webhook --namespace "${namespace}" 2>/dev/null || true
 
 # patch validatingwebhook.yaml with CA_BUNDLE and create service and validatingwebhookconfiguration

--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -31,6 +31,11 @@ webhooks:
         apiVersions: ["v1", "v1beta1"]
         operations:  ["CREATE", "UPDATE"]
         resources:   ["storageclasses"]
+      - apiGroups:   [""]
+        apiVersions: ["v1", "v1beta1"]
+        operations:  ["UPDATE", "DELETE"]
+        resources:   ["persistentvolumeclaims"]
+        scope: "Namespaced"
     sideEffects: None
     admissionReviewVersions: ["v1"]
     failurePolicy: Fail
@@ -40,6 +45,31 @@ apiVersion: v1
 metadata:
   name: vsphere-csi-webhook
   namespace: vmware-system-csi
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-webhook-cluster-role
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-webhook-cluster-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-webhook
+    namespace: vmware-system-csi
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-webhook-cluster-role
+  apiGroup: rbac.authorization.k8s.io
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -139,7 +139,8 @@ func StartWebhookServer(ctx context.Context) error {
 			return err
 		}
 	}
-	if containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
+	if containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) ||
+		containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot) {
 		certs, err := tls.LoadX509KeyPair(cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile)
 		if err != nil {
 			log.Errorf("failed to load key pair. certFile: %q, keyFile: %q err: %v",
@@ -239,6 +240,8 @@ func validationHandler(w http.ResponseWriter, r *http.Request) {
 			switch ar.Request.Kind.Kind {
 			case "StorageClass":
 				admissionResponse = validateStorageClass(ctx, &ar)
+			case "PersistentVolumeClaim":
+				admissionResponse = validatePVC(ctx, &ar)
 			default:
 				log.Infof("Skipping validation for resource type: %q", ar.Request.Kind.Kind)
 				admissionResponse = &admissionv1.AdmissionResponse{

--- a/pkg/syncer/admissionhandler/validatepvc.go
+++ b/pkg/syncer/admissionhandler/validatepvc.go
@@ -1,0 +1,202 @@
+package admissionhandler
+
+import (
+	"context"
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
+)
+
+const (
+	ExpandVolumeWithSnapshotErrorMessage = "Expanding volume with snapshots is not allowed"
+	DeleteVolumeWithSnapshotErrorMessage = "Deleting volume with snapshots is not allowed"
+)
+
+// validatePVC helps validate AdmissionReview requests for PersistentVolumeClaim.
+func validatePVC(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	if containerOrchestratorUtility != nil && !containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot) {
+		// If CSI block volume snapshot is disabled and webhook is running,
+		// skip validation for PersistentVolumeClaim.
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
+	if ar.Request.Operation != admissionv1.Update && ar.Request.Operation != admissionv1.Delete {
+		// If AdmissionReview request operation is out of expectation,
+		// skip validation for PersistentVolumeClaim.
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
+	log := logger.GetLogger(ctx)
+	req := ar.Request
+	var result *metav1.Status
+	allowed := true
+
+	switch req.Kind.Kind {
+	case "PersistentVolumeClaim":
+		oldPVC := corev1.PersistentVolumeClaim{}
+		log.Debugf("JSON req.OldObject.Raw: %v", string(req.OldObject.Raw))
+		// req.OldObject is null for CREATE and CONNECT operations.
+		if err := json.Unmarshal(req.OldObject.Raw, &oldPVC); err != nil {
+			log.Warnf("error deserializing old pvc: %v. skipping validation.", err)
+			return &admissionv1.AdmissionResponse{
+				// skip validation if there is pvc deserialization error
+				Allowed: true,
+			}
+		}
+		oldReq := oldPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+
+		if !isRWOVolumeRequest(oldPVC.Spec.AccessModes) {
+			log.Info("the access mode of PVC is not ReadWriteOnce. skipping validation.")
+			return &admissionv1.AdmissionResponse{
+				// skip validation if the pvc is not RWO
+				Allowed: true,
+			}
+		}
+
+		var newReq resource.Quantity
+		if req.Operation != admissionv1.Delete {
+			newPVC := corev1.PersistentVolumeClaim{}
+			log.Debugf("JSON req.Object.Raw: %v", string(req.Object.Raw))
+			// req.Object is null for DELETE operations.
+			if err := json.Unmarshal(req.Object.Raw, &newPVC); err != nil {
+				log.Warnf("error deserializing old pvc: %v. skipping validation.", err)
+				return &admissionv1.AdmissionResponse{
+					// skip validation if there is pvc deserialization error
+					Allowed: true,
+				}
+			}
+
+			newReq = newPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+		} else {
+			reclaimPolicy, err := getPVReclaimPolicyForPVC(ctx, oldPVC)
+			if err != nil {
+				log.Warnf("error getting reclaim policy for pvc: %v. skipping validation.", err)
+				return &admissionv1.AdmissionResponse{
+					// skip validation if there is any error in getting reclaim policy for pvc
+					Allowed: true,
+				}
+			}
+
+			if reclaimPolicy != corev1.PersistentVolumeReclaimDelete {
+				log.Info("the reclaim policy of PVC is not Delete. skipping validation.")
+				return &admissionv1.AdmissionResponse{
+					// skip validation if the reclaim policy of PVC is not Delete
+					Allowed: true,
+				}
+			}
+		}
+
+		// only admit PVC deletion or expansion events.
+		if req.Operation == admissionv1.Delete || req.Operation == admissionv1.Update && newReq.Cmp(oldReq) > 0 {
+			snapshots, err := getSnapshotsForPVC(ctx, oldPVC.Namespace, oldPVC.Name)
+			if err != nil {
+				log.Warnf("error getting snapshots for pvc: %v. skipping validation.", err)
+				return &admissionv1.AdmissionResponse{
+					// skip validation if there is any error in getting volume snapshots associated with the pvc
+					Allowed: true,
+				}
+			}
+			if len(snapshots) != 0 {
+				allowed = false
+				if req.Operation == admissionv1.Update {
+					result = &metav1.Status{
+						Reason: ExpandVolumeWithSnapshotErrorMessage,
+					}
+				} else if req.Operation == admissionv1.Delete {
+					result = &metav1.Status{
+						Reason: DeleteVolumeWithSnapshotErrorMessage,
+					}
+				}
+			}
+		}
+	default:
+		allowed = false
+		log.Errorf("Can't validate resource kind: %q using validatePVC function", req.Kind.Kind)
+	}
+
+	// return AdmissionResponse result
+	return &admissionv1.AdmissionResponse{
+		Allowed: allowed,
+		Result:  result,
+	}
+}
+
+func getPVReclaimPolicyForPVC(ctx context.Context, pvc corev1.PersistentVolumeClaim) (
+	corev1.PersistentVolumeReclaimPolicy, error) {
+	log := logger.GetLogger(ctx)
+
+	var result corev1.PersistentVolumeReclaimPolicy
+
+	if pvc.Spec.VolumeName == "" {
+		return result, logger.LogNewErrorf(log, "No PV is bound to the PVC %s/%s", pvc.Namespace, pvc.Name)
+	}
+
+	kubeClient, err := k8s.NewClient(ctx)
+	if err != nil {
+		return result, logger.LogNewErrorf(log, "failed to get kube client with error: %v. "+
+			"Stopping getting reclaim policy for PVC, %s/%s", err, pvc.Namespace, pvc.Name)
+	}
+
+	pv, err := kubeClient.CoreV1().PersistentVolumes().Get(ctx, pvc.Spec.VolumeName, metav1.GetOptions{})
+	if err != nil {
+		return result, logger.LogNewErrorf(log, "failed to get PV %v with error: %v. "+
+			"Stopping getting reclaim policy for PVC, %s/%s", err, pvc.Spec.VolumeName, pvc.Namespace, pvc.Name)
+	}
+
+	return pv.Spec.PersistentVolumeReclaimPolicy, nil
+}
+
+func isRWOVolumeRequest(accessModes []corev1.PersistentVolumeAccessMode) bool {
+	for _, accessMode := range accessModes {
+		if accessMode != corev1.ReadWriteOnce {
+			return false
+		}
+	}
+	return true
+}
+
+func getSnapshotsForPVC(ctx context.Context, ns string, name string) ([]snapshotv1.VolumeSnapshot, error) {
+	log := logger.GetLogger(ctx)
+
+	var result []snapshotv1.VolumeSnapshot
+
+	snapshotterClient, err := k8s.NewSnapshotterClient(ctx)
+	if err != nil {
+		log.Errorf("failed to get snapshotterClient with error: %v. "+
+			"Stopping getting snapshots for PVC, %s/%s", err, ns, name)
+		return result, err
+	}
+
+	volumeSnapshotList, err := snapshotterClient.SnapshotV1().VolumeSnapshots(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("failed to list VolumeSnapshot with error: %v. "+
+			"Stopping getting snapshots for PVC, %s/%s", err, ns, name)
+		return result, err
+	}
+
+	for _, volumeSnapshot := range volumeSnapshotList.Items {
+		if volumeSnapshot.Spec.Source.PersistentVolumeClaimName == nil {
+			continue
+		}
+
+		pvcName := *volumeSnapshot.Spec.Source.PersistentVolumeClaimName
+		if pvcName == name {
+			result = append(result, volumeSnapshot)
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/syncer/admissionhandler/validatepvc_test.go
+++ b/pkg/syncer/admissionhandler/validatepvc_test.go
@@ -1,0 +1,436 @@
+package admissionhandler
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/agiledragon/gomonkey"
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
+	snapshotclientfake "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
+)
+
+var (
+	testStorageClassName        = "test-sc"
+	testNamespace               = "test"
+	testFirstPVCName            = "test-vanilla-block-pvc-1"
+	testSecondPVCName           = "test-vanilla-block-pvc-2"
+	testVolumeSnapshotName      = "test-volume-snapshot"
+	testVolumeSnapshotClassName = "test-volume-snapshot-class"
+	testPVName                  = "test-pv"
+	testPV                      = &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testPVName,
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+		},
+	}
+	oldPVC = &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testFirstPVCName,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &testStorageClassName,
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("5Gi"),
+				},
+			},
+			VolumeName: testPVName,
+		},
+	}
+	newPVC = &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testFirstPVCName,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &testStorageClassName,
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+			VolumeName: testPVName,
+		},
+	}
+	pvcAdmissionTestInstance *pvcAdmissionTest
+	onceForPVCAdmissionTest  sync.Once
+)
+
+type pvcAdmissionTest struct {
+	oldPVCRaw []byte
+	newPVCRaw []byte
+}
+
+func getPVCAdmissionTest(t *testing.T) *pvcAdmissionTest {
+	onceForPVCAdmissionTest.Do(func() {
+		oldPVCRaw, err := json.Marshal(oldPVC)
+		if err != nil {
+			t.Fatalf("Failed to marshall the old PVC, %v: %v", oldPVC, err)
+		}
+
+		newPVCRaw, err := json.Marshal(newPVC)
+		if err != nil {
+			t.Fatalf("Failed to marshall the new PVC, %v: %v", newPVC, err)
+		}
+
+		pvcAdmissionTestInstance = &pvcAdmissionTest{
+			oldPVCRaw: oldPVCRaw,
+			newPVCRaw: newPVCRaw,
+		}
+	})
+	return pvcAdmissionTestInstance
+}
+
+func TestValidatePVC(t *testing.T) {
+	testInstance := getPVCAdmissionTest(t)
+
+	tests := []struct {
+		name             string
+		kubeObjs         []runtime.Object
+		snapshotObjs     []runtime.Object
+		admissionReview  *admissionv1.AdmissionReview
+		expectedResponse *admissionv1.AdmissionResponse
+	}{
+		{
+			name: "TestDeletePVCwithSnapshotShouldFail",
+			kubeObjs: []runtime.Object{
+				testPV,
+			},
+			snapshotObjs: []runtime.Object{
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      testVolumeSnapshotName,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: &testFirstPVCName,
+						},
+						VolumeSnapshotClassName: &testVolumeSnapshotClassName,
+					},
+				},
+			},
+			admissionReview: &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw: testInstance.oldPVCRaw,
+					},
+				},
+			},
+			expectedResponse: &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Reason: DeleteVolumeWithSnapshotErrorMessage,
+				},
+			},
+		},
+		{
+			name: "TestDeletePVCwithoutSnapshotShouldPass",
+			kubeObjs: []runtime.Object{
+				testPV,
+			},
+			snapshotObjs: []runtime.Object{
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      testVolumeSnapshotName,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: &testSecondPVCName,
+						},
+						VolumeSnapshotClassName: &testVolumeSnapshotClassName,
+					},
+				},
+			},
+			admissionReview: &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw: testInstance.oldPVCRaw,
+					},
+				},
+			},
+			expectedResponse: &admissionv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+		{
+			name: "TestExpandPVCwithSnapshotShouldFail",
+			snapshotObjs: []runtime.Object{
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      testVolumeSnapshotName,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: &testFirstPVCName,
+						},
+						VolumeSnapshotClassName: &testVolumeSnapshotClassName,
+					},
+				},
+			},
+			admissionReview: &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: testInstance.oldPVCRaw,
+					},
+					Object: runtime.RawExtension{
+						Raw: testInstance.newPVCRaw,
+					},
+				},
+			},
+			expectedResponse: &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Reason: ExpandVolumeWithSnapshotErrorMessage,
+				},
+			},
+		},
+		{
+			name: "TestExpandPVCwithoutSnapshotShouldPass",
+			snapshotObjs: []runtime.Object{
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      testVolumeSnapshotName,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: &testSecondPVCName,
+						},
+						VolumeSnapshotClassName: &testVolumeSnapshotClassName,
+					},
+				},
+			},
+			admissionReview: &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: testInstance.oldPVCRaw,
+					},
+					Object: runtime.RawExtension{
+						Raw: testInstance.newPVCRaw,
+					},
+				},
+			},
+			expectedResponse: &admissionv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+		{
+			name: "TestCreatePVCShouldPass",
+			snapshotObjs: []runtime.Object{
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      testVolumeSnapshotName,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: &testSecondPVCName,
+						},
+						VolumeSnapshotClassName: &testVolumeSnapshotClassName,
+					},
+				},
+			},
+			admissionReview: &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: testInstance.newPVCRaw,
+					},
+				},
+			},
+			expectedResponse: &admissionv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+		{
+			name: "TestDeleteNonRwoPVCwithSnapshotShouldPass",
+			kubeObjs: []runtime.Object{
+				testPV,
+			},
+			snapshotObjs: []runtime.Object{
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      testVolumeSnapshotName,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: &testFirstPVCName,
+						},
+						VolumeSnapshotClassName: &testVolumeSnapshotClassName,
+					},
+				},
+			},
+			admissionReview: &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw: func() []byte {
+							pvc := oldPVC.DeepCopy()
+							pvc.Spec.AccessModes[0] = corev1.ReadWriteMany
+							pvcRaw, _ := json.Marshal(pvc)
+							return pvcRaw
+						}(),
+					},
+				},
+			},
+			expectedResponse: &admissionv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+		{
+			name: "TestExpandNonRwoPVCwithSnapshotShouldPass",
+			snapshotObjs: []runtime.Object{
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      testVolumeSnapshotName,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: &testFirstPVCName,
+						},
+						VolumeSnapshotClassName: &testVolumeSnapshotClassName,
+					},
+				},
+			},
+			admissionReview: &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: func() []byte {
+							pvc := oldPVC.DeepCopy()
+							pvc.Spec.AccessModes[0] = corev1.ReadWriteMany
+							pvcRaw, _ := json.Marshal(pvc)
+							return pvcRaw
+						}(),
+					},
+					Object: runtime.RawExtension{
+						Raw: func() []byte {
+							pvc := newPVC.DeepCopy()
+							pvc.Spec.AccessModes[0] = corev1.ReadWriteMany
+							pvcRaw, _ := json.Marshal(pvc)
+							return pvcRaw
+						}(),
+					},
+				},
+			},
+			expectedResponse: &admissionv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+		{
+			name: "TestDeletePVCwithSnapshotwithRetainPolicyShouldPass",
+			kubeObjs: []runtime.Object{
+				func() *corev1.PersistentVolume {
+					pv := testPV.DeepCopy()
+					pv.Spec.PersistentVolumeReclaimPolicy = corev1.PersistentVolumeReclaimRetain
+					return pv
+				}(),
+			},
+			snapshotObjs: []runtime.Object{
+				&snapshotv1.VolumeSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      testVolumeSnapshotName,
+					},
+					Spec: snapshotv1.VolumeSnapshotSpec{
+						Source: snapshotv1.VolumeSnapshotSource{
+							PersistentVolumeClaimName: &testFirstPVCName,
+						},
+						VolumeSnapshotClassName: &testVolumeSnapshotClassName,
+					},
+				},
+			},
+			admissionReview: &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw: testInstance.oldPVCRaw,
+					},
+				},
+			},
+			expectedResponse: &admissionv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshotClient := snapshotclientfake.NewSimpleClientset(test.snapshotObjs...)
+			kubeClient := fake.NewSimpleClientset(test.kubeObjs...)
+
+			var patches *gomonkey.Patches
+			patches = gomonkey.ApplyFunc(
+				k8s.NewSnapshotterClient, func(ctx context.Context) (snapshotterClientSet.Interface, error) {
+					return snapshotClient, nil
+				})
+			defer patches.Reset()
+
+			patches = gomonkey.ApplyFunc(
+				k8s.NewClient, func(ctx context.Context) (clientset.Interface, error) {
+					return kubeClient, nil
+				})
+			defer patches.Reset()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			actualResponse := validatePVC(ctx, test.admissionReview)
+			assert.Equal(t, actualResponse, test.expectedResponse)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adding validating admission webhooks in vanilla cluster for the block volume snapshot feature which would potential help improve the health of CSI service.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

* Unit test: passed
* Functional test: passed
* Regression test: passed with one unrelated error

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added validating admission webhooks in vanilla cluster for the block volume snapshot feature
```
