### PR TITLE
Update the default version of external-snapshotter

### DIFF
--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -31,13 +31,13 @@ Refer to https://kubernetes-csi.github.io/docs/snapshot-controller.html for furt
 
 Example command:
 
-./deploy-csi-snapshot-components.sh --release v4.1.1
+./deploy-csi-snapshot-components.sh --release v5.0.1
 
 usage: ${0} [OPTIONS]
 The following flags are required.
        --release        The external-snapshot release files to use.
-                        Default: v4.1.1
-                        Supported: v4.1.0, v4.1.1
+                        Default: v5.0.1
+                        Qualified: v4.1.1, v5.0.0, v5.0.1
 EOF
     exit 1
 fi
@@ -70,15 +70,15 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
+qualified_releases=("v4.1.1" "v5.0.0" "v5.0.1")
 
 if [ -z "${release}" ]
 then
-  release=v4.1.1
+  release=v5.0.1
 else
-  if [ "${release}" != "v4.1.1" ] && [ "${release}" != "v4.1.0" ]
+  if [[ ! "${qualified_releases[*]}" =~ ${release} ]]
   then
-    echo -e "❌ ERROR: Only v4.1.1 or v4.1.0 is supported"
-    exit 1
+    echo -e "❗ WARNING: Attempting to use ${release} version, only v4.1.1, v5.0.0 and v5.0.1 are qualified versions"
   fi
 fi
 echo "Using release version: ${release}"
@@ -212,5 +212,4 @@ EOF
 
 echo -e "Patching vSphere CSI driver.."
 kubectl patch deployment vsphere-csi-controller -n vmware-system-csi --patch "$(cat "${tmpdir}"/patch.yaml)"
-echo -e "✅ Successfully patched vSphere CSI driver, please wait till deployment is updated.."
-echo -e "\n✅ Successfully deployed all components for CSI Snapshot feature.\n"
+echo -e "\n✅ Successfully deployed all components for CSI Snapshot feature, please wait till vSphere CSI driver deployment is updated..\n"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Updates the default version of external-snapshotter

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
dkinni@dkinni-a02 vanilla % ./deploy-csi-snapshot-components.sh
✅ Verified that block-volume-snapshot feature is enabled
Using release version: v5.0.0
customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io created
customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io created
customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io created
✅ Deployed VolumeSnapshot CRDs
serviceaccount/snapshot-controller created
clusterrole.rbac.authorization.k8s.io/snapshot-controller-runner created
clusterrolebinding.rbac.authorization.k8s.io/snapshot-controller-role created
role.rbac.authorization.k8s.io/snapshot-controller-leaderelection created
rolebinding.rbac.authorization.k8s.io/snapshot-controller-leaderelection created
✅ Created  RBACs for snapshot-controller
deployment.apps/snapshot-controller created
✅ Deployed snapshot-controller
waiting for snapshot-controller to complete..
waiting for snapshot-controller to complete..
waiting for snapshot-controller to complete..
✅ snapshot-controller successfully deployed!
creating certs in tmpdir /var/folders/31/y77ywvzd6lqc0g60r4xnfyd80000gp/T/tmp.08pbbn07MC 
Generating a 2048 bit RSA private key
.................................................+++
............+++
writing new private key to '/var/folders/31/y77ywvzd6lqc0g60r4xnfyd80000gp/T/tmp.08pbbn07MC/ca.key'
-----
Generating RSA private key, 2048 bit long modulus
...............................................................................................................................................+++
....................+++
e is 65537 (0x10001)
Signature ok
subject=/CN=snapshot-validation-service.kube-system.svc
Getting CA Private Key
secret/snapshot-webhook-certs created
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2238  100  2238    0     0   9024      0 --:--:-- --:--:-- --:--:--  8987
service/snapshot-validation-service created
validatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook.snapshot.storage.k8s.io created
deployment.apps/snapshot-validation-deployment created
✅ Deployed snapshot-validation-deployment
waiting for snapshot-validation-deployment to complete..
waiting for snapshot-validation-deployment to complete..
✅ snapshot-validation-deployment successfully deployed!
creating patch file in tmpdir /var/folders/31/y77ywvzd6lqc0g60r4xnfyd80000gp/T/tmp.3Y4gcVPB04
Patching vSphere CSI driver..
deployment.apps/vsphere-csi-controller patched

✅ Successfully deployed all components for CSI Snapshot feature, please wait till vSphere CSI driver deployment is updated..
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>