### PR TITLE
Document vSphere CSI controller panic due to concurrent map writes

### DIFF
--- a/docs/book/releases/v2.0.0.md
+++ b/docs/book/releases/v2.0.0.md
@@ -87,6 +87,13 @@
         - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
     - Workaround:
         - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
+12. vSphere CSI controller may panic and crash during multiple concurrent requests to create a PersistentVolumeClaim.
+    - Impact:
+        - vSphere CSI controller will panic with the message `stderr F fatal error: concurrent map writes`.
+        - In flight requests to provision storage on a datastore will be lost to CSI when it restarts.
+        - Orphan volumes will remain on the datastore.
+    - Workaround:
+        - None.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.0.1.md
+++ b/docs/book/releases/v2.0.1.md
@@ -66,6 +66,13 @@
       - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
    - Workaround:
       - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
+10. vSphere CSI controller may panic and crash during multiple concurrent requests to create a PersistentVolumeClaim.
+    - Impact:
+        - vSphere CSI controller will panic with the message `stderr F fatal error: concurrent map writes`.
+        - In flight requests to provision storage on a datastore will be lost to CSI when it restarts.
+        - Orphan volumes will remain on the datastore.
+    - Workaround:
+       - None.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.1.0.md
+++ b/docs/book/releases/v2.1.0.md
@@ -71,6 +71,13 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
       - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
     - Workaround:
       - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
+13. vSphere CSI controller may panic and crash during multiple concurrent requests to create a PersistentVolumeClaim.
+    - Impact:
+        - vSphere CSI controller will panic with the message `stderr F fatal error: concurrent map writes`.
+        - In flight requests to provision storage on a datastore will be lost to CSI when it restarts.
+        - Orphan volumes will remain on the datastore.
+    - Workaround:
+        - None.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.1.1.md
+++ b/docs/book/releases/v2.1.1.md
@@ -72,6 +72,13 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
       - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
     - Workaround:
       - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
+12. vSphere CSI controller may panic and crash during multiple concurrent requests to create a PersistentVolumeClaim.
+    - Impact:
+        - vSphere CSI controller will panic with the message `stderr F fatal error: concurrent map writes`.
+        - In flight requests to provision storage on a datastore will be lost to CSI when it restarts.
+        - Orphan volumes will remain on the datastore.
+    - Workaround:
+        - None.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.2.0.md
+++ b/docs/book/releases/v2.2.0.md
@@ -63,6 +63,13 @@
       - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
    - Workaround:
       - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
+7. vSphere CSI controller may panic and crash during multiple concurrent requests to create a PersistentVolumeClaim.
+    - Impact:
+        - vSphere CSI controller will panic with the message `stderr F fatal error: concurrent map writes`.
+        - In flight requests to provision storage on a datastore will be lost to CSI when it restarts.
+        - Orphan volumes will remain on the datastore.
+    - Workaround:
+        - None.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.2.1.md
+++ b/docs/book/releases/v2.2.1.md
@@ -55,6 +55,13 @@
       - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
    - Workaround:
       - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
+7. vSphere CSI controller may panic and crash during multiple concurrent requests to create a PersistentVolumeClaim.
+    - Impact:
+        - vSphere CSI controller will panic with the message `stderr F fatal error: concurrent map writes`.
+        - In flight requests to provision storage on a datastore will be lost to CSI when it restarts.
+        - Orphan volumes will remain on the datastore.
+    - Workaround:
+        - None.
 
 ### Kubernetes issues
 

--- a/docs/book/releases/v2.3.0.md
+++ b/docs/book/releases/v2.3.0.md
@@ -67,6 +67,13 @@
       - Restarting vCenter while volumes are getting created may leave orphan volumes on the datastores.
     - Workaround:
       - If 1 hour wait is longer for SLA, restart the vSphere CSI driver Pod to clean up pending vCenter cached tasks objects for which session is already destroyed. Note: This action will leave orphan volume on the datastore.
+6. vSphere CSI controller may panic and crash during multiple concurrent requests to create a PersistentVolumeClaim.
+    - Impact:
+        - vSphere CSI controller will panic with the message `stderr F fatal error: concurrent map writes`.
+        - In flight requests to provision storage on a datastore will be lost to CSI when it restarts.
+        - Orphan volumes will remain on the datastore.
+    - Workaround:
+        - None.
 
 ### Kubernetes issues
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR documents the issue of vSphere CSI controller crashing due to `concurrent map writes` and its impact. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Document vSphere CSI controller panic due to concurrent map writes
```
