### PR TITLE
Added tests for vsan-stretched cluster testing - PART 1

### DIFF
--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -19,6 +19,11 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -36,14 +41,18 @@ import (
 
 var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", func() {
 	f := framework.NewDefaultFramework("vsan-stretch")
+	const defaultVolumeOpsScale = 30
 	var (
-		client            clientset.Interface
-		namespace         string
-		nodeList          *v1.NodeList
-		storagePolicyName string
-		scParameters      map[string]string
-		storageClassName  string
-		csiNs             string
+		client                 clientset.Interface
+		namespace              string
+		nodeList               *v1.NodeList
+		storagePolicyName      string
+		scParameters           map[string]string
+		storageClassName       string
+		csiNs                  string
+		fullSyncWaitTime       int
+		volumeOpsScale         int
+		storageThickPolicyName string
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -69,9 +78,13 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
+		storageThickPolicyName = os.Getenv(envStoragePolicyNameWithThickProvision)
+		if storageThickPolicyName == "" {
+			ginkgo.Skip(envStoragePolicyNameWithThickProvision + " env variable not set")
+		}
 		sc, err := client.StorageV1().StorageClasses().Get(ctx, defaultNginxStorageClassName, metav1.GetOptions{})
-		framework.ExpectNoError(err, "Unable to fetch storage class "+defaultNginxStorageClassName)
-		if sc != nil {
+		framework.Logf("Storageclass is %v and err is %v", sc, err)
+		if (!strings.Contains(err.Error(), "not found")) && sc != nil {
 			framework.ExpectNoError(client.StorageV1().StorageClasses().Delete(ctx, defaultNginxStorageClassName,
 				*metav1.NewDeleteOptions(0)), "Unable to delete storage class "+defaultNginxStorageClassName)
 		}
@@ -81,6 +94,13 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find k8s nodes")
 		}
+		if os.Getenv("VOLUME_OPS_SCALE") != "" {
+			volumeOpsScale, err = strconv.Atoi(os.Getenv(envVolumeOperationsScale))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		} else {
+			volumeOpsScale = defaultVolumeOpsScale
+		}
+		framework.Logf("VOLUME_OPS_SCALE is set to %d", volumeOpsScale)
 
 	})
 
@@ -361,6 +381,548 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
+
+	})
+
+	/*
+	   Statefulset scale up/down while primary site goes down
+	   Steps:
+	   1.  Configure a vanilla multi-master K8s cluster with inter and intra site replication
+	   2.  Create two statefulset with replica count 1(sts1) and 5(sts2) respectively using a thick provision policy
+	       and wait for all replicas to be running
+	   3.  Change replica count of sts1 and sts2 to 3
+	   4.  Bring down primary site
+	   5.  Verify that the VMs on the primary site are started up on the other esx servers in the secondary site
+	   6.  Verify there were no issue with replica scale up/down and verify pod entry in CNS volumemetadata for the
+	       volumes associated with the PVC used by statefulsets are updated
+	   7.  Change replica count of sts1 to 5 a sts2 to 1 and verify they are successful
+	   8.  Delete statefulsets and its pvcs created in step 2
+	   9.  Bring primary site up and wait for testbed to be back to normal
+	*/
+	ginkgo.It("Statefulset scale up/down while primary site goes down", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass for Statefulset")
+		// decide which test setup is available to run
+		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+		scParameters = map[string]string{}
+		scParameters["StoragePolicyName"] = storageThickPolicyName
+		storageClassName = "nginx-sc-thick"
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+		statefulset1 := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset statefulset1")
+		statefulset1.Spec.VolumeClaimTemplates[len(statefulset1.Spec.VolumeClaimTemplates)-1].
+			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+		*(statefulset1.Spec.Replicas) = 1
+		CreateStatefulSet(namespace, statefulset1, client)
+		replicas1 := *(statefulset1.Spec.Replicas)
+		// Waiting for pods status to be Ready
+		fss.WaitForStatusReadyReplicas(client, statefulset1, replicas1)
+		gomega.Expect(fss.CheckMount(client, statefulset1, mountPath)).NotTo(gomega.HaveOccurred())
+		ss1PodsBeforeScaleDown := fss.GetPodList(client, statefulset1)
+		gomega.Expect(ss1PodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			"Unable to get list of Pods from the Statefulset: %v", statefulset1.Name)
+		gomega.Expect(len(ss1PodsBeforeScaleDown.Items) == int(replicas1)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset: %v should match with number of replicas: %v",
+			statefulset1.Name, replicas1)
+
+		// Get the list of Volumes attached to Pods of sts1 before scale up
+		for _, ss1pod := range ss1PodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, ss1pod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range ss1pod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset1.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					// Verify the attached volume match the one in CNS cache
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, ss1pod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		statefulset2 := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset statefulset2")
+		statefulset2.Spec.VolumeClaimTemplates[len(statefulset2.Spec.VolumeClaimTemplates)-1].
+			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+		statefulset2.Name = "web-nginx"
+		statefulset2.Spec.Template.Labels["app"] = statefulset2.Name
+		statefulset2.Spec.Selector.MatchLabels["app"] = statefulset2.Name
+		*(statefulset2.Spec.Replicas) = 5
+		CreateStatefulSet(namespace, statefulset2, client)
+		replicas2 := *(statefulset2.Spec.Replicas)
+		// Waiting for pods status to be Ready
+		fss.WaitForStatusReadyReplicas(client, statefulset2, replicas2)
+		gomega.Expect(fss.CheckMount(client, statefulset2, mountPath)).NotTo(gomega.HaveOccurred())
+		ss2PodsBeforeScaleDown := fss.GetPodList(client, statefulset2)
+		gomega.Expect(ss2PodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			"Unable to get list of Pods from the Statefulset: %v", statefulset2.Name)
+		gomega.Expect(len(ss2PodsBeforeScaleDown.Items) == int(replicas2)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset: %v should match with number of replicas: %v",
+			statefulset2.Name, replicas2)
+
+		// Get the list of Volumes attached to Pods of sts2 before scale down
+		for _, ss2pod := range ss2PodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, ss2pod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range ss2pod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset2.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					// Verify the attached volume match the one in CNS cache
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, ss2pod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		defer func() {
+			scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
+			pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, claim := range pvcs.Items {
+				err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				ginkgo.By("Verify it's PV and corresponding volumes are deleted from CNS")
+				pv := getPvFromClaim(client, statefulset1.Namespace, claim.Name)
+				err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+					pollTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volumeHandle := pv.Spec.CSI.VolumeHandle
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+					fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+						"kubernetes", volumeHandle))
+			}
+		}()
+
+		// Get the list of csi pods running in CSI namespace
+		csipods, err := client.CoreV1().Pods(csiNs).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		replicas1 += 2
+		ginkgo.By(fmt.Sprintf("Scaling up statefulset %v to number of Replica: %v", statefulset1.Name, replicas1))
+		fss.UpdateReplicas(client, statefulset1, replicas1)
+
+		replicas2 -= 2
+		ginkgo.By(fmt.Sprintf("Scaling down statefulset: %v to number of Replica: %v", statefulset2.Name, replicas2))
+		fss.UpdateReplicas(client, statefulset2, replicas2)
+
+		ginkgo.By("Bring down the primary site")
+		siteFailover(true)
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Check if csi pods are running fine after site failure
+		err = fpod.WaitForPodsRunningReady(client, csiNs, int32(csipods.Size()), 0, pollTimeout, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		fss.WaitForStatusReadyReplicas(client, statefulset1, replicas1)
+		ss1PodsAfterScaleUp := fss.GetPodList(client, statefulset1)
+		gomega.Expect(ss1PodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
+			"Unable to get list of Pods from the Statefulset: %v", statefulset1.Name)
+		gomega.Expect(len(ss1PodsAfterScaleUp.Items) == int(replicas1)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset: %v should match with number of replicas: %v",
+			statefulset1.Name, replicas1)
+
+		fss.WaitForStatusReadyReplicas(client, statefulset2, replicas2)
+		ss2PodsAfterScaleDown := fss.GetPodList(client, statefulset2)
+		gomega.Expect(ss2PodsAfterScaleDown.Items).NotTo(gomega.BeEmpty(),
+			"Unable to get list of Pods from the Statefulset: %v", statefulset2.Name)
+		gomega.Expect(len(ss2PodsAfterScaleDown.Items) == int(replicas2)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset: %v should match with number of replicas %v",
+			statefulset2.Name, replicas2)
+
+		// After scale up of sts1, verify all vSphere volumes are attached to node VMs.
+		ginkgo.By("Verify all volumes are attached to Nodes after Statefulsets is scaled up")
+		for _, ss1pod := range ss1PodsAfterScaleUp.Items {
+			err := fpod.WaitForPodsReady(client, statefulset1.Namespace, ss1pod.Name, 0)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pod, err := client.CoreV1().Pods(namespace).Get(ctx, ss1pod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range pod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset1.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+						pv.Spec.CSI.VolumeHandle, ss1pod.Spec.NodeName))
+					var vmUUID string
+					var exists bool
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					if vanillaCluster {
+						vmUUID = getNodeUUID(ctx, client, ss1pod.Spec.NodeName)
+					} else {
+						annotations := pod.Annotations
+						vmUUID, exists = annotations[vmUUIDLabel]
+						gomega.Expect(exists).To(
+							gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+						_, err := e2eVSphere.getVMByUUID(ctx, vmUUID)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+					isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Disk is not attached to the node")
+					gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached")
+					ginkgo.By("After scale up, verify the attached volumes match those in CNS Cache")
+					err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, ss1pod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		// After scale down of sts2, verify vSphere volumes are detached from deleted pods
+		ginkgo.By("Verify Volumes are detached from Nodes after Statefulsets is scaled down")
+		for _, ss2pod := range ss2PodsAfterScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, ss2pod.Name, metav1.GetOptions{})
+			if err != nil {
+				gomega.Expect(apierrors.IsNotFound(err), gomega.BeTrue())
+				for _, volumespec := range ss2pod.Spec.Volumes {
+					if volumespec.PersistentVolumeClaim != nil {
+						pv := getPvFromClaim(client, statefulset2.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+						if vanillaCluster {
+							isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(
+								client, pv.Spec.CSI.VolumeHandle, ss2pod.Spec.NodeName)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+								fmt.Sprintf("Volume %q is not detached from the node %q",
+									pv.Spec.CSI.VolumeHandle, ss2pod.Spec.NodeName))
+						} else {
+							annotations := ss2pod.Annotations
+							vmUUID, exists := annotations[vmUUIDLabel]
+							gomega.Expect(exists).To(gomega.BeTrue(),
+								fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+
+							ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s",
+								pv.Spec.CSI.VolumeHandle, ss2pod.Spec.NodeName))
+							ctx, cancel := context.WithCancel(context.Background())
+							defer cancel()
+							_, err := e2eVSphere.getVMByUUIDWithWait(ctx, vmUUID, supervisorClusterOperationsTimeout)
+							gomega.Expect(err).To(gomega.HaveOccurred(),
+								fmt.Sprintf(
+									"PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM",
+									vmUUID, ss2pod.Spec.NodeName))
+						}
+					}
+				}
+			}
+		}
+
+		// After scale down of sts2, verify the attached volumes match those in CNS Cache
+		for _, ss2pod := range ss2PodsAfterScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, ss2pod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range ss2pod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset2.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, ss2pod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		// Scaling up statefulset sts1
+		replicas1 += 2
+		ginkgo.By(fmt.Sprintf("Scaling up statefulset: %v to number of Replica: %v", statefulset1.Name, replicas1))
+		_, scaleupErr := fss.Scale(client, statefulset1, replicas1)
+		gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset1, replicas1)
+		fss.WaitForStatusReadyReplicas(client, statefulset1, replicas1)
+
+		ss1PodsAfterScaleUp = fss.GetPodList(client, statefulset1)
+		gomega.Expect(ss1PodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
+			"Unable to get list of Pods from the Statefulset: %v", statefulset1.Name)
+		gomega.Expect(len(ss1PodsAfterScaleUp.Items) == int(replicas1)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset: %v should match with number of replicas: %v",
+			statefulset1.Name, replicas1)
+
+		// Scaling down statefulset sts2
+		replicas2 -= 2
+		ginkgo.By(fmt.Sprintf("Scaling down statefulset: %v to number of Replica: %v", statefulset2.Name, replicas2))
+		_, scaledownErr := fss.Scale(client, statefulset2, replicas2)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset2, replicas2)
+		fss.WaitForStatusReadyReplicas(client, statefulset2, replicas2)
+
+		ss2PodsAfterScaleDown = fss.GetPodList(client, statefulset2)
+		gomega.Expect(ss2PodsAfterScaleDown.Items).NotTo(gomega.BeEmpty(),
+			"Unable to get list of Pods from the Statefulset: %v", statefulset2.Name)
+		gomega.Expect(len(ss2PodsAfterScaleDown.Items) == int(replicas2)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset: %v should match with number of replicas: %v",
+			statefulset2.Name, replicas2)
+
+		scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
+		pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, claim := range pvcs.Items {
+			err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Verify it's PV and corresponding volumes are deleted from CNS")
+			pv := getPvFromClaim(client, statefulset1.Namespace, claim.Name)
+			err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+				pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			volumeHandle := pv.Spec.CSI.VolumeHandle
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+					"kubernetes", volumeHandle))
+		}
+
+		ginkgo.By("Bring up the primary site")
+		siteRestore(true)
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		// wait for the VMs to move back
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/*
+	   Pod deletion while primary site goes down
+	   Steps:
+	   1.  Configure a vanilla multi-master K8s cluster with inter and intra site replication
+	   2.  Create 30 PVCs and wait for its binding of each pvc with a PV
+	   3.  Create a pod with each PVC created in step 2
+	   4.  Delete the pod created in step 3
+	   5.  Bring down primary site
+	   6.  Verify that the VMs on the primary site are started up on the other esx servers in the secondary site
+	   7.  wait for full sync
+	   8.  Verify volume attachment are also deleted for the pods and pod entry in CNS volumemetadata for the
+	       volume associated with the PVC created in step 2 is removed
+	   9.  Bring primary site up and wait for testbed to be back to normal
+	   10. Delete the PVCs created in step 2
+
+	*/
+	ginkgo.It("Pod deletion while primary site goes down", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass")
+		// decide which test setup is available to run
+		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+		scParameters = map[string]string{}
+		scParameters["StoragePolicyName"] = storagePolicyName
+		storageClassName = "nginx-sc-default"
+		if os.Getenv(envFullSyncWaitTime) != "" {
+			fullSyncWaitTime, err := strconv.Atoi(os.Getenv(envFullSyncWaitTime))
+			framework.Logf("Full-Sync interval time value is = %v", fullSyncWaitTime)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		} else {
+			fullSyncWaitTime = defaultFullSyncWaitTime
+		}
+		var pods []*v1.Pod
+		var pvclaims []*v1.PersistentVolumeClaim = make([]*v1.PersistentVolumeClaim, volumeOpsScale)
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		for i := 0; i < volumeOpsScale; i++ {
+			framework.Logf("Creating pvc")
+			pvclaims[i], err = createPVC(client, namespace, nil, diskSize, sc, "")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for i := 0; i < volumeOpsScale; i++ {
+			volHandle := persistentvolumes[i].Spec.CSI.VolumeHandle
+			gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		}
+		defer func() {
+			for _, claim := range pvclaims {
+				err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			for _, pv := range persistentvolumes {
+				err := fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+					pollTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volumeHandle := pv.Spec.CSI.VolumeHandle
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+					fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+						"kubernetes", volumeHandle))
+			}
+		}()
+
+		ginkgo.By("Create pods")
+		for i := 0; i < volumeOpsScale; i++ {
+			pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaims[i]}, false, execCommand)
+			framework.Logf("Created pod %s", pod.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pods = append(pods, pod)
+		}
+		defer func() {
+			for _, pod := range pods {
+				err = fpod.DeletePodWithWait(client, pod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		// Get the list of csi pods running in CSI namespace
+		csipods, err := client.CoreV1().Pods(csiNs).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Bring down the primary site while deleting pods")
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go deletePodsInParallel(client, namespace, pods, &wg)
+		go siteFailureInParallel(true, &wg)
+		wg.Wait()
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Check if csi pods are running fine after site failure
+		err = fpod.WaitForPodsRunningReady(client, csiNs, int32(csipods.Size()), 0, pollTimeout, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		framework.Logf("Sleeping full-sync interval for all the pod Metadata " +
+			"to be deleted")
+		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
+
+		ginkgo.By("Verify volume is detached from the node")
+		for i := 0; i < volumeOpsScale; i++ {
+			volHandle := persistentvolumes[i].Spec.CSI.VolumeHandle
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, volHandle, pods[i].Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, pods[i].Spec.NodeName))
+
+			err = verifyVolumeMetadataInCNS(&e2eVSphere, volHandle,
+				pvclaims[i].Name, persistentvolumes[i].Name, pods[i].Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		ginkgo.By("Bring up the primary site")
+		siteRestore(true)
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		// wait for the VMs to move back
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	})
+
+	/*
+	   PVC creation while primary site goes down
+	   Steps:
+	   1.  Configure a vanilla multi-master K8s cluster with inter and intra site replication
+	   2.  Create 30 PVCs using a thick provision policy so that it takes some time for PVC creation to go through
+	   3.  Bring down primary site
+	   4.  Verify that the VMs on the primary site are started up on the other esx servers in the secondary site
+	   5.  Verify that the PVCs created in step 2 is bound successfully
+	   6.  Bring primary site up and wait for testbed to be back to normal
+	   7.  Delete PVCs created in step 2
+	*/
+	ginkgo.It("PVC creation while primary site goes down", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass")
+		// decide which test setup is available to run
+		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+		scParameters = map[string]string{}
+		scParameters["StoragePolicyName"] = storageThickPolicyName
+		storageClassName = "nginx-sc-thick"
+		var pvclaims []*v1.PersistentVolumeClaim
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Get the list of csi pods running in CSI namespace
+		csipods, err := client.CoreV1().Pods(csiNs).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Bring down the primary site while creating pvcs")
+		var wg sync.WaitGroup
+		ch := make(chan *v1.PersistentVolumeClaim)
+		lock := &sync.Mutex{}
+		wg.Add(2)
+		go createPvcInParallel(client, namespace, diskSize, sc, ch, lock, &wg, volumeOpsScale)
+		go func() {
+			for v := range ch {
+				pvclaims = append(pvclaims, v)
+			}
+		}()
+		go siteFailureInParallel(true, &wg)
+		wg.Wait()
+		close(ch)
+
+		defer func() {
+			for _, pvclaim := range pvclaims {
+				err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				pvclaim = nil
+			}
+		}()
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Check if csi pods are running fine after site failure
+		err = fpod.WaitForPodsRunningReady(client, csiNs, int32(csipods.Size()), 0, pollTimeout, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for i := 0; i < volumeOpsScale; i++ {
+			volHandle := persistentvolumes[i].Spec.CSI.VolumeHandle
+			gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		}
+
+		for _, pvclaim := range pvclaims {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		ginkgo.By("Verify PVs, volumes are deleted from CNS")
+		for _, pv := range persistentvolumes {
+			err := fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+				pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			volumeHandle := pv.Spec.CSI.VolumeHandle
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		// TODO: List orphan volumes
+
+		ginkgo.By("Bring up the primary site")
+		siteRestore(true)
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		// wait for the VMs to move back
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 	})
 
 })


### PR DESCRIPTION
**What this PR does / why we need it**: Includes 3 testcases and utils for site failure for automation vsan stretch cluster feature

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/89c98dbe1c1db79fde0ef91df346f526

**Special notes for your reviewer**:
make check output:
```
base) kai@kai-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/kai_vsan_stretch/vsphere-csi-driver /Users/kai/CSI/kai_vsan_stretch /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (files|types_sizes|compiled_files|deps|exports_file|imports|name) took 1.700934676s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 88.616727ms 
INFO [linters context/goanalysis] analyzers took 5.537279977s with top 10 stages: buildir: 521.327179ms, S1038: 453.135384ms, misspell: 364.925009ms, S1039: 243.044119ms, SA1012: 195.934637ms, S1024: 167.143184ms, directives: 157.002798ms, unused: 149.553637ms, S1012: 122.627992ms, SA1013: 120.72172ms 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 110/110, skip_files: 110/110, identifier_marker: 21/21, cgo: 110/110, filename_unadjuster: 110/110, skip_dirs: 110/110, exclude: 21/21, nolint: 0/1, autogenerated_exclude: 21/110, exclude-rules: 1/21 
INFO [runner] processing took 11.608301ms with stages: nolint: 9.25448ms, autogenerated_exclude: 1.221895ms, path_prettifier: 617.257µs, identifier_marker: 258.598µs, skip_dirs: 134.508µs, exclude-rules: 101.068µs, cgo: 9.42µs, filename_unadjuster: 7.69µs, max_same_issues: 592ns, uniq_by_line: 547ns, max_from_linter: 280ns, diff: 276ns, source_code: 244ns, skip_files: 238ns, exclude: 235ns, severity-rules: 220ns, path_shortener: 217ns, sort_results: 214ns, max_per_file_from_linter: 194ns, path_prefixer: 128ns 
INFO [runner] linters took 5.9528138s with stages: goanalysis_metalinter: 5.941133751s 
INFO File cache stats: 83 entries of total size 2.1MiB 
INFO Memory: 79 samples, avg is 224.8MB, max is 481.9MB 
INFO Execution took 7.755703949s 
```
**Release note**:
This is run for all 3 deployment models ie. (primary centric, distributed and SEB) for vsan stretched cluster setup in vanilla block flavour.
