### PR TITLE
add examples for windows

### DIFF
--- a/example/vanilla-k8s-RWO-filesystem-volumes/example-windows-pod.yaml
+++ b/example/vanilla-k8s-RWO-filesystem-volumes/example-windows-pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example-windows-pod
+spec:
+  nodeSelector:
+    kubernetes.io/os: windows
+  containers:
+    - name: test-container
+      image: mcr.microsoft.com/windows/servercore:ltsc2019
+      command:
+        - "powershell.exe"
+        - "-Command"
+        - "while (1) { Add-Content -Encoding Ascii C:\\test\\data.txt $(Get-Date -Format u); sleep 1 }"
+      volumeMounts:
+        - name: test-volume
+          mountPath: "/test/"
+          readOnly: false
+  volumes:
+    - name: test-volume
+      persistentVolumeClaim:
+        claimName: example-windows-pvc

--- a/example/vanilla-k8s-RWO-filesystem-volumes/example-windows-pvc.yaml
+++ b/example/vanilla-k8s-RWO-filesystem-volumes/example-windows-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: example-windows-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: example-windows-sc
+  volumeMode: Filesystem

--- a/example/vanilla-k8s-RWO-filesystem-volumes/example-windows-sc.yaml
+++ b/example/vanilla-k8s-RWO-filesystem-volumes/example-windows-sc.yaml
@@ -1,0 +1,10 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: example-windows-sc
+provisioner: csi.vsphere.vmware.com
+allowVolumeExpansion: true  # Optional: only applicable to vSphere 7.0U1 and above
+parameters:
+  storagepolicyname: "vSAN Default Storage Policy"  # Optional Parameter
+  #datastoreurl: "ds:///vmfs/volumes/vsan:52cdfa80721ff516-ea1e993113acfc77/"  # Optional Parameter
+  #csi.storage.k8s.io/fstype: "ntfs"  # Optional Parameter


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add example to create storage class, pvc and pod on setup with windows node

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
none

**Testing done**:

```
make build, make image
make check
hack/check-format.sh
go get: installing executables with 'go get' in module mode is deprecated.
	...
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
	..
go get: upgraded honnef.co/go/tools v0.0.1-2020.1.3 => v0.2.0
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/nigupta/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/nigupta/work/vsphere-csi-driver-forked /Users/nigupta/work /Users/nigupta /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (exports_file|name|imports|types_sizes|compiled_files|deps|files) took 3.829559263s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 77.929948ms
INFO [linters context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 111, after processing: 0
INFO [runner] Processors filtering stat (out/in): identifier_marker: 22/22, exclude: 22/22, skip_files: 111/111, autogenerated_exclude: 22/111, cgo: 111/111, nolint: 0/1, exclude-rules: 1/22, path_prettifier: 111/111, skip_dirs: 111/111, filename_unadjuster: 111/111
INFO [runner] processing took 10.127856ms with stages: nolint: 7.521918ms, autogenerated_exclude: 1.399437ms, path_prettifier: 558.311µs, identifier_marker: 280.52µs, skip_dirs: 179.023µs, exclude-rules: 121.149µs, uniq_by_line: 25.737µs, sort_results: 13.897µs, cgo: 13.826µs, filename_unadjuster: 10.842µs, max_same_issues: 966ns, max_from_linter: 358ns, diff: 325ns, source_code: 296ns, skip_files: 248ns, exclude: 237ns, path_shortener: 221ns, severity-rules: 216ns, max_per_file_from_linter: 213ns, path_prefixer: 116ns
INFO [runner] linters took 2.236034486s with stages: goanalysis_metalinter: 2.225821411s
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 63 samples, avg is 98.5MB, max is 140.9MB
INFO Execution took 6.157131107s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add example YAMLs to create storage class, PVC, and pod on cluster with windows node
```
