### PR TITLE
embed CRD manifests within binary

### DIFF
--- a/cmd/vsphere-csi/main.go
+++ b/cmd/vsphere-csi/main.go
@@ -23,7 +23,6 @@ import (
 	"os"
 
 	"github.com/rexray/gocsi"
-
 	csiconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/provider"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service"

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/yaml.v2 v2.4.0
+	honnef.co/go/tools v0.2.0 // indirect
 	k8s.io/api v0.21.1
 	k8s.io/apiextensions-apiserver v0.21.1
 	k8s.io/apimachinery v0.21.1

--- a/go.sum
+++ b/go.sum
@@ -788,6 +788,7 @@ golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1111,6 +1112,8 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
+honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 k8s.io/api v0.21.1 h1:94bbZ5NTjdINJEdzOkpS4vdPhkb1VFpTYC9zh43f75c=
 k8s.io/api v0.21.1/go.mod h1:FstGROTmsSHBarKc8bylzXih8BLNYTiS3TZcsoEDg2s=
 k8s.io/apiextensions-apiserver v0.21.1 h1:AA+cnsb6w7SZ1vD32Z+zdgfXdXY8X9uGX5bN6EoPEIo=

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -54,8 +54,6 @@ ARG GIT_COMMIT
 LABEL git_commit=$GIT_COMMIT
 LABEL "maintainers"="Divyen Patel <divyenp@vmware.com>, Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>, Xing Yang <yangxi@vmware.com>"
 
-ADD pkg/apis/migration/config/cns.vmware.com_cnsvspherevolumemigrations.yaml /config/
-
 # install nfs-utils, util-linux and e2fsprogs
 # nfs-utils  : The nfs-utils package contains simple nfs client service.
 # util-linux : Utilities for handling file systems, consoles, partitions.
@@ -73,9 +71,5 @@ RUN tdnf -y install \
 RUN tdnf clean all
 
 COPY --from=builder /build/vsphere-csi /bin/vsphere-csi
-
-RUN mkdir -p config
-ADD pkg/internalapis/cnsvolumeoperationrequest/config/cns.vmware.com_cnsvolumeoperationrequests.yaml /config/
-ADD pkg/apis/migration/config/cns.vmware.com_cnsvspherevolumemigrations.yaml /config/
 
 ENTRYPOINT ["/bin/vsphere-csi"]

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -56,28 +56,4 @@ LABEL git_commit=$GIT_COMMIT
 
 COPY --from=builder /build/vsphere-syncer /bin/vsphere-syncer
 
-RUN mkdir -p config
-
-ADD pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmattachments.yaml /config/
-
-ADD pkg/apis/cnsoperator/config/cns.vmware.com_cnsvolumemetadata.yaml /config/
-
-ADD pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml /config/
-
-ADD pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml /config/
-
-ADD pkg/apis/storagepool/config/cns.vmware.com_storagepools.yaml /config/
-
-ADD pkg/internalapis/cnsoperator/config/cnsfilevolumeclient_crd.yaml /config/
-
-ADD pkg/internalapis/cnsoperator/config/triggercsifullsync_crd.yaml /config/
-
-ADD pkg/internalapis/cnsvolumeoperationrequest/config/cns.vmware.com_cnsvolumeoperationrequests.yaml /config/
-
-ADD pkg/internalapis/csinodetopology/config/cns.vmware.com_csinodetopologies.yaml /config/
-
-ADD pkg/internalapis/featurestates/config/cns.vmware.com_cnscsisvfeaturestates.yaml /config/
-
-ADD pkg/apis/migration/config/cns.vmware.com_cnsvspherevolumemigrations.yaml /config/
-
 ENTRYPOINT ["/bin/vsphere-syncer"]

--- a/pkg/apis/cnsoperator/config/config.go
+++ b/pkg/apis/cnsoperator/config/config.go
@@ -1,0 +1,23 @@
+package config
+
+import "embed"
+
+//go:embed cns.vmware.com_cnsnodevmattachments.yaml
+var EmbedCnsNodeVmAttachmentCRFile embed.FS
+
+const EmbedCnsNodeVmAttachmentCRFileName = "cns.vmware.com_cnsnodevmattachments.yaml"
+
+//go:embed cns.vmware.com_cnsvolumemetadata.yaml
+var EmbedCnsVolumeMetadataCRFile embed.FS
+
+const EmbedCnsVolumeMetadataCRFileName = "cns.vmware.com_cnsvolumemetadata.yaml"
+
+//go:embed cnsfileaccessconfig_crd.yaml
+var EmbedCnsFileAccessConfigCRFile embed.FS
+
+const EmbedCnsFileAccessConfigCRFileName = "cnsfileaccessconfig_crd.yaml"
+
+//go:embed cnsregistervolume_crd.yaml
+var EmbedCnsRegisterVolumeCRFile embed.FS
+
+const EmbedCnsRegisterVolumeCRFileName = "cnsregistervolume_crd.yaml"

--- a/pkg/apis/migration/config/config.go
+++ b/pkg/apis/migration/config/config.go
@@ -1,0 +1,8 @@
+package config
+
+import "embed"
+
+//go:embed cns.vmware.com_cnsvspherevolumemigrations.yaml
+var EmbedCnsVSphereVolumeMigrationFile embed.FS
+
+const EmbedCnsVSphereVolumeMigrationFileName = "cns.vmware.com_cnsvspherevolumemigrations.yaml"

--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	migrationconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config"
 
 	migrationv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
@@ -120,7 +121,8 @@ func GetVolumeMigrationService(ctx context.Context, volumeManager *cnsvolume.Man
 			// This is idempotent if CRD is pre-created then we continue with
 			// initialization of volumeMigrationInstance.
 			volumeMigrationServiceInitErr := k8s.CreateCustomResourceDefinitionFromManifest(ctx,
-				"cns.vmware.com_cnsvspherevolumemigrations.yaml")
+				migrationconfig.EmbedCnsVSphereVolumeMigrationFile, migrationconfig.EmbedCnsVSphereVolumeMigrationFileName)
+
 			if volumeMigrationServiceInitErr != nil {
 				log.Errorf("failed to create volume migration CRD. Error: %v", volumeMigrationServiceInitErr)
 				return nil, volumeMigrationServiceInitErr

--- a/pkg/apis/storagepool/config/config.go
+++ b/pkg/apis/storagepool/config/config.go
@@ -1,0 +1,8 @@
+package config
+
+import "embed"
+
+//go:embed cns.vmware.com_storagepools.yaml
+var EmbedStoragePoolCRFile embed.FS
+
+const EmbedStoragePoolCRFileName = "cns.vmware.com_storagepools.yaml"

--- a/pkg/internalapis/cnsoperator/config/config.go
+++ b/pkg/internalapis/cnsoperator/config/config.go
@@ -1,0 +1,13 @@
+package config
+
+import "embed"
+
+//go:embed cnsfilevolumeclient_crd.yaml
+var EmbedCnsFileVolumeClientFile embed.FS
+
+const EmbedCnsFileVolumeClientFileName = "cnsfilevolumeclient_crd.yaml"
+
+//go:embed triggercsifullsync_crd.yaml
+var EmbedTriggerCsiFullSync embed.FS
+
+const EmbedTriggerCsiFullSyncName = "triggercsifullsync_crd.yaml"

--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
@@ -27,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	cnsvolumeoperationrequestconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config"
 
 	csiconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
@@ -78,7 +79,9 @@ func InitVolumeOperationRequestInterface(ctx context.Context, cleanupInterval in
 		log.Info(
 			"Creating CnsVolumeOperationRequest definition on API server and initializing VolumeOperationRequest instance",
 		)
-		err := k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cns.vmware.com_cnsvolumeoperationrequests.yaml")
+		err := k8s.CreateCustomResourceDefinitionFromManifest(ctx,
+			cnsvolumeoperationrequestconfig.EmbedCnsVolumeOperationRequestFile,
+			cnsvolumeoperationrequestconfig.EmbedCnsVolumeOperationRequestFileName)
 		if err != nil {
 			log.Errorf("failed to create CnsVolumeOperationRequest CRD with error: %v", err)
 			return nil, err

--- a/pkg/internalapis/cnsvolumeoperationrequest/config/config.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/config/config.go
@@ -1,0 +1,8 @@
+package config
+
+import "embed"
+
+//go:embed cns.vmware.com_cnsvolumeoperationrequests.yaml
+var EmbedCnsVolumeOperationRequestFile embed.FS
+
+const EmbedCnsVolumeOperationRequestFileName = "cns.vmware.com_cnsvolumeoperationrequests.yaml"

--- a/pkg/internalapis/csinodetopology/config/config.go
+++ b/pkg/internalapis/csinodetopology/config/config.go
@@ -1,0 +1,8 @@
+package config
+
+import "embed"
+
+//go:embed cns.vmware.com_csinodetopologies.yaml
+var EmbedCSINodeTopologyFile embed.FS
+
+const EmbedCSINodeTopologyFileName = "cns.vmware.com_csinodetopologies.yaml"

--- a/pkg/internalapis/featurestates/config/config.go
+++ b/pkg/internalapis/featurestates/config/config.go
@@ -1,0 +1,8 @@
+package config
+
+import "embed"
+
+//go:embed cns.vmware.com_cnscsisvfeaturestates.yaml
+var EmbedCnsCsiSvFeatureStatesCRFile embed.FS
+
+const EmbedCnsCsiSvFeatureStatesCRFileName = "cns.vmware.com_cnscsisvfeaturestates.yaml"

--- a/pkg/internalapis/featurestates/featurestates.go
+++ b/pkg/internalapis/featurestates/featurestates.go
@@ -32,6 +32,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	featurestatesconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config"
 
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis"
@@ -95,7 +96,8 @@ func StartSvFSSReplicationService(ctx context.Context, svFeatureStatConfigMapNam
 	var err error
 	// This is idempotent if CRD is pre-created then we continue with
 	// initialization of svFSSReplicationService.
-	err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cns.vmware.com_cnscsisvfeaturestates.yaml")
+	err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, featurestatesconfig.EmbedCnsCsiSvFeatureStatesCRFile,
+		featurestatesconfig.EmbedCnsCsiSvFeatureStatesCRFileName)
 	if err != nil {
 		log.Errorf("failed to create CnsCsiSvFeatureStates CRD. Error: %v", err)
 		return err

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -30,6 +30,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	cnsoperatorconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config"
+	internalapiscnsoperatorconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config"
+	csinodetopologyconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config"
 
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
@@ -95,7 +98,8 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 	// Create CRD's for WCP flavor.
 	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		// Create CnsNodeVmAttachment CRD
-		err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cns.vmware.com_cnsnodevmattachments.yaml")
+		err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, cnsoperatorconfig.EmbedCnsNodeVmAttachmentCRFile,
+			cnsoperatorconfig.EmbedCnsNodeVmAttachmentCRFileName)
 		if err != nil {
 			crdNameNodeVMAttachment := cnsoperatorv1alpha1.CnsNodeVMAttachmentPlural +
 				"." + cnsoperatorv1alpha1.SchemeGroupVersion.Group
@@ -104,7 +108,8 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 		}
 
 		// Create CnsVolumeMetadata CRD
-		err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cns.vmware.com_cnsvolumemetadata.yaml")
+		err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, cnsoperatorconfig.EmbedCnsVolumeMetadataCRFile,
+			cnsoperatorconfig.EmbedCnsVolumeMetadataCRFileName)
 		if err != nil {
 			crdKindVolumeMetadata := reflect.TypeOf(cnsvolumemetadatav1alpha1.CnsVolumeMetadata{}).Name()
 			log.Errorf("failed to create %q CRD. Err: %+v", crdKindVolumeMetadata, err)
@@ -112,7 +117,8 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 		}
 
 		// Create CnsRegisterVolume CRD from manifest.
-		err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cnsregistervolume_crd.yaml")
+		err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, cnsoperatorconfig.EmbedCnsRegisterVolumeCRFile,
+			cnsoperatorconfig.EmbedCnsRegisterVolumeCRFileName)
 		if err != nil {
 			log.Errorf("Failed to create %q CRD. Err: %+v", cnsoperatorv1alpha1.CnsRegisterVolumePlural, err)
 			return err
@@ -121,14 +127,16 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 		if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.FileVolume) {
 			// Create CnsFileAccessConfig CRD from manifest if file volume feature
 			// is enabled.
-			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cnsfileaccessconfig_crd.yaml")
+			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, cnsoperatorconfig.EmbedCnsFileAccessConfigCRFile,
+				cnsoperatorconfig.EmbedCnsFileAccessConfigCRFileName)
 			if err != nil {
 				log.Errorf("Failed to create %q CRD. Err: %+v", cnsoperatorv1alpha1.CnsFileAccessConfigPlural, err)
 				return err
 			}
 			// Create FileVolumeClients CRD from manifest if file volume feature
 			// is enabled.
-			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cnsfilevolumeclient_crd.yaml")
+			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, internalapiscnsoperatorconfig.EmbedCnsFileVolumeClientFile,
+				internalapiscnsoperatorconfig.EmbedCnsFileVolumeClientFileName)
 			if err != nil {
 				log.Errorf("Failed to create %q CRD. Err: %+v", internalapis.CnsFileVolumeClientPlural, err)
 				return err
@@ -157,7 +165,8 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeTopology) {
 			// Create CSINodeTopology CRD.
-			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cns.vmware.com_csinodetopologies.yaml")
+			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, csinodetopologyconfig.EmbedCSINodeTopologyFile,
+				csinodetopologyconfig.EmbedCSINodeTopologyFileName)
 			if err != nil {
 				log.Errorf("Failed to create %q CRD. Error: %+v", csinodetopology.CRDSingular, err)
 				return err
@@ -235,7 +244,8 @@ func InitCommonModules(ctx context.Context, clusterFlavor cnstypes.CnsClusterFla
 	}
 	if coCommonInterface.IsFSSEnabled(ctx, common.TriggerCsiFullSync) {
 		log.Infof("Triggerfullsync feature enabled")
-		err := k8s.CreateCustomResourceDefinitionFromManifest(ctx, "triggercsifullsync_crd.yaml")
+		err := k8s.CreateCustomResourceDefinitionFromManifest(ctx, internalapiscnsoperatorconfig.EmbedTriggerCsiFullSync,
+			internalapiscnsoperatorconfig.EmbedTriggerCsiFullSyncName)
 		if err != nil {
 			log.Errorf("Failed to create %q CRD. Err: %+v", internalapis.TriggerCsiFullSyncPlural, err)
 			return err

--- a/pkg/syncer/storagepool/service.go
+++ b/pkg/syncer/storagepool/service.go
@@ -24,6 +24,7 @@ import (
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	storagepoolconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config"
 
 	spv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
@@ -62,7 +63,8 @@ func InitStoragePoolService(ctx context.Context,
 	}
 
 	// Create StoragePool CRD.
-	err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, "cns.vmware.com_storagepools.yaml")
+	err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, storagepoolconfig.EmbedStoragePoolCRFile,
+		storagepoolconfig.EmbedStoragePoolCRFileName)
 	if err != nil {
 		crdKind := reflect.TypeOf(spv1alpha1.StoragePool{}).Name()
 		log.Errorf("Failed to create %q CRD. Err: %+v", crdKind, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is embedding CRD manifest files within the binary.
We need this change for deployment where we are running CSI driver as a process. Having required config files embedded within binary helps remove the dependency of placing these config files on the machine from where the process is started.
 

**Testing done**:
Verified new images does not contain config directory and CRD manifest files.

```
divyenp@divyenp-a02 ~ % exec kubectl exec -i -t -n vmware-system-csi vsphere-csi-controller-7c7847d9b9-bj827 -c vsphere-csi-controller "--" sh -c "clear; (bash || ash || sh)"
'xterm': unknown terminal type.
root [ / ]# pwd
/
root [ / ]# ls
bin  boot  csi  dev  etc  home  lib  lib64  media  mnt  proc  root  run  sbin  srv  sys  tmp  usr  var
root [ / ]# 
```

Without config folder and without CRD manifest files in the image verified driver is able to create CRs.

```
# kubectl get customresourcedefinitions
NAME                                        CREATED AT
cnsvolumeoperationrequests.cns.vmware.com   2021-10-22T20:47:38Z
csinodetopologies.cns.vmware.com            2021-10-22T20:47:59Z
```
**Special notes for your reviewer**:
This change needs to be cherry-picked to 2.4 release.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
embed CRD manifests within binary
```
