### PR TITLE
Add manifests for 1.22 K8s for Supervisor and Guestclusters

### DIFF
--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -1,0 +1,461 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .PVCSINamespace }}
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: {{ .PVCSINamespace }}
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-node
+  namespace: {{ .PVCSINamespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods", "configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["triggercsifullsyncs"]
+    verbs: ["create", "get", "update", "watch", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames: ["vmware-system-privileged"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-role
+  namespace: {{ .PVCSINamespace }}
+rules:
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames: ["vmware-system-privileged"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: {{ .PVCSINamespace }}
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-binding
+  namespace: {{ .PVCSINamespace }}
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: {{ .PVCSINamespace }}
+roleRef:
+  kind: Role
+  name: vsphere-csi-node-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: {{ .PVCSINamespace }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: vsphere-csi-controller
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-controller
+        role: vsphere-csi
+    spec:
+      serviceAccountName: vsphere-csi-controller
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - operator: "Exists"
+          key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
+      containers:
+        - name: csi-attacher
+          image: vmware.io/csi-attacher:<image_tag>
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+          imagePullPolicy: "IfNotPresent"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: vsphere-csi-controller
+          image: vmware.io/vsphere-csi:<image_tag>
+          args:
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 2112
+              name: prometheus
+              protocol: TCP
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: CLUSTER_FLAVOR
+              value: "GUEST_CLUSTER"
+            - name: X_CSI_MODE
+              value: "controller"
+            - name: GC_CONFIG
+              value: /etc/cloud/pvcsi-config/cns-csi.conf
+            - name: PROVISION_TIMEOUT_MINUTES
+              value: "4"
+            - name: ATTACHER_TIMEOUT_MINUTES
+              value: "4"
+            - name: RESIZE_TIMEOUT_MINUTES
+              value: "4"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: SUPERVISOR_CLIENT_QPS
+              value: "50"
+            - name: SUPERVISOR_CLIENT_BURST
+              value: "50"
+            - name: INCLUSTER_CLIENT_QPS
+              value: "50"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "50"
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
+          volumeMounts:
+            - mountPath: /etc/cloud/pvcsi-provider
+              name: pvcsi-provider-volume
+              readOnly: true
+            - mountPath: /etc/cloud/pvcsi-config
+              name: pvcsi-config-volume
+              readOnly: true
+            - mountPath: /csi
+              name: socket-dir
+        - name: vsphere-syncer
+          image: vmware.io/syncer:<image_tag>
+          args:
+            - "--leader-election"
+            - "--supervisor-fss-name=csi-feature-states"
+            - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
+          env:
+            - name: FULL_SYNC_INTERVAL_MINUTES
+              value: "30"
+            - name: GC_CONFIG
+              value: /etc/cloud/pvcsi-config/cns-csi.conf
+            - name: CLUSTER_FLAVOR
+              value: "GUEST_CLUSTER"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: CSI_NAMESPACE
+              value: {{ .PVCSINamespace }}
+          volumeMounts:
+          - mountPath: /etc/cloud/pvcsi-provider
+            name: pvcsi-provider-volume
+            readOnly: true
+          - mountPath: /etc/cloud/pvcsi-config
+            name: pvcsi-config-volume
+            readOnly: true
+        - name: liveness-probe
+          image: vmware.io/csi-livenessprobe:<image_tag>
+          args:
+            - "--csi-address=$(ADDRESS)"
+          imagePullPolicy: "IfNotPresent"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: csi-provisioner
+          image: vmware.io/csi-provisioner/csi-provisioner:<image_tag>
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--default-fstype=ext4"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+          imagePullPolicy: "IfNotPresent"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: csi-resizer
+          image: vmware.io/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:<image_tag>
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--handle-volume-inuse-error=false"  # Set this to true if used in vSphere 7.0U1
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+        - name: pvcsi-provider-volume
+          secret:
+            secretName: pvcsi-provider-creds
+        - name: pvcsi-config-volume
+          configMap:
+            name: pvcsi-config
+        - name: socket-dir
+          emptyDir: {}
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi.vsphere.vmware.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-node
+  namespace: {{ .PVCSINamespace }}
+spec:
+  selector:
+    matchLabels:
+      app: vsphere-csi-node
+  updateStrategy:
+    type: "RollingUpdate"
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-node
+        role: vsphere-csi
+    spec:
+      hostNetwork: true
+      dnsPolicy: "ClusterFirstWithHostNet"
+      serviceAccountName: vsphere-csi-node
+      priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
+      containers:
+      - name: node-driver-registrar
+        image: vmware.io/csi-node-driver-registrar:<image_tag>
+        imagePullPolicy: "IfNotPresent"
+        args:
+          - "--v=5"
+          - "--csi-address=$(ADDRESS)"
+          - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          - "--health-port=9809"
+        env:
+          - name: ADDRESS
+            value: /csi/csi.sock
+          - name: DRIVER_REG_SOCK_PATH
+            value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+        volumeMounts:
+          - name: plugin-dir
+            mountPath: /csi
+          - name: registration-dir
+            mountPath: /registration
+        ports:
+          - containerPort: 9809
+            name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+      - name: vsphere-csi-node
+        image: vmware.io/vsphere-csi:<image_tag>
+        args:
+          - "--supervisor-fss-name=csi-feature-states"
+          - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
+        imagePullPolicy: "IfNotPresent"
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        - name: X_CSI_MODE
+          value: "node"
+        - name: X_CSI_SPEC_REQ_VALIDATION
+          value: "false"
+        - name: CLUSTER_FLAVOR
+          value: "GUEST_CLUSTER"
+        - name: LOGGER_LEVEL
+          value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          value: {{ .PVCSINamespace }}
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+        - name: pods-mount-dir
+          mountPath: /var/lib/kubelet
+          mountPropagation: "Bidirectional"
+        - name: device-dir
+          mountPath: /dev
+        - name: blocks-dir
+          mountPath: /sys/block
+        - name: sys-devices-dir
+          mountPath: /sys/devices
+      - name: liveness-probe
+        image: vmware.io/csi-livenessprobe:<image_tag>
+        args:
+        - --csi-address=/csi/csi.sock
+        imagePullPolicy: "IfNotPresent"
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+      volumes:
+      - name: registration-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry
+          type: Directory
+      - name: plugin-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/
+          type: DirectoryOrCreate
+      - name: pods-mount-dir
+        hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+      - name: device-dir
+        hostPath:
+          path: /dev
+      - name: blocks-dir
+        hostPath:
+          path: /sys/block
+          type: Directory
+      - name: sys-devices-dir
+        hostPath:
+          path: /sys/devices
+          type: Directory
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+---
+apiVersion: v1
+data:
+  cns-csi.conf: |
+    [GC]
+    endpoint = "{{ .SupervisorMasterEndpointHostName }}"
+    port = "{{ .SupervisorMasterPort }}"
+    tanzukubernetescluster-uid = "{{ .TanzuKubernetesClusterUID }}"
+    tanzukubernetescluster-name = "{{ .TanzuKubernetesClusterName }}"
+kind: ConfigMap
+metadata:
+  name: pvcsi-config
+  namespace: {{ .PVCSINamespace }}
+---
+apiVersion: v1
+data:
+  "volume-extend": "true"
+  "volume-health": "true"
+  "online-volume-extend": "true"
+  "file-volume": "true"
+  "csi-sv-feature-states-replication": "false"
+  "block-volume-snapshot": "false"
+kind: ConfigMap
+metadata:
+  name: internal-feature-states.csi.vsphere.vmware.com
+  namespace: {{ .PVCSINamespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: {{ .PVCSINamespace }}
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -1,0 +1,383 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods", "configmaps", "resourcequotas", "namespaces", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsnodevmattachments", "cnsvolumemetadatas", "cnsfileaccessconfigs"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnscsisvfeaturestates"]
+    verbs: ["create", "get", "list", "update", "watch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsfilevolumeclients"]
+    verbs: ["get", "update", "create", "delete"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsregistervolumes"]
+    verbs: ["get", "list", "watch", "update", "delete"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["triggercsifullsyncs"]
+    verbs: ["create", "get", "update", "watch", "list"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["storagepools"]
+    verbs: ["get", "watch", "list", "delete", "update", "create", "patch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["vmoperator.vmware.com"]
+    resources: ["virtualmachines"]
+    verbs: ["get", "list"]
+  - apiGroups: ["vmware.com"]
+    resources: ["virtualnetworks"]
+    verbs: ["get"]
+  - apiGroups: ["netoperator.vmware.com"]
+    resources: ["networkinterfaces"]
+    verbs: ["get"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvolumeoperationrequests"]
+    verbs: ["create", "get", "list", "update", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: vmware-system-csi
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csiRole
+  namespace: vmware-system-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: wcp-privileged-psp
+subjects:
+  # For the vmware-system-csi nodes.
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts:vmware-system-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: vmware-system-csi
+  name: vsphere-csi-secret-reader
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vsphere-csi-provisioner-secret-binding
+  namespace: vmware-system-csi
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: vmware-system-csi
+roleRef:
+  kind: Role
+  name: vsphere-csi-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vsphere-csi-controller
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-controller
+        role: vsphere-csi
+    spec:
+      serviceAccount: vsphere-csi-controller
+      nodeSelector:
+        node-role.kubernetes.io/master: ''
+      tolerations:
+        - operator: "Exists"
+          key: "node-role.kubernetes.io/master"
+          effect: "NoSchedule"
+        - operator: "Equal"
+          key: "kubeadmNode"
+          effect: "NoSchedule"
+          value: "master"
+      hostNetwork: true
+      containers:
+        - name: csi-provisioner
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.5
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--feature-gates=Topology=true"
+            - "--strict-topology"
+            - "--leader-election"
+            - "--enable-hostlocal-placement=true"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+            - "--default-fstype=ext4"
+            - "--use-service-for-placement-engine=false"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_PORT
+              value: "29000"
+            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAME # service name to be used by csi-provisioner to connect to placement engine
+              value: vmware-system-psp-operator-k8s-cloud-operator-service
+            - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAMESPACE # namespace for service name to be used by csi-provisioner to connect to placement engine
+              value: vmware-system-appplatform-operator-system                
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-attacher
+          image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-resizer
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=4
+            - --timeout=300s
+            - --handle-volume-inuse-error=false  # Set this to true if used in vSphere 7.0U1
+            - --csi-address=$(ADDRESS)
+            - --leader-election
+            - --kube-api-qps=100
+            - --kube-api-burst=100
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: vsphere-csi-controller
+          image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
+          ports:
+           - containerPort: 2112
+             name: prometheus
+             protocol: TCP
+           - name: healthz
+             containerPort: 9808
+             protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: CLUSTER_FLAVOR
+              value: "WORKLOAD"
+            - name: X_CSI_MODE
+              value: "controller"
+            - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
+              value: 3m
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+            - name: POD_LISTENER_SERVICE_PORT
+              value: "29000"
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "50"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "50"
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - mountPath: /etc/vmware/wcp
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /etc/vmware/wcp/tls/
+              name: host-vmca
+        - name: liveness-probe
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
+          args:
+            - "--csi-address=/csi/csi.sock"
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: vsphere-syncer
+          image: localhost:5000/vmware/syncer:<syncer_ver>
+          args:
+            - "--leader-election"
+          env:
+            - name: CLUSTER_FLAVOR
+              value: "WORKLOAD"
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+            - name: FULL_SYNC_INTERVAL_MINUTES
+              value: "30"
+            - name: VOLUME_HEALTH_INTERVAL_MINUTES
+              value: "5"
+            - name: POD_POLL_INTERVAL_SECONDS
+              value: "2"
+            - name: POD_LISTENER_SERVICE_PORT
+              value: "29000"
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/vmware/wcp/vsphere-cloud-provider.conf" # here vsphere-cloud-provider.conf is the name of the file used for creating secret using "--from-file" flag
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "50"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "50"
+          imagePullPolicy: "IfNotPresent"
+          ports:
+           - containerPort: 2113
+             name: prometheus
+             protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/vmware/wcp
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /etc/vmware/wcp/tls/
+              name: host-vmca
+      volumes:
+        - name: vsphere-config-volume
+          secret:
+            secretName: vsphere-config-secret
+        - name: socket-dir
+          emptyDir: {}
+        - name: host-vmca
+          hostPath:
+            path: /etc/vmware/wcp/tls/
+            type: Directory
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: csi.vsphere.vmware.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+---
+apiVersion: v1
+data:
+  "volume-extend": "true"
+  "volume-health": "true"
+  "online-volume-extend": "true"
+  "file-volume": "true"
+  "csi-auth-check": "true"
+  "vsan-direct-disk-decommission": "false"
+  "trigger-csi-fullsync": "false"
+  "csi-sv-feature-states-replication": "true"
+  "fake-attach": "true"
+  "async-query-volume": "false"
+  "improved-csi-idempotency": "false"
+  "block-volume-snapshot": "false"
+  "sibling-replica-bound-pvc-check": "true"
+kind: ConfigMap
+metadata:
+  name: csi-feature-states
+  namespace: vmware-system-csi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller
+  type: LoadBalancer


### PR DESCRIPTION
**What this PR does / why we need it**:
Add CSI driver manifests for Supervisor and Guestclusters

**Testing done**:
None

```release-note
Add manifests for 1.22 K8s for Supervisor and Guestclusters
```
