### PR TITLE
update provisioner image in 1.19 supervisor cluster

### DIFF
--- a/manifests/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.19/cns-csi.yaml
@@ -158,7 +158,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.5
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -170,6 +170,7 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--default-fstype=ext4"
+            - "--use-service-for-placement-engine=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This fix addresses bug #2855574. After provisioner image update in supervisor cluster, wcp upgrade using kubernetes 1.19 is failing. It is because changes were not done to 1.19 yamls.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
ran make build, make test and wcp precheckin pipelines. Have checked the controller deployment after manually replacing the images.

**Special notes for your reviewer**:

**Release note**:
```
change 1.19 supervisor csi deployment to use new version of provisioner image
```
