### PR TITLE
Update known issue docs for VC IP & hostname change not honored by CSI

### DIFF
--- a/docs/book/releases/v2.0.0.md
+++ b/docs/book/releases/v2.0.0.md
@@ -77,7 +77,7 @@
 9. vSAN file share volumes (ReadWriteMany/ ReadOnlyMany vSphere CSI Volumes) become inaccessible after vSphere CSI driver Node DaemonSet Pod restarts.
     - Impact: Pod can not write/read data on vSAN file share volumes
     - Workaround: Remount vSAN file services volumes used by the application pods at the same location from the Node VM Guest OS directly. Detailed steps are available [here](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/upgrade.html#if-you-have-rwm-volumes-backed-by-vsan-file-service-deployed-using-vsphere-csi-driver-please-refer-to-the-following-steps-before-upgrading-vsphere-csi-driver).
-10. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
+10. `user`, `ca-file` and `VirtualCenter` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
     - Impact: Volume lifecycle operations fail until the controller pod restarts.
     - Workaround: Restart `vsphere-csi-controller` deployment Pod.
 11. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.

--- a/docs/book/releases/v2.0.1.md
+++ b/docs/book/releases/v2.0.1.md
@@ -56,7 +56,7 @@
 7. vSAN file share volumes (ReadWriteMany/ ReadOnlyMany vSphere CSI Volumes) become inaccessible after vSphere CSI driver Node DaemonSet Pod restarts.
    - Impact: Pod can not write/read data on vSAN file share volumes
    - Workaround: Remount vSAN file services volumes used by the application pods at the same location from the Node VM Guest OS directly. Detailed steps are available [here](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/upgrade.html#if-you-have-rwm-volumes-backed-by-vsan-file-service-deployed-using-vsphere-csi-driver-please-refer-to-the-following-steps-before-upgrading-vsphere-csi-driver).
-8. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
+8. `user`, `ca-file` and `VirtualCenter` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
    - Impact: Volume lifecycle operations fail until the controller pod restarts.
    - Workaround: Restart `vsphere-csi-controller` deployment Pod.
 9. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.

--- a/docs/book/releases/v2.1.0.md
+++ b/docs/book/releases/v2.1.0.md
@@ -61,7 +61,7 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
 10. vSAN file share volumes (ReadWriteMany/ ReadOnlyMany vSphere CSI Volumes) become inaccessible after vSphere CSI driver Node DaemonSet Pod restarts.
     - Impact: Pod can not write/read data on vSAN file share volumes
     - Workaround: Remount vSAN file services volumes used by the application pods at the same location from the Node VM Guest OS directly. Detailed steps are available [here](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/upgrade.html#if-you-have-rwm-volumes-backed-by-vsan-file-service-deployed-using-vsphere-csi-driver-please-refer-to-the-following-steps-before-upgrading-vsphere-csi-driver).
-11. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
+11. `user`, `ca-file` and `VirtualCenter` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
     - Impact: Volume lifecycle operations fail until the controller pod restarts.
     - Workaround: Restart `vsphere-csi-controller` deployment Pod.
 12. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.

--- a/docs/book/releases/v2.1.1.md
+++ b/docs/book/releases/v2.1.1.md
@@ -62,7 +62,7 @@ Note: For vSphere CSI Migration feature the minimum Kubernetes version requireme
 9. vSAN file share volumes (ReadWriteMany/ ReadOnlyMany vSphere CSI Volumes) become inaccessible after vSphere CSI driver Node DaemonSet Pod restarts.
    - Impact: Pod can not write/read data on vSAN file share volumes
    - Workaround: Remount vSAN file services volumes used by the application pods at the same location from the Node VM Guest OS directly. Detailed steps are available [here](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/upgrade.html#if-you-have-rwm-volumes-backed-by-vsan-file-service-deployed-using-vsphere-csi-driver-please-refer-to-the-following-steps-before-upgrading-vsphere-csi-driver).
-10. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
+10. `user`, `ca-file` and `VirtualCenter` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
     - Impact: Volume lifecycle operations fail until the controller pod restarts.
     - Workaround: Restart `vsphere-csi-controller` deployment Pod.
 11. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.

--- a/docs/book/releases/v2.2.0.md
+++ b/docs/book/releases/v2.2.0.md
@@ -53,7 +53,7 @@
 4. vSAN file share volumes (ReadWriteMany/ ReadOnlyMany vSphere CSI Volumes) become inaccessible after vSphere CSI driver Node DaemonSet Pod restarts.
     - Impact: Pod can not write/read data on vSAN file share volumes
     - Workaround: Remount vSAN file services volumes used by the application pods at the same location from the Node VM Guest OS directly. Detailed steps are available [here](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/upgrade.html#if-you-have-rwm-volumes-backed-by-vsan-file-service-deployed-using-vsphere-csi-driver-please-refer-to-the-following-steps-before-upgrading-vsphere-csi-driver).
-5. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
+5. `user`, `ca-file` and `VirtualCenter` in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
     - Impact: Volume lifecycle operations fail until the controller pod restarts.
     - Workaround: Restart `vsphere-csi-controller` deployment Pod.
 6. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.

--- a/docs/book/releases/v2.2.1.md
+++ b/docs/book/releases/v2.2.1.md
@@ -45,7 +45,7 @@
 4. vSAN file share volumes (ReadWriteMany/ ReadOnlyMany vSphere CSI Volumes) become inaccessible after vSphere CSI driver Node DaemonSet Pod restarts.
    - Impact: Pod can not write/read data on vSAN file share volumes
    - Workaround: Remount vSAN file services volumes used by the application pods at the same location from the Node VM Guest OS directly. Detailed steps are available [here](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/upgrade.html#if-you-have-rwm-volumes-backed-by-vsan-file-service-deployed-using-vsphere-csi-driver-please-refer-to-the-following-steps-before-upgrading-vsphere-csi-driver).
-5. `user` and `ca-file` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
+5. `user`, `ca-file` and `VirtualCenter` change in the [vsphere-config-secret](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html#create-a-configuration-file-with-vsphere-credentials-) is not honored until vSphere CSI Controller Pod restarts.
    - Impact: Volume lifecycle operations fail until the controller pod restarts.
    - Workaround: Restart `vsphere-csi-controller` deployment Pod.
 6. vCenter restart may leave Kubernetes persistent volume claims in the Pending state.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Documenting the known issue - changes to VC IP or FQDN in vsphere-config-secret leaves volume operations in failed state.
Workaround - restart CSI driver.
This is addressed by extending the already documented known issues related to changes in other fields of vsphere-config-secret

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update known issue docs for VC IP & hostname change not honored by CSI
```
