### PR TITLE
[e2e-test]: Fix spelling error for "default"

### DIFF
--- a/tests/e2e/gc_rwx_security_context.go
+++ b/tests/e2e/gc_rwx_security_context.go
@@ -623,7 +623,7 @@ var _ = ginkgo.Describe("File Volume Test with security context", func() {
 		4. Verify the error message on the failure
 		5. Delete PVC
 	*/
-	ginkgo.It("[rwm-csi-tkg] Exceed resource quota on deafult SC while provisioning file volume", func() {
+	ginkgo.It("[rwm-csi-tkg] Exceed resource quota on default SC while provisioning file volume", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var pvclaim *v1.PersistentVolumeClaim

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -694,7 +694,7 @@ func updateSCtoDefault(ctx context.Context, scName, isDefault string) error {
 	updatedSC, err := clientSet.StorageV1().StorageClasses().Patch(ctx,
 		scName, "application/merge-patch+json", patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		log.Errorf("Failed to patch the storage class object with isDeafult. Err = %+v", err)
+		log.Errorf("Failed to patch the storage class object with isDefault. Err = %+v", err)
 		return err
 	}
 	log.Debug("Successfully updated is default annotations of storage class: ", scName, updatedSC.Annotations)


### PR DESCRIPTION
Fixing a spelling error for string "default"

**Testing done**:
Yes
https://gist.github.com/rpanduranga/b200d167d256557ee5458fbb1782ca38

**Special notes for your reviewer**:
NA

**Release note**:
NA