### PR TITLE
Add diskDecomm as a field to storagepool

### DIFF
--- a/pkg/apis/storagepool/cns/v1alpha1/storagepool_types.go
+++ b/pkg/apis/storagepool/cns/v1alpha1/storagepool_types.go
@@ -45,6 +45,9 @@ type StoragePoolStatus struct {
 	// Error that has occurred on the storage pool. Present only when there is an error.
 	// +optional
 	Error StoragePoolError `json:"error,omitempty"`
+	// DiskDecomm indicates the status of disk decommission for the given storagepool
+	// +optional
+	DiskDecomm map[string]string `json:"diskDecomm,omitempty"`
 }
 
 // PoolCapacity is the storage capacity of the storage pool

--- a/pkg/apis/storagepool/config/cns.vmware.com_storagepools.yaml
+++ b/pkg/apis/storagepool/config/cns.vmware.com_storagepools.yaml
@@ -86,6 +86,12 @@ spec:
                 items:
                   type: string
                 type: array
+              diskDecomm:
+                additionalProperties:
+                  type: string
+                description: DiskDecomm indicates the status of disk decommission
+                  for the given storagepool
+                type: object
               error:
                 description: Error that has occurred on the storage pool. Present
                   only when there is an error.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
After the recent change where version of CRDs is changed from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1, unknown fields are pruned by default. So, if there's a field which is not recognised by the CRD, then such a field will be removed from the CR.

`diskDecomm` is such a field and this is causing Disk Decommission workflow to not work as expected. WCP waits for `diskDecomm` field to get updated. But since with the new version of CRD, this field gets pruned, WCP times out waiting for the status to change.

In this change, I am adding `diskDecomm` as a valid field so that it doesn't get pruned.

**Testing done**:
Took a live cluster where we were seeing failures in disk decomm, replaced CSI image with the changes and then triggered disk decommission for a new disk. It went through, as expected.

Here are some CSI logs for a failure case where disk vsand-10.161.97.110-naa.6000c296116a65c8f8e08502316d3ee6 could not be evacuated:

```
{"level":"info","time":"2022-01-06T05:54:03.042803752Z","caller":"storagepool/migrationController.go:246","msg":"Total number of successful migrations: 0, unsuccessful migrations: 1"}
{"level":"info","time":"2022-01-06T05:54:03.095443957Z","caller":"storagepool/util.go:298","msg":"Errorstring: Fail to migrate all volumes from StoragePool storagepool-vsand-10.161.97.110-naa.6000c29532e7d961ffe8ac8737d2af78"}
```


Storagepool also gets updated with failed status, as expected:

```
root@420a640bf09ead37174d9d79dd1bae18 [ ~ ]# kubectl get storagepool -oyaml storagepool-vsand-10.161.97.110-naa.6000c29532e7d961ffe8ac8737d2af78
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePool
metadata:
  creationTimestamp: "2022-01-03T10:39:20Z"
  generation: 5
  labels:
    cns.vmware.com/StoragePoolType: vsanD
  name: storagepool-vsand-10.161.97.110-naa.6000c29532e7d961ffe8ac8737d2af78
  resourceVersion: "2563795"
  selfLink: /apis/cns.vmware.com/v1alpha1/storagepools/storagepool-vsand-10.161.97.110-naa.6000c29532e7d961ffe8ac8737d2af78
  uid: 543c158f-0bed-41f3-8ac1-65a4857f4db9
spec:
  driver: csi.vsphere.vmware.com
  parameters:
    datastoreUrl: ds:///vmfs/volumes/61d2d256-da7dff42-ec88-0200436d8140/
    decommMode: evacuateAll
status:
  accessibleNodes:
  - sc-rdops-vm12-dhcp-97-110.eng.vmware.com
  capacity:
    allocatableSpace: 303424339968
    freeSpace: 303428534272
    total: 307090161664
  compatibleStorageClasses:
  - sample-vsan-direct-thick
  diskDecomm:
    reason: Fail to migrate all volumes from StoragePool storagepool-vsand-10.161.97.110-naa.6000c29532e7d961ffe8ac8737d2af78
    status: fail
``` 

Storagepool where disk decomm suceeded:
```
root@420a1509dbbfd53862f132ab89f95fe4 [ ~ ]# kubectl get storagepool storagepool-vsand-10.161.106.204-naa.6000c296900dcd7b2190c53e8a2ca5ff -oyaml
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePool
metadata:
  creationTimestamp: "2022-01-03T08:43:10Z"
  generation: 5
  labels:
    cns.vmware.com/StoragePoolType: vsanD
  name: storagepool-vsand-10.161.106.204-naa.6000c296900dcd7b2190c53e8a2ca5ff
  resourceVersion: "1710157"
  selfLink: /apis/cns.vmware.com/v1alpha1/storagepools/storagepool-vsand-10.161.106.204-naa.6000c296900dcd7b2190c53e8a2ca5ff
  uid: cdebe993-28e4-4b0e-a40f-7879f3c5f095
spec:
  driver: csi.vsphere.vmware.com
  parameters:
    datastoreUrl: ds:///vmfs/volumes/61d2b1b9-c215816b-a167-02004379076f/
    decommMode: evacuateAll
status:
  accessibleNodes:
  - sc-rdops-vm12-dhcp-106-204.eng.vmware.com
  capacity:
    allocatableSpace: 305572872192
    freeSpace: 305577066496
    total: 307090161664
  compatibleStorageClasses:
  - sample-vsan-direct-thick
  diskDecomm:
    status: done
```