### PR TITLE
Volume health test-case code fixes

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -3020,6 +3020,14 @@ func runCommandOnESX(username string, addr string, cmd string) (string, error) {
 			if code = exiterr.ExitStatus(); code != 0 {
 				err = nil
 			}
+		}
+		if exiterr, ok := err.(*ssh.ExitMissingError); ok {
+			/* If err is ExitMissingError and the exit code is zero, we'll
+			consider the SSH is successful but the cmd is executed successfully on the host */
+			framework.Logf(exiterr.Error())
+			if code == 0 {
+				err = nil
+			}
 		} else {
 			err = fmt.Errorf("failed running `%s` on %s@%s: '%v'", cmd, config.User, addr, err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed code issue for volume health test-case.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Yes
https://gist.github.com/sipriyaa/bdae654712c2a98f588b7e35efd83632

**Special notes for your reviewer**:

make check output:

sipriya@sipriya-a02 vsphere-csi-driver % golangci-lint run --enable=lll                      
sipriya@sipriya-a02 vsphere-csi-driver % make golangci-lint                                  
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/Documents/pr-fix/vsphere-csi-driver /Users/sipriya/Documents/pr-fix /Users/sipriya/Documents /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|exports_file|files|types_sizes|compiled_files|imports|name) took 6.040136367s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 79.296955ms 
INFO [linters context/goanalysis] analyzers took 7.092808125s with top 10 stages: buildir: 737.051795ms, misspell: 512.536132ms, S1038: 499.174494ms, SA1012: 289.176065ms, directives: 262.245524ms, S1039: 245.831995ms, unused: 204.551601ms, S1024: 192.323397ms, SA1013: 187.318254ms, isgenerated: 164.145779ms 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude-rules: 1/21, filename_unadjuster: 110/110, path_prettifier: 110/110, autogenerated_exclude: 21/110, identifier_marker: 21/21, exclude: 21/21, cgo: 110/110, skip_files: 110/110, skip_dirs: 110/110, nolint: 0/1 
INFO [runner] processing took 12.826339ms with stages: nolint: 10.144418ms, autogenerated_exclude: 1.413762ms, path_prettifier: 665.299µs, identifier_marker: 309.658µs, skip_dirs: 151.509µs, exclude-rules: 114.118µs, cgo: 13.997µs, filename_unadjuster: 8.735µs, max_same_issues: 995ns, max_from_linter: 742ns, uniq_by_line: 616ns, skip_files: 473ns, diff: 346ns, source_code: 310ns, severity-rules: 271ns, max_per_file_from_linter: 247ns, exclude: 239ns, path_shortener: 237ns, sort_results: 226ns, path_prefixer: 141ns 
INFO [runner] linters took 5.111002726s with stages: goanalysis_metalinter: 5.098069301s 
INFO File cache stats: 76 entries of total size 1.9MiB 
INFO Memory: 114 samples, avg is 197.9MB, max is 547.7MB 
INFO Execution took 11.24026907s                  
sipriya@sipriya-a02 vsphere-csi-driver % 
