### PR TITLE
CRD support from apiextensions.k8s.io/v1beta1 API to v1 API for WCP/TKG APIs

### DIFF
--- a/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1/doc.go
+++ b/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1/doc.go
@@ -1,0 +1,5 @@
+// +k8s:deepcopy-gen=package
+// +k8s:defaulter-gen=TypeMeta
+// +groupName=cns.vmware.com
+
+package v1alpha1

--- a/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1/doc.go
+++ b/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1/doc.go
@@ -1,0 +1,5 @@
+// +k8s:deepcopy-gen=package
+// +k8s:defaulter-gen=TypeMeta
+// +groupName=cns.vmware.com
+
+package v1alpha1

--- a/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1/doc.go
+++ b/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1/doc.go
@@ -1,0 +1,5 @@
+// +k8s:deepcopy-gen=package
+// +k8s:defaulter-gen=TypeMeta
+// +groupName=cns.vmware.com
+
+package v1alpha1

--- a/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/doc.go
+++ b/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/doc.go
@@ -1,0 +1,5 @@
+// +k8s:deepcopy-gen=package
+// +k8s:defaulter-gen=TypeMeta
+// +groupName=cns.vmware.com
+
+package v1alpha1

--- a/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmattachments.yaml
+++ b/pkg/apis/cnsoperator/config/cns.vmware.com_cnsnodevmattachments.yaml
@@ -1,0 +1,85 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: cnsnodevmattachments.cns.vmware.com
+spec:
+  group: cns.vmware.com
+  names:
+    kind: CnsNodeVmAttachment
+    listKind: CnsNodeVmAttachmentList
+    plural: cnsnodevmattachments
+    singular: cnsnodevmattachment
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CnsNodeVmAttachment is the Schema for the cnsnodevmattachments
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CnsNodeVmAttachmentSpec defines the desired state of CnsNodeVmAttachment
+            properties:
+              nodeuuid:
+                description: NodeUUID indicates the UUID of the node where the volume
+                  needs to be attached to. Here NodeUUID is the bios UUID of the node.
+                type: string
+              volumename:
+                description: VolumeName indicates the name of the volume on the supervisor
+                  Cluster. This is guaranteed to be unique in Supervisor cluster.
+                type: string
+            required:
+            - nodeuuid
+            - volumename
+            type: object
+          status:
+            description: CnsNodeVmAttachmentStatus defines the observed state of CnsNodeVmAttachment
+            properties:
+              attached:
+                description: Indicates the volume is successfully attached. This field
+                  must only be set by the entity completing the attach operation,
+                  i.e. the CNS Operator.
+                type: boolean
+              error:
+                description: The last error encountered during attach/detach operation,
+                  if any. This field must only be set by the entity completing the
+                  attach operation, i.e. the CNS Operator.
+                type: string
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Before successful attach, this field is populated with
+                  CNS volume ID. Upon successful attach, this field is populated with
+                  any information returned by the attach operation. This field must
+                  only be set by the entity completing the attach operation, i.e.
+                  the CNS Operator
+                type: object
+            required:
+            - attached
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/apis/cnsoperator/config/cns.vmware.com_cnsvolumemetadata.yaml
+++ b/pkg/apis/cnsoperator/config/cns.vmware.com_cnsvolumemetadata.yaml
@@ -1,0 +1,132 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: cnsvolumemetadatas.cns.vmware.com
+spec:
+  group: cns.vmware.com
+  names:
+    kind: CnsVolumeMetadata
+    listKind: CnsVolumeMetadataList
+    plural: cnsvolumemetadatas
+    singular: cnsvolumemetadata
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CnsVolumeMetadata is the Schema for the cnsvolumemetadata API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CnsVolumeMetadataSpec defines the desired state of CnsVolumeMetadata
+            properties:
+              clusterdistribution:
+                description: ClusterDistribution indicates the cluster distribution
+                  where the PVCSI driver is deployed
+                type: string
+              entityname:
+                description: EntityName indicates name of the entity in the guest
+                  cluster.
+                type: string
+              entityreferences:
+                description: EntityReferences indicate the other entities that this
+                  entity refers to. A Pod in the guest cluster can refers to one or
+                  more PVCs in the guest cluster. A PVC in the guest cluster refers
+                  to a PV in the guest cluster. A PV in the guest cluster refers to
+                  a PVC in the supervisor cluster. A Pod/PVC in the guest cluster
+                  referring to a PVC/PV respectively in the guest cluster must set
+                  the ClusterID field. A PV in the guest cluster referring to a PVC
+                  in the supervisor cluster must leave the ClusterID field unset.
+                  This field is mandatory.
+                type: array
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              entitytype:
+                description: EntityType indicates type of entity whose metadata this
+                  instance represents.
+                type: string
+              guestclusterid:
+                description: GuestClusterID indicates the guest cluster ID in which
+                  this volume is referenced.
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels indicates user labels assigned to the entity in
+                  the guest cluster. Should only be populated if EntityType is PERSISTENT_VOLUME
+                  OR PERSISTENT_VOLUME_CLAIM. CNS Operator will return a failure to
+                  the client if labels are set for objects whose EntityType is POD.
+                type: object
+              namespace:
+                description: Namespace indicates namespace of entity in guest cluster.
+                  Should only be populated if EntityType is PERSISTENT_VOLUME_CLAIM
+                  or POD. CNS Operator will return a failure to the client if namespace
+                  is set for objects whose EntityType is PERSISTENT_VOLUME.
+                type: string
+              volumenames:
+                description: VolumeNames indicates the unique ID of the volume. For
+                  volumes created in a guest cluster, this will be “<guestcluster-ID>-<UID>”
+                  where UID is the pvc.UUID in supervisor cluster. Instances of POD
+                  entity type can have multiple volume names. Instances of PV and
+                  PVC entity types will have only one volume name.
+                items:
+                  type: string
+                type: array
+            required:
+            - entityname
+            - entityreferences
+            - entitytype
+            - guestclusterid
+            - volumenames
+            type: object
+          status:
+            description: CnsVolumeMetadataStatus defines the observed state of CnsVolumeMetadata
+            properties:
+              volumestatus:
+                description: The last error encountered, per volume, during update
+                  operation. This field must only be set by the entity completing
+                  the update operation, i.e. the CNS Operator. This string may be
+                  logged, so it should not contain sensitive information.
+                items:
+                  description: CnsVolumeMetadataVolumeStatus defines the status of
+                    the last update operation on CNS for the given volume. Error message
+                    will be empty if no error was encountered.
+                  properties:
+                    errormessage:
+                      type: string
+                    updated:
+                      type: boolean
+                    volumename:
+                      type: string
+                  required:
+                  - updated
+                  - volumename
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml
@@ -1,6 +1,11 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
   name: cnsfileaccessconfigs.cns.vmware.com
 spec:
   group: cns.vmware.com
@@ -10,56 +15,63 @@ spec:
     plural: cnsfileaccessconfigs
     singular: cnsfileaccessconfig
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: CnsFileAccessConfig is the Schema for the cnsfileaccessconfig API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          type: object
-          description: CnsFileAccessConfigSpec defines the desired state of CnsFileAccessConfig
-          properties:
-            pvcName:
-              description: PvcName indicates the name of the PVC on the supervisor Cluster.
-              type: string
-              pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
-            vmName:
-              description: VMName is the name of VirtualMachine instance on SV cluster.
-              type: string
-              pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
-          required:
-          - pvcName
-          type: object
-        status:
-          type: object
-          description: CnsFileAccessConfigStatus defines the observed state of CnsFileAccessConfig.
-          properties:
-            done:
-              description: Done indicates whether the ACL has been configured on file volume.
-              type: boolean
-            accessPoints:
-              description: Access points per protocol supported by the volume.
-              additionalProperties:
-                items:
-                  type: string
-              type: object
-            error:
-              description: The last error encountered during file volume config operation, if any
-              type: string
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CnsFileAccessConfig is the Schema for the CnsFileAccessConfig
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CnsFileAccessConfigSpec defines the desired state of CnsFileAccessConfig
+            properties:
+              pvcName:
+                description: PvcName indicates the name of the PVC on the supervisor
+                  Cluster. This is guaranteed to be unique in Supervisor cluster.
+                type: string
+              vmName:
+                description: VmName is the name of VirtualMachine instance on SV cluster
+                  Support for PodVm will be added in the near future and either VMName
+                  or PodVMName needs to be set.
+                type: string
+            required:
+            - pvcName
+            type: object
+          status:
+            description: CnsFileAccessConfigStatus defines the observed state of CnsFileAccessConfig
+            properties:
+              accessPoints:
+                additionalProperties:
+                  type: string
+                description: Access points per protocol supported by the volume. This
+                  field must only be set by the entity completing the config operation,
+                  i.e. the CNS Operator. AccessPoints field will only be set when
+                  the CnsFileAccessConfig.Status.Done field is set to true.
+                type: object
+              done:
+                description: Done indicates whether the ACL has been configured on
+                  file volume. This field must only be set by the entity completing
+                  the register operation, i.e. the CNS Operator.
+                type: boolean
+              error:
+                description: The last error encountered during file volume config
+                  operation, if any This field must only be set by the entity completing
+                  the config operation, i.e. the CNS Operator.
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml
@@ -1,6 +1,11 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
   name: cnsregistervolumes.cns.vmware.com
 spec:
   group: cns.vmware.com
@@ -10,60 +15,78 @@ spec:
     plural: cnsregistervolumes
     singular: cnsregistervolume
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: CnsRegisterVolume is the Schema for the cnsregistervolumes API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          type: object
-          description: CnsRegisterVolumeSpec defines the desired state of CnsRegisterVolume
-          properties:
-            pvcName:
-              description: Name of the PVC
-              type: string
-              pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
-            volumeID:
-              description: VolumeID indicates an existing vsphere volume to be imported
-                into Project Pacific cluster
-              type: string
-              pattern: '^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$'
-            accessMode:
-              description: AccessMode contains the actual access mode the volume backing
-                the CnsRegisterVolume has
-              type: string
-            diskURLPath:
-              description: DiskUrlPath is URL path to an existing block volume to be
-                imported into Project Pacific cluster.
-              type: string
-              pattern: '^(http[s]?:\/\/)?([^\/\s]+\/folder\/)(.*)$'
-          required:
-          - pvcName
-          type: object
-        status:
-          type: object
-          description: CnsRegisterVolumeStatus defines the observed state of CnsRegisterVolume
-          properties:
-            registered:
-              description: Indicates the volume is successfully imported.
-              type: boolean
-            error:
-              description: The last error encountered during import operation, if any.
-              type: string
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CnsRegisterVolume is the Schema for the cnsregistervolumes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CnsRegisterVolumeSpec defines the desired state of CnsRegisterVolume
+            properties:
+              accessMode:
+                description: AccessMode contains the actual access mode the volume
+                  backing the CnsRegisterVolume has. AccessMode must be specified
+                  if VolumeID is specified.
+                type: string
+              diskURLPath:
+                description: 'DiskUrlPath is URL path to an existing block volume
+                  to be imported into Project Pacific cluster. VolumeID and DiskUrlPath
+                  cannot be specified together. DiskUrlPath is explicitly used for
+                  block volumes. AccessMode need not be specified and will be defaulted
+                  to "ReadWriteOnce". This field must be in the following format:
+                  Format: https://<vc_ip>/folder/<vm_vmdk_path>?dcPath=<datacenterName>&dsName=<datastoreName>
+                  Ex: https://10.192.255.221/folder/34a9c05d-5f03-e254-e692-02004479cb91/        vm2_1.vmdk?dcPath=Datacenter-1&dsName=vsanDatastore
+                  This is for a 34a9c05d-5f03-e254-e692-02004479cb91/vm2_1.vmdk file
+                  under datacenter "Datacenter-1" and datastore "vsanDatastore".'
+                type: string
+                pattern: '^(http[s]?:\/\/)?([^\/\s]+\/folder\/)(.*)$'
+              pvcName:
+                description: Name of the PVC
+                type: string
+                pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+              volumeID:
+                description: VolumeID indicates an existing vsphere volume to be imported
+                  into Project Pacific cluster. If the AccessMode is "ReadWriteMany"
+                  or "ReadOnlyMany", then this VolumeID can be either an existing
+                  FileShare (or) CNS file volume backed FileShare. If the AccessMode
+                  is "ReadWriteOnce", then this VolumeID can be either an existing
+                  FCD (or) a CNS backed FCD. VolumeID and DiskUrlPath cannot be specified
+                  together.
+                type: string
+                pattern: '^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$'
+            required:
+            - pvcName
+            type: object
+          status:
+            description: CnsRegisterVolumeStatus defines the observed state of CnsRegisterVolume
+            properties:
+              error:
+                description: The last error encountered during import operation, if
+                  any. This field must only be set by the entity completing the import
+                  operation, i.e. the CNS Operator.
+                type: string
+              registered:
+                description: Indicates the volume is successfully registered. This
+                  field must only be set by the entity completing the register operation,
+                  i.e. the CNS Operator.
+                type: boolean
+            required:
+            - registered
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/pkg/apis/cnsoperator/config/config.go
+++ b/pkg/apis/cnsoperator/config/config.go
@@ -2,6 +2,16 @@ package config
 
 import "embed"
 
+//go:embed cns.vmware.com_cnsnodevmattachments.yaml
+var EmbedCnsNodeVmAttachmentCRFile embed.FS
+
+const EmbedCnsNodeVmAttachmentCRFileName = "cns.vmware.com_cnsnodevmattachments.yaml"
+
+//go:embed cns.vmware.com_cnsvolumemetadata.yaml
+var EmbedCnsVolumeMetadataCRFile embed.FS
+
+const EmbedCnsVolumeMetadataCRFileName = "cns.vmware.com_cnsvolumemetadata.yaml"
+
 //go:embed cnsfileaccessconfig_crd.yaml
 var EmbedCnsFileAccessConfigCRFile embed.FS
 

--- a/pkg/apis/storagepool/cns/v1alpha1/storagepool_types.go
+++ b/pkg/apis/storagepool/cns/v1alpha1/storagepool_types.go
@@ -97,6 +97,7 @@ var (
 
 // StoragePool is the Schema for the storagepools API
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:scope=Cluster
 type StoragePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/storagepool/config/cns.vmware.com_storagepools.yaml
+++ b/pkg/apis/storagepool/config/cns.vmware.com_storagepools.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: StoragePoolList
     plural: storagepools
     singular: storagepool
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -105,7 +105,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			config.Global.CnsVolumeOperationRequestCleanupIntervalInMin,
 			func() bool {
 				return commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
-			}, cnstypes.CnsClusterFlavorVanilla)
+			})
 		if err != nil {
 			log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
 			return err
@@ -319,7 +319,7 @@ func (c *controller) ReloadConfiguration() error {
 				c.manager.CnsConfig.Global.CnsVolumeOperationRequestCleanupIntervalInMin,
 				func() bool {
 					return commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
-				}, cnstypes.CnsClusterFlavorVanilla)
+				})
 			if err != nil {
 				log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
 				return err

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -98,7 +98,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			config.Global.CnsVolumeOperationRequestCleanupIntervalInMin,
 			func() bool {
 				return commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
-			}, cnstypes.CnsClusterFlavorWorkload)
+			})
 		if err != nil {
 			log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
 			return err
@@ -282,7 +282,7 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 				c.manager.CnsConfig.Global.CnsVolumeOperationRequestCleanupIntervalInMin,
 				func() bool {
 					return commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
-				}, cnstypes.CnsClusterFlavorWorkload)
+				})
 			if err != nil {
 				log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
 				return err

--- a/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1/doc.go
+++ b/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1/doc.go
@@ -1,0 +1,5 @@
+// +k8s:deepcopy-gen=package
+// +k8s:defaulter-gen=TypeMeta
+// +groupName=cns.vmware.com
+
+package v1alpha1

--- a/pkg/internalapis/cnsvolumeoperationrequest/util.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/util.go
@@ -23,12 +23,6 @@ import (
 )
 
 const (
-	// CRDName represent the name of cnsvolumeoperationrequest CRD.
-	crdName = "cnsvolumeoperationrequests.cns.vmware.com"
-	// CRDSingular represent the singular name of cnsvolumeoperationrequest CRD.
-	crdSingular = "cnsvolumeoperationrequest"
-	// CRDPlural represent the plural name of cnsvolumeoperationrequest CRD.
-	crdPlural = "cnsvolumeoperationrequests"
 	// maxEntriesInLatestOperationDetails specifies the maximum length of the
 	// LatestOperationDetails allowed in a cnsvolumeoperationrequest instance.
 	maxEntriesInLatestOperationDetails = 10

--- a/pkg/internalapis/featurestates/config/cns.vmware.com_cnscsisvfeaturestates.yaml
+++ b/pkg/internalapis/featurestates/config/cns.vmware.com_cnscsisvfeaturestates.yaml
@@ -6,22 +6,21 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
-  name: cnsfilevolumeclients.cns.vmware.com
+  name: cnscsisvfeaturestates.cns.vmware.com
 spec:
   group: cns.vmware.com
   names:
-    kind: CnsFileVolumeClient
-    listKind: CnsFileVolumeClientList
-    plural: cnsfilevolumeclients
-    singular: cnsfilevolumeclient
+    kind: CnsCsiSvFeatureStates
+    listKind: CnsCsiSvFeatureStatesList
+    plural: cnscsisvfeaturestates
+    singular: cnscsisvfeaturestate
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: CnsFileVolumeClient is the Schema for the cnsfilevolumeclients
-          CRD. This CRD is used by CNS-CSI for internal bookkeeping purposes only
-          and is not an API.
+        description: CnsCsiSvFeatureStates is the Schema for the cnscsisvfeaturestates
+          API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -36,21 +35,25 @@ spec:
           metadata:
             type: object
           spec:
-            description: CnsFileVolumeClientSpec defines the desired state of CnsFileVolumeClient.
+            description: CnsCsiSvFeatureStatesSpec defines the desired state of CnsCsiSvFeatureStates
             properties:
-              externalIPtoClientVms:
-                additionalProperties:
-                  items:
-                    type: string
-                  type: array
-                description: ExternalIPtoClientVms maintains a mapping of External
-                  IP address to list of names of ClientVms. ClientsVms can be TKC
-                  Vms for TKC cluster (or) PodVms for SV. Keys are External IP Addresses
-                  that have access to a volume. Values are list of names of ClientVms.
-                  Each ClientVm in the list mounts this volume and is exposed to the
-                  external network by this IP address. PodVMs names will be prefixed
-                  with "POD_VM" and guest VMs will be prefix with "GUEST_VM".
-                type: object
+              featureStates:
+                items:
+                  description: FeatureState defines the feature name and its state
+                  properties:
+                    enabled:
+                      description: Enabled is set to true when feature is enabled,
+                        else it is set to false
+                      type: boolean
+                    name:
+                      description: Name is the unique identifier of the feature, this
+                        must be unique
+                      type: string
+                  required:
+                  - enabled
+                  - name
+                  type: object
+                type: array
             type: object
         type: object
     served: true

--- a/pkg/internalapis/featurestates/config/config.go
+++ b/pkg/internalapis/featurestates/config/config.go
@@ -1,0 +1,8 @@
+package config
+
+import "embed"
+
+//go:embed cns.vmware.com_cnscsisvfeaturestates.yaml
+var EmbedCnsCsiSvFeatureStatesCRFile embed.FS
+
+const EmbedCnsCsiSvFeatureStatesCRFileName = "cns.vmware.com_cnscsisvfeaturestates.yaml"

--- a/pkg/internalapis/featurestates/featurestates.go
+++ b/pkg/internalapis/featurestates/featurestates.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -33,6 +32,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	featurestatesconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config"
 
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis"
@@ -96,9 +96,8 @@ func StartSvFSSReplicationService(ctx context.Context, svFeatureStatConfigMapNam
 	var err error
 	// This is idempotent if CRD is pre-created then we continue with
 	// initialization of svFSSReplicationService.
-	err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, CRDName, CRDSingular, CRDPlural,
-		reflect.TypeOf(featurestatesv1alpha1.CnsCsiSvFeatureStates{}).Name(), CRDGroupName,
-		internalapis.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
+	err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, featurestatesconfig.EmbedCnsCsiSvFeatureStatesCRFile,
+		featurestatesconfig.EmbedCnsCsiSvFeatureStatesCRFileName)
 	if err != nil {
 		log.Errorf("failed to create CnsCsiSvFeatureStates CRD. Error: %v", err)
 		return err

--- a/pkg/internalapis/featurestates/v1alpha1/doc.go
+++ b/pkg/internalapis/featurestates/v1alpha1/doc.go
@@ -1,0 +1,5 @@
+// +k8s:deepcopy-gen=package
+// +k8s:defaulter-gen=TypeMeta
+// +groupName=cns.vmware.com
+
+package v1alpha1

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -19,7 +19,6 @@ package kubernetes
 import (
 	"context"
 	"embed"
-	"errors"
 	"flag"
 	"io/ioutil"
 	"net"
@@ -27,12 +26,9 @@ import (
 	"strconv"
 	"time"
 
-	jsontypes "encoding/json"
-
 	vmoperatorv1alpha1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -383,92 +379,40 @@ func getClientThroughput(ctx context.Context, isSupervisorClient bool) (float32,
 // CreateCustomResourceDefinitionFromSpec creates the custom resource definition
 // from given spec. If there is error, function will do the clean up.
 func CreateCustomResourceDefinitionFromSpec(ctx context.Context, crdName string, crdSingular string, crdPlural string,
-	crdKind string, crdGroup string, crdVersion string, crdScope apiextensionsv1beta1.ResourceScope) error {
-	crdSpec := &apiextensionsv1beta1.CustomResourceDefinition{
+	crdKind string, crdGroup string, crdVersion string, crdScope apiextensionsv1.ResourceScope) error {
+	crdSpec := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crdName,
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 			Group: crdGroup,
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{
 					Name:    crdVersion,
 					Served:  true,
 					Storage: true,
 				}},
 			Scope: crdScope,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural:   crdPlural,
 				Singular: crdSingular,
 				Kind:     crdKind,
 			},
 		},
 	}
-	return createCustomResourceDefinitionv1beta1(ctx, crdSpec)
+	return createCustomResourceDefinition(ctx, crdSpec)
 }
 
 // CreateCustomResourceDefinitionFromManifest creates custom resource definition
 // spec from manifest file.
 func CreateCustomResourceDefinitionFromManifest(ctx context.Context, embedFiles embed.FS, fileName string) error {
 	log := logger.GetLogger(ctx)
-	manifestcrdv1, manifestcrdv1beta1, err := getCRDFromManifest(ctx, embedFiles, fileName)
+	manifestcrd, err := getCRDFromManifest(ctx, embedFiles, fileName)
 	if err != nil {
 		log.Errorf("Failed to read the CRD spec from manifest file: %s with err: %+v", fileName, err)
 		return err
 	}
-	if manifestcrdv1 != nil {
-		return createCustomResourceDefinitionv1(ctx, manifestcrdv1)
-	}
-	return createCustomResourceDefinitionv1beta1(ctx, manifestcrdv1beta1)
-}
-
-// createCustomResourceDefinition takes a custom resource definition spec and
-// creates it on the API server.
-func createCustomResourceDefinitionv1beta1(ctx context.Context,
-	newCrd *apiextensionsv1beta1.CustomResourceDefinition) error {
-	log := logger.GetLogger(ctx)
-	// Get a config to talk to the apiserver.
-	cfg, err := GetKubeConfig(ctx)
-	if err != nil {
-		log.Errorf("failed to get Kubernetes config. Err: %+v", err)
-		return err
-	}
-	apiextensionsClientSet, err := apiextensionsclientset.NewForConfig(cfg)
-	if err != nil {
-		log.Errorf("failed to create Kubernetes client using config. Err: %+v", err)
-		return err
-	}
-
-	crdName := newCrd.ObjectMeta.Name
-	crd, err := apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(ctx,
-		crdName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx,
-			newCrd, metav1.CreateOptions{})
-		if err != nil {
-			log.Errorf("Failed to create %q CRD with err: %+v", crdName, err)
-			return err
-		}
-		log.Infof("%q CRD created successfully", crdName)
-	} else {
-		// Update the existing CRD with new CRD.
-		crd.Spec = newCrd.Spec
-		crd.Status = newCrd.Status
-		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Update(ctx,
-			crd, metav1.UpdateOptions{})
-		if err != nil {
-			log.Errorf("Failed to update %q CRD with err: %+v", crdName, err)
-			return err
-		}
-		log.Infof("%q CRD updated successfully", crdName)
-		return nil
-	}
-
-	err = waitForCustomResourceToBeEstablishedv1beta1(ctx, apiextensionsClientSet, crdName)
-	if err != nil {
-		log.Errorf("CRD %q created but failed to establish. Err: %+v", crdName, err)
-	}
-	return err
+	return createCustomResourceDefinition(ctx, manifestcrd)
 }
 
 // GetNodeIdFromCSINode gets the UUID from CSINode object
@@ -484,7 +428,7 @@ func GetNodeIdFromCSINode(csiNode *storagev1.CSINode) string {
 
 // createCustomResourceDefinition takes a custom resource definition spec and
 // creates it on the API server.
-func createCustomResourceDefinitionv1(ctx context.Context, newCrd *apiextensionsv1.CustomResourceDefinition) error {
+func createCustomResourceDefinition(ctx context.Context, newCrd *apiextensionsv1.CustomResourceDefinition) error {
 	log := logger.GetLogger(ctx)
 	// Get a config to talk to the apiserver.
 	cfg, err := GetKubeConfig(ctx)
@@ -523,7 +467,7 @@ func createCustomResourceDefinitionv1(ctx context.Context, newCrd *apiextensions
 		return nil
 	}
 
-	err = waitForCustomResourceToBeEstablishedv1(ctx, apiextensionsClientSet, crdName)
+	err = waitForCustomResourceToBeEstablished(ctx, apiextensionsClientSet, crdName)
 	if err != nil {
 		log.Errorf("CRD %q created but failed to establish. Err: %+v", crdName, err)
 	}
@@ -531,44 +475,7 @@ func createCustomResourceDefinitionv1(ctx context.Context, newCrd *apiextensions
 }
 
 // waitForCustomResourceToBeEstablished waits until the CRD status is Established.
-func waitForCustomResourceToBeEstablishedv1beta1(ctx context.Context,
-	clientSet apiextensionsclientset.Interface, crdName string) error {
-	log := logger.GetLogger(ctx)
-	err := wait.Poll(pollTime, timeout, func() (bool, error) {
-		crd, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
-		if err != nil {
-			log.Errorf("Failed to get %q CRD with err: %+v", crdName, err)
-			return false, err
-		}
-		for _, cond := range crd.Status.Conditions {
-			switch cond.Type {
-			case apiextensionsv1beta1.Established:
-				if cond.Status == apiextensionsv1beta1.ConditionTrue {
-					return true, err
-				}
-			case apiextensionsv1beta1.NamesAccepted:
-				if cond.Status == apiextensionsv1beta1.ConditionFalse {
-					log.Debugf("Name conflict while waiting for %q CRD creation", cond.Reason)
-				}
-			}
-		}
-		return false, err
-	})
-
-	// If there is an error, delete the object to keep it clean.
-	if err != nil {
-		log.Infof("Cleanup %q CRD because the CRD created was not successfully established. Err: %+v", crdName, err)
-		deleteErr := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(ctx,
-			crdName, *metav1.NewDeleteOptions(0))
-		if deleteErr != nil {
-			log.Errorf("Failed to delete %q CRD with err: %+v", crdName, deleteErr)
-		}
-	}
-	return err
-}
-
-// waitForCustomResourceToBeEstablished waits until the CRD status is Established.
-func waitForCustomResourceToBeEstablishedv1(ctx context.Context,
+func waitForCustomResourceToBeEstablished(ctx context.Context,
 	clientSet apiextensionsclientset.Interface, crdName string) error {
 	log := logger.GetLogger(ctx)
 	err := wait.Poll(pollTime, timeout, func() (bool, error) {
@@ -606,43 +513,23 @@ func waitForCustomResourceToBeEstablishedv1(ctx context.Context,
 
 // getCRDFromManifest reads a .json/yaml file and returns the CRD in it.
 func getCRDFromManifest(ctx context.Context, embedFS embed.FS, fileName string) (
-	*apiextensionsv1.CustomResourceDefinition, *apiextensionsv1beta1.CustomResourceDefinition, error) {
-	var crdv1beta1 apiextensionsv1beta1.CustomResourceDefinition
-	var crdv1 apiextensionsv1.CustomResourceDefinition
-	var obj interface{}
+	*apiextensionsv1.CustomResourceDefinition, error) {
+	var crd apiextensionsv1.CustomResourceDefinition
 	log := logger.GetLogger(ctx)
 	data, err := embedFS.ReadFile(fileName)
 	if err != nil {
 		log.Errorf("Failed to read the manifest file: %s. Error: %+v", fileName, err)
-		return nil, nil, err
+		return nil, err
 	}
 	json, err := utilyaml.ToJSON(data)
 	if err != nil {
 		log.Errorf("Failed to convert the manifest file: %s content to JSON with error: %+v", fileName, err)
-		return nil, nil, err
+		return nil, err
 	}
-	if err := jsontypes.Unmarshal(json, &obj); err != nil {
-		log.Errorf("Failed to unmarshal the data: %+v with error: %+v", json, err)
-		return nil, nil, err
+
+	if err := runtime.DecodeInto(legacyscheme.Codecs.UniversalDecoder(), json, &crd); err != nil {
+		log.Errorf("Failed to decode json content: %+v to crd with error: %+v", json, err)
+		return nil, err
 	}
-	fields, ok := obj.(map[string]interface{})
-	if !ok {
-		log.Errorf("Error in unmarshalling the data: %+v with error: %+v", json, err)
-		return nil, nil, err
-	}
-	apiVersion := fields["apiVersion"]
-	if apiVersion == "apiextensions.k8s.io/v1" {
-		if err := runtime.DecodeInto(legacyscheme.Codecs.UniversalDecoder(), json, &crdv1); err != nil {
-			log.Errorf("Failed to decode json content: %+v to crd with error: %+v", json, err)
-			return nil, nil, err
-		}
-		return &crdv1, nil, nil
-	} else if apiVersion == "apiextensions.k8s.io/v1beta1" {
-		if err := runtime.DecodeInto(legacyscheme.Codecs.UniversalDecoder(), json, &crdv1beta1); err != nil {
-			log.Errorf("Failed to decode json content: %+v to crd with error: %+v", json, err)
-			return nil, nil, err
-		}
-		return nil, &crdv1beta1, nil
-	}
-	return nil, nil, errors.New("invalid CRD apiVersion")
+	return &crd, nil
 }

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	cnstypes "github.com/vmware/govmomi/cns/types"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -36,7 +35,6 @@ import (
 	csinodetopologyconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config"
 
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator"
-	cnsnodevmattachmentv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
@@ -100,28 +98,20 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 	// Create CRD's for WCP flavor.
 	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		// Create CnsNodeVmAttachment CRD
-		crdKindNodeVMAttachment := reflect.TypeOf(cnsnodevmattachmentv1alpha1.CnsNodeVmAttachment{}).Name()
-		crdNameNodeVMAttachment := cnsoperatorv1alpha1.CnsNodeVMAttachmentPlural + "." +
-			cnsoperatorv1alpha1.SchemeGroupVersion.Group
-		err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, crdNameNodeVMAttachment,
-			cnsoperatorv1alpha1.CnsNodeVMAttachmentSingular, cnsoperatorv1alpha1.CnsNodeVMAttachmentPlural,
-			crdKindNodeVMAttachment, cnsoperatorv1alpha1.SchemeGroupVersion.Group,
-			cnsoperatorv1alpha1.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
+		err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, cnsoperatorconfig.EmbedCnsNodeVmAttachmentCRFile,
+			cnsoperatorconfig.EmbedCnsNodeVmAttachmentCRFileName)
 		if err != nil {
+			crdNameNodeVMAttachment := cnsoperatorv1alpha1.CnsNodeVMAttachmentPlural +
+				"." + cnsoperatorv1alpha1.SchemeGroupVersion.Group
 			log.Errorf("failed to create %q CRD. Err: %+v", crdNameNodeVMAttachment, err)
 			return err
 		}
 
 		// Create CnsVolumeMetadata CRD
-		crdKindVolumeMetadata := reflect.TypeOf(cnsvolumemetadatav1alpha1.CnsVolumeMetadata{}).Name()
-		crdNameVolumeMetadata := cnsoperatorv1alpha1.CnsVolumeMetadataPlural + "." +
-			cnsoperatorv1alpha1.SchemeGroupVersion.Group
-
-		err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, crdNameVolumeMetadata,
-			cnsoperatorv1alpha1.CnsVolumeMetadataSingular, cnsoperatorv1alpha1.CnsVolumeMetadataPlural,
-			crdKindVolumeMetadata, cnsoperatorv1alpha1.SchemeGroupVersion.Group,
-			cnsoperatorv1alpha1.SchemeGroupVersion.Version, apiextensionsv1beta1.NamespaceScoped)
+		err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, cnsoperatorconfig.EmbedCnsVolumeMetadataCRFile,
+			cnsoperatorconfig.EmbedCnsVolumeMetadataCRFileName)
 		if err != nil {
+			crdKindVolumeMetadata := reflect.TypeOf(cnsvolumemetadatav1alpha1.CnsVolumeMetadata{}).Name()
 			log.Errorf("failed to create %q CRD. Err: %+v", crdKindVolumeMetadata, err)
 			return err
 		}

--- a/pkg/syncer/storagepool/service.go
+++ b/pkg/syncer/storagepool/service.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	storagepoolconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config"
 
 	spv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
@@ -63,14 +63,10 @@ func InitStoragePoolService(ctx context.Context,
 	}
 
 	// Create StoragePool CRD.
-	crdKind := reflect.TypeOf(spv1alpha1.StoragePool{}).Name()
-	crdSingular := "storagepool"
-	crdPlural := "storagepools"
-	crdName := crdPlural + "." + spv1alpha1.SchemeGroupVersion.Group
-	err = k8s.CreateCustomResourceDefinitionFromSpec(ctx, crdName, crdSingular, crdPlural,
-		crdKind, spv1alpha1.SchemeGroupVersion.Group, spv1alpha1.SchemeGroupVersion.Version,
-		apiextensionsv1beta1.ClusterScoped)
+	err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, storagepoolconfig.EmbedStoragePoolCRFile,
+		storagepoolconfig.EmbedStoragePoolCRFileName)
 	if err != nil {
+		crdKind := reflect.TypeOf(spv1alpha1.StoragePool{}).Name()
 		log.Errorf("Failed to create %q CRD. Err: %+v", crdKind, err)
 		return err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds back the CRD support from apiextensions.k8s.io/v1beta1 API to v1 API for WCP/TKG APIs. The support for creating fields from older versions of TKG is retained by utilizing the `x-kubernetes-preserve-unknown-fields: true` property in the schema.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified backward & forward compatibility in WCP for TKGs with older and newer CSI).

CRs created by TKG with 2.3.0 CSI (v1beta1) on WCP(released versions + CSI built from this PR)

```
kubectl describe cnsvolumemetadata -A
Name:         dd85dc0d-25e8-4925-be21-c631f89253f1-6a5b00aa-12e7-41cf-862d-26b52329a75d
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsVolumeMetadata
Metadata:
  Creation Timestamp:  2021-11-16T19:59:39Z
  Finalizers:
    cns.vmware.com
  Generation:  2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"cns.vmware.com":
        f:ownerReferences:
          .:
          k:{"uid":"dd85dc0d-25e8-4925-be21-c631f89253f1"}:
            .:
            f:apiVersion:
            f:blockOwnerDeletion:
            f:controller:
            f:kind:
            f:name:
            f:uid:
      f:spec:
        .:
        f:clusterdistribution:
        f:entityname:
        f:entityreferences:
        f:entitytype:
        f:guestclusterid:
        f:volumenames:
      f:status:
        .:
        f:volumestatus:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2021-11-16T19:59:42Z
  Owner References:
    API Version:           run.tanzu.vmware.com/v1alpha1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  TanzuKubernetesCluster
    Name:                  test-cluster-e2e-script
    UID:                   dd85dc0d-25e8-4925-be21-c631f89253f1
  Resource Version:        20449212
  Self Link:               /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsvolumemetadatas/dd85dc0d-25e8-4925-be21-c631f89253f1-6a5b00aa-12e7-41cf-862d-26b52329a75d
  UID:                     7b77d73f-535f-420a-895c-92b98ff16926
Spec:
  Clusterdistribution:  TKGService
  Entityname:           pvc-884dcdd2-543c-4dfb-8d15-b55ed2100c4c
  Entityreferences:
    Cluster ID:    
    Entity Name:   dd85dc0d-25e8-4925-be21-c631f89253f1-884dcdd2-543c-4dfb-8d15-b55ed2100c4c
    Entity Type:   PERSISTENT_VOLUME_CLAIM
    Namespace:     test-gc-e2e-demo-ns
  Entitytype:      PERSISTENT_VOLUME
  Guestclusterid:  dd85dc0d-25e8-4925-be21-c631f89253f1
  Volumenames:
    dd85dc0d-25e8-4925-be21-c631f89253f1-884dcdd2-543c-4dfb-8d15-b55ed2100c4c
Status:
  Volumestatus:
    Updated:     true
    Volumename:  dd85dc0d-25e8-4925-be21-c631f89253f1-884dcdd2-543c-4dfb-8d15-b55ed2100c4c
Events:
  Type    Reason           Age   From            Message
  ----    ------           ----  ----            -------
  Normal  UpdateSucceeded  8s    cns.vmware.com  ReconcileCnsVolumeMetadata: Successfully updated entry in CNS for instance with name "pvc-884dcdd2-543c-4dfb-8d15-b55ed2100c4c" and entity type "PERSISTENT_VOLUME" in the guest cluster "dd85dc0d-25e8-4925-be21-c631f89253f1".


Name:         dd85dc0d-25e8-4925-be21-c631f89253f1-884dcdd2-543c-4dfb-8d15-b55ed2100c4c
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsVolumeMetadata
Metadata:
  Creation Timestamp:  2021-11-16T19:59:39Z
  Finalizers:
    cns.vmware.com
  Generation:  2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"cns.vmware.com":
        f:ownerReferences:
          .:
          k:{"uid":"dd85dc0d-25e8-4925-be21-c631f89253f1"}:
            .:
            f:apiVersion:
            f:blockOwnerDeletion:
            f:controller:
            f:kind:
            f:name:
            f:uid:
      f:spec:
        .:
        f:clusterdistribution:
        f:entityname:
        f:entityreferences:
        f:entitytype:
        f:guestclusterid:
        f:namespace:
        f:volumenames:
      f:status:
        .:
        f:volumestatus:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2021-11-16T19:59:44Z
  Owner References:
    API Version:           run.tanzu.vmware.com/v1alpha1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  TanzuKubernetesCluster
    Name:                  test-cluster-e2e-script
    UID:                   dd85dc0d-25e8-4925-be21-c631f89253f1
  Resource Version:        20449234
  Self Link:               /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsvolumemetadatas/dd85dc0d-25e8-4925-be21-c631f89253f1-884dcdd2-543c-4dfb-8d15-b55ed2100c4c
  UID:                     47d42eb5-f54c-4b76-91dc-67332ee651d6
Spec:
  Clusterdistribution:  TKGService
  Entityname:           example-vanilla-rwo-pvc
  Entityreferences:
    Cluster ID:    dd85dc0d-25e8-4925-be21-c631f89253f1
    Entity Name:   pvc-884dcdd2-543c-4dfb-8d15-b55ed2100c4c
    Entity Type:   PERSISTENT_VOLUME
    Namespace:     
  Entitytype:      PERSISTENT_VOLUME_CLAIM
  Guestclusterid:  dd85dc0d-25e8-4925-be21-c631f89253f1
  Namespace:       default
  Volumenames:
    dd85dc0d-25e8-4925-be21-c631f89253f1-884dcdd2-543c-4dfb-8d15-b55ed2100c4c
Status:
  Volumestatus:
    Updated:     true
    Volumename:  dd85dc0d-25e8-4925-be21-c631f89253f1-884dcdd2-543c-4dfb-8d15-b55ed2100c4c
Events:
  Type    Reason           Age   From            Message
  ----    ------           ----  ----            -------
  Normal  UpdateSucceeded  6s    cns.vmware.com  ReconcileCnsVolumeMetadata: Successfully updated entry in CNS for instance with name "example-vanilla-rwo-pvc" and entity type "PERSISTENT_VOLUME_CLAIM" in the guest cluster "dd85dc0d-25e8-4925-be21-c631f89253f1".
```

CRs created by TKG with 2.4.0 CSI (v1)  on WCP(released versions + CSI built from this PR)

```
Name:         dd85dc0d-25e8-4925-be21-c631f89253f1-1743a7f9-b78a-4c97-8c00-aadada85416b
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsVolumeMetadata
Metadata:
  Creation Timestamp:  2021-11-16T19:55:55Z
  Finalizers:
    cns.vmware.com
  Generation:  2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"cns.vmware.com":
        f:ownerReferences:
          .:
          k:{"uid":"dd85dc0d-25e8-4925-be21-c631f89253f1"}:
            .:
            f:apiVersion:
            f:blockOwnerDeletion:
            f:controller:
            f:kind:
            f:name:
            f:uid:
      f:spec:
        .:
        f:clusterdistribution:
        f:entityname:
        f:entityreferences:
        f:entitytype:
        f:guestclusterid:
        f:namespace:
        f:volumenames:
      f:status:
        .:
        f:volumestatus:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2021-11-16T19:55:58Z
  Owner References:
    API Version:           run.tanzu.vmware.com/v1alpha1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  TanzuKubernetesCluster
    Name:                  test-cluster-e2e-script
    UID:                   dd85dc0d-25e8-4925-be21-c631f89253f1
  Resource Version:        20447216
  Self Link:               /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsvolumemetadatas/dd85dc0d-25e8-4925-be21-c631f89253f1-1743a7f9-b78a-4c97-8c00-aadada85416b
  UID:                     5382a6b3-a7eb-4f23-836d-e0b5f0ed6ec3
Spec:
  Clusterdistribution:  TKGService
  Entityname:           example-vanilla-rwo-pvc
  Entityreferences:
    Cluster ID:    dd85dc0d-25e8-4925-be21-c631f89253f1
    Entity Name:   pvc-1743a7f9-b78a-4c97-8c00-aadada85416b
    Entity Type:   PERSISTENT_VOLUME
    Namespace:     
  Entitytype:      PERSISTENT_VOLUME_CLAIM
  Guestclusterid:  dd85dc0d-25e8-4925-be21-c631f89253f1
  Namespace:       default
  Volumenames:
    dd85dc0d-25e8-4925-be21-c631f89253f1-1743a7f9-b78a-4c97-8c00-aadada85416b
Status:
  Volumestatus:
    Updated:     true
    Volumename:  dd85dc0d-25e8-4925-be21-c631f89253f1-1743a7f9-b78a-4c97-8c00-aadada85416b
Events:
  Type    Reason           Age   From            Message
  ----    ------           ----  ----            -------
  Normal  UpdateSucceeded  4s    cns.vmware.com  ReconcileCnsVolumeMetadata: Successfully updated entry in CNS for instance with name "example-vanilla-rwo-pvc" and entity type "PERSISTENT_VOLUME_CLAIM" in the guest cluster "dd85dc0d-25e8-4925-be21-c631f89253f1".


Name:         dd85dc0d-25e8-4925-be21-c631f89253f1-3e0258bb-1fb3-4bce-ba01-995e5d17b2bb
Namespace:    test-gc-e2e-demo-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsVolumeMetadata
Metadata:
  Creation Timestamp:  2021-11-16T19:55:55Z
  Finalizers:
    cns.vmware.com
  Generation:  2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"cns.vmware.com":
        f:ownerReferences:
          .:
          k:{"uid":"dd85dc0d-25e8-4925-be21-c631f89253f1"}:
            .:
            f:apiVersion:
            f:blockOwnerDeletion:
            f:controller:
            f:kind:
            f:name:
            f:uid:
      f:spec:
        .:
        f:clusterdistribution:
        f:entityname:
        f:entityreferences:
        f:entitytype:
        f:guestclusterid:
        f:volumenames:
      f:status:
        .:
        f:volumestatus:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2021-11-16T19:55:59Z
  Owner References:
    API Version:           run.tanzu.vmware.com/v1alpha1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  TanzuKubernetesCluster
    Name:                  test-cluster-e2e-script
    UID:                   dd85dc0d-25e8-4925-be21-c631f89253f1
  Resource Version:        20447223
  Self Link:               /apis/cns.vmware.com/v1alpha1/namespaces/test-gc-e2e-demo-ns/cnsvolumemetadatas/dd85dc0d-25e8-4925-be21-c631f89253f1-3e0258bb-1fb3-4bce-ba01-995e5d17b2bb
  UID:                     710e561c-98e8-4fd4-9178-2501f97f9e83
Spec:
  Clusterdistribution:  TKGService
  Entityname:           pvc-1743a7f9-b78a-4c97-8c00-aadada85416b
  Entityreferences:
    Cluster ID:    
    Entity Name:   dd85dc0d-25e8-4925-be21-c631f89253f1-1743a7f9-b78a-4c97-8c00-aadada85416b
    Entity Type:   PERSISTENT_VOLUME_CLAIM
    Namespace:     test-gc-e2e-demo-ns
  Entitytype:      PERSISTENT_VOLUME
  Guestclusterid:  dd85dc0d-25e8-4925-be21-c631f89253f1
  Volumenames:
    dd85dc0d-25e8-4925-be21-c631f89253f1-1743a7f9-b78a-4c97-8c00-aadada85416b
Status:
  Volumestatus:
    Updated:     true
    Volumename:  dd85dc0d-25e8-4925-be21-c631f89253f1-1743a7f9-b78a-4c97-8c00-aadada85416b
Events:
  Type    Reason           Age   From            Message
  ----    ------           ----  ----            -------
  Normal  UpdateSucceeded  3s    cns.vmware.com  ReconcileCnsVolumeMetadata: Successfully updated entry in CNS for instance with name "pvc-1743a7f9-b78a-4c97-8c00-aadada85416b" and entity type "PERSISTENT_VOLUME" in the guest cluster "dd85dc0d-25e8-4925-be21-c631f89253f1".
```


CRD structure:

```
kubectl describe crd cnsvolumemetadata -A
Name:         cnsvolumemetadatas.cns.vmware.com
Namespace:    
Labels:       <none>
Annotations:  controller-gen.kubebuilder.io/version: v0.6.2
API Version:  apiextensions.k8s.io/v1
Kind:         CustomResourceDefinition
Metadata:
  Creation Timestamp:  2021-11-16T19:41:50Z
  Generation:          1
  Managed Fields:
    API Version:  apiextensions.k8s.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:acceptedNames:
          f:kind:
          f:listKind:
          f:plural:
          f:singular:
        f:conditions:
          k:{"type":"Established"}:
            .:
            f:lastTransitionTime:
            f:message:
            f:reason:
            f:status:
            f:type:
          k:{"type":"NamesAccepted"}:
            .:
            f:lastTransitionTime:
            f:message:
            f:reason:
            f:status:
            f:type:
    Manager:      kube-apiserver
    Operation:    Update
    Time:         2021-11-16T19:41:50Z
    API Version:  apiextensions.k8s.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:controller-gen.kubebuilder.io/version:
      f:spec:
        f:conversion:
          .:
          f:strategy:
        f:group:
        f:names:
          f:kind:
          f:listKind:
          f:plural:
          f:singular:
        f:scope:
        f:versions:
    Manager:         vsphere-syncer
    Operation:       Update
    Time:            2021-11-16T19:41:50Z
  Resource Version:  20439772
  Self Link:         /apis/apiextensions.k8s.io/v1/customresourcedefinitions/cnsvolumemetadatas.cns.vmware.com
  UID:               ca9535ec-0906-4805-8b2d-b8c500dac686
Spec:
  Conversion:
    Strategy:  None
  Group:       cns.vmware.com
  Names:
    Kind:       CnsVolumeMetadata
    List Kind:  CnsVolumeMetadataList
    Plural:     cnsvolumemetadatas
    Singular:   cnsvolumemetadata
  Scope:        Namespaced
  Versions:
    Name:  v1alpha1
    Schema:
      openAPIV3Schema:
        Description:  CnsVolumeMetadata is the Schema for the cnsvolumemetadata API
        Properties:
          API Version:
            Description:  APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
            Type:         string
          Kind:
            Description:  Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
            Type:         string
          Metadata:
            Type:  object
          Spec:
            Description:  CnsVolumeMetadataSpec defines the desired state of CnsVolumeMetadata
            Properties:
              Clusterdistribution:
                Description:  ClusterDistribution indicates the cluster distribution where the PVCSI driver is deployed
                Type:         string
              Entityname:
                Description:  EntityName indicates name of the entity in the guest cluster.
                Type:         string
              Entityreferences:
                Description:  EntityReferences indicate the other entities that this entity refers to. A Pod in the guest cluster can refers to one or more PVCs in the guest cluster. A PVC in the guest cluster refers to a PV in the guest cluster. A PV in the guest cluster refers to a PVC in the supervisor cluster. A Pod/PVC in the guest cluster referring to a PVC/PV respectively in the guest cluster must set the ClusterID field. A PV in the guest cluster referring to a PVC in the supervisor cluster must leave the ClusterID field unset. This field is mandatory.
                Items:
                  Type:                                          object
                  X - Kubernetes - Preserve - Unknown - Fields:  true
                Type:                                            array
              Entitytype:
                Description:  EntityType indicates type of entity whose metadata this instance represents.
                Type:         string
              Guestclusterid:
                Description:  GuestClusterID indicates the guest cluster ID in which this volume is referenced.
                Type:         string
              Labels:
                Additional Properties:
                  Type:       string
                Description:  Labels indicates user labels assigned to the entity in the guest cluster. Should only be populated if EntityType is PERSISTENT_VOLUME OR PERSISTENT_VOLUME_CLAIM. CNS Operator will return a failure to the client if labels are set for objects whose EntityType is POD.
                Type:         object
              Namespace:
                Description:  Namespace indicates namespace of entity in guest cluster. Should only be populated if EntityType is PERSISTENT_VOLUME_CLAIM or POD. CNS Operator will return a failure to the client if namespace is set for objects whose EntityType is PERSISTENT_VOLUME.
                Type:         string
              Volumenames:
                Description:  VolumeNames indicates the unique ID of the volume. For volumes created in a guest cluster, this will be “<guestcluster-ID>-<UID>” where UID is the pvc.UUID in supervisor cluster. Instances of POD entity type can have multiple volume names. Instances of PV and PVC entity types will have only one volume name.
                Items:
                  Type:  string
                Type:    array
            Required:
              entityname
              entityreferences
              entitytype
              guestclusterid
              volumenames
            Type:  object
          Status:
            Description:  CnsVolumeMetadataStatus defines the observed state of CnsVolumeMetadata
            Properties:
              Volumestatus:
                Description:  The last error encountered, per volume, during update operation. This field must only be set by the entity completing the update operation, i.e. the CNS Operator. This string may be logged, so it should not contain sensitive information.
                Items:
                  Description:  CnsVolumeMetadataVolumeStatus defines the status of the last update operation on CNS for the given volume. Error message will be empty if no error was encountered.
                  Properties:
                    Errormessage:
                      Type:  string
                    Updated:
                      Type:  boolean
                    Volumename:
                      Type:  string
                  Required:
                    updated
                    volumename
                  Type:  object
                Type:    array
            Type:        object
        Type:            object
    Served:              true
    Storage:             true
Status:
  Accepted Names:
    Kind:       CnsVolumeMetadata
    List Kind:  CnsVolumeMetadataList
    Plural:     cnsvolumemetadatas
    Singular:   cnsvolumemetadata
  Conditions:
    Last Transition Time:  2021-11-16T19:41:50Z
    Message:               no conflicts found
    Reason:                NoConflicts
    Status:                True
    Type:                  NamesAccepted
    Last Transition Time:  2021-11-16T19:41:51Z
    Message:               the initial names have been accepted
    Reason:                InitialNamesAccepted
    Status:                True
    Type:                  Established
  Stored Versions:
    v1alpha1
Events:  <none>

```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
CRD support from apiextensions.k8s.io/v1beta1 API to v1 API for WCP/TKG APIs
```
