### PR TITLE
Fixed parsing of /proc/self/mountinfo with spaces

### DIFF
--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -142,7 +142,7 @@ func (osUtils *OsUtils) NodeStageBlockVolume(
 		log.Debugf("nodeStageBlockVolume: Device already mounted. Checking mount flags %v for correctness.",
 			params.MntFlags)
 		for _, m := range mnts {
-			if m.Path == params.StagingTarget {
+			if unescape(ctx, m.Path) == params.StagingTarget {
 				rwo := "rw"
 				if params.Ro {
 					rwo = "ro"
@@ -410,7 +410,7 @@ func (osUtils *OsUtils) PublishMountVol(
 	if len(devMnts) > 1 {
 		// check if publish is already there.
 		for _, m := range devMnts {
-			if m.Path == params.Target {
+			if unescape(ctx, m.Path) == params.Target {
 				// volume already published to target.
 				// If mount options look good, do nothing.
 				rwo := "rw"
@@ -497,7 +497,7 @@ func (osUtils *OsUtils) PublishBlockVol(
 		log.Debugf("PublishBlockVolume: Bind mount successful to path %q", params.Target)
 	} else if len(devMnts) == 1 {
 		// Already mounted, make sure it's what we want.
-		if devMnts[0].Path != params.Target {
+		if unescape(ctx, devMnts[0].Path) != params.Target {
 			return nil, logger.LogNewErrorCode(log, codes.Internal,
 				"device already in use and mounted elsewhere")
 		}
@@ -543,7 +543,7 @@ func (osUtils *OsUtils) PublishFileVol(
 	}
 	log.Debugf("PublishFileVolume: Mounts - %+v", mnts)
 	for _, m := range mnts {
-		if m.Path == params.Target {
+		if unescape(ctx, m.Path) == params.Target {
 			// Volume already published to target.
 			// If mount options look good, do nothing.
 			rwo := "rw"
@@ -884,7 +884,7 @@ func (osUtils *OsUtils) GetDevFromMount(ctx context.Context, target string) (*De
 	// Opts:[rw relatime]
 
 	for _, m := range mnts {
-		if m.Path == target {
+		if unescape(ctx, m.Path) == target {
 			// Something is mounted to target, get underlying disk.
 			d := m.Device
 			if m.Device == "udev" || m.Device == "devtmpfs" {
@@ -992,7 +992,7 @@ func (osUtils *OsUtils) VerifyVolumeAttachedAndFillParams(ctx context.Context,
 func isFileVolumeMount(ctx context.Context, target string, mnts []gofsutil.Info) (bool, error) {
 	log := logger.GetLogger(ctx)
 	for _, m := range mnts {
-		if m.Path == target {
+		if unescape(ctx, m.Path) == target {
 			if m.Type == common.NfsFsType || m.Type == common.NfsV4FsType {
 				log.Debug("IsFileVolumeMount: Found file volume")
 				return true, nil
@@ -1010,7 +1010,7 @@ func isFileVolumeMount(ctx context.Context, target string, mnts []gofsutil.Info)
 func isTargetInMounts(ctx context.Context, target string, mnts []gofsutil.Info) bool {
 	log := logger.GetLogger(ctx)
 	for _, m := range mnts {
-		if m.Path == target {
+		if unescape(ctx, m.Path) == target {
 			log.Debugf("Found target %q in list of mounts", target)
 			return true
 		}
@@ -1022,4 +1022,24 @@ func isTargetInMounts(ctx context.Context, target string, mnts []gofsutil.Info) 
 // decides if node should continue
 func (osUtils *OsUtils) ShouldContinue(ctx context.Context) {
 	// no op for linux
+}
+
+// un-escapes "\nnn" sequences in /proc/self/mounts. For example, replaces "\040" with space " ".
+func unescape(ctx context.Context, in string) string {
+	log := logger.GetLogger(ctx)
+	out := make([]rune, 0, len(in))
+	s := in
+	for len(s) > 0 {
+		// Un-escape single character.
+		// UnquoteChar will un-escape also \r, \n, \Unnnn and other sequences, but they should not be used in /proc/mounts.
+		rune, _, tail, err := strconv.UnquoteChar(s, '"')
+		if err != nil {
+			log.Infof("Error parsing mount %q: %s", in, err)
+			// Use escaped string as a fallback
+			return in
+		}
+		out = append(out, rune)
+		s = tail
+	}
+	return string(out)
 }

--- a/pkg/csi/service/osutils/linux_os_utils_test.go
+++ b/pkg/csi/service/osutils/linux_os_utils_test.go
@@ -1,0 +1,50 @@
+//go:build darwin || linux
+// +build darwin linux
+
+package osutils
+
+import (
+	"context"
+	"strconv"
+	"testing"
+)
+
+func TestUnescape(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{
+			// Space is unescaped. This is basically the only test that can happen in reality
+			// and only when in-tree in-line volume in a Pod is used with CSI migration enabled.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+		},
+		{
+			// Multiple spaces are unescaped.
+			in:  `/var/lib/kube\040let/plug\040ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo\040bar\040baz`,
+			out: `/var/lib/kube let/plug ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo bar baz`,
+		},
+		{
+			// Too short escape sequence. Expect the same string on output.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
+		},
+		{
+			// Wrong characters in the escape sequence. Expect the same string on output.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
+		},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			out := unescape(ctx, test.in)
+			if out != test.out {
+				t.Errorf("Expected %q to be unescaped as %q, got %q", test.in, test.out, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When a mount point contains space, it is escaped in `/proc/self/mountifo` as `\040`:

```
7331 6783 8:32 / /var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-fce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount rw,relatime - ext4 /dev/sdc rw,seclabel
```

Un-escape this sequence (and any other `\nnn` sequences) before comparing the parsed mount path.

This happens only for in-line in-tree vSphere volumes when CSI migration is enabled. Whole `[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk` is used as a volumeHandle (and thus in global mount dir) and at the same time as a fake PV name for CSI migration (and thus is in pod local mount dir).

**Which issue this PR fixes** *
fixes #1466

**Testing done**:
Tested on OpenShift with Kubernetes 1.22 + CSI driver v2.4.0 + this patch. In-tree vSphere tests passed when CSI migration was enabled, including those that use in-line in-tree vSphere volume.

**Special notes for your reviewer**:
I'm fixing it in linux_os_utils.go because `github.com/akutz/gofsutil` that is used for /proc/self/mounts parsing looks abandoned.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed un-mounting of in-tree in-line vSphere volumes when CSI migration is enabled.
```
