### PR TITLE
Timeout NodeGetInfo calls until all the nodes are registered in the node manager (#1378)

### DIFF
--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	// ErrNodeNotFound is returned when a node isn't found.
+	// ErrNodeNotFound is returned when a node isn't found in the node manager cache.
 	ErrNodeNotFound = errors.New("node wasn't found")
 )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Cherry pick #1378 to release-2.4 branch

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: NA

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherry-pick: Timeout NodeGetInfo calls until all the nodes are registered in the node manager (#1378)
```
