### PR TITLE
Revert back CnsVolumeMetadata entity references from json to xml

### DIFF
--- a/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
+++ b/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
@@ -132,14 +132,7 @@ const (
 	CnsOperatorEntityTypePOD = CnsOperatorEntityType(cnstypes.CnsKubernetesEntityTypePOD)
 )
 
-// CnsOperatorEntityReference defines the type for entityreference
-// parameter in cnsvolumemetadata API.
-type CnsOperatorEntityReference struct {
-	EntityType string `json:"entityType"`
-	EntityName string `json:"entityName"`
-	Namespace  string `json:"namespace,omitempty"`
-	ClusterID  string `json:"clusterId,omitempty"`
-}
+type CnsOperatorEntityReference cnstypes.CnsKubernetesEntityReference
 
 // CreateCnsVolumeMetadataSpec returns a cnsvolumemetadata object from the
 // input parameters.


### PR DESCRIPTION
**What this PR does / why we need it**:
Deploy a new TKG on released SV builds was running into issues where CnsOperator is unable update volume metadata on CNS. The idea here is to support latest pvCSI version on old SV releases.

**Testing done**:
1. Deploy TKG with latest pvCSI driver and on old SV cluster.
2. Create a PVC on TKG.
3. Verify VolumeMetadata is reconciled on SV.
```
root@421d9484a7570df19645e0cc09b3003d [ ~ ]# kubectl get cnsvolumemetadatas dd85dc0d-25e8-4925-be21-c631f89253f1-63e1d50a-5d00-4d92-b173-c9ae266a9781 -n test-gc-e2e-demo-ns -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsVolumeMetadata
metadata:
  creationTimestamp: "2021-11-03T22:10:26Z"
  generation: 1
  name: dd85dc0d-25e8-4925-be21-c631f89253f1-63e1d50a-5d00-4d92-b173-c9ae266a9781
  namespace: test-gc-e2e-demo-ns
  ownerReferences:
  - apiVersion: run.tanzu.vmware.com/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: TanzuKubernetesCluster
    name: test-cluster-e2e-script
    uid: dd85dc0d-25e8-4925-be21-c631f89253f1
  resourceVersion: "10669564"
  selfLink: /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsvolumemetadatas/dd85dc0d-25e8-4925-be21-c631f89253f1-63e1d50a-5d00-4d92-b173-c9ae266a9781
  uid: 1386618f-8168-442c-805a-2e9e265e603b
spec:
  clusterdistribution: TKGService
  entityname: pvc-4db789dc-058f-46ed-a921-d93ad8c14ef5
  entityreferences:
  - entityName: dd85dc0d-25e8-4925-be21-c631f89253f1-4db789dc-058f-46ed-a921-d93ad8c14ef5
    entityType: PERSISTENT_VOLUME_CLAIM
    namespace: test-gc-e2e-demo-ns
  entitytype: PERSISTENT_VOLUME
  guestclusterid: dd85dc0d-25e8-4925-be21-c631f89253f1
  volumenames:
  - dd85dc0d-25e8-4925-be21-c631f89253f1-4db789dc-058f-46ed-a921-d93ad8c14ef5
status: {}



====


root@421d9484a7570df19645e0cc09b3003d [ ~ ]# kubectl get cnsvolumemetadatas dd85dc0d-25e8-4925-be21-c631f89253f1-4db789dc-058f-46ed-a921-d93ad8c14ef5 -n test-gc-e2e-demo-ns -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsVolumeMetadata
metadata:
  creationTimestamp: "2021-11-03T22:10:26Z"
  generation: 1
  name: dd85dc0d-25e8-4925-be21-c631f89253f1-4db789dc-058f-46ed-a921-d93ad8c14ef5
  namespace: test-gc-e2e-demo-ns
  ownerReferences:
  - apiVersion: run.tanzu.vmware.com/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: TanzuKubernetesCluster
    name: test-cluster-e2e-script
    uid: dd85dc0d-25e8-4925-be21-c631f89253f1
  resourceVersion: "10669562"
  selfLink: /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsvolumemetadatas/dd85dc0d-25e8-4925-be21-c631f89253f1-4db789dc-058f-46ed-a921-d93ad8c14ef5
  uid: a75c1328-c1e3-44af-8d8c-f50c4572e08f
spec:
  clusterdistribution: TKGService
  entityname: example-vanilla-rwo-pvc-10
  entityreferences:
  - clusterId: dd85dc0d-25e8-4925-be21-c631f89253f1
    entityName: pvc-4db789dc-058f-46ed-a921-d93ad8c14ef5
    entityType: PERSISTENT_VOLUME
  entitytype: PERSISTENT_VOLUME_CLAIM
  guestclusterid: dd85dc0d-25e8-4925-be21-c631f89253f1
  namespace: default
  volumenames:
  - dd85dc0d-25e8-4925-be21-c631f89253f1-4db789dc-058f-46ed-a921-d93ad8c14ef5
status: {}



====



root@421d9484a7570df19645e0cc09b3003d [ ~ ]# kubectl describe cnsvolumemetadatas dd85dc0d-25e8-4925-be21-c631f89253f1-63e1d50a-5d00-4d92-b173-c9ae266a9781 -n test-gc-e2e-demo-ns
Name:         dd85dc0d-25e8-4925-be21-c631f89253f1-63e1d50a-5d00-4d92-b173-c9ae266a9781
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsVolumeMetadata
Metadata:
  Creation Timestamp:  2021-11-03T22:10:26Z
  Generation:          1
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
      f:spec:
        .:
        f:clusterdistribution:
        f:entityname:
        f:entityreferences:
        f:entitytype:
        f:guestclusterid:
        f:volumenames:
      f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2021-11-03T22:10:26Z
  Owner References:
    API Version:           run.tanzu.vmware.com/v1alpha1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  TanzuKubernetesCluster
    Name:                  test-cluster-e2e-script
    UID:                   dd85dc0d-25e8-4925-be21-c631f89253f1
  Resource Version:        10669564
  Self Link:               /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsvolumemetadatas/dd85dc0d-25e8-4925-be21-c631f89253f1-63e1d50a-5d00-4d92-b173-c9ae266a9781
  UID:                     1386618f-8168-442c-805a-2e9e265e603b
Spec:
  Clusterdistribution:  TKGService
  Entityname:           pvc-4db789dc-058f-46ed-a921-d93ad8c14ef5
  Entityreferences:
    Entity Name:   dd85dc0d-25e8-4925-be21-c631f89253f1-4db789dc-058f-46ed-a921-d93ad8c14ef5
    Entity Type:   PERSISTENT_VOLUME_CLAIM
    Namespace:     test-gc-e2e-demo-ns
  Entitytype:      PERSISTENT_VOLUME
  Guestclusterid:  dd85dc0d-25e8-4925-be21-c631f89253f1
  Volumenames:
    dd85dc0d-25e8-4925-be21-c631f89253f1-4db789dc-058f-46ed-a921-d93ad8c14ef5
Status:
Events:
  Type     Reason        Age                 From            Message
  ----     ------        ----                ----            -------
  Warning  UpdateFailed  54s (x8 over 3m1s)  cns.vmware.com  ReconcileCnsVolumeMetadata: Failed to validate reconcile request with error: PERSISTENT_VOLUME instances can only refer to PERSISTENT_VOLUME_CLAIM instances
```


```
root@421d9484a7570df19645e0cc09b3003d [ ~ ]# kubectl describe cnsvolumemetadatas dd85dc0d-25e8-4925-be21-c631f89253f1-4db789dc-058f-46ed-a921-d93ad8c14ef5 -n test-gc-e2e-demo-ns
Name:         dd85dc0d-25e8-4925-be21-c631f89253f1-4db789dc-058f-46ed-a921-d93ad8c14ef5
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsVolumeMetadata
Metadata:
  Creation Timestamp:  2021-11-03T22:10:26Z
  Generation:          1
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
      f:spec:
        .:
        f:clusterdistribution:
        f:entityname:
        f:entityreferences:
        f:entitytype:
        f:guestclusterid:
        f:namespace:
        f:volumenames:
      f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2021-11-03T22:10:26Z
  Owner References:
    API Version:           run.tanzu.vmware.com/v1alpha1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  TanzuKubernetesCluster
    Name:                  test-cluster-e2e-script
    UID:                   dd85dc0d-25e8-4925-be21-c631f89253f1
  Resource Version:        10669562
  Self Link:               /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsvolumemetadatas/dd85dc0d-25e8-4925-be21-c631f89253f1-4db789dc-058f-46ed-a921-d93ad8c14ef5
  UID:                     a75c1328-c1e3-44af-8d8c-f50c4572e08f
Spec:
  Clusterdistribution:  TKGService
  Entityname:           example-vanilla-rwo-pvc-10
  Entityreferences:
    Cluster Id:    dd85dc0d-25e8-4925-be21-c631f89253f1
    Entity Name:   pvc-4db789dc-058f-46ed-a921-d93ad8c14ef5
    Entity Type:   PERSISTENT_VOLUME
  Entitytype:      PERSISTENT_VOLUME_CLAIM
  Guestclusterid:  dd85dc0d-25e8-4925-be21-c631f89253f1
  Namespace:       default
  Volumenames:
    dd85dc0d-25e8-4925-be21-c631f89253f1-4db789dc-058f-46ed-a921-d93ad8c14ef5
Status:
Events:
  Type     Reason        Age                  From            Message
  ----     ------        ----                 ----            -------
  Warning  UpdateFailed  83s (x8 over 3m30s)  cns.vmware.com  ReconcileCnsVolumeMetadata: Failed to validate reconcile request with error: EntityReferences.ClusterID should not be empty for PERSISTENT_VOLUME_CLAIM instances
```

**Release note**:
```release-note
Revert back CnsVolumeMetadata entity references from json to xml
```
