### PR TITLE
CreateVolume pvcsi changes for tkgs-ha

### DIFF
--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -57,6 +57,9 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]
     verbs: ["update", "patch"]
+  - apiGroups: [ "cns.vmware.com" ]
+    resources: [ "csinodetopologies" ]
+    verbs: [ "get", "update", "watch", "list" ]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -50,6 +50,7 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 				"csi-migration":         "true",
 				"file-volume":           "true",
 				"block-volume-snapshot": "true",
+				"tkgs-ha":               "true",
 			},
 		}
 		return fakeCO, nil

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -195,10 +195,18 @@ const (
 	// provisioned/deleted by its corresponding CSI driver.
 	AnnMigratedTo = "pv.kubernetes.io/migrated-to"
 
+	// AnnBetaStorageProvisioner annotation is added to a PVC that is supposed to
+	// be dynamically provisioned. Its value is name of volume plugin that is
+	// supposed to provision a volume for this PVC.
+	AnnBetaStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
+
 	// AnnStorageProvisioner annotation is added to a PVC that is supposed to
 	// be dynamically provisioned. Its value is name of volume plugin that is
 	// supposed to provision a volume for this PVC.
-	AnnStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
+	AnnStorageProvisioner = "volume.kubernetes.io/storage-provisioner"
+
+	// vSphereCSIDriverName vSphere CSI driver name
+	VSphereCSIDriverName = "csi.vsphere.vmware.com"
 
 	// AnnDynamicallyProvisioned annotation is added to a PV that has been
 	// dynamically provisioned by Kubernetes. Its value is name of volume plugin
@@ -249,6 +257,12 @@ const (
 	// TopologyLabelsDomain is the domain name used to identify user-defined
 	// topology labels applied on the node by vSphere CSI driver.
 	TopologyLabelsDomain = "topology.csi.vmware.com"
+
+	//AnnGuestClusterRequestedTopology is the key for guest cluster requested topology
+	AnnGuestClusterRequestedTopology = "csi.vsphere.guest-cluster-requested-topology"
+
+	//AnnVolumeAccessibleTopology is the annotation set by the supervisor cluster on PVC
+	AnnVolumeAccessibleTopology = "csi.vsphere.volumeAccessibleTopology"
 )
 
 // Supported container orchestrators.

--- a/pkg/csi/service/wcpguest/controller_test.go
+++ b/pkg/csi/service/wcpguest/controller_test.go
@@ -19,9 +19,12 @@ package wcpguest
 import (
 	"context"
 	"os"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -202,4 +205,218 @@ func TestGuestClusterControllerFlow(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
+
+// TestGuestClusterControllerFlowForTkgsHA creates volume.
+func TestGuestClusterControllerFlowForTkgsHA(t *testing.T) {
+	ct := getControllerTest(t)
+	// Create.
+	params := make(map[string]string)
+
+	params[common.AttributeSupervisorStorageClass] = testStorageClass
+	if v := os.Getenv("SUPERVISOR_STORAGE_CLASS"); v != "" {
+		params[common.AttributeSupervisorStorageClass] = v
+	}
+	capabilities := []*csi.VolumeCapability{
+		{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+
+	topologyRequirement := createTestTopologyRequirement()
+
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName,
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters:                params,
+		VolumeCapabilities:        capabilities,
+		AccessibilityRequirements: topologyRequirement,
+	}
+
+	var respCreate *csi.CreateVolumeResponse
+	var err error
+
+	if isUnitTest {
+		// Invoking CreateVolume in a separate thread and then setting the
+		// Status to Bound explicitly.
+		response := make(chan *csi.CreateVolumeResponse)
+		error := make(chan error)
+
+		go createVolume(ctx, ct, reqCreate, response, error)
+		time.Sleep(1 * time.Second)
+		pvc, _ := ct.controller.supervisorClient.CoreV1().PersistentVolumeClaims(
+			ct.controller.supervisorNamespace).Get(ctx, testSupervisorPVCName, metav1.GetOptions{})
+		// Update annotation on the supervisor PVC
+		pvcAnnotations := make(map[string]string)
+		pvcAnnotations[common.AnnVolumeAccessibleTopology] = `[{"R1" : "Zone1"}]`
+		pvc.Annotations = pvcAnnotations
+		pvc.Status.Phase = "Bound"
+		_, err = ct.controller.supervisorClient.CoreV1().PersistentVolumeClaims(
+			ct.controller.supervisorNamespace).Update(ctx, pvc, metav1.UpdateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		respCreate, err = <-response, <-error
+	} else {
+		// TODO: Skip currently until supervisor side changes are completed
+		t.Skipf("Skipping test until supervisor side changes are complete.")
+		//respCreate, err = ct.controller.CreateVolume(ctx, reqCreate)
+		// Wait for create volume finish.
+		//time.Sleep(1 * time.Second)
+		return
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the response to ensure Accessibility topology is set.
+	if respCreate.Volume.AccessibleTopology == nil {
+		t.Fatalf("AccessibleTopology was unset when volume was created with topology on guest cluster")
+	}
+
+	// Retrieve the segments
+	respAccessibleTopology := respCreate.Volume.AccessibleTopology[0].Segments
+	if val, ok := respAccessibleTopology["R1"]; !ok {
+		t.Fatalf("AccessibleTopology inccorectly populated, key not present")
+	} else {
+		if val != "Zone1" {
+			t.Fatalf("AccessibleTopology inccorectly populated, value incorrect")
+		}
+	}
+	t.Log("AccessibleTopology was correctly set in create volume response")
+
+	supervisorPVCName := respCreate.Volume.VolumeId
+	// Verify the pvc has been created.
+	_, err = ct.controller.supervisorClient.CoreV1().PersistentVolumeClaims(
+		ct.controller.supervisorNamespace).Get(ctx, supervisorPVCName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete.
+	reqDelete := &csi.DeleteVolumeRequest{
+		VolumeId: supervisorPVCName,
+	}
+	_, err = ct.controller.DeleteVolume(ctx, reqDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for delete volume finish.
+	time.Sleep(1 * time.Second)
+	// Verify the pvc has been deleted.
+	_, err = ct.controller.supervisorClient.CoreV1().PersistentVolumeClaims(
+		ct.controller.supervisorNamespace).Get(ctx, supervisorPVCName, metav1.GetOptions{})
+	if !errors.IsNotFound(err) {
+		t.Fatal(err)
+	}
+}
+
+func createTestTopologyRequirement() *csi.TopologyRequirement {
+	// Create a dummy topology requirement.
+	segment := make(map[string]string)
+	segment["R1"] = "Zone1"
+	topology := &csi.Topology{
+		Segments: segment,
+	}
+	topologyRequirement := &csi.TopologyRequirement{
+		Requisite: []*csi.Topology{topology},
+		Preferred: []*csi.Topology{topology},
+	}
+	return topologyRequirement
+}
+
+// TestGenerateAccessibilityRequirementsFromPVCAnnotation helps unit test
+// generateVolumeAccessibilityRequirementsFromPVCAnnotation function
+func TestGenerateAccessibilityRequirementsFromPVCAnnotation(t *testing.T) {
+	claim := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "ns",
+		},
+	}
+	claim.Annotations = make(map[string]string)
+	claim.Annotations[common.AnnVolumeAccessibleTopology] =
+		"[{\"topology.kubernetes.io/zone\":\"zone1\"},{\"topology.kubernetes.io/zone\":\"zone2\"}]"
+
+	t.Logf("Calling generateVolumeAccessibilityRequirementsFromPVCAnnotation with "+
+		"%s annotation value %q", common.AnnVolumeAccessibleTopology,
+		claim.Annotations[common.AnnVolumeAccessibleTopology])
+
+	topologyRequirement, err := generateVolumeAccessibilityRequirementsFromPVCAnnotation(claim)
+	if err != nil {
+		t.Fatalf("failed to generate AccessibilityRequirements from PVC annotation. Err: %v", err)
+	}
+
+	topology := make([]*csi.Topology, 0)
+	topology = append(topology, &csi.Topology{Segments: map[string]string{"topology.kubernetes.io/zone": "zone1"}})
+	topology = append(topology, &csi.Topology{Segments: map[string]string{"topology.kubernetes.io/zone": "zone2"}})
+
+	expectedTopologyRequirement := &csi.TopologyRequirement{
+		Requisite: topology,
+		Preferred: topology,
+	}
+
+	if !reflect.DeepEqual(topologyRequirement, expectedTopologyRequirement) {
+		t.Fatalf("topologyRequirement %v does not match with expectedTopologyRequirement: %v",
+			topologyRequirement, expectedTopologyRequirement)
+	}
+	t.Logf("topologyRequirement %v match with expectedTopologyRequirement: %v",
+		topologyRequirement, expectedTopologyRequirement)
+}
+
+// TestGenerateVolumeAccessibilityRequirementsFromInvalidPVCAnnotation helps unit test
+// generateVolumeAccessibilityRequirementsFromPVCAnnotation function for ill-formed annotation
+func TestGenerateVolumeAccessibilityRequirementsFromInvalidPVCAnnotation(t *testing.T) {
+	claim := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "ns",
+		},
+	}
+	claim.Annotations = make(map[string]string)
+	claim.Annotations[common.AnnVolumeAccessibleTopology] =
+		"[{\"topology.kubernetes.io/zone\":\"zone1\",{\"topology.kubernetes.io/zone\":\"zone2\"}]"
+
+	t.Logf("Calling generateVolumeAccessibilityRequirementsFromPVCAnnotation with "+
+		"%s annotation value %q", common.AnnVolumeAccessibleTopology,
+		claim.Annotations[common.AnnVolumeAccessibleTopology])
+
+	topologyRequirement, err := generateVolumeAccessibilityRequirementsFromPVCAnnotation(claim)
+	if err == nil {
+		t.Fatalf("generateVolumeAccessibilityRequirementsFromPVCAnnotation should have failed. "+
+			"topologyRequirement: %v", topologyRequirement)
+	} else {
+		t.Logf("expected error: %v", err)
+	}
+}
+
+// TestGenerateGuestClusterRequestedTopologyJSON helps unit test
+// generateGuestClusterRequestedTopologyJSON function
+func TestGenerateGuestClusterRequestedTopologyJSON(t *testing.T) {
+	volumeAccessibleTopology := make([]*csi.Topology, 0)
+	volumeAccessibleTopology = append(volumeAccessibleTopology,
+		&csi.Topology{Segments: map[string]string{"topology.kubernetes.io/zone": "zone1"}})
+	volumeAccessibleTopology = append(volumeAccessibleTopology,
+		&csi.Topology{Segments: map[string]string{"topology.kubernetes.io/zone": "zone2"}})
+
+	t.Logf("Calling generateGuestClusterRequestedTopologyJSON with topologies: %v", volumeAccessibleTopology)
+	volumeAccessibleTopologyJSON, err := generateGuestClusterRequestedTopologyJSON(volumeAccessibleTopology)
+	if err != nil {
+		t.Fatalf("failed to generate json string from volumeAccessibleTopology. Err: %v", err)
+	}
+	expectedVolumeAccessibleTopologyJSON :=
+		"[{\"topology.kubernetes.io/zone\":\"zone1\"},{\"topology.kubernetes.io/zone\":\"zone2\"}]"
+
+	if !reflect.DeepEqual(volumeAccessibleTopologyJSON, expectedVolumeAccessibleTopologyJSON) {
+		t.Fatalf("volumeAccessibleTopologyJSON %v does not match with expectedVolumeAccessibleTopologyJSON: %v",
+			volumeAccessibleTopologyJSON, expectedVolumeAccessibleTopologyJSON)
+	}
+	t.Logf("volumeAccessibleTopologyJSON %v match with expectedVolumeAccessibleTopologyJSON: %v",
+		volumeAccessibleTopologyJSON, expectedVolumeAccessibleTopologyJSON)
 }

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -230,15 +230,15 @@ func isValidvSphereVolumeClaim(ctx context.Context, pvcMetadata metav1.ObjectMet
 	// Checking if the migrated-to annotation is found in the PVC metadata.
 	if annotation, annMigratedToFound := pvcMetadata.Annotations[common.AnnMigratedTo]; annMigratedToFound {
 		if annotation == csitypes.Name &&
-			pvcMetadata.Annotations[common.AnnStorageProvisioner] == common.InTreePluginName {
+			pvcMetadata.Annotations[common.AnnBetaStorageProvisioner] == common.InTreePluginName {
 			log.Debugf("%v annotation found with value %q for PVC: %q",
 				common.AnnMigratedTo, csitypes.Name, pvcMetadata.Name)
 			return true
 		}
 	} else { // Checking if the PVC was provisioned by CSI.
-		if pvcMetadata.Annotations[common.AnnStorageProvisioner] == csitypes.Name {
+		if pvcMetadata.Annotations[common.AnnBetaStorageProvisioner] == csitypes.Name {
 			log.Debugf("%v annotation found with value %q for PVC: %q",
-				common.AnnStorageProvisioner, csitypes.Name, pvcMetadata.Name)
+				common.AnnBetaStorageProvisioner, csitypes.Name, pvcMetadata.Name)
 			return true
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Change in the PVCSI Create Volume Controller to create PVC in SV namespace using topology annotations.
2. Change in the PVCSI Create Volume Controller to publish AccessibleTopology by Reading SV PVC annotation
3. RBAC Changes for PV-CSI Controller

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
=== RUN   TestGuestClusterControllerFlowForTkgsHA
{"level":"info","time":"2022-01-14T12:13:42.51282-08:00","caller":"wcpguest/controller.go:238","msg":"CreateVolume: called with args {Name:pvc-12345 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[svstorageclass:test-storageclass] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:\"R1\" value:\"Zone1\" > > preferred:<segments:<key:\"R1\" value:\"Zone1\" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"24366271-b277-4cc1-87e6-59378aa6fb3b"}
{"level":"info","time":"2022-01-14T12:13:42.512953-08:00","caller":"wcpguest/controller_helper.go:259","msg":"Waiting up to 240 seconds for PersistentVolumeClaim -12345 in namespace test-namespace to have phase Bound","TraceId":"24366271-b277-4cc1-87e6-59378aa6fb3b"}
{"level":"info","time":"2022-01-14T12:13:43.515551-08:00","caller":"wcpguest/controller_helper.go:283","msg":"PersistentVolumeClaim -12345 in namespace test-namespace is in state Bound","TraceId":"24366271-b277-4cc1-87e6-59378aa6fb3b"}
    controller_test.go:290: AccessibleTopology was correctly set in create volume response
{"level":"info","time":"2022-01-14T12:13:43.515805-08:00","caller":"wcpguest/controller.go:405","msg":"DeleteVolume: called with args: {VolumeId:-12345 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"6e0320c0-3802-4011-834b-1db575ec7a62"}
{"level":"info","time":"2022-01-14T12:13:43.51584-08:00","caller":"wcpguest/controller.go:450","msg":"DeleteVolume: Volume deleted successfully. VolumeID: \"-12345\"","TraceId":"6e0320c0-3802-4011-834b-1db575ec7a62"}
--- PASS: TestGuestClusterControllerFlowForTkgsHA (2.01s)

=== RUN   TestGenerateAccessibilityRequirementsFromPVCAnnotation
    controller_test.go:346: Calling generateVolumeAccessibilityRequirementsFromPVCAnnotation with csi.vsphere.volumeAccessibleTopology annotation value "[{\"topology.kubernetes.io/zone\":\"zone1\"},{\"topology.kubernetes.io/zone\":\"zone2\"}]"
    controller_test.go:368: topologyRequirement requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone1" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone2" > >  match with expectedTopologyRequirement: requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone1" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone2" > >
--- PASS: TestGenerateAccessibilityRequirementsFromPVCAnnotation (0.00s)

=== RUN   TestGenerateVolumeAccessibilityRequirementsFromInvalidPVCAnnotation
    controller_test.go:385: Calling generateVolumeAccessibilityRequirementsFromPVCAnnotation with csi.vsphere.volumeAccessibleTopology annotation value "[{\"topology.kubernetes.io/zone\":\"zone1\",{\"topology.kubernetes.io/zone\":\"zone2\"}]"
    controller_test.go:393: expected error: failed to parse annotation: "csi.vsphere.volumeAccessibleTopology" value [{"topology.kubernetes.io/zone":"zone1",{"topology.kubernetes.io/zone":"zone2"}] from the claim: "name", namespace: "ns". err: invalid character '{' looking for beginning of object key string
--- PASS: TestGenerateVolumeAccessibilityRequirementsFromInvalidPVCAnnotation (0.00s)

=== RUN   TestGenerateGuestClusterRequestedTopologyJSON
    controller_test.go:406: Calling generateGuestClusterRequestedTopologyJSON with topologies: [segments:<key:"topology.kubernetes.io/zone" value:"zone1" >  segments:<key:"topology.kubernetes.io/zone" value:"zone2" > ]
    controller_test.go:417: volumeAccessibleTopologyJSON [{"topology.kubernetes.io/zone":"zone1"},{"topology.kubernetes.io/zone":"zone2"}] match with expectedVolumeAccessibleTopologyJSON: [{"topology.kubernetes.io/zone":"zone1"},{"topology.kubernetes.io/zone":"zone2"}]
--- PASS: TestGenerateGuestClusterRequestedTopologyJSON (0.00s)
PASS

```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
CreateVolume pvcsi changes for tkgs-ha
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>