### PR TITLE
static fileshare volume provisioning without fstype

### DIFF
--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -329,7 +329,7 @@ func getVolumeSpecs(ctx context.Context, pvList []*v1.PersistentVolume, pvToCnsE
 		switch operationType {
 		case "createVolume":
 			var volumeType string
-			if pv.Spec.CSI.FSType == common.NfsV4FsType || pv.Spec.CSI.FSType == common.NfsFsType {
+			if IsMultiAttachAllowed(pv) {
 				volumeType = common.FileVolumeType
 			} else {
 				volumeType = common.BlockVolumeType

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -702,7 +702,7 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 	volumeOperationsLock.Lock()
 	defer volumeOperationsLock.Unlock()
 
-	if pv.Spec.CSI.FSType == common.NfsV4FsType || pv.Spec.CSI.FSType == common.NfsFsType {
+	if IsMultiAttachAllowed(pv) {
 		log.Debugf("PVDeleted: vSphere CSI Driver is calling UpdateVolumeMetadata to delete volume metadata references for PV: %q", pv.Name)
 		var metadataList []cnstypes.BaseCnsEntityMetadata
 		pvMetadata := cnsvsphere.GetCnsKubernetesEntityMetaData(pv.Name, nil, true, string(cnstypes.CnsKubernetesEntityTypePV), "", metadataSyncer.configInfo.Cfg.Global.ClusterID, nil)

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -95,3 +95,20 @@ func getQueryResults(ctx context.Context, volumeIds []cnstypes.CnsVolumeId, clus
 	}
 	return allQueryResults, nil
 }
+
+// IsMultiAttachAllowed helps check accessModes on the PV and return true if volume can be attached to
+// multiple nodes.
+func IsMultiAttachAllowed(pv *v1.PersistentVolume) bool {
+	if pv == nil {
+		return false
+	}
+	if len(pv.Spec.AccessModes) == 0 {
+		return false
+	}
+	for _, accessMode := range pv.Spec.AccessModes {
+		if accessMode == v1.ReadWriteMany || accessMode == v1.ReadOnlyMany {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is cherry-picking https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/345 to release-2.0 branch for 2.0.2 release.


**Which issue this PR fixes**
Refer to https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/345

**Testing done**:
In progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
static fileshare volume provisioning without fstype
```
