### PR TITLE
Invoke extend disk always for vSphere version 8 and above

### DIFF
--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -219,6 +219,25 @@ func UseVslmAPIs(ctx context.Context, aboutInfo vim25types.AboutInfo) (bool, err
 	return false, nil
 }
 
+func IsvSphere8AndAbove(ctx context.Context, aboutInfo vim25types.AboutInfo) (bool, error) {
+	log := logger.GetLogger(ctx)
+	items := strings.Split(aboutInfo.ApiVersion, ".")
+	apiVersion := strings.Join(items[:], "")
+	// Convert version string to int, e.g. 8.0.0.0" to 700.
+	vSphereMajorVersionInt, err := strconv.Atoi(string(apiVersion[0]))
+	if err != nil {
+		return false, logger.LogNewErrorf(log,
+			"Error while converting ApiVersion %q to integer, err %+v", apiVersion, err)
+	}
+
+	// Check if the current vSphere version is greater 8
+	if vSphereMajorVersionInt > VSphere8VersionMajorInt {
+		return true, nil
+	}
+	// For all other versions.
+	return false, nil
+}
+
 // ValidateControllerExpandVolumeRequest is the helper function to validate
 // ControllerExpandVolumeRequest for all block controllers.
 // Function returns error if validation fails otherwise returns nil.

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -138,6 +138,9 @@ const (
 	// to support volume migration feature.
 	VSphere7Version string = "7.0.0"
 
+	// VSphere8VersionMajor indicates the major version value in integer
+	VSphere8VersionMajorInt int = 8
+
 	// VSphere67u3lBuildInfo is the build number for vCenter in 6.7 Update 3l
 	// GA bits.
 	VSphere67u3lBuildInfo int = 17137327

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -605,9 +605,28 @@ func ExpandVolumeUtil(ctx context.Context, manager *Manager, volumeID string, ca
 		log.Infof("Successfully expanded volume for volumeid %q to new size %d Mb.", volumeID, capacityInMb)
 		return "", nil
 	} else {
-		expansionRequired, err := isExpansionRequired(ctx, volumeID, capacityInMb, manager, useAsyncQueryVolume)
+		var expansionRequired bool
+		vc, err := GetVCenter(ctx, manager)
 		if err != nil {
+			log.Errorf("failed to get vcenter. err=%v", err)
 			return csifault.CSIInternalFault, err
+		}
+		isvSphere8AndAbove, err := IsvSphere8AndAbove(ctx, vc.Client.ServiceContent.About)
+		if err != nil {
+			return "", logger.LogNewErrorf(log,
+				"Error while determining whether vSphere version is 8 and above %q, Error= %+v",
+				vc.Client.ServiceContent.About.ApiVersion, err)
+		}
+		// For vSphere 8 and above we avoid querying volume to check the size.
+		// This is handled internally in the FCD layer, CSI will just invoke
+		// ExtendDisk() all the time for vSphere version 8 and above.
+		if !isvSphere8AndAbove {
+			expansionRequired, err = isExpansionRequired(ctx, volumeID, capacityInMb, manager, useAsyncQueryVolume)
+			if err != nil {
+				return csifault.CSIInternalFault, err
+			}
+		} else {
+			expansionRequired = true
 		}
 		if expansionRequired {
 			faultType, err = manager.VolumeManager.ExpandVolume(ctx, volumeID, capacityInMb)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making sure CSI avoids querying volume size before calling ExtendDisk. With recent improvements in the FCD layer in vSphere 8.0 w.r.t volume expansion workflow, CSI no longer needs to check for expected volume size and current volume size. 
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Must run e2e pipelines once FCD side changes are in.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Invoke extend disk always for vSphere version 8 and above
```
