### PR TITLE
Fix parsing of volume path

### DIFF
--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -388,7 +388,7 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volu
 			"failed to extract datastore name from in-tree volume path: %q", volumeSpec.VolumePath)
 	}
 	datastoreFullPath := re.FindAllString(volumeSpec.VolumePath, -1)[0]
-	vmdkPath := strings.TrimSpace(strings.Trim(volumeSpec.VolumePath, datastoreFullPath))
+	vmdkPath := strings.TrimSpace(strings.TrimPrefix(volumeSpec.VolumePath, datastoreFullPath))
 	datastoreFullPath = strings.Trim(strings.Trim(datastoreFullPath, "["), "]")
 	datastorePathSplit := strings.Split(datastoreFullPath, "/")
 	datastoreName := datastorePathSplit[len(datastorePathSplit)-1]


### PR DESCRIPTION
Remove datastore name from `VolumePath` using `TrimPrefix`. `Trim` will remove all matching characters from the end of the `VolumePath`, e.g. it can remove `"vmdk"` if the datastore name contains charactes `"v"`, `"m"`, `"d"` and `"k"` (anywhere in the datastore name).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1447

**Testing done**:
I tested a driver with this patch in my Kubernetes cluster, fixed #1447 for me.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed parsing of volume IDs of in-tree PVs when CSI migration is enabled.
```
