### PR TITLE
Vsan stretched cluster tests [PART-2]

### DIFF
--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -119,6 +119,19 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		}
 	})
 
+	ginkgo.JustAfterEach(func() {
+		if len(fds.hostsDown) > 0 {
+			powerOnHostParallel(fds.hostsDown)
+			fds.hostsDown = []string{}
+		}
+		if len(fds.hostsPartitioned) > 0 {
+			toggleNetworkFailureParallel(fds.hostsPartitioned, false)
+			fds.hostsPartitioned = []string{}
+		}
+		fds.primarySiteHosts = []string{}
+		fds.secondarySiteHosts = []string{}
+	})
+
 	/*
 		Primary site down
 		Steps:
@@ -140,6 +153,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		scParameters = map[string]string{}
 		scParameters["StoragePolicyName"] = storagePolicyName
 		storageClassName = "nginx-sc-default"
+		var pvclaims []*v1.PersistentVolumeClaim
 
 		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
@@ -226,6 +240,14 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 
 		ginkgo.By("Bring down the primary site")
 		siteFailover(true)
+
+		defer func() {
+			ginkgo.By("Bring up the primary site before terminating the test")
+			if len(fds.hostsDown) > 0 {
+				siteRestore(true)
+				fds.hostsDown = []string{}
+			}
+		}()
 
 		ginkgo.By("Wait for k8s cluster to be healthy")
 		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
@@ -373,7 +395,10 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		}
 
 		ginkgo.By("Bring up the primary site")
-		siteRestore(true)
+		if len(fds.hostsDown) > 0 {
+			siteRestore(true)
+			fds.hostsDown = []string{}
+		}
 
 		ginkgo.By("Wait for k8s cluster to be healthy")
 		// wait for the VMs to move back
@@ -494,10 +519,10 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 			pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			for _, claim := range pvcs.Items {
+				pv := getPvFromClaim(client, namespace, claim.Name)
 				err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				ginkgo.By("Verify it's PV and corresponding volumes are deleted from CNS")
-				pv := getPvFromClaim(client, statefulset1.Namespace, claim.Name)
 				err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
 					pollTimeout)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -523,6 +548,14 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 
 		ginkgo.By("Bring down the primary site")
 		siteFailover(true)
+
+		defer func() {
+			ginkgo.By("Bring up the primary site before terminating the test")
+			if len(fds.hostsDown) > 0 {
+				siteRestore(true)
+				fds.hostsDown = []string{}
+			}
+		}()
 
 		ginkgo.By("Wait for k8s cluster to be healthy")
 		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
@@ -671,10 +704,10 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		for _, claim := range pvcs.Items {
+			pv := getPvFromClaim(client, namespace, claim.Name)
 			err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ginkgo.By("Verify it's PV and corresponding volumes are deleted from CNS")
-			pv := getPvFromClaim(client, statefulset1.Namespace, claim.Name)
 			err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
 				pollTimeout)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -686,7 +719,10 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		}
 
 		ginkgo.By("Bring up the primary site")
-		siteRestore(true)
+		if len(fds.hostsDown) > 0 {
+			siteRestore(true)
+			fds.hostsDown = []string{}
+		}
 
 		ginkgo.By("Wait for k8s cluster to be healthy")
 		// wait for the VMs to move back
@@ -792,6 +828,14 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		go siteFailureInParallel(true, &wg)
 		wg.Wait()
 
+		defer func() {
+			ginkgo.By("Bring up the primary site before terminating the test")
+			if len(fds.hostsDown) > 0 {
+				siteRestore(true)
+				fds.hostsDown = []string{}
+			}
+		}()
+
 		ginkgo.By("Wait for k8s cluster to be healthy")
 		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
 		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
@@ -818,7 +862,10 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		ginkgo.By("Bring up the primary site")
-		siteRestore(true)
+		if len(fds.hostsDown) > 0 {
+			siteRestore(true)
+			fds.hostsDown = []string{}
+		}
 
 		ginkgo.By("Wait for k8s cluster to be healthy")
 		// wait for the VMs to move back
@@ -877,6 +924,14 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		close(ch)
 
 		defer func() {
+			ginkgo.By("Bring up the primary site before terminating the test")
+			if len(fds.hostsDown) > 0 {
+				siteRestore(true)
+				fds.hostsDown = []string{}
+			}
+		}()
+
+		defer func() {
 			for _, pvclaim := range pvclaims {
 				err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -916,6 +971,405 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		// TODO: List orphan volumes
 
 		ginkgo.By("Bring up the primary site")
+		if len(fds.hostsDown) > 0 {
+			siteRestore(true)
+			fds.hostsDown = []string{}
+		}
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		// wait for the VMs to move back
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	})
+
+	/*
+		Primary site network isolation
+		Steps:
+		1.	Configure a vanilla multi-master K8s cluster with inter and intra site replication
+		2.	Create a statefulset, deployment with volumes from the stretched datastore
+		3.	Isolate primary site from witness and secondary site
+		4.	Verify that the VMs hosted by esx servers are brought up on the other site
+		5.	Verify that the k8s cluster is healthy and all the k8s constructs created in step 2 are running
+			and volume and application lifecycle actions work fine
+		6.	Re-establish primary site network and wait for testbed to be back to normal
+		7.	Delete all objects created in step 2
+	*/
+	ginkgo.It("Primary site network isolation", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass for Statefulset")
+		// decide which test setup is available to run
+		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+		scParameters = map[string]string{}
+		scParameters["StoragePolicyName"] = storagePolicyName
+		storageClassName = "nginx-sc-default"
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating PVC")
+		pvclaim, err := createPVC(client, namespace, nil, diskSize, sc, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pvclaims = append(pvclaims, pvclaim)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
+		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pvclaim = nil
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		// Waiting for pods status to be Ready
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			"Unable to get list of Pods from the Statefulset: %v", statefulset.Name)
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset %s, %v, should match with number of required replicas %v",
+			statefulset.Name, ssPodsBeforeScaleDown.Size(), replicas)
+
+		// Get the list of Volumes attached to Pods before scale down
+		var volumesBeforeScaleDown []string
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					volumesBeforeScaleDown = append(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)
+					// Verify the attached volume match the one in CNS cache
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By("Creating Deployment")
+		labelsMap := make(map[string]string)
+		labelsMap["app"] = "test"
+		deployment, err := createDeployment(
+			ctx, client, 1, labelsMap, nil, namespace, pvclaims, "", false, busyBoxImageOnGcr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		deployment, err = client.AppsV1().Deployments(namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pods, err := fdep.GetPodsForDeployment(client, deployment)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pod := pods.Items[0]
+		err = fpod.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Get the list of csi pods running in CSI namespace
+		csipods, err := client.CoreV1().Pods(csiNs).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Cause a network failure on primary site
+		ginkgo.By("Isolate primary site from witness and secondary site")
+		siteNetworkFailure(true, false)
+
+		defer func() {
+			ginkgo.By("Bring up the primary site before terminating the test")
+			siteNetworkFailure(true, true)
+		}()
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Check if csi pods are running fine after network failure
+		err = fpod.WaitForPodsRunningReady(client, csiNs, int32(csipods.Size()), 0, pollTimeout, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Checking if volumes and pods post network failure are healthy")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = fpod.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+
+		pvc1, err := createPVC(client, namespace, nil, diskSize, sc, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pvs, err := fpv.WaitForPVClaimBoundPhase(
+			client, []*v1.PersistentVolumeClaim{pvc1}, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvc1}, false, execCommand)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		deletePodAndWaitForVolsToDetach(ctx, client, pod1)
+
+		err = fpv.DeletePersistentVolumeClaim(client, pvc1.Name, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = e2eVSphere.waitForCNSVolumeToBeDeleted(pvs[0].Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		scaleDownReplicas := replicas - 1
+		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", scaleDownReplicas))
+		_, scaledownErr := fss.Scale(client, statefulset, scaleDownReplicas)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReadyReplicas(client, statefulset, scaleDownReplicas)
+		ssPodsAfterScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(scaleDownReplicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset %s, %v, should match with number of replicas %v",
+			statefulset.Name, ssPodsAfterScaleDown.Size(), scaleDownReplicas,
+		)
+
+		// After scale down, verify vSphere volumes are detached from deleted pods
+		ginkgo.By("Verify Volumes are detached from Nodes after Statefulsets is scaled down")
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			if err != nil {
+				gomega.Expect(apierrors.IsNotFound(err), gomega.BeTrue())
+				for _, volumespec := range sspod.Spec.Volumes {
+					if volumespec.PersistentVolumeClaim != nil {
+						pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+						if vanillaCluster {
+							isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(
+								client, pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+								fmt.Sprintf("Volume %q is not detached from the node %q",
+									pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+						} else {
+							annotations := sspod.Annotations
+							vmUUID, exists := annotations[vmUUIDLabel]
+							gomega.Expect(exists).To(gomega.BeTrue(),
+								fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+
+							ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s",
+								pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+							ctx, cancel := context.WithCancel(context.Background())
+							defer cancel()
+							_, err := e2eVSphere.getVMByUUIDWithWait(ctx, vmUUID, supervisorClusterOperationsTimeout)
+							gomega.Expect(err).To(gomega.HaveOccurred(),
+								fmt.Sprintf(
+									"PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM",
+									vmUUID, sspod.Spec.NodeName))
+						}
+					}
+				}
+			}
+		}
+
+		// After scale down, verify the attached volumes match those in CNS Cache
+		for _, sspod := range ssPodsAfterScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By(fmt.Sprintf("Scaling up statefulsets to number of Replica: %v", replicas))
+		_, scaleupErr := fss.Scale(client, statefulset, replicas)
+		gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+
+		ssPodsAfterScaleUp := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset %s, %v, should match with number of replicas %v",
+			statefulset.Name, ssPodsAfterScaleUp.Size(), replicas,
+		)
+
+		// After scale up, verify all vSphere volumes are attached to node VMs.
+		ginkgo.By("Verify all volumes are attached to Nodes after Statefulsets is scaled up")
+		for _, sspod := range ssPodsAfterScaleUp.Items {
+			err := fpod.WaitForPodsReady(client, statefulset.Namespace, sspod.Name, 0)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range pod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					ginkgo.By("Verify scale up operation should not introduced new volume")
+					gomega.Expect(contains(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)).To(gomega.BeTrue())
+					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+					var vmUUID string
+					var exists bool
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					if vanillaCluster {
+						vmUUID = getNodeUUID(ctx, client, sspod.Spec.NodeName)
+					} else {
+						annotations := pod.Annotations
+						vmUUID, exists = annotations[vmUUIDLabel]
+						gomega.Expect(exists).To(
+							gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+						_, err := e2eVSphere.getVMByUUID(ctx, vmUUID)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+					isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Disk is not attached to the node")
+					gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached")
+					ginkgo.By("After scale up, verify the attached volumes match those in CNS Cache")
+					err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By("Bring up the primary site")
+		siteNetworkFailure(true, true)
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		// wait for the VMs to move back
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
+		pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, claim := range pvcs.Items {
+			pv := getPvFromClaim(client, namespace, claim.Name)
+			err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Verify it's PV and corresponding volumes are deleted from CNS")
+			err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+				pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			volumeHandle := pv.Spec.CSI.VolumeHandle
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+					"kubernetes", volumeHandle))
+		}
+	})
+
+	/*
+		PVC deletion while primary site goes down
+		Steps:
+		1.	Configure a vanilla multi-master K8s cluster with inter and intra site replication
+		2.	Create 30 PVCs and wait for each pvc to bind to its PV
+		3.	Delete the PVCs created in step2
+		4.	Bring down primary site
+		5.	Verify that the VMs on the primary site are started up on the other esx servers in the secondary site
+		6.	Verify PVs and CNS volumes associated with PVCs created in step 2 are also deleted successfully
+		7.	Bring primary site up and wait for testbed to be back to normal
+	*/
+	ginkgo.It("PVC deletion while primary site goes down", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass")
+		// decide which test setup is available to run
+		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+		scParameters = map[string]string{}
+		scParameters["StoragePolicyName"] = storagePolicyName
+		storageClassName = "nginx-sc-default"
+		var pvclaims []*v1.PersistentVolumeClaim = make([]*v1.PersistentVolumeClaim, volumeOpsScale)
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		for i := 0; i < volumeOpsScale; i++ {
+			framework.Logf("Creating pvc %v", i)
+			pvclaims[i], err = createPVC(client, namespace, nil, diskSize, sc, "")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for i := 0; i < volumeOpsScale; i++ {
+			volHandle := persistentvolumes[i].Spec.CSI.VolumeHandle
+			gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		}
+
+		// Get the list of csi pods running in CSI namespace
+		csipods, err := client.CoreV1().Pods(csiNs).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Bring down the primary site while deleting pvcs")
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go deletePvcInParallel(client, pvclaims, namespace, &wg)
+		go siteFailureInParallel(true, &wg)
+		wg.Wait()
+
+		defer func() {
+			ginkgo.By("Bring up the primary site before terminating the test")
+			if len(fds.hostsDown) > 0 {
+				siteRestore(true)
+				fds.hostsDown = []string{}
+			}
+		}()
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Check if csi pods are running fine after site failure
+		err = fpod.WaitForPodsRunningReady(client, csiNs, int32(csipods.Size()), 0, pollTimeout, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PVs, volumes are deleted from CNS")
+		for _, pv := range persistentvolumes {
+			err := fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+				pollTimeout)
+			if !apierrors.IsNotFound(err) {
+				framework.Logf("Persistent Volume %v still not deleted with err %v", pv.Name, err)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volumeHandle := pv.Spec.CSI.VolumeHandle
+				// Orphan volumes may be left over here, hence logging those PVs and ignoring the error for now.
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+				framework.Logf("Volume %v still not deleted from CNS with err %v", pv.Name, err)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+
+		}
+		ginkgo.By("Bring up the primary site")
+		if len(fds.hostsDown) > 0 {
+			siteRestore(true)
+			fds.hostsDown = []string{}
+		}
+
 		siteRestore(true)
 
 		ginkgo.By("Wait for k8s cluster to be healthy")
@@ -923,6 +1377,137 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+	})
+
+	/*
+		Pod creation while primary site goes down
+		Steps:
+		1.  Configure a vanilla multi-master K8s cluster with inter and intra site replication
+		2.	Create 30 PVCs and wait for each pvc to bind to its PV
+		3.	Create a POD using each PVC created in step 2
+		4.	Bring down primary site
+		5.	Verify that the VMs on the primary site are started up on the other esx servers in the secondary site
+		6.	Verify that the pod created in step 4 come up successfully
+		7.	Bring primary site up and wait for testbed to be back to normal
+		8.	Delete pods created in step 3
+		9.	Delete PVCs created in step 2
+
+	*/
+	ginkgo.It("Pod creation while primary site goes down", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass")
+		// decide which test setup is available to run
+		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+		scParameters = map[string]string{}
+		scParameters["StoragePolicyName"] = storagePolicyName
+		storageClassName = "nginx-sc-default"
+		var pods []*v1.Pod
+		var pvclaims []*v1.PersistentVolumeClaim = make([]*v1.PersistentVolumeClaim, volumeOpsScale)
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		for i := 0; i < volumeOpsScale; i++ {
+			framework.Logf("Creating pvc %v", i)
+			pvclaims[i], err = createPVC(client, namespace, nil, diskSize, sc, "")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		defer func() {
+			for _, pvclaim := range pvclaims {
+				err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				pvclaim = nil
+			}
+		}()
+
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for i := 0; i < volumeOpsScale; i++ {
+			volHandle := persistentvolumes[i].Spec.CSI.VolumeHandle
+			gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		}
+		defer func() {
+			for _, claim := range pvclaims {
+				err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			for _, pv := range persistentvolumes {
+				err := fpv.WaitForPersistentVolumeDeleted(client, pv.Name, framework.Poll,
+					framework.PodDeleteTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volumeHandle := pv.Spec.CSI.VolumeHandle
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		/// Get the list of csi pods running in CSI namespace
+		csipods, err := client.CoreV1().Pods(csiNs).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Bring down the primary site while creating pods")
+		var wg sync.WaitGroup
+		wg.Add(2)
+		ch := make(chan *v1.Pod)
+		lock := &sync.Mutex{}
+		go createPodsInParallel(client, namespace, pvclaims, ctx, lock, ch, &wg, volumeOpsScale)
+		go func() {
+			for v := range ch {
+				pods = append(pods, v)
+			}
+		}()
+		go siteFailureInParallel(true, &wg)
+		wg.Wait()
+		close(ch)
+
+		defer func() {
+			ginkgo.By("Bring up the primary site before terminating the test")
+			if len(fds.hostsDown) > 0 {
+				siteRestore(true)
+				fds.hostsDown = []string{}
+			}
+		}()
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Check if csi pods are running fine after site failure
+		err = fpod.WaitForPodsRunningReady(client, csiNs, int32(csipods.Size()), 0, pollTimeout, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Checking whether pods are in Running or ExitCode:0 state")
+		for _, pod := range pods {
+			framework.Logf("Pod is %s", pod.Name)
+			err = waitForPodsToBeInErrorOrRunning(client, pod.Name, namespace, pollTimeout*4)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By("Bring up the primary site")
+		if len(fds.hostsDown) > 0 {
+			siteRestore(true)
+			fds.hostsDown = []string{}
+		}
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		// wait for the VMs to move back
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		for _, pod := range pods {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
 	})
 
 })


### PR DESCRIPTION
**What this PR does / why we need it**:  3 testcases and utils for network failure for automation  vsan stretch cluster feature
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/cb8680e13b3b9f58deb9d0c7381852e4
**Special notes for your reviewer**:
make check output:
```
(base) kai@kai-a01 vsphere-csi-driver % make check   
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/stretch-part2/vsphere-csi-driver /Users/kai/CSI/stretch-part2 /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (exports_file|files|name|deps|imports|types_sizes|compiled_files) took 1.775715131s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 80.540573ms 
INFO [linters context/goanalysis] analyzers took 6.270717591s with top 10 stages: buildir: 492.675189ms, S1038: 401.339855ms, misspell: 356.707496ms, S1039: 202.838568ms, unused: 176.4161ms, S1028: 164.091996ms, SA1012: 162.815053ms, ineffassign: 157.424382ms, S1024: 154.206492ms, SA1013: 141.722597ms 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 110/110, autogenerated_exclude: 21/110, exclude: 21/21, filename_unadjuster: 110/110, skip_dirs: 110/110, exclude-rules: 1/21, cgo: 110/110, nolint: 0/1, skip_files: 110/110, identifier_marker: 21/21 
INFO [runner] processing took 11.785224ms with stages: nolint: 9.017376ms, autogenerated_exclude: 1.416743ms, path_prettifier: 814.898µs, identifier_marker: 260.928µs, skip_dirs: 148.186µs, exclude-rules: 103.775µs, cgo: 10.875µs, filename_unadjuster: 8.038µs, max_same_issues: 927ns, uniq_by_line: 851ns, source_code: 391ns, skip_files: 358ns, diff: 347ns, max_from_linter: 290ns, path_shortener: 246ns, exclude: 243ns, severity-rules: 213ns, max_per_file_from_linter: 195ns, path_prefixer: 177ns, sort_results: 167ns 
INFO [runner] linters took 6.251492596s with stages: goanalysis_metalinter: 6.239614939s 
INFO File cache stats: 81 entries of total size 2.0MiB 
INFO Memory: 83 samples, avg is 245.8MB, max is 548.2MB 
INFO Execution took 8.120318925s                  


```