### PR TITLE
Decouple CPI from CSI - Remove dependency on K8s Node ProviderID set by CPI from CSI

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -148,6 +148,7 @@ data:
   "improved-volume-topology": "true"
   "block-volume-snapshot": "false"
   "csi-windows-support": "false"
+  "use-csinode-id": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -37,6 +37,10 @@ var (
 type Manager interface {
 	// SetKubernetesClient sets kubernetes client for node manager.
 	SetKubernetesClient(client clientset.Interface)
+	// SetUseNodeUuid sets whether the node manager should use
+	// K8s CSINode API object or the K8s Node API object to retrieve
+	// the node UUID.
+	SetUseNodeUuid(useNodeUuid bool)
 	// RegisterNode registers a node given its UUID, name.
 	RegisterNode(ctx context.Context, nodeUUID string, nodeName string) error
 	// DiscoverNode discovers a registered node given its UUID. This method
@@ -92,11 +96,21 @@ type defaultManager struct {
 	nodeNameToUUID sync.Map
 	// k8s client.
 	k8sClient clientset.Interface
+	// useNodeUuid uses K8s CSINode API instead of
+	// K8s Node to retrieve the node UUID.
+	useNodeUuid bool
 }
 
 // SetKubernetesClient sets specified kubernetes client to defaultManager.k8sClient
 func (m *defaultManager) SetKubernetesClient(client clientset.Interface) {
 	m.k8sClient = client
+}
+
+// SetUseNodeUuid sets whether the node manager should use
+// K8s CSINode API object or the K8s Node API object to retrieve
+// node UUID.
+func (m *defaultManager) SetUseNodeUuid(useNodeUuid bool) {
+	m.useNodeUuid = useNodeUuid
 }
 
 // RegisterNode registers a node with node manager using its UUID, name.
@@ -141,9 +155,10 @@ func (m *defaultManager) GetNodeByName(ctx context.Context, nodeName string) (*v
 		return m.GetNode(ctx, nodeUUID.(string), nil)
 	}
 	log.Infof("Empty nodeUUID observed in cache for the node: %q", nodeName)
-	k8snodeUUID, err := k8s.GetNodeVMUUID(ctx, m.k8sClient, nodeName)
+	k8snodeUUID, err := k8s.GetNodeUUID(ctx, m.k8sClient, nodeName,
+		m.useNodeUuid)
 	if err != nil {
-		log.Errorf("failed to get providerId from node: %q. Err: %v", nodeName, err)
+		log.Errorf("failed to get node UUID from node: %q. Err: %v", nodeName, err)
 		return nil, err
 	}
 	m.nodeNameToUUID.Store(nodeName, k8snodeUUID)
@@ -221,13 +236,15 @@ func (m *defaultManager) GetAllNodes(ctx context.Context) ([]*vsphere.VirtualMac
 	m.nodeNameToUUID.Range(func(nodeName, nodeUUID interface{}) bool {
 		if nodeName != nil && nodeUUID != nil && nodeUUID.(string) == "" {
 			log.Infof("Empty node UUID observed for the node: %q", nodeName)
-			k8snodeUUID, err := k8s.GetNodeVMUUID(ctx, m.k8sClient, nodeName.(string))
+			k8snodeUUID, err := k8s.GetNodeUUID(ctx, m.k8sClient,
+				nodeName.(string), m.useNodeUuid)
 			if err != nil {
-				log.Errorf("failed to get providerId from node: %q. Err: %v", nodeName, err)
+				log.Errorf("failed to get node UUID from node: %q. Err: %v", nodeName, err)
 				return true
 			}
 			if k8snodeUUID == "" {
-				log.Errorf("Node: %q with empty providerId found in the cluster. aborting get all nodes", nodeName)
+				log.Errorf("Node: %q with empty node UUID found in the cluster. "+
+					"aborting get all nodes", nodeName)
 				return true
 			}
 			m.nodeNameToUUID.Store(nodeName, k8snodeUUID)

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -301,4 +301,8 @@ const (
 	// CSIWindowsSupport is the feature to support csi block volumes for windows
 	// node.
 	CSIWindowsSupport = "csi-windows-support"
+	// UseCSINodeId is the feature to make sure CSI will no longer use
+	// ProviderID on K8s Node API object set by CPI. If not set, CSI
+	// will continue to use the Provider ID from K8s Node API object.
+	UseCSINodeId = "use-csinode-id"
 )

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -53,13 +53,14 @@ import (
 
 // NodeManagerInterface provides functionality to manage (VM) nodes.
 type NodeManagerInterface interface {
-	Initialize(ctx context.Context) error
+	Initialize(ctx context.Context, useNodeUuid bool) error
 	GetSharedDatastoresInK8SCluster(ctx context.Context) ([]*cnsvsphere.DatastoreInfo, error)
 	GetSharedDatastoresInTopology(ctx context.Context, topologyRequirement *csi.TopologyRequirement,
 		tagManager *tags.Manager, zoneKey string, regionKey string) ([]*cnsvsphere.DatastoreInfo,
 		map[string][]map[string]string, error)
 	GetNodeByName(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
 	GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error)
+	GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error)
 	GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachine, error)
 }
 
@@ -155,8 +156,13 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		log.Errorf("checkAPI failed for vcenter API version: %s, err=%v", vc.Client.ServiceContent.About.ApiVersion, err)
 		return err
 	}
+
+	useNodeUuid := false
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
+		useNodeUuid = true
+	}
 	c.nodeMgr = &node.Nodes{}
-	err = c.nodeMgr.Initialize(ctx)
+	err = c.nodeMgr.Initialize(ctx, useNodeUuid)
 	if err != nil {
 		log.Errorf("failed to initialize nodeMgr. err=%v", err)
 		return err
@@ -323,8 +329,12 @@ func (c *controller) ReloadConfiguration() error {
 		c.manager.VcenterConfig = newVCConfig
 		c.manager.VolumeManager = cnsvolume.GetManager(ctx, vcenter, operationStore, idempotencyHandlingEnabled)
 		// Re-Initialize Node Manager to cache latest vCenter config.
+		useNodeUuid := false
+		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
+			useNodeUuid = true
+		}
 		c.nodeMgr = &node.Nodes{}
-		err = c.nodeMgr.Initialize(ctx)
+		err = c.nodeMgr.Initialize(ctx, useNodeUuid)
 		if err != nil {
 			log.Errorf("failed to re-initialize nodeMgr. err=%v", err)
 			return err
@@ -1027,7 +1037,12 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 						"failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
 				}
 			}
-			node, err := c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+			var node *cnsvsphere.VirtualMachine
+			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
+				node, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
+			} else {
+				node, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+			}
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to find VirtualMachine for node:%q. Error: %v", req.NodeId, err)
@@ -1146,7 +1161,12 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		}
 		// Block Volume.
 		volumeType = prometheus.PrometheusBlockVolumeType
-		node, err := c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+		var node *cnsvsphere.VirtualMachine
+		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
+			node, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
+		} else {
+			node, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+		}
 		if err != nil {
 			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to find VirtualMachine for node:%q. Error: %v", req.NodeId, err)

--- a/pkg/kubernetes/informers.go
+++ b/pkg/kubernetes/informers.go
@@ -76,6 +76,20 @@ func (im *InformerManager) AddNodeListener(
 	})
 }
 
+// AddCSINodeNodeListener hooks up add, update, delete callbacks.
+func (im *InformerManager) AddCSINodeListener(
+	add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {
+	if im.nodeInformer == nil {
+		im.nodeInformer = im.informerFactory.Storage().V1().CSINodes().Informer()
+	}
+
+	im.nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    add,
+		UpdateFunc: update,
+		DeleteFunc: remove,
+	})
+}
+
 // AddPVCListener hooks up add, update, delete callbacks.
 func (im *InformerManager) AddPVCListener(
 	add func(obj interface{}), update func(oldObj, newObj interface{}), remove func(obj interface{})) {

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -183,8 +183,12 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			}
 			// Initialize node manager so that CSINodeTopology controller can
 			// retrieve NodeVM using the NodeID in the spec.
+			useNodeUuid := false
+			if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.UseCSINodeId) {
+				useNodeUuid = true
+			}
 			nodeMgr := &node.Nodes{}
-			err = nodeMgr.Initialize(ctx)
+			err = nodeMgr.Initialize(ctx, useNodeUuid)
 			if err != nil {
 				log.Errorf("failed to initialize nodeManager. Error: %+v", err)
 				return err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR remove dependency on K8s Node ProviderID set by CPI from CSI.
This PR introduces a new feature flag `use-csinode-id` which when set to true will make CSI no longer depend on the K8s Node ProviderID set by CPI. If the feature flag `use-csinode-id` is not set, CSI will continue to use the K8s Node ProviderID for all create/attach operations.

When the feature flag - `use-csinode-id` is set

1. Each individual node will start publishing nodeUUID as part of CSINode object.
2. Node manager is modified to listen on CSINode objects and populate nodeuuid -> vmRef map.
3. CSI controller will use the populated map for Create, Attach, Detach operations.

**Testing done**:
1. Verify if all the CSINode objects publish nodeUUID.
```
root@k8s-control-59-1633633108:~# kubectl describe csinodes
Name:               k8s-control-59-1633633108
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Thu, 07 Oct 2021 19:00:13 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  NodeUUID##422a3b9a-dc76-e91e-6ce5-437c3326432c
Events:         <none>


Name:               k8s-node-109-1633633128
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Thu, 07 Oct 2021 19:01:56 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  NodeUUID##422a97ac-d4b2-baaf-07b5-00e32e5707bb
Events:         <none>


Name:               k8s-node-130-1633633137
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Thu, 07 Oct 2021 19:02:19 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  NodeUUID##422a9ca5-1cd6-e1a3-13b3-6fbd3020ba45
Events:         <none>


Name:               k8s-node-951-1633633119
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Thu, 07 Oct 2021 19:01:33 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  NodeUUID##422a3431-4ead-b66e-74db-68cff999bffa
Events:         <none>
```

2. Create PVC logs

```
2021-10-07T20:22:22.028Z	INFO	vanilla/controller.go:802	CreateVolume: called with args {Name:pvc-1cff5099-e7d6-4ab9-b07a-233b8b87baaa CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[storagepolicyname:vSAN Default Storage Policy] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.061Z	DEBUG	node/manager.go:285	Updated VM VirtualMachine:vm-50 [VirtualCenterHost: 10.185.226.37, UUID: 422a3b9a-dc76-e91e-6ce5-437c3326432c, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.226.37]] for node with nodeUUID 422a3b9a-dc76-e91e-6ce5-437c3326432c	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.061Z	DEBUG	node/manager.go:285	Updated VM VirtualMachine:vm-51 [VirtualCenterHost: 10.185.226.37, UUID: 422a3431-4ead-b66e-74db-68cff999bffa, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.226.37]] for node with nodeUUID 422a3431-4ead-b66e-74db-68cff999bffa	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.061Z	DEBUG	node/manager.go:285	Updated VM VirtualMachine:vm-52 [VirtualCenterHost: 10.185.226.37, UUID: 422a97ac-d4b2-baaf-07b5-00e32e5707bb, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.226.37]] for node with nodeUUID 422a97ac-d4b2-baaf-07b5-00e32e5707bb	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.061Z	DEBUG	node/manager.go:285	Updated VM VirtualMachine:vm-53 [VirtualCenterHost: 10.185.226.37, UUID: 422a9ca5-1cd6-e1a3-13b3-6fbd3020ba45, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.226.37]] for node with nodeUUID 422a9ca5-1cd6-e1a3-13b3-6fbd3020ba45	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.061Z	DEBUG	vsphere/virtualmachine.go:364	Getting accessible datastores for node VirtualMachine:vm-50	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.076Z	DEBUG	vsphere/virtualmachine.go:364	Getting accessible datastores for node VirtualMachine:vm-51	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.092Z	DEBUG	vsphere/virtualmachine.go:364	Getting accessible datastores for node VirtualMachine:vm-52	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.105Z	DEBUG	vsphere/virtualmachine.go:364	Getting accessible datastores for node VirtualMachine:vm-53	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.119Z	DEBUG	node/nodes.go:369	sharedDatastores : [Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/4a58ee8f-1f327ca9/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:528c900075e7032a-30b27ed925bb0a8e/]	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.119Z	DEBUG	vanilla/controller.go:352	filterDatastores: dsMap map[ds:///vmfs/volumes/4a58ee8f-1f327ca9/:Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/4a58ee8f-1f327ca9/ ds:///vmfs/volumes/615f3abe-08a775f0-721c-020094c6d809/:Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/615f3abe-08a775f0-721c-020094c6d809/ ds:///vmfs/volumes/615f3abf-8680f286-41bb-020094c6d809/:Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/615f3abf-8680f286-41bb-020094c6d809/ ds:///vmfs/volumes/615f3ac0-d32adc7c-9e3e-020094c71ae3/:Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/615f3ac0-d32adc7c-9e3e-020094c71ae3/ ds:///vmfs/volumes/615f3ac1-580dfa44-338d-020094c71ae3/:Datastore: Datastore:datastore-40, datastore URL: ds:///vmfs/volumes/615f3ac1-580dfa44-338d-020094c71ae3/ ds:///vmfs/volumes/615f3ac3-cabebb8a-108b-020094bad288/:Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/615f3ac3-cabebb8a-108b-020094bad288/ ds:///vmfs/volumes/615f3ac4-4416ca62-aede-020094bad288/:Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/615f3ac4-4416ca62-aede-020094bad288/ ds:///vmfs/volumes/615f3ac5-4b5e9252-a947-0200944c9b2c/:Datastore: Datastore:datastore-43, datastore URL: ds:///vmfs/volumes/615f3ac5-4b5e9252-a947-0200944c9b2c/ ds:///vmfs/volumes/615f3ac6-f5e169b2-f79e-0200944c9b2c/:Datastore: Datastore:datastore-44, datastore URL: ds:///vmfs/volumes/615f3ac6-f5e169b2-f79e-0200944c9b2c/ ds:///vmfs/volumes/vsan:528c900075e7032a-30b27ed925bb0a8e/:Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:528c900075e7032a-30b27ed925bb0a8e/] sharedDatastores [Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/4a58ee8f-1f327ca9/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:528c900075e7032a-30b27ed925bb0a8e/]	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.119Z	DEBUG	vanilla/controller.go:361	filterDatastores: filteredDatastores [Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/4a58ee8f-1f327ca9/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:528c900075e7032a-30b27ed925bb0a8e/]	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.201Z	DEBUG	common/vsphereutil.go:241	vSphere CSI driver creating volume pvc-1cff5099-e7d6-4ab9-b07a-233b8b87baaa with create spec (*types.CnsVolumeCreateSpec)(0xc00056a500)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-1cff5099-e7d6-4ab9-b07a-233b8b87baaa",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=2 cap=2) {
  (types.ManagedObjectReference) Datastore:datastore-35,
  (types.ManagedObjectReference) Datastore:datastore-47
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=8) "cluster1",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA",
   ClusterDistribution: (string) (len=11) "CSI-Vanilla"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=8) "cluster1",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA",
    ClusterDistribution: (string) (len=11) "CSI-Vanilla"
   }
  }
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc0006d1860)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 1024
  },
  BackingDiskId: (string) "",
  BackingDiskUrlPath: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) (len=1 cap=1) {
  (*types.VirtualMachineDefinedProfileSpec)(0xc0007a1b80)({
   VirtualMachineProfileSpec: (types.VirtualMachineProfileSpec) {
    DynamicData: (types.DynamicData) {
    }
   },
   ProfileId: (string) (len=36) "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
   ReplicationSpec: (*types.ReplicationSpec)(<nil>),
   ProfileData: (*types.VirtualMachineProfileRawData)(<nil>),
   ProfileParams: ([]types.KeyValue) <nil>
  })
 },
 CreateSpec: (types.BaseCnsBaseCreateSpec) <nil>,
 VolumeSource: (types.BaseCnsVolumeSource) <nil>
})
	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:22.210Z	DEBUG	volume/util.go:198	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:24.739Z	INFO	volume/manager.go:457	CreateVolume: VolumeName: "pvc-1cff5099-e7d6-4ab9-b07a-233b8b87baaa", opId: "3d5d44db"	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:24.745Z	INFO	volume/util.go:327	Volume created successfully. VolumeName: "pvc-1cff5099-e7d6-4ab9-b07a-233b8b87baaa", volumeID: "a89c93a5-220c-4666-8133-55aed5872bfe"	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:24.745Z	DEBUG	volume/util.go:329	CreateVolume volumeId {{} "a89c93a5-220c-4666-8133-55aed5872bfe"} is placed on datastore "ds:///vmfs/volumes/vsan:528c900075e7032a-30b27ed925bb0a8e/"	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:24.745Z	DEBUG	volume/manager.go:525	internalCreateVolume: returns fault ""	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
2021-10-07T20:22:24.747Z	DEBUG	vanilla/controller.go:833	createVolumeInternal: returns fault ""	{"TraceId": "6b8a6b11-3f08-4dc5-af63-e2fbc77b1a02"}
```

3. Create Pod logs
```
2021-10-07T20:26:23.250Z	INFO	vanilla/controller.go:950	ControllerPublishVolume: called with args {VolumeId:af7e31a5-b348-48e9-a912-f4a82df61e18 NodeId:NodeUUID##422a9ca5-1cd6-e1a3-13b3-6fbd3020ba45 VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[storage.kubernetes.io/csiProvisionerIdentity:1633637747277-8081-csi.vsphere.vmware.com type:vSphere CNS Block Volume] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "fffda121-1b02-436d-9ff4-9cf266cd4a6c"}
2021-10-07T20:26:23.255Z	DEBUG	node/manager.go:225	VM VirtualMachine:vm-53 [VirtualCenterHost: 10.185.226.37, UUID: 422a9ca5-1cd6-e1a3-13b3-6fbd3020ba45, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.226.37]] was successfully renewed with nodeUUID "422a9ca5-1cd6-e1a3-13b3-6fbd3020ba45"	{"TraceId": "fffda121-1b02-436d-9ff4-9cf266cd4a6c"}
2021-10-07T20:26:23.255Z	DEBUG	vanilla/controller.go:1040	Found VirtualMachine for node:"NodeUUID##422a9ca5-1cd6-e1a3-13b3-6fbd3020ba45".	{"TraceId": "fffda121-1b02-436d-9ff4-9cf266cd4a6c"}
2021-10-07T20:26:23.255Z	DEBUG	common/vsphereutil.go:547	vSphere CSI driver is attaching volume: "af7e31a5-b348-48e9-a912-f4a82df61e18" to vm: "VirtualMachine:vm-53 [VirtualCenterHost: 10.185.226.37, UUID: 422a9ca5-1cd6-e1a3-13b3-6fbd3020ba45, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.226.37]]"	{"TraceId": "fffda121-1b02-436d-9ff4-9cf266cd4a6c"}
2021-10-07T20:26:24.695Z	INFO	volume/manager.go:583	AttachVolume: volumeID: "af7e31a5-b348-48e9-a912-f4a82df61e18", vm: "VirtualMachine:vm-53 [VirtualCenterHost: 10.185.226.37, UUID: 422a9ca5-1cd6-e1a3-13b3-6fbd3020ba45, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.226.37]]", opId: "3d5d458d"	{"TraceId": "fffda121-1b02-436d-9ff4-9cf266cd4a6c"}
2021-10-07T20:26:24.696Z	INFO	volume/manager.go:618	AttachVolume: Volume attached successfully. volumeID: "af7e31a5-b348-48e9-a912-f4a82df61e18", opId: "3d5d458d", vm: "VirtualMachine:vm-53 [VirtualCenterHost: 10.185.226.37, UUID: 422a9ca5-1cd6-e1a3-13b3-6fbd3020ba45, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.226.37]]", diskUUID: "6000C293-a704-463b-fa3b-be391c862097"	{"TraceId": "fffda121-1b02-436d-9ff4-9cf266cd4a6c"}
2021-10-07T20:26:24.696Z	DEBUG	volume/manager.go:625	internalAttachVolume: returns fault "" for volume "af7e31a5-b348-48e9-a912-f4a82df61e18"	{"TraceId": "fffda121-1b02-436d-9ff4-9cf266cd4a6c"}
2021-10-07T20:26:24.697Z	DEBUG	common/vsphereutil.go:553	Successfully attached disk af7e31a5-b348-48e9-a912-f4a82df61e18 to VM VirtualMachine:vm-53 [VirtualCenterHost: 10.185.226.37, UUID: 422a9ca5-1cd6-e1a3-13b3-6fbd3020ba45, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.226.37]]. Disk UUID is 6000C293-a704-463b-fa3b-be391c862097	{"TraceId": "fffda121-1b02-436d-9ff4-9cf266cd4a6c"}
2021-10-07T20:26:24.697Z	INFO	vanilla/controller.go:1050	ControllerPublishVolume successful with publish context: map[diskUUID:6000c293a704463bfa3bbe391c862097 type:vSphere CNS Block Volume]	{"TraceId": "fffda121-1b02-436d-9ff4-9cf266cd4a6c"}
2021-10-07T20:26:24.697Z	DEBUG	vanilla/controller.go:1057	controllerPublishVolumeInternal: returns fault "" for volume "af7e31a5-b348-48e9-a912-f4a82df61e18"	{"TraceId": "fffda121-1b02-436d-9ff4-9cf266cd4a6c"}
```

**Release note**:
```release-note
Remove dependency on K8s Node ProviderID set by CPI from CSI
```

@divyenpatel @chethanv28 