### PR TITLE
fix linter errors

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -419,7 +419,8 @@ func GetClusterComputeResourceMoIds(ctx context.Context) ([]string, error) {
 	for _, az := range azList.Items {
 		clusterComputeResourceMoId, found, err := unstructured.NestedString(az.Object, "spec", "clusterComputeResourceMoId")
 		if !found || err != nil {
-			return nil, fmt.Errorf("failed to get clusterComputeResourceMoId from AvailabilityZone instance: %+v, err:%+v", az.Object, err)
+			return nil, fmt.Errorf("failed to get clusterComputeResourceMoId "+
+				"from AvailabilityZone instance: %+v, err:%+v", az.Object, err)
 		}
 		clusterComputeResourceMoIds = append(clusterComputeResourceMoIds, clusterComputeResourceMoId)
 	}

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -149,7 +149,8 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 				}
 				// Create FileVolumeClients CRD from manifest if file volume feature
 				// is enabled.
-				err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, internalapiscnsoperatorconfig.EmbedCnsFileVolumeClientFile,
+				err = k8s.CreateCustomResourceDefinitionFromManifest(ctx,
+					internalapiscnsoperatorconfig.EmbedCnsFileVolumeClientFile,
 					internalapiscnsoperatorconfig.EmbedCnsFileVolumeClientFileName)
 				if err != nil {
 					log.Errorf("Failed to create %q CRD. Err: %+v", internalapis.CnsFileVolumeClientPlural, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixed following linter errors

```
03:54:41  level=info msg="[runner] linters took 44.718695642s with stages: goanalysis_metalinter: 44.70251487s"
03:54:41  level=info msg="File cache stats: 266 entries of total size 3.7MiB"
03:54:41  pkg/csi/service/common/util.go:422: line is 130 characters (lll)
03:54:41  			return nil, fmt.Errorf("failed to get clusterComputeResourceMoId from AvailabilityZone instance: %+v, err:%+v", az.Object, err)
03:54:41  pkg/syncer/cnsoperator/manager/init.go:152: line is 121 characters (lll)
03:54:41  				err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, internalapiscnsoperatorconfig.EmbedCnsFileVolumeClientFile,
03:54:41  level=info msg="Memory: 1057 samples, avg is 714.2MB, max is 2369.1MB"
03:54:41  level=info msg="Execution took 1m49.63559336s"
03:54:41  make: *** [golangci-lint] Error 1
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Executed make check locally to verify no other linter failure present on the master branch.

**Special notes for your reviewer**:
This fix is needed to unblock pipeline.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix linter errors
```
