### PR TITLE
lint error fixed

### DIFF
--- a/tests/e2e/vsphere_shared_datastore.go
+++ b/tests/e2e/vsphere_shared_datastore.go
@@ -242,12 +242,13 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 
 		// Delete SC with Immediate Binding Mode
 		ginkgo.By("Delete SC created with Immediate Binding Mode")
-		client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+		err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Create SC with same name but with WaitForFirstConusmer Binding Mode
 		ginkgo.By("Recreate SC with same name but with WaitForFirstConusmer Binding Mode")
-		storageclass, err = createStorageClass(client, scParameters, nil, "", storagev1.VolumeBindingWaitForFirstConsumer, false, storageclass.Name)
+		storageclass, err = createStorageClass(client, scParameters, nil, "", 
+		storagev1.VolumeBindingWaitForFirstConsumer, false, storageclass.Name)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		framework.Logf("storageclass name :%s", storageclass.GetName())
 		defer func() {
@@ -257,7 +258,9 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 				// If Supervisor Cluster, delete SC and recreate again with Immediate Binding Mode
 				err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				createStorageClass(client, scParameters, nil, "", storagev1.VolumeBindingImmediate, false, storageclass.Name)
+				_, err = createStorageClass(client, scParameters, nil, "", 
+				storagev1.VolumeBindingImmediate, false, storageclass.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
 

--- a/tests/e2e/vsphere_shared_datastore.go
+++ b/tests/e2e/vsphere_shared_datastore.go
@@ -247,8 +247,8 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 
 		// Create SC with same name but with WaitForFirstConusmer Binding Mode
 		ginkgo.By("Recreate SC with same name but with WaitForFirstConusmer Binding Mode")
-		storageclass, err = createStorageClass(client, scParameters, nil, "", 
-		storagev1.VolumeBindingWaitForFirstConsumer, false, storageclass.Name)
+		storageclass, err = createStorageClass(client, scParameters, nil, "",
+			storagev1.VolumeBindingWaitForFirstConsumer, false, storageclass.Name)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		framework.Logf("storageclass name :%s", storageclass.GetName())
 		defer func() {
@@ -258,8 +258,8 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 				// If Supervisor Cluster, delete SC and recreate again with Immediate Binding Mode
 				err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				_, err = createStorageClass(client, scParameters, nil, "", 
-				storagev1.VolumeBindingImmediate, false, storageclass.Name)
+				_, err = createStorageClass(client, scParameters, nil, "",
+					storagev1.VolumeBindingImmediate, false, storageclass.Name)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Lint error Fixed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Yes

sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll          
sipriya@sipriya-a01 vsphere-csi-driver % 
sipriya@sipriya-a01 vsphere-csi-driver % 

sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint                           
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/lint-error/vsphere-csi-driver /Users/sipriya/lint-error /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (name|compiled_files|deps|exports_file|files|types_sizes|imports) took 3.548860315s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 79.299814ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 110/110, skip_dirs: 110/110, exclude: 21/21, exclude-rules: 1/21, filename_unadjuster: 110/110, skip_files: 110/110, cgo: 110/110, nolint: 0/1, autogenerated_exclude: 21/110, identifier_marker: 21/21 
INFO [runner] processing took 11.452951ms with stages: nolint: 9.307314ms, autogenerated_exclude: 1.035622ms, path_prettifier: 555.607µs, identifier_marker: 272.294µs, skip_dirs: 145.382µs, exclude-rules: 103.73µs, cgo: 14.132µs, filename_unadjuster: 13.823µs, max_same_issues: 1.32µs, uniq_by_line: 636ns, exclude: 561ns, max_from_linter: 436ns, diff: 333ns, skip_files: 333ns, source_code: 321ns, severity-rules: 256ns, path_shortener: 239ns, max_per_file_from_linter: 238ns, sort_results: 227ns, path_prefixer: 147ns 
INFO [runner] linters took 1.992179704s with stages: goanalysis_metalinter: 1.98062484s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 58 samples, avg is 98.6MB, max is 141.1MB 
INFO Execution took 5.635960067s


