### PR TITLE
Update release script to use correct release version for csi driver images

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -41,7 +41,7 @@ PUSH=
 LATEST=
 CSI_IMAGE_NAME=
 SYNCER_IMAGE_NAME=
-VERSION=$(git log -1 --format=%h)
+VERSION=$(git describe --dirty --always 2>/dev/null)
 GCR_KEY_FILE="${GCR_KEY_FILE:-}"
 GOPROXY="${GOPROXY:-https://proxy.golang.org}"
 BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR updates release script to use correct release version for csi driver images

-> make images
```
$  make images
hack/release.sh
building gcr.io/cloud-provider-vsphere/csi/ci/driver:v2.4.0-rc.1-dirty for linux
error: no builder "vsphere-csi-builder-win" found
builder instance not found, safe to proceed
[+] Building 145.1s (15/20)                                                                                                                                                                      
 => => sha256:1c50b5b0f7f6634e622d2cf8dd831cabde607e662e4fd08233bd93cfa0b985ee 1.96kB / 1.96kB                                                                                              0.0s
 => => sha256:55de889bd7054c3431b5c9d1410084d436bf9381a304b7f95b7dc911401d5188 15.97MB / 15.97MB                                                                                            1.9s
 => => sha256:d766849d39eee5a8ad04597c23a220b26b767c3cb71e06cfc70c1c04b1150c77 460.69kB / 460.69kB                                                                                          0.8s
 => => extracting sha256:55de889bd7054c3431b5c9d1410084d436bf9381a304b7f95b7dc911401d5188                                                                                                   0.8s
 => => extracting sha256:d766849d39eee5a8ad04597c23a220b26b767c3cb71e06cfc70c1c04b1150c77                                                                                                   0.1s
 => CACHED [builder 2/6] WORKDIR /build                                                                                                                                                     0.0s
 => [builder 3/6] COPY go.mod go.sum ./                                                                                                                                                     0.1s
 => [builder 4/6] COPY pkg/    pkg/                                                                                                                                                         0.1s
 => [builder 5/6] COPY cmd/    cmd/                                                                                                                                                         0.1s
 => [builder 6/6] RUN go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service.Version=v2.4.0-rc.1-dirty" -o vsphere-csi ./cmd/vsphere-csi   
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Mentioned above^^

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update release script to use correct release version for csi driver images
```
