### PR TITLE
add cnsvolumeoperationrequests.yaml and cnsvspherevolumemigrations.yaml to driver image

### DIFF
--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -74,4 +74,8 @@ RUN tdnf clean all
 
 COPY --from=builder /build/vsphere-csi /bin/vsphere-csi
 
+RUN mkdir -p config
+ADD pkg/internalapis/cnsvolumeoperationrequest/config/cns.vmware.com_cnsvolumeoperationrequests.yaml /config/
+ADD pkg/apis/migration/config/cns.vmware.com_cnsvspherevolumemigrations.yaml /config/
+
 ENTRYPOINT ["/bin/vsphere-csi"]


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is adding pkg/internalapis/cnsvolumeoperationrequest/config/cns.vmware.com_cnsvolumeoperationrequests.yaml and pkg/apis/migration/config/cns.vmware.com_cnsvspherevolumemigrations.yaml files in the driver image.

These files are read by the controller to create CR.

If these files are not present in the driver image, the driver container is crashing.

```
2021-10-17T04:18:49.278Z	INFO	vanilla/controller.go:102	CSI Volume manager idempotency handling feature flag is enabled.	{"TraceId": "633ddad2-dbb6-4bcb-a344-9d3b3bcfabc8"}
2021-10-17T04:18:49.279Z	INFO	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:78	Creating CnsVolumeOperationRequest definition on API server and initializing VolumeOperationRequest instance	{"TraceId": "633ddad2-dbb6-4bcb-a344-9d3b3bcfabc8"}
2021-10-17T04:18:49.281Z	ERROR	kubernetes/kubernetes.go:491	Manifest file: /config/cns.vmware.com_cnsvolumeoperationrequests.yaml doesn't exist. Error: open /config/cns.vmware.com_cnsvolumeoperationrequests.yaml: no such file or directory	{"TraceId": "633ddad2-dbb6-4bcb-a344-9d3b3bcfabc8"}
sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes.getCRDFromManifest
 /build/pkg/kubernetes/kubernetes.go:491
sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes.CreateCustomResourceDefinitionFromManifest
 /build/pkg/kubernetes/kubernetes.go:388
sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest.InitVolumeOperationRequestInterface
 /build/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:81
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).Init
 /build/pkg/csi/service/vanilla/controller.go:103
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service.(*vsphereCSIDriver).BeforeServe
 /build/pkg/csi/service/driver.go:142
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service.(*vsphereCSIDriver).Run
 /build/pkg/csi/service/driver.go:156
main.main
 /build/cmd/vsphere-csi/main.go:90
runtime.main
 /usr/local/go/src/runtime/proc.go:225
```


**Testing done**:
After this change, the driver image has required YAML files to create CRDs

```
% exec kubectl exec -i -t -n vmware-system-csi vsphere-csi-controller-78f7d4fcfc-9wgw2 -c vsphere-csi-controller "--" sh -c "clear; (bash || ash || sh)"
'xterm': unknown terminal type.
root [ / ]# pwd
/
root [ / ]# cd /config/
root [ /config ]# ls
cns.vmware.com_cnsvolumeoperationrequests.yaml  cns.vmware.com_cnsvspherevolumemigrations.yaml
```

controller is no longer crashing when `improved-idempotency` feature is enabled.


```
{"level":"info","time":"2021-10-17T17:24:43.01553213Z","caller":"vanilla/controller.go:102","msg":"CSI Volume manager idempotency handling feature flag is enabled.","TraceId":"ae092428-7eb4-4288-a657-f3db933d21b8"}
{"level":"info","time":"2021-10-17T17:24:43.015573168Z","caller":"cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:78","msg":"Creating CnsVolumeOperationRequest definition on API server and initializing VolumeOperationRequest instance","TraceId":"ae092428-7eb4-4288-a657-f3db933d21b8"}
{"level":"info","time":"2021-10-17T17:24:43.022502665Z","caller":"kubernetes/kubernetes.go:86","msg":"k8s client using in-cluster config","TraceId":"ae092428-7eb4-4288-a657-f3db933d21b8"}
{"level":"info","time":"2021-10-17T17:24:43.022775488Z","caller":"kubernetes/kubernetes.go:353","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"ae092428-7eb4-4288-a657-f3db933d21b8"}
{"level":"info","time":"2021-10-17T17:24:43.045745643Z","caller":"kubernetes/kubernetes.go:434","msg":"\"cnsvolumeoperationrequests.cns.vmware.com\" CRD updated successfully","TraceId":"ae092428-7eb4-4288-a657-f3db933d21b8"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add cnsvolumeoperationrequests.yaml and cnsvspherevolumemigrations.yaml to driver image
```
