### PR TITLE
Pv to BackingDiskObjectId mapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae
-	github.com/vmware/govmomi v0.27.0
+	github.com/vmware/govmomi v0.27.4
 	go.uber.org/zap v1.17.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
@@ -36,7 +36,6 @@ require (
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/yaml.v2 v2.4.0
-	honnef.co/go/tools v0.2.0 // indirect
 	k8s.io/api v0.21.1
 	k8s.io/apiextensions-apiserver v0.21.1
 	k8s.io/apimachinery v0.21.1

--- a/go.sum
+++ b/go.sum
@@ -688,8 +688,8 @@ github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1
 github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae h1:R7ukgIC/uN4vULAvwWJxuq2XLcUEJkR4psxdRNssqSI=
 github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/vmware/govmomi v0.27.0 h1:KoQ8IsLAa7V78s5d7dgpZA8d039GBM83cVxgAq9uWuw=
-github.com/vmware/govmomi v0.27.0/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
+github.com/vmware/govmomi v0.27.4 h1:5kY8TAkhB20lsjzrjE073eRb8+HixBI29PVMG5lxq6I=
+github.com/vmware/govmomi v0.27.4/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
@@ -783,7 +783,6 @@ golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1106,8 +1105,6 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
-honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 k8s.io/api v0.21.1 h1:94bbZ5NTjdINJEdzOkpS4vdPhkb1VFpTYC9zh43f75c=
 k8s.io/api v0.21.1/go.mod h1:FstGROTmsSHBarKc8bylzXih8BLNYTiS3TZcsoEDg2s=
 k8s.io/apiextensions-apiserver v0.21.1 h1:AA+cnsb6w7SZ1vD32Z+zdgfXdXY8X9uGX5bN6EoPEIo=

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -18,8 +18,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "persistentvolumeclaims", "pods", "configmaps"]
+    resources: ["nodes", "pods", "configmaps"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]
     verbs: ["patch"]
@@ -150,6 +153,7 @@ data:
   "csi-windows-support": "false"
   "use-csinode-id": "false"
   "list-volumes": "false"
+  "pv-to-backingdiskobjectid-mapping": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -297,3 +297,20 @@ func IsvSphere8AndAbove(ctx context.Context, aboutInfo vim25types.AboutInfo) (bo
 	// For all other versions.
 	return false, nil
 }
+
+// CheckPVtoBackingDiskObjectIdSupport internally checks if the vCenter version is 7.0.2.
+// Support both vsan and vvol.
+func CheckPVtoBackingDiskObjectIdSupport(ctx context.Context, vc *cnsvsphere.VirtualCenter) bool {
+	log := logger.GetLogger(ctx)
+	currentVcVersion := vc.Client.ServiceContent.About.ApiVersion
+	err := CheckAPI(currentVcVersion, PVtoBackingDiskObjectIdSupportedVCenterMajor, PVtoBackingDiskObjectIdSupportedVCenterMinor,
+		PVtoBackingDiskObjectIdSupportedVCenterPatch)
+	if err != nil {
+		log.Errorf("checkAPI failed for PV to BackingDiskObjectId mapping support on vCenter API version: %s, err=%v",
+			currentVcVersion, err)
+		return false
+	}
+	// vCenter version supported.
+	log.Infof("vCenter API version: %s supports CNS PV to BackingDiskObjectId mapping.", currentVcVersion)
+	return true
+}

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -271,6 +271,18 @@ const (
 
 	//AnnVolumeAccessibleTopology is the annotation set by the supervisor cluster on PVC
 	AnnVolumeAccessibleTopology = "csi.vsphere.volumeAccessibleTopology"
+
+	// PVtoBackingDiskObjectIdSupportedVCenterMajor is the minimum major version of vCenter
+	// on which PV to BackingDiskObjectId mapping feature is supported.
+	PVtoBackingDiskObjectIdSupportedVCenterMajor int = 7
+
+	// PVtoBackingDiskObjectIdSupportedVCenterMinor is the minimum minor version of vCenter
+	// on which PV to BackingDiskObjectId mapping feature is supported.
+	PVtoBackingDiskObjectIdSupportedVCenterMinor int = 0
+
+	// PVtoBackingDiskObjectIdSupportedVCenterPatch is the minimum patch version of vCenter
+	// on which PV to BackingDiskObjectId mapping feature is supported.
+	PVtoBackingDiskObjectIdSupportedVCenterPatch int = 2
 )
 
 // Supported container orchestrators.
@@ -332,4 +344,6 @@ const (
 	TKGsHA = "tkgs-ha"
 	// ListVolumes is the feature to support list volumes API
 	ListVolumes = "list-volumes"
+	// PVtoBackingDiskObjectIdMapping is the feature to support pv to backingDiskObjectId mapping on vSphere CSI driver.
+	PVtoBackingDiskObjectIdMapping = "pv-to-backingdiskobjectid-mapping"
 )

--- a/pkg/syncer/pv_to_backingdiskobjectid_mapping.go
+++ b/pkg/syncer/pv_to_backingdiskobjectid_mapping.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"strings"
+
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
+)
+
+// TODO: refactor pv to backingdiskobjectid and volume health code to reduce duplicated code
+func csiGetPVtoBackingDiskObjectIdMapping(ctx context.Context, k8sclient clientset.Interface,
+	metadataSyncer *metadataSyncInformer) {
+	log := logger.GetLogger(ctx)
+	log.Debug("csiGetPVtoBackingDiskObjectIdMapping: start")
+	// Call CNS QueryAll to get container volumes by cluster ID.
+	queryFilter := cnstypes.CnsQueryFilter{
+		ContainerClusterIds: []string{
+			metadataSyncer.configInfo.Cfg.Global.ClusterID,
+		},
+	}
+
+	querySelection := cnstypes.CnsQuerySelection{
+		Names: []string{
+			string(cnstypes.QuerySelectionNameTypeBackingObjectDetails),
+		},
+	}
+	queryAllResult, err := metadataSyncer.volumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
+	if err != nil {
+		log.Errorf("csiGetPVtoBackingDiskObjectIdMapping: failed to QueryAllVolume with err=%+v", err.Error())
+		return
+	}
+
+	// Get K8s PVs in State "Bound".
+	k8sPVs, err := getBoundPVs(ctx, metadataSyncer)
+	if err != nil {
+		log.Errorf("csiGetPVtoBackingDiskObjectIdMapping: Failed to get PVs from kubernetes. Err: %+v", err)
+		return
+	}
+
+	// volumeHandleToPvcMap maps pv.Spec.CSI.VolumeHandle to the pvc object which
+	// bounded to the pv.
+	volumeHandleToPvcMap := make(volumeHandlePVCMap, len(k8sPVs))
+	// volumeHandleToPvUidMap maps volumehandle to pv uid
+	volumeHandleToPvUidMap := make(volumeIdToPvUidMap, len(k8sPVs))
+
+	for _, pv := range k8sPVs {
+		if pv.Spec.ClaimRef != nil && pv.Status.Phase == v1.VolumeBound {
+			pvc, err := metadataSyncer.pvcLister.PersistentVolumeClaims(
+				pv.Spec.ClaimRef.Namespace).Get(pv.Spec.ClaimRef.Name)
+			if err != nil {
+				log.Warnf("csiGetPVtoBackingDiskObjectIdMapping: Failed to get pvc for namespace %s and name %s. err=%+v",
+					pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name, err)
+				continue
+			}
+			volumeHandleToPvcMap[pv.Spec.CSI.VolumeHandle] = pvc
+			log.Debugf("csiGetPVtoBackingDiskObjectIdMapping: pvc %s/%s is backed by pv %s volumeHandle %s, pv uid is %s",
+				pvc.Namespace, pvc.Name, pv.Name, pv.Spec.CSI.VolumeHandle, string(pv.UID))
+			volumeHandleToPvUidMap[pv.Spec.CSI.VolumeHandle] = string(pv.UID)
+		}
+	}
+
+	// pv to backingDiskObjectId Map maps vol.VolumeId.Id to backingobjectId.
+	volumeIdToBackingObjectIdMap := make(volumeIdToPvUidMap, len(queryAllResult.Volumes))
+
+	for _, vol := range queryAllResult.Volumes {
+		// NOTE: BackingDiskObjectId is the id of vvol or vSan; BackingDiskId is the same as VolumeId.
+		volumeIdToBackingObjectIdMap[vol.VolumeId.Id] = vol.BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).BackingDiskObjectId
+	}
+
+	for volID, pvc := range volumeHandleToPvcMap {
+		pvToBackingDiskObjectIdPair := volumeHandleToPvUidMap[volID] + ":" + volumeIdToBackingObjectIdMap[volID]
+		updated, err := updatePVtoBackingDiskObjectIdMappingStatus(ctx, k8sclient, pvc, pvToBackingDiskObjectIdPair)
+		if err != nil {
+			log.Error("csiGetPVtoBackingDiskObjectIdMapping: Failed to update pv to backingDiskObjectId mapping")
+			return
+		}
+		if updated {
+			log.Infof("csiGetPVtoBackingDiskObjectIdMapping: pvc %s is updated with pv to backingDiskObjectId mapping %s", pvc.Name, pvToBackingDiskObjectIdPair)
+		}
+	}
+
+	log.Debug("csiGetPVtoBackingDiskObjectIdMapping: end")
+}
+
+func validatePvToBackingDiskObjectIdPair(pvToBackingDiskObjectIdPair string) bool {
+	split := strings.Split(pvToBackingDiskObjectIdPair, ":")
+	if len(split) < 2 {
+		return false
+	}
+	if split[0] == "" || split[1] == "" {
+		return false
+	}
+	return true
+}
+
+func updatePVtoBackingDiskObjectIdMappingStatus(ctx context.Context, k8sclient clientset.Interface,
+	pvc *v1.PersistentVolumeClaim, pvToBackingDiskObjectIdPair string) (bool, error) {
+	log := logger.GetLogger(ctx)
+
+	val, found := pvc.Annotations[annPVtoBackingDiskObjectId]
+	isValidate := validatePvToBackingDiskObjectIdPair(pvToBackingDiskObjectIdPair)
+
+	if !isValidate {
+		if !found {
+			log.Debugf("updatePVtoBackingDiskObjectIdMappingStatus: no previous mapping found in annotation. No need to update.")
+			return false, nil
+		} else {
+			// If there is any previous pv to backingdiskobjectid mapping found, set it as empty as queryAll returns nothing in this cycle
+			pvToBackingDiskObjectIdPair = ""
+		}
+	}
+
+	if !found || val != pvToBackingDiskObjectIdPair {
+		// PVToBackingDiskObjectId annotation on pvc is changed, set it to new value.
+		metav1.SetMetaDataAnnotation(&pvc.ObjectMeta, annPVtoBackingDiskObjectId, pvToBackingDiskObjectIdPair)
+
+		log.Infof("updatePVtoBackingDiskObjectIdMappingStatus: set pv to backingdiskobjectid annotation for pvc %s/%s from old "+
+			"value %s to new value %s",
+			pvc.Namespace, pvc.Name, val, pvToBackingDiskObjectIdPair)
+		_, err := k8sclient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(ctx, pvc, metav1.UpdateOptions{})
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				log.Debugf("updatePVtoBackingDiskObjectIdMappingStatus: Failed to update pvc %s/%s with err:%+v, will retry the update",
+					pvc.Namespace, pvc.Name, err)
+				// pvc get from pvcLister may be stale, try to get updated pvc which
+				// bound to pv from API server.
+				newPvc, err := k8sclient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(
+					ctx, pvc.Name, metav1.GetOptions{})
+				if err != nil {
+					log.Errorf("updatePVtoBackingDiskObjectIdMappingStatus: pv to backingdiskobjectid annotation for pvc %s/%s is not updated because "+
+						"failed to get pvc from API server. err=%+v",
+						pvc.Namespace, pvc.Name, err)
+					return false, err
+				}
+
+				log.Infof("updatePVtoBackingDiskObjectIdMappingStatus: updating pv to backingdiskobjectid annotation for pvc %s/%s which "+
+					"get from API server from old value %s to new value %s",
+					newPvc.Namespace, newPvc.Name, val, pvToBackingDiskObjectIdPair)
+				metav1.SetMetaDataAnnotation(&newPvc.ObjectMeta, annPVtoBackingDiskObjectId, pvToBackingDiskObjectIdPair)
+				_, err = k8sclient.CoreV1().PersistentVolumeClaims(newPvc.Namespace).Update(ctx,
+					newPvc, metav1.UpdateOptions{})
+				if err != nil {
+					log.Errorf("updatePVtoBackingDiskObjectIdMappingStatus: Failed to update pvc %s/%s with err:%+v",
+						newPvc.Namespace, newPvc.Name, err)
+					return false, err
+				} else {
+					return true, nil
+				}
+			} else {
+				log.Errorf("updatePVtoBackingDiskObjectIdMappingStatus: pv to backingdiskobjectid annotation for pvc %s/%s is not updated because "+
+					"failed to get pvc from API server. err=%+v",
+					pvc.Namespace, pvc.Name, err)
+				return false, err
+			}
+
+		}
+		log.Debug("updatePVtoBackingDiskObjectIdMappingStatus: annotation on pvc updated")
+		return true, nil
+	}
+	log.Debug("updatePVtoBackingDiskObjectIdMappingStatus: no change to annotation on pvc, skip update")
+	return false, nil
+}

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -45,6 +45,9 @@ const (
 	// key for HealthStatus annotation on PVC
 	annVolumeHealth = "volumehealth.storage.kubernetes.io/health"
 
+	// key for PV to backingDiskObjectId mapping annotation on PVC
+	annPVtoBackingDiskObjectId = "cns.vmware.com/pv-to-backingdiskobjectid-mapping"
+
 	// key for expressing timestamp for volume health annotation
 	annVolumeHealthTS = "volumehealth.storage.kubernetes.io/health-timestamp"
 
@@ -61,6 +64,9 @@ const (
 	volumeHealthWorkers = 10
 	// key for dynamically provisioned PV in volume attributes of PV spec
 	attribCSIProvisionerID = "storage.kubernetes.io/csiProvisionerIdentity"
+
+	// default interval for pv to backingdiskobjectid mapping
+	defaultPVtoBackingDiskObjectIdIntervalInMin = 10
 )
 
 var (
@@ -89,6 +95,8 @@ type (
 	volumeHandlePVCMap = map[string]*v1.PersistentVolumeClaim
 	// Maps CnsVolume's VolumeId.Id to vol.HealthStatus
 	volumeIdHealthStatusMap = map[string]string
+	// Maps CnsVolume's VolumeId.Id to pvuid
+	volumeIdToPvUidMap = map[string]string
 )
 
 type metadataSyncInformer struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Implement PV to BackingDiskObjectId mapping in Vanilla Cluster.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
1. Manually tested whether feature state works.
2. Manually tested and check pvc annotation:
```
# kubectl get pvc -n test-pv-to-objectId -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      cns.vmware.com/pv-to-backingdiskobjectid-mapping: b2ac2c4b-3f79-49be-9682-b266e732abcf:45f4e85a-8019-4655-b50c-77764e86ce75
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
    creationTimestamp: "2022-02-07T00:05:24Z"
    finalizers:
    - kubernetes.io/pvc-protection
    labels:
      app: kibishii
    managedFields:
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        f:metadata:
          f:labels:
            .: {}
            f:app: {}
        f:spec:
          f:accessModes: {}
          f:resources:
            f:requests:
              .: {}
              f:storage: {}
          f:storageClassName: {}
          f:volumeMode: {}
      manager: backup-driver-server
      operation: Update
      time: "2022-02-07T00:05:24Z"
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        f:metadata:
          f:annotations:
            .: {}
            f:pv.kubernetes.io/bind-completed: {}
            f:pv.kubernetes.io/bound-by-controller: {}
            f:volume.beta.kubernetes.io/storage-provisioner: {}
        f:spec:
          f:volumeName: {}
        f:status:
          f:accessModes: {}
          f:capacity:
            .: {}
            f:storage: {}
          f:phase: {}
      manager: kube-controller-manager
      operation: Update
      time: "2022-02-07T00:05:26Z"
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        f:metadata:
          f:annotations:
            f:cns.vmware.com/pv-to-backingdiskobjectid-mapping: {}
      manager: vsphere-syncer
      operation: Update
      time: "2022-02-08T00:44:42Z"
    name: kibishii-data-kibishii-deployment-0
    namespace: test-ns-llszpls
    resourceVersion: "279113"
    uid: 3f96c332-1fca-407b-a8df-38338adc702d
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 100Mi
    storageClassName: kibishii-storage-class
    volumeMode: Filesystem
    volumeName: pvc-3f96c332-1fca-407b-a8df-38338adc702d
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 100Mi
    phase: Bound
```
 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Implement PV to BackingDiskObjectId mapping in Vanilla Cluster.
```
