### PR TITLE
[Fix-linter error]: Fix linter error introduced on the PR #1439

### DIFF
--- a/tests/e2e/improved_csi_idempotency.go
+++ b/tests/e2e/improved_csi_idempotency.go
@@ -667,7 +667,8 @@ func extendVolumeWithServiceDown(serviceName string, namespace string, client cl
 		}
 		var allowExpansion = true
 		storageclass.AllowVolumeExpansion = &allowExpansion
-		client.StorageV1().StorageClasses().Update(ctx, storageclass, metav1.UpdateOptions{})
+		storageclass, err = client.StorageV1().StorageClasses().Update(ctx, storageclass, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix linter error introduced on the PR #1439


**Testing done**:
Yes
>make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: upgraded honnef.co/go/tools v0.0.1-2020.1.3 => v0.2.0
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/rpanduranga/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/rpanduranga/CSI-Code/vsphere-csi-driver /Users/rpanduranga/CSI-Code /Users/rpanduranga /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (types_sizes|compiled_files|exports_file|name|deps|files|imports) took 1.704665924s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 78.14533ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): cgo: 110/110, filename_unadjuster: 110/110, path_prettifier: 110/110, exclude-rules: 1/21, skip_files: 110/110, skip_dirs: 110/110, autogenerated_exclude: 21/110, nolint: 0/1, identifier_marker: 21/21, exclude: 21/21 
INFO [runner] processing took 9.985164ms with stages: nolint: 7.909704ms, autogenerated_exclude: 1.004941ms, path_prettifier: 536.676µs, identifier_marker: 230.358µs, skip_dirs: 183.656µs, exclude-rules: 91.033µs, cgo: 14.92µs, filename_unadjuster: 10.646µs, max_same_issues: 721ns, uniq_by_line: 437ns, source_code: 265ns, diff: 256ns, exclude: 230ns, max_from_linter: 213ns, skip_files: 213ns, path_shortener: 205ns, sort_results: 204ns, severity-rules: 190ns, max_per_file_from_linter: 188ns, path_prefixer: 108ns 
INFO [runner] linters took 1.975778287s with stages: goanalysis_metalinter: 1.965710057s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 39 samples, avg is 108.9MB, max is 140.6MB 
INFO Execution took 3.771061518s  

**Special notes for your reviewer**:
NA

**Release note**:
NA
