### PR TITLE
Revert back CnsVolumeMetadata entityreferences from json to xml (#1401)

### DIFF
--- a/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
+++ b/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
@@ -132,14 +132,7 @@ const (
 	CnsOperatorEntityTypePOD = CnsOperatorEntityType(cnstypes.CnsKubernetesEntityTypePOD)
 )
 
-// CnsOperatorEntityReference defines the type for entityreference
-// parameter in cnsvolumemetadata API.
-type CnsOperatorEntityReference struct {
-	EntityType string `json:"entityType"`
-	EntityName string `json:"entityName"`
-	Namespace  string `json:"namespace,omitempty"`
-	ClusterID  string `json:"clusterId,omitempty"`
-}
+type CnsOperatorEntityReference cnstypes.CnsKubernetesEntityReference
 
 // CreateCnsVolumeMetadataSpec returns a cnsvolumemetadata object from the
 // input parameters.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry-pick of https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1401 to release-2.4 branch

**Release note**:

```release-note
Revert back CnsVolumeMetadata entityreferences from json to xml
```
