### PR TITLE
fix linter failure for long line

### DIFF
--- a/pkg/csi/service/osutils/linux_os_utils_test.go
+++ b/pkg/csi/service/osutils/linux_os_utils_test.go
@@ -16,8 +16,12 @@ func TestUnescape(t *testing.T) {
 		{
 			// Space is unescaped. This is basically the only test that can happen in reality
 			// and only when in-tree in-line volume in a Pod is used with CSI migration enabled.
-			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
-			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+			in: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com` +
+				`-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/` +
+				`e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com` +
+				`-[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/` +
+				`e2e-vmdk-1641374604660540311.vmdk/globalmount`,
 		},
 		{
 			// Multiple spaces are unescaped.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix linter failure for a long line.

before this fix

```
rpanduranga@rpanduranga-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/rpanduranga/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/rpanduranga/CSI-Code/vsphere-csi-driver /Users/rpanduranga/CSI-Code /Users/rpanduranga /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (types_sizes|deps|exports_file|imports|compiled_files|files|name) took 1.943415239s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 94.486074ms 
INFO [linters context/goanalysis] analyzers took 27.728598444s with top 10 stages: buildir: 12.5657634s, misspell: 1.417699449s, S1038: 1.007893945s, unused: 727.636087ms, S1039: 598.586833ms, printf: 517.81945ms, S1028: 485.519538ms, SA1012: 477.420637ms, directives: 422.386659ms, ctrlflow: 349.226644ms 
INFO [runner] Issues before processing: 112, after processing: 2 
INFO [runner] Processors filtering stat (out/in): max_per_file_from_linter: 2/2, max_same_issues: 2/2, nolint: 2/3, filename_unadjuster: 112/112, source_code: 2/2, cgo: 112/112, skip_files: 112/112, skip_dirs: 112/112, autogenerated_exclude: 23/112, exclude-rules: 3/23, uniq_by_line: 2/2, max_from_linter: 2/2, sort_results: 2/2, path_prettifier: 112/112, exclude: 23/23, diff: 2/2, path_shortener: 2/2, severity-rules: 2/2, path_prefixer: 2/2, identifier_marker: 23/23 
INFO [runner] processing took 14.187898ms with stages: nolint: 11.103036ms, autogenerated_exclude: 1.557741ms, path_prettifier: 685.415µs, identifier_marker: 316.815µs, source_code: 202.109µs, skip_dirs: 153.768µs, exclude-rules: 139.715µs, cgo: 9.08µs, filename_unadjuster: 8.783µs, max_same_issues: 3.084µs, uniq_by_line: 2.607µs, max_from_linter: 1.393µs, path_shortener: 1.31µs, max_per_file_from_linter: 1.095µs, sort_results: 493ns, diff: 357ns, skip_files: 326ns, path_prefixer: 278ns, exclude: 261ns, severity-rules: 232ns 
INFO [runner] linters took 9.001190457s with stages: goanalysis_metalinter: 8.986821379s 
pkg/csi/service/osutils/linux_os_utils_test.go:19: line is 185 characters (lll)
                        in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
pkg/csi/service/osutils/linux_os_utils_test.go:20: line is 182 characters (lll)
                        out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
INFO File cache stats: 195 entries of total size 3.6MiB 
INFO Memory: 111 samples, avg is 460.4MB, max is 1020.7MB 
INFO Execution took 11.051911002s                 
make: *** [golangci-lint] Error 1
```



**Testing done**:

Yes


```
=== RUN   TestUnescape
=== RUN   TestUnescape/0
=== PAUSE TestUnescape/0
=== RUN   TestUnescape/1
=== PAUSE TestUnescape/1
=== RUN   TestUnescape/2
=== PAUSE TestUnescape/2
=== RUN   TestUnescape/3
=== PAUSE TestUnescape/3
=== CONT  TestUnescape/0
=== CONT  TestUnescape/2
=== CONT  TestUnescape/1
=== CONT  TestUnescape/3
{"level":"info","time":"2022-01-31T11:05:28.941161-08:00","caller":"osutils/linux_os_utils.go:1037","msg":"Error parsing mount \"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\\\\04\": invalid syntax"}
{"level":"info","time":"2022-01-31T11:05:28.941273-08:00","caller":"osutils/linux_os_utils.go:1037","msg":"Error parsing mount \"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\\\\0bc\": invalid syntax"}
--- PASS: TestUnescape (0.00s)
    --- PASS: TestUnescape/0 (0.00s)
    --- PASS: TestUnescape/1 (0.00s)
    --- PASS: TestUnescape/2 (0.00s)
    --- PASS: TestUnescape/3 (0.00s)
```


```
% make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/divyenp/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/divyenp/go/src/github.com/divyenpatel/vsphere-csi-driver /Users/divyenp/go/src/github.com/divyenpatel /Users/divyenp/go/src/github.com /Users/divyenp/go/src /Users/divyenp/go /Users/divyenp /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|imports|name|files|types_sizes) took 1.469772169s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 90.618457ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 110/110, nolint: 0/1, filename_unadjuster: 110/110, skip_files: 110/110, autogenerated_exclude: 21/110, identifier_marker: 21/21, exclude: 21/21, cgo: 110/110, skip_dirs: 110/110, exclude-rules: 1/21 
INFO [runner] processing took 9.837609ms with stages: nolint: 8.064997ms, autogenerated_exclude: 888.992µs, path_prettifier: 392.68µs, identifier_marker: 240.594µs, exclude-rules: 108.488µs, skip_dirs: 105.396µs, cgo: 22.625µs, filename_unadjuster: 10.604µs, max_same_issues: 666ns, uniq_by_line: 432ns, max_from_linter: 284ns, diff: 258ns, exclude: 253ns, source_code: 234ns, skip_files: 209ns, path_shortener: 207ns, severity-rules: 198ns, sort_results: 193ns, max_per_file_from_linter: 181ns, path_prefixer: 118ns 
INFO [runner] linters took 1.798792395s with stages: goanalysis_metalinter: 1.788878079s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 35 samples, avg is 111.7MB, max is 140.9MB 
INFO Execution took 3.368957682s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix linter failure for long line
```
