### PR TITLE
Enable offline volume resize in 6.7U3

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcentermanager.go
+++ b/pkg/common/cns-lib/vsphere/virtualcentermanager.go
@@ -52,8 +52,6 @@ type VirtualCenterManager interface {
 	UnregisterAllVirtualCenters(ctx context.Context) error
 	// IsvSANFileServicesSupported checks if vSAN file services is supported or not.
 	IsvSANFileServicesSupported(ctx context.Context, host string) (bool, error)
-	// IsExtendVolumeSupported checks if extend volume is supported or not.
-	IsExtendVolumeSupported(ctx context.Context, host string) (bool, error)
 	// IsOnlineExtendVolumeSupported checks if online extend volume is supported
 	// or not on the vCenter Host.
 	IsOnlineExtendVolumeSupported(ctx context.Context, host string) (bool, error)
@@ -158,17 +156,6 @@ func (m *defaultVirtualCenterManager) UnregisterAllVirtualCenters(ctx context.Co
 
 // IsvSANFileServicesSupported checks if vSAN file services is supported or not.
 func (m *defaultVirtualCenterManager) IsvSANFileServicesSupported(ctx context.Context, host string) (bool, error) {
-	log := logger.GetLogger(ctx)
-	is67u3Release, err := isVsan67u3Release(ctx, m, host)
-	if err != nil {
-		log.Errorf("Failed to identify the vCenter release with error: %+v", err)
-		return false, err
-	}
-	return !is67u3Release, nil
-}
-
-// IsExtendVolumeSupported checks if extend volume is supported or not.
-func (m *defaultVirtualCenterManager) IsExtendVolumeSupported(ctx context.Context, host string) (bool, error) {
 	log := logger.GetLogger(ctx)
 	is67u3Release, err := isVsan67u3Release(ctx, m, host)
 	if err != nil {

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1210,7 +1210,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		log := logger.GetLogger(ctx)
 
 		log.Infof("ControllerExpandVolume: called with args %+v", *req)
-		//TODO: If the err is returned by invoking CNS API, then faultType should be
+		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
 		// If thr reqeust failed due to object not found, "csi.fault.NotFound" will be return.
@@ -1221,17 +1221,6 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		if strings.Contains(req.VolumeId, ".vmdk") {
 			return nil, csifault.CSIUnimplementedFault, logger.LogNewErrorCodef(log, codes.Unimplemented,
 				"cannot expand migrated vSphere volume. :%q", req.VolumeId)
-		}
-
-		isExtendSupported, err := c.manager.VcenterManager.IsExtendVolumeSupported(ctx, c.manager.VcenterConfig.Host)
-		if err != nil {
-			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
-				"failed to verify if extend volume is supported or not. Error: %+v", err)
-		}
-		if !isExtendSupported {
-			return nil, csifault.CSIInternalFault, logger.LogNewErrorCode(log, codes.Internal,
-				"volume Expansion is not supported in this vSphere release. "+
-					"Upgrade to vSphere 7.0 for offline expansion and vSphere 7.0U2 for online expansion support.")
 		}
 
 		isOnlineExpansionSupported, err := c.manager.VcenterManager.IsOnlineExtendVolumeSupported(ctx,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR enables offline resize in vSphere 6.7U3. We plan to crossport this change to 2.4 branch.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
PVC created pre-upgrade:
```
root@k8s-master-304:~# kubectl get pvc
NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
block-pvc   Bound    pvc-c56484c9-a59e-4f37-99a4-5303465fb7f4   1Gi        RWO            block-sc       8m20s
```

After upgrade to 2.4 with this change:
```
root@k8s-master-304:~# kubectl edit pvc block-pvc
persistentvolumeclaim/block-pvc edited
```
Describe PVC:
```
root@k8s-master-304:~# kubectl describe pvc block-pvc
Name:          block-pvc
Namespace:     default
StorageClass:  block-sc
Status:        Bound
Volume:        pvc-c56484c9-a59e-4f37-99a4-5303465fb7f4
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    <none>
Conditions:
  Type                      Status  LastProbeTime                     LastTransitionTime                Reason  Message
  ----                      ------  -----------------                 ------------------                ------  -------
  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Wed, 08 Dec 2021 20:46:51 +0000           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
Events:
  Type     Reason                    Age                    From                                                                                                 Message
  ----     ------                    ----                   ----                                                                                                 -------
  Normal   Provisioning              8m49s                  csi.vsphere.vmware.com_vsphere-csi-controller-5b96797885-khzg5_b938417b-5931-412e-8793-73ac6564503b  External provisioner is provisioning volume for claim "default/block-pvc"
  Normal   ExternalProvisioning      8m26s (x3 over 8m49s)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   ProvisioningSucceeded     8m21s                  csi.vsphere.vmware.com_vsphere-csi-controller-5b96797885-khzg5_b938417b-5931-412e-8793-73ac6564503b  Successfully provisioned volume pvc-c56484c9-a59e-4f37-99a4-5303465fb7f4
  Normal   Resizing                  5s                     external-resizer csi.vsphere.vmware.com                                                              External resizer is resizing volume pvc-c56484c9-a59e-4f37-99a4-5303465fb7f4
  Warning  ExternalExpanding         5s                     volume_expand                                                                                        Ignoring the PVC: didn't find a plugin capable of expanding the volume; waiting for an external controller to process this PVC.
  Normal   FileSystemResizeRequired  1s                     external-resizer csi.vsphere.vmware.com                                                              Require file system resize of volume on node
```

Create Pod
```
root@k8s-master-304:~# ka pod.yaml 
pod/block-pod created
```

Describe PVC:
```
root@k8s-master-304:~# kdsc pvc block-pvc
Name:          block-pvc
Namespace:     default
StorageClass:  block-sc
Status:        Bound
Volume:        pvc-c56484c9-a59e-4f37-99a4-5303465fb7f4
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      2Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    block-pod
Events:
  Type     Reason                      Age                    From                                                                                                 Message
  ----     ------                      ----                   ----                                                                                                 -------
  Normal   Provisioning                9m43s                  csi.vsphere.vmware.com_vsphere-csi-controller-5b96797885-khzg5_b938417b-5931-412e-8793-73ac6564503b  External provisioner is provisioning volume for claim "default/block-pvc"
  Normal   ExternalProvisioning        9m20s (x3 over 9m43s)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   ProvisioningSucceeded       9m15s                  csi.vsphere.vmware.com_vsphere-csi-controller-5b96797885-khzg5_b938417b-5931-412e-8793-73ac6564503b  Successfully provisioned volume pvc-c56484c9-a59e-4f37-99a4-5303465fb7f4
  Normal   Resizing                    59s                    external-resizer csi.vsphere.vmware.com                                                              External resizer is resizing volume pvc-c56484c9-a59e-4f37-99a4-5303465fb7f4
  Warning  ExternalExpanding           59s                    volume_expand                                                                                        Ignoring the PVC: didn't find a plugin capable of expanding the volume; waiting for an external controller to process this PVC.
  Normal   FileSystemResizeRequired    55s                    external-resizer csi.vsphere.vmware.com                                                              Require file system resize of volume on node
  Normal   FileSystemResizeSuccessful  3s                     kubelet                                                                                              MountVolume.NodeExpandVolume succeeded for volume "pvc-c56484c9-a59e-4f37-99a4-5303465fb7f4"
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enable offline volume resize in 6.7U3
```
