### PR TITLE
Update golang to 1.17.2 to address critical VULNS

### DIFF
--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -17,7 +17,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.16
+ARG GOLANG_IMAGE=golang:1.17.2
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.16
+ARG GOLANG_IMAGE=golang:1.17.2
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.16
+ARG GOLANG_IMAGE=golang:1.17.2
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest

--- a/images/windows/driver/Dockerfile
+++ b/images/windows/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.16
+ARG GOLANG_IMAGE=golang:1.17.2
 ARG OSVERSION
 ARG ARCH=amd64
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is attempting to resolve the below vulnerabilities reported by appcheck:
https://nvd.nist.gov/vuln/detail/CVE-2021-29923
https://nvd.nist.gov/vuln/detail/CVE-2021-38297

Although the above vulnerabilities do not directly affect the product, we need to make an attempt to move to latest and stable versions to ensure we do not have any critical vulnerabilities in external projects which may import CSI.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running e2e pipelines

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update golang to 1.17.2 to address critical VULNS
```
