### PR TITLE
Added patch verb for volumesnapshotcontents resource to vsphere-csi-controller-role for the compatibility with external-snapshotter 5.0

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -61,7 +61,7 @@ rules:
     verbs: [ "watch", "get", "list" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents" ]
-    verbs: [ "create", "get", "list", "watch", "update", "delete" ]
+    verbs: [ "create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update", "patch" ]


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Based on https://github.com/kubernetes-csi/external-snapshotter/pull/526/, the RABC rules for csi-snapshotter needs to be updated if vSphere CSI driver uses external-snapshotter 5.0 onward. So, we need to make this manifest update.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Testing done**:

- Manual testing: Dynamically provision a RWO volume and provision a snapshot of the volume. Both of them works fine.

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added patch verb for volumesnapshotcontents resource to vsphere-csi-controller-role for the compatibility with external-snapshotter 5.0
```
