### PR TITLE
[e2e-test]: Improved Idempotency Test automation - part2

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -40,6 +40,7 @@ const (
 	csiSystemNamespace                         = "vmware-system-csi"
 	csiVolAttrVolType                          = "vSphere CNS Block Volume"
 	defaultFullSyncIntervalInMin               = "30"
+	defaultProvisionerTimeInSec                = "300"
 	defaultFullSyncWaitTime                    = 1800
 	defaultPandoraSyncWaitTime                 = 90
 	defaultVCRebootWaitTime                    = 180
@@ -93,6 +94,7 @@ const (
 	healthStatusAccessible                    = "accessible"
 	healthStatusInAccessible                  = "inaccessible"
 	healthStatusWaitTime                      = 2 * time.Minute
+	hostdServiceName                          = "hostd"
 	invalidFSType                             = "ext10"
 	k8sPodTerminationTimeOut                  = 7 * time.Minute
 	k8sPodTerminationTimeOutLong              = 10 * time.Minute
@@ -126,6 +128,7 @@ const (
 	scParamFsType                             = "csi.storage.k8s.io/fstype"
 	scParamStoragePolicyID                    = "StoragePolicyId"
 	scParamStoragePolicyName                  = "StoragePolicyName"
+	shortProvisionerTimeout                   = "10"
 	sleepTimeOut                              = 30
 	oneMinuteWaitTimeInSeconds                = 60
 	spsServiceName                            = "sps"
@@ -134,6 +137,7 @@ const (
 	startOperation                            = "start"
 	svcStoppedMessage                         = "Stopped"
 	stopOperation                             = "stop"
+	statusOperation                           = "status"
 	supervisorClusterOperationsTimeout        = 3 * time.Minute
 	svClusterDistribution                     = "SupervisorCluster"
 	svOperationTimeout                        = 240 * time.Second


### PR DESCRIPTION
**What this PR does / why we need it**:
[e2e-test]: Improved Idempotency Test automation - part2
Adding a test to create volumes by reducing the external provisioner timeout
Adding test to create volumes when the hostd service is down on the esx host or esx host is disconnected

**Testing done**:
Yes
Block Vanilla : https://gist.github.com/rpanduranga/5a5780f5c8e8f7a0cce8c000f6a03a9b
File Vanilla: https://gist.github.com/rpanduranga/2ad3a9e5caec86b5cf2ae852222395b5

**Special notes for your reviewer**:
NA

**Release note**:
NA