### PR TITLE
Update the error type check of NotFound in DeleteSnapshot

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -2139,7 +2139,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 		}
 
 		// Ignore errors, NotFound and InvalidArgument, in DeleteSnapshot
-		if cnsvsphere.IsNotFoundError(err) {
+		if cnsvsphere.IsVimFaultNotFoundError(err) {
 			log.Infof("Snapshot %q on volume %q might have already been deleted "+
 				"with the error %v. Ignore the error for DeleteSnapshot", snapshotID, volumeID,
 				spew.Sdump(deleteSnapshotsOperationRes.Fault))

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -90,6 +90,14 @@ func IsInvalidArgumentError(err error) bool {
 	return isInvalidArgumentError
 }
 
+func IsVimFaultNotFoundError(err error) bool {
+	isNotFoundError := false
+	if soap.IsVimFault(err) {
+		_, isNotFoundError = soap.ToVimFault(err).(*types.NotFound)
+	}
+	return isNotFoundError
+}
+
 // GetCnsKubernetesEntityMetaData creates a CnsKubernetesEntityMetadataObject
 // object from given parameters.
 func GetCnsKubernetesEntityMetaData(entityName string, labels map[string]string,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Update the error type check of NotFound to catch the expected from underlying layer.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
- Regression test: Done (Automated)
- Functional test: Done (Please check the Test Description below)

Test Description: simulate a scenario where deleting a VolumeSnapshot from k8s whose snapshot in the backend is missing. Verified the expected error is thrown and caught.

1. Create a VolumeSnapshot in a vanilla k8s cluster.
2. Delete the FCD snapshot in the backend using vSphere API.
3. Delete the VolumeSnapshot from k8s cluster and verified the expectation.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update the error type check of NotFound in DeleteSnapshot
```
