### PR TITLE
Removing e2e test dependency on pkg/csi/service/common package

### DIFF
--- a/tests/e2e/csi_static_provisioning_file_basic.go
+++ b/tests/e2e/csi_static_provisioning_file_basic.go
@@ -41,7 +41,6 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 	vsanfstypes "github.com/vmware/govmomi/vsan/vsanfs/types"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
 )
 
 var _ = ginkgo.Describe("[csi-file-vanilla] Basic File Volume Static Provisioning", func() {
@@ -329,7 +328,7 @@ func getFileShareCreateSpec(datastore types.ManagedObjectReference) *cnstypes.Cn
 	containerClusterArray = append(containerClusterArray, *containerCluster)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{
 		Name:       "testFileSharex",
-		VolumeType: common.FileVolumeType,
+		VolumeType: "FILE",
 		Datastores: []types.ManagedObjectReference{datastore},
 		BackingObjectDetails: &cnstypes.CnsVsanFileShareBackingDetails{
 			CnsFileBackingDetails: cnstypes.CnsFileBackingDetails{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Without this PR, e2e tests can not be executed on the master branch
e2e test will fail with

```
--- FAIL: TestE2E (0.00s)
panic: /home/worker/workspace/kai-tests-vanilla/Results/38/vsphere-csi-driver/tests/e2e/e2e.test flag redefined: kubeconfig [recovered]
        panic: /home/worker/workspace/kai-tests-vanilla/Results/38/vsphere-csi-driver/tests/e2e/e2e.test flag redefined: kubeconfig
```

e2e test without using `sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common` is running fine.

```
% make test-e2e
hack/run-e2e-test.sh
go get: upgraded github.com/fsnotify/fsnotify v1.4.9 => v1.5.1
go get: upgraded golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 => v0.0.0-20211015210444-4f30a5c0130f
go get: upgraded golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 => v0.0.0-20220114195835-da31bd327af9
go get: upgraded golang.org/x/tools v0.1.1 => v0.1.8
Jan 25 16:13:46.627: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
W0125 16:13:46.627036   24003 test_context.go:444] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
Running Suite: CNS CSI Driver End-to-End Tests
==============================================
Random Seed: 1643156001 - Will randomize all specs
Will run 1 of 280 specs
```



**Testing done**:
Yes

executed `make test-e2e` locally.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Removing e2e test dependency on pkg/csi/service/common package
```
