### PR TITLE
ignore the default-token-* volumes attached to pods while checking volume detachment upon pod deletion

### DIFF
--- a/tests/e2e/vcp_to_csi_attach_detach.go
+++ b/tests/e2e/vcp_to_csi_attach_detach.go
@@ -520,11 +520,14 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Re-create pod for test18")
+
+		pod18 = createPodWithMultipleVolsVerifyVolMounts(
+			ctx, client, namespace, []*v1.PersistentVolumeClaim{pvc18},
+		)
 		podsToDelete = append(
 			podsToDelete,
-			createPodWithMultipleVolsVerifyVolMounts(ctx, client, namespace, []*v1.PersistentVolumeClaim{pvc18}),
+			pod18,
 		)
-
 		ginkgo.By("Wait and verify CNS entries for all CNS volumes")
 		verifyCnsVolumeMetadataAndCnsVSphereVolumeMigrationCrdForPvcs(
 			ctx, client, append(append(vcpPvcsPreMig, vcpPvcsPreMig2...), vcpPvcsPostMig...),

--- a/tests/e2e/vcp_to_csi_attach_detach.go
+++ b/tests/e2e/vcp_to_csi_attach_detach.go
@@ -58,6 +58,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 		pvsToDelete                []*v1.PersistentVolume
 		fullSyncWaitTime           int
 		podsToDelete               []*v1.Pod
+		csiNamespace               string
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -92,6 +93,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 		} else {
 			fullSyncWaitTime = defaultFullSyncWaitTime
 		}
+		csiNamespace = GetAndExpectStringEnvVar(envCSINamespace)
 	})
 
 	ginkgo.JustAfterEach(func() {
@@ -511,10 +513,10 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 
 		ginkgo.By("Restart CSI driver")
 		framework.Logf("Stopping CSI driver")
-		err = updateDeploymentReplicawithWait(client, 0, vSphereCSIControllerPodNamePrefix, csiSystemNamespace)
+		err = updateDeploymentReplicawithWait(client, 0, vSphereCSIControllerPodNamePrefix, csiNamespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		framework.Logf("Starting CSI driver")
-		err = updateDeploymentReplicawithWait(client, 1, vSphereCSIControllerPodNamePrefix, csiSystemNamespace)
+		err = updateDeploymentReplicawithWait(client, 1, vSphereCSIControllerPodNamePrefix, csiNamespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Re-create pod for test18")

--- a/tests/e2e/vcp_to_csi_syncer.go
+++ b/tests/e2e/vcp_to_csi_syncer.go
@@ -1614,10 +1614,15 @@ func deletePodAndWaitForVolsToDetach(ctx context.Context, client clientset.Inter
 	} else {
 		return
 	}
+	framework.Logf("pod info:\n%s", spew.Sdump(pod))
 	for _, vol := range pod.Spec.Volumes {
 		if strings.Contains(vol.Name, "kube-api-access") {
 			continue
 		}
+		if strings.Contains(vol.Name, "token") {
+			continue
+		}
+		framework.Logf("vol info:\n%s", spew.Sdump(vol))
 		pv := getPvFromClaim(client, pod.Namespace, vol.PersistentVolumeClaim.ClaimName)
 		volhandles = append(volhandles, getVolHandle4Pv(ctx, client, pv))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: ignore the default-token-* volumes attached to pods while checking volume detachment upon pod deletion

**Testing done**:
[2.2.3vcptocsi7.log](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/7874907/2.2.3vcptocsi7.log)

**Special notes for your reviewer**:
```bash
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver vcptocsi223 ⇡ 33s ❯ make check                                  17:38:39
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: upgraded honnef.co/go/tools v0.0.1-2020.1.3 => v0.2.0
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sashrith/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sashrith/csi/vsphere-csi-driver /Users/sashrith/csi /Users/sashrith /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (name|types_sizes|deps|exports_file|files|imports|compiled_files) took 3.357300762s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 98.610189ms
INFO [linters context/goanalysis] analyzers took 45.162362468s with top 10 stages: buildir: 25.06129405s, nilness: 1.312068287s, printf: 1.218295804s, typedness: 1.156531994s, ctrlflow: 1.146231469s, S1038: 1.125569624s, SA5012: 1.112263476s, fact_purity: 1.03590893s, fact_deprecated: 1.026031587s, misspell: 955.96453ms
INFO [runner] Issues before processing: 110, after processing: 0
INFO [runner] Processors filtering stat (out/in): nolint: 0/1, filename_unadjuster: 110/110, path_prettifier: 110/110, skip_dirs: 110/110, autogenerated_exclude: 21/110, exclude-rules: 1/21, cgo: 110/110, skip_files: 110/110, identifier_marker: 21/21, exclude: 21/21
INFO [runner] processing took 16.209236ms with stages: nolint: 12.862117ms, autogenerated_exclude: 1.871344ms, path_prettifier: 743.06µs, identifier_marker: 372.168µs, skip_dirs: 193.198µs, exclude-rules: 143.293µs, cgo: 9.161µs, filename_unadjuster: 8.604µs, max_same_issues: 1.28µs, uniq_by_line: 755ns, diff: 735ns, max_from_linter: 628ns, exclude: 619ns, source_code: 461ns, skip_files: 414ns, severity-rules: 319ns, max_per_file_from_linter: 313ns, path_shortener: 294ns, sort_results: 281ns, path_prefixer: 192ns
INFO [runner] linters took 10.529167264s with stages: goanalysis_metalinter: 10.512833446s
INFO File cache stats: 156 entries of total size 3.0MiB
INFO Memory: 140 samples, avg is 492.9MB, max is 1023.0MB
INFO Execution took 13.99668081s
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver vcptocsi223* ⇡ 2m 41s ❯
```

