### PR TITLE
Remove securityContext from windows csi node deployment

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -595,11 +595,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
               value: "1"
-          securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
-            allowPrivilegeEscalation: true
           volumeMounts:
             - name: plugin-dir
               mountPath: 'C:\csi'


### PR DESCRIPTION
During testing with docker env, found that node yaml is incorrectly specifying security context for windows node.  Because of this csi node pod did not come up in docker based windows node. Correcting this.

**What this PR does / why we need it**:
Without this csi deployment in windows node with docker env is failing.


**Testing done**:
make build; make images; make check

**Special notes for your reviewer**:

**Release note**:
```
Remove securityContext from windows CSI Node deployment
```
