### PR TITLE
exit windows plugin node if feature is not enabled

### DIFF
--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -334,6 +334,8 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 	log := logger.GetLogger(ctx)
 	log.Infof("NodeGetInfo: called with args %+v", *req)
 
+	driver.osUtils.ShouldContinue(ctx)
+
 	var nodeInfoResponse *csi.NodeGetInfoResponse
 
 	nodeName := os.Getenv("NODE_NAME")

--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -1019,3 +1019,8 @@ func isTargetInMounts(ctx context.Context, target string, mnts []gofsutil.Info) 
 	log.Debugf("Target %q not found in list of mounts", target)
 	return false
 }
+
+// decides if node should continue
+func (osUtils *OsUtils) ShouldContinue(ctx context.Context) {
+	// no op for linux
+}

--- a/pkg/csi/service/osutils/windows_os_utils.go
+++ b/pkg/csi/service/osutils/windows_os_utils.go
@@ -19,6 +19,7 @@ package osutils
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -29,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8svol "k8s.io/kubernetes/pkg/volume"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter"
 )
@@ -449,4 +451,14 @@ func (osUtils *OsUtils) ConvertUUID(uuid string) (string, error) {
 	// need to add dashes, e.g. "564d395e-d807-e18a-cb25-b79f65eb2b9f"
 	uuid = fmt.Sprintf("%s-%s-%s-%s-%s", uuid[0:8], uuid[8:12], uuid[12:16], uuid[16:20], uuid[20:32])
 	return uuid, nil
+}
+
+// decides if node should continue
+func (osUtils *OsUtils) ShouldContinue(ctx context.Context) {
+	log := logger.GetLogger(ctx)
+	if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIWindowsSupport) {
+		log.Errorf("csi plugin started on windows node without enabling feature switch")
+		os.Exit(1)
+	}
+	return
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr adds code to check if windows csi-windows-support feature switch is enabled. This check will happen in the NodeGetInfo as CO calls this once after node plugin has started. On linux nodes its a noop.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
none
**Testing done**:
Created driver image and deployed on windows setup. Checked that node stops when feature switch is disabled and continues when feature switch is enabled.
Verified in linux nodes that their is no effect.

when feature switch is disabled, windows csi node plugin logs:
```
{"level":"info","time":"2021-10-14T17:06:20.3897125-07:00","caller":"k8sorchestrator/k8sorchestrator.go:485","msg":"configMapAdded: Internal feature state values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[async-query-volume:true block-volume-snapshot:false csi-auth-check:true csi-migration:false csi-windows-support:false improved-csi-idempotency:false improved-volume-topology:false online-volume-extend:true trigger-csi-fullsync:false]","TraceId":"4b22dd55-80ad-4849-9e18-02796b87e226"}
{"level":"error","time":"2021-10-14T17:06:20.3897125-07:00","caller":"k8sorchestrator/k8sorchestrator.go:489","msg":"csi plugin started on windows node without enabling feature switch","TraceId":"4b22dd55-80ad-4849-9e18-02796b87e226","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator.configMapAdded\n\t/build/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:489\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator.initFSS.func2\n\t/build/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:399\nk8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd\n\t/go/pkg/mod/k8s.io/client-go@v0.21.1/tools/cache/controller.go:231\nk8s.io/client-go/tools/cache.(*processorListener).run.func1\n\t/go/pkg/mod/k8s.io/client-go@v0.21.1/tools/cache/shared_informer.go:777\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.21.1/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.21.1/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.21.1/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.21.1/pkg/util/wait/wait.go:90\nk8s.io/client-go/tools/cache.(*processorListener).run\n\t/go/pkg/mod/k8s.io/client-go@v0.21.1/tools/cache/shared_informer.go:771\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.21.1/pkg/util/wait/wait.go:7
``` 

**Special notes for your reviewer**:

**Release note**:

```
disallow windows csi node plugin to come up when csi-windows-support  is disabled. 
```
