### PR TITLE
Polling-changes for GC tests

### DIFF
--- a/tests/e2e/csi_cns_telemetry_vc_reboot.go
+++ b/tests/e2e/csi_cns_telemetry_vc_reboot.go
@@ -39,9 +39,8 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 	"CNS-CSI Cluster Distribution Operations during VC reboot", func() {
 	f := framework.NewDefaultFramework("csi-cns-telemetry")
 	var (
-		client           clientset.Interface
-		namespace        string
-		vcRebootWaitTime int
+		client    clientset.Interface
+		namespace string
 	)
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
@@ -53,13 +52,6 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
-		}
-
-		if os.Getenv(envVCRebootWaitTime) != "" {
-			vcRebootWaitTime, err = strconv.Atoi(os.Getenv(envVCRebootWaitTime))
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		} else {
-			vcRebootWaitTime = defaultVCRebootWaitTime
 		}
 
 		if vanillaCluster {
@@ -157,6 +149,9 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterReboot(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Done with reboot")
 
 		// Sleep for a short while for the VC to shutdown, before invoking PVC
 		// creation and cluster-distribution value.
@@ -195,9 +190,10 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 
 		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		ginkgo.By(fmt.Sprintf("Waiting for %v for host to come up fully", vcRebootWaitTime))
-		time.Sleep(time.Duration(vcRebootWaitTime) * time.Second)
 		ginkgo.By("Done with reboot")
+		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
+		err = checkVcenterServicesRunning(vcAddress, essentialServices)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// After reboot.
 		bootstrap()
@@ -298,9 +294,10 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		ginkgo.By(fmt.Sprintf("Waiting for %v for host to come up fully", vcRebootWaitTime))
-		time.Sleep(time.Duration(vcRebootWaitTime) * time.Second)
 		ginkgo.By("Done with reboot")
+		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
+		err = checkVcenterServicesRunning(vcAddress, essentialServices)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// After reboot.
 		bootstrap()

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -44,7 +44,6 @@ const (
 	defaultProvisionerTimeInSec                = "300"
 	defaultFullSyncWaitTime                    = 1800
 	defaultPandoraSyncWaitTime                 = 90
-	defaultVCRebootWaitTime                    = 180
 	destinationDatastoreURL                    = "DESTINATION_VSPHERE_DATASTORE_URL"
 	disklibUnlinkErr                           = "DiskLib_Unlink"
 	diskSize                                   = "2Gi"
@@ -59,7 +58,6 @@ const (
 	envInaccessibleZoneDatastoreURL            = "INACCESSIBLE_ZONE_VSPHERE_DATASTORE_URL"
 	envNonSharedStorageClassDatastoreURL       = "NONSHARED_VSPHERE_DATASTORE_URL"
 	envPandoraSyncWaitTime                     = "PANDORA_SYNC_WAIT_TIME"
-	envVCRebootWaitTime                        = "VC_REBOOT_WAIT_TIME"
 	envRegionZoneWithNoSharedDS                = "TOPOLOGY_WITH_NO_SHARED_DATASTORE"
 	envRegionZoneWithSharedDS                  = "TOPOLOGY_WITH_SHARED_DATASTORE"
 	envSharedDatastoreURL                      = "SHARED_VSPHERE_DATASTORE_URL"

--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -250,12 +250,12 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		ginkgo.By("Checking for resize on SVC PV")
 		verifyPVSizeinSupervisor(svcPVCName, newSize)
 
-		ginkgo.By("Checking for conditions on pvc")
-		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
+		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
+		err = waitForSvcPvcToReachFileSystemResizePendingCondition(svcPVCName, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
-		_, err = checkSvcPvcHasGivenStatusCondition(svcPVCName, true, v1.PersistentVolumeClaimFileSystemResizePending)
+		ginkgo.By("Checking for conditions on pvc")
+		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
@@ -457,12 +457,12 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		ginkgo.By("Checking for resize on SVC PV")
 		verifyPVSizeinSupervisor(svcPVCName, newSize)
 
-		ginkgo.By("Checking for conditions on pvc")
-		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
+		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
+		err = waitForSvcPvcToReachFileSystemResizePendingCondition(svcPVCName, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
-		_, err = checkSvcPvcHasGivenStatusCondition(svcPVCName, true, v1.PersistentVolumeClaimFileSystemResizePending)
+		ginkgo.By("Checking for conditions on pvc")
+		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
@@ -586,12 +586,12 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		ginkgo.By("Checking for resize on SVC PV")
 		verifyPVSizeinSupervisor(svcPVCName, newSize3)
 
-		ginkgo.By("Checking for conditions on pvc")
-		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
+		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
+		err = waitForSvcPvcToReachFileSystemResizePendingCondition(svcPVCName, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
-		_, err = checkSvcPvcHasGivenStatusCondition(svcPVCName, true, v1.PersistentVolumeClaimFileSystemResizePending)
+		ginkgo.By("Checking for conditions on pvc")
+		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
@@ -694,12 +694,12 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		ginkgo.By("Checking for resize on SVC PV")
 		verifyPVSizeinSupervisor(svcPVCName, newSize)
 
-		ginkgo.By("Checking for conditions on pvc")
-		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
+		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
+		err = waitForSvcPvcToReachFileSystemResizePendingCondition(svcPVCName, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
-		_, err = checkSvcPvcHasGivenStatusCondition(svcPVCName, true, v1.PersistentVolumeClaimFileSystemResizePending)
+		ginkgo.By("Checking for conditions on pvc")
+		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
@@ -859,12 +859,12 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		ginkgo.By("Checking for resize on SVC PV")
 		verifyPVSizeinSupervisor(svcPVCName, newSize)
 
-		ginkgo.By("Checking for conditions on pvc")
-		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
+		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
+		err = waitForSvcPvcToReachFileSystemResizePendingCondition(svcPVCName, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
-		_, err = checkSvcPvcHasGivenStatusCondition(svcPVCName, true, v1.PersistentVolumeClaimFileSystemResizePending)
+		ginkgo.By("Checking for conditions on pvc")
+		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
@@ -970,12 +970,12 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		ginkgo.By("Checking for resize on SVC PV")
 		verifyPVSizeinSupervisor(svcPVCName, newSize)
 
-		ginkgo.By("Checking for conditions on pvc")
-		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
+		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
+		err = waitForSvcPvcToReachFileSystemResizePendingCondition(svcPVCName, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
-		_, err = checkSvcPvcHasGivenStatusCondition(svcPVCName, true, v1.PersistentVolumeClaimFileSystemResizePending)
+		ginkgo.By("Checking for conditions on pvc")
+		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
@@ -2120,12 +2120,12 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		ginkgo.By("Checking for resize on SVC PV")
 		verifyPVSizeinSupervisor(svcPVCName, newSize)
 
-		ginkgo.By("Checking for conditions on pvc")
-		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
+		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
+		err = waitForSvcPvcToReachFileSystemResizePendingCondition(svcPVCName, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
-		_, err = checkSvcPvcHasGivenStatusCondition(svcPVCName, true, v1.PersistentVolumeClaimFileSystemResizePending)
+		ginkgo.By("Checking for conditions on pvc")
+		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
@@ -2264,7 +2264,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		}()
 
 		ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
-		_, err = waitForPVCToReachFileSystemResizePendingCondition(svcClient, svcNamespace, svcPVCName, pollTimeout)
+		err = waitForSvcPvcToReachFileSystemResizePendingCondition(svcPVCName, pollTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Bringing GC CSI controller up...")

--- a/tests/e2e/vc_reboot_volume_lifecycle.go
+++ b/tests/e2e/vc_reboot_volume_lifecycle.go
@@ -19,8 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -42,7 +40,6 @@ var _ bool = ginkgo.Describe("Verify volume life_cycle operations works fine aft
 		client            clientset.Interface
 		namespace         string
 		storagePolicyName string
-		VCRebootWaitTime  int
 		scParameters      map[string]string
 	)
 	ginkgo.BeforeEach(func() {
@@ -58,12 +55,6 @@ var _ bool = ginkgo.Describe("Verify volume life_cycle operations works fine aft
 		scParameters = make(map[string]string)
 		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 
-		if os.Getenv(envVCRebootWaitTime) != "" {
-			VCRebootWaitTime, err = strconv.Atoi(os.Getenv(envVCRebootWaitTime))
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		} else {
-			VCRebootWaitTime = defaultVCRebootWaitTime
-		}
 		if guestCluster {
 			svcClient, svNamespace := getSvcClientAndNamespace()
 			setResourceQuota(svcClient, svNamespace, rqLimit)
@@ -185,9 +176,15 @@ var _ bool = ginkgo.Describe("Verify volume life_cycle operations works fine aft
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		ginkgo.By(fmt.Sprintf("Waiting for %v for host to come up fully", VCRebootWaitTime))
-		time.Sleep(time.Duration(VCRebootWaitTime) * time.Second)
 		ginkgo.By("Done with reboot")
+		var essentialServices []string
+		if vanillaCluster {
+			essentialServices = []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
+		} else {
+			essentialServices = []string{spsServiceName, vsanhealthServiceName, vpxdServiceName, wcpServiceName}
+		}
+		err = checkVcenterServicesRunning(vcAddress, essentialServices)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		//After reboot
 		bootstrap()


### PR DESCRIPTION
**What this PR does / why we need it**: Test fixes to poll and check the status for GC workloads

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes 

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/b034ac0f806d757789964693fc827978
**Special notes for your reviewer**: make-check output:
```
(base) kai@kai-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/kai_polling/vsphere-csi-driver /Users/kai/CSI/kai_polling /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|exports_file|files|types_sizes|deps|imports|name) took 3.458912131s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 167.342787ms 
INFO [linters context/goanalysis] analyzers took 11.309110142s with top 10 stages: buildir: 952.111142ms, S1038: 864.330095ms, misspell: 712.245151ms, S1039: 370.746757ms, unused: 327.765785ms, S1024: 322.853574ms, SA1012: 322.828184ms, S1028: 314.277411ms, directives: 261.474099ms, SA1013: 236.040524ms 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): identifier_marker: 21/21, cgo: 110/110, filename_unadjuster: 110/110, skip_files: 110/110, exclude-rules: 1/21, nolint: 0/1, path_prettifier: 110/110, skip_dirs: 110/110, autogenerated_exclude: 21/110, exclude: 21/21 
INFO [runner] processing took 22.549938ms with stages: nolint: 17.379149ms, autogenerated_exclude: 2.792261ms, path_prettifier: 1.288461ms, identifier_marker: 532.679µs, skip_dirs: 277.671µs, exclude-rules: 237.27µs, cgo: 19.302µs, filename_unadjuster: 15.793µs, max_same_issues: 1.636µs, uniq_by_line: 1.076µs, source_code: 583ns, skip_files: 582ns, max_from_linter: 582ns, diff: 516ns, path_shortener: 507ns, severity-rules: 417ns, sort_results: 405ns, exclude: 399ns, max_per_file_from_linter: 391ns, path_prefixer: 258ns 
INFO [runner] linters took 10.61191158s with stages: goanalysis_metalinter: 10.589191896s 
INFO File cache stats: 76 entries of total size 1.9MiB 
INFO Memory: 144 samples, avg is 227.3MB, max is 481.9MB 
INFO Execution took 14.260833648s        
```    
**Release note**:
1.   Added to poll deployment when full sync interval is changed in GC
2.  Added polling to check when VC is up and its services in GC and vanilla VC reboot testcases.
3.  Modified setResourceQuota to poll for updated resource quota in GC.
4.  Modified GC volume testcases to check for SVC pvc resize before checking for GC pvc resize completion.

