### PR TITLE
Update debug log to print the the name and url in right order

### DIFF
--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -358,7 +358,7 @@ func getDatastoresWithBlockVolumePrivs(ctx context.Context, vc *cnsvsphere.Virtu
 		}
 		if hasPriv {
 			dsURLToInfoMap[dsURLs[index]] = dsInfos[index]
-			log.Debugf("auth manager: datastore with URL %s and name %s has privileges and is added to dsURLToInfoMap",
+			log.Debugf("auth manager: datastore with name %s and URL %s has privileges and is added to dsURLToInfoMap",
 				dsInfos[index].Info.Name, dsURLs[index])
 		}
 	}


### PR DESCRIPTION
I see the following log in CSI Controller's log in 2.4.0-rc.2, 
`2021-11-02T01:49:50.762Z	DEBUG	common/authmanager.go:361	auth manager: datastore with URL local-ds-4-0 and name ds:///vmfs/volumes/612f4dae-6102c4a7-3b53-02005172bdaa/ has privileges and is added to dsURLToInfoMap	{"TraceId": "4e66a5ba-970b-4a97-8b44-cfce4f049c33"}`

Obviously the order of "name" and "URL" isn't correct. The master branch has this minor issue as well. 