### PR TITLE
Fix for failures in volumeExpansionTests

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1815,10 +1815,20 @@ func createResourceQuota(client clientset.Interface, namespace string, size stri
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	waitTime := 15
+	var executeCreateResourceQuota bool
+	executeCreateResourceQuota = true
 	storagePolicyNameForSharedDatastores := GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 
-	_, err := client.CoreV1().ResourceQuotas(namespace).Get(ctx, namespace+"-storagequota", metav1.GetOptions{})
-	if err != nil || !(scName == storagePolicyNameForSharedDatastores) {
+	if supervisorCluster {
+		_, err := client.CoreV1().ResourceQuotas(namespace).Get(ctx, namespace+"-storagequota", metav1.GetOptions{})
+		if err != nil || !(scName == storagePolicyNameForSharedDatastores) {
+			executeCreateResourceQuota = true
+		} else {
+			executeCreateResourceQuota = false
+		}
+	}
+
+	if executeCreateResourceQuota {
 		// deleteResourceQuota if already present.
 		deleteResourceQuota(client, namespace)
 


### PR DESCRIPTION
What this PR does / why we need it: Fix for GC volume expansion test cases

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes # The test was not altering resource quota in case of GC 

Release notes: Recently there was a change made in storage class creation code in case of supervisor. The same code was causing not to delete the existing quota . That caused few test failures in GC. 

Special notes for your reviewer: Recently there was a change made in storage class creation code in case of supervisor. The same code was causing not to delete the existing quota . That caused few test failures in GC. 