### PR TITLE
rectify systemUUID for windows

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -50,7 +50,6 @@ ARCH=amd64
 OSVERSION=1809
 # OS Version for the Windows images: 1809, 1903, 1909 2004, 20H2, ltsc2022
 OSVERSION_WIN=(1809 1903 1909 2004 20H2 ltsc2022)
-
 # The output type could either be docker (local), or registry.
 # If it is registry, it will also allow us to push the Windows images.
 WINDOWS_IMAGE_OUTPUT="type=tar,dest=.build/windows-driver.tar"
@@ -316,6 +315,8 @@ case "${BUILD_RELEASE_TYPE}" in
     fatal "invalid BUILD_RELEASE_TYPE: ${BUILD_RELEASE_TYPE}"
     ;;
 esac
+
+mkdir -p .build
 
 # make sure that Docker is available
 docker ps >/dev/null 2>&1 || fatal "Docker not available"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -625,7 +625,9 @@ spec:
             - name: csi-proxy-filesystem-v1
               mountPath: \\.\pipe\csi-proxy-filesystem-v1
             - name: csi-proxy-disk-v1
-              mountPath: \\.\pipe\csi-proxy-disk-v1        
+              mountPath: \\.\pipe\csi-proxy-disk-v1    
+            - name: csi-proxy-system-v1alpha1
+              mountPath: \\.\pipe\csi-proxy-system-v1alpha1
           ports:
             - name: healthz
               containerPort: 9808
@@ -674,6 +676,10 @@ spec:
         - name: csi-proxy-filesystem-v1
           hostPath:
             path: \\.\pipe\csi-proxy-filesystem-v1
+            type: ''
+        - name: csi-proxy-system-v1alpha1
+          hostPath:
+            path: \\.\pipe\csi-proxy-system-v1alpha1
             type: ''
       tolerations:
         - effect: NoExecute

--- a/pkg/csi/service/mounter/mounter_linux.go
+++ b/pkg/csi/service/mounter/mounter_linux.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build darwin || linux
+// +build darwin linux
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -410,7 +410,7 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 				"failed to read CNS config. Error: %v", err)
 		}
 		// Fetch topology labels using VC TagManager.
-		accessibleTopology, err = fetchTopologyLabelsUsingVCCreds(ctx, nodeID, cfg)
+		accessibleTopology, err = driver.fetchTopologyLabelsUsingVCCreds(ctx, nodeID, cfg)
 	}
 	if err != nil {
 		return nil, err
@@ -450,7 +450,8 @@ func initVolumeTopologyService(ctx context.Context) error {
 // fetchTopologyLabelsUsingVCCreds retrieves topology information of the nodes
 // using VC credentials mounted on the nodes. This approach will be deprecated
 // soon.
-func fetchTopologyLabelsUsingVCCreds(ctx context.Context, nodeID string, cfg *cnsconfig.Config) (
+func (driver *vsphereCSIDriver) fetchTopologyLabelsUsingVCCreds(
+	ctx context.Context, nodeID string, cfg *cnsconfig.Config) (
 	map[string]string, error) {
 	log := logger.GetLogger(ctx)
 
@@ -488,7 +489,7 @@ func fetchTopologyLabelsUsingVCCreds(ctx context.Context, nodeID string, cfg *cn
 			"failed to connect to vcenter host: %s. err: %v", vcenter.Config.Host, err)
 	}
 	// Get VM UUID.
-	uuid, err := osutils.GetSystemUUID(ctx)
+	uuid, err := driver.osUtils.GetSystemUUID(ctx)
 	if err != nil {
 		return nil, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to get system uuid for node VM. err: %v", err)
@@ -497,7 +498,7 @@ func fetchTopologyLabelsUsingVCCreds(ctx context.Context, nodeID string, cfg *cn
 	nodeVM, err := cnsvsphere.GetVirtualMachineByUUID(ctx, uuid, false)
 	if err != nil || nodeVM == nil {
 		log.Errorf("failed to get nodeVM for uuid: %s. err: %+v", uuid, err)
-		uuid, err = osutils.ConvertUUID(uuid)
+		uuid, err = driver.osUtils.ConvertUUID(uuid)
 		if err != nil {
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"convertUUID failed with error: %v", err)

--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -812,7 +812,7 @@ func (osUtils *OsUtils) GetDevMounts(ctx context.Context,
 }
 
 // GetSystemUUID returns the UUID used to identify node vm
-func GetSystemUUID(ctx context.Context) (string, error) {
+func (osUtils *OsUtils) GetSystemUUID(ctx context.Context) (string, error) {
 	log := logger.GetLogger(ctx)
 	idb, err := ioutil.ReadFile(path.Join(dmiDir, "id", "product_uuid"))
 	if err != nil {
@@ -827,7 +827,7 @@ func GetSystemUUID(ctx context.Context) (string, error) {
 // convertUUID helps convert UUID to vSphere format, for example,
 // Input uuid:    6B8C2042-0DD1-D037-156F-435F999D94C1
 // Returned uuid: 42208c6b-d10d-37d0-156f-435f999d94c1
-func ConvertUUID(uuid string) (string, error) {
+func (osUtils *OsUtils) ConvertUUID(uuid string) (string, error) {
 	if len(uuid) != 36 {
 		return "", errors.New("uuid length should be 36")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr uses csi proxy to get system uuid in windows node. This uuid is used to identify the nodes uniquely. 
CSI proxy exposes GetBIOSSerialNumber which is used to get the uuid. Please refer: https://github.com/kubernetes-csi/csi-proxy/blob/master/client/api/system/v1alpha1/api.proto

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
none

**Testing done**:
Ran make build, make images, replaced windows images and tested:
{"level":"info","time":"2021-10-13T12:47:26.9220836-07:00","caller":"osutils/windows_os_utils.go:429","msg":"Bios serial number: VMware-42 02 e9 7e 3d ad 2a 49-22 86 7f f9 89 c6 64 ef  ","TraceId":"66632789-d060-4e64-b9e6-9888978197c5"}
{"level":"info","time":"2021-10-13T12:47:26.9220836-07:00","caller":"service/node.go:343","msg":"4202e97e-3dad-2a49-2286-7ff989c664ef","TraceId":"66632789-d060-4e64-b9e6-9888978197c5"}
replaced linux images and tested create, delete, getsystemuuid functions.


**Special notes for your reviewer**:

**Release note**:

```
Use csi proxy to get system uuid for windows nodes.
```
