### PR TITLE
[CSI-Snapshot]Do not error out operation if the volume is not found

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/vsphere-csi-driver/v2
 go 1.16
 
 require (
-	github.com/agiledragon/gomonkey v2.0.2+incompatible
+	github.com/agiledragon/gomonkey/v2 v2.3.1
 	github.com/akutz/gofsutil v0.1.2
 	github.com/container-storage-interface/spec v1.4.0
 	github.com/davecgh/go-spew v1.1.1
@@ -37,7 +37,6 @@ require (
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/yaml.v2 v2.4.0
-	honnef.co/go/tools v0.2.0 // indirect
 	k8s.io/api v0.21.1
 	k8s.io/apiextensions-apiserver v0.21.1
 	k8s.io/apimachinery v0.21.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
-github.com/agiledragon/gomonkey v2.0.2+incompatible h1:eXKi9/piiC3cjJD1658mEE2o3NjkJ5vDLgYjCQu0Xlw=
-github.com/agiledragon/gomonkey v2.0.2+incompatible/go.mod h1:2NGfXu1a80LLr2cmWXGBDaHEjb1idR6+FVlX5T3D9hw=
+github.com/agiledragon/gomonkey/v2 v2.3.1 h1:k+UnUY0EMNYUFUAQVETGY9uUTxjMdnUkP0ARyJS1zzs=
+github.com/agiledragon/gomonkey/v2 v2.3.1/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/akutz/gofsutil v0.1.2 h1:aCdWrZdxajx8kllNQSKaMDpRJWSE2wcyKNy7eDMXkrI=
@@ -317,10 +317,7 @@ github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/cadvisor v0.39.0/go.mod h1:rjQFmK4jPCpxeUdLq9bYhNFFsjgGOtpnDmDeap0+nsw=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -693,8 +690,6 @@ github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1
 github.com/vmware-tanzu/vm-operator-api v0.1.3 h1:4vxewu0jAN3fSoCBI6FhjmRGJ7ci0R2WNu/I6hacTYs=
 github.com/vmware-tanzu/vm-operator-api v0.1.3/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/vmware/govmomi v0.26.2-0.20210907233321-5196d831d88e h1:irZ+ONb0L2RGUxFkwt/5BAKxb2nvnP+w+U+6/asl4Qg=
-github.com/vmware/govmomi v0.26.2-0.20210907233321-5196d831d88e/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
 github.com/vmware/govmomi v0.27.0 h1:KoQ8IsLAa7V78s5d7dgpZA8d039GBM83cVxgAq9uWuw=
 github.com/vmware/govmomi v0.27.0/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
@@ -790,7 +785,6 @@ golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1114,8 +1108,6 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
-honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 k8s.io/api v0.21.1 h1:94bbZ5NTjdINJEdzOkpS4vdPhkb1VFpTYC9zh43f75c=
 k8s.io/api v0.21.1/go.mod h1:FstGROTmsSHBarKc8bylzXih8BLNYTiS3TZcsoEDg2s=
 k8s.io/apiextensions-apiserver v0.21.1 h1:AA+cnsb6w7SZ1vD32Z+zdgfXdXY8X9uGX5bN6EoPEIo=

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -174,7 +174,7 @@ func QuerySnapshotsUtil(ctx context.Context, m cnsvolume.Manager, snapshotQueryF
 	return allQuerySnapshotResults, "", nil
 }
 
-type cnsVolumeDetails struct {
+type CnsVolumeDetails struct {
 	VolumeID     string
 	SizeInMB     int64
 	DatastoreUrl string
@@ -183,9 +183,9 @@ type cnsVolumeDetails struct {
 
 // Query Capacity in MB and datastore URL for the source volume with expected volume type
 func QueryVolumeDetailsUtil(ctx context.Context, m cnsvolume.Manager, volumeIds []cnstypes.CnsVolumeId) (
-	map[string]*cnsVolumeDetails, error) {
+	map[string]*CnsVolumeDetails, error) {
 	log := logger.GetLogger(ctx)
-	volumeDetailsMap := make(map[string]*cnsVolumeDetails)
+	volumeDetailsMap := make(map[string]*CnsVolumeDetails)
 	// TODO: Update govmomi to have datastore url as selection criteria as a enum
 	datastoreSelection := "DATASTORE_URL"
 	// Select only the backing object details, volume type and datastore.
@@ -214,7 +214,7 @@ func QueryVolumeDetailsUtil(ctx context.Context, m cnsvolume.Manager, volumeIds 
 		volumeType := res.VolumeType
 		log.Debugf("VOLUME: %s, TYPE: %s, DATASTORE: %s, CAPACITY: %d", volumeId, volumeType, datastoreUrl,
 			volumeCapacityInMB)
-		volumeDetails := &cnsVolumeDetails{
+		volumeDetails := &CnsVolumeDetails{
 			VolumeID:     volumeId.Id,
 			SizeInMB:     volumeCapacityInMB,
 			DatastoreUrl: datastoreUrl,

--- a/pkg/csi/service/common/vsphereutil_test.go
+++ b/pkg/csi/service/common/vsphereutil_test.go
@@ -1,0 +1,153 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/vim25/types"
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils"
+)
+
+func TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsCnsVolumeNotFoundFault(t *testing.T) {
+	volumeId := "dummy-id"
+	patches := gomonkey.ApplyFunc(utils.QuerySnapshotsUtil, func(_ context.Context, _ cnsvolume.Manager,
+		_ cnstypes.CnsSnapshotQueryFilter, _ int64) ([]cnstypes.CnsSnapshotQueryResultEntry, string, error) {
+		resultEntry := cnstypes.CnsSnapshotQueryResultEntry{
+			Snapshot: cnstypes.CnsSnapshot{},
+			Error: &types.LocalizedMethodFault{
+				Fault: cnstypes.CnsVolumeNotFoundFault{
+					CnsFault: cnstypes.CnsFault{},
+					VolumeId: cnstypes.CnsVolumeId{
+						Id: volumeId,
+					},
+				},
+				LocalizedMessage: "volume not found",
+			},
+		}
+		return []cnstypes.CnsSnapshotQueryResultEntry{resultEntry}, "", nil
+	})
+	defer patches.Reset()
+	patches.ApplyFunc(utils.QueryVolumeDetailsUtil, func(_ context.Context, _ cnsvolume.Manager,
+		_ []cnstypes.CnsVolumeId) (
+		map[string]*utils.CnsVolumeDetails, error) {
+		return make(map[string]*utils.CnsVolumeDetails), nil
+	})
+	results, _, err := QueryVolumeSnapshotsByVolumeID(context.TODO(), nil, volumeId, 100)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 0, len(results))
+}
+
+func TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsUnexpectedFault(t *testing.T) {
+	volumeId := "dummy-id"
+	patches := gomonkey.ApplyFunc(utils.QuerySnapshotsUtil, func(_ context.Context, _ cnsvolume.Manager,
+		_ cnstypes.CnsSnapshotQueryFilter, _ int64) ([]cnstypes.CnsSnapshotQueryResultEntry, string, error) {
+		resultEntry := cnstypes.CnsSnapshotQueryResultEntry{
+			Snapshot: cnstypes.CnsSnapshot{},
+			Error: &types.LocalizedMethodFault{
+				Fault: &types.InvalidArgument{
+					RuntimeFault:    types.RuntimeFault{},
+					InvalidProperty: "unexpected",
+				},
+				LocalizedMessage: "unknown fault",
+			},
+		}
+		return []cnstypes.CnsSnapshotQueryResultEntry{resultEntry}, "", nil
+	})
+	defer patches.Reset()
+	patches.ApplyFunc(utils.QueryVolumeDetailsUtil, func(_ context.Context, _ cnsvolume.Manager,
+		_ []cnstypes.CnsVolumeId) (
+		map[string]*utils.CnsVolumeDetails, error) {
+		return make(map[string]*utils.CnsVolumeDetails), nil
+	})
+	_, _, err := QueryVolumeSnapshotsByVolumeID(context.TODO(), nil, volumeId, 100)
+	assert.Error(t, err)
+}
+
+func TestQueryVolumeSnapshotWithQuerySnapshotsCnsSnapshotNotFoundFault(t *testing.T) {
+	volumeId := "dummy-id"
+	snapId := "dummy-snap-id"
+	patches := gomonkey.ApplyFunc(utils.QuerySnapshotsUtil, func(_ context.Context, _ cnsvolume.Manager,
+		_ cnstypes.CnsSnapshotQueryFilter, _ int64) ([]cnstypes.CnsSnapshotQueryResultEntry, string, error) {
+		resultEntry := cnstypes.CnsSnapshotQueryResultEntry{
+			Snapshot: cnstypes.CnsSnapshot{},
+			Error: &types.LocalizedMethodFault{
+				Fault: cnstypes.CnsSnapshotNotFoundFault{
+					CnsFault: cnstypes.CnsFault{},
+					VolumeId: cnstypes.CnsVolumeId{
+						Id: volumeId,
+					},
+					SnapshotId: cnstypes.CnsSnapshotId{
+						DynamicData: types.DynamicData{},
+						Id:          snapId,
+					},
+				},
+				LocalizedMessage: "volume snapshot not found",
+			},
+		}
+		return []cnstypes.CnsSnapshotQueryResultEntry{resultEntry}, "", nil
+	})
+	defer patches.Reset()
+	patches.ApplyFunc(utils.QueryVolumeDetailsUtil, func(_ context.Context, _ cnsvolume.Manager,
+		_ []cnstypes.CnsVolumeId) (
+		map[string]*utils.CnsVolumeDetails, error) {
+		return make(map[string]*utils.CnsVolumeDetails), nil
+	})
+	_, err := QueryVolumeSnapshot(context.TODO(), nil, volumeId, snapId, 100)
+	assert.Error(t, err)
+}
+
+func TestQueryVolumeSnapshotWithQuerySnapshotsUnexpectedFault(t *testing.T) {
+	volumeId := "dummy-id"
+	snapId := "dummy-snap-id"
+	patches := gomonkey.ApplyFunc(utils.QuerySnapshotsUtil, func(_ context.Context, _ cnsvolume.Manager,
+		_ cnstypes.CnsSnapshotQueryFilter, _ int64) ([]cnstypes.CnsSnapshotQueryResultEntry, string, error) {
+		resultEntry := cnstypes.CnsSnapshotQueryResultEntry{
+			Snapshot: cnstypes.CnsSnapshot{},
+			Error: &types.LocalizedMethodFault{
+				Fault: &types.InvalidArgument{
+					RuntimeFault:    types.RuntimeFault{},
+					InvalidProperty: "unexpected",
+				},
+				LocalizedMessage: "unknown fault",
+			},
+		}
+		return []cnstypes.CnsSnapshotQueryResultEntry{resultEntry}, "", nil
+	})
+	defer patches.Reset()
+	patches.ApplyFunc(utils.QueryVolumeDetailsUtil, func(_ context.Context, _ cnsvolume.Manager,
+		_ []cnstypes.CnsVolumeId) (
+		map[string]*utils.CnsVolumeDetails, error) {
+		return make(map[string]*utils.CnsVolumeDetails), nil
+	})
+	_, err := QueryVolumeSnapshot(context.TODO(), nil, volumeId, snapId, 100)
+	assert.Error(t, err)
+}
+
+func TestQueryAllVolumeSnapshotsWithQuerySnapshotsUnexpectedFault(t *testing.T) {
+	patches := gomonkey.ApplyFunc(utils.QuerySnapshotsUtil, func(_ context.Context, _ cnsvolume.Manager,
+		_ cnstypes.CnsSnapshotQueryFilter, _ int64) ([]cnstypes.CnsSnapshotQueryResultEntry, string, error) {
+		resultEntry := cnstypes.CnsSnapshotQueryResultEntry{
+			Snapshot: cnstypes.CnsSnapshot{},
+			Error: &types.LocalizedMethodFault{
+				Fault: &types.InvalidArgument{
+					RuntimeFault:    types.RuntimeFault{},
+					InvalidProperty: "unexpected",
+				},
+				LocalizedMessage: "unknown fault",
+			},
+		}
+		return []cnstypes.CnsSnapshotQueryResultEntry{resultEntry}, "", nil
+	})
+	defer patches.Reset()
+	patches.ApplyFunc(utils.QueryVolumeDetailsUtil, func(_ context.Context, _ cnsvolume.Manager,
+		_ []cnstypes.CnsVolumeId) (
+		map[string]*utils.CnsVolumeDetails, error) {
+		return make(map[string]*utils.CnsVolumeDetails), nil
+	})
+	_, _, err := QueryAllVolumeSnapshots(context.TODO(), nil, "", 100)
+	assert.Error(t, err)
+}

--- a/pkg/syncer/admissionhandler/validatepvc_test.go
+++ b/pkg/syncer/admissionhandler/validatepvc_test.go
@@ -8,7 +8,7 @@ import (
 
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/agiledragon/gomonkey"
+	"github.com/agiledragon/gomonkey/v2"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
 	snapshotclientfake "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned/fake"


### PR DESCRIPTION
**What this PR does / why we need it**:
`QueryVolumeSnapshotsByVolumeID` is called from expand-volume, delete-volume, or list-snapshot. During this, we invoke CNS `QuerySnapshot` API to determine the snapshots for the volume, under the scenario where the volume is not present we should not error out, instead return empty results. Doing this ensures API idempotency, for example, if the external-provisioner happens to call delete-volume twice, assuming the first delete-volume succeeds, any more delete-volume calls on the same volume-id should return a success. However, in the current implementation, 'QuerySnapshots' would not return the volume during the second delete-volume call(as it was deleted successfully in the previous call), then we return an error for the second delete-volume call, this is a bug, and it's fixed in this PR.

This PR ignores queryResult fields that have error set as we will not be able to reliably retrieve the necessary fields.
Improved error messages.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
--- PASS: TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsCnsVolumeNotFoundFault (0.00s)
--- PASS: TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsUnexpectedFault (0.00s)
--- PASS: TestQueryVolumeSnapshotWithQuerySnapshotsCnsSnapshotNotFoundFault (0.00s)
--- PASS: TestQueryVolumeSnapshotWithQuerySnapshotsUnexpectedFault (0.00s)

=== RUN   TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsCnsVolumeNotFoundFault
{"level":"warn","time":"2021-11-03T12:39:16.209698-07:00","caller":"common/vsphereutil.go:852","msg":"volume dummy-id was not found during QuerySnapshots, ignore volume.."}
--- PASS: TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsCnsVolumeNotFoundFault (0.00s)
=== RUN   TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsUnexpectedFault
{"level":"error","time":"2021-11-03T12:39:16.209898-07:00","caller":"common/vsphereutil.go:854","msg":"unexpected fault &{RuntimeFault:{MethodFault:{FaultCause:<nil> FaultMessage:[]}} InvalidProperty:unexpected} received in QuerySnapshots result: {DynamicData:{} Snapshot:{DynamicData:{} SnapshotId:{DynamicData:{} Id:} VolumeId:{DynamicData:{} Id:} Description: CreateTime:0001-01-01 00:00:00 +0000 UTC} Error:0xc00012a140}","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.QueryVolumeSnapshotsByVolumeID\n\t/Users/dkinni/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/pkg/csi/service/common/vsphereutil.go:854\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsUnexpectedFault\n\t/Users/dkinni/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/pkg/csi/service/common/vsphereutil_test.go:62\ntesting.tRunner\n\t/usr/local/Cellar/go/1.17.2/libexec/src/testing/testing.go:1259"}
--- PASS: TestQueryVolumeSnapshotsByVolumeIDWithQuerySnapshotsUnexpectedFault (0.00s)
=== RUN   TestQueryVolumeSnapshotWithQuerySnapshotsCnsSnapshotNotFoundFault
{"level":"error","time":"2021-11-03T12:39:16.210214-07:00","caller":"common/vsphereutil.go:706","msg":"snapshot-id: dummy-snap-id not found for volume-id: dummy-id during QuerySnapshots, err: {CnsFault:{BaseMethodFault:<nil> Reason:} VolumeId:{DynamicData:{} Id:dummy-id} SnapshotId:{DynamicData:{} Id:dummy-snap-id}}","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.QueryVolumeSnapshot\n\t/Users/dkinni/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/pkg/csi/service/common/vsphereutil.go:706\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.TestQueryVolumeSnapshotWithQuerySnapshotsCnsSnapshotNotFoundFault\n\t/Users/dkinni/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/pkg/csi/service/common/vsphereutil_test.go:94\ntesting.tRunner\n\t/usr/local/Cellar/go/1.17.2/libexec/src/testing/testing.go:1259"}
--- PASS: TestQueryVolumeSnapshotWithQuerySnapshotsCnsSnapshotNotFoundFault (0.00s)
=== RUN   TestQueryVolumeSnapshotWithQuerySnapshotsUnexpectedFault
{"level":"error","time":"2021-11-03T12:39:16.21048-07:00","caller":"common/vsphereutil.go:709","msg":"unexpected error received when retrieving snapshot info for volume-id: dummy-id snapshot-id: dummy-snap-id err: &{RuntimeFault:{MethodFault:{FaultCause:<nil> FaultMessage:[]}} InvalidProperty:unexpected}","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.QueryVolumeSnapshot\n\t/Users/dkinni/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/pkg/csi/service/common/vsphereutil.go:709\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.TestQueryVolumeSnapshotWithQuerySnapshotsUnexpectedFault\n\t/Users/dkinni/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/pkg/csi/service/common/vsphereutil_test.go:119\ntesting.tRunner\n\t/usr/local/Cellar/go/1.17.2/libexec/src/testing/testing.go:1259"}
--- PASS: TestQueryVolumeSnapshotWithQuerySnapshotsUnexpectedFault (0.00s)
PASS

```

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>