### PR TITLE
prevent calling register volume in parallel for same vmdk

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -882,7 +882,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 				// Error is already wrapped in CSI error code.
 				return nil, csifault.CSIInternalFault, err
 			}
-			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, &migration.VolumeSpec{VolumePath: req.VolumeId})
+			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, &migration.VolumeSpec{VolumePath: req.VolumeId}, false)
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
@@ -1021,7 +1021,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 					return nil, csifault.CSIInternalFault, err
 				}
 				req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx,
-					&migration.VolumeSpec{VolumePath: volumePath, StoragePolicyName: storagePolicyName})
+					&migration.VolumeSpec{VolumePath: volumePath, StoragePolicyName: storagePolicyName}, false)
 				if err != nil {
 					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 						"failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
@@ -1138,7 +1138,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 				// Error is already wrapped in CSI error code.
 				return nil, csifault.CSIInternalFault, err
 			}
-			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, &migration.VolumeSpec{VolumePath: volumePath})
+			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, &migration.VolumeSpec{VolumePath: volumePath}, false)
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -73,7 +73,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) erro
 			migrationVolumeSpec := &migration.VolumeSpec{
 				VolumePath:        pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
+			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
 			if err != nil {
 				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for spec: %v. Err: %+v",
 					migrationVolumeSpec, err)
@@ -174,7 +174,7 @@ func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVo
 			migrationVolumeSpec := &migration.VolumeSpec{
 				VolumePath:        pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
+			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
 			if err != nil {
 				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for spec: %v. Err: %+v",
 					migrationVolumeSpec, err)
@@ -239,7 +239,7 @@ func fullSyncDeleteVolumes(ctx context.Context, volumeIDDeleteArray []cnstypes.C
 			migrationVolumeSpec := &migration.VolumeSpec{
 				VolumePath:        pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
+			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
 			if err != nil {
 				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for spec: %v. Err: %+v",
 					migrationVolumeSpec, err)
@@ -391,7 +391,7 @@ func fullSyncConstructVolumeMaps(ctx context.Context, pvList []*v1.PersistentVol
 			migrationVolumeSpec := &migration.VolumeSpec{
 				VolumePath:        pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
+			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
 			if err != nil {
 				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for spec: %v. Err: %+v",
 					migrationVolumeSpec, err)
@@ -473,7 +473,7 @@ func fullSyncGetVolumeSpecs(ctx context.Context, vCenterVersion string, pvList [
 			migrationVolumeSpec := &migration.VolumeSpec{
 				VolumePath:        pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
+			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
 			if err != nil {
 				log.Warnf("FullSync: Failed to get VolumeID from volumeMigrationService for spec: %v. Err: %+v",
 					migrationVolumeSpec, err)

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -880,7 +880,7 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 		}
 		migrationVolumeSpec := &migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath,
 			StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
+		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
 		if err != nil {
 			log.Errorf("PVC Updated: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v "+
 				"with error %+v", migrationVolumeSpec, err)
@@ -983,7 +983,7 @@ func csiPVCDeleted(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 		}
 		migrationVolumeSpec := &migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath,
 			StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
+		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
 		if err != nil {
 			log.Errorf("PVC Deleted: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v "+
 				"with error %+v", migrationVolumeSpec, err)
@@ -1036,7 +1036,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 		}
 		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx,
 			&migration.VolumeSpec{VolumePath: newPv.Spec.VsphereVolume.VolumePath,
-				StoragePolicyName: newPv.Spec.VsphereVolume.StoragePolicyName})
+				StoragePolicyName: newPv.Spec.VsphereVolume.StoragePolicyName}, true)
 		if err != nil {
 			log.Errorf("PVUpdated: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v",
 				newPv.Spec.VsphereVolume.VolumePath, err)
@@ -1230,7 +1230,7 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 			}
 			migrationVolumeSpec := &migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
+			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
 			if err != nil {
 				log.Errorf("PVDeleted: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v "+
 					"with error %+v", migrationVolumeSpec, err)
@@ -1295,7 +1295,7 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 					}
 					migrationVolumeSpec := &migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath,
 						StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-					volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
+					volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
 					if err != nil {
 						log.Errorf("Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v "+
 							"with error %+v", migrationVolumeSpec, err)
@@ -1330,7 +1330,7 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 						return
 					}
 					migrationVolumeSpec := &migration.VolumeSpec{VolumePath: volume.VsphereVolume.VolumePath}
-					volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
+					volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
 					if err != nil {
 						log.Warnf("Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v "+
 							"with error %+v", migrationVolumeSpec, err)

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -85,7 +85,7 @@ func fullSyncGetInlineMigratedVolumesInfo(ctx context.Context,
 			if migrationFeatureState && volume.VsphereVolume != nil {
 				volumeHandle, err := volumeMigrationService.GetVolumeID(ctx,
 					&migration.VolumeSpec{VolumePath: volume.VsphereVolume.VolumePath,
-						StoragePolicyName: volume.VsphereVolume.StoragePolicyName})
+						StoragePolicyName: volume.VsphereVolume.StoragePolicyName}, true)
 				if err != nil {
 					log.Warnf(
 						"FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

We have a bug in the FCD which might generate different FCD IDs for the same vmdk. If this happens, migrated volume is not guaranteed to be used with the cached Volume ID in the VolumeMigrationService.

This PR prevents calling Register Volume in parallel for the same vmdk.

This PR also prevents calling RegisterVolume from the CSI Controller Pod. Only the syncer container will be able to perform volume registration after this PR is merged. If for any reason, volume registration fails, the syncer container can attempt to re-register the volume during a full sync cycle. If vSphere CSI controller gets any call to operate on the migrated volume before it is registered, it will return an error, and CSI driver will retry the operation in the next attempt.


**Testing done**:
Verified enabling Migration when syncer is down, so migrated PV did not register before creating the Pod.
During Pod Creation, Controller Publish failed with an expected error.

```
Events:
  Type     Reason                  Age                From                     Message
  ----     ------                  ----               ----                     -------
  Normal   Scheduled               60s                default-scheduler        Successfully assigned default/pvpod to k8s-node-470-1636402267
  Warning  FailedAttachVolume      19s (x6 over 37s)  attachdetach-controller  AttachVolume.Attach failed for volume "pvc-ab2abaf9-6704-436e-b958-05411e9a86af" : rpc error: code = Internal desc = failed to get VolumeID from volumeMigrationService for volumePath: "[vsanDatastore] 83b38961-4a3f-c694-0552-0200abf20dd7/kubernetes-dynamic-pvc-ab2abaf9-6704-436e-b958-05411e9a86af.vmdk"
  Normal   SuccessfulAttachVolume  2s                 attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-ab2abaf9-6704-436e-b958-05411e9a86af"
```
and later when the syncer container has registered vmdk as FCD, attach operation succeeded.



cc: @bandyopadhyays-vmware @chethanv28 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
prevent calling register volume in parallel for same vmdk
```
