### PR TITLE
remove dependency on driver packages from e2e tests - part1

### DIFF
--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -45,7 +45,6 @@ import (
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
 var _ = ginkgo.Describe("Basic Static Provisioning", func() {
@@ -558,7 +557,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		// Create supvervisor cluster client.
 		var svcClient clientset.Interface
 		if k8senv := GetAndExpectStringEnvVar("SUPERVISOR_CLUSTER_KUBE_CONFIG"); k8senv != "" {
-			svcClient, err = k8s.CreateKubernetesClientFromConfig(k8senv)
+			svcClient, err = createKubernetesClientFromConfig(k8senv)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		svNamespace := GetAndExpectStringEnvVar(envSupervisorClusterNamespace)

--- a/tests/e2e/data_persistence.go
+++ b/tests/e2e/data_persistence.go
@@ -36,7 +36,6 @@ import (
 	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 )
 
 // Steps
@@ -311,7 +310,6 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		var volumeFiles []string
 
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
 		defer cancel()
 
 		// Get a config to talk to the apiserver.
@@ -328,7 +326,7 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		ginkgo.By("Get the Profile ID")
 		ginkgo.By(fmt.Sprintf("storagePolicyName: %s", storagePolicyName))
 		profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
-		log.Infof("Profile ID :%s", profileID)
+		framework.Logf("Profile ID :%s", profileID)
 		scParameters := make(map[string]string)
 		scParameters["storagePolicyID"] = profileID
 
@@ -349,7 +347,7 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		framework.ExpectNoError(waitForCNSRegisterVolumeToGetCreated(ctx,
 			restConfig, namespace, cnsRegisterVolume, poll, pollTimeout))
 		cnsRegisterVolumeName := cnsRegisterVolume.GetName()
-		log.Infof("cnsRegisterVolumeName : %s", cnsRegisterVolumeName)
+		framework.Logf("cnsRegisterVolumeName : %s", cnsRegisterVolumeName)
 
 		ginkgo.By("verify created PV, PVC and check the bidirectional referance")
 		pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -52,6 +52,7 @@ const (
 	diskSizeInMinMb                            = int64(200)
 	e2eTestPassword                            = "E2E-test-password!23"
 	e2evSphereCSIDriverName                    = "csi.vsphere.vmware.com"
+	envClusterFlavor                           = "CLUSTER_FLAVOR"
 	envCSINamespace                            = "CSI_NAMESPACE"
 	envEsxHostIP                               = "ESX_TEST_HOST_IP"
 	envFileServiceDisabledSharedDatastoreURL   = "FILE_SERVICE_DISABLED_SHARED_VSPHERE_DATASTORE_URL"

--- a/tests/e2e/gc_block_resize_retain_policy.go
+++ b/tests/e2e/gc_block_resize_retain_policy.go
@@ -40,7 +40,6 @@ import (
 	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
 var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation policy retain", func() {
@@ -170,11 +169,11 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 	//    policy set to 'Retain'.
 	// 2. create a GC PVC using the SC created in step 1 and wait for binding
 	//    with PV.
-	// 3. Create a pod  in GC to use PVC created in step 2 and file system init.
+	// 3. Create a pod  in GC to use PVC created in step 2 and file system init.
 	// 4. Delete GC pod created in step 3.
 	// 5. Delete GC PVC created in step 2.
 	// 6. Verify GC PVC is removed but SVC PVC, PV and GC PV still exists.
-	// 7. Remove claimRef from the PV lingering in GC  to get it to Available
+	// 7. Remove claimRef from the PV lingering in GC  to get it to Available
 	//    state.
 	// 8. Create new PVC in GC using the PV lingering in GC using the same SC
 	//    from step 1.
@@ -378,7 +377,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 	//    policy set to delete.
 	// 8. Create new PV in GC2 using the SVC PVC from step 5 and SC created in
 	//    step 7.
-	// 9. create new  PVC in GC2 using PV created in step 8.
+	// 9. create new  PVC in GC2 using PV created in step 8.
 	// 10. verify a new PVC API object is created.
 	// 11. Resize PVC from step 9 in GC2.
 	// 12. Wait for PVC in GC2 and SVC to reach "FilesystemResizePending" state.
@@ -396,7 +395,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		if newGcKubconfigPath == "" {
 			ginkgo.Skip("Env NEW_GUEST_CLUSTER_KUBE_CONFIG is missing")
 		}
-		clientNewGc, err = k8s.CreateKubernetesClientFromConfig(newGcKubconfigPath)
+		clientNewGc, err = createKubernetesClientFromConfig(newGcKubconfigPath)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 			fmt.Sprintf("Error creating k8s client with %v: %v", newGcKubconfigPath, err))
 		ginkgo.By("Creating namespace on second GC")
@@ -795,7 +794,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		if newGcKubconfigPath == "" {
 			ginkgo.Skip("Env NEW_GUEST_CLUSTER_KUBE_CONFIG is missing")
 		}
-		clientNewGc, err = k8s.CreateKubernetesClientFromConfig(newGcKubconfigPath)
+		clientNewGc, err = createKubernetesClientFromConfig(newGcKubconfigPath)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 			fmt.Sprintf("Error creating k8s client with %v: %v", newGcKubconfigPath, err))
 		ginkgo.By("Creating namespace on second GC")

--- a/tests/e2e/gc_cns_nodevm_attachment.go
+++ b/tests/e2e/gc_cns_nodevm_attachment.go
@@ -34,7 +34,6 @@ import (
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
 var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
@@ -285,7 +284,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 
 		var svcClient clientset.Interface
 		if k8senv := GetAndExpectStringEnvVar("SUPERVISOR_CLUSTER_KUBE_CONFIG"); k8senv != "" {
-			svcClient, err = k8s.CreateKubernetesClientFromConfig(k8senv)
+			svcClient, err = createKubernetesClientFromConfig(k8senv)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -669,7 +668,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
-		clientNewGc, err = k8s.CreateKubernetesClientFromConfig(newGcKubconfigPath)
+		clientNewGc, err = createKubernetesClientFromConfig(newGcKubconfigPath)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 			fmt.Sprintf("Error creating k8s client with %v: %v", newGcKubconfigPath, err))
 		ginkgo.By("Creating namespace on second GC")

--- a/tests/e2e/gc_metadata_syncer.go
+++ b/tests/e2e/gc_metadata_syncer.go
@@ -35,7 +35,6 @@ import (
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
 var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
@@ -1232,7 +1231,7 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 		pvStorageClass := pv.Spec.StorageClassName
 
 		// Create PV in New GC.
-		clientNewGc, err = k8s.CreateKubernetesClientFromConfig(newGcKubconfigPath)
+		clientNewGc, err = createKubernetesClientFromConfig(newGcKubconfigPath)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 			fmt.Sprintf("Error creating k8s client with %v: %v", newGcKubconfigPath, err))
 		ginkgo.By("Creating namespace on second GC")
@@ -1250,7 +1249,7 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 
 		var svClient clientset.Interface
 		if k8senvsv := GetAndExpectStringEnvVar("SUPERVISOR_CLUSTER_KUBE_CONFIG"); k8senvsv != "" {
-			svClient, err = k8s.CreateKubernetesClientFromConfig(k8senvsv)
+			svClient, err = createKubernetesClientFromConfig(k8senvsv)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		svcNamespace := os.Getenv("SVC_NAMESPACE")
@@ -1457,7 +1456,7 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 
 		var svClient clientset.Interface
 		if k8senvsv := GetAndExpectStringEnvVar("SUPERVISOR_CLUSTER_KUBE_CONFIG"); k8senvsv != "" {
-			svClient, err = k8s.CreateKubernetesClientFromConfig(k8senvsv)
+			svClient, err = createKubernetesClientFromConfig(k8senvsv)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		svcNamespace := os.Getenv("SVC_NAMESPACE")

--- a/tests/e2e/gc_rwx_destructive.go
+++ b/tests/e2e/gc_rwx_destructive.go
@@ -29,7 +29,6 @@ import (
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
 var _ = ginkgo.Describe("[rwm-csi-destructive-tkg] Statefulsets with File Volumes and Delete Guest Cluster", func() {
@@ -122,7 +121,7 @@ var _ = ginkgo.Describe("[rwm-csi-destructive-tkg] Statefulsets with File Volume
 			ginkgo.Skip("Env TKG_CLUSTER_TO_DELETE is missing")
 		}
 
-		clientNewGc, err := k8s.CreateKubernetesClientFromConfig(newGcKubconfigPath)
+		clientNewGc, err := createKubernetesClientFromConfig(newGcKubconfigPath)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 			fmt.Sprintf("Error creating k8s client with %v: %v", newGcKubconfigPath, err))
 

--- a/tests/e2e/gc_rwx_multi_gc.go
+++ b/tests/e2e/gc_rwx_multi_gc.go
@@ -33,7 +33,6 @@ import (
 	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
 var _ = ginkgo.Describe("[rwm-csi-tkg] Volume Provision Across TKG clusters", func() {
@@ -223,7 +222,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] Volume Provision Across TKG clusters", fu
 		gomega.Expect(strings.Contains(output, "Hello message from test into Pod1")).NotTo(gomega.BeFalse())
 
 		// Getting the client for the second GC
-		clientNewGc, err = k8s.CreateKubernetesClientFromConfig(newGcKubconfigPath)
+		clientNewGc, err = createKubernetesClientFromConfig(newGcKubconfigPath)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 			fmt.Sprintf("Error creating k8s client with %v: %v", newGcKubconfigPath, err))
 
@@ -463,7 +462,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] Volume Provision Across TKG clusters", fu
 		gomega.Expect(fcdIDInCNS).NotTo(gomega.BeEmpty())
 
 		// Getting the client for the second GC
-		clientNewGc, err = k8s.CreateKubernetesClientFromConfig(newGcKubconfigPath)
+		clientNewGc, err = createKubernetesClientFromConfig(newGcKubconfigPath)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 			fmt.Sprintf("Error creating k8s client with %v: %v", newGcKubconfigPath, err))
 
@@ -695,7 +694,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] Volume Provision Across TKG clusters", fu
 		gomega.Expect(fcdIDInCNS).NotTo(gomega.BeEmpty())
 
 		// Getting the client for the second GC
-		clientNewGc, err = k8s.CreateKubernetesClientFromConfig(newGcKubconfigPath)
+		clientNewGc, err = createKubernetesClientFromConfig(newGcKubconfigPath)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 			fmt.Sprintf("Error creating k8s client with %v: %v", newGcKubconfigPath, err))
 

--- a/tests/e2e/gc_rwx_multi_ns_gc.go
+++ b/tests/e2e/gc_rwx_multi_ns_gc.go
@@ -33,7 +33,6 @@ import (
 	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
 var _ = ginkgo.Describe("[rwm-csi-tkg] Volume Provision Across Namespace", func() {
@@ -242,7 +241,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] Volume Provision Across Namespace", func(
 
 			var svClient clientset.Interface
 			if k8senvsv := GetAndExpectStringEnvVar("SUPERVISOR_CLUSTER_KUBE_CONFIG"); k8senvsv != "" {
-				svClient, err = k8s.CreateKubernetesClientFromConfig(k8senvsv)
+				svClient, err = createKubernetesClientFromConfig(k8senvsv)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 

--- a/tests/e2e/gc_rwx_security_context.go
+++ b/tests/e2e/gc_rwx_security_context.go
@@ -517,11 +517,11 @@ var _ = ginkgo.Describe("File Volume Test with security context", func() {
 		ginkgo.By("CNS_TEST: Running for GC setup")
 
 		framework.Logf("Patch storage class as default SC")
-		err = updateSCtoDefault(ctx, storagePolicyName, "true")
+		err = updateSCtoDefault(ctx, client, storagePolicyName, "true")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
-			err = updateSCtoDefault(ctx, storagePolicyName, "false")
+			err = updateSCtoDefault(ctx, client, storagePolicyName, "false")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -632,11 +632,11 @@ var _ = ginkgo.Describe("File Volume Test with security context", func() {
 		ginkgo.By("CNS_TEST: Running for GC setup")
 
 		framework.Logf("Patch storage class as default SC")
-		err := updateSCtoDefault(ctx, storagePolicyName, "true")
+		err := updateSCtoDefault(ctx, client, storagePolicyName, "true")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
-			err = updateSCtoDefault(ctx, storagePolicyName, "false")
+			err = updateSCtoDefault(ctx, client, storagePolicyName, "false")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 

--- a/tests/e2e/gc_rwx_service_down.go
+++ b/tests/e2e/gc_rwx_service_down.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
 var _ = ginkgo.Describe("File Volume Test on Service down", func() {
@@ -664,7 +663,7 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 
 		var svClient clientset.Interface
 		if k8senvsv := GetAndExpectStringEnvVar("SUPERVISOR_CLUSTER_KUBE_CONFIG"); k8senvsv != "" {
-			svClient, err = k8s.CreateKubernetesClientFromConfig(k8senvsv)
+			svClient, err = createKubernetesClientFromConfig(k8senvsv)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -27,8 +27,6 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
-
-	csitypes "sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types"
 )
 
 const kubeconfigEnvVar = "KUBECONFIG"
@@ -41,7 +39,7 @@ func init() {
 		os.Setenv(kubeconfigEnvVar, kubeconfig)
 	}
 	framework.AfterReadingAllFlags(&framework.TestContext)
-	clusterFlavor := cnstypes.CnsClusterFlavor(os.Getenv(csitypes.EnvClusterFlavor))
+	clusterFlavor := cnstypes.CnsClusterFlavor(os.Getenv(envClusterFlavor))
 	setClusterFlavor(clusterFlavor)
 }
 

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -81,7 +81,6 @@ import (
 	cnsnodevmattachmentv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1"
 	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
@@ -701,16 +700,11 @@ func createStorageClass(client clientset.Interface, scParameters map[string]stri
 }
 
 // updateSCtoDefault updates the given SC to default
-func updateSCtoDefault(ctx context.Context, scName, isDefault string) error {
-	log := logger.GetLogger(ctx)
-	clientSet, err := k8s.NewClient(ctx)
+func updateSCtoDefault(ctx context.Context, client clientset.Interface, scName, isDefault string) error {
+
+	sc, err := client.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
 	if err != nil {
-		log.Errorf("Failed to create k8s client for cluster, err=%+v", err)
-		return err
-	}
-	_, err = clientSet.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
-	if err != nil {
-		log.Errorf("Failed to get storage class object from cluster, err=%+v", err)
+		framework.Failf("Failed to get storage class %s from cluster, err=%+v", sc.Name, err)
 		return err
 	}
 
@@ -723,18 +717,18 @@ func updateSCtoDefault(ctx context.Context, scName, isDefault string) error {
 	}
 	patchBytes, err := json.Marshal(patch)
 	if err != nil {
-		log.Errorf("Failed to marshal patch(%s): %s", patch, err)
+		framework.Failf("Failed to marshal patch(%s): %s", patch, err)
 		return err
 	}
 
 	// Patch the storage class with the updated annotation.
-	updatedSC, err := clientSet.StorageV1().StorageClasses().Patch(ctx,
+	updatedSC, err := client.StorageV1().StorageClasses().Patch(ctx,
 		scName, "application/merge-patch+json", patchBytes, metav1.PatchOptions{})
 	if err != nil {
-		log.Errorf("Failed to patch the storage class object with isDefault. Err = %+v", err)
+		framework.Failf("Failed to patch the storage class object with isDefault. Err = %+v", err)
 		return err
 	}
-	log.Debug("Successfully updated is default annotations of storage class: ", scName, updatedSC.Annotations)
+	framework.Logf("Successfully updated annotations of storage class '%s' to:\n%v", scName, updatedSC.Annotations)
 	return nil
 }
 
@@ -922,7 +916,7 @@ func getSvcClientAndNamespace() (clientset.Interface, string) {
 	var err error
 	if svcClient == nil {
 		if k8senv := GetAndExpectStringEnvVar("SUPERVISOR_CLUSTER_KUBE_CONFIG"); k8senv != "" {
-			svcClient, err = k8s.CreateKubernetesClientFromConfig(k8senv)
+			svcClient, err = createKubernetesClientFromConfig(k8senv)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		svcNamespace = GetAndExpectStringEnvVar(envSupervisorClusterNamespace)
@@ -2065,7 +2059,7 @@ func getVolumeIDFromSupervisorCluster(pvcName string) string {
 	var svcClient clientset.Interface
 	var err error
 	if k8senv := GetAndExpectStringEnvVar("SUPERVISOR_CLUSTER_KUBE_CONFIG"); k8senv != "" {
-		svcClient, err = k8s.CreateKubernetesClientFromConfig(k8senv)
+		svcClient, err = createKubernetesClientFromConfig(k8senv)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 	svNamespace := GetAndExpectStringEnvVar(envSupervisorClusterNamespace)
@@ -2080,7 +2074,7 @@ func getPvFromSupervisorCluster(pvcName string) *v1.PersistentVolume {
 	var svcClient clientset.Interface
 	var err error
 	if k8senv := GetAndExpectStringEnvVar("SUPERVISOR_CLUSTER_KUBE_CONFIG"); k8senv != "" {
-		svcClient, err = k8s.CreateKubernetesClientFromConfig(k8senv)
+		svcClient, err = createKubernetesClientFromConfig(k8senv)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 	svNamespace := GetAndExpectStringEnvVar(envSupervisorClusterNamespace)
@@ -2669,8 +2663,7 @@ func getCNSRegisterVolumeSpec(ctx context.Context, namespace string, fcdID strin
 	var (
 		cnsRegisterVolume *cnsregistervolumev1alpha1.CnsRegisterVolume
 	)
-	log := logger.GetLogger(ctx)
-	log.Infof("get CNSRegisterVolume spec")
+	framework.Logf("get CNSRegisterVolume spec")
 	cnsRegisterVolume = &cnsregistervolumev1alpha1.CnsRegisterVolume{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
@@ -2698,11 +2691,10 @@ func getCNSRegisterVolumeSpec(ctx context.Context, namespace string, fcdID strin
 // Create CNS register volume.
 func createCNSRegisterVolume(ctx context.Context, restConfig *rest.Config,
 	cnsRegisterVolume *cnsregistervolumev1alpha1.CnsRegisterVolume) error {
-	log := logger.GetLogger(ctx)
 
 	cnsOperatorClient, err := k8s.NewClientForGroup(ctx, restConfig, cnsoperatorv1alpha1.GroupName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	log.Infof("Create CNSRegisterVolume")
+	framework.Logf("Create CNSRegisterVolume")
 	err = cnsOperatorClient.Create(ctx, cnsRegisterVolume)
 
 	return err
@@ -2713,8 +2705,7 @@ func createCNSRegisterVolume(ctx context.Context, restConfig *rest.Config,
 func queryCNSRegisterVolume(ctx context.Context, restClientConfig *rest.Config,
 	cnsRegistervolumeName string, namespace string) bool {
 	isPresent := false
-	log := logger.GetLogger(ctx)
-	log.Infof("cleanUpCnsRegisterVolumeInstances: start")
+	framework.Logf("cleanUpCnsRegisterVolumeInstances: start")
 	cnsOperatorClient, err := k8s.NewClientForGroup(ctx, restClientConfig, cnsoperatorv1alpha1.GroupName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -2726,7 +2717,7 @@ func queryCNSRegisterVolume(ctx context.Context, restClientConfig *rest.Config,
 	cns := &cnsregistervolumev1alpha1.CnsRegisterVolume{}
 	err = cnsOperatorClient.Get(ctx, pkgtypes.NamespacedName{Name: cnsRegistervolumeName, Namespace: namespace}, cns)
 	if err == nil {
-		log.Infof("CNS RegisterVolume %s Found in the namespace  %s:", cnsRegistervolumeName, namespace)
+		framework.Logf("CNS RegisterVolume %s Found in the namespace  %s:", cnsRegistervolumeName, namespace)
 		isPresent = true
 	}
 
@@ -2738,7 +2729,6 @@ func queryCNSRegisterVolume(ctx context.Context, restClientConfig *rest.Config,
 // provisioning.
 func verifyBidirectionalReferenceOfPVandPVC(ctx context.Context, client clientset.Interface,
 	pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume, fcdID string) {
-	log := logger.GetLogger(ctx)
 
 	pvcName := pvc.GetName()
 	pvcNamespace := pvc.GetNamespace()
@@ -2752,21 +2742,21 @@ func verifyBidirectionalReferenceOfPVandPVC(ctx context.Context, client clientse
 	pvvolumeHandle := pv.Spec.PersistentVolumeSource.CSI.VolumeHandle
 
 	if pvClaimRefName != pvcName && pvClaimRefNamespace != pvcNamespace {
-		log.Infof("PVC Name :%s PVC namespace : %s", pvcName, pvcNamespace)
-		log.Infof("PV Name :%s PVnamespace : %s", pvcName, pvcNamespace)
-		log.Errorf("Mismatch in PV and PVC name and namespace")
+		framework.Logf("PVC Name :%s PVC namespace : %s", pvcName, pvcNamespace)
+		framework.Logf("PV Name :%s PVnamespace : %s", pvcName, pvcNamespace)
+		framework.Failf("Mismatch in PV and PVC name and namespace")
 	}
 
 	if pvcvolume != pvName {
-		log.Errorf("PVC volume :%s PV name : %s expected to be same", pvcvolume, pvName)
+		framework.Failf("PVC volume :%s PV name : %s expected to be same", pvcvolume, pvName)
 	}
 
 	if pvvolumeHandle != fcdID {
-		log.Errorf("Mismatch in PV volumeHandle:%s and the actual fcdID: %s", pvvolumeHandle, fcdID)
+		framework.Failf("Mismatch in PV volumeHandle:%s and the actual fcdID: %s", pvvolumeHandle, fcdID)
 	}
 
 	if pvccapacity != pvcapacity {
-		log.Errorf("Mismatch in pv capacity:%d and pvc capacity: %d", pvcapacity, pvccapacity)
+		framework.Failf("Mismatch in pv capacity:%d and pvc capacity: %d", pvcapacity, pvccapacity)
 	}
 }
 
@@ -4831,4 +4821,20 @@ func (o replicaSetsByCreationTimestampDate) Less(i, j int) bool {
 		return o[i].Name < o[j].Name
 	}
 	return o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
+}
+
+// createKubernetesClientFromConfig creaates a newk8s client from given
+// kubeConfig file.
+func createKubernetesClientFromConfig(kubeConfigPath string) (clientset.Interface, error) {
+
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := clientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
 }

--- a/tests/e2e/vcp_to_csi_create_delete.go
+++ b/tests/e2e/vcp_to_csi_create_delete.go
@@ -41,7 +41,6 @@ import (
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator"
 	migrationv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
@@ -191,7 +190,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 	ginkgo.It("Create volumes using VCP SC with parameters supported by CSI before and after migration", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		log := logger.GetLogger(ctx)
 		ginkgo.By("Creating VCP SCs")
 		scParams := make(map[string]string)
 		scParams[vcpScParamDatastoreName] = GetAndExpectStringEnvVar(envSharedDatastoreName)
@@ -245,7 +243,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		for _, pvc := range append(vcpPvcsPreMig, vcpPvcsPostMig...) {
 			vpath := getvSphereVolumePathFromClaim(ctx, client, namespace, pvc.Name)
 			pv := getPvFromClaim(client, namespace, pvc.Name)
-			log.Info("Processing PVC: " + pvc.Name)
+			framework.Logf("Processing PVC: " + pvc.Name)
 			crd, err := waitForCnsVSphereVolumeMigrationCrd(ctx, vpath)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = waitAndVerifyCnsVolumeMetadata(crd.Spec.VolumeID, pvc, pv, nil)
@@ -282,7 +280,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 	ginkgo.It("Create volumes using VCP SC with parameters not supported by CSI before and after migration", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		log := logger.GetLogger(ctx)
 		ginkgo.By("Creating VCP SCs")
 		scParams := make(map[string]string)
 		scParams[vcpScParamDatastoreName] = GetAndExpectStringEnvVar(envSharedDatastoreName)
@@ -330,7 +327,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		for _, pvc := range vcpPvcsPreMig {
 			vpath := getvSphereVolumePathFromClaim(ctx, client, namespace, pvc.Name)
 			pv := getPvFromClaim(client, namespace, pvc.Name)
-			log.Info("Processing PVC: " + pvc.Name)
+			framework.Logf("Processing PVC: " + pvc.Name)
 			crd, err := waitForCnsVSphereVolumeMigrationCrd(ctx, vpath)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = waitAndVerifyCnsVolumeMetadata(crd.Spec.VolumeID, pvc, pv, nil)
@@ -395,7 +392,6 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 	ginkgo.It("Create/delete volumes using VCP SC via CSI when SPS/CNS service is down", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		log := logger.GetLogger(ctx)
 		ginkgo.By("Creating VCP SCs")
 		scParams := make(map[string]string)
 		scParams[vcpScParamDatastoreName] = GetAndExpectStringEnvVar(envSharedDatastoreName)
@@ -423,7 +419,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		var crd *migrationv1alpha1.CnsVSphereVolumeMigration
 
 		vpath = getvSphereVolumePathFromClaim(ctx, client, namespace, pvc2.Name)
-		log.Info("Processing PVC: " + pvc2.Name)
+		framework.Logf("Processing PVC: " + pvc2.Name)
 		var found bool
 		found, crd = getCnsVSphereVolumeMigrationCrd(ctx, vpath)
 		gomega.Expect(found).To(gomega.BeTrue())
@@ -514,7 +510,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 		ginkgo.By("Wait and verify CNS entries for all CNS volumes and CnsVSphereVolumeMigration CRDs to get ")
 		for _, pvc := range vcpPvcsPostMig {
 			vpath = getvSphereVolumePathFromClaim(ctx, client, namespace, pvc.Name)
-			log.Info("Processing PVC: " + pvc.Name)
+			framework.Logf("Processing PVC: " + pvc.Name)
 			pv := getPvFromClaim(client, namespace, pvc.Name)
 			var found bool
 			found, crd = getCnsVSphereVolumeMigrationCrd(ctx, vpath)

--- a/tests/e2e/vmc_delete_tkg.go
+++ b/tests/e2e/vmc_delete_tkg.go
@@ -30,7 +30,6 @@ import (
 	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
 var _ = ginkgo.Describe("Delete TKG", func() {
@@ -100,7 +99,7 @@ var _ = ginkgo.Describe("Delete TKG", func() {
 			ginkgo.Skip("Env TKG_CLUSTER_TO_DELETE is missing")
 		}
 
-		clientNewGc, err := k8s.CreateKubernetesClientFromConfig(newGcKubconfigPath)
+		clientNewGc, err := createKubernetesClientFromConfig(newGcKubconfigPath)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
 			fmt.Sprintf("Error creating k8s client with %v: %v", newGcKubconfigPath, err))
 

--- a/tests/e2e/volume_health_test.go
+++ b/tests/e2e/volume_health_test.go
@@ -34,8 +34,6 @@ import (
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
-	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
 var _ = ginkgo.Describe("Volume health check", func() {
@@ -144,7 +142,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
 		defer cancel()
 
 		ginkgo.By("Invoking Test for validating health status")
@@ -227,7 +224,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 
 		}
@@ -317,7 +314,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
 		defer cancel()
 		ginkgo.By("Invoking Test for validating health status")
 		// Decide which test setup is available to run.
@@ -430,7 +426,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 
 		}
@@ -465,7 +461,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
 		defer cancel()
 		ginkgo.By("Invoking Test for validating health status")
 		// Decide which test setup is available to run.
@@ -530,7 +525,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volHandle)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 
 		}
@@ -587,7 +582,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(len(queryResult.Volumes) > 0)
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 		}
 	})
@@ -612,7 +607,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
 		defer cancel()
 		ginkgo.By("Invoking Test for validating health status")
 		// Decide which test setup is available to run.
@@ -725,7 +719,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 
 		}
@@ -753,7 +747,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
 		defer cancel()
 		ginkgo.By("Invoking Test for validating health status")
 		// Decide which test setup is available to run.
@@ -859,7 +852,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(len(queryResult.Volumes) > 0)
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 		}
 	})
@@ -967,7 +960,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
 		defer cancel()
 		ginkgo.By("Invoking Test for validating health status")
 		// Decide which test setup is available to run.
@@ -1026,7 +1018,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(len(queryResult.Volumes) > 0)
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 
 		}
@@ -1053,7 +1045,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
 		defer cancel()
 		ginkgo.By("Invoking Test for validating health status")
 
@@ -1134,7 +1125,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(len(queryResult.Volumes) > 0)
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 		}
 
@@ -1254,7 +1245,6 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var err error
 		var isControllerUP = true
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
 		defer cancel()
 
 		ginkgo.By("Creating Storage Class and PVC")
@@ -1298,7 +1288,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 		var gcClient clientset.Interface
 		if k8senv := GetAndExpectStringEnvVar("KUBECONFIG"); k8senv != "" {
-			gcClient, err = k8s.CreateKubernetesClientFromConfig(k8senv)
+			gcClient, err = createKubernetesClientFromConfig(k8senv)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		ginkgo.By("Get svcClient and svNamespace")
@@ -1351,7 +1341,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(len(queryResult.Volumes) > 0)
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 
 		}
@@ -1373,7 +1363,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var pvc *v1.PersistentVolumeClaim
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
+
 		defer cancel()
 
 		if supervisorCluster {
@@ -1464,7 +1454,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(len(queryResult.Volumes) > 0)
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 
 		}
@@ -1493,7 +1483,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var err error
 		var isControllerUP = true
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
+
 		defer cancel()
 
 		raid0StoragePolicyName = os.Getenv("RAID_0_STORAGE_POLICY")
@@ -1601,7 +1591,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(len(queryResult.Volumes) > 0)
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 
 		}
@@ -1631,7 +1621,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var pvclaims []*v1.PersistentVolumeClaim
 		var pv *v1.PersistentVolume
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
+
 		defer cancel()
 
 		raid0StoragePolicyName = os.Getenv("RAID_0_STORAGE_POLICY")
@@ -1742,7 +1732,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		// It checks the colour code returned by cns for pv.
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red)")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthRed))
 		}
 
@@ -1773,7 +1763,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(len(queryResult.Volumes)).NotTo(gomega.BeZero())
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 		}
 	})
@@ -1800,7 +1790,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var pvclaims []*v1.PersistentVolumeClaim
 		var isSvcUp bool
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
+
 		defer cancel()
 
 		raid0StoragePolicyName = os.Getenv("RAID_0_STORAGE_POLICY")
@@ -1860,7 +1850,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 		ginkgo.By("Bringing SV API server down")
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		log.Infof("VC ip address: %v", vcAddress)
+		framework.Logf("VC ip address: %v", vcAddress)
 
 		err = bringSvcK8sAPIServerDown(vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1916,7 +1906,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var pvclaims []*v1.PersistentVolumeClaim
 		var pv *v1.PersistentVolume
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
+
 		defer cancel()
 		raid0StoragePolicyName = os.Getenv("RAID_0_STORAGE_POLICY")
 		if raid0StoragePolicyName == "" {
@@ -2063,7 +2053,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(len(queryResult.Volumes) > 0)
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 		}
 	})
@@ -2093,7 +2083,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var err error
 		var isControllerUP = true
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
+
 		defer cancel()
 
 		raid0StoragePolicyName = os.Getenv("RAID_0_STORAGE_POLICY")
@@ -2129,7 +2119,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 		var gcClient clientset.Interface
 		if k8senv := GetAndExpectStringEnvVar("KUBECONFIG"); k8senv != "" {
-			gcClient, err = k8s.CreateKubernetesClientFromConfig(k8senv)
+			gcClient, err = createKubernetesClientFromConfig(k8senv)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -2202,7 +2192,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		gomega.Expect(len(queryResult.Volumes) > 0)
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 		}
 	})
@@ -2460,7 +2450,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
 		ctx, cancel := context.WithCancel(context.Background())
-		log := logger.GetLogger(ctx)
+
 		defer cancel()
 		raid0StoragePolicyName = os.Getenv("RAID_0_STORAGE_POLICY")
 		if raid0StoragePolicyName == "" {
@@ -2545,7 +2535,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volHandle)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthRed))
 		}
 
@@ -2610,7 +2600,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 
 		ginkgo.By("Verifying the volume health status returned by CNS(green/yellow/red")
 		for _, vol := range queryResult.Volumes {
-			log.Infof("Volume health status: %s", vol.HealthStatus)
+			framework.Logf("Volume health status: %s", vol.HealthStatus)
 			gomega.Expect(vol.HealthStatus).Should(gomega.BeEquivalentTo(healthGreen))
 		}
 	})


### PR DESCRIPTION
**What this PR does / why we need it**: remove dependency on driver packages from e2e tests - part1

**Testing done**:
Both block vanilla and file vanilla logs are in this gist - https://gist.github.com/sashrith/b344a16f3804bea9b25d91f5e7a44e3f

The failures seen in the logs are due to etcd crash/leader election

**Special notes for your reviewer**:
```zsh
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver removedevpkgdepse2e ⇡ ❯ make check                              15:48:56
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sashrith/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sashrith/csi/vsphere-csi-driver /Users/sashrith/csi /Users/sashrith /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (types_sizes|deps|imports|name|compiled_files|exports_file|files) took 1.658878473s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 90.1446ms
INFO [linters context/goanalysis] analyzers took 26.65491213s with top 10 stages: buildir: 10.825484598s, misspell: 1.233990317s, S1038: 973.608402ms, SA1012: 619.825186ms, directives: 552.763115ms, S1039: 524.185054ms, unused: 501.570664ms, S1028: 350.095262ms, S1024: 337.310782ms, varcheck: 310.259153ms
INFO [runner] Issues before processing: 110, after processing: 0
INFO [runner] Processors filtering stat (out/in): cgo: 110/110, path_prettifier: 110/110, skip_files: 110/110, autogenerated_exclude: 21/110, nolint: 0/1, skip_dirs: 110/110, filename_unadjuster: 110/110, identifier_marker: 21/21, exclude: 21/21, exclude-rules: 1/21
INFO [runner] processing took 13.18111ms with stages: nolint: 10.530689ms, autogenerated_exclude: 1.445229ms, path_prettifier: 600.34µs, identifier_marker: 295.298µs, skip_dirs: 172.41µs, exclude-rules: 112.442µs, cgo: 12.88µs, filename_unadjuster: 7.276µs, max_same_issues: 1.175µs, uniq_by_line: 628ns, max_from_linter: 430ns, source_code: 331ns, diff: 311ns, severity-rules: 293ns, max_per_file_from_linter: 259ns, exclude: 256ns, path_shortener: 254ns, skip_files: 252ns, sort_results: 221ns, path_prefixer: 136ns
INFO [runner] linters took 7.879367768s with stages: goanalysis_metalinter: 7.866089566s
INFO File cache stats: 198 entries of total size 3.6MiB
INFO Memory: 98 samples, avg is 454.2MB, max is 1089.8MB
INFO Execution took 9.639375911s
sashrith@sashrith-a01 ~/csi/vsphere-csi-driver removedevpkgdepse2e ⇡ 1m 3s ❯
```
