### PR TITLE
[WIP]Storagepolicyname can't be specified when creating sc in statfulsets test

### DIFF
--- a/tests/e2e/statefulsets.go
+++ b/tests/e2e/statefulsets.go
@@ -98,6 +98,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-supervisor] statefulset", func
 		if vanillaCluster {
 			ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
 			scParameters = nil
+			scParameters[scParamStoragePolicyName] = storagePolicyName
 		} else {
 			ginkgo.By("CNS_TEST: Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
@@ -271,6 +272,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-supervisor] statefulset", func
 		if vanillaCluster {
 			ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
 			scParameters = nil
+			scParameters[scParamStoragePolicyName] = storagePolicyName
 		} else {
 			ginkgo.By("Running for WCP setup")
 			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When do statefulsets test, the sc is created with default storagepolicy named "vSAN Default Storage Policy", and could not use the specified storagepolicy name.

As my team is using a public cloud like VMC on aws or avs, we must create SC/PVC/PV with my own storagepolicyname instead of "vSAN Default Storage Policy".
If not specify the storagepolicyname in sc, the pv sometime is created on datastore/datacenter which I have no privilege, cluster nodes failed to attach cns volume and cause pods created failed as failed attach pvc
csi-controller logs:
{"level":"error","time":"2021-10-29T06:39:59.874866145Z","caller":"vanilla/controller.go:832","msg":"failed to attach disk: \"6d3d5012-d794-4119-8ed4-cf174d286df1\" with node: \"tkg-vc-maas-antrea-md-0-c5647c475-lxcmv\" err failed to attach cns volume: \"6d3d5012-d794-4119-8ed4-cf174d286df1\" to node vm: \"VirtualMachine:vm-1048 [VirtualCenterHost: 10.2.224.4, UUID: 423f3fa5-536a-f215-101f-440dac657ef2, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.2.224.4]]\".
From the error logs, we can see the volume is created on datacenter-3, but my privileged datacenter is "SDDC-Datacenter", so I must give my own storagepolicyname for my datacenter, not use "vSAN Default Storage Policy".

This PR specifies the storagepolicyname whic is given for SC, then it can cover more test environment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified it manually.

**Special notes for your reviewer**:

**Release note**:

```release-note
```
