### PR TITLE
kube-controller-manager instances was expected to be 1 always, fixing that

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -98,6 +98,7 @@ const (
 	invalidFSType                             = "ext10"
 	k8sPodTerminationTimeOut                  = 7 * time.Minute
 	k8sPodTerminationTimeOutLong              = 10 * time.Minute
+	k8sVmPasswd                               = "ca$hc0w"
 	kcmManifest                               = "/etc/kubernetes/manifests/kube-controller-manager.yaml"
 	kubeAPIPath                               = "/etc/kubernetes/manifests/"
 	kubeAPIfile                               = "kube-apiserver.yaml"

--- a/tests/e2e/vcp_to_csi_attach_detach.go
+++ b/tests/e2e/vcp_to_csi_attach_detach.go
@@ -799,12 +799,12 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 		ginkgo.By("Waiting for migration related annotations on PV/PVCs created before migration")
 		waitForMigAnnotationsPvcPvLists(ctx, client, vcpPvcsPreMig, vcpPvsPreMig, true)
 
-		ginkgo.By("Verify CnsVSphereVolumeMigration crds and CNS volume metadata on pvc created before migration")
-		verifyCnsVolumeMetadataAndCnsVSphereVolumeMigrationCrdForPvcs(ctx, client, vcpPvcsPreMig)
-
 		ginkgo.By("wait for some time and make sure POD is ready")
 		err = fpod.WaitTimeoutForPodReadyInNamespace(client, pod.Name, namespace, pollTimeout*2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify CnsVSphereVolumeMigration crds and CNS volume metadata on pvc created before migration")
+		verifyCnsVolumeMetadataAndCnsVSphereVolumeMigrationCrdForPvcs(ctx, client, vcpPvcsPreMig)
 
 		// Get fresh pod info.
 		pod, err = client.CoreV1().Pods(namespace).Get(ctx, pod.Name, metav1.GetOptions{})
@@ -1003,12 +1003,12 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 		ginkgo.By("Waiting for migration related annotations on PV/PVCs created before migration")
 		waitForMigAnnotationsPvcPvLists(ctx, client, vcpPvcsPreMig, vcpPvsPreMig, true)
 
-		ginkgo.By("Verify CnsVSphereVolumeMigration crds and CNS volume metadata on pvc created before migration")
-		verifyCnsVolumeMetadataAndCnsVSphereVolumeMigrationCrdForPvcs(ctx, client, vcpPvcsPreMig)
-
 		ginkgo.By("wait for some time and make sure POD is created and it is in running state")
 		err = fpod.WaitTimeoutForPodReadyInNamespace(client, pod.Name, namespace, pollTimeout*2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify CnsVSphereVolumeMigration crds and CNS volume metadata on pvc created before migration")
+		verifyCnsVolumeMetadataAndCnsVSphereVolumeMigrationCrdForPvcs(ctx, client, vcpPvcsPreMig)
 
 		// Get fresh pod info.
 		pod, err = client.CoreV1().Pods(namespace).Get(ctx, pod.Name, metav1.GetOptions{})

--- a/tests/e2e/vcp_to_csi_syncer.go
+++ b/tests/e2e/vcp_to_csi_syncer.go
@@ -1774,7 +1774,7 @@ func scaleDownNDeleteStsDeploymentsInNamespace(ctx context.Context, c clientset.
 func wait4DeploymentPodsCreation(c clientset.Interface, dep *appsv1.Deployment) (*v1.PodList, error) {
 	var pods *v1.PodList
 	var err error
-	waitErr := wait.PollImmediate(poll, pollTimeoutShort, func() (bool, error) {
+	waitErr := wait.PollImmediate(poll, pollTimeout, func() (bool, error) {
 		pods, err = fdep.GetPodsForDeployment(c, dep)
 		if err != nil {
 			if strings.Contains(err.Error(), "progressing") {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: running instances of kube-controller-manager was expected to be always 1, fixing that
Also, moved wait for pods to be running before CNS volume metadata verification in tests,
- VSAN health is down before enabling migration
- SPS is down before enabling migration

**Testing done**:
https://gist.github.com/sashrith/dd83dfedc7249735898447f6f6304dd2

**Special notes for your reviewer**:
```bash
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver vcp2csi_multimaster ⇡ ❯ make check                              17:52:43
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: upgraded honnef.co/go/tools v0.0.1-2020.1.3 => v0.2.0
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sashrith/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sashrith/csi/vsphere-csi-driver /Users/sashrith/csi /Users/sashrith /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|files|imports|types_sizes|name) took 2.565866193s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 105.182702ms
INFO [linters context/goanalysis] analyzers took 12.85879123s with top 10 stages: buildir: 799.937624ms, S1038: 692.526871ms, misspell: 555.603591ms, S1039: 412.798625ms, SA1012: 371.133126ms, S1028: 332.55179ms, SA1013: 272.785273ms, S1030: 260.103921ms, S1024: 259.640375ms, directives: 248.74323ms
INFO [runner] Issues before processing: 110, after processing: 0
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 110/110, path_prettifier: 110/110, skip_files: 110/110, skip_dirs: 110/110, exclude-rules: 1/21, autogenerated_exclude: 21/110, identifier_marker: 21/21, exclude: 21/21, nolint: 0/1, cgo: 110/110
INFO [runner] processing took 14.407249ms with stages: nolint: 11.352136ms, autogenerated_exclude: 1.733116ms, path_prettifier: 635.834µs, identifier_marker: 348.757µs, skip_dirs: 159.367µs, exclude-rules: 151.758µs, cgo: 12.222µs, filename_unadjuster: 8.994µs, max_same_issues: 1.152µs, uniq_by_line: 857ns, diff: 438ns, source_code: 426ns, max_per_file_from_linter: 358ns, max_from_linter: 351ns, skip_files: 305ns, severity-rules: 265ns, exclude: 263ns, path_shortener: 249ns, sort_results: 246ns, path_prefixer: 155ns
INFO [runner] linters took 7.567745059s with stages: goanalysis_metalinter: 7.553229065s
INFO File cache stats: 76 entries of total size 1.9MiB
INFO Memory: 104 samples, avg is 258.0MB, max is 481.5MB
INFO Execution took 10.253852713s
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver vcp2csi_multimaster* ⇡ 2m 14s ❯
```

