### PR TITLE
fetch node VM uuid from csinode when use-csinode-id FSS is enabled

### DIFF
--- a/tests/e2e/binding_modes_with_topology.go
+++ b/tests/e2e/binding_modes_with_topology.go
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		pv = getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
-		vmUUID := getNodeUUID(client, pod.Spec.NodeName)
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
 		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")

--- a/tests/e2e/csi_cns_telemetry_vc_reboot.go
+++ b/tests/e2e/csi_cns_telemetry_vc_reboot.go
@@ -145,7 +145,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 		nodeName := pod.Spec.NodeName
 
 		if vanillaCluster {
-			vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 		}
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID, nodeName))
@@ -217,7 +217,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 		nodeName2 := pod2.Spec.NodeName
 
 		if vanillaCluster {
-			vmUUID2 = getNodeUUID(client, pod2.Spec.NodeName)
+			vmUUID2 = getNodeUUID(ctx, client, pod2.Spec.NodeName)
 		}
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID2, nodeName2))
@@ -353,7 +353,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 		nodeName := pod.Spec.NodeName
 
 		if vanillaCluster {
-			vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 		}
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID, nodeName))

--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -317,7 +317,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
-		vmUUID := getNodeUUID(client, pod.Spec.NodeName)
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
 		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")

--- a/tests/e2e/data_persistence.go
+++ b/tests/e2e/data_persistence.go
@@ -176,7 +176,7 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		var vmUUID string
 		var exists bool
 		if vanillaCluster {
-			vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 		} else if supervisorCluster {
 			annotations := pod.Annotations
 			vmUUID, exists = annotations[vmUUIDLabel]
@@ -231,7 +231,7 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 
 		if vanillaCluster {
-			vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 		} else if supervisorCluster {
 			annotations := pod.Annotations
 			vmUUID, exists = annotations[vmUUIDLabel]

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -39,6 +39,7 @@ const (
 	crdGroup                                   = "cns.vmware.com"
 	crdVersion                                 = "v1alpha1"
 	csiSystemNamespace                         = "vmware-system-csi"
+	csiFssCM                                   = "internal-feature-states.csi.vsphere.vmware.com"
 	csiVolAttrVolType                          = "vSphere CNS Block Volume"
 	defaultFullSyncIntervalInMin               = "30"
 	defaultProvisionerTimeInSec                = "300"
@@ -199,6 +200,11 @@ var (
 // For vsan stretched cluster tests
 var (
 	envTestbedInfoJsonPath = "TESTBEDINFO_JSON"
+)
+
+// CSI Internal FSSs
+var (
+	useCsiNodeID = "use-csinode-id"
 )
 
 // GetAndExpectStringEnvVar parses a string from env variable.

--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -828,7 +828,7 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		}()
 
 		ginkgo.By("create a pod pod1, using pvc1")
-		pod, _ := createPODandVerifyVolumeMount(f, client, namespace, pvc, volHandle)
+		pod, _ := createPODandVerifyVolumeMount(ctx, f, client, namespace, pvc, volHandle)
 		defer func() {
 			err := fpod.DeletePodWithWait(client, pod)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -897,7 +897,7 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		pod2, err = client.CoreV1().Pods(namespace).Get(ctx, pod2.Name, metav1.GetOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		if vanillaCluster {
-			vmUUID = getNodeUUID(client, pod2.Spec.NodeName)
+			vmUUID = getNodeUUID(ctx, client, pod2.Spec.NodeName)
 		} else if guestCluster {
 			vmUUID, err = getVMUUIDFromNodeName(pod2.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/labelupdates.go
+++ b/tests/e2e/labelupdates.go
@@ -328,7 +328,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelize
 		var vmUUID string
 		var exists bool
 		if vanillaCluster {
-			vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 		} else {
 			annotations := pod.Annotations
 			vmUUID, exists = annotations[vmUUIDLabel]

--- a/tests/e2e/multi_master_k8s.go
+++ b/tests/e2e/multi_master_k8s.go
@@ -177,7 +177,7 @@ var _ = ginkgo.Describe("[csi-multi-master-block-e2e]", func() {
 		// power off the node where vsphere-csi-controller pod is currently running
 		nodeNameOfvSphereCSIControllerPod := nodeList[0]
 		ginkgo.By(fmt.Sprintf("Power off the node: %v", nodeNameOfvSphereCSIControllerPod))
-		vmUUID := getNodeUUID(client, nodeNameOfvSphereCSIControllerPod)
+		vmUUID := getNodeUUID(ctx, client, nodeNameOfvSphereCSIControllerPod)
 		gomega.Expect(vmUUID).NotTo(gomega.BeEmpty())
 		framework.Logf("VM uuid is: %s for node: %s", vmUUID, nodeNameOfvSphereCSIControllerPod)
 		vmRef, err := e2eVSphere.getVMByUUID(ctx, vmUUID)

--- a/tests/e2e/operationstorm.go
+++ b/tests/e2e/operationstorm.go
@@ -178,7 +178,7 @@ var _ = utils.SIGDescribe("[csi-block-vanilla] [csi-block-vanilla-parallelized] 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			if vanillaCluster {
-				vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+				vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 			} else {
 				annotations := pod.Annotations
 				vmUUID, exists = annotations[vmUUIDLabel]
@@ -309,7 +309,7 @@ var _ = utils.SIGDescribe("[csi-block-vanilla] [csi-block-vanilla-parallelized] 
 
 			volumeID := pv.Spec.CSI.VolumeHandle
 			if vanillaCluster {
-				vmUUID = getNodeUUID(client, podArray[podCount].Spec.NodeName)
+				vmUUID = getNodeUUID(ctx, client, podArray[podCount].Spec.NodeName)
 			}
 			if guestCluster {
 				vmUUID, err = getVMUUIDFromNodeName(podArray[podCount].Spec.NodeName)

--- a/tests/e2e/partial_topology_values.go
+++ b/tests/e2e/partial_topology_values.go
@@ -110,7 +110,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
-		vmUUID := getNodeUUID(client, pod.Spec.NodeName)
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
 		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
@@ -187,7 +187,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
-		vmUUID := getNodeUUID(client, pod.Spec.NodeName)
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
 		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")

--- a/tests/e2e/provision_with_multiple_zones.go
+++ b/tests/e2e/provision_with_multiple_zones.go
@@ -130,7 +130,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
-		vmUUID := getNodeUUID(client, pod.Spec.NodeName)
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
 		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")

--- a/tests/e2e/statefulsets.go
+++ b/tests/e2e/statefulsets.go
@@ -249,7 +249,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
 					if vanillaCluster {
-						vmUUID = getNodeUUID(client, sspod.Spec.NodeName)
+						vmUUID = getNodeUUID(ctx, client, sspod.Spec.NodeName)
 					} else {
 						annotations := pod.Annotations
 						vmUUID, exists = annotations[vmUUIDLabel]
@@ -444,7 +444,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
 					if vanillaCluster {
-						vmUUID = getNodeUUID(client, sspod.Spec.NodeName)
+						vmUUID = getNodeUUID(ctx, client, sspod.Spec.NodeName)
 					} else {
 						annotations := pod.Annotations
 						vmUUID, exists = annotations[vmUUIDLabel]

--- a/tests/e2e/storagepolicy.go
+++ b/tests/e2e/storagepolicy.go
@@ -227,7 +227,7 @@ func verifyStoragePolicyBasedVolumeProvisioning(f *framework.Framework, client c
 		_, err := e2eVSphere.getVMByUUID(ctx, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	} else if vanillaCluster {
-		vmUUID = getNodeUUID(client, nodeName)
+		vmUUID = getNodeUUID(ctx, client, nodeName)
 	} else {
 		vmUUID, _ = getVMUUIDFromNodeName(nodeName)
 	}

--- a/tests/e2e/topology_aware_node_poweroff.go
+++ b/tests/e2e/topology_aware_node_poweroff.go
@@ -115,7 +115,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By(fmt.Sprintf("Power off the node: %v", nodeNameToPowerOff))
 
-		vmUUID := getNodeUUID(client, nodeNameToPowerOff)
+		vmUUID := getNodeUUID(ctx, client, nodeNameToPowerOff)
 		gomega.Expect(vmUUID).NotTo(gomega.BeEmpty())
 		framework.Logf("VM uuid is: %s for node: %s", vmUUID, nodeNameToPowerOff)
 		vmRef, err := e2eVSphere.getVMByUUID(ctx, vmUUID)
@@ -159,7 +159,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		failoverNode := pod.Spec.NodeName
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, failoverNode))
-		vmUUID = getNodeUUID(client, failoverNode)
+		vmUUID = getNodeUUID(ctx, client, failoverNode)
 		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
@@ -247,7 +247,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By(fmt.Sprintf("Power off the node: %v", nodeNameBeforePowerOff))
 
-		vmUUID := getNodeUUID(client, nodeNameBeforePowerOff)
+		vmUUID := getNodeUUID(ctx, client, nodeNameBeforePowerOff)
 		gomega.Expect(vmUUID).NotTo(gomega.BeEmpty())
 		framework.Logf("VM uuid is: %s for node: %s", vmUUID, nodeNameBeforePowerOff)
 		vmRef, err := e2eVSphere.getVMByUUID(ctx, vmUUID)

--- a/tests/e2e/vc_reboot_volume_lifecycle.go
+++ b/tests/e2e/vc_reboot_volume_lifecycle.go
@@ -171,7 +171,7 @@ var _ bool = ginkgo.Describe("Verify volume life_cycle operations works fine aft
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		if vanillaCluster {
-			vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 		}
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID, nodeName))

--- a/tests/e2e/vcp_to_csi_attach_detach.go
+++ b/tests/e2e/vcp_to_csi_attach_detach.go
@@ -1069,7 +1069,7 @@ func createMultiplePods(ctx context.Context, client clientset.Interface,
 		for _, pvc := range pvclaims2d[i] {
 			if verifyAttachment {
 				if vanillaCluster {
-					vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+					vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 				} else if guestCluster {
 					vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/vcp_to_csi_syncer.go
+++ b/tests/e2e/vcp_to_csi_syncer.go
@@ -1549,7 +1549,7 @@ func createPodWithMultipleVolsVerifyVolMounts(ctx context.Context, client client
 	var vmUUID string
 
 	if vanillaCluster {
-		vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+		vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 	} else if guestCluster {
 		vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/volume_provisioning_with_topology.go
+++ b/tests/e2e/volume_provisioning_with_topology.go
@@ -91,6 +91,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 	verifyBasicTopologyBasedVolumeProvisioning := func(f *framework.Framework, client clientset.Interface,
 		namespace string, scParameters map[string]string, allowedTopologies []v1.TopologySelectorLabelRequirement) {
 
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
 		storageclass, pvclaim, err = createPVCAndStorageClass(client,
 			namespace, nil, scParameters, "", allowedTopologies, "", false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -115,7 +118,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 
 		ginkgo.By(fmt.Sprintf("Verify volume:%s is attached to the node: %s",
 			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
-		vmUUID := getNodeUUID(client, pod.Spec.NodeName)
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
 		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")

--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -332,7 +332,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
 					if vanillaCluster {
-						vmUUID = getNodeUUID(client, sspod.Spec.NodeName)
+						vmUUID = getNodeUUID(ctx, client, sspod.Spec.NodeName)
 					} else {
 						annotations := pod.Annotations
 						vmUUID, exists = annotations[vmUUIDLabel]

--- a/tests/e2e/vsphere_shared_datastore.go
+++ b/tests/e2e/vsphere_shared_datastore.go
@@ -205,7 +205,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 		var exists bool
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volHandle, pod.Spec.NodeName))
 		if vanillaCluster {
-			vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 		} else if guestCluster {
 			vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -300,7 +300,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}()
 
 		ginkgo.By("Create Pod using the above PVC")
-		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, vmUUID := createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
 			// Delete Pod.
@@ -361,7 +361,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}()
 
 		ginkgo.By("Create POD")
-		pod, _ := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, _ := createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
 			// Delete Pod.
@@ -413,7 +413,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}()
 
 		ginkgo.By("Create POD")
-		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, vmUUID := createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
 			// Delete POD
@@ -482,7 +482,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}()
 
 		ginkgo.By("Create POD")
-		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, vmUUID := createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
 			// Delete POD
@@ -550,7 +550,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}()
 
 		ginkgo.By("Create POD")
-		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, vmUUID := createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 		//Fetch original FileSystemSize
 		ginkgo.By("Verify filesystem size for mount point /mnt/volume1 before expansion")
@@ -678,7 +678,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}()
 
 		ginkgo.By("Create POD")
-		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, vmUUID := createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 		//Fetch original FileSystemSize
 		ginkgo.By("Verify filesystem size for mount point /mnt/volume1 before expansion")
@@ -812,7 +812,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}()
 
 		ginkgo.By("Create Pod using the above PVC")
-		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, vmUUID := createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 		//Fetch original FileSystemSize
 		ginkgo.By("Verify filesystem size for mount point /mnt/volume1 before expansion")
@@ -956,7 +956,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 
 		if vanillaCluster || guestCluster {
 			ginkgo.By("Create POD using the above PVC")
-			pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+			pod, vmUUID = createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 		}
 
 		defer func() {
@@ -1046,7 +1046,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 
 		if vanillaCluster || guestCluster {
 			ginkgo.By("Create POD using the above PVC")
-			pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+			pod, vmUUID = createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 		}
 
 		defer func() {
@@ -1137,7 +1137,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 
 		if vanillaCluster || guestCluster {
 			ginkgo.By("Create POD using the above PVC")
-			pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+			pod, vmUUID = createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 		}
 
 		defer func() {
@@ -1397,7 +1397,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		gomega.Expect(err).To(gomega.HaveOccurred())
 
 		ginkgo.By("Create Pod using the above PVC")
-		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, vmUUID := createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
 			// Delete POD
@@ -1798,7 +1798,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}()
 
 		ginkgo.By("Create Pod using the above PVC")
-		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, vmUUID := createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
 			// Delete POD
@@ -1857,7 +1857,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}
 
 		ginkgo.By("re-create Pod using the same PVC")
-		pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, vmUUID = createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 		ginkgo.By("Waiting for file system resize to finish")
 		pvclaim, err = waitForFSResize(pvclaim, client)
@@ -1922,7 +1922,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}()
 
 		ginkgo.By("Create Pod using the above PVC")
-		pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, vmUUID := createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
 			// Delete POD
@@ -2027,7 +2027,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		}()
 
 		ginkgo.By("Create Pod using the above PVC")
-		pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, vmUUID = createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 		defer func() {
 			// Delete POD
 			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
@@ -2177,7 +2177,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		svcCsiDeployment = updateDeploymentReplica(client, 1, vSphereCSIControllerPodNamePrefix, csiSystemNamespace)
 
 		ginkgo.By("Create Pod using the above PVC")
-		pod, vmUUID = createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+		pod, vmUUID = createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 		defer func() {
 			// Delete POD
@@ -2579,7 +2579,7 @@ func createSCwithVolumeExpansionTrueAndDynamicPVC(f *framework.Framework,
 }
 
 //createPODandVerifyVolumeMount this method creates Pod and verifies VolumeMount
-func createPODandVerifyVolumeMount(f *framework.Framework, client clientset.Interface,
+func createPODandVerifyVolumeMount(ctx context.Context, f *framework.Framework, client clientset.Interface,
 	namespace string, pvclaim *v1.PersistentVolumeClaim, volHandle string) (*v1.Pod, string) {
 	// Create a Pod to use this PVC, and verify volume has been attached
 	ginkgo.By("Creating pod to attach PV to the node")
@@ -2590,7 +2590,7 @@ func createPODandVerifyVolumeMount(f *framework.Framework, client clientset.Inte
 	var vmUUID string
 	ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volHandle, pod.Spec.NodeName))
 	if vanillaCluster {
-		vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+		vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 	} else if guestCluster {
 		vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2793,7 +2793,7 @@ func invokeTestForVolumeExpansion(f *framework.Framework, client clientset.Inter
 	var exists bool
 	ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volHandle, pod.Spec.NodeName))
 	if vanillaCluster {
-		vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+		vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 	} else if guestCluster {
 		vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2921,7 +2921,7 @@ func invokeTestForVolumeExpansionWithFilesystem(f *framework.Framework, client c
 
 	var vmUUID string
 	ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
-	vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+	vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 	if guestCluster {
 		vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -3015,7 +3015,7 @@ func invokeTestForVolumeExpansionWithFilesystem(f *framework.Framework, client c
 
 	ginkgo.By(fmt.Sprintf("Verify volume after expansion: %s is attached to the node: %s",
 		pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
-	vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+	vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 	if guestCluster {
 		vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -3445,7 +3445,7 @@ func invokeTestForExpandVolumeMultipleTimes(f *framework.Framework, client clien
 	var exists bool
 	ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volHandle, pod.Spec.NodeName))
 	if vanillaCluster {
-		vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+		vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 	} else if guestCluster {
 		vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -3768,6 +3768,9 @@ func testCleanUpUtil(ctx context.Context, restClientConfig *restclient.Config, c
 
 func offlineVolumeExpansionOnSupervisorPVC(client clientset.Interface, f *framework.Framework, namespace string,
 	volHandle string, pvclaim *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, *v1.Pod, string) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	ginkgo.By("Expanding current pvc")
 	currentPvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
 	newSize := currentPvcSize.DeepCopy()
@@ -3806,7 +3809,7 @@ func offlineVolumeExpansionOnSupervisorPVC(client clientset.Interface, f *framew
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	ginkgo.By("Create Pod using the above PVC")
-	pod, vmUUID := createPODandVerifyVolumeMount(f, client, namespace, pvclaim, volHandle)
+	pod, vmUUID := createPODandVerifyVolumeMount(ctx, f, client, namespace, pvclaim, volHandle)
 
 	ginkgo.By("Waiting for file system resize to finish")
 	pvclaim, err = waitForFSResize(pvclaim, client)

--- a/tests/e2e/vsphere_volume_fsgroup.go
+++ b/tests/e2e/vsphere_volume_fsgroup.go
@@ -149,7 +149,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-guest] [csi
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 		if vanillaCluster {
-			vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 		} else if guestCluster {
 			vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/vsphere_volume_fstype.go
+++ b/tests/e2e/vsphere_volume_fstype.go
@@ -50,14 +50,14 @@ import (
 // Test to verify if an invalid fstype specified in storage class fails pod
 // creation.
 //
-// Steps
-// 1. Create StorageClass with inavlid.
-// 2. Create PVC which uses the StorageClass created in step 1.
-// 3. Wait for PV to be provisioned.
-// 4. Wait for PVC's status to become Bound.
-// 5. Create pod using PVC.
-// 6. Verify if the pod creation fails.
-// 7. Verify if the MountVolume.MountDevice fails because it is unable to find
+// Steps
+// 1. Create StorageClass with inavlid.
+// 2. Create PVC which uses the StorageClass created in step 1.
+// 3. Wait for PV to be provisioned.
+// 4. Wait for PVC's status to become Bound.
+// 5. Create pod using PVC.
+// 6. Verify if the pod creation fails.
+// 7. Verify if the MountVolume.MountDevice fails because it is unable to find
 //    the file system executable file on the node.
 
 var _ = ginkgo.Describe("[csi-block-vanilla] Volume Filesystem Type Test", func() {
@@ -134,7 +134,7 @@ func invokeTestForFstype(f *framework.Framework, client clientset.Interface,
 	pv := persistentvolumes[0]
 	var vmUUID string
 	ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
-	vmUUID = getNodeUUID(client, pod.Spec.NodeName)
+	vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 	isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: fetch node VM uuid from csinode when use-csinode-id FSS is enabled

**Testing done**:
https://gist.github.com/sashrith/49db3e6aa9041e5aa243db3774a691b6

**Special notes for your reviewer**:
```bash
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver decouple ⇡ ❯ make check                                         14:28:10
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: upgraded honnef.co/go/tools v0.0.1-2020.1.3 => v0.2.0
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sashrith/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sashrith/csi/vsphere-csi-driver /Users/sashrith/csi /Users/sashrith /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (imports|name|compiled_files|deps|exports_file|files|types_sizes) took 1.582408533s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 86.766526ms
INFO [linters context/goanalysis] analyzers took 13.145449465s with top 10 stages: buildir: 3.489310388s, misspell: 692.168236ms, S1038: 652.342511ms, S1039: 352.886877ms, unused: 318.78422ms, directives: 315.863108ms, SA1012: 307.881735ms, lll: 223.988535ms, S1028: 207.869918ms, assign: 194.849207ms
INFO [runner] Issues before processing: 110, after processing: 0
INFO [runner] Processors filtering stat (out/in): skip_files: 110/110, autogenerated_exclude: 21/110, filename_unadjuster: 110/110, skip_dirs: 110/110, path_prettifier: 110/110, identifier_marker: 21/21, exclude-rules: 1/21, cgo: 110/110, exclude: 21/21, nolint: 0/1
INFO [runner] processing took 14.127067ms with stages: nolint: 10.753706ms, autogenerated_exclude: 1.973902ms, path_prettifier: 739.133µs, identifier_marker: 316.33µs, skip_dirs: 185.77µs, exclude-rules: 120.7µs, filename_unadjuster: 19.089µs, cgo: 14.027µs, max_same_issues: 890ns, uniq_by_line: 604ns, max_from_linter: 473ns, source_code: 367ns, diff: 358ns, skip_files: 293ns, path_shortener: 280ns, severity-rules: 257ns, exclude: 257ns, max_per_file_from_linter: 248ns, sort_results: 230ns, path_prefixer: 153ns
INFO [runner] linters took 6.175135738s with stages: goanalysis_metalinter: 6.160904143s
INFO File cache stats: 124 entries of total size 2.4MiB
INFO Memory: 80 samples, avg is 310.6MB, max is 751.1MB
INFO Execution took 7.855008886s
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver decouple* ⇡ 56s ❯
```
