### PR TITLE
Test-fix for volume expansion tests 

### DIFF
--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -731,7 +731,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
 
 		if !featureEnabled {
-			ginkgo.By("File system resize should not succeed since SPS service is down. Expecting an error")
+			ginkgo.By("File system resize should not succeed since SPS service is down" +
+				" and cns new sync feature is disabled. Expecting an error")
 			if guestCluster {
 				expectedErrMsg = "didn't find a plugin capable of expanding the volume"
 			} else {
@@ -1501,7 +1502,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
 
 		if !featureEnabled {
-			ginkgo.By("File system resize should not succeed since SPS service is down. Expecting an error")
+			ginkgo.By("File system resize should not succeed since SPS service is down" +
+				" and cns new sync feature is disabled. Expecting an error")
 			expectedErrMsg := "failed to expand volume"
 			framework.Logf("Expected failure message: %+q", expectedErrMsg)
 			err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -1500,7 +1500,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
 
-		if featureEnabled {
+		if !featureEnabled {
 			ginkgo.By("File system resize should not succeed since SPS service is down. Expecting an error")
 			expectedErrMsg := "failed to expand volume"
 			framework.Logf("Expected failure message: %+q", expectedErrMsg)


### PR DESCRIPTION
**What this PR does / why we need it**: Test fix to succeed volume expansion if cns new sync feature is not enabled.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes bug 2896961
https://bugzilla.eng.vmware.com/show_bug.cgi?id=2896961

**Testing done**:
WCP: https://gist.github.com/Aishwarya-Hebbar/bbecf9b9810ba8b1e39e3410da36e414

**Special notes for your reviewer**:

**Release note**:
WCP: Verify Offline volume expansion when SPS-Service is down


