### PR TITLE
Reverting a storage class fix for GC

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -661,7 +661,7 @@ func createStorageClass(client clientset.Interface, scParameters map[string]stri
 		"and ReclaimPolicy: %+v and allowVolumeExpansion: %t",
 		scName, scParameters, allowedTopologies, scReclaimPolicy, allowVolumeExpansion))
 
-	if supervisorCluster || guestCluster {
+	if supervisorCluster {
 		storageclass, err = client.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
 		if !apierrors.IsNotFound(err) {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
What this PR does / why we need it:  GC uses different storage policy . Hence Reverting a check made in storage class creation

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged):  2883608

Release notes:
 GC uses different storage policy . Hence Reverting a check made in storage class creation
