### PR TITLE
Topology testcases for 2 level topology enabled testbed

### DIFF
--- a/tests/e2e/provision_with_multiple_zones.go
+++ b/tests/e2e/provision_with_multiple_zones.go
@@ -32,6 +32,7 @@ import (
 	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
 )
 
 var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With-Multiple-Zones", func() {
@@ -156,6 +157,72 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		ginkgo.By("Verify if PV is deleted")
 		framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
 		pv = nil
-
 	})
+
+	/*
+		Provisioning volume using storage policy with multiple zone and region details
+			in the allowed topology
+		//Steps
+		1. Create SC with multiple Zone and region details specified in the SC
+		2. Create statefulset with replica 5 using the above SC
+		3. Wait for PV, PVC to bound
+		4. Statefulset should get distributed across zones.
+		5. Describe PV and verify node affinity details should contain both
+			zone and region details
+		5a. If a volume provisioned on datastore that is shared only within
+			zone1 then node affinity will have details of only zone1
+		5b. If a volume provisioned on datastore that is shared only on zone2 then
+			node affinity will have details of only zone2
+		6. Verify statefulset pod is running on the same node as mentioned in
+			node affinity details
+		7. Delete POD,PVC,PV
+	*/
+	ginkgo.It("Provisioning volume using storage policy with multiple zone and region "+
+		"details in the allowed topology", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Took Region1, Zone1 of Cluster1 and Region2, Zone2 of Cluster2
+		topologyLabelsCluster1 := GetAndExpectStringEnvVar(envRegionZoneWithSharedDS)
+		topologyLabelsCluster2 := GetAndExpectStringEnvVar(envRegionZoneWithNoSharedDS)
+		topologyValues := topologyLabelsCluster1 + "," + topologyLabelsCluster2
+		regionValues, zoneValues, allowedTopologies = topologyParameterForStorageClass(topologyValues)
+
+		// Creating StorageClass with multiple zone and region topology details
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Creating statefulset with 5 replicas
+		ginkgo.By("Creating statefulset with 5 replica")
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		var replica int32 = 5
+		statefulset.Spec.Replicas = &replica
+		replicas := *(statefulset.Spec.Replicas)
+		CreateStatefulSet(namespace, statefulset, client)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		/* Verify node and pv topology affinity should contains specified zone and region
+		details of SC and statefulset is distributed across zones and regions */
+		ginkgo.By("Verify node and pv topology affinity should contains specified zone and region details of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsets(ctx, client, statefulset, namespace, zoneValues, regionValues)
+	})
+
 })

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -68,9 +68,11 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	fdep "k8s.io/kubernetes/test/e2e/framework/deployment"
 	"k8s.io/kubernetes/test/e2e/framework/manifest"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 	fssh "k8s.io/kubernetes/test/e2e/framework/ssh"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
 
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator"
 	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
@@ -92,6 +94,8 @@ var (
 	restConfig             *rest.Config
 	pvclaims               []*v1.PersistentVolumeClaim
 	pvclaimsToDelete       []*v1.PersistentVolumeClaim
+	pvZone                 string
+	pvRegion               string
 )
 
 type TKGCluster struct {
@@ -4026,6 +4030,43 @@ func collectPodLogs(ctx context.Context, client clientset.Interface, namespace s
 			framework.Logf("Writing the logs into the file %v", "logs/"+pod.Name+cont.Name+filename)
 			err = writeToFile("logs/"+pod.Name+cont.Name+filename, output)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	}
+}
+
+/*
+This method works for 2 level topology enabled testbeds.
+verifyPVnodeAffinityAndPODnodedetailsForStatefulsets verifies that PV node Affinity rules
+should match the topology constraints specified in the storage class.
+Also it verifies that a pod is scheduled on a node that belongs to the topology on
+which PV is provisioned.
+*/
+func verifyPVnodeAffinityAndPODnodedetailsForStatefulsets(ctx context.Context,
+	client clientset.Interface, statefulset *appsv1.StatefulSet,
+	namespace string, zoneValues []string, regionValues []string) {
+	ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+	for _, sspod := range ssPodsBeforeScaleDown.Items {
+		_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, volumespec := range sspod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+				// verify pv node affinity details
+				pvRegion, pvZone, err = verifyVolumeTopology(pv, zoneValues, regionValues)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				nodeList, err := fnodes.GetReadySchedulableNodes(client)
+				framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+				if !(len(nodeList.Items) > 0) {
+					framework.Failf("Unable to find ready and schedulable Node")
+				}
+				//verify node topology details
+				err = verifyPodLocation(&sspod, nodeList, pvZone, pvRegion)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// Verify the attached volume match the one in CNS cache
+				error := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+					volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+				gomega.Expect(error).NotTo(gomega.HaveOccurred())
+			}
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Topology testcases automation for 2 level topology enabled testbed

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
yes
E2E Test results : https://gist.github.com/sipriyaa/88a61ea282f5761fd54183d591c0a305

**Special notes for your reviewer**:

**Release note**:

make check output:

sipriya@sipriya-a02 vsphere-csi-driver % golangci-lint run --enable=lll               
sipriya@sipriya-a02 vsphere-csi-driver % make golangci-lint                           
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/topology_type1_table1/vsphere-csi-driver /Users/sipriya/topology_type1_table1 /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|exports_file|imports|compiled_files|name|types_sizes|files) took 8.316469997s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 83.055212ms 
INFO [linters context/goanalysis] analyzers took 7.355971728s with top 10 stages: buildir: 630.23842ms, S1038: 538.303719ms, misspell: 461.23829ms, SA1012: 276.638003ms, S1039: 266.047405ms, directives: 214.236776ms, S1024: 201.735421ms, unused: 173.016612ms, S1019: 163.547194ms, S1012: 154.115357ms 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 110/110, skip_dirs: 110/110, identifier_marker: 21/21, exclude-rules: 1/21, cgo: 110/110, skip_files: 110/110, autogenerated_exclude: 21/110, exclude: 21/21, filename_unadjuster: 110/110, nolint: 0/1 
INFO [runner] processing took 12.991352ms with stages: nolint: 10.231232ms, autogenerated_exclude: 1.449537ms, path_prettifier: 709.604µs, identifier_marker: 286.532µs, skip_dirs: 175.397µs, exclude-rules: 109.92µs, cgo: 13.313µs, filename_unadjuster: 10.232µs, uniq_by_line: 1.333µs, max_same_issues: 1.166µs, skip_files: 435ns, max_from_linter: 390ns, diff: 382ns, source_code: 335ns, exclude: 320ns, sort_results: 306ns, max_per_file_from_linter: 267ns, severity-rules: 233ns, path_shortener: 225ns, path_prefixer: 193ns 
INFO [runner] linters took 6.410150302s with stages: goanalysis_metalinter: 6.397048777s 
INFO File cache stats: 82 entries of total size 2.0MiB 
INFO Memory: 150 samples, avg is 174.1MB, max is 547.4MB 
INFO Execution took 14.824577109s                 
sipriya@sipriya-a02 vsphere-csi-driver % 