### PR TITLE
Added a workaround to handle the deletion of non-existent snapshot

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -82,6 +82,14 @@ func IsManagedObjectNotFound(err error, moRef types.ManagedObjectReference) bool
 	return false
 }
 
+func IsInvalidArgumentError(err error) bool {
+	isInvalidArgumentError := false
+	if soap.IsVimFault(err) {
+		_, isInvalidArgumentError = soap.ToVimFault(err).(*types.InvalidArgument)
+	}
+	return isInvalidArgumentError
+}
+
 // GetCnsKubernetesEntityMetaData creates a CnsKubernetesEntityMetadataObject
 // object from given parameters.
 func GetCnsKubernetesEntityMetaData(entityName string, labels map[string]string,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Ignore certain error types which implies the snapshot is non-existent after deleting snapshot.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Regression test: Ongoing
E2E test: Passed
1. Create a snapshot in a vanilla K8s cluster using VolumeSnapshot.
2. Delete the snapshot from vSphere using FCD API
3. Delete the snapshot from k8s.
4. Verify the snapshot can be deleted properly.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added a workaround to handle the deletion of non-existent snapshot
```
