### PR TITLE
Update findExistingTopologyLabels to only search beta topology labels

### DIFF
--- a/pkg/syncer/cnsoperator/controller/csinodetopology/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/controller_test.go
@@ -18,6 +18,8 @@ package csinodetopology
 
 import (
 	"context"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -151,9 +153,9 @@ func TestFindExistingTopologyLabels(t *testing.T) {
 					},
 				},
 			},
-			expectedZoneLabel:   "",
-			expectedRegionLabel: "",
-			expectedErr:         true,
+			expectedZoneLabel:   corev1.LabelTopologyZone,
+			expectedRegionLabel: corev1.LabelTopologyRegion,
+			expectedErr:         false,
 		},
 		{
 			name: "NoStandardLabelsOnNodes",
@@ -180,6 +182,14 @@ func TestFindExistingTopologyLabels(t *testing.T) {
 			expectedErr:         false,
 		},
 	}
+
+	var err error
+	commonco.ContainerOrchestratorUtility, err =
+		unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+	if err != nil {
+		t.Fatalf("Failed to create the container orchestrator interface. err: %v", err)
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actualZoneLabel, actualRegionLabel, actualErr := findExistingTopologyLabels(ctx, tt.nodeList)


### PR DESCRIPTION
When the existing worker nodes have a mix of beta topology labels and GA labels and users enable the improved topology feature with the old configuation, then there will be error message in the syncer something like `"…found conflicting topology labels…"`, and the CSI Node crashes as well.

This PR is to fix the above issue. 

Firstly, In previous versions (<2.4.0), only beta labels (i.e. "failure-domain.beta.kubernetes.io/zone") are used, so we only need to search the beta labels on the existing nodes.

Secondly, In the upgrade scenario, if previously the existing nodes did not participate in the topology setup, but the worker nodes have the beta topology labels (some K8s distributions may add such labels to nodes), then the beta topology labels should continue to be used by the improved topology feature. It isn't expected, but it shouldn't be a problem, because users are supposed to define the new configuration, i.e. "topology-categories=region,zone", rather than the old configuration like below in the csi-vsphere.con file in this case,
```
[labels]
zone=k8s-zone
region=k8s-region
```

Thirdly, this issue can only be reproduced in 2.4.0. In previous versions ( < 2.4.0), when the existing nodes have a mix a beta topology labels and GA labels, it isn't a problem at all. So we can say the 2.4.0 breaks user experiences.  So we should fix it in 2.4.

cc @divyenpatel  @shalini-b 