### PR TITLE
Support for Improved Volume topology feature when Use-CSINode-Id feature is enabled

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -95,7 +95,7 @@ metadata:
 rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["csinodetopologies"]
-    verbs: ["create", "watch"]
+    verbs: ["create", "watch", "get", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -132,8 +132,8 @@ func (c *FakeK8SOrchestrator) InitTopologyServiceInController(ctx context.Contex
 
 // InitTopologyServiceInNode returns a singleton implementation of the
 //commoncotypes.NodeTopologyService interface for the FakeK8SOrchestrator.
-func (c *FakeK8SOrchestrator) InitTopologyServiceInNode(ctx context.Context) (commoncotypes.NodeTopologyService,
-	error) {
+func (c *FakeK8SOrchestrator) InitTopologyServiceInNode(ctx context.Context) (
+	commoncotypes.NodeTopologyService, error) {
 	// TODO: Mock the custom k8sClients and watchers.
 	return &mockNodeVolumeTopology{}, nil
 }

--- a/pkg/internalapis/csinodetopology/config/cns.vmware.com_csinodetopologies.yaml
+++ b/pkg/internalapis/csinodetopology/config/cns.vmware.com_csinodetopologies.yaml
@@ -37,7 +37,10 @@ spec:
             description: CSINodeTopologySpec defines the desired state of CSINodeTopology.
             properties:
               nodeID:
-                description: NodeID refers to the unique ID by which a Node is recognised.
+                description: NodeID refers to the node name by which a Node is recognised.
+                type: string
+              nodeuuid:
+                description: NodeUUID refers to the unique VM UUID by which a Node is recognised.
                 type: string
             required:
             - nodeID

--- a/pkg/internalapis/csinodetopology/v1alpha1/csinodetopology_types.go
+++ b/pkg/internalapis/csinodetopology/v1alpha1/csinodetopology_types.go
@@ -23,8 +23,11 @@ import (
 // CSINodeTopologySpec defines the desired state of CSINodeTopology.
 type CSINodeTopologySpec struct {
 
-	// NodeID refers to the unique ID by which a Node is recognised.
+	// NodeID refers to the node name by which a Node is recognised.
 	NodeID string `json:"nodeID"`
+
+	// NodeUUID refers to the unique VM UUID by which a Node is recognised.
+	NodeUUID string `json:"nodeuuid,omitempty"`
 }
 
 type CRDStatus string


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

1. Deploy 2.5 CSI driver `use-csinode-id` feature disabled.

a. CSINode objects are populated with Nodename.
```
root@k8s-control-253-1643019726:~# kubectl describe csinode
Name:               k8s-control-253-1643019726
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Mon, 24 Jan 2022 10:25:09 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  k8s-control-253-1643019726
      Allocatables:
        Count:  59
Events:         <none>

Name:               k8s-node-395-1643019787
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Mon, 24 Jan 2022 10:27:35 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  k8s-node-395-1643019787
      Allocatables:
        Count:  59
Events:         <none>

Name:               k8s-node-594-1643019767
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Mon, 24 Jan 2022 10:27:02 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  k8s-node-594-1643019767
      Allocatables:
        Count:  59
Events:         <none>

Name:               k8s-node-716-1643019745
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Mon, 24 Jan 2022 10:26:32 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  k8s-node-716-1643019745
      Allocatables:
        Count:  59
Events:         <none>
```

b. CSINodeTopology instances are populated with CSINodeTopology.Spec.NodeID only.

```
$ kubectl describe CSINodeTopology

Name:         k8s-node-716-1643019745
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-01-27T17:37:46Z
  Generation:          2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"c17c6975-8cb4-4166-853f-a48eaba29b3a"}:
      f:spec:
        .:
        f:nodeID:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2022-01-27T17:37:46Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2022-01-27T17:38:10Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-716-1643019745
    UID:             c17c6975-8cb4-4166-853f-a48eaba29b3a
  Resource Version:  803335
  UID:               2e21cea5-457f-4cb9-9dc3-4def34e41db5
Spec:
  Node ID:  k8s-node-716-1643019745
Status:
  Status:  Success
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  66s   cns.vmware.com  Not a topology aware cluster.
```

c. Node daemonset logs which shows Topology service is initialized and CSINodeTopology instance is created.

```
2022-01-27T17:37:45.906Z	INFO	k8sorchestrator/topology.go:371	Topology service initiated successfully	{"TraceId": "e541343b-e265-48d2-b20c-8fdb8dbadeb5"}
2022-01-27T17:37:45.941Z	INFO	k8sorchestrator/topology.go:531	Successfully created a CSINodeTopology instance for NodeName: "k8s-node-395-1643019787"	{"TraceId": "e541343b-e265-48d2-b20c-8fdb8dbadeb5"}
2022-01-27T17:37:45.941Z	INFO	k8sorchestrator/topology.go:556	Timeout is set to 1 minute(s)	{"TraceId": "e541343b-e265-48d2-b20c-8fdb8dbadeb5"}
2022-01-27T17:38:11.014Z	INFO	service/node.go:466	NodeGetInfo response: node_id:"k8s-node-395-1643019787" max_volumes_per_node:59 accessible_topology:<> 	{"TraceId": "e541343b-e265-48d2-b20c-8fdb8dbadeb5”}
```

d. On node daemonset restarts to make it sees the CSINodeTopology instance is already created and won't create new one again.

```
2022-01-27T17:41:24.069Z	INFO	k8sorchestrator/topology.go:371	Topology service initiated successfully	{"TraceId": "59187372-7f0c-446f-a075-7c0251fc67cb"}
2022-01-27T17:41:24.100Z	INFO	k8sorchestrator/topology.go:528	CSINodeTopology instance already exists for NodeName: "k8s-node-395-1643019787"	{"TraceId": "59187372-7f0c-446f-a075-7c0251fc67cb"}
2022-01-27T17:41:24.100Z	INFO	k8sorchestrator/topology.go:556	Timeout is set to 1 minute(s)	{"TraceId": "59187372-7f0c-446f-a075-7c0251fc67cb"}
2022-01-27T17:41:24.108Z	INFO	service/node.go:466	NodeGetInfo response: node_id:"k8s-node-395-1643019787" max_volumes_per_node:59 accessible_topology:<> 	{"TraceId": "59187372-7f0c-446f-a075-7c0251fc67cb”}
```

e. Able to create PVC successfully

```
root@k8s-control-253-1643019726:~# kubectl get pvc
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
example-raw-block-pvc   Bound    pvc-deabe181-cb5c-474e-8ad3-0ce00df29ebf   1Gi        RWO            example-raw-block-sc   19s
```

f. Creating a pod with volume

```
root@k8s-control-253-1643019726:~# kubectl get pod
NAME                    READY   STATUS    RESTARTS   AGE
example-raw-block-pod   1/1     Running   0          26s

2022-01-27T18:02:12.730Z	INFO	vanilla/controller.go:965	ControllerPublishVolume: called with args {VolumeId:1afe7e56-5ef1-484f-b6b9-ba906f5a6c2e NodeId:k8s-node-395-1643019787 VolumeCapability:block:<> access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[storage.kubernetes.io/csiProvisionerIdentity:1643305071532-8081-csi.vsphere.vmware.com type:vSphere CNS Block Volume] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "a639b210-78e1-4d33-bd52-5ea0e9085e52"}
2022-01-27T18:02:12.733Z	DEBUG	node/manager.go:218	Renewing virtual machine VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]] with nodeUUID "422186b6-b6c1-50c5-c0d2-b88f19994c0d"	{"TraceId": "a639b210-78e1-4d33-bd52-5ea0e9085e52"}
2022-01-27T18:02:12.751Z	DEBUG	node/manager.go:225	VM VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]] was successfully renewed with nodeUUID "422186b6-b6c1-50c5-c0d2-b88f19994c0d"	{"TraceId": "a639b210-78e1-4d33-bd52-5ea0e9085e52"}
2022-01-27T18:02:12.751Z	DEBUG	vanilla/controller.go:1054	Found VirtualMachine for node:"k8s-node-395-1643019787".	{"TraceId": "a639b210-78e1-4d33-bd52-5ea0e9085e52"}
2022-01-27T18:02:12.751Z	DEBUG	common/vsphereutil.go:547	vSphere CSI driver is attaching volume: "1afe7e56-5ef1-484f-b6b9-ba906f5a6c2e" to vm: "VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]"	{"TraceId": "a639b210-78e1-4d33-bd52-5ea0e9085e52"}
2022-01-27T18:02:15.776Z	INFO	volume/manager.go:632	AttachVolume: volumeID: "1afe7e56-5ef1-484f-b6b9-ba906f5a6c2e", vm: "VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]", opId: "307761e9"	{"TraceId": "a639b210-78e1-4d33-bd52-5ea0e9085e52"}
2022-01-27T18:02:15.777Z	INFO	volume/manager.go:667	AttachVolume: Volume attached successfully. volumeID: "1afe7e56-5ef1-484f-b6b9-ba906f5a6c2e", opId: "307761e9", vm: "VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]", diskUUID: "6000C29e-bc74-42be-97f8-77ad9e7ad6fd"	{"TraceId": "a639b210-78e1-4d33-bd52-5ea0e9085e52"}
2022-01-27T18:02:15.777Z	DEBUG	volume/manager.go:674	internalAttachVolume: returns fault "" for volume "1afe7e56-5ef1-484f-b6b9-ba906f5a6c2e"	{"TraceId": "a639b210-78e1-4d33-bd52-5ea0e9085e52"}
2022-01-27T18:02:15.777Z	DEBUG	common/vsphereutil.go:553	Successfully attached disk 1afe7e56-5ef1-484f-b6b9-ba906f5a6c2e to VM VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]. Disk UUID is 6000C29e-bc74-42be-97f8-77ad9e7ad6fd	{"TraceId": "a639b210-78e1-4d33-bd52-5ea0e9085e52"}
2022-01-27T18:02:15.777Z	INFO	vanilla/controller.go:1064	ControllerPublishVolume successful with publish context: map[diskUUID:6000c29ebc7442be97f877ad9e7ad6fd type:vSphere CNS Block Volume]	{"TraceId": "a639b210-78e1-4d33-bd52-5ea0e9085e52"}
2022-01-27T18:02:15.777Z	DEBUG	vanilla/controller.go:1071	controllerPublishVolumeInternal: returns fault "" for volume "1afe7e56-5ef1-484f-b6b9-ba906f5a6c2e"	{"TraceId": "a639b210-78e1-4d33-bd52-5ea0e9085e52"}
```



===========

2. Upgrade CSI driver from 2.4 to 2.5 with `use-csinode-id` feature and `improved-volume-topology` feature enabled.

a. Existing CsiNodeTopology instances is patched with CsiNodeTopology.spec.nodeUUID set.

```
root@k8s-control-253-1643019726:~# kubectl describe csinodetopology
Name:         k8s-control-253-1643019726
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-01-27T18:48:20Z
  Generation:          3
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:      vsphere-syncer
    Operation:    Update
    Time:         2022-01-27T18:48:42Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"a35b1528-af5c-4b11-9f00-8df94535939d"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:    vsphere-csi
    Operation:  Update
    Time:       2022-01-27T18:54:08Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-control-253-1643019726
    UID:             a35b1528-af5c-4b11-9f00-8df94535939d
  Resource Version:  816661
  UID:               a3f1de31-a24d-4736-ba91-5acea836dd8c
Spec:
  Node ID:   k8s-control-253-1643019726
  Nodeuuid:  4221cfe8-3ac0-0cad-f0e5-c0b177720a06
Status:
  Status:  Success
Events:
  Type    Reason                      Age    From            Message
  ----    ------                      ----   ----            -------
  Normal  TopologyRetrievalSucceeded  7m12s  cns.vmware.com  Not a topology aware cluster.
  Normal  TopologyRetrievalSucceeded  105s   cns.vmware.com  Not a topology aware cluster.


Name:         k8s-node-395-1643019787
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-01-27T18:48:19Z
  Generation:          3
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:      vsphere-syncer
    Operation:    Update
    Time:         2022-01-27T18:48:42Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"4f0280b2-a0dc-4e96-9442-32c566e74fb6"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:    vsphere-csi
    Operation:  Update
    Time:       2022-01-27T18:55:23Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-395-1643019787
    UID:             4f0280b2-a0dc-4e96-9442-32c566e74fb6
  Resource Version:  816931
  UID:               7f9c5c1b-d8ba-426f-8860-16476e93cf50
Spec:
  Node ID:   k8s-node-395-1643019787
  Nodeuuid:  422186b6-b6c1-50c5-c0d2-b88f19994c0d
Status:
  Status:  Success
Events:
  Type    Reason                      Age    From            Message
  ----    ------                      ----   ----            -------
  Normal  TopologyRetrievalSucceeded  7m12s  cns.vmware.com  Not a topology aware cluster.
  Normal  TopologyRetrievalSucceeded  31s    cns.vmware.com  Not a topology aware cluster.


Name:         k8s-node-594-1643019767
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-01-27T18:48:19Z
  Generation:          3
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:      vsphere-syncer
    Operation:    Update
    Time:         2022-01-27T18:48:42Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"7318dc95-5c85-4d2d-a55f-72279b01a4c8"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:    vsphere-csi
    Operation:  Update
    Time:       2022-01-27T18:53:29Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-594-1643019767
    UID:             7318dc95-5c85-4d2d-a55f-72279b01a4c8
  Resource Version:  816506
  UID:               c090ba84-5b23-4019-a50b-7676cb9389ab
Spec:
  Node ID:   k8s-node-594-1643019767
  Nodeuuid:  42214291-febc-8d46-5b6a-ee9695f04a6e
Status:
  Status:  Success
Events:
  Type    Reason                      Age    From            Message
  ----    ------                      ----   ----            -------
  Normal  TopologyRetrievalSucceeded  7m13s  cns.vmware.com  Not a topology aware cluster.
  Normal  TopologyRetrievalSucceeded  2m     cns.vmware.com  Not a topology aware cluster.


Name:         k8s-node-716-1643019745
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-01-27T18:48:20Z
  Generation:          3
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:      vsphere-syncer
    Operation:    Update
    Time:         2022-01-27T18:48:42Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"c17c6975-8cb4-4166-853f-a48eaba29b3a"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:    vsphere-csi
    Operation:  Update
    Time:       2022-01-27T18:54:44Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-716-1643019745
    UID:             c17c6975-8cb4-4166-853f-a48eaba29b3a
  Resource Version:  816787
  UID:               80d68f16-76d2-44bc-84e2-44ef82fba863
Spec:
  Node ID:   k8s-node-716-1643019745
  Nodeuuid:  42216625-53b0-5fff-b724-203018af9d30
Status:
  Status:  Success
Events:
  Type    Reason                      Age    From            Message
  ----    ------                      ----   ----            -------
  Normal  TopologyRetrievalSucceeded  7m13s  cns.vmware.com  Not a topology aware cluster.
  Normal  TopologyRetrievalSucceeded  70s    cns.vmware.com  Not a topology aware cluster.

```
b. CSINode objects are created with nodeUUID set.

```
root@k8s-control-253-1643019726:~# kubectl describe csinodes
Name:               k8s-control-253-1643019726
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Mon, 24 Jan 2022 10:25:09 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  4221cfe8-3ac0-0cad-f0e5-c0b177720a06
      Allocatables:
        Count:  59
Events:         <none>


Name:               k8s-node-395-1643019787
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Mon, 24 Jan 2022 10:27:35 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  422186b6-b6c1-50c5-c0d2-b88f19994c0d
      Allocatables:
        Count:  59
Events:         <none>


Name:               k8s-node-594-1643019767
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Mon, 24 Jan 2022 10:27:02 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  42214291-febc-8d46-5b6a-ee9695f04a6e
      Allocatables:
        Count:  59
Events:         <none>


Name:               k8s-node-716-1643019745
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Mon, 24 Jan 2022 10:26:32 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  42216625-53b0-5fff-b724-203018af9d30
      Allocatables:
        Count:  59
Events:         <none>
```

c. CSI node daemonset logs show that CSINodetopology instance is patched with nodeUUID

```
2022-01-27T18:55:22.963Z	INFO	k8sorchestrator/topology.go:371	Topology service initiated successfully	{"TraceId": "a8c3ef64-f687-46fd-a500-0c1dd5bc70b7"}
2022-01-27T18:55:22.976Z	INFO	k8sorchestrator/topology.go:406	CSINodeTopology instance: "k8s-node-395-1643019787" with empty nodeUUID found. Patching the instance with nodeUUID	{"TraceId": "a8c3ef64-f687-46fd-a500-0c1dd5bc70b7"}
2022-01-27T18:55:22.992Z	INFO	k8sorchestrator/topology.go:423	Successfully patched CSINodeTopology instance: "k8s-node-395-1643019787" with Uuid: "422186b6-b6c1-50c5-c0d2-b88f19994c0d"	{"TraceId": "a8c3ef64-f687-46fd-a500-0c1dd5bc70b7"}
2022-01-27T18:55:22.992Z	INFO	k8sorchestrator/topology.go:556	Timeout is set to 1 minute(s)	{"TraceId": "a8c3ef64-f687-46fd-a500-0c1dd5bc70b7"}
2022-01-27T18:55:23.005Z	INFO	service/node.go:466	NodeGetInfo response: node_id:"422186b6-b6c1-50c5-c0d2-b88f19994c0d" max_volumes_per_node:59 accessible_topology:<> 	{"TraceId": "a8c3ef64-f687-46fd-a500-0c1dd5bc70b7"}
```

d. Create PVC successfully.

```
root@k8s-control-253-1643019726:~# kubectl get pvc
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
example-raw-block-pvc   Bound    pvc-74ff41f0-6705-43e8-abdb-b67a89e5a365   1Gi        RWO            example-raw-block-sc   37s
```


e. Create pod successfully

```
root@k8s-control-253-1643019726:~# kubectl get pods
NAME                    READY   STATUS    RESTARTS   AGE
example-raw-block-pod   1/1     Running   0          45s


2022-01-27T19:00:30.101Z	INFO	vanilla/controller.go:965	ControllerPublishVolume: called with args {VolumeId:9ec9a32d-146a-4eb9-b369-f659b8d86be1 NodeId:422186b6-b6c1-50c5-c0d2-b88f19994c0d VolumeCapability:block:<> access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[storage.kubernetes.io/csiProvisionerIdentity:1643309615905-8081-csi.vsphere.vmware.com type:vSphere CNS Block Volume] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "4076b0d2-8346-4d3e-ae5b-9709c4c1fc25"}
2022-01-27T19:00:30.109Z	DEBUG	node/manager.go:218	Renewing virtual machine VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]] with nodeUUID "422186b6-b6c1-50c5-c0d2-b88f19994c0d"	{"TraceId": "4076b0d2-8346-4d3e-ae5b-9709c4c1fc25"}
2022-01-27T19:00:30.123Z	DEBUG	node/manager.go:225	VM VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]] was successfully renewed with nodeUUID "422186b6-b6c1-50c5-c0d2-b88f19994c0d"	{"TraceId": "4076b0d2-8346-4d3e-ae5b-9709c4c1fc25"}
2022-01-27T19:00:30.123Z	DEBUG	vanilla/controller.go:1054	Found VirtualMachine for node:"422186b6-b6c1-50c5-c0d2-b88f19994c0d".	{"TraceId": "4076b0d2-8346-4d3e-ae5b-9709c4c1fc25"}
2022-01-27T19:00:30.124Z	DEBUG	common/vsphereutil.go:547	vSphere CSI driver is attaching volume: "9ec9a32d-146a-4eb9-b369-f659b8d86be1" to vm: "VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]"	{"TraceId": "4076b0d2-8346-4d3e-ae5b-9709c4c1fc25"}
2022-01-27T19:00:44.435Z	INFO	volume/manager.go:632	AttachVolume: volumeID: "9ec9a32d-146a-4eb9-b369-f659b8d86be1", vm: "VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]", opId: "30777152"	{"TraceId": "4076b0d2-8346-4d3e-ae5b-9709c4c1fc25"}
2022-01-27T19:00:44.436Z	INFO	volume/manager.go:667	AttachVolume: Volume attached successfully. volumeID: "9ec9a32d-146a-4eb9-b369-f659b8d86be1", opId: "30777152", vm: "VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]", diskUUID: "6000C29d-55fa-034f-9722-b0c6b3e2c096"	{"TraceId": "4076b0d2-8346-4d3e-ae5b-9709c4c1fc25"}
2022-01-27T19:00:44.436Z	DEBUG	volume/manager.go:674	internalAttachVolume: returns fault "" for volume "9ec9a32d-146a-4eb9-b369-f659b8d86be1"	{"TraceId": "4076b0d2-8346-4d3e-ae5b-9709c4c1fc25"}
2022-01-27T19:00:44.436Z	DEBUG	common/vsphereutil.go:553	Successfully attached disk 9ec9a32d-146a-4eb9-b369-f659b8d86be1 to VM VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]. Disk UUID is 6000C29d-55fa-034f-9722-b0c6b3e2c096	{"TraceId": "4076b0d2-8346-4d3e-ae5b-9709c4c1fc25"}
2022-01-27T19:00:44.437Z	INFO	vanilla/controller.go:1064	ControllerPublishVolume successful with publish context: map[diskUUID:6000c29d55fa034f9722b0c6b3e2c096 type:vSphere CNS Block Volume]	{"TraceId": "4076b0d2-8346-4d3e-ae5b-9709c4c1fc25"}
2022-01-27T19:00:44.437Z	DEBUG	vanilla/controller.go:1071	controllerPublishVolumeInternal: returns fault "" for volume "9ec9a32d-146a-4eb9-b369-f659b8d86be1"	{"TraceId": "4076b0d2-8346-4d3e-ae5b-9709c4c1fc25"}
```


f. Delete Pod successfully

```
root@k8s-control-253-1643019726:~# kubectl delete -f pod.yaml 


2022-01-27T19:02:32.208Z	INFO	vanilla/controller.go:1095	ControllerUnpublishVolume: called with args {VolumeId:9ec9a32d-146a-4eb9-b369-f659b8d86be1 NodeId:422186b6-b6c1-50c5-c0d2-b88f19994c0d Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "26841149-0cf2-4c40-9835-856391bb51ca"}
2022-01-27T19:02:32.281Z	DEBUG	node/manager.go:218	Renewing virtual machine VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]] with nodeUUID "422186b6-b6c1-50c5-c0d2-b88f19994c0d"	{"TraceId": "26841149-0cf2-4c40-9835-856391bb51ca"}
2022-01-27T19:02:32.291Z	DEBUG	node/manager.go:225	VM VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]] was successfully renewed with nodeUUID "422186b6-b6c1-50c5-c0d2-b88f19994c0d"	{"TraceId": "26841149-0cf2-4c40-9835-856391bb51ca"}
2022-01-27T19:02:32.291Z	DEBUG	common/vsphereutil.go:563	vSphere CSI driver is detaching volume: 9ec9a32d-146a-4eb9-b369-f659b8d86be1 from node vm: 	{"TraceId": "26841149-0cf2-4c40-9835-856391bb51ca"}
2022-01-27T19:02:33.503Z	INFO	volume/manager.go:753	DetachVolume: volumeID: "9ec9a32d-146a-4eb9-b369-f659b8d86be1", vm: "VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]", opId: "307771f6"	{"TraceId": "26841149-0cf2-4c40-9835-856391bb51ca"}
2022-01-27T19:02:33.503Z	INFO	volume/manager.go:788	DetachVolume: Volume detached successfully. volumeID: "9ec9a32d-146a-4eb9-b369-f659b8d86be1", vm: "307771f6", opId: "VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]"	{"TraceId": "26841149-0cf2-4c40-9835-856391bb51ca"}
2022-01-27T19:02:33.503Z	DEBUG	volume/manager.go:795	internalDetachVolume: returns fault "" for volume "9ec9a32d-146a-4eb9-b369-f659b8d86be1"	{"TraceId": "26841149-0cf2-4c40-9835-856391bb51ca"}
2022-01-27T19:02:33.503Z	DEBUG	common/vsphereutil.go:569	Successfully detached disk 9ec9a32d-146a-4eb9-b369-f659b8d86be1 from VM VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]].	{"TraceId": "26841149-0cf2-4c40-9835-856391bb51ca"}
2022-01-27T19:02:33.504Z	INFO	vanilla/controller.go:1184	ControllerUnpublishVolume successful for volume ID: 9ec9a32d-146a-4eb9-b369-f659b8d86be1	{"TraceId": "26841149-0cf2-4c40-9835-856391bb51ca"}
2022-01-27T19:02:33.504Z	DEBUG	vanilla/controller.go:1189	controllerUnpublishVolumeInternal: returns fault "" for volume "9ec9a32d-146a-4eb9-b369-f659b8d86be1"	{"TraceId": "26841149-0cf2-4c40-9835-856391bb51ca”}

```



=======


3. Deploy new CSI 2.5 driver with `use-csinode-id` feature enabled by default

a. CSINodeTopology instance is created with CSINodeTopology.Spec.NodeID set to nodeName and CSINodeTopology.Spec.NodeUUID set ti nodeUUID.

```
root@k8s-control-253-1643019726:~# kubectl describe csinodetopology
Name:         k8s-control-253-1643019726
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-01-27T19:06:27Z
  Generation:          2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"a35b1528-af5c-4b11-9f00-8df94535939d"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2022-01-27T19:06:27Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2022-01-27T19:06:50Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-control-253-1643019726
    UID:             a35b1528-af5c-4b11-9f00-8df94535939d
  Resource Version:  819037
  UID:               de5f0e3c-a40e-412e-9ea0-29d55f4c1735
Spec:
  Node ID:   k8s-control-253-1643019726
  Nodeuuid:  4221cfe8-3ac0-0cad-f0e5-c0b177720a06
Status:
  Status:  Success
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  82s   cns.vmware.com  Not a topology aware cluster.


Name:         k8s-node-395-1643019787
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-01-27T19:06:25Z
  Generation:          2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"4f0280b2-a0dc-4e96-9442-32c566e74fb6"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2022-01-27T19:06:25Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2022-01-27T19:06:50Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-395-1643019787
    UID:             4f0280b2-a0dc-4e96-9442-32c566e74fb6
  Resource Version:  819042
  UID:               52360e83-751b-42e7-91d8-a0a2078ff378
Spec:
  Node ID:   k8s-node-395-1643019787
  Nodeuuid:  422186b6-b6c1-50c5-c0d2-b88f19994c0d
Status:
  Status:  Success
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  82s   cns.vmware.com  Not a topology aware cluster.


Name:         k8s-node-594-1643019767
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-01-27T19:06:25Z
  Generation:          2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"7318dc95-5c85-4d2d-a55f-72279b01a4c8"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2022-01-27T19:06:25Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2022-01-27T19:06:50Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-594-1643019767
    UID:             7318dc95-5c85-4d2d-a55f-72279b01a4c8
  Resource Version:  819038
  UID:               03bfabba-5e1d-47f2-b172-1cc0c9b278ad
Spec:
  Node ID:   k8s-node-594-1643019767
  Nodeuuid:  42214291-febc-8d46-5b6a-ee9695f04a6e
Status:
  Status:  Success
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  82s   cns.vmware.com  Not a topology aware cluster.


Name:         k8s-node-716-1643019745
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-01-27T19:06:26Z
  Generation:          2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"c17c6975-8cb4-4166-853f-a48eaba29b3a"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2022-01-27T19:06:26Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2022-01-27T19:06:50Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-716-1643019745
    UID:             c17c6975-8cb4-4166-853f-a48eaba29b3a
  Resource Version:  819047
  UID:               d1033d4a-b02f-4445-b76b-59f8e3e99b17
Spec:
  Node ID:   k8s-node-716-1643019745
  Nodeuuid:  42216625-53b0-5fff-b724-203018af9d30
Status:
  Status:  Success
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  82s   cns.vmware.com  Not a topology aware cluster.
```

b. CSINode object are created with NodeUUID populated.

```
root@k8s-control-253-1643019726:~# kubectl describe csinode
Name:               k8s-control-253-1643019726
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Mon, 24 Jan 2022 10:25:09 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  4221cfe8-3ac0-0cad-f0e5-c0b177720a06
      Allocatables:
        Count:  59
Events:         <none>


Name:               k8s-node-395-1643019787
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Mon, 24 Jan 2022 10:27:35 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  422186b6-b6c1-50c5-c0d2-b88f19994c0d
      Allocatables:
        Count:  59
Events:         <none>


Name:               k8s-node-594-1643019767
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Mon, 24 Jan 2022 10:27:02 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  42214291-febc-8d46-5b6a-ee9695f04a6e
      Allocatables:
        Count:  59
Events:         <none>


Name:               k8s-node-716-1643019745
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/cinder
CreationTimestamp:  Mon, 24 Jan 2022 10:26:32 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  42216625-53b0-5fff-b724-203018af9d30
      Allocatables:
        Count:  59
Events:         <none>
```

c. Node daemonset logs show new CSINodeTopology instance is created.

```
2022-01-27T19:06:26.103Z	INFO	k8sorchestrator/topology.go:371	Topology service initiated successfully	{"TraceId": "f85f0ae1-7540-4e8d-80ab-34d19a22476e"}
2022-01-27T19:06:26.139Z	INFO	k8sorchestrator/topology.go:531	Successfully created a CSINodeTopology instance for NodeName: "k8s-node-716-1643019745"	{"TraceId": "f85f0ae1-7540-4e8d-80ab-34d19a22476e"}
2022-01-27T19:06:26.139Z	INFO	k8sorchestrator/topology.go:556	Timeout is set to 1 minute(s)	{"TraceId": "f85f0ae1-7540-4e8d-80ab-34d19a22476e"}
2022-01-27T19:06:50.606Z	INFO	service/node.go:466	NodeGetInfo response: node_id:"42216625-53b0-5fff-b724-203018af9d30" max_volumes_per_node:59 accessible_topology:<> 	{"TraceId": "f85f0ae1-7540-4e8d-80ab-34d19a22476e”}
```

d. Create PVC successfull

```
root@k8s-control-253-1643019726:~# kubectl get pvc
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
example-raw-block-pvc   Bound    pvc-6dd77ca5-c651-4e82-a32b-c5595b40bb94   1Gi        RWO            example-raw-block-sc   16s
```

e. Create pod successfull

```
root@k8s-control-253-1643019726:~# kubectl get pods
NAME                    READY   STATUS    RESTARTS   AGE
example-raw-block-pod   1/1     Running   0          65s


2022-01-27T19:09:41.183Z	INFO	vanilla/controller.go:965	ControllerPublishVolume: called with args {VolumeId:59d006f6-c7ca-4272-90c6-9b358429b37c NodeId:422186b6-b6c1-50c5-c0d2-b88f19994c0d VolumeCapability:block:<> access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[storage.kubernetes.io/csiProvisionerIdentity:1643310391131-8081-csi.vsphere.vmware.com type:vSphere CNS Block Volume] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "c832bb0d-30b2-4a20-a787-8ee6675ef670"}
2022-01-27T19:09:41.197Z	DEBUG	node/manager.go:218	Renewing virtual machine VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]] with nodeUUID "422186b6-b6c1-50c5-c0d2-b88f19994c0d"	{"TraceId": "c832bb0d-30b2-4a20-a787-8ee6675ef670"}
2022-01-27T19:09:41.213Z	DEBUG	node/manager.go:225	VM VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]] was successfully renewed with nodeUUID "422186b6-b6c1-50c5-c0d2-b88f19994c0d"	{"TraceId": "c832bb0d-30b2-4a20-a787-8ee6675ef670"}
2022-01-27T19:09:41.214Z	DEBUG	vanilla/controller.go:1054	Found VirtualMachine for node:"422186b6-b6c1-50c5-c0d2-b88f19994c0d".	{"TraceId": "c832bb0d-30b2-4a20-a787-8ee6675ef670"}
2022-01-27T19:09:41.217Z	DEBUG	common/vsphereutil.go:547	vSphere CSI driver is attaching volume: "59d006f6-c7ca-4272-90c6-9b358429b37c" to vm: "VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]"	{"TraceId": "c832bb0d-30b2-4a20-a787-8ee6675ef670"}
2022-01-27T19:09:54.833Z	INFO	volume/manager.go:632	AttachVolume: volumeID: "59d006f6-c7ca-4272-90c6-9b358429b37c", vm: "VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]", opId: "3077736b"	{"TraceId": "c832bb0d-30b2-4a20-a787-8ee6675ef670"}
2022-01-27T19:09:54.834Z	INFO	volume/manager.go:667	AttachVolume: Volume attached successfully. volumeID: "59d006f6-c7ca-4272-90c6-9b358429b37c", opId: "3077736b", vm: "VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]", diskUUID: "6000C29e-c7b9-44eb-4df0-7e2c4069a390"	{"TraceId": "c832bb0d-30b2-4a20-a787-8ee6675ef670"}
2022-01-27T19:09:54.834Z	DEBUG	volume/manager.go:674	internalAttachVolume: returns fault "" for volume "59d006f6-c7ca-4272-90c6-9b358429b37c"	{"TraceId": "c832bb0d-30b2-4a20-a787-8ee6675ef670"}
2022-01-27T19:09:54.836Z	DEBUG	common/vsphereutil.go:553	Successfully attached disk 59d006f6-c7ca-4272-90c6-9b358429b37c to VM VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]. Disk UUID is 6000C29e-c7b9-44eb-4df0-7e2c4069a390	{"TraceId": "c832bb0d-30b2-4a20-a787-8ee6675ef670"}
2022-01-27T19:09:54.837Z	INFO	vanilla/controller.go:1064	ControllerPublishVolume successful with publish context: map[diskUUID:6000c29ec7b944eb4df07e2c4069a390 type:vSphere CNS Block Volume]	{"TraceId": "c832bb0d-30b2-4a20-a787-8ee6675ef670"}
2022-01-27T19:09:54.838Z	DEBUG	vanilla/controller.go:1071	controllerPublishVolumeInternal: returns fault "" for volume "59d006f6-c7ca-4272-90c6-9b358429b37c"	{"TraceId": "c832bb0d-30b2-4a20-a787-8ee6675ef670”}
```

f. Delete pod is successful 

```
2022-01-27T19:11:48.944Z	INFO	vanilla/controller.go:1095	ControllerUnpublishVolume: called with args {VolumeId:59d006f6-c7ca-4272-90c6-9b358429b37c NodeId:422186b6-b6c1-50c5-c0d2-b88f19994c0d Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "b10a26a5-5397-4ed4-818a-2d6bbb6082ba"}
2022-01-27T19:11:48.975Z	DEBUG	node/manager.go:218	Renewing virtual machine VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]] with nodeUUID "422186b6-b6c1-50c5-c0d2-b88f19994c0d"	{"TraceId": "b10a26a5-5397-4ed4-818a-2d6bbb6082ba"}
2022-01-27T19:11:48.985Z	DEBUG	node/manager.go:225	VM VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]] was successfully renewed with nodeUUID "422186b6-b6c1-50c5-c0d2-b88f19994c0d"	{"TraceId": "b10a26a5-5397-4ed4-818a-2d6bbb6082ba"}
2022-01-27T19:11:48.986Z	DEBUG	common/vsphereutil.go:563	vSphere CSI driver is detaching volume: 59d006f6-c7ca-4272-90c6-9b358429b37c from node vm: 	{"TraceId": "b10a26a5-5397-4ed4-818a-2d6bbb6082ba"}
2022-01-27T19:11:49.831Z	INFO	volume/manager.go:753	DetachVolume: volumeID: "59d006f6-c7ca-4272-90c6-9b358429b37c", vm: "VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]", opId: "3077740a"	{"TraceId": "b10a26a5-5397-4ed4-818a-2d6bbb6082ba"}
2022-01-27T19:11:49.832Z	INFO	volume/util.go:364	Extract vimfault type: +*types.NotFound  vimFault: +&{{{<nil> []}}} Fault: &{DynamicData:{} Fault:0xc00060df60 LocalizedMessage:The object or item referred to could not be found.} from resp: +&{{} {{} } 0xc00060df40}	{"TraceId": "b10a26a5-5397-4ed4-818a-2d6bbb6082ba"}
2022-01-27T19:11:49.865Z	DEBUG	volume/util.go:112	Volume 59d006f6-c7ca-4272-90c6-9b358429b37c is not attached to VM: VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]	{"TraceId": "b10a26a5-5397-4ed4-818a-2d6bbb6082ba"}
2022-01-27T19:11:49.865Z	INFO	volume/manager.go:780	DetachVolume: volumeID: "59d006f6-c7ca-4272-90c6-9b358429b37c" not found on vm: VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]]. Assuming it is already detached	{"TraceId": "b10a26a5-5397-4ed4-818a-2d6bbb6082ba"}
2022-01-27T19:11:49.865Z	DEBUG	volume/manager.go:795	internalDetachVolume: returns fault "" for volume "59d006f6-c7ca-4272-90c6-9b358429b37c"	{"TraceId": "b10a26a5-5397-4ed4-818a-2d6bbb6082ba"}
2022-01-27T19:11:49.865Z	DEBUG	common/vsphereutil.go:569	Successfully detached disk 59d006f6-c7ca-4272-90c6-9b358429b37c from VM VirtualMachine:vm-51 [VirtualCenterHost: 10.184.71.111, UUID: 422186b6-b6c1-50c5-c0d2-b88f19994c0d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.184.71.111]].	{"TraceId": "b10a26a5-5397-4ed4-818a-2d6bbb6082ba"}
2022-01-27T19:11:49.865Z	INFO	vanilla/controller.go:1184	ControllerUnpublishVolume successful for volume ID: 59d006f6-c7ca-4272-90c6-9b358429b37c	{"TraceId": "b10a26a5-5397-4ed4-818a-2d6bbb6082ba"}
2022-01-27T19:11:49.865Z	DEBUG	vanilla/controller.go:1189	controllerUnpublishVolumeInternal: returns fault "" for volume "59d006f6-c7ca-4272-90c6-9b358429b37c"	{"TraceId": "b10a26a5-5397-4ed4-818a-2d6bbb6082ba”}
```

**Make check result**

```
bdontu-a02:vsphere-csi-driver bdontu$ make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/bdontu/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/bdontu/src/go/src/github.com/BaluDontu/vsphere-csi-driver /Users/bdontu/src/go/src/github.com/BaluDontu /Users/bdontu/src/go/src/github.com /Users/bdontu/src/go/src /Users/bdontu/src/go /Users/bdontu/src /Users/bdontu /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (name|types_sizes|compiled_files|files|imports|deps|exports_file) took 3.614797782s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 178.570657ms 
INFO [linters context/goanalysis] analyzers took 10.032954285s with top 10 stages: buildir: 6.334882562s, misspell: 232.008516ms, unused: 208.22463ms, directives: 191.830427ms, S1038: 174.283586ms, printf: 123.914143ms, ctrlflow: 107.476714ms, S1012: 100.461434ms, bools: 94.140083ms, S1024: 93.692457ms 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_dirs: 110/110, identifier_marker: 21/21, exclude-rules: 1/21, nolint: 0/1, cgo: 110/110, filename_unadjuster: 110/110, exclude: 21/21, autogenerated_exclude: 21/110, path_prettifier: 110/110, skip_files: 110/110 
INFO [runner] processing took 12.57866ms with stages: nolint: 9.963413ms, autogenerated_exclude: 1.193658ms, path_prettifier: 838.369µs, identifier_marker: 293.967µs, skip_dirs: 158.624µs, exclude-rules: 109.189µs, filename_unadjuster: 8.755µs, cgo: 8.454µs, max_same_issues: 1.032µs, uniq_by_line: 579ns, diff: 355ns, source_code: 354ns, max_from_linter: 297ns, exclude: 272ns, max_per_file_from_linter: 268ns, skip_files: 241ns, path_shortener: 239ns, severity-rules: 238ns, sort_results: 222ns, path_prefixer: 134ns 
INFO [runner] linters took 6.479924116s with stages: goanalysis_metalinter: 6.467254599s 
INFO File cache stats: 68 entries of total size 980.0KiB 
INFO Memory: 104 samples, avg is 272.4MB, max is 748.9MB 
INFO Execution took 10.285675146s        
```

**Release note**:
```release-note
Support for Improved Volume topology feature when Use-CSINode-Id feature is enabled
```

cc @divyenpatel @shalini-b 