### PR TITLE
ignore the default-token-* volumes attached to pods

### DIFF
--- a/tests/e2e/vcp_to_csi_attach_detach.go
+++ b/tests/e2e/vcp_to_csi_attach_detach.go
@@ -512,11 +512,15 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration attach, detach tests
 		deletePodAndWaitForVolsToDetach(ctx, client, pod18)
 
 		ginkgo.By("Restart CSI driver")
+		csiDeployment, err := client.AppsV1().Deployments(csiNamespace).Get(
+			ctx, vSphereCSIControllerPodNamePrefix, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		csiReplicas := csiDeployment.Spec.Replicas
 		framework.Logf("Stopping CSI driver")
 		err = updateDeploymentReplicawithWait(client, 0, vSphereCSIControllerPodNamePrefix, csiNamespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		framework.Logf("Starting CSI driver")
-		err = updateDeploymentReplicawithWait(client, 1, vSphereCSIControllerPodNamePrefix, csiNamespace)
+		err = updateDeploymentReplicawithWait(client, *csiReplicas, vSphereCSIControllerPodNamePrefix, csiNamespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Re-create pod for test18")
@@ -1115,6 +1119,9 @@ func deletePodsAndWaitForVolsToDetach(
 			}
 			for _, vol := range pod.Spec.Volumes {
 				if strings.Contains(vol.Name, "kube-api-access") {
+					continue
+				}
+				if strings.Contains(vol.Name, "token") {
 					continue
 				}
 				pv := getPvFromClaim(client, pod.Namespace, vol.PersistentVolumeClaim.ClaimName)

--- a/tests/e2e/vcp_to_csi_syncer.go
+++ b/tests/e2e/vcp_to_csi_syncer.go
@@ -1525,6 +1525,9 @@ func getPodTryingToUsePvc(ctx context.Context, c clientset.Interface, namespace 
 			if strings.Contains(volume.Name, "kube-api-access") {
 				continue
 			}
+			if strings.Contains(volume.Name, "token") {
+				continue
+			}
 			if volume.VolumeSource.PersistentVolumeClaim != nil &&
 				volume.VolumeSource.PersistentVolumeClaim.ClaimName == pvcName {
 				return &pod


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This is a continuation of the fixes made in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1485

Added code to,
1. ignore default-token-* volumes in couple of places more
2. csi controller replica count was set to 1 always when it was started back up, fixed it

**Testing done**:
https://gist.github.com/sashrith/7aa13dc56ab84c15d6637a7a0c470b8f

**Special notes for your reviewer**:
```zsh
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver vcp2csi223rc1failure ⇡ ❯ make check                             13:42:41
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sashrith/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sashrith/csi/vsphere-csi-driver /Users/sashrith/csi /Users/sashrith /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (types_sizes|deps|exports_file|files|compiled_files|imports|name) took 3.03525734s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 91.989942ms
INFO [linters context/goanalysis] analyzers took 28.983774113s with top 10 stages: buildir: 11.803754802s, misspell: 1.313486615s, S1038: 1.140641358s, directives: 805.315841ms, SA1012: 618.967254ms, unused: 599.64036ms, S1039: 595.644174ms, S1028: 469.583133ms, fact_deprecated: 465.150044ms, printf: 398.807188ms
INFO [runner] Issues before processing: 112, after processing: 2
INFO [runner] Processors filtering stat (out/in): nolint: 2/3, uniq_by_line: 2/2, max_per_file_from_linter: 2/2, path_prefixer: 2/2, cgo: 112/112, path_prettifier: 112/112, skip_dirs: 112/112, exclude-rules: 3/23, sort_results: 2/2, skip_files: 112/112, autogenerated_exclude: 23/112, exclude: 23/23, max_from_linter: 2/2, source_code: 2/2, path_shortener: 2/2, filename_unadjuster: 112/112, identifier_marker: 23/23, diff: 2/2, max_same_issues: 2/2, severity-rules: 2/2
INFO [runner] processing took 20.15219ms with stages: nolint: 13.415721ms, autogenerated_exclude: 4.701683ms, identifier_marker: 798.671µs, path_prettifier: 668.256µs, exclude-rules: 208.085µs, source_code: 168.959µs, skip_dirs: 162.235µs, filename_unadjuster: 8.306µs, cgo: 7.625µs, uniq_by_line: 3.949µs, max_same_issues: 2.996µs, max_from_linter: 1.428µs, path_shortener: 1.366µs, max_per_file_from_linter: 804ns, skip_files: 510ns, diff: 432ns, sort_results: 374ns, exclude: 361ns, severity-rules: 282ns, path_prefixer: 147ns
INFO [runner] linters took 8.151939679s with stages: goanalysis_metalinter: 8.13160532s
pkg/csi/service/osutils/linux_os_utils_test.go:19: line is 185 characters (lll)
			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
pkg/csi/service/osutils/linux_os_utils_test.go:20: line is 182 characters (lll)
			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
INFO File cache stats: 206 entries of total size 3.6MiB
INFO Memory: 114 samples, avg is 394.7MB, max is 954.1MB
INFO Execution took 11.289314344s
make: *** [golangci-lint] Error 1
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver vcp2csi223rc1failure ⇡ 2m 10s ❯
```
The linter errors above are currently present on the master as well.