### PR TITLE
Cleanup stale volume operation requests from snapshot operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.14.5 // indirect
 	github.com/kubernetes-csi/csi-lib-utils v0.7.0
 	github.com/kubernetes-csi/csi-proxy/client v1.0.1
+	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.1.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -445,6 +445,8 @@ github.com/kubernetes-csi/csi-lib-utils v0.7.0 h1:t1cS7HTD7z5D7h9iAdjWuHtMxJPb9s
 github.com/kubernetes-csi/csi-lib-utils v0.7.0/go.mod h1:bze+2G9+cmoHxN6+WyG1qT4MDxgZJMLGwc7V4acPNm0=
 github.com/kubernetes-csi/csi-proxy/client v1.0.1 h1:BPK9e5Fy0GcDRjDc9hqu7TnouSRujG6IvbH+PXSDOsY=
 github.com/kubernetes-csi/csi-proxy/client v1.0.1/go.mod h1:URLOkEbRhOwKVvGvug6HSKRTpLSFuQ/Gt3xahDag8qc=
+github.com/kubernetes-csi/external-snapshotter/client/v4 v4.1.0 h1:DecASDOSUnp0ftwi4aU87joEpZfLv9iMPwNYzrGb9Lc=
+github.com/kubernetes-csi/external-snapshotter/client/v4 v4.1.0/go.mod h1:YBCo4DoEeDndqvAn6eeu0vWM7QdXmHEeI9cFWplmBys=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
@@ -924,6 +926,7 @@ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba h1:O8mE0/t419eoIwhTFpKVkHiTs/Igowgfkj25AcZrtiE=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -2018,7 +2018,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 		// Reference to the DeleteVolume task on CNS.
 		deleteSnapshotTask *object.Task
 		// Name of the CnsVolumeOperationRequest instance.
-		instanceName = "deletesnapshot-" + snapshotID + "-" + volumeID
+		instanceName = "deletesnapshot-" + volumeID + "-" + snapshotID
 		// Local instance of DeleteSnapshot details that needs to be persisted.
 		volumeOperationDetails *cnsvolumeoperationrequest.VolumeOperationRequestDetails
 		// error

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	apiutils "sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
+	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator"
 	migrationv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
@@ -102,6 +103,17 @@ func NewClient(ctx context.Context) (clientset.Interface, error) {
 		return nil, err
 	}
 	return clientset.NewForConfig(config)
+}
+
+// NewSnapshotterClient creates a new external-snapshotter client based on a service account.
+func NewSnapshotterClient(ctx context.Context) (snapshotterClientSet.Interface, error) {
+	log := logger.GetLogger(ctx)
+	config, err := GetKubeConfig(ctx)
+	if err != nil {
+		log.Errorf("Failed to get KubeConfig. err: %v", err)
+		return nil, err
+	}
+	return snapshotterClientSet.NewForConfig(config)
 }
 
 // GetRestClientConfigForSupervisor returns restclient config for given


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cleanup stale volume operation requests from snapshot operations

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

regression test: PASS
functional test: PASS

```
2021-10-11T07:00:35.259Z        INFO    cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:80       Creating CnsVolumeOperationRequest definition on API server and initializing VolumeOperationRequest instance {"TraceId": "bb2edc4d-b73f-4149-ab53-eaa9a80d4507"}
2021-10-11T07:00:35.274Z        INFO    kubernetes/kubernetes.go:434    "cnsvolumeoperationrequests.cns.vmware.com" CRD updated successfully    {"TraceId": "bb2edc4d-b73f-4149-ab53-eaa9a80d4507"}
2021-10-11T07:00:35.307Z        INFO    cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:315      CnsVolumeOperationRequest clean up interval is set to 120 minutes    {"TraceId": "ed38494d-be52-4503-9fef-d11d0b39157d"}
2021-10-11T07:00:35.307Z        INFO    cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:317      Cleaning up stale CnsVolumeOperationRequest instances.  {"TraceId": "ed38494d-be52-4503-9fef-d11d0b39157d"}
2021-10-11T07:00:35.343Z        DEBUG   cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:293      Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/deletesnapshot-b6d66f4d-dabd-43cd-9337-314d5dd04240-bd45f52b-e1d7-43f8-90a9-33dd058a38fa     {"TraceId": "ed38494d-be52-4503-9fef-d11d0b39157d"}
2021-10-11T07:00:35.352Z        DEBUG   cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:293      Deleting CnsVolumeOperationRequest instance with name vmware-system-csi/snapshot-a2787e7e-afd9-4d0a-b4d7-9a680e67fe92-b6d66f4d-dabd-43cd-9337-314d5dd04240   {"TraceId": "ed38494d-be52-4503-9fef-d11d0b39157d"}
2021-10-11T07:00:35.357Z        INFO    cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:406      Clean up of stale CnsVolumeOperationRequest complete.   {"TraceId": "ed38494d-be52-4503-9fef-d11d0b39157d"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cleanup stale volume operation requests from snapshot operations
```
