### PR TITLE
set MAX_VOLUMES_PER_NODE to 59 for Vanilla and Guest Cluster Nodes

### DIFF
--- a/manifests/guestcluster/1.21/pvcsi.yaml
+++ b/manifests/guestcluster/1.21/pvcsi.yaml
@@ -349,6 +349,8 @@ spec:
               fieldPath: spec.nodeName
         - name: CSI_ENDPOINT
           value: unix:///csi/csi.sock
+        - name: MAX_VOLUMES_PER_NODE
+          value: "59" # Maximum number of volumes that controller can publish to the node. If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
         - name: X_CSI_MODE
           value: "node"
         - name: X_CSI_SPEC_REQ_VALIDATION

--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -349,6 +349,8 @@ spec:
               fieldPath: spec.nodeName
         - name: CSI_ENDPOINT
           value: unix:///csi/csi.sock
+        - name: MAX_VOLUMES_PER_NODE
+          value: "59" # Maximum number of volumes that controller can publish to the node. If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
         - name: X_CSI_MODE
           value: "node"
         - name: X_CSI_SPEC_REQ_VALIDATION

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -430,7 +430,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: MAX_VOLUMES_PER_NODE
-              value: "0" # Maximum number of volumes that controller can publish to the node. If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
+              value: "59" # Maximum number of volumes that controller can publish to the node. If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
             - name: X_CSI_MODE
               value: "node"
             - name: X_CSI_SPEC_REQ_VALIDATION


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Lot of customers are observing Pod failure due to `CNS: Failed to attach disk because missing SCSI controller`.

This happens because the vSphere CSI driver does not enforce a limit for the number of volumes per Node. So when Node VM runs out of SCSI controller slots to attach a disk, a new Pod with vSphere CSI volume can not come up.

In this PR we are setting MAX_VOLUMES_PER_NODE to 59 for Vanilla and Guest Cluster Nodes.
Even though file volumes are not directly attached to the Node VM, since we use a single driver for both file and block volume, this `59` MAX_VOLUMES_PER_NODE includes both file and block volume per Node VM.



**Testing done**:
For Vanilla Flavor of k8s testing was already done as part of https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/847 

When all node reaches max volume capacity, new Pod will not get scheduled and we will see failure as below 
```
0/5 nodes are available: 4 node(s) exceed max volume count.
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
set MAX_VOLUMES_PER_NODE to 59 for Vanilla and Guest Cluster Nodes
```
