### PR TITLE
Adding P0 metrics to volume health feature in SV and Vanilla flavors

### DIFF
--- a/pkg/common/prometheus/metrics.go
+++ b/pkg/common/prometheus/metrics.go
@@ -78,6 +78,10 @@ const (
 	PrometheusCnsCreateSnapshotOpType = "create-snapshot"
 	// PrometheusCnsDeleteSnapshotOpType represents DeleteSnapshot operation.
 	PrometheusCnsDeleteSnapshotOpType = "delete-snapshot"
+	// PrometheusAccessibleVolumes represents accessible volumes.
+	PrometheusAccessibleVolumes = "accessible-volumes"
+	// PrometheusInaccessibleVolumes represents inaccessible volumes.
+	PrometheusInaccessibleVolumes = "inaccessible-volumes"
 
 	// PrometheusPassStatus represents a successful API run.
 	PrometheusPassStatus = "pass"
@@ -127,4 +131,12 @@ var (
 		// Possible optype - "create-volume", "delete-volume", "attach-volume", "detach-volume", "expand-volume", etc
 		// Possible status - "pass", "fail"
 		[]string{"optype", "status"})
+
+	// VolumeHealthGaugeVec is a gauge metric to observe the number of accessible and inaccessible volumes.
+	VolumeHealthGaugeVec = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "vsphere_volume_health_gauge",
+		Help: "Gauge for total number of accessible and inaccessible volumes",
+	},
+		// Possible volume_health_type - "accessible-volumes", "inaccessible-volumes"
+		[]string{"volume_health_type"})
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**What this PR does / why we need it**:
This PR adds P0 metrics to volume health feature. It gauges the number of accessible and inaccessible volumes at any point of time.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual testing:

1. Create a PVC and verify its accessible:
```
# kubectl describe pvc -A
Name:          60f31483-5c2b-484c-8437-a710b7cc8bf4-4ef9af38-e455-4d67-9783-958e06865b36
Namespace:     test-gc-e2e-demo-ns
...
               volumehealth.storage.kubernetes.io/health: accessible
...
```
2. Validate volume health metrics
```
# kubectl exec -it vsphere-csi-controller-654684cf-4ckms -n vmware-system-csi -c vsphere-syncer -- curl localhost:2113/metrics | grep access
# HELP vsphere_volume_health_gauge Gauge for total number of accessible and inaccessible volumes
vsphere_volume_health_gauge{volume_health_type="accessible-volumes"} 2
vsphere_volume_health_gauge{volume_health_type="inaccessible-volumes"} 0
```
3. PSOD the host where the volume is placed and verify volume is inaccessible
```
# kubectl describe pvc -A
Name:          60f31483-5c2b-484c-8437-a710b7cc8bf4-4ef9af38-e455-4d67-9783-958e06865b36
Namespace:     test-gc-e2e-demo-ns
...
               volumehealth.storage.kubernetes.io/health: inaccessible
...
```
4. Validate volume health metrics
```
# kubectl exec -it vsphere-csi-controller-654684cf-4ckms -n vmware-system-csi -c vsphere-syncer -- curl localhost:2113/metrics | grep access
# HELP vsphere_volume_health_gauge Gauge for total number of accessible and inaccessible volumes
vsphere_volume_health_gauge{volume_health_type="accessible-volumes"} 0
vsphere_volume_health_gauge{volume_health_type="inaccessible-volumes"} 2
```

5. After some time, when the host is reconnected:
```
# kubectl exec -it vsphere-csi-controller-654684cf-4ckms -n vmware-system-csi -c vsphere-syncer -- curl localhost:2113/metrics | grep access
# HELP vsphere_volume_health_gauge Gauge for total number of accessible and inaccessible volumes
vsphere_volume_health_gauge{volume_health_type="accessible-volumes"} 2
vsphere_volume_health_gauge{volume_health_type="inaccessible-volumes"} 0
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adding P0 metrics to volume health feature
```
