### PR TITLE
TKGS-HA Supervisor CreateVolume workflow

### DIFF
--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -77,7 +77,7 @@ rules:
     verbs: ["list"]
   - apiGroups: ["topology.tanzu.vmware.com"]
     resources: ["availabilityzones"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -314,6 +314,7 @@ func GetTagManager(ctx context.Context, vc *VirtualCenter) (*tags.Manager, error
 // The 2nd output parameter will be vSAN-direct managed datastores.
 func GetCandidateDatastoresInCluster(ctx context.Context, vc *VirtualCenter, clusterID string) (
 	[]*DatastoreInfo, []*DatastoreInfo, error) {
+	log := logger.GetLogger(ctx)
 	// Get all vsan direct datastore urls in VC. Later, filter in this cluster.
 	allVsanDirectUrls, err := getVsanDirectDatastores(ctx, vc, clusterID)
 	if err != nil {
@@ -366,6 +367,8 @@ func GetCandidateDatastoresInCluster(ctx context.Context, vc *VirtualCenter, clu
 	if len(sharedDatastores) == 0 && len(vsanDirectDatastores) == 0 {
 		return nil, nil, fmt.Errorf("no candidates datastores found in the Kubernetes cluster")
 	}
+	log.Infof("Found shared datastores: %+v and vSAN Direct datastores: %+v", sharedDatastores,
+		vsanDirectDatastores)
 	return sharedDatastores, vsanDirectDatastores, nil
 }
 

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration"
@@ -110,14 +109,14 @@ func (nodeTopology *mockNodeVolumeTopology) GetNodeTopologyLabels(ctx context.Co
 
 // GetSharedDatastoresInTopology retrieves shared datastores of nodes which satisfy a given topology requirement.
 func (cntrlTopology *mockControllerVolumeTopology) GetSharedDatastoresInTopology(ctx context.Context,
-	topologyRequirement *csi.TopologyRequirement) ([]*cnsvsphere.DatastoreInfo, error) {
+	reqParams interface{}) ([]*cnsvsphere.DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
 	return nil, logger.LogNewError(log, "GetSharedDatastoresInTopology is not yet implemented.")
 }
 
 // GetTopologyInfoFromNodes retrieves the topology information of the given list of node names.
 func (cntrlTopology *mockControllerVolumeTopology) GetTopologyInfoFromNodes(ctx context.Context,
-	nodeNames []string, datastoreURL string) ([]map[string]string, error) {
+	reqParams interface{}) ([]map[string]string, error) {
 	log := logger.GetLogger(ctx)
 	return nil, logger.LogNewError(log, "GetTopologyInfoFromNodes is not yet implemented.")
 }

--- a/pkg/csi/service/common/commonco/types/types.go
+++ b/pkg/csi/service/common/commonco/types/types.go
@@ -33,15 +33,64 @@ type NodeInfo struct {
 	NodeID string
 }
 
+// VanillaTopologyFetchDSParams represents the params required to call
+// GetSharedDatastoresInTopology in vanilla cluster.
+type VanillaTopologyFetchDSParams struct {
+	// TopologyRequirement represents the topology conditions
+	// which need to be satisfied during volume provisioning.
+	TopologyRequirement *csi.TopologyRequirement
+}
+
+// WCPTopologyFetchDSParams represents the params required to call
+// GetSharedDatastoresInTopology in workload cluster.
+type WCPTopologyFetchDSParams struct {
+	// TopologyRequirement represents the topology conditions
+	// which need to be satisfied during volume provisioning.
+	TopologyRequirement *csi.TopologyRequirement
+	// Vc is the vcenter instance using which the potential
+	// datastores will be calculated.
+	Vc *cnsvsphere.VirtualCenter
+}
+
+// VanillaRetrieveTopologyInfoParams represents the params
+// required to be able to call GetTopologyInfoFromNodes in
+// vanilla cluster.
+type VanillaRetrieveTopologyInfoParams struct {
+	// NodeNames is the list of node names which have
+	// access to the selected datastore.
+	NodeNames []string
+	// DatastoreURL is the selected datastore for which the topology
+	// information needs to be retrieved.
+	DatastoreURL string
+}
+
+// WCPRetrieveTopologyInfoParams represents the params required to call
+// GetTopologyInfoFromNodes in workload cluster.
+type WCPRetrieveTopologyInfoParams struct {
+	// DatastoreURL is the selected datastore for which the topology
+	// information needs to be retrieved.
+	DatastoreURL string
+	// StorageTopologyType is a storageClass parameter.
+	// It represents a zonal or a crossZonal volume provisioning.
+	StorageTopologyType string
+	// TopologyRequirement represents the topology conditions
+	// which need to be satisfied during volume provisioning.
+	TopologyRequirement *csi.TopologyRequirement
+	// Vc is the vcenter instance using which the potential
+	// datastores will be calculated.
+	Vc *cnsvsphere.VirtualCenter
+}
+
 // ControllerTopologyService is an interface which exposes functionality
 // related to topology aware clusters in the controller mode.
 type ControllerTopologyService interface {
 	// GetSharedDatastoresInTopology gets the list of shared datastores which adhere to the topology
-	// requirement given as a parameter.
-	GetSharedDatastoresInTopology(ctx context.Context, topologyRequirement *csi.TopologyRequirement) (
-		[]*cnsvsphere.DatastoreInfo, error)
-	// GetTopologyInfoFromNodes retrieves the topology information of the given list of node names.
-	GetTopologyInfoFromNodes(ctx context.Context, nodeNames []string, datastoreURL string) ([]map[string]string, error)
+	// requirement given in the CreateVolume request.
+	GetSharedDatastoresInTopology(ctx context.Context, topologyFetchDSParams interface{}) ([]*cnsvsphere.DatastoreInfo,
+		error)
+	// GetTopologyInfoFromNodes retrieves the topology information of the nodes after the datastore has been
+	// selected for volume provisioning.
+	GetTopologyInfoFromNodes(ctx context.Context, retrieveTopologyInfoParams interface{}) ([]map[string]string, error)
 }
 
 // NodeTopologyService is an interface which exposes functionality related to

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -55,6 +55,11 @@ const (
 	// For example: StorageClassName: "silver".
 	AttributeSupervisorStorageClass = "svstorageclass"
 
+	// AttributeStorageTopologyType is a storageClass parameter.
+	// It represents a zonal or a crossZonal volume provisioning.
+	// For example: StorageTopologyType: "zonal"
+	AttributeStorageTopologyType = "storagetopologytype"
+
 	// AttributeFsType represents filesystem type in the Storage Classs.
 	// For Example: FsType: "ext4".
 	AttributeFsType = "fstype"

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -45,6 +45,8 @@ const (
 	defaultK8sCloudOperatorServicePort = 10000
 )
 
+var ErrAvailabilityZoneCRNotRegistered = errors.New("AvailabilityZone custom resource not registered")
+
 // GetVCenter returns VirtualCenter object from specified Manager object.
 // Before returning VirtualCenter object, vcenter connection is established if
 // session doesn't exist.
@@ -417,6 +419,7 @@ func GetClusterComputeResourceMoIds(ctx context.Context) ([]string, error) {
 	}
 
 	for _, az := range azList.Items {
+		// TODO: TKGS-HA - convert to slice when appropriate
 		clusterComputeResourceMoId, found, err := unstructured.NestedString(az.Object, "spec", "clusterComputeResourceMoId")
 		if !found || err != nil {
 			return nil, fmt.Errorf("failed to get clusterComputeResourceMoId "+

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -496,7 +496,8 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			}
 
 			// Get shared accessible datastores for matching topology requirement.
-			sharedDatastores, err = c.topologyMgr.GetSharedDatastoresInTopology(ctx, topologyRequirement)
+			sharedDatastores, err = c.topologyMgr.GetSharedDatastoresInTopology(ctx,
+				commoncotypes.VanillaTopologyFetchDSParams{TopologyRequirement: topologyRequirement})
 			if err != nil || len(sharedDatastores) == 0 {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to get shared datastores for topology requirement: %+v. Error: %+v",
@@ -713,7 +714,11 @@ func (c *controller) getAccessibleTopologiesForDatastore(ctx context.Context, vc
 		accessibleNodeNames = append(accessibleNodeNames, nodeName)
 	}
 
-	datastoreAccessibleTopology, err = c.topologyMgr.GetTopologyInfoFromNodes(ctx, accessibleNodeNames, datastoreURL)
+	datastoreAccessibleTopology, err = c.topologyMgr.GetTopologyInfoFromNodes(ctx,
+		commoncotypes.VanillaRetrieveTopologyInfoParams{
+			NodeNames:    accessibleNodeNames,
+			DatastoreURL: datastoreURL,
+		})
 	if err != nil {
 		return nil, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to find accessible topologies for the remaining nodes %v. Error: %+v",

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -446,3 +446,26 @@ func getOverlappingNodes(accessibleNodes []string, topologyRequirement *csi.Topo
 	}
 	return overlappingNodes, nil
 }
+
+// checkTopologyKeysFromAccessibilityReqs checks if the topology requirement contains zone or hostname labels.
+func checkTopologyKeysFromAccessibilityReqs(topologyRequirement *csi.TopologyRequirement) (bool, bool) {
+	var hostnameLabelPresent, zoneLabelPresent bool
+
+	if topologyRequirement == nil || topologyRequirement.GetPreferred() == nil {
+		return hostnameLabelPresent, zoneLabelPresent
+	}
+	for _, topology := range topologyRequirement.GetPreferred() {
+		segments := topology.GetSegments()
+		if _, exists := segments[v1.LabelHostname]; exists {
+			hostnameLabelPresent = true
+		}
+		if _, exists := segments[v1.LabelTopologyZone]; exists {
+			zoneLabelPresent = true
+		}
+		// If both zone and hostname labels are present, exit the loop and return.
+		if hostnameLabelPresent && zoneLabelPresent {
+			return hostnameLabelPresent, zoneLabelPresent
+		}
+	}
+	return hostnameLabelPresent, zoneLabelPresent
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR takes care of the CreateVolume workflow from supervisor side for TKGS-HA feature.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manually tested vanilla CreateVolume and application deployment for regressions.

Linter check - 
```
sbhaskara-a01:vsphere-csi-driver sbhaskara$ make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
Unable to find image 'gcr.io/cluster-api-provider-vsphere/extra/shellcheck:v0.7.1' locally
v0.7.1: Pulling from cluster-api-provider-vsphere/extra/shellcheck
75cb2ebf3b3c: Pull complete 
d8cc84507434: Pull complete 
cd376a308b24: Pull complete 
7852a05dcd82: Pull complete 
Digest: sha256:23b8cfc08f7279f334fc60dcf3d60f9e9889f1bb14e8268cf045e89d3abf64cc
Status: Downloaded newer image for gcr.io/cluster-api-provider-vsphere/extra/shellcheck:v0.7.1
hack/check-staticcheck.sh
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sbhaskara/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sbhaskara/github-csi/vsphere-csi-driver /Users/sbhaskara/github-csi /Users/sbhaskara /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|exports_file|files|types_sizes|deps|imports|name) took 6.336533161s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 167.952332ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude-rules: 1/21, cgo: 110/110, path_prettifier: 110/110, autogenerated_exclude: 21/110, skip_files: 110/110, nolint: 0/1, filename_unadjuster: 110/110, skip_dirs: 110/110, identifier_marker: 21/21, exclude: 21/21 
INFO [runner] processing took 24.357727ms with stages: nolint: 18.928124ms, autogenerated_exclude: 3.022002ms, path_prettifier: 1.268159ms, identifier_marker: 540.25µs, skip_dirs: 322.8µs, exclude-rules: 208.955µs, cgo: 36.311µs, filename_unadjuster: 24.057µs, max_same_issues: 1.654µs, uniq_by_line: 837ns, source_code: 585ns, max_from_linter: 583ns, skip_files: 521ns, diff: 510ns, exclude: 487ns, path_shortener: 421ns, severity-rules: 413ns, max_per_file_from_linter: 404ns, sort_results: 382ns, path_prefixer: 272ns 
INFO [runner] linters took 6.134430397s with stages: goanalysis_metalinter: 6.109889365s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 128 samples, avg is 106.6MB, max is 140.9MB 
INFO Execution took 12.65918376s                  
```

**Manual testing -** 

CreateVolume call
```
{"level":"info","time":"2022-01-28T22:56:21.166565392Z","caller":"wcp/controller.go:648","msg":"CreateVolume: called with args {Name:pvc-251b0852-3550-4072-896e-657b25e75053 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[storagePolicyID:60b16e72-4808-4832-8d51-e128adaaa765] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"vmware-system-legacy\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"vmware-system-legacy\" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"3bfc80c7-4c7b-4a2c-9a59-737ee5263eb9"}
{"level":"info","time":"2022-01-28T22:56:21.172150536Z","caller":"wcp/controller.go:404","msg":"Topology aware environment detected with requirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"vmware-system-legacy\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"vmware-system-legacy\" > > ","TraceId":"3bfc80c7-4c7b-4a2c-9a59-737ee5263eb9"}
{"level":"info","time":"2022-01-28T22:56:21.172211533Z","caller":"k8sorchestrator/topology.go:954","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:vmware-system-legacy] are [domain-c8]","TraceId":"3bfc80c7-4c7b-4a2c-9a59-737ee5263eb9"}
{"level":"info","time":"2022-01-28T22:56:21.247071981Z","caller":"vsphere/utils.go:362","msg":"Found shared datastores: [Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/ec1c6c84-a68b2d6d/] and vSAN Direct datastores: []","TraceId":"3bfc80c7-4c7b-4a2c-9a59-737ee5263eb9"}
{"level":"info","time":"2022-01-28T22:56:21.689322268Z","caller":"volume/manager.go:504","msg":"CreateVolume: VolumeName: \"pvc-251b0852-3550-4072-896e-657b25e75053\", opId: \"547b3c45\"","TraceId":"3bfc80c7-4c7b-4a2c-9a59-737ee5263eb9"}
{"level":"info","time":"2022-01-28T22:56:21.692321323Z","caller":"volume/util.go:322","msg":"Volume created successfully. VolumeName: \"pvc-251b0852-3550-4072-896e-657b25e75053\", volumeID: \"16fdaf73-7f15-4ffe-854a-4584c6c3f2d1\"","TraceId":"3bfc80c7-4c7b-4a2c-9a59-737ee5263eb9"}
{"level":"info","time":"2022-01-28T22:56:21.693838277Z","caller":"k8sorchestrator/topology.go:1054","msg":"Topology of the provisioned volume detected as [map[topology.kubernetes.io/zone:vmware-system-legacy]]","TraceId":"3bfc80c7-4c7b-4a2c-9a59-737ee5263eb9"}
```

PVC:
```
root@42276a481e2e1739e351e9df1486b0e7 [ ~ ]# kdsc pvc -n test-namespace
Name:          example-vanilla-rwo-pvc
Namespace:     test-namespace
StorageClass:  wcpglobal-storage-profile
Status:        Bound
Volume:        pvc-251b0852-3550-4072-896e-657b25e75053
Labels:        <none>
Annotations:   csi.vsphere.guest-cluster-requested-topology: [{"topology.kubernetes.io/zone":"vmware-system-legacy"}]
               csi.vsphere.volumeAccessibleTopology: [{"topology.kubernetes.io/zone":"vmware-system-legacy"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Fri Jan 28 22:56:34 UTC 2022
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                From                                                                                          Message
  ----    ------                 ----               ----                                                                                          -------
  Normal  ExternalProvisioning   27s (x2 over 27s)  persistentvolume-controller                                                                   waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  Provisioning           27s                csi.vsphere.vmware.com_4227cb055b04e85f29e5f41cea141f41_580e7819-fe79-43d1-bad0-d5f69ac41ac9  External provisioner is provisioning volume for claim "test-namespace/example-vanilla-rwo-pvc"
  Normal  ProvisioningSucceeded  27s                csi.vsphere.vmware.com_4227cb055b04e85f29e5f41cea141f41_580e7819-fe79-43d1-bad0-d5f69ac41ac9  Successfully provisioned volume pvc-251b0852-3550-4072-896e-657b25e75053
```

PV:
```
root@42276a481e2e1739e351e9df1486b0e7 [ ~ ]# kdsc pv
Name:              pvc-251b0852-3550-4072-896e-657b25e75053
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      wcpglobal-storage-profile
Status:            Bound
Claim:             test-namespace/example-vanilla-rwo-pvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.kubernetes.io/zone in [vmware-system-legacy]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      16fdaf73-7f15-4ffe-854a-4584c6c3f2d1
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1643410550840-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
TKGS-HA Supervisor CreateVolume workflow
```
