### PR TITLE
vsan stretch vanilla - Primary site down - test and libs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/yaml.v2 v2.4.0
+	honnef.co/go/tools v0.2.0 // indirect
 	k8s.io/api v0.21.1
 	k8s.io/apiextensions-apiserver v0.21.1
 	k8s.io/apimachinery v0.21.1

--- a/go.sum
+++ b/go.sum
@@ -785,6 +785,7 @@ golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1108,6 +1109,8 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
+honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 k8s.io/api v0.21.1 h1:94bbZ5NTjdINJEdzOkpS4vdPhkb1VFpTYC9zh43f75c=
 k8s.io/api v0.21.1/go.mod h1:FstGROTmsSHBarKc8bylzXih8BLNYTiS3TZcsoEDg2s=
 k8s.io/apiextensions-apiserver v0.21.1 h1:AA+cnsb6w7SZ1vD32Z+zdgfXdXY8X9uGX5bN6EoPEIo=

--- a/tests/e2e/docs/vanilla_cluster_setup.md
+++ b/tests/e2e/docs/vanilla_cluster_setup.md
@@ -70,11 +70,13 @@ list of datastore URLs where you want to deploy file share volumes. Retrieve thi
     # For VCP to CSI migration tests following are needed as well
     export SHARED_VSPHERE_DATASTORE_NAME="vsanDatastore"
     export ESX_TEST_HOST_IP="<esx_host_ip>"  # for static provisioning tests
-
     # SHARED_VSPHERE_DATASTORE_NAME and SHARED_VSPHERE_DATASTORE_URL should correspond to same shared datastore
-   
     # To run e2e test for VCP to CSI migration, need to set the following env variable
     export GINKGO_FOCUS="csi-vcp-mig"
+
+    # For vsan stretched cluster tests
+    export TESTBEDINFO_JSON="/path/to/nimbus_testbedinfo.json"
+    export GINKGO_FOCUS="vsan-stretch-vanilla"
 
     # To run common e2e tests (block & file), need to set the following env variable to identify the file volume setup
     export ACCESS_MODE="RWX"

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -114,8 +114,8 @@ const (
 	pollTimeout                               = 5 * time.Minute
 	pollTimeoutShort                          = 1 * time.Minute
 	pollTimeoutSixMin                         = 6 * time.Minute
-	healthStatusPollTimeout                   = 15 * time.Minute
-	healthStatusPollInterval                  = 15 * time.Second
+	healthStatusPollTimeout                   = 20 * time.Minute
+	healthStatusPollInterval                  = 30 * time.Second
 	psodTime                                  = "120"
 	pvcHealthAnnotation                       = "volumehealth.storage.kubernetes.io/health"
 	pvcHealthTimestampAnnotation              = "volumehealth.storage.kubernetes.io/health-timestamp"
@@ -194,6 +194,11 @@ var (
 	pvAnnotationProvisionedBy       = "pv.kubernetes.io/provisioned-by"
 	scAnnotation4Statefulset        = "volume.beta.kubernetes.io/storage-class"
 	nodeMapper                      = &NodeMapper{}
+)
+
+// For vsan stretched cluster tests
+var (
+	envTestbedInfoJsonPath = "TESTBEDINFO_JSON"
 )
 
 // GetAndExpectStringEnvVar parses a string from env variable.

--- a/tests/e2e/nimbus_utils.go
+++ b/tests/e2e/nimbus_utils.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/onsi/gomega"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+type TestbedBasicInfo struct {
+	name     string `default:"worker"`
+	user     string
+	location string
+	vcIp     string
+	vcVmName string
+	esxHosts []map[string]string
+}
+
+var tbinfo TestbedBasicInfo
+
+//vMPowerMgmt power on/off given nimbus VMs (space separated list)
+func vMPowerMgmt(user string, location string, hostList string, shouldBePoweredOn bool) error {
+	var err error
+	op := "off"
+	if shouldBePoweredOn {
+		op = "on"
+	}
+	nimbusCmd := fmt.Sprintf("USER=%s /mts/git/bin/nimbus-ctl --nimbusLocation %s %s %s", user, location, op, hostList)
+	framework.Logf("Running command: %s", nimbusCmd)
+	cmd := exec.Command("/bin/bash", "-c", nimbusCmd)
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+	err = cmd.Wait()
+
+	framework.Logf("stdout:\n%v\nstderr:\n%v\n", cmd.Stdout, cmd.Stderr)
+	return err
+}
+
+//readVcEsxIpsViaTestbedInfoJson read basic testbed info from the json file
+func readVcEsxIpsViaTestbedInfoJson(filePath string) {
+	tbinfo = TestbedBasicInfo{}
+
+	file, err := ioutil.ReadFile(filePath)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	framework.Logf("Fetching basic testbed info from json file")
+
+	var tb map[string]interface{}
+	err = json.Unmarshal(file, &tb)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	vcs := tb["vc"].([]interface{})
+	vc1 := vcs[0].(map[string]interface{})
+	tbinfo.vcIp = vc1["ip"].(string)
+	tbinfo.vcVmName = vc1["name"].(string)
+
+	esxs := tb["esx"].([]interface{})
+
+	esxHosts := []map[string]string{}
+
+	for _, esx := range esxs {
+		host := make(map[string]string)
+		host["ip"] = esx.(map[string]interface{})["ip"].(string)
+		host["vmName"] = esx.(map[string]interface{})["name"].(string)
+		esxHosts = append(esxHosts, host)
+	}
+	tbinfo.esxHosts = esxHosts
+	tbinfo.name = tb["name"].(string)
+	tbinfo.user = tb["user_name"].(string)
+	tbinfo.location = tb["nimbusLocation"].(string)
+
+	framework.Logf("Basic testbed info:\n%s\n", spew.Sdump(tbinfo))
+}

--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -1,0 +1,366 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fdep "k8s.io/kubernetes/test/e2e/framework/deployment"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+)
+
+var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", func() {
+	f := framework.NewDefaultFramework("vsan-stretch")
+	var (
+		client            clientset.Interface
+		namespace         string
+		nodeList          *v1.NodeList
+		storagePolicyName string
+		scParameters      map[string]string
+		storageClassName  string
+		csiNs             string
+	)
+
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		namespace = getNamespaceToRunTests(f)
+		bootstrap()
+		var err error
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
+		readVcEsxIpsViaTestbedInfoJson(GetAndExpectStringEnvVar(envTestbedInfoJsonPath))
+
+		csiNs = GetAndExpectStringEnvVar(envCSINamespace)
+
+		initialiseFdsVar(ctx)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		framework.ExpectNoError(err, "cluster not completely healthy")
+
+		// TODO: verify csi pods are up
+
+		nodeList, err = fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+		sc, err := client.StorageV1().StorageClasses().Get(ctx, defaultNginxStorageClassName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "Unable to fetch storage class "+defaultNginxStorageClassName)
+		if sc != nil {
+			framework.ExpectNoError(client.StorageV1().StorageClasses().Delete(ctx, defaultNginxStorageClassName,
+				*metav1.NewDeleteOptions(0)), "Unable to delete storage class "+defaultNginxStorageClassName)
+		}
+		scParameters = make(map[string]string)
+		nodeList, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		framework.ExpectNoError(err, "Unable to list k8s nodes")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find k8s nodes")
+		}
+
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
+		ginkgo.By(fmt.Sprintf("Deleting service nginx in namespace: %v", namespace))
+		err := client.CoreV1().Services(namespace).Delete(ctx, servicename, *metav1.NewDeleteOptions(0))
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		err = client.StorageV1().StorageClasses().Delete(ctx, storageClassName, *metav1.NewDeleteOptions(0))
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	})
+
+	/*
+		Primary site down
+		Steps:
+		1.	Configure a vanilla multi-master K8s cluster with inter and intra site replication
+		2.	Create a statefulset, deployment with volumes from the stretched datastore
+		3.	Bring down the primary site
+		4.	Verify that the VMs hosted by esx servers are brought up on the other site
+		5.	Verify that the k8s cluster is healthy and all the k8s constructs created in step 2 are running and volume
+			and application lifecycle actions work fine
+		6.	Bring primary site up and wait for testbed to be back to normal
+		7.	Delete all objects created in step 2 and 5
+	*/
+	ginkgo.It("Primary site down", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass for Statefulset")
+		// decide which test setup is available to run
+		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+		scParameters = map[string]string{}
+		scParameters["StoragePolicyName"] = storagePolicyName
+		storageClassName = "nginx-sc-default"
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating PVC")
+		pvclaim, err := createPVC(client, namespace, nil, diskSize, sc, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pvclaims = append(pvclaims, pvclaim)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
+		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pvclaim = nil
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		// Waiting for pods status to be Ready
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			"Unable to get list of Pods from the Statefulset: %v", statefulset.Name)
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset %s, %v, should match with number of required replicas %v",
+			statefulset.Name, ssPodsBeforeScaleDown.Size(), replicas)
+
+		// Get the list of Volumes attached to Pods before scale down
+		var volumesBeforeScaleDown []string
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					volumesBeforeScaleDown = append(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)
+					// Verify the attached volume match the one in CNS cache
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By("Creating Deployment")
+		labelsMap := make(map[string]string)
+		labelsMap["app"] = "test"
+		deployment, err := createDeployment(
+			ctx, client, 1, labelsMap, nil, namespace, pvclaims, "", false, busyBoxImageOnGcr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		deployment, err = client.AppsV1().Deployments(namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pods, err := fdep.GetPodsForDeployment(client, deployment)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pod := pods.Items[0]
+		err = fpod.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		csipods, err := client.CoreV1().Pods(csiNs).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Bring down the primary site")
+		siteFailover(true)
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = fpod.WaitForPodsRunningReady(client, csiNs, int32(csipods.Size()), 0, pollTimeout, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pvc1, err := createPVC(client, namespace, nil, diskSize, sc, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pvs, err := fpv.WaitForPVClaimBoundPhase(
+			client, []*v1.PersistentVolumeClaim{pvc1}, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvc1}, false, execCommand)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = fpod.DeletePodWithWait(client, pod1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		deletePodAndWaitForVolsToDetach(ctx, client, pod1)
+
+		err = fpv.DeletePersistentVolumeClaim(client, pvc1.Name, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = e2eVSphere.waitForCNSVolumeToBeDeleted(pvs[0].Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		scaleDownReplicas := replicas - 1
+		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", scaleDownReplicas))
+		_, scaledownErr := fss.Scale(client, statefulset, scaleDownReplicas)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReadyReplicas(client, statefulset, scaleDownReplicas)
+		ssPodsAfterScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(scaleDownReplicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset %s, %v, should match with number of replicas %v",
+			statefulset.Name, ssPodsAfterScaleDown.Size(), scaleDownReplicas,
+		)
+
+		// After scale down, verify vSphere volumes are detached from deleted pods
+		ginkgo.By("Verify Volumes are detached from Nodes after Statefulsets is scaled down")
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			if err != nil {
+				gomega.Expect(apierrors.IsNotFound(err), gomega.BeTrue())
+				for _, volumespec := range sspod.Spec.Volumes {
+					if volumespec.PersistentVolumeClaim != nil {
+						pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+						if vanillaCluster {
+							isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(
+								client, pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+								fmt.Sprintf("Volume %q is not detached from the node %q",
+									pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+						} else {
+							annotations := sspod.Annotations
+							vmUUID, exists := annotations[vmUUIDLabel]
+							gomega.Expect(exists).To(gomega.BeTrue(),
+								fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+
+							ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s",
+								pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+							ctx, cancel := context.WithCancel(context.Background())
+							defer cancel()
+							_, err := e2eVSphere.getVMByUUIDWithWait(ctx, vmUUID, supervisorClusterOperationsTimeout)
+							gomega.Expect(err).To(gomega.HaveOccurred(),
+								fmt.Sprintf(
+									"PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM",
+									vmUUID, sspod.Spec.NodeName))
+						}
+					}
+				}
+			}
+		}
+
+		// After scale down, verify the attached volumes match those in CNS Cache
+		for _, sspod := range ssPodsAfterScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By(fmt.Sprintf("Scaling up statefulsets to number of Replica: %v", replicas))
+		_, scaleupErr := fss.Scale(client, statefulset, replicas)
+		gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+
+		ssPodsAfterScaleUp := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset %s, %v, should match with number of replicas %v",
+			statefulset.Name, ssPodsAfterScaleUp.Size(), replicas,
+		)
+
+		// After scale up, verify all vSphere volumes are attached to node VMs.
+		ginkgo.By("Verify all volumes are attached to Nodes after Statefulsets is scaled up")
+		for _, sspod := range ssPodsAfterScaleUp.Items {
+			err := fpod.WaitForPodsReady(client, statefulset.Namespace, sspod.Name, 0)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range pod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					ginkgo.By("Verify scale up operation should not introduced new volume")
+					gomega.Expect(contains(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)).To(gomega.BeTrue())
+					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+					var vmUUID string
+					var exists bool
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					if vanillaCluster {
+						vmUUID = getNodeUUID(client, sspod.Spec.NodeName)
+					} else {
+						annotations := pod.Annotations
+						vmUUID, exists = annotations[vmUUIDLabel]
+						gomega.Expect(exists).To(
+							gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+						_, err := e2eVSphere.getVMByUUID(ctx, vmUUID)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+					isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Disk is not attached to the node")
+					gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached")
+					ginkgo.By("After scale up, verify the attached volumes match those in CNS Cache")
+					err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By("Bring up the primary site")
+		siteRestore(true)
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		// wait for the VMs to move back
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
+	})
+
+})

--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/vmware/govmomi/find"
+	vsan "github.com/vmware/govmomi/vsan"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+)
+
+type FaultDomains struct {
+	primarySiteHosts   []string
+	secondarySiteHosts []string
+	witness            string
+	hostsDown          []string `default:"[]"`
+	// isNetworkPartitioned bool     `default:"false"`
+}
+
+var fds FaultDomains
+
+//initialiseFdsVar initialise fds variable
+func initialiseFdsVar(ctx context.Context) {
+	fdMap := createFaultDomainMap(ctx, &e2eVSphere)
+	hostsWithoutFD := []string{}
+	for host, site := range fdMap {
+		if strings.Contains(site, "rimary") {
+			fds.primarySiteHosts = append(fds.primarySiteHosts, host)
+		} else if strings.Contains(site, "econdary") {
+			fds.secondarySiteHosts = append(fds.secondarySiteHosts, host)
+		} else {
+			hostsWithoutFD = append(hostsWithoutFD, host)
+		}
+	}
+
+	// assuming we don't have hosts which are not part of the vsan stretched cluster in the testbed here
+	gomega.Expect(len(hostsWithoutFD) == 1).To(gomega.BeTrue())
+	fds.witness = hostsWithoutFD[0]
+
+}
+
+//siteFailover causes a site failover by powering off hosts of the given site
+func siteFailover(primarySite bool) {
+	hostsToPowerOff := fds.secondarySiteHosts
+	if primarySite {
+		hostsToPowerOff = fds.primarySiteHosts
+	}
+	framework.Logf("hosts to power off: %v", hostsToPowerOff)
+	powerOffHostParallel(hostsToPowerOff)
+}
+
+//powerOffHostParallel powers off given hosts
+func powerOffHostParallel(hostsToPowerOff []string) {
+	hostlist := ""
+	for _, host := range hostsToPowerOff {
+		for _, esxHost := range tbinfo.esxHosts {
+			if esxHost["ip"] == host {
+				hostlist += esxHost["vmName"] + " "
+			}
+		}
+		fds.hostsDown = append(fds.hostsDown, host)
+	}
+
+	err := vMPowerMgmt(tbinfo.user, tbinfo.location, hostlist, false)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	for _, host := range hostsToPowerOff {
+		err = waitForHostToBeDown(host)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+}
+
+//siteRestore restores a site by powering on hosts of the given site
+func siteRestore(primarySite bool) {
+	hostsToPowerOn := fds.secondarySiteHosts
+	if primarySite {
+		hostsToPowerOn = fds.primarySiteHosts
+	}
+	framework.Logf("hosts to power on: %v", hostsToPowerOn)
+	powerOnHostParallel(hostsToPowerOn)
+}
+
+//powerOnHostParallel powers on given hosts
+func powerOnHostParallel(hostsToPowerOn []string) {
+	hostlist := ""
+	for _, host := range hostsToPowerOn {
+		for _, esxHost := range tbinfo.esxHosts {
+			if esxHost["ip"] == host {
+				hostlist += esxHost["vmName"] + " "
+			}
+		}
+		fds.hostsDown = append(fds.hostsDown, host)
+	}
+	err := vMPowerMgmt(tbinfo.user, tbinfo.location, hostlist, true)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	for _, host := range hostsToPowerOn {
+		err = waitForHostToBeUp(host)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+}
+
+// createFaultDomainMap returns the host to fault domain mapping
+func createFaultDomainMap(ctx context.Context, vs *vSphere) map[string]string {
+	fdMap := make(map[string]string)
+	c := newClient(ctx, vs)
+
+	datacenter := strings.Split(e2eVSphere.Config.Global.Datacenters, ",")[0]
+
+	vsanHealthClient, err := newVsanHealthSvcClient(ctx, c.Client)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	vsanClient, err := vsan.NewClient(ctx, vsanHealthClient.vim25Client)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	finder := find.NewFinder(vsanHealthClient.vim25Client, false)
+	dc, err := finder.Datacenter(ctx, datacenter)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	finder.SetDatacenter(dc)
+	hosts, err := finder.HostSystemList(ctx, "*")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	for _, host := range hosts {
+		vsanSystem, _ := host.ConfigManager().VsanSystem(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		hostConfig, err := vsanClient.VsanHostGetConfig(ctx, vsanSystem.Reference())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		fdMap[host.Name()] = ""
+		if hostConfig.FaultDomainInfo != nil {
+			fdMap[host.Name()] = hostConfig.FaultDomainInfo.Name
+			framework.Logf("host: %s, site: %s", host.Name(), hostConfig.FaultDomainInfo.Name)
+		}
+	}
+
+	return fdMap
+}
+
+//waitForHostToBeDown wait for host to be down
+func waitForHostToBeDown(ip string) error {
+	framework.Logf("checking host status of %s", ip)
+	gomega.Expect(ip).NotTo(gomega.BeNil())
+	gomega.Expect(ip).NotTo(gomega.BeEmpty())
+	waitErr := wait.Poll(poll*2, pollTimeoutShort*2, func() (bool, error) {
+		_, err := net.DialTimeout("tcp", ip+":22", poll)
+		if err == nil {
+			framework.Logf("host is reachable")
+			return false, nil
+		}
+		framework.Logf("host is now unreachable. Error: %s", err.Error())
+		return true, nil
+	})
+	return waitErr
+}
+
+// waitForAllNodes2BeReady checks whether all registered nodes are ready and all required Pods are running on them.
+func waitForAllNodes2BeReady(ctx context.Context, c clientset.Interface, timeout time.Duration) error {
+	framework.Logf("Waiting up to %v for all nodes to be ready", timeout)
+
+	var notReady []v1.Node
+	err := wait.PollImmediate(poll, timeout, func() (bool, error) {
+		notReady = nil
+		nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, node := range nodes.Items {
+			if !fnodes.IsConditionSetAsExpected(&node, v1.NodeReady, true) {
+				notReady = append(notReady, node)
+			}
+		}
+		return len(notReady) == 0, nil
+	})
+	if len(notReady) > 0 {
+		return fmt.Errorf("not ready nodes: %v", notReady)
+	}
+
+	return err
+}
+
+//wait4AllK8sNodesToBeUp wait for all k8s nodes to be reachable
+func wait4AllK8sNodesToBeUp(
+	ctx context.Context, client clientset.Interface, k8sNodes *v1.NodeList) {
+	var nodeIp string
+	for _, node := range k8sNodes.Items {
+		addrs := node.Status.Addresses
+		for _, addr := range addrs {
+			if addr.Type == v1.NodeInternalIP && (net.ParseIP(addr.Address)).To4() != nil {
+				nodeIp = addr.Address
+			}
+		}
+		err := waitForHostToBeUp(nodeIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: vsan stretch cluster for vanilla cluster - 'Primary site down' test and libs

**Testing done**:
https://gist.github.com/sashrith/1c141740caeb2514324cf7c60caf325e

**Special notes for your reviewer**:
In the test logs, storage class cleanup failed, hence the failure.
I have fixed that now.

```bash
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver vsan_stretch ⇡ ❯ make check 
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sashrith/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sashrith/csi/vsphere-csi-driver /Users/sashrith/csi /Users/sashrith /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (files|imports|types_sizes|compiled_files|exports_file|name|deps) took 1.681684371s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 101.16447ms
INFO [linters context/goanalysis] analyzers took 7.368060886s with top 10 stages: buildir: 733.471036ms, S1038: 587.996965ms, misspell: 550.930733ms, S1039: 338.178989ms, SA1012: 297.775126ms, lll: 259.75555ms, S1028: 246.229743ms, directives: 231.565276ms, S1012: 228.140651ms, unused: 215.661405ms
INFO [runner] Issues before processing: 110, after processing: 0
INFO [runner] Processors filtering stat (out/in): identifier_marker: 21/21, exclude: 21/21, skip_files: 110/110, skip_dirs: 110/110, autogenerated_exclude: 21/110, cgo: 110/110, nolint: 0/1, path_prettifier: 110/110, exclude-rules: 1/21, filename_unadjuster: 110/110
INFO [runner] processing took 16.069947ms with stages: nolint: 12.678657ms, autogenerated_exclude: 1.859921ms, path_prettifier: 726.3µs, identifier_marker: 474.819µs, skip_dirs: 164.025µs, exclude-rules: 137.347µs, cgo: 12.954µs, filename_unadjuster: 10.316µs, max_same_issues: 1.273µs, exclude: 764ns, uniq_by_line: 705ns, skip_files: 529ns, max_from_linter: 410ns, source_code: 395ns, diff: 353ns, max_per_file_from_linter: 282ns, severity-rules: 249ns, path_shortener: 248ns, sort_results: 243ns, path_prefixer: 157ns
INFO [runner] linters took 5.20676879s with stages: goanalysis_metalinter: 5.190582463s
INFO File cache stats: 79 entries of total size 1.9MiB
INFO Memory: 71 samples, avg is 247.5MB, max is 481.1MB
INFO Execution took 7.00261493s
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver vsan_stretch ⇡ 53s ❯
```
