### PR TITLE
Fix metadata syncer for static PV

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1143,7 +1143,8 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 	if newPv.Spec.CSI != nil {
 		_, isdynamicCSIPV = newPv.Spec.CSI.VolumeAttributes[attribCSIProvisionerID]
 	}
-	if oldPv.Status.Phase == v1.VolumePending && newPv.Status.Phase == v1.VolumeAvailable &&
+	if oldPv.Status.Phase == v1.VolumePending &&
+		(newPv.Status.Phase == v1.VolumeAvailable || newPv.Status.Phase == v1.VolumeBound) &&
 		!isdynamicCSIPV && newPv.Spec.CSI != nil {
 		// Static PV is Created.
 		var volumeType string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
While processing a static PV, metadata syncer only checks that PV goes from Pending to Available phase. Only then it processes the volume to register in CNS, else it invokes `UpdateVolumeMetadata` assuming the volume is already registered in CNS.

We have seen cases where PV directly goes from Pending to Bound by the time it's processed by metadata syncer. Because of this, it skips volume creation in CNS and directly invokes `UpdateVolumeMetadata` which fails as the volume is not registered as a CNS volume.

This PR fixes that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running pre-checking e2e pipelines.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix metadata syncer for static PV
```
