### PR TITLE
Added the node topology discovery workflow for TKGS HA feature - csinodetopology consumer and manifest update

### DIFF
--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -59,7 +59,32 @@ rules:
     verbs: ["update", "patch"]
   - apiGroups: [ "cns.vmware.com" ]
     resources: [ "csinodetopologies" ]
-    verbs: [ "get", "update", "watch", "list" ]
+    verbs: ["get", "update", "watch", "list"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-role
+rules:
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["csinodetopologies"]
+    verbs: ["create", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-cluster-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-node
+    namespace: vmware-system-csi
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-node-cluster-role
+  apiGroup: rbac.authorization.k8s.io
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -381,7 +381,8 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 		}
 	}
 
-	if cnstypes.CnsClusterFlavor(os.Getenv(csitypes.EnvClusterFlavor)) == cnstypes.CnsClusterFlavorGuest {
+	if cnstypes.CnsClusterFlavor(os.Getenv(csitypes.EnvClusterFlavor)) == cnstypes.CnsClusterFlavorGuest &&
+		!commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
 		nodeInfoResponse = &csi.NodeGetInfoResponse{
 			NodeId:             nodeID,
 			MaxVolumesPerNode:  maxVolumesPerNode,
@@ -394,7 +395,8 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 	var (
 		accessibleTopology map[string]string
 	)
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeTopology) {
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeTopology) ||
+		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
 		// Initialize volume topology service.
 		if err = initVolumeTopologyService(ctx); err != nil {
 			return nil, err

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -184,6 +184,16 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 				return err
 			}
 		}
+	} else if clusterFlavor == cnstypes.CnsClusterFlavorGuest {
+		if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.TKGsHA) {
+			// Create CSINodeTopology CRD.
+			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, csinodetopologyconfig.EmbedCSINodeTopologyFile,
+				csinodetopologyconfig.EmbedCSINodeTopologyFileName)
+			if err != nil {
+				log.Errorf("Failed to create %q CRD. Error: %+v", csinodetopology.CRDSingular, err)
+				return err
+			}
+		}
 	}
 
 	// Create a new operator to provide shared dependencies and start components


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
- regression test: Done. Failed with unrelated errors at GC 219.
- E2E test: Done

After boot of node daemonset, one `csinodetopology` CR is created for each worker node.
```
$ kubectl --kubeconfig gc-config.yaml -n vmware-system-csi get csinodetopology
NAME                                           AGE
np-cluster-control-plane-75xnt                 13m
np-cluster-control-plane-7hwc7                 14m
np-cluster-control-plane-t9s2b                 14m
np-cluster-nodepool-1-d97zs-54455f88cf-bm49v   13m
np-cluster-nodepool-1-d97zs-54455f88cf-gcthz   14m
np-cluster-nodepool-2-bwh4v-67c8558bbf-9gnqx   14m
np-cluster-nodepool-2-bwh4v-67c8558bbf-bnzc4   14m
np-cluster-nodepool-3-kv9sj-6cd6c67878-rjgdn   13m
np-cluster-nodepool-3-kv9sj-6cd6c67878-x5b9m   13m
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Updated pvcsi node plugin and pvcsi manifest for the node topology discovery in TKGS HA
```
