### PR TITLE
add documentation for windows support

### DIFF
--- a/docs/book/SUMMARY.md
+++ b/docs/book/SUMMARY.md
@@ -27,6 +27,7 @@
   * [Volume Expansion](features/volume_expansion.md)
   * [Volume Topology](features/volume_topology.md)
   * [vSphere CSI Migration](features/vsphere_csi_migration.md)
+  * [vSphere CSI on Windows](features/csi_driver_on_windows.md)
 * [Known Issues](known_issues.md)
 * [Troubleshooting](troubleshooting.md)
 * [Development](development.md)

--- a/docs/book/features/csi_driver_on_windows.md
+++ b/docs/book/features/csi_driver_on_windows.md
@@ -1,0 +1,165 @@
+<!-- markdownlint-disable MD033 -->
+<!-- markdownlint-disable MD034 -->
+# vSphere CSI Driver - Windows Support
+
+- [Introduction](#introduction)
+- [Prerequisite](#prereq)
+- [How to enable vSphere CSI with windows nodes](#how-to-enable-vsphere-csi-win)
+- [Examples to Deploy a Windows pod with PVC mount](#examples)
+
+## Introduction <a id="introduction"></a>
+
+Windows node support will be added in vSphere CSI driver 2.4 as an [Alpha feature](https://vsphere-csi-driver.sigs.k8s.io/supported_features_matrix.html#alpha).
+
+Following features are not supported for Windows Node:
+
+1. ReadWriteMany volumes based on vSAN file service are not supported on Windows Node.
+2. [Raw Block Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#raw-block-volume-support) are not supported.
+3. Windows Nodes will be used as Worker nodes only. vSphere CSI will not support a `mixture of Linux worker nodes and Windows Worker Nodes`.
+
+## Prerequisite <a id="prereq"></a>
+
+In addition to prerequisites mentioned [here](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/prerequisites.html), following needs to be fullfilled to support windows in vSphere CSI:
+
+1. Minimum kubernetes version required is 1.20.
+2. Minimum vSphere CSI driver version required is 2.4.
+3. Master nodes should be running Linux.
+4. Worker nodes should have Windows server 2019. Other windows server version are not supported. Please refer [this](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/)
+5. if containerd is used in nodes, containerd version should be greater than or equal to 1.5, refer: https://github.com/containerd/containerd/issues/5405
+6. `CSI Proxy` should be installed in each of the Windows nodes. To install csi proxy follow steps from https://github.com/kubernetes-csi/csi-proxy#installation
+
+## How to enable vSphere CSI with Windows nodes <a id="how-to-enable-vsphere-csi-win"></a>
+
+- Install vSphere CSI driver 2.4 by following https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html
+- To enable windows support, patch the configmap to enable csi-windows-support feature switch by running following command:
+  
+  ```bash
+  kubectl patch configmap/internal-feature-states.csi.vsphere.vmware.com \
+  -n vmware-system-csi \
+  --type merge \
+  -p '{"data":{"csi-windows-support":"true"}}'
+  ```
+
+- vSphere CSI driver 2.4 will introduce a new node daemonset which will be running on all windows nodes. To verify this run:
+
+  ```bash
+  $ kubectl get daemonsets vsphere-csi-node-windows --namespace=vmware-system-csi
+  NAME                       DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR              AGE
+  vsphere-csi-node-windows   1         1         1       1            1           kubernetes.io/os=windows   7m10s
+  ```
+
+## Examples <a id="examples"></a>
+
+- Define a storage class example-windows-sc.yaml as defined [here](https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/example/vanilla-k8s-RWO-filesystem-volumes/example-windows-sc.yaml)
+
+  ```bash
+  kind: StorageClass
+  apiVersion: storage.k8s.io/v1
+  metadata:
+    name: example-windows-sc
+  provisioner: csi.vsphere.vmware.com
+  allowVolumeExpansion: true  # Optional: only applicable to vSphere 7.0U1 and above
+  parameters:
+    storagepolicyname: "vSAN Default Storage Policy"  # Optional Parameter
+    #datastoreurl: "ds:///vmfs/volumes/vsan:52cdfa80721ff516-ea1e993113acfc77/"  # Optional Parameter
+    #csi.storage.k8s.io/fstype: "ntfs"  # Optional Parameter
+  ```
+
+  'csi.storage.k8s.io/fstype' is an optional parameter. From the Windows file systems, only ntfs can be set to its value, as vSphere CSI Driver can only support the NTFS filesystem on Windows Nodes.
+  
+- Import this `StorageClass` into `Vanilla Kubernetes` cluster:
+  
+  ```bash
+  kubectl create -f example-sc.yaml
+  ```
+
+- Define a `PersistentVolumeClaim` request example-windows-pvc.yaml as shown in the spec [here](https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/example/vanilla-k8s-RWO-filesystem-volumes/example-windows-pvc.yaml)
+  
+  ```bash
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: example-windows-pvc
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 5Gi
+    storageClassName: example-windows-sc
+    volumeMode: Filesystem
+  ```
+  
+  The pvc definition is same as Linux and only 'ReadWriteOnce' can be specified as accessModes.
+
+- Import this `PersistentVolumeClaim` into `Vanilla Kubernetes` cluster:
+
+    ```bash
+    kubectl create -f example-windows-pvc.yaml
+    ```
+
+- Verify a `PersistentVolume` was created successfully
+  
+  The `Status` should say `Bound`.
+  
+  ```bash
+  $ kubectl describe pvc example-windows-pvc
+  Name:          example-windows-pvc
+  Namespace:     default
+  StorageClass:  example-windows-sc
+  Status:        Bound
+  Volume:        pvc-e64e0716-ff63-47b8-8ee4-d1eb4f86dcd7
+  Labels:        <none>
+  Annotations:   pv.kubernetes.io/bind-completed: yes
+                pv.kubernetes.io/bound-by-controller: yes
+                volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
+  Finalizers:    [kubernetes.io/pvc-protection]
+  Capacity:      5Gi
+  Access Modes:  RWO
+  VolumeMode:    Filesystem
+  Used By:       example-windows-pod
+  Events:        <none>
+  ```
+
+- To use the above pvc in a Windows pod, you can create a pod spec example-windows-pod.yaml like [this](https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/example/vanilla-k8s-RWO-filesystem-volumes/example-windows-pod.yaml)
+  
+  ```bash
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: example-windows-pod
+  spec:
+    nodeSelector:
+      kubernetes.io/os: windows
+    containers:
+      - name: test-container
+        image: mcr.microsoft.com/windows/servercore:ltsc2019
+        command:
+          - "powershell.exe"
+          - "-Command"
+          - "while (1) { Add-Content -Encoding Ascii C:\\test\\data.txt $(Get-Date -Format u); sleep 1 }"
+        volumeMounts:
+          - name: test-volume
+            mountPath: "/test/"
+            readOnly: false
+    volumes:
+      - name: test-volume
+        persistentVolumeClaim:
+          claimName: example-windows-pvc
+  ```
+
+- Create the pod
+  
+  ```bash
+  kubectl create -f example-windows-pod.yaml
+  ```
+
+- Verify pod was created succussfully
+  
+  ```bash
+  $ kubectl get pod example-windows-pod
+  NAME                  READY   STATUS    RESTARTS   AGE
+  example-windows-pod   1/1     Running   0          4m13s
+  ```
+  
+  In this example, example-windows-pvc is formatted as NTFS file system and is mounted to "C:\\test" directory.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds documentation for windows container support in vSphere CSI. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

```
make build
make check
hack/check-format.sh
go get: installing executables with 'go get' in module mode is deprecated.
..
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
...
go get: upgraded honnef.co/go/tools v0.0.1-2020.1.3 => v0.2.0
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/nigupta/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/nigupta/work/vsphere-csi-driver-forked /Users/nigupta/work /Users/nigupta /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|types_sizes|files|imports|name) took 3.666346549s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 76.351718ms
INFO [linters context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 111, after processing: 0
INFO [runner] Processors filtering stat (out/in): exclude-rules: 1/22, skip_files: 111/111, filename_unadjuster: 111/111, path_prettifier: 111/111, skip_dirs: 111/111, autogenerated_exclude: 22/111, identifier_marker: 22/22, exclude: 22/22, nolint: 0/1, cgo: 111/111
INFO [runner] processing took 12.332833ms with stages: nolint: 10.245598ms, autogenerated_exclude: 1.0812ms, path_prettifier: 462.105µs, identifier_marker: 263.6µs, skip_dirs: 128.875µs, exclude-rules: 119.403µs, cgo: 15.685µs, filename_unadjuster: 10.657µs, max_from_linter: 1.984µs, max_same_issues: 999ns, uniq_by_line: 476ns, source_code: 375ns, diff: 326ns, severity-rules: 272ns, exclude: 246ns, max_per_file_from_linter: 225ns, skip_files: 216ns, sort_results: 208ns, path_shortener: 202ns, path_prefixer: 181ns
INFO [runner] linters took 2.189319308s with stages: goanalysis_metalinter: 2.1768951s
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 61 samples, avg is 99.1MB, max is 140.8MB
INFO Execution took 5.946941695s
```
**Special notes for your reviewer**:
Preview - https://deploy-preview-1366--kubernetes-sigs-vsphere-csi-driver.netlify.app/features/csi_driver_on_windows.html 

**Release note**:
``` 
Add documentation for windows support
```
