### PR TITLE
Replace all the deprecated ioutil with os and io

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -545,7 +544,7 @@ func GetSupervisorNamespace(ctx context.Context) (string, error) {
 	const (
 		namespaceFile = DefaultpvCSIProviderPath + "/namespace"
 	)
-	namespace, err := ioutil.ReadFile(namespaceFile)
+	namespace, err := os.ReadFile(namespaceFile)
 	if err != nil {
 		log.Errorf("Expected to load namespace from %s, but got err: %v", namespaceFile, err)
 		return "", err

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -79,7 +78,7 @@ func configFromCustomizedSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool)
 		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"",
 		cfg.Global.InsecureFlag, cfg.Global.VCenterIP, cfg.Global.User, cfg.Global.Password,
 		cfg.Global.Datacenters, cfg.Global.VCenterPort))
-	err = ioutil.WriteFile("test_vsphere.conf", conf, 0644)
+	err = os.WriteFile("test_vsphere.conf", conf, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -627,7 +626,7 @@ func (osUtils *OsUtils) RescanDevice(ctx context.Context, dev *Device) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(devRescanPath, []byte{'1'}, 0666)
+	err = os.WriteFile(devRescanPath, []byte{'1'}, 0666)
 	if err != nil {
 		msg := fmt.Sprintf("error rescanning block device %q. %v", dev.RealDev, err)
 		log.Error(msg)
@@ -650,14 +649,14 @@ func (osUtils *OsUtils) GetDeviceRescanPath(dev *Device) (string, error) {
 
 // GetDiskPath return the full DiskPath for diskID
 // The files parameter is optional for testing purposes.
-func (osUtils *OsUtils) GetDiskPath(id string, files []os.FileInfo) (string, error) {
+func (osUtils *OsUtils) GetDiskPath(id string, files []os.DirEntry) (string, error) {
 	var (
-		devs []os.FileInfo
+		devs []os.DirEntry
 		err  error
 	)
 
 	if files == nil {
-		devs, err = ioutil.ReadDir(devDiskID)
+		devs, err = os.ReadDir(devDiskID)
 		if err != nil {
 			return "", err
 		}
@@ -813,7 +812,7 @@ func (osUtils *OsUtils) GetDevMounts(ctx context.Context,
 // GetSystemUUID returns the UUID used to identify node vm
 func (osUtils *OsUtils) GetSystemUUID(ctx context.Context) (string, error) {
 	log := logger.GetLogger(ctx)
-	idb, err := ioutil.ReadFile(path.Join(dmiDir, "id", "product_uuid"))
+	idb, err := os.ReadFile(path.Join(dmiDir, "id", "product_uuid"))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/csi/service/osutils/os_utils_test.go
+++ b/pkg/csi/service/osutils/os_utils_test.go
@@ -30,22 +30,22 @@ import (
 func TestGetDiskPath(t *testing.T) {
 	osUtils, _ := NewOsUtils(context.TODO())
 	tests := []struct {
-		devs  []os.FileInfo
+		devs  []os.DirEntry
 		volID string
 		match bool
 	}{
 		{
-			devs: []os.FileInfo{
-				&FakeFileInfo{name: "wwn-0x702438570234875"},
-				&FakeFileInfo{name: "wwn-0x702345804753484"},
+			devs: []os.DirEntry{
+				&fakeDirEntry{name: "wwn-0x702438570234875"},
+				&fakeDirEntry{name: "wwn-0x702345804753484"},
 			},
 			volID: "702438570234875",
 			match: true,
 		},
 		{
-			devs: []os.FileInfo{
-				&FakeFileInfo{name: "wwn-0x702438570234435"},
-				&FakeFileInfo{name: "wwn-0x702345804753484"},
+			devs: []os.DirEntry{
+				&fakeDirEntry{name: "wwn-0x702438570234435"},
+				&fakeDirEntry{name: "wwn-0x702345804753484"},
 			},
 			volID: "702438570234875",
 			match: false,
@@ -101,4 +101,25 @@ func (fi *FakeFileInfo) IsDir() bool {
 
 func (fi *FakeFileInfo) Sys() interface{} {
 	return nil
+}
+
+// fakeDirEntry implements interface os.DirEntry
+type fakeDirEntry struct {
+	name string
+}
+
+func (fe *fakeDirEntry) Name() string {
+	return fe.name
+}
+
+func (fe *fakeDirEntry) IsDir() bool {
+	return false
+}
+
+func (fe *fakeDirEntry) Type() os.FileMode {
+	return 0
+}
+
+func (fe *fakeDirEntry) Info() (os.FileInfo, error) {
+	return &FakeFileInfo{fe.Name()}, nil
 }

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -125,7 +124,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.
 		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"",
 		cfg.Global.InsecureFlag, cfg.Global.VCenterIP, cfg.Global.User, cfg.Global.Password,
 		cfg.Global.Datacenters, cfg.Global.VCenterPort))
-	err = ioutil.WriteFile("test_vsphere.conf", conf, 0644)
+	err = os.WriteFile("test_vsphere.conf", conf, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -105,7 +104,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.
 		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"",
 		cfg.Global.InsecureFlag, cfg.Global.VCenterIP, cfg.Global.User, cfg.Global.Password,
 		cfg.Global.Datacenters, cfg.Global.VCenterPort))
-	err = ioutil.WriteFile("test_vsphere.conf", conf, 0644)
+	err = os.WriteFile("test_vsphere.conf", conf, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -21,7 +21,6 @@ import (
 	"embed"
 	"errors"
 	"flag"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -129,7 +128,7 @@ func GetRestClientConfigForSupervisor(ctx context.Context, endpoint string, port
 		tokenFile  = cnsconfig.DefaultpvCSIProviderPath + "/token"
 		rootCAFile = cnsconfig.DefaultpvCSIProviderPath + "/ca.crt"
 	)
-	token, err := ioutil.ReadFile(tokenFile)
+	token, err := os.ReadFile(tokenFile)
 	if err != nil {
 		return nil
 	}

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -21,7 +21,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -204,7 +204,7 @@ func validationHandler(w http.ResponseWriter, r *http.Request) {
 	var body []byte
 	ctx, log := logger.GetNewContextWithLogger()
 	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
+		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		}
 	}

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -124,7 +123,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*cnsconf
 		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"",
 		cfg.Global.InsecureFlag, cfg.Global.VCenterIP, cfg.Global.User, cfg.Global.Password,
 		cfg.Global.Datacenters, cfg.Global.VCenterPort))
-	err = ioutil.WriteFile("test_vsphere.conf", conf, 0644)
+	err = os.WriteFile("test_vsphere.conf", conf, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net"
 	"net/http"
@@ -1197,7 +1197,7 @@ func httpRequest(client *http.Client, req *http.Request) ([]byte, int) {
 	resp, err := client.Do(req)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	defer resp.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	framework.Logf("API Response status %d", resp.StatusCode)
 
@@ -1318,7 +1318,7 @@ func upgradeTKG(wcpHost string, wcpToken string, tkgCluster string, tkgImage str
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	defer resp.Body.Close()
 
-	bodyBytes, err = ioutil.ReadAll(resp.Body)
+	bodyBytes, err = io.ReadAll(resp.Body)
 	framework.Logf("API Response status %v", resp.StatusCode)
 	gomega.Expect(resp.StatusCode).Should(gomega.BeNumerically("==", 200))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1341,7 +1341,7 @@ func createGC(wcpHost string, wcpToken string) {
 	tkg_yaml, err := filepath.Abs(gcManifestPath + "tkg.yaml")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	framework.Logf("Taking yaml from %v", tkg_yaml)
-	gcBytes, err := ioutil.ReadFile(tkg_yaml)
+	gcBytes, err := os.ReadFile(tkg_yaml)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	req, err := http.NewRequest("POST", createGCURL, bytes.NewBuffer(gcBytes))


### PR DESCRIPTION
The ioutil package has already been deprecated in golang 1.16, please see [go1.16#ioutil](https://golang.org/doc/go1.16#ioutil). So we need to replace all the ioutil with os and io.