### PR TITLE
fix volume expand issue with improved-Idempotency feature and add vSphere 8.0 support

### DIFF
--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -277,3 +277,23 @@ func GetNamespaceFromContext(ctx context.Context) string {
 	}
 	return prometheus.PrometheusUnknownNamespace
 }
+
+// IsvSphere8AndAbove returns true if vSphere version if 8.0 and above
+func IsvSphere8AndAbove(ctx context.Context, aboutInfo vim25types.AboutInfo) (bool, error) {
+	log := logger.GetLogger(ctx)
+	items := strings.Split(aboutInfo.ApiVersion, ".")
+	apiVersion := strings.Join(items[:], "")
+	// Convert version string to int, e.g. 8.0.0.0" to 800.
+	vSphereMajorVersionInt, err := strconv.Atoi(string(apiVersion[0]))
+	if err != nil {
+		return false, logger.LogNewErrorf(log,
+			"Error while converting ApiVersion %q to integer, err %+v", apiVersion, err)
+	}
+
+	// Check if the current vSphere version is greater 8
+	if vSphereMajorVersionInt >= VSphere8VersionMajorInt {
+		return true, nil
+	}
+	// For all other versions.
+	return false, nil
+}

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -143,6 +143,9 @@ const (
 	// to support volume migration feature.
 	VSphere7Version string = "7.0.0"
 
+	// VSphere8VersionMajorInt indicates the major version value in integer
+	VSphere8VersionMajorInt int = 8
+
 	// VSphere67u3lBuildInfo is the build number for vCenter in 6.7 Update 3l
 	// GA bits.
 	VSphere67u3lBuildInfo int = 17137327

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1259,8 +1259,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		}
 
 		faultType, err = common.ExpandVolumeUtil(ctx, c.manager, volumeID, volSizeMB,
-			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume),
-			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency))
+			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to expand volume: %q to size: %d with error: %+v", volumeID, volSizeMB, err)

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1064,8 +1064,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
 		var faultType string
 		faultType, err = common.ExpandVolumeUtil(ctx, c.manager, volumeID, volSizeMB,
-			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume),
-			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency))
+			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to expand volume: %+q to size: %d err %+v", volumeID, volSizeMB, err)


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**fix volume expand issue with improved-Idempotency feature** 
---

Imagine a scenario where ControllerExpandVolume is called for the first time for 2GB on a volume with a current capacity of 1GB. The current code makes a call to CNS ExtendVolume and keeps monitoring the task. If the host side task to expand volume succeeded but the VC task on which we are listening failed for some reason. The idempotency code at https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/common/cns-lib/volume/manager.go#L1338 marks the task as a failure. 
The next time ControllerExpandVolume is retried with the same requested storage of 2GB, the code reaches https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/common/cns-lib/volume/manager.go#L1297 point and calls CNS ExtendVolume again. 

This is an issue as vsphere versions below 8 will start erroring out ExtendVolume call as the volume underneath had already expanded due to the host task success. As a result CSI also errors out even though there is no real error. 
To prevent this scenario, we used to call QueryVolume before ExtendVolume before idempotency handling was enabled. Idempotency should handle this case.


**add vSphere 8.0 support**
---

in vSphere 8.0, we do not need to query volume to confirm volume capacity is already expanded or not.
This PR is making sure CSI avoids querying volume size before calling ExtendDisk in vSphere 8.0. 
With recent improvements in the FCD layer in vSphere 8.0 w.r.t volume expansion workflow, CSI no longer needs to check for expected volume size and current volume size.


**Testing done**:
Refer to - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1519#issuecomment-1028379689

**Special notes for your reviewer**:
Here in this PR, I am borrowing code from @chethanv28  and @shalini-b from https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1493 and https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1514 and making the fix that can be cherry-picked to `release-2.5` branch.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix volume expand issue with improved-Idempotency feature and add vSphere 8.0 support
```
