### PR TITLE
Fix the issue that calling initSyncerComponents with older config. 

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -92,11 +92,7 @@ func main() {
 	} else if *operationMode == operationModeMetaDataSync {
 		log.Infof("Starting container with operation mode: %v", operationModeMetaDataSync)
 		var err error
-		configInfo, err := common.InitConfigInfo(ctx)
-		if err != nil {
-			log.Errorf("failed to initialize the configInfo. Err: %+v", err)
-			os.Exit(1)
-		}
+
 		// run will be executed if this instance is elected as the leader
 		// or if leader election is not enabled.
 		var run func(ctx context.Context)
@@ -128,7 +124,7 @@ func main() {
 
 		// Initialize syncer components that are dependant on the outcome of
 		// leader election, if enabled.
-		run = initSyncerComponents(ctx, clusterFlavor, configInfo, &syncer.COInitParams)
+		run = initSyncerComponents(ctx, clusterFlavor, &syncer.COInitParams)
 
 		if !*enableLeaderElection {
 			run(context.TODO())
@@ -159,9 +155,14 @@ func main() {
 // TODO: Change name from initSyncerComponents to init<Name>Components where
 // <Name> will be the name of this container.
 func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
-	configInfo *config.ConfigurationInfo, coInitParams *interface{}) func(ctx context.Context) {
+	coInitParams *interface{}) func(ctx context.Context) {
 	return func(ctx context.Context) {
 		log := logger.GetLogger(ctx)
+		configInfo, err := common.InitConfigInfo(ctx)
+		if err != nil {
+			log.Errorf("failed to initialize the configInfo. Err: %+v", err)
+			os.Exit(1)
+		}
 		if err := manager.InitCommonModules(ctx, clusterFlavor, coInitParams); err != nil {
 			log.Errorf("Error initializing common modules for all flavors. Error: %+v", err)
 			os.Exit(1)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We are reading config before leader election and when the leader is elected, we are calling initSyncerComponents with older config read before the leader is elected.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
I did the following test manually.

Step 1: create a storage class, the original cluster-distribution set in vsphere-csi-secret is “CSI-Vanilla"

Step 2: reboot VC

Step 3: edit the vsphere-csi-secret to change  cluster-distribution  to "CSI-Vanilla-liping"

Step 4:  create pvc
```
root@k8s-control-369-1634151990:~# kubectl create -f pvc2.yaml 
```
Step5: wait for VC reboot finish, and pvc enter the Bound state
```
root@k8s-control-369-1634151990:~# kubectl describe pvc example-raw-block-pvc-2 
Name:          example-raw-block-pvc-2
Namespace:     default
StorageClass:  example-raw-block-sc
Status:        Bound
Volume:        pvc-e4ff0d7f-9260-43a3-95e7-4dbb1a6eec41
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      500Mi
Access Modes:  RWO
VolumeMode:    Block
Used By:       <none>
Events:
  Type     Reason                 Age                     From                                                                                                Message
  ----     ------                 ----                    ----                                                                                                -------
  Warning  ProvisioningFailed     7m59s (x6 over 8m52s)   csi.vsphere.vmware.com_vsphere-csi-controller-5c679c6db-ghcls_3b374213-1235-47b1-8003-969dfdbcc0a4  failed to provision volume with StorageClass "example-raw-block-sc": rpc error: code = Internal desc = failed to get shared datastores in kubernetes cluster. Error: Post "https://10.184.75.225:443/sdk": dial tcp 10.184.75.225:443: connect: connection refused
  Normal   Provisioning           4m15s (x9 over 8m52s)   csi.vsphere.vmware.com_vsphere-csi-controller-5c679c6db-ghcls_3b374213-1235-47b1-8003-969dfdbcc0a4  External provisioner is provisioning volume for claim "default/example-raw-block-pvc-2"
  Warning  ProvisioningFailed     4m15s (x3 over 7m27s)   csi.vsphere.vmware.com_vsphere-csi-controller-5c679c6db-ghcls_3b374213-1235-47b1-8003-969dfdbcc0a4  failed to provision volume with StorageClass "example-raw-block-sc": rpc error: code = Internal desc = failed to get shared datastores in kubernetes cluster. Error: POST "/sdk": 503 Service Unavailable
  Normal   ExternalProvisioning   2m43s (x26 over 8m52s)  persistentvolume-controller                                                                         waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   Provisioning           23s (x2 over 40s)       csi.vsphere.vmware.com_vsphere-csi-controller-5c679c6db-ghcls_79e6dc02-3571-4606-a9d7-fc987b8a7445  External provisioner is provisioning volume for claim "default/example-raw-block-pvc-2"
  Warning  ProvisioningFailed     23s                     csi.vsphere.vmware.com_vsphere-csi-controller-5c679c6db-ghcls_79e6dc02-3571-4606-a9d7-fc987b8a7445  failed to provision volume with StorageClass "example-raw-block-sc": rpc error: code = Internal desc = failed to create volume. Error: failed to create volume with fault: "(*types.LocalizedMethodFault)(0xc000914c20)({\n DynamicData: (types.DynamicData) {\n },\n Fault: (types.CnsFault) {\n  BaseMethodFault: (types.BaseMethodFault) <nil>,\n  Reason: (string) (len=16) \"VSLM task failed\"\n },\n LocalizedMessage: (string) (len=32) \"CnsFault error: VSLM task failed\"\n})\n"
  Normal   ExternalProvisioning   19s                     persistentvolume-controller                                                                         waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   ProvisioningSucceeded  6s                      csi.vsphere.vmware.com_vsphere-csi-controller-5c679c6db-ghcls_79e6dc02-3571-4606-a9d7-fc987b8a7445  Successfully provisioned volume pvc-e4ff0d7f-9260-43a3-95e7-4dbb1a6eec41

```

Step 6 : check the CNS log, both CreateVolume spec and UpdateVolumeMetadata spec has the clusterDistributiion set to new value  "CSI-Vanilla-liping"

```
2021-10-14T21:34:30.114Z info vsanvcmgmtd[12792] [vSAN@6876 sub=CnsVolMgr opId=155eee6a] Creating volume with spec: (vim.cns.VolumeCreateSpec) [
-->    (vim.cns.VolumeCreateSpec) {
-->       name = "pvc-e4ff0d7f-9260-43a3-95e7-4dbb1a6eec41",
-->       volumeType = "BLOCK",
-->       datastores = (vim.Datastore) [
-->          'vim.Datastore:datastore-38',
-->          'vim.Datastore:datastore-48'
-->       ],
-->       metadata = (vim.cns.VolumeMetadata) {
-->          containerCluster = (vim.cns.ContainerCluster) {
-->             clusterType = "KUBERNETES",
-->             clusterId = "cluster1",
-->             vSphereUser = "VSPHERE.LOCAL\Administrator",
-->             clusterFlavor = "VANILLA",
-->             clusterDistribution = "CSI-Vanilla-liping"
-->          },
-->          containerClusterArray = (vim.cns.ContainerCluster) [
-->             (vim.cns.ContainerCluster) {
-->                clusterType = "KUBERNETES",
-->                clusterId = "cluster1",
-->                vSphereUser = "Administrator@vsphere.local",
-->                clusterFlavor = "VANILLA",
-->                clusterDistribution = "CSI-Vanilla-liping"
-->             }
-->          ],
-->       },
-->       backingObjectDetails = (vim.cns.BlockBackingDetails) {
-->          capacityInMb = 500,
-->       },
-->    }
--> ]



2021-10-14T21:35:03.961Z info vsanvcmgmtd[12791] [vSAN@6876 sub=CnsVolMgr opId=155eeedd] CNS: UpdateVolumeMetadata with spec: (vim.cns.VolumeMetadataUpdateSpec) [
-->    (vim.cns.VolumeMetadataUpdateSpec) {
-->       volumeId = (vim.cns.VolumeId) {
-->          id = "298d3fa2-4693-45ad-894a-c6f2a9e9cdf4"
-->       },
-->       metadata = (vim.cns.VolumeMetadata) {
-->          containerCluster = (vim.cns.ContainerCluster) {
-->             clusterType = "KUBERNETES",
-->             clusterId = "cluster1",
-->             vSphereUser = "VSPHERE.LOCAL\Administrator",
-->             clusterFlavor = "VANILLA",
-->             clusterDistribution = "CSI-Vanilla-liping"
-->          },
-->          entityMetadata = (vim.cns.EntityMetadata) [
-->             (vim.cns.KubernetesEntityMetadata) {
-->                entityName = "pvc-e4ff0d7f-9260-43a3-95e7-4dbb1a6eec41",
-->                clusterId = "cluster1",
-->                entityType = "PERSISTENT_VOLUME",
-->             }
-->          ],
-->          containerClusterArray = (vim.cns.ContainerCluster) [
-->             (vim.cns.ContainerCluster) {
-->                clusterType = "KUBERNETES",
-->                clusterId = "cluster1",
-->                vSphereUser = "Administrator@vsphere.local",
-->                clusterFlavor = "VANILLA",
-->                clusterDistribution = "CSI-Vanilla-liping"
-->             }
-->          ]
-->       }
-->    }
--> ]
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix the issue that calling initSyncerComponents with older config
```
