### PR TITLE
In case of CNS_NEW_SYNC, Volume expansion to succeed when SPS is down.

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -31,6 +31,7 @@ const (
 	adminPassword                              = "Admin!23"
 	busyBoxImageOnGcr                          = "gcr.io/google_containers/busybox:1.27"
 	nginxImage                                 = "k8s.gcr.io/nginx-slim:0.8"
+	cnsNewSync                                 = "CNS_NEW_SYNC"
 	configSecret                               = "vsphere-config-secret"
 	crdCNSNodeVMAttachment                     = "cnsnodevmattachments"
 	crdCNSVolumeMetadatas                      = "cnsvolumemetadatas"

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -31,7 +31,7 @@ const (
 	adminPassword                              = "Admin!23"
 	busyBoxImageOnGcr                          = "gcr.io/google_containers/busybox:1.27"
 	nginxImage                                 = "k8s.gcr.io/nginx-slim:0.8"
-	cnsNewSync                                 = "CNS_NEW_SYNC"
+	cnsNewSyncFSS                              = "CNS_NEW_SYNC"
 	configSecret                               = "vsphere-config-secret"
 	crdCNSNodeVMAttachment                     = "cnsnodevmattachments"
 	crdCNSVolumeMetadatas                      = "cnsvolumemetadatas"

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1168,6 +1168,18 @@ func invokeVCenterServiceControl(command, service, host string) error {
 	return nil
 }
 
+//checks if vCenter has a particular FSS enabled or
+func isFssEnabled(host, fss string) bool {
+	sshCmd := fmt.Sprintf("python /usr/sbin/feature-state-wrapper.py %s", fss)
+	framework.Logf("Checking if fss is enabled on vCenter host %v", host)
+	result, err := fssh.SSH(sshCmd, host, framework.TestContext.Provider)
+	if err == nil || result.Code == 0 {
+		//fssh.LogResult(result)
+		return strings.Replace(result.Stdout, "\n", "", -1) == "enabled"
+	}
+	return false
+}
+
 // waitVCenterServiceToBeInState invokes the status check for the given service and waits
 // via service-control on the given vCenter host over SSH.
 func waitVCenterServiceToBeInState(serviceName string, host string, state string) error {

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1168,14 +1168,18 @@ func invokeVCenterServiceControl(command, service, host string) error {
 	return nil
 }
 
-//checks if vCenter has a particular FSS enabled or
-func isFssEnabled(host, fss string) bool {
+// isFssEnabled invokes the given command to check if vCenter
+// has a particular FSS enabled or not
+func isFssEnabled(host, fss string) {
 	sshCmd := fmt.Sprintf("python /usr/sbin/feature-state-wrapper.py %s", fss)
 	framework.Logf("Checking if fss is enabled on vCenter host %v", host)
 	result, err := fssh.SSH(sshCmd, host, framework.TestContext.Provider)
-	if err == nil || result.Code == 0 {
-		//fssh.LogResult(result)
+	fssh.LogResult(result)
+	if err == nil && result.Code == 0 {
 		return strings.Replace(result.Stdout, "\n", "", -1) == "enabled"
+	}
+	else {
+		return fmt.Errorf("couldn't execute command: %s on vCenter host: %v", sshCmd, err)
 	}
 	return false
 }

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1176,11 +1176,10 @@ func isFssEnabled(host, fss string) bool {
 	result, err := fssh.SSH(sshCmd, host, framework.TestContext.Provider)
 	fssh.LogResult(result)
 	if err == nil && result.Code == 0 {
-		return strings.Replace(result.Stdout, "\n", "", -1) == "enabled"
+		return strings.TrimSpace(result.Stdout) == "enabled"
 	} else {
 		ginkgo.By(fmt.Sprintf("couldn't execute command: %s on vCenter host: %v", sshCmd, err))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
 	}
 	return false
 }

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1170,16 +1170,17 @@ func invokeVCenterServiceControl(command, service, host string) error {
 
 // isFssEnabled invokes the given command to check if vCenter
 // has a particular FSS enabled or not
-func isFssEnabled(host, fss string) {
+func isFssEnabled(host, fss string) bool {
 	sshCmd := fmt.Sprintf("python /usr/sbin/feature-state-wrapper.py %s", fss)
 	framework.Logf("Checking if fss is enabled on vCenter host %v", host)
 	result, err := fssh.SSH(sshCmd, host, framework.TestContext.Provider)
 	fssh.LogResult(result)
 	if err == nil && result.Code == 0 {
 		return strings.Replace(result.Stdout, "\n", "", -1) == "enabled"
-	}
-	else {
-		return fmt.Errorf("couldn't execute command: %s on vCenter host: %v", sshCmd, err)
+	} else {
+		ginkgo.By(fmt.Sprintf("couldn't execute command: %s on vCenter host: %v", sshCmd, err))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 	}
 	return false
 }

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -650,6 +650,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 
 		var originalSizeInMb, fsSize int64
 		var err error
+		var expectedErrMsg string
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		featureEnabled := isFssEnabled(vcAddress, "CNS_NEW_SYNC")
 
@@ -1435,6 +1436,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 
 		var fsSize int64
 		var err error
+
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		featureEnabled := isFssEnabled(vcAddress, "CNS_NEW_SYNC")
 

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -717,16 +717,6 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
 
-		//ginkgo.By("File system resize should succeed Since SPS service is down.")
-		//if guestCluster {
-		//	expectedErrMsg = "didn't find a plugin capable of expanding the volume"
-		//} else {
-		//	expectedErrMsg = "failed to expand volume"
-		//}
-		//framework.Logf("Expected failure message: %+q", expectedErrMsg)
-		//err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		//gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
 		ginkgo.By("Waiting for file system resize to finish")
 		pvclaim, err = waitForFSResize(pvclaim, client)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1476,6 +1466,13 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Bringup SPS service")
+		err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isSPSServiceStopped = false
+
 		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
 		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volHandle)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1484,31 +1481,12 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			err = fmt.Errorf("queryCNSVolumeWithResult returned no volume")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		//pvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
-		//if pvcSize.Cmp(newSize) != 0 {
-		//	framework.Failf("error updating pvc size %q", pvclaim.Name)
-		//}
-		//expectedErrMsg := "failed to expand volume"
-		//framework.Logf("Expected failure message: %+q", expectedErrMsg)
-		//err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		//gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verifying disk size requested in volume expansion is honored")
 		newSizeInMb := int64(3072)
 		if queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).CapacityInMb != newSizeInMb {
 			err = fmt.Errorf("got wrong disk size after volume expansion")
 		}
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		ginkgo.By("Bringup SPS service")
-		err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		isSPSServiceStopped = false
-
-		//pvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
-		//if pvcSize.Cmp(newSize) != 0 {
-		//	framework.Failf("error updating pvc size %q", pvclaim.Name)
-		//}
 
 		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -652,7 +652,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		var err error
 		var expectedErrMsg string
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		featureEnabled := isFssEnabled(vcAddress, cnsNewSync)
+		featureEnabled := isFssEnabled(vcAddress, cnsNewSyncFSS)
 
 		volHandle, pvclaim, pv, storageclass := createSCwithVolumeExpansionTrueAndDynamicPVC(
 			f, client, "", storagePolicyName, namespace)
@@ -1440,7 +1440,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		var err error
 
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		featureEnabled := isFssEnabled(vcAddress, cnsNewSync)
+		featureEnabled := isFssEnabled(vcAddress, cnsNewSyncFSS)
 
 		volHandle, pvclaim, pv, storageclass := createSCwithVolumeExpansionTrueAndDynamicPVC(
 			f, client, "", storagePolicyName, namespace)

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -657,8 +657,10 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		volHandle, pvclaim, pv, storageclass := createSCwithVolumeExpansionTrueAndDynamicPVC(
 			f, client, "", storagePolicyName, namespace)
 		defer func() {
-			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			if !supervisorCluster {
+				err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
 			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
@@ -1443,8 +1445,10 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		volHandle, pvclaim, pv, storageclass := createSCwithVolumeExpansionTrueAndDynamicPVC(
 			f, client, "", storagePolicyName, namespace)
 		defer func() {
-			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			if !supervisorCluster {
+				err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
 			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -652,7 +652,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		var err error
 		var expectedErrMsg string
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		featureEnabled := isFssEnabled(vcAddress, "CNS_NEW_SYNC")
+		featureEnabled := isFssEnabled(vcAddress, cnsNewSync)
 
 		volHandle, pvclaim, pv, storageclass := createSCwithVolumeExpansionTrueAndDynamicPVC(
 			f, client, "", storagePolicyName, namespace)
@@ -719,7 +719,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
 
 		if !featureEnabled {
-			ginkgo.By("File system resize should not succeed Since SPS service is down. Expect an error")
+			ginkgo.By("File system resize should not succeed since SPS service is down. Expecting an error")
 			if guestCluster {
 				expectedErrMsg = "didn't find a plugin capable of expanding the volume"
 			} else {
@@ -1438,7 +1438,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		var err error
 
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		featureEnabled := isFssEnabled(vcAddress, "CNS_NEW_SYNC")
+		featureEnabled := isFssEnabled(vcAddress, cnsNewSync)
 
 		volHandle, pvclaim, pv, storageclass := createSCwithVolumeExpansionTrueAndDynamicPVC(
 			f, client, "", storagePolicyName, namespace)
@@ -1475,7 +1475,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
 
 		if featureEnabled {
-			ginkgo.By("File system resize should not succeed Since SPS service is down. Expect an error")
+			ginkgo.By("File system resize should not succeed since SPS service is down. Expecting an error")
 			expectedErrMsg := "failed to expand volume"
 			framework.Logf("Expected failure message: %+q", expectedErrMsg)
 			err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
@@ -1518,6 +1518,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		if queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).CapacityInMb != newSizeInMb {
 			err = fmt.Errorf("got wrong disk size after volume expansion")
 		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Create a Pod to use this PVC, and verify volume has been attached
 		ginkgo.By("Creating pod to attach PV to the node")

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -650,7 +650,6 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 
 		var originalSizeInMb, fsSize int64
 		var err error
-		//var expectedErrMsg string
 
 		volHandle, pvclaim, pv, storageclass := createSCwithVolumeExpansionTrueAndDynamicPVC(
 			f, client, "", storagePolicyName, namespace)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Modifying volume expansion testcase to succeed when SPS is down in case of CNS_NEW_SYNC is enabled.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes bug 2865342
https://bugzilla.eng.vmware.com/show_bug.cgi?id=2865342

**Special notes for your reviewer**:

**Release note**:

1. Vanilla + WCP : Verify online volume expansion when SPS-Service is down
2. WCP: Verify Offline volume expansion when SPS-Service is down

Testing:
Vanilla: 
with cns_new_sync: https://gist.github.com/Aishwarya-Hebbar/4c53ad84165787742110d829bbe56a48
without cns_new_sync: https://gist.github.com/Aishwarya-Hebbar/988ffddfeb1dfbefc22b34eb81748ab1
WCP:
with cns_new_sync: In progress
without cns_new_sync: https://gist.github.com/Aishwarya-Hebbar/a1cd691df3814283ec5d5d92fd2eae59