### PR TITLE
Update Makefile to use correct release version for csi driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,17 @@ deps:
 ##                                VERSIONS                                    ##
 ################################################################################
 # Ensure the version is injected into the binaries via a linker flag.
-export VERSION ?= $(git describe --dirty --always 2>/dev/null)
+# From users' perspective, a tag makes more sense than a commit ID. When we check the
+# CSI Driver's version from the log, it's not convenient to see a commit ID, because
+# each time we need to find out the related tag so as to confirm the human readable version.
+#
+# So we only use the commit id as the version for the binaries built from master branch,
+# and use the tag as the version for any release branches.
+ifeq ($(shell git rev-parse --abbrev-ref HEAD), master)
+VERSION := $(shell git log -1 --format=%h)
+else
+VERSION := $(shell git describe --dirty --always 2>/dev/null)
+endif
 
 .PHONY: version
 version:


### PR DESCRIPTION
The version in the csi-controller's log is still a commit id, for example, 
`{"level":"info","time":"2021-10-22T00:34:50.7285343Z","caller":"vsphere-csi/main.go:57","msg":"Version : b56e4ce","TraceId":"fa8e0fbd-987f-46e7-9086-6e6a55e80e3e"}
`
This PR is to update the Makefile to use correct release version for csi driver. 

The [commit](https://github.com/kubernetes-sigs/vsphere-csi-driver/commit/b56e4cecf627d17d94353ac554cf9de54a5c9078) only updates hack/release.sh, we should update the Makefile as well. 