### PR TITLE
Add P0 metrics to CSI Full Sync 

### DIFF
--- a/pkg/common/prometheus/metrics.go
+++ b/pkg/common/prometheus/metrics.go
@@ -139,4 +139,16 @@ var (
 	},
 		// Possible volume_health_type - "accessible-volumes", "inaccessible-volumes"
 		[]string{"volume_health_type"})
+
+	// FullSyncOpsHistVec is a histogram vector metric to observe CSI Full Sync.
+	FullSyncOpsHistVec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "vsphere_full_sync_ops_histogram",
+		Help: "Histogram vector for CSI Full Sync operations.",
+		// Creating more buckets for operations that takes few seconds and less buckets
+		// for those that are taking a long time. A Full Sync operation taking a long time is
+		// unexpected and we don't have to be accurate(just approximation is fine).
+		Buckets: []float64{1, 2, 3, 4, 5, 7, 10, 12, 15, 18, 20, 25, 30, 60, 120, 180, 300},
+	},
+		// Possible status - "pass", "fail"
+		[]string{"status"})
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds P0 metrics for CSI and pvCSI full sync, including:
- Full sync count
- Time taken for full sync cycle and whether there was an error


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

1. Verified the new metrics are exposed by syncer:

```
# kubectl exec -it vsphere-csi-controller-864dbc7869-w8t2m -c vsphere-syncer -n vmware-system-csi -- curl localhost:2113/metrics | grep sync
# HELP vsphere_full_sync_ops_histogram Histogram vector for CSI Full Sync operations.
# TYPE vsphere_full_sync_ops_histogram histogram
vsphere_full_sync_ops_histogram_bucket{status="pass",le="1"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="2"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="3"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="4"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="5"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="7"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="10"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="12"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="15"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="18"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="20"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="25"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="30"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="60"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="120"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="180"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="300"} 3
vsphere_full_sync_ops_histogram_bucket{status="pass",le="+Inf"} 3
vsphere_full_sync_ops_histogram_sum{status="pass"} 0.090792422
vsphere_full_sync_ops_histogram_count{status="pass"} 3
# HELP vsphere_syncer_info Syncer Info
# TYPE vsphere_syncer_info gauge
vsphere_syncer_info{version="c7679f0"} 1
```

All full sync e2e tests passed. 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add metrics to CSI Full Sync
```
