### PR TITLE
Run snapshot-controller and snapshot-validation-deployment on CP nodes

### DIFF
--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -118,6 +118,8 @@ echo -e "✅ Created  RBACs for snapshot-controller"
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/"${release}"/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml 2>/dev/null || true
 echo -e "✅ Deployed snapshot-controller"
 
+kubectl patch deployment -n kube-system snapshot-controller --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/master": ""}, "tolerations": [{"key":"node-role.kubernetes.io/master","operator":"Exists", "effect":"NoSchedule"}]}}}}'
+
 wait_for_deployment snapshot-controller kube-system
 
 # Deploy the snapshot validating webhook.
@@ -184,6 +186,8 @@ kubectl delete deployment snapshot-validation-deployment --namespace "${namespac
 # patch csi-snapshot-validatingwebhook.yaml with CA_BUNDLE and create service and validatingwebhookconfiguration
 curl https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/vanilla/csi-snapshot-validatingwebhook.yaml | sed "s/caBundle: .*$/caBundle: ${CA_BUNDLE}/g" | kubectl apply -f -
 echo -e "✅ Deployed snapshot-validation-deployment"
+
+kubectl patch deployment -n kube-system snapshot-validation-deployment --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/master": ""}, "tolerations": [{"key":"node-role.kubernetes.io/master","operator":"Exists", "effect":"NoSchedule"}]}}}}'
 
 wait_for_deployment snapshot-validation-deployment kube-system
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Run snapshot-controller and snapshot-validation-deployment on CP nodes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
dkinni@dkinni-a02 vanilla % ./deploy-csi-snapshot-components.sh
✅ Verified that block-volume-snapshot feature is enabled
Using release version: v5.0.1
customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io configured
customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io configured
customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io configured
✅ Deployed VolumeSnapshot CRDs
serviceaccount/snapshot-controller unchanged
clusterrole.rbac.authorization.k8s.io/snapshot-controller-runner unchanged
clusterrolebinding.rbac.authorization.k8s.io/snapshot-controller-role unchanged
role.rbac.authorization.k8s.io/snapshot-controller-leaderelection unchanged
rolebinding.rbac.authorization.k8s.io/snapshot-controller-leaderelection unchanged
✅ Created  RBACs for snapshot-controller
deployment.apps/snapshot-controller unchanged
✅ Deployed snapshot-controller
deployment.apps/snapshot-controller patched (no change)
✅ snapshot-controller successfully deployed!
creating certs in tmpdir /var/folders/31/y77ywvzd6lqc0g60r4xnfyd80000gp/T/tmp.XeelB9Yqal 
Generating a 2048 bit RSA private key
.........................................................+++
.+++
writing new private key to '/var/folders/31/y77ywvzd6lqc0g60r4xnfyd80000gp/T/tmp.XeelB9Yqal/ca.key'
-----
Generating RSA private key, 2048 bit long modulus
...............................+++
....................................+++
e is 65537 (0x10001)
Signature ok
subject=/CN=snapshot-validation-service.kube-system.svc
Getting CA Private Key
secret "snapshot-webhook-certs" deleted
secret/snapshot-webhook-certs created
service "snapshot-validation-service" deleted
deployment.apps "snapshot-validation-deployment" deleted
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2238  100  2238    0     0   9605      0 --:--:-- --:--:-- --:--:--  9564
service/snapshot-validation-service created
validatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook.snapshot.storage.k8s.io configured
deployment.apps/snapshot-validation-deployment created
✅ Deployed snapshot-validation-deployment
deployment.apps/snapshot-validation-deployment patched
waiting for snapshot-validation-deployment to complete..
waiting for snapshot-validation-deployment to complete..
✅ snapshot-validation-deployment successfully deployed!
creating patch file in tmpdir /var/folders/31/y77ywvzd6lqc0g60r4xnfyd80000gp/T/tmp.cCyEIthHXm
Patching vSphere CSI driver..
deployment.apps/vsphere-csi-controller patched (no change)

✅ Successfully deployed all components for CSI Snapshot feature, please wait till vSphere CSI driver deployment is updated..
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>