### PR TITLE
Cherry-pick #1350: Set default mount options for file volumes

### DIFF
--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -39,9 +39,6 @@ import (
 
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
-	csitypes "sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types"
-
-	cnstypes "github.com/vmware/govmomi/cns/types"
 )
 
 const (
@@ -49,6 +46,9 @@ const (
 	blockPrefix = "wwn-0x"
 	dmiDir      = "/sys/class/dmi"
 )
+
+// defaultFileMountOptions are the mount flag options used by default while publishing a file volume.
+var defaultFileMountOptions = []string{"hard", "sec=sys", "vers=4", "minorversion=1"}
 
 // NewOsUtils creates OsUtils with a linux specific mounter
 func NewOsUtils(ctx context.Context) (*OsUtils, error) {
@@ -566,9 +566,8 @@ func (osUtils *OsUtils) PublishFileVol(
 	if params.Ro {
 		mntFlags = append(mntFlags, "ro")
 	}
-	if cnstypes.CnsClusterFlavor(os.Getenv(csitypes.EnvClusterFlavor)) == cnstypes.CnsClusterFlavorGuest {
-		mntFlags = append(mntFlags, "hard")
-	}
+	// Add defaultFileMountOptions to the mntFlags.
+	mntFlags = append(mntFlags, defaultFileMountOptions...)
 	// Retrieve the file share access point from publish context.
 	mntSrc, ok := req.GetPublishContext()[common.Nfsv4AccessPoint]
 	if !ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Cherry pick PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1350 to release 2.4 branch

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: Testing is already done in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1350 PR.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add default mount options while publishing a file volume

```
