### PR TITLE
Added the node topology discovery workflow for TKGS HA feature - csinodetopology controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
-	github.com/vmware-tanzu/vm-operator-api v0.1.3
+	github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae
 	github.com/vmware/govmomi v0.27.0
 	go.uber.org/zap v1.17.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83

--- a/go.sum
+++ b/go.sum
@@ -689,6 +689,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vmware-tanzu/vm-operator-api v0.1.3 h1:4vxewu0jAN3fSoCBI6FhjmRGJ7ci0R2WNu/I6hacTYs=
 github.com/vmware-tanzu/vm-operator-api v0.1.3/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
+github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae h1:R7ukgIC/uN4vULAvwWJxuq2XLcUEJkR4psxdRNssqSI=
+github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.27.0 h1:KoQ8IsLAa7V78s5d7dgpZA8d039GBM83cVxgAq9uWuw=
 github.com/vmware/govmomi v0.27.0/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -263,6 +263,12 @@ const (
 
 	//AnnVolumeAccessibleTopology is the annotation set by the supervisor cluster on PVC
 	AnnVolumeAccessibleTopology = "csi.vsphere.volumeAccessibleTopology"
+
+	// WellKnownTopologyLabelsDomain is the well-known domain name of topology labels
+	WellKnownTopologyLabelsDomain = "topology.kubernetes.io"
+
+	// TopologyLabelsZoneKey is zone key of the topology labels
+	TopologyLabelsZoneKey = "zone"
 )
 
 // Supported container orchestrators.

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -263,12 +263,6 @@ const (
 
 	//AnnVolumeAccessibleTopology is the annotation set by the supervisor cluster on PVC
 	AnnVolumeAccessibleTopology = "csi.vsphere.volumeAccessibleTopology"
-
-	// WellKnownTopologyLabelsDomain is the well-known domain name of topology labels
-	WellKnownTopologyLabelsDomain = "topology.kubernetes.io"
-
-	// TopologyLabelsZoneKey is zone key of the topology labels
-	TopologyLabelsZoneKey = "zone"
 )
 
 // Supported container orchestrators.

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -566,8 +566,10 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 			// volume in the spec and patching virtualMachine instance.
 			vmvolumes := vmoperatortypes.VirtualMachineVolume{
 				Name: req.VolumeId,
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: req.VolumeId,
+				PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: req.VolumeId,
+					},
 				},
 			}
 			virtualMachineLock.Lock()

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -403,7 +403,7 @@ func getNodeTopologyInfoForGuest(ctx context.Context, instance *csinodetopologyv
 		topologyLabels = make([]csinodetopologyv1alpha1.TopologyLabel, 0)
 		topologyLabels = append(topologyLabels,
 			csinodetopologyv1alpha1.TopologyLabel{
-				Key:   common.WellKnownTopologyLabelsDomain + "/" + common.TopologyLabelsZoneKey,
+				Key:   corev1.LabelZoneFailureDomainStable,
 				Value: virtualMachine.Status.Zone,
 			},
 		)

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -101,7 +101,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	var vmOperatorClient client.Client
 	var supervisorNamespace string
 	if enableTKGsHAinGuest {
-		log.Info("The %s FSS is enabled in %s", common.TKGsHA, cnstypes.CnsClusterFlavorGuest)
+		log.Infof("The %s FSS is enabled in %s", common.TKGsHA, cnstypes.CnsClusterFlavorGuest)
 		restClientConfigForSupervisor :=
 			k8s.GetRestClientConfigForSupervisor(ctx, configInfo.Cfg.GC.Endpoint, configInfo.Cfg.GC.Port)
 		vmOperatorClient, err = k8s.NewClientForGroup(ctx, restClientConfigForSupervisor, vmoperatortypes.GroupName)

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
@@ -68,8 +71,8 @@ var (
 func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	configInfo *cnsconfig.ConfigurationInfo, volumeManager volumes.Manager) error {
 	ctx, log := logger.GetNewContextWithLogger()
-	if clusterFlavor != cnstypes.CnsClusterFlavorVanilla {
-		log.Debug("Not initializing the CSINodetopology Controller as it is not a Vanilla CSI deployment")
+	if clusterFlavor != cnstypes.CnsClusterFlavorVanilla && clusterFlavor != cnstypes.CnsClusterFlavorGuest {
+		log.Debug("Not initializing the CSINodetopology Controller as it is not a Vanilla or Guest CSI deployment")
 		return nil
 	}
 
@@ -79,10 +82,38 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		log.Errorf("failed to create CO agnostic interface. Err: %v", err)
 		return err
 	}
-	if !coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeTopology) {
-		log.Infof("Not initializing the CSINodetopology Controller as %s FSS is disabled",
-			common.ImprovedVolumeTopology)
+
+	if clusterFlavor == cnstypes.CnsClusterFlavorVanilla &&
+		!coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeTopology) {
+		log.Infof("Not initializing the CSINodetopology Controller as %s FSS is disabled in %s cluster",
+			common.ImprovedVolumeTopology, cnstypes.CnsClusterFlavorVanilla)
 		return nil
+	}
+
+	if clusterFlavor == cnstypes.CnsClusterFlavorGuest && !coCommonInterface.IsFSSEnabled(ctx, common.TKGsHA) {
+		log.Infof("Not initializing the CSINodetopology Controller as %s FSS is disabled in %s cluster",
+			common.TKGsHA, cnstypes.CnsClusterFlavorGuest)
+		return nil
+	}
+
+	enableTKGsHAinGuest := clusterFlavor == cnstypes.CnsClusterFlavorGuest &&
+		coCommonInterface.IsFSSEnabled(ctx, common.TKGsHA)
+	var vmOperatorClient client.Client
+	var supervisorNamespace string
+	if enableTKGsHAinGuest {
+		restClientConfigForSupervisor :=
+			k8s.GetRestClientConfigForSupervisor(ctx, configInfo.Cfg.GC.Endpoint, configInfo.Cfg.GC.Port)
+		vmOperatorClient, err = k8s.NewClientForGroup(ctx, restClientConfigForSupervisor, vmoperatortypes.GroupName)
+		if err != nil {
+			log.Errorf("failed to create vmOperatorClient. Error: %+v", err)
+			return err
+		}
+
+		supervisorNamespace, err = cnsconfig.GetSupervisorNamespace(ctx)
+		if err != nil {
+			log.Errorf("failed to get supervisor namespace. Error: %+v", err)
+			return err
+		}
 	}
 
 	useNodeUuid := coCommonInterface.IsFSSEnabled(ctx, common.UseCSINodeId)
@@ -102,14 +133,17 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	)
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme,
 		corev1.EventSource{Component: csinodetopologyv1alpha1.GroupName})
-	return add(mgr, newReconciler(mgr, configInfo, recorder, useNodeUuid))
+	return add(mgr, newReconciler(mgr, configInfo, recorder, useNodeUuid,
+		enableTKGsHAinGuest, vmOperatorClient, supervisorNamespace))
 }
 
 // newReconciler returns a new `reconcile.Reconciler`.
-func newReconciler(mgr manager.Manager, configInfo *cnsconfig.ConfigurationInfo,
-	recorder record.EventRecorder, useNodeUuid bool) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, configInfo *cnsconfig.ConfigurationInfo, recorder record.EventRecorder,
+	useNodeUuid bool, enableTKGsHAinGuest bool, vmOperatorClient client.Client,
+	supervisorNamespace string) reconcile.Reconciler {
 	return &ReconcileCSINodeTopology{client: mgr.GetClient(), scheme: mgr.GetScheme(),
-		configInfo: configInfo, recorder: recorder, useNodeUuid: useNodeUuid}
+		configInfo: configInfo, recorder: recorder, useNodeUuid: useNodeUuid, enableTKGsHAinGuest: enableTKGsHAinGuest,
+		vmOperatorClient: vmOperatorClient, supervisorNamespace: supervisorNamespace}
 }
 
 // add adds a new Controller to mgr with r as the `reconcile.Reconciler`.
@@ -168,11 +202,14 @@ var _ reconcile.Reconciler = &ReconcileCSINodeTopology{}
 type ReconcileCSINodeTopology struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver.
-	client      client.Client
-	scheme      *runtime.Scheme
-	configInfo  *cnsconfig.ConfigurationInfo
-	recorder    record.EventRecorder
-	useNodeUuid bool
+	client              client.Client
+	scheme              *runtime.Scheme
+	configInfo          *cnsconfig.ConfigurationInfo
+	recorder            record.EventRecorder
+	useNodeUuid         bool
+	enableTKGsHAinGuest bool
+	vmOperatorClient    client.Client
+	supervisorNamespace string
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -180,7 +217,17 @@ type ReconcileCSINodeTopology struct {
 // Note: The Controller will requeue the Request to be processed again if the
 // returned error is non-nil or Result.Requeue is true, otherwise upon
 // completion it will remove the work from the queue.
-func (r *ReconcileCSINodeTopology) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcileCSINodeTopology) Reconcile(ctx context.Context, request reconcile.Request) (
+	reconcile.Result, error) {
+	if r.enableTKGsHAinGuest {
+		return r.reconcileForGuest(ctx, request)
+	} else {
+		return r.reconcileForVanilla(ctx, request)
+	}
+}
+
+func (r *ReconcileCSINodeTopology) reconcileForVanilla(ctx context.Context, request reconcile.Request) (
+	reconcile.Result, error) {
 	log := logger.GetLogger(ctx)
 
 	// Fetch the CSINodeTopology instance.
@@ -273,6 +320,93 @@ func (r *ReconcileCSINodeTopology) Reconcile(ctx context.Context, request reconc
 	backOffDurationMapMutex.Unlock()
 	log.Infof("Successfully updated topology labels for nodeVM %q", instance.Name)
 	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileCSINodeTopology) reconcileForGuest(ctx context.Context, request reconcile.Request) (
+	reconcile.Result, error) {
+	log := logger.GetLogger(ctx)
+
+	// Fetch the CSINodeTopology instance.
+	instance := &csinodetopologyv1alpha1.CSINodeTopology{}
+	err := r.client.Get(ctx, request.NamespacedName, instance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Infof("CSINodeTopology resource with name %q not found. Ignoring since object must have "+
+				"been deleted.", request.Name)
+			return reconcile.Result{}, nil
+		}
+		log.Errorf("Failed to fetch the CSINodeTopology instance with name: %q. Error: %+v", request.Name, err)
+		// Error reading the object - return with err.
+		return reconcile.Result{}, err
+	}
+
+	// Initialize backOffDuration for the instance, if required.
+	var timeout time.Duration
+	func() {
+		backOffDurationMapMutex.Lock()
+		defer backOffDurationMapMutex.Unlock()
+		if _, exists := backOffDuration[instance.Name]; !exists {
+			backOffDuration[instance.Name] = time.Second
+		}
+		timeout = backOffDuration[instance.Name]
+	}()
+
+	// Fetch topology labels for guest worker node backed by vmop VM.
+	topologyLabels, err := getNodeTopologyInfoForGuest(ctx, instance, r.vmOperatorClient, r.supervisorNamespace)
+	if err != nil {
+		msg := fmt.Sprintf("failed to fetch topology information for the worker node %q. Error: %v",
+			instance.Name, err)
+		log.Error(msg)
+		_ = updateCRStatus(ctx, r, instance, csinodetopologyv1alpha1.CSINodeTopologyError, msg)
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
+
+	// Update CSINodeTopology instance.
+	instance.Status.TopologyLabels = topologyLabels
+	if err := updateCRStatus(ctx, r, instance, csinodetopologyv1alpha1.CSINodeTopologySuccess,
+		fmt.Sprintf("Topology labels successfully updated for the worker node %q", instance.Name)); err != nil {
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
+
+	// On successful event, remove instance from backOffDuration.
+	func() {
+		backOffDurationMapMutex.Lock()
+		defer backOffDurationMapMutex.Unlock()
+		delete(backOffDuration, instance.Name)
+	}()
+
+	log.Infof("Successfully updated topology labels for worker %q", instance.Name)
+	return reconcile.Result{}, nil
+}
+
+func getNodeTopologyInfoForGuest(ctx context.Context, instance *csinodetopologyv1alpha1.CSINodeTopology,
+	vmOperatorClient client.Client, supervisorNamespace string) ([]csinodetopologyv1alpha1.TopologyLabel, error) {
+	log := logger.GetLogger(ctx)
+
+	virtualMachine := &vmoperatortypes.VirtualMachine{}
+	vmKey := types.NamespacedName{
+		Namespace: supervisorNamespace,
+		Name:      instance.Name, // use the nodeName as the VM key
+	}
+
+	var err error
+	if err = vmOperatorClient.Get(ctx, vmKey, virtualMachine); err != nil {
+		return nil, logger.LogNewErrorf(log,
+			"failed to get VirtualMachines for the node: %q. Error: %+v", instance.Name, err)
+	}
+
+	var topologyLabels []csinodetopologyv1alpha1.TopologyLabel
+	if virtualMachine.Status.Zone != "" {
+		topologyLabels = make([]csinodetopologyv1alpha1.TopologyLabel, 0)
+		topologyLabels = append(topologyLabels,
+			csinodetopologyv1alpha1.TopologyLabel{
+				Key:   common.WellKnownTopologyLabelsDomain + "/" + common.TopologyLabelsZoneKey,
+				Value: virtualMachine.Status.Zone,
+			},
+		)
+	}
+
+	return topologyLabels, nil
 }
 
 func updateCRStatus(ctx context.Context, r *ReconcileCSINodeTopology, instance *csinodetopologyv1alpha1.CSINodeTopology,

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -85,13 +85,13 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 
 	if clusterFlavor == cnstypes.CnsClusterFlavorVanilla &&
 		!coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeTopology) {
-		log.Infof("Not initializing the CSINodetopology Controller as %s FSS is disabled in %s cluster",
+		log.Infof("Not initializing the CSINodetopology Controller as %s FSS is disabled in %s",
 			common.ImprovedVolumeTopology, cnstypes.CnsClusterFlavorVanilla)
 		return nil
 	}
 
 	if clusterFlavor == cnstypes.CnsClusterFlavorGuest && !coCommonInterface.IsFSSEnabled(ctx, common.TKGsHA) {
-		log.Infof("Not initializing the CSINodetopology Controller as %s FSS is disabled in %s cluster",
+		log.Infof("Not initializing the CSINodetopology Controller as %s FSS is disabled in %s",
 			common.TKGsHA, cnstypes.CnsClusterFlavorGuest)
 		return nil
 	}
@@ -101,6 +101,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 	var vmOperatorClient client.Client
 	var supervisorNamespace string
 	if enableTKGsHAinGuest {
+		log.Info("The %s FSS is enabled in %s", common.TKGsHA, cnstypes.CnsClusterFlavorGuest)
 		restClientConfigForSupervisor :=
 			k8s.GetRestClientConfigForSupervisor(ctx, configInfo.Cfg.GC.Endpoint, configInfo.Cfg.GC.Port)
 		vmOperatorClient, err = k8s.NewClientForGroup(ctx, restClientConfigForSupervisor, vmoperatortypes.GroupName)
@@ -325,6 +326,7 @@ func (r *ReconcileCSINodeTopology) reconcileForVanilla(ctx context.Context, requ
 func (r *ReconcileCSINodeTopology) reconcileForGuest(ctx context.Context, request reconcile.Request) (
 	reconcile.Result, error) {
 	log := logger.GetLogger(ctx)
+	log.Infof("Start reconciling the CSINodeTopology request %s in %s", request.Name, cnstypes.CnsClusterFlavorGuest)
 
 	// Fetch the CSINodeTopology instance.
 	instance := &csinodetopologyv1alpha1.CSINodeTopology{}
@@ -375,7 +377,8 @@ func (r *ReconcileCSINodeTopology) reconcileForGuest(ctx context.Context, reques
 		delete(backOffDuration, instance.Name)
 	}()
 
-	log.Infof("Successfully updated topology labels for worker %q", instance.Name)
+	log.Infof("Successfully updated topology labels for worker %q in %s",
+		instance.Name, cnstypes.CnsClusterFlavorGuest)
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
 	csinodetopologyv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1"
 )
 
@@ -44,7 +44,7 @@ func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
 		testUnexpectedVmName    = "test-unexpected-vm-name"
 		testNodeIDInSpec        = "test-node-id"
 		testSupervisorNamespace = "test-supervisor-namespace"
-		expectedZoneKey         = common.WellKnownTopologyLabelsDomain + "/" + common.TopologyLabelsZoneKey
+		expectedZoneKey         = corev1.LabelZoneFailureDomainStable
 		expectedZoneValue       = "zone-1"
 		testCSINodeTopology     = &csinodetopologyv1alpha1.CSINodeTopology{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csinodetopology
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	vmoperatortypes "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
+	csinodetopologyv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1"
+)
+
+func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
+	var (
+		testNodeName            = "test-node-name"
+		testNodeUID             = uuid.New().String()
+		testCSINodeTopologyName = "test-csinodetopology-name"
+		testUnexpectedVmName    = "test-unexpected-vm-name"
+		testNodeIDInSpec        = "test-node-id"
+		testSupervisorNamespace = "test-supervisor-namespace"
+		expectedZoneKey         = common.WellKnownTopologyLabelsDomain + "/" + common.TopologyLabelsZoneKey
+		expectedZoneValue       = "zone-1"
+		testCSINodeTopology     = &csinodetopologyv1alpha1.CSINodeTopology{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testCSINodeTopologyName,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "Node",
+						Name:       testNodeName,
+						UID:        types.UID(testNodeUID),
+					},
+				},
+			},
+			Spec: csinodetopologyv1alpha1.CSINodeTopologySpec{
+				NodeID: testNodeIDInSpec,
+			},
+		}
+		testVMwithZone = &vmoperatortypes.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testCSINodeTopologyName,
+				Namespace: testSupervisorNamespace,
+			},
+			Status: vmoperatortypes.VirtualMachineStatus{
+				Zone: expectedZoneValue,
+			},
+		}
+		testVMwithoutZone = &vmoperatortypes.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testCSINodeTopologyName,
+				Namespace: testSupervisorNamespace,
+			},
+		}
+		testUnexpectedVM = &vmoperatortypes.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testUnexpectedVmName,
+				Namespace: testSupervisorNamespace,
+			},
+		}
+		testBufferSize = 1024
+	)
+
+	tests := []struct {
+		name                    string
+		csiNodeTopology         *csinodetopologyv1alpha1.CSINodeTopology
+		vm                      *vmoperatortypes.VirtualMachine
+		expectedTopologyLabels  []csinodetopologyv1alpha1.TopologyLabel
+		expectedCRDStatus       csinodetopologyv1alpha1.CRDStatus
+		expectedReconcileResult reconcile.Result
+		expectedReconcileError  error
+	}{
+		{
+			name:            "TestWithVmStatusZonePopulated",
+			csiNodeTopology: testCSINodeTopology.DeepCopy(),
+			vm:              testVMwithZone.DeepCopy(),
+			expectedTopologyLabels: []csinodetopologyv1alpha1.TopologyLabel{
+				{
+					Key:   expectedZoneKey,
+					Value: expectedZoneValue,
+				},
+			},
+			expectedCRDStatus:       csinodetopologyv1alpha1.CSINodeTopologySuccess,
+			expectedReconcileResult: reconcile.Result{},
+			expectedReconcileError:  nil,
+		},
+		{
+			name:                    "TestWithVmStatusZoneEmpty",
+			csiNodeTopology:         testCSINodeTopology.DeepCopy(),
+			vm:                      testVMwithoutZone.DeepCopy(),
+			expectedTopologyLabels:  nil,
+			expectedCRDStatus:       csinodetopologyv1alpha1.CSINodeTopologySuccess,
+			expectedReconcileResult: reconcile.Result{},
+			expectedReconcileError:  nil,
+		},
+		{
+			name:                    "TestWithGetVmFailure",
+			csiNodeTopology:         testCSINodeTopology.DeepCopy(),
+			vm:                      testUnexpectedVM.DeepCopy(),
+			expectedTopologyLabels:  nil,
+			expectedCRDStatus:       csinodetopologyv1alpha1.CSINodeTopologyError,
+			expectedReconcileResult: reconcile.Result{RequeueAfter: time.Second},
+			expectedReconcileError:  nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// objects to track in the fake client.
+			objs := []runtime.Object{test.csiNodeTopology}
+
+			// Register operator types with the runtime scheme.
+			s := scheme.Scheme
+			s.AddKnownTypes(csinodetopologyv1alpha1.SchemeGroupVersion, test.csiNodeTopology)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithRuntimeObjects(objs...).
+				Build()
+
+			supervisorObjs := []runtime.Object{test.vm}
+
+			supervisor_scheme := scheme.Scheme
+			supervisor_scheme.AddKnownTypes(vmoperatortypes.SchemeGroupVersion, test.vm)
+
+			fakeVmOperatorClient := fake.NewClientBuilder().
+				WithScheme(supervisor_scheme).
+				WithRuntimeObjects(supervisorObjs...).
+				Build()
+
+			r := &ReconcileCSINodeTopology{
+				client:              fakeClient,
+				scheme:              s,
+				configInfo:          &cnsconfig.ConfigurationInfo{},
+				recorder:            record.NewFakeRecorder(testBufferSize),
+				useNodeUuid:         true,
+				enableTKGsHAinGuest: true,
+				vmOperatorClient:    fakeVmOperatorClient,
+				supervisorNamespace: testSupervisorNamespace,
+			}
+
+			backOffDuration = make(map[string]time.Duration)
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testCSINodeTopologyName,
+					Namespace: "",
+				},
+			}
+
+			res, err := r.Reconcile(context.TODO(), req)
+			if err != nil {
+				t.Fatal("Unexpected reconcile error")
+			}
+
+			assert.Equal(t, test.expectedReconcileResult, res)
+			assert.Equal(t, test.expectedReconcileError, err)
+
+			updatedCSINodeTopology := &csinodetopologyv1alpha1.CSINodeTopology{}
+			if err := r.client.Get(context.TODO(), req.NamespacedName, updatedCSINodeTopology); err != nil {
+				t.Fatalf("get updatedCSINodeTopology: %v", err)
+			}
+
+			assert.Equal(t, test.expectedCRDStatus, updatedCSINodeTopology.Status.Status)
+			assert.Equal(t, test.expectedTopologyLabels, updatedCSINodeTopology.Status.TopologyLabels)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Updated pvcsi syncer to add csinodetopology controller for retrieve node topology during its reconciliation. 

FYI, in reconciliation of csinodetopology controller, there is a dependency on recent API change in https://github.com/vmware-tanzu/vm-operator-api/commit/992b48c128aefa56bc2184d71e7a0f87dd9b3ae8. That is why we need to update `go.mod` and `pkg/csi/service/wcpguest/controller.go` in this change. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
- regression test: Done. Failed with unrelated errors
- unit test: Done.

```
--- PASS: TestCSINodeTopologyControllerForTKGSHA (0.00s)
    --- PASS: TestCSINodeTopologyControllerForTKGSHA/TestWithVmStatusZonePopulated (0.00s)
    --- PASS: TestCSINodeTopologyControllerForTKGSHA/TestWithVmStatusZoneEmpty (0.00s)
    --- PASS: TestCSINodeTopologyControllerForTKGSHA/TestWithGetVmFailure (0.00s)
```
- E2E test: Done.

Verified that csinodetopology controller watches and reconciles csinodetopology instances as expected. 
`topologyLabels` is populated as expected in each csinodetopology instance.

```
kubectl --kubeconfig gc-config.yaml get csinodetopology -o json | jq .items[].status
{
  "status": "Success",
  "topologyLabels": [
    {
      "key": "topology.kubernetes.io/zone",
      "value": "zone-1"
    }
  ]
}
{
  "status": "Success",
  "topologyLabels": [
    {
      "key": "topology.kubernetes.io/zone",
      "value": "zone-2"
    }
  ]
}
{
  "status": "Success",
  "topologyLabels": [
    {
      "key": "topology.kubernetes.io/zone",
      "value": "zone-3"
    }
  ]
}
{
  "status": "Success",
  "topologyLabels": [
    {
      "key": "topology.kubernetes.io/zone",
      "value": "zone-1"
    }
  ]
}
{
  "status": "Success",
  "topologyLabels": [
    {
      "key": "topology.kubernetes.io/zone",
      "value": "zone-1"
    }
  ]
}
{
  "status": "Success",
  "topologyLabels": [
    {
      "key": "topology.kubernetes.io/zone",
      "value": "zone-2"
    }
  ]
}
{
  "status": "Success",
  "topologyLabels": [
    {
      "key": "topology.kubernetes.io/zone",
      "value": "zone-2"
    }
  ]
}
{
  "status": "Success",
  "topologyLabels": [
    {
      "key": "topology.kubernetes.io/zone",
      "value": "zone-3"
    }
  ]
}
{
  "status": "Success",
  "topologyLabels": [
    {
      "key": "topology.kubernetes.io/zone",
      "value": "zone-3"
    }
  ]
}
```

Verified all CSINode instances.
```
kubectl --kubeconfig get csinodes -o jsonpath='{range .items[*]}{.metadata.name} {.spec}{"\n"}{end}'
np-cluster-control-plane-75k8f {"drivers":[{"name":"csi.vsphere.vmware.com","nodeID":"np-cluster-control-plane-75k8f","topologyKeys":["topology.kubernetes.io/zone"]}]}
np-cluster-control-plane-lf862 {"drivers":[{"name":"csi.vsphere.vmware.com","nodeID":"np-cluster-control-plane-lf862","topologyKeys":["topology.kubernetes.io/zone"]}]}
np-cluster-control-plane-wnttj {"drivers":[{"name":"csi.vsphere.vmware.com","nodeID":"np-cluster-control-plane-wnttj","topologyKeys":["topology.kubernetes.io/zone"]}]}
np-cluster-nodepool-1-7n54m-6cbf4776b9-q65g9 {"drivers":[{"name":"csi.vsphere.vmware.com","nodeID":"np-cluster-nodepool-1-7n54m-6cbf4776b9-q65g9","topologyKeys":["topology.kubernetes.io/zone"]}]}
np-cluster-nodepool-1-7n54m-6cbf4776b9-sct7w {"drivers":[{"name":"csi.vsphere.vmware.com","nodeID":"np-cluster-nodepool-1-7n54m-6cbf4776b9-sct7w","topologyKeys":["topology.kubernetes.io/zone"]}]}
np-cluster-nodepool-2-58h2b-5bcccc554-qkvgp {"drivers":[{"name":"csi.vsphere.vmware.com","nodeID":"np-cluster-nodepool-2-58h2b-5bcccc554-qkvgp","topologyKeys":["topology.kubernetes.io/zone"]}]}
np-cluster-nodepool-2-58h2b-5bcccc554-znvvk {"drivers":[{"name":"csi.vsphere.vmware.com","nodeID":"np-cluster-nodepool-2-58h2b-5bcccc554-znvvk","topologyKeys":["topology.kubernetes.io/zone"]}]}
np-cluster-nodepool-3-59qwp-78dfc9777c-hbngj {"drivers":[{"name":"csi.vsphere.vmware.com","nodeID":"np-cluster-nodepool-3-59qwp-78dfc9777c-hbngj","topologyKeys":["topology.kubernetes.io/zone"]}]}
np-cluster-nodepool-3-59qwp-78dfc9777c-nx49d {"drivers":[{"name":"csi.vsphere.vmware.com","nodeID":"np-cluster-nodepool-3-59qwp-78dfc9777c-nx49d","topologyKeys":["topology.kubernetes.io/zone"]}]}
```

Verified topology keys on k8s node objects.

```
kubectl --kubeconfig gc-config.yaml get nodes --show-labels
NAME                                           STATUS   ROLES                  AGE    VERSION            LABELS
np-cluster-control-plane-75k8f                 Ready    control-plane,master   2d7h   v1.21.6+vmware.1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=np-cluster-control-plane-75k8f,kubernetes.io/os=linux,node-role.kubernetes.io/control-plane=,node-role.kubernetes.io/master=,node.kubernetes.io/exclude-from-external-load-balancers=,run.tanzu.vmware.com/kubernetesDistributionVersion=v1.21.6_vmware.1-tkg.1.b3d708a,topology.kubernetes.io/zone=zone-1
np-cluster-control-plane-lf862                 Ready    control-plane,master   2d7h   v1.21.6+vmware.1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=np-cluster-control-plane-lf862,kubernetes.io/os=linux,node-role.kubernetes.io/control-plane=,node-role.kubernetes.io/master=,node.kubernetes.io/exclude-from-external-load-balancers=,run.tanzu.vmware.com/kubernetesDistributionVersion=v1.21.6_vmware.1-tkg.1.b3d708a,topology.kubernetes.io/zone=zone-2
np-cluster-control-plane-wnttj                 Ready    control-plane,master   2d7h   v1.21.6+vmware.1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=np-cluster-control-plane-wnttj,kubernetes.io/os=linux,node-role.kubernetes.io/control-plane=,node-role.kubernetes.io/master=,node.kubernetes.io/exclude-from-external-load-balancers=,run.tanzu.vmware.com/kubernetesDistributionVersion=v1.21.6_vmware.1-tkg.1.b3d708a,topology.kubernetes.io/zone=zone-3
np-cluster-nodepool-1-7n54m-6cbf4776b9-q65g9   Ready    <none>                 2d7h   v1.21.6+vmware.1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=np-cluster-nodepool-1-7n54m-6cbf4776b9-q65g9,kubernetes.io/os=linux,run.tanzu.vmware.com/kubernetesDistributionVersion=v1.21.6_vmware.1-tkg.1.b3d708a,topology.kubernetes.io/zone=zone-1
np-cluster-nodepool-1-7n54m-6cbf4776b9-sct7w   Ready    <none>                 2d7h   v1.21.6+vmware.1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=np-cluster-nodepool-1-7n54m-6cbf4776b9-sct7w,kubernetes.io/os=linux,run.tanzu.vmware.com/kubernetesDistributionVersion=v1.21.6_vmware.1-tkg.1.b3d708a,topology.kubernetes.io/zone=zone-1
np-cluster-nodepool-2-58h2b-5bcccc554-qkvgp    Ready    <none>                 2d7h   v1.21.6+vmware.1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=np-cluster-nodepool-2-58h2b-5bcccc554-qkvgp,kubernetes.io/os=linux,run.tanzu.vmware.com/kubernetesDistributionVersion=v1.21.6_vmware.1-tkg.1.b3d708a,topology.kubernetes.io/zone=zone-2
np-cluster-nodepool-2-58h2b-5bcccc554-znvvk    Ready    <none>                 2d7h   v1.21.6+vmware.1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=np-cluster-nodepool-2-58h2b-5bcccc554-znvvk,kubernetes.io/os=linux,run.tanzu.vmware.com/kubernetesDistributionVersion=v1.21.6_vmware.1-tkg.1.b3d708a,topology.kubernetes.io/zone=zone-2
np-cluster-nodepool-3-59qwp-78dfc9777c-hbngj   Ready    <none>                 2d7h   v1.21.6+vmware.1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=np-cluster-nodepool-3-59qwp-78dfc9777c-hbngj,kubernetes.io/os=linux,run.tanzu.vmware.com/kubernetesDistributionVersion=v1.21.6_vmware.1-tkg.1.b3d708a,topology.kubernetes.io/zone=zone-3
np-cluster-nodepool-3-59qwp-78dfc9777c-nx49d   Ready    <none>                 2d7h   v1.21.6+vmware.1   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=np-cluster-nodepool-3-59qwp-78dfc9777c-nx49d,kubernetes.io/os=linux,run.tanzu.vmware.com/kubernetesDistributionVersion=v1.21.6_vmware.1-tkg.1.b3d708a,topology.kubernetes.io/zone=zone-3
```

**Special notes for your reviewer**:
this PR is expected to be merged after https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1480.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Updated pvcsi syncer to add csinodetopology controller for retrieve node topology during its reconciliation
```
