### PR TITLE
Fix cns volume metadata entity references

### DIFF
--- a/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
+++ b/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
@@ -134,7 +134,12 @@ const (
 
 // CnsOperatorEntityReference defines the type for entityreference
 // parameter in cnsvolumemetadata API.
-type CnsOperatorEntityReference cnstypes.CnsKubernetesEntityReference
+type CnsOperatorEntityReference struct {
+	EntityType string `json:"entityType"`
+	EntityName string `json:"entityName"`
+	Namespace  string `json:"namespace,omitempty"`
+	ClusterID  string `json:"clusterId,omitempty"`
+}
 
 // CreateCnsVolumeMetadataSpec returns a cnsvolumemetadata object from the
 // input parameters.

--- a/pkg/apis/cnsoperator/config/cns.vmware.com_cnsvolumemetadata.yaml
+++ b/pkg/apis/cnsoperator/config/cns.vmware.com_cnsvolumemetadata.yaml
@@ -54,11 +54,21 @@ spec:
                   the ClusterID field. A PV in the guest cluster referring to a PVC
                   in the supervisor cluster must leave the ClusterID field unset.
                   This field is mandatory.
-                items:
-                  description: CnsOperatorEntityReference defines the type for entityreference
-                    parameter in cnsvolumemetadata API.
-                  type: object
                 type: array
+                items:
+                  type: object
+                  required: ["entityType", "entityName"]
+                  description: OperationDetails stores the details of the operation
+                    performed on a volume.
+                  properties:
+                    entityType:
+                      type: string
+                    entityName:
+                      type: string
+                    namespace:
+                      type: string
+                    clusterId:
+                      type: string
               entitytype:
                 description: EntityType indicates type of entity whose metadata this
                   instance represents.


### PR DESCRIPTION
**What this PR does / why we need it**:
Observed that the TKG cluster which creates the CnsVolumeMetadata CR instance doesn't populate the CnsVolumeMetadata.Spec.EntityReferences. Because of this CnsVolumeMetadata controller in Supervisor cluster fails to process the any CnsVolumeMetadata CR's.

What this PR does is 2 things:
1. Update CnsVolumeMetadata CRD to use EntityReferences attributes in CnsVolumeMetadata CRD YAML definition.
2. CnsOperatorEntityReference via cnstypes.CnsKubernetesEntityReference is using xml attributes because of which any CnsVolumeMetadata instances that are created have failed to recognize any attributes of CnsOperatorEntityReference. What we have done here is to move to using `json` attributes.

**Testing done**:
1. Created a PVC in TKG cluster
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: example-vanilla-rwo-pvc-8
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 5Mi
  storageClassName: gc-storage-profile 
```

2. Observed 2 CnsVolumeMetadata instances are created by pvCSI on Supervisor etcd.
```
root@421d9484a7570df19645e0cc09b3003d [ ~ ]# kubectl get cnsvolumemetadatas.cns.vmware.com -A
NAMESPACE             NAME                                                                        AGE
test-gc-e2e-demo-ns   dd85dc0d-25e8-4925-be21-c631f89253f1-d6b905d3-7808-4160-87a3-bfe3837036fd   35m
test-gc-e2e-demo-ns   dd85dc0d-25e8-4925-be21-c631f89253f1-e27112ed-62ce-482c-a017-e90674918657   35m
```

3. CnsVolumeMetadata reconciler processes both the instances and updates the information on CNS successfully.

**CnsVolumeMetadata CR instance for PERSISTENT_VOLUME_CLAIM**
```
Name:         dd85dc0d-25e8-4925-be21-c631f89253f1-e27112ed-62ce-482c-a017-e90674918657
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsVolumeMetadata
Metadata:
  Creation Timestamp:  2021-11-01T04:30:07Z
  Finalizers:
    cns.vmware.com
  Generation:  2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"cns.vmware.com":
        f:ownerReferences:
          .:
          k:{"uid":"dd85dc0d-25e8-4925-be21-c631f89253f1"}:
            .:
            f:apiVersion:
            f:blockOwnerDeletion:
            f:controller:
            f:kind:
            f:name:
            f:uid:
      f:spec:
        .:
        f:entityname:
        f:entityreferences:
        f:entitytype:
        f:guestclusterid:
        f:namespace:
        f:volumenames:
      f:status:
        .:
        f:volumestatus:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2021-11-01T04:30:11Z
  Owner References:
    API Version:           run.tanzu.vmware.com/v1alpha1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  TanzuKubernetesCluster
    Name:                  test-cluster-e2e-script
    UID:                   dd85dc0d-25e8-4925-be21-c631f89253f1
  Resource Version:        8600330
  Self Link:               /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsvolumemetadatas/dd85dc0d-25e8-4925-be21-c631f89253f1-e27112ed-62ce-482c-a017-e90674918657
  UID:                     f90b8044-6492-4a7d-bc98-755c7ac9cc2d
Spec:
  Entityname:  example-vanilla-rwo-pvc-8
  Entityreferences:
    Cluster Id:    dd85dc0d-25e8-4925-be21-c631f89253f1
    Entity Name:   pvc-e27112ed-62ce-482c-a017-e90674918657
    Entity Type:   PERSISTENT_VOLUME
  Entitytype:      PERSISTENT_VOLUME_CLAIM
  Guestclusterid:  dd85dc0d-25e8-4925-be21-c631f89253f1
  Namespace:       default
  Volumenames:
    dd85dc0d-25e8-4925-be21-c631f89253f1-e27112ed-62ce-482c-a017-e90674918657
Status:
  Volumestatus:
    Updated:     true
    Volumename:  dd85dc0d-25e8-4925-be21-c631f89253f1-e27112ed-62ce-482c-a017-e90674918657
Events:
  Type    Reason           Age   From            Message
  ----    ------           ----  ----            -------
  Normal  UpdateSucceeded  78s   cns.vmware.com  ReconcileCnsVolumeMetadata: Successfully updated entry in CNS for instance with name "example-vanilla-rwo-pvc-8" and entity type "PERSISTENT_VOLUME_CLAIM" in the guest cluster "dd85dc0d-25e8-4925-be21-c631f89253f1".
```

**CnsVolumeMetadata CR instance for PERSISTENT_VOLUME**
```
Name:         dd85dc0d-25e8-4925-be21-c631f89253f1-d6b905d3-7808-4160-87a3-bfe3837036fd
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsVolumeMetadata
Metadata:
  Creation Timestamp:  2021-11-01T04:30:07Z
  Finalizers:
    cns.vmware.com
  Generation:  2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"cns.vmware.com":
        f:ownerReferences:
          .:
          k:{"uid":"dd85dc0d-25e8-4925-be21-c631f89253f1"}:
            .:
            f:apiVersion:
            f:blockOwnerDeletion:
            f:controller:
            f:kind:
            f:name:
            f:uid:
      f:spec:
        .:
        f:entityname:
        f:entityreferences:
        f:entitytype:
        f:guestclusterid:
        f:volumenames:
      f:status:
        .:
        f:volumestatus:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2021-11-01T04:30:09Z
  Owner References:
    API Version:           run.tanzu.vmware.com/v1alpha1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  TanzuKubernetesCluster
    Name:                  test-cluster-e2e-script
    UID:                   dd85dc0d-25e8-4925-be21-c631f89253f1
  Resource Version:        8600319
  Self Link:               /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsvolumemetadatas/dd85dc0d-25e8-4925-be21-c631f89253f1-d6b905d3-7808-4160-87a3-bfe3837036fd
  UID:                     ffec680d-5b2d-4ded-b94f-f9b903cfdff4
Spec:
  Entityname:  pvc-e27112ed-62ce-482c-a017-e90674918657
  Entityreferences:
    Entity Name:   dd85dc0d-25e8-4925-be21-c631f89253f1-e27112ed-62ce-482c-a017-e90674918657
    Entity Type:   PERSISTENT_VOLUME_CLAIM
    Namespace:     test-gc-e2e-demo-ns
  Entitytype:      PERSISTENT_VOLUME
  Guestclusterid:  dd85dc0d-25e8-4925-be21-c631f89253f1
  Volumenames:
    dd85dc0d-25e8-4925-be21-c631f89253f1-e27112ed-62ce-482c-a017-e90674918657
Status:
  Volumestatus:
    Updated:     true
    Volumename:  dd85dc0d-25e8-4925-be21-c631f89253f1-e27112ed-62ce-482c-a017-e90674918657
Events:
  Type    Reason           Age   From            Message
  ----    ------           ----  ----            -------
  Normal  UpdateSucceeded  79s   cns.vmware.com  ReconcileCnsVolumeMetadata: Successfully updated entry in CNS for instance with name "pvc-e27112ed-62ce-482c-a017-e90674918657" and entity type "PERSISTENT_VOLUME" in the guest cluster "dd85dc0d-25e8-4925-be21-c631f89253f1".
```

**Release note**:
```release-note
Fix cns volume metadata entity references
```

cc @chethanv28 @divyenpatel 