### PR TITLE
Automation test-cases for Topology Table2

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -169,6 +169,11 @@ const (
 	zoneKey                                   = "failure-domain.beta.kubernetes.io/zone"
 	tkgAPI                                    = "/apis/run.tanzu.vmware.com/v1alpha1/namespaces" +
 		"/test-gc-e2e-demo-ns/tanzukubernetesclusters/"
+	topologykey                                = "topology.csi.vmware.com"
+	topologyMap                                = "TOPOLOGY_MAP"
+	datstoreSharedBetweenClusters              = "DATASTORE_SHARED_BETWEEN_TWO_CLUSTERS"
+	datastoreUrlSpecificToCluster              = "DATASTORE_URL_SPECIFIC_TO_CLUSTER"
+	storagePolicyForDatastoreSpecificToCluster = "STORAGE_POLICY_FOR_DATASTORE_SPECIFIC_TO_CLUSTER"
 )
 
 // The following variables are required to know cluster type to run common e2e

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -32,6 +32,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -65,6 +66,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubectl/pkg/drain"
+	"k8s.io/kubectl/pkg/util/podutils"
 	"k8s.io/kubernetes/test/e2e/framework"
 	fdep "k8s.io/kubernetes/test/e2e/framework/deployment"
 	"k8s.io/kubernetes/test/e2e/framework/manifest"
@@ -4181,4 +4183,652 @@ func isCsiFssEnabled(ctx context.Context, client clientset.Interface, namespace 
 	gomega.Expect(fssFound).To(
 		gomega.BeTrue(), "FSS %s not found in the %s configmap in namespace %s", fss, csiFssCM, namespace)
 	return false
+}
+
+/*
+This wrapper method is used to create the topology map of allowed topologies specified on VC.
+TOPOLOGY_MAP = "region:region1;zone:zone1;building:building1;level:level1;rack:rack1,rack2,rack3"
+*/
+func createTopologyMapLevel5(topologyMapStr string, level int) (map[string][]string, []string) {
+	topologyMap := make(map[string][]string)
+	var categories []string
+	if level != 5 {
+		return nil, categories
+	}
+	topologyCategories := strings.Split(topologyMapStr, ";")
+	for _, category := range topologyCategories {
+		categoryVal := strings.Split(category, ":")
+		key := categoryVal[0]
+		categories = append(categories, key)
+		values := strings.Split(categoryVal[1], ",")
+		topologyMap[key] = values
+	}
+	return topologyMap, categories
+}
+
+/*
+This wrapper method is used to create allowed topologies set required for creating Storage Class.
+*/
+func createAllowedTopolgies(topologyMapStr string, level int) []v1.TopologySelectorLabelRequirement {
+	topologyMap, _ := createTopologyMapLevel5(topologyMapStr, level)
+	allowedTopologies := []v1.TopologySelectorLabelRequirement{}
+	for key, val := range topologyMap {
+		allowedTopology := v1.TopologySelectorLabelRequirement{
+			Key:    topologykey + "/" + key,
+			Values: val,
+		}
+		allowedTopologies = append(allowedTopologies, allowedTopology)
+	}
+	return allowedTopologies
+}
+
+/*
+This is a wrapper method which is used to create a topology map of all tags and categoties.
+*/
+func createAllowedTopologiesMap(allowedTopologies []v1.TopologySelectorLabelRequirement) map[string][]string {
+	allowedTopologiesMap := make(map[string][]string)
+	for _, topologySelector := range allowedTopologies {
+		allowedTopologiesMap[topologySelector.Key] = topologySelector.Values
+	}
+	return allowedTopologiesMap
+}
+
+// GetPodList gets the current Pods in ss.
+func GetListOfPodsInSts(c clientset.Interface, ss *appsv1.StatefulSet) *v1.PodList {
+	selector, err := metav1.LabelSelectorAsSelector(ss.Spec.Selector)
+	framework.ExpectNoError(err)
+	var StatefulSetPods *v1.PodList = new(v1.PodList)
+	podList, err := c.CoreV1().Pods(ss.Namespace).List(context.TODO(),
+		metav1.ListOptions{LabelSelector: selector.String()})
+	framework.ExpectNoError(err)
+	for _, sspod := range podList.Items {
+		if strings.Contains(sspod.Name, ss.Name) {
+			StatefulSetPods.Items = append(StatefulSetPods.Items, sspod)
+		}
+	}
+	return StatefulSetPods
+}
+
+/*
+verifyVolumeTopologyForLevel5 verifies that the pv node affinity details should match the
+allowed topologies specified in the storage class.
+This method returns true if allowed topologies of SC matches with the PV node
+affinity details else return error and false.
+*/
+func verifyVolumeTopologyForLevel5(pv *v1.PersistentVolume, allowedTopologiesMap map[string][]string) (bool, error) {
+	if pv.Spec.NodeAffinity == nil || len(pv.Spec.NodeAffinity.Required.NodeSelectorTerms) == 0 {
+		return false, fmt.Errorf("node Affinity rules for PV should exist in topology aware provisioning")
+	}
+	for _, nodeSelector := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms {
+		for _, topology := range nodeSelector.MatchExpressions {
+			if val, ok := allowedTopologiesMap[topology.Key]; ok {
+				if !compareStringLists(val, topology.Values) {
+					return false, fmt.Errorf("PV node affinity details does not exist in the allowed topologies specified in SC")
+				}
+			} else {
+				return false, fmt.Errorf("PV node affinity details does not exist in the allowed topologies specified in SC")
+			}
+		}
+	}
+	return true, nil
+}
+
+/*
+This is a wrapper method which is used to compare 2 string list and returns true if value matches else returns false.
+*/
+func compareStringLists(strList1 []string, strList2 []string) bool {
+	strMap := make(map[string]bool)
+	for _, str := range strList1 {
+		strMap[str] = true
+	}
+	for _, str := range strList2 {
+		if _, ok := strMap[str]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+/*
+For Statefulset Pod
+verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5 for Statefulset verifies that PV
+node Affinity rules should match the topology constraints specified in the storage class.
+Also it verifies that a pod is scheduled on a node that belongs to the topology on
+which PV is provisioned.
+*/
+func verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx context.Context,
+	client clientset.Interface, statefulset *appsv1.StatefulSet, namespace string,
+	allowedTopologies []v1.TopologySelectorLabelRequirement, parallelStatefulSetCreation bool) {
+	allowedTopologiesMap := createAllowedTopologiesMap(allowedTopologies)
+	var ssPodsBeforeScaleDown *v1.PodList
+	if parallelStatefulSetCreation {
+		ssPodsBeforeScaleDown = GetListOfPodsInSts(client, statefulset)
+	} else {
+		ssPodsBeforeScaleDown = fss.GetPodList(client, statefulset)
+	}
+	for _, sspod := range ssPodsBeforeScaleDown.Items {
+		_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, volumespec := range sspod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				// get pv details
+				pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+
+				// verify pv node affinity details as specified on SC
+				ginkgo.By("Verifying PV node affinity details")
+				res, err := verifyVolumeTopologyForLevel5(pv, allowedTopologiesMap)
+				if res {
+					framework.Logf("PV %s node affinity details lies in the specified allowed topologies of Storage Class", pv.Name)
+				}
+				gomega.Expect(res).To(gomega.BeTrue(), "PV %s node affinity details is not in the "+
+					"specified allowed topologies of Storage Class", pv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// fetch node details
+				nodeList, err := fnodes.GetReadySchedulableNodes(client)
+				framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+				if !(len(nodeList.Items) > 0) {
+					framework.Failf("Unable to find ready and schedulable Node")
+				}
+				// verify pod is running on appropriate nodes
+				ginkgo.By("Verifying If Pods are running on appropriate nodes as mentioned in SC")
+				res, err = verifyPodLocationLevel5(&sspod, nodeList, allowedTopologiesMap)
+				if res {
+					framework.Logf("Pod %v is running on appropriate node as specified "+
+						"in the allowed topolgies of Storage Class", sspod.Name)
+				}
+				gomega.Expect(res).To(gomega.BeTrue(), "Pod %v is not running on appropriate node "+
+					"as specified in allowed topolgies of Storage Class", sspod.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify the attached volume match the one in CNS cache
+				error := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+					volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+				gomega.Expect(error).NotTo(gomega.HaveOccurred())
+			}
+		}
+	}
+}
+
+/*
+verifyPodLocationLevel5 verifies that a pod is scheduled on a node that belongs to the
+topology on which PV is provisioned.
+This method returns true if all topology labels matches else returns false and error.
+*/
+func verifyPodLocationLevel5(pod *v1.Pod, nodeList *v1.NodeList,
+	allowedTopologiesMap map[string][]string) (bool, error) {
+	for _, node := range nodeList.Items {
+		if pod.Spec.NodeName == node.Name {
+			for labelKey, labelValue := range node.Labels {
+				if topologyValue, ok := allowedTopologiesMap[labelKey]; ok {
+					if !contains(topologyValue, labelValue) {
+						return false, fmt.Errorf("Pod is not running on node located in %s" + labelValue)
+					}
+				}
+			}
+		}
+	}
+	return true, nil
+}
+
+// udpate updates a statefulset, and it is only used within rest.go
+func updateSts(c clientset.Interface, ns, name string, update func(ss *appsv1.StatefulSet)) *appsv1.StatefulSet {
+	for i := 0; i < 3; i++ {
+		ss, err := c.AppsV1().StatefulSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			framework.Failf("failed to get statefulset %q: %v", name, err)
+		}
+		update(ss)
+		ss, err = c.AppsV1().StatefulSets(ns).Update(context.TODO(), ss, metav1.UpdateOptions{})
+		if err == nil {
+			return ss
+		}
+		if !apierrors.IsConflict(err) && !apierrors.IsServerTimeout(err) {
+			framework.Failf("failed to update statefulset %q: %v", name, err)
+		}
+	}
+	framework.Failf("too many retries draining statefulset %q", name)
+	return nil
+}
+
+// Scale scales ss to count replicas.
+func ScaleDownSts(c clientset.Interface, ss *appsv1.StatefulSet, count int32) (*appsv1.StatefulSet, error) {
+	name := ss.Name
+	ns := ss.Namespace
+	StatefulSetPoll := 10 * time.Second
+	StatefulSetTimeout := 10 * time.Minute
+	framework.Logf("Scaling statefulset %s to %d", name, count)
+	ss = updateSts(c, ns, name, func(ss *appsv1.StatefulSet) { *(ss.Spec.Replicas) = count })
+
+	var statefulPodList *v1.PodList
+	pollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout, func() (bool, error) {
+		statefulPodList = GetListOfPodsInSts(c, ss)
+		if int32(len(statefulPodList.Items)) == count {
+			return true, nil
+		}
+		return false, nil
+	})
+	if pollErr != nil {
+		unhealthy := []string{}
+		for _, statefulPod := range statefulPodList.Items {
+			delTs, phase, readiness := statefulPod.DeletionTimestamp, statefulPod.Status.Phase,
+				podutils.IsPodReady(&statefulPod)
+			if delTs != nil || phase != v1.PodRunning || !readiness {
+				unhealthy = append(unhealthy, fmt.Sprintf("%v: deletion %v, phase %v, readiness %v",
+					statefulPod.Name, delTs, phase, readiness))
+			}
+		}
+		return ss, fmt.Errorf("failed to scale statefulset to %d in %v. "+
+			"Remaining pods:\n%v", count, StatefulSetTimeout, unhealthy)
+	}
+	return ss, nil
+}
+
+/*
+scaleDownStatefulSetPod is a utility method which is used to scale down the count of StatefulSet replicas.
+*/
+func scaleDownStatefulSetPod(ctx context.Context, client clientset.Interface,
+	statefulset *appsv1.StatefulSet, namespace string, replicas int32, parallelStatefulSetCreation bool) {
+	ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas))
+	var ssPodsAfterScaleDown *v1.PodList
+	if parallelStatefulSetCreation {
+		_, scaledownErr := ScaleDownSts(client, statefulset, replicas)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulset)
+	} else {
+		_, scaledownErr := fss.Scale(client, statefulset, replicas)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		ssPodsAfterScaleDown = fss.GetPodList(client, statefulset)
+	}
+
+	// After scale down, verify vSphere volumes are detached from deleted pods
+	ginkgo.By("Verify Volumes are detached from Nodes after Statefulsets is scaled down")
+	//ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+	for _, sspod := range ssPodsAfterScaleDown.Items {
+		_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+		if err != nil {
+			gomega.Expect(apierrors.IsNotFound(err), gomega.BeTrue())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(
+						client, pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+						fmt.Sprintf("Volume %q is not detached from the node %q",
+							pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+				}
+			}
+		}
+	}
+	// After scale down, verify the attached volumes match those in CNS Cache
+	for _, sspod := range ssPodsAfterScaleDown.Items {
+		_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, volumespec := range sspod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+				err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+					volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+	}
+}
+
+/*
+scaleUpStatefulSetPod is a utility method which is used to scale up the count of StatefulSet replicas.
+*/
+func scaleUpStatefulSetPod(ctx context.Context, client clientset.Interface,
+	statefulset *appsv1.StatefulSet, namespace string, replicas int32, parallelStatefulSetCreation bool) {
+	ginkgo.By(fmt.Sprintf("Scaling up statefulsets to number of Replica: %v", replicas))
+	var ssPodsAfterScaleUp *v1.PodList
+	if parallelStatefulSetCreation {
+		_, scaleupErr := ScaleDownSts(client, statefulset, replicas)
+		gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+
+		ssPodsAfterScaleUp = GetListOfPodsInSts(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+	} else {
+		_, scaleupErr := fss.Scale(client, statefulset, replicas)
+		gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+
+		ssPodsAfterScaleUp = fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+	}
+
+	// After scale up, verify all vSphere volumes are attached to node VMs.
+	ginkgo.By("Verify all volumes are attached to Nodes after Statefulsets is scaled up")
+	for _, sspod := range ssPodsAfterScaleUp.Items {
+		err := fpod.WaitForPodsReady(client, statefulset.Namespace, sspod.Name, 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, volumespec := range pod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+				ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+					pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+				var vmUUID string
+				var exists bool
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				if vanillaCluster {
+					vmUUID = getNodeUUID(ctx, client, sspod.Spec.NodeName)
+				} else {
+					annotations := pod.Annotations
+					vmUUID, exists = annotations[vmUUIDLabel]
+					gomega.Expect(exists).To(gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+					_, err := e2eVSphere.getVMByUUID(ctx, vmUUID)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+				isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Disk is not attached to the node")
+				gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached")
+				ginkgo.By("After scale up, verify the attached volumes match those in CNS Cache")
+				err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+					volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+	}
+}
+
+/*
+This wrapper method is used to fetch allowed topologies from default topology set
+required for creating Storage Class specific to testcase scenarios.
+*/
+func getTopologySelector(topologyAffinityDetails map[string][]string,
+	topologyCategories []string, level int,
+	position ...int) []v1.TopologySelectorLabelRequirement {
+	allowedTopologyForSC := []v1.TopologySelectorLabelRequirement{}
+	updateLvl := -1
+	var rnges []int
+	if len(position) > 0 {
+		updateLvl = position[0]
+		rnges = position[1:]
+	}
+	for i := 0; i < level; i++ {
+		var values []string
+		category := topologyCategories[i]
+		if i == updateLvl {
+			for _, rng := range rnges {
+				values = append(values, topologyAffinityDetails[category][rng])
+			}
+		} else {
+			values = topologyAffinityDetails[category]
+		}
+		topologySelector := v1.TopologySelectorLabelRequirement{
+			Key:    topologykey + "/" + category,
+			Values: values,
+		}
+		allowedTopologyForSC = append(allowedTopologyForSC, topologySelector)
+	}
+	return allowedTopologyForSC
+}
+
+// GetPodsForDeployment gets pods for the given deployment
+func GetPodsForMultipleDeployment(client clientset.Interface, deployment *appsv1.Deployment) (*v1.PodList, error) {
+	replicaSetSelector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+	replicaSetListOptions := metav1.ListOptions{LabelSelector: replicaSetSelector.String()}
+	allReplicaSets, err := client.AppsV1().ReplicaSets(deployment.Namespace).List(context.TODO(), replicaSetListOptions)
+	if err != nil {
+		return nil, err
+	}
+	ownedReplicaSets := make([]*appsv1.ReplicaSet, 0, len(allReplicaSets.Items))
+	for _, rs := range allReplicaSets.Items {
+		if !metav1.IsControlledBy(&rs, deployment) {
+			continue
+		}
+		if strings.Contains(rs.Name, deployment.Name) {
+			ownedReplicaSets = append(ownedReplicaSets, &rs)
+		}
+	}
+	var replicaSet *appsv1.ReplicaSet
+	sort.Sort(replicaSetsByCreationTimestampDate(ownedReplicaSets))
+	for _, rs := range ownedReplicaSets {
+		replicaSet = rs
+	}
+
+	if replicaSet == nil {
+		return nil, fmt.Errorf("expected a new replica set for deployment %q, found none", deployment.Name)
+	}
+
+	podSelector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+	podListOptions := metav1.ListOptions{LabelSelector: podSelector.String()}
+	allPods, err := client.CoreV1().Pods(deployment.Namespace).List(context.TODO(), podListOptions)
+	if err != nil {
+		return nil, err
+	}
+	ownedPods := &v1.PodList{Items: make([]v1.Pod, 0, len(allPods.Items))}
+	for _, pod := range allPods.Items {
+		if strings.Contains(pod.Name, deployment.Name) {
+			ownedPods.Items = append(ownedPods.Items, pod)
+		}
+	}
+	return ownedPods, nil
+}
+
+/*
+For Deployment Pod
+verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5 for Deployment verifies that PV node
+Affinity rules should match the topology constraints specified in the storage class.
+Also it verifies that a pod is scheduled on a node that belongs to the topology on which
+PV is provisioned.
+*/
+func verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5(ctx context.Context,
+	client clientset.Interface, deployment *appsv1.Deployment, namespace string,
+	allowedTopologies []v1.TopologySelectorLabelRequirement, parallelDeplCreation bool) {
+	allowedTopologiesMap := createAllowedTopologiesMap(allowedTopologies)
+	var pods *v1.PodList
+	var err error
+	if parallelDeplCreation {
+		pods, err = GetPodsForMultipleDeployment(client, deployment)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	} else {
+		pods, err = fdep.GetPodsForDeployment(client, deployment)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+	for _, sspod := range pods.Items {
+		_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, volumespec := range sspod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				// get pv details
+				pv := getPvFromClaim(client, deployment.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+
+				// verify pv node affinity details as specified on SC
+				ginkgo.By("Verifying PV node affinity details")
+				res, err := verifyVolumeTopologyForLevel5(pv, allowedTopologiesMap)
+				if res {
+					framework.Logf("PV %s node affinity details lies in the specified allowed topologies of Storage Class", pv.Name)
+				}
+				gomega.Expect(res).To(gomega.BeTrue(), "PV %s node affinity details is not in the "+
+					"specified allowed topologies of Storage Class", pv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// fetch node details
+				nodeList, err := fnodes.GetReadySchedulableNodes(client)
+				framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+				if !(len(nodeList.Items) > 0) {
+					framework.Failf("Unable to find ready and schedulable Node")
+				}
+				// verify pod is running on appropriate nodes
+				ginkgo.By("Verifying If Pods are running on appropriate nodes as mentioned in SC")
+				res, err = verifyPodLocationLevel5(&sspod, nodeList, allowedTopologiesMap)
+				if res {
+					framework.Logf("Pod %v is running on appropriate node as specified in the "+
+						"allowed topolgies of Storage Class", sspod.Name)
+				}
+				gomega.Expect(res).To(gomega.BeTrue(), "Pod %v is not running on appropriate node "+
+					"as specified in allowed topolgies of Storage Class", sspod.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Verify the attached volume match the one in CNS cache
+				error := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+					volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+				gomega.Expect(error).NotTo(gomega.HaveOccurred())
+			}
+		}
+	}
+}
+
+/*
+For Standalone Pod
+verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5 for Standalone Pod verifies that PV
+node Affinity rules should match the topology constraints specified in the storage class.
+Also it verifies that a pod is scheduled on a node that belongs to the topology on which PV
+is provisioned.
+*/
+func verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx context.Context,
+	client clientset.Interface, pod *v1.Pod, namespace string,
+	allowedTopologies []v1.TopologySelectorLabelRequirement) {
+	allowedTopologiesMap := createAllowedTopologiesMap(allowedTopologies)
+	for _, volumespec := range pod.Spec.Volumes {
+		if volumespec.PersistentVolumeClaim != nil {
+			// get pv details
+			pv := getPvFromClaim(client, pod.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+
+			// verify pv node affinity details as specified on SC
+			ginkgo.By("Verifying PV node affinity details")
+			res, err := verifyVolumeTopologyForLevel5(pv, allowedTopologiesMap)
+			if res {
+				framework.Logf("PV %s node affinity details lies in the specified allowed topologies of Storage Class", pv.Name)
+			}
+			gomega.Expect(res).To(gomega.BeTrue(), "PV %s node affinity details is not in the specified "+
+				"allowed topologies of Storage Class", pv.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// fetch node details
+			nodeList, err := fnodes.GetReadySchedulableNodes(client)
+			framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+			if !(len(nodeList.Items) > 0) {
+				framework.Failf("Unable to find ready and schedulable Node")
+			}
+			// verify pod is running on appropriate nodes
+			ginkgo.By("Verifying If Pods are running on appropriate nodes as mentioned in SC")
+			res, err = verifyPodLocationLevel5(pod, nodeList, allowedTopologiesMap)
+			if res {
+				framework.Logf("Pod %v is running on appropriate node as specified in the allowed "+
+					"topolgies of Storage Class", pod.Name)
+			}
+			gomega.Expect(res).To(gomega.BeTrue(), "Pod %v is not running on appropriate node as "+
+				"specified in allowed topolgies of Storage Class", pod.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Verify the attached volume match the one in CNS cache
+			error := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+				volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, pod.Name)
+			gomega.Expect(error).NotTo(gomega.HaveOccurred())
+		}
+	}
+}
+
+func getPersistentVolumeSpecWithStorageClassFCDNodeSelector(volumeHandle string,
+	persistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy, storageClass string,
+	labels map[string]string, sizeOfDisk string,
+	allowedTopologies []v1.TopologySelectorLabelRequirement) *v1.PersistentVolume {
+	var (
+		pvConfig fpv.PersistentVolumeConfig
+		pv       *v1.PersistentVolume
+		claimRef *v1.ObjectReference
+	)
+	pvConfig = fpv.PersistentVolumeConfig{
+		NamePrefix: "vspherepv-",
+		PVSource: v1.PersistentVolumeSource{
+			CSI: &v1.CSIPersistentVolumeSource{
+				Driver:       e2evSphereCSIDriverName,
+				VolumeHandle: volumeHandle,
+				ReadOnly:     false,
+				FSType:       "ext4",
+			},
+		},
+		Prebind: nil,
+	}
+
+	pv = &v1.PersistentVolume{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: pvConfig.NamePrefix,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: persistentVolumeReclaimPolicy,
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse(sizeOfDisk),
+			},
+			PersistentVolumeSource: pvConfig.PVSource,
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			ClaimRef:         claimRef,
+			StorageClassName: storageClass,
+		},
+		Status: v1.PersistentVolumeStatus{},
+	}
+	if labels != nil {
+		pv.Labels = labels
+	}
+	// Annotation needed to delete a statically created pv.
+	annotations := make(map[string]string)
+	annotations["pv.kubernetes.io/provisioned-by"] = e2evSphereCSIDriverName
+	pv.Annotations = annotations
+	pv.Spec.NodeAffinity = new(v1.VolumeNodeAffinity)
+	pv.Spec.NodeAffinity.Required = new(v1.NodeSelector)
+	pv.Spec.NodeAffinity.Required.NodeSelectorTerms = getNodeSelectorTerms(allowedTopologies)
+	return pv
+}
+
+func getNodeSelectorTerms(allowedTopologies []v1.TopologySelectorLabelRequirement) []v1.NodeSelectorTerm {
+	var nodeSelectorRequirements []v1.NodeSelectorRequirement
+	var nodeSelectorTerms []v1.NodeSelectorTerm
+
+	for i := 0; i < len(allowedTopologies)-1; i++ {
+		topologySelector := allowedTopologies[i]
+		var nodeSelectorRequirement v1.NodeSelectorRequirement
+		nodeSelectorRequirement.Key = topologySelector.Key
+		nodeSelectorRequirement.Operator = "In"
+		nodeSelectorRequirement.Values = topologySelector.Values
+		nodeSelectorRequirements = append(nodeSelectorRequirements, nodeSelectorRequirement)
+	}
+	rackTopology := allowedTopologies[len(allowedTopologies)-1]
+	for i := 0; i < len(rackTopology.Values); i++ {
+		var nodeSelectorTerm v1.NodeSelectorTerm
+		var nodeSelectorRequirement v1.NodeSelectorRequirement
+		nodeSelectorRequirement.Key = rackTopology.Key
+		nodeSelectorRequirement.Operator = "In"
+		nodeSelectorRequirement.Values = append(nodeSelectorRequirement.Values, rackTopology.Values[i])
+		nodeSelectorTerm.MatchExpressions = append(nodeSelectorRequirements, nodeSelectorRequirement)
+		nodeSelectorTerms = append(nodeSelectorTerms, nodeSelectorTerm)
+	}
+	return nodeSelectorTerms
+}
+
+// replicaSetsByCreationTimestamp sorts a list of ReplicaSet by creation timestamp, using their names as a tie breaker.
+type replicaSetsByCreationTimestampDate []*appsv1.ReplicaSet
+
+func (o replicaSetsByCreationTimestampDate) Len() int      { return len(o) }
+func (o replicaSetsByCreationTimestampDate) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+func (o replicaSetsByCreationTimestampDate) Less(i, j int) bool {
+	if o[i].CreationTimestamp.Equal(&o[j].CreationTimestamp) {
+		return o[i].Name < o[j].Name
+	}
+	return o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
 }

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -1,0 +1,1327 @@
+/*
+	Copyright 2019 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
+)
+
+var _ = ginkgo.Describe("[csi-topology-vanilla-level5] Topology-Aware-Provisioning-With-Statefulset-Level5", func() {
+	f := framework.NewDefaultFramework("e2e-vsphere-topology-aware-provisioning")
+	var (
+		client                    clientset.Interface
+		namespace                 string
+		bindingMode               storagev1.VolumeBindingMode
+		allowedTopologies         []v1.TopologySelectorLabelRequirement
+		storagePolicyName         string
+		topologyAffinityDetails   map[string][]string
+		topologyCategories        []string
+		pandoraSyncWaitTime       int
+		defaultDatacenter         *object.Datacenter
+		defaultDatastore          *object.Datastore
+		DSSharedToSpecificCluster *object.Datastore
+		datastoreURL              string
+		topologyLength            int
+		leafNode                  int
+		leafNodeTag0              int
+		leafNodeTag1              int
+		leafNodeTag2              int
+	)
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		bootstrap()
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+		bindingMode = storagev1.VolumeBindingWaitForFirstConsumer
+		topologyLength, leafNode, leafNodeTag0, leafNodeTag1, leafNodeTag2 = 5, 4, 0, 1, 2
+
+		topologyMap := GetAndExpectStringEnvVar(topologyMap)
+		topologyAffinityDetails, topologyCategories = createTopologyMapLevel5(topologyMap,
+			topologyLength)
+		allowedTopologies = createAllowedTopolgies(topologyMap, topologyLength)
+		if os.Getenv(envPandoraSyncWaitTime) != "" {
+			pandoraSyncWaitTime, err = strconv.Atoi(os.Getenv(envPandoraSyncWaitTime))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		} else {
+			pandoraSyncWaitTime = defaultPandoraSyncWaitTime
+		}
+		var datacenters []string
+		datastoreURL = GetAndExpectStringEnvVar(envSharedDatastoreURL)
+		SharedDSURLToSpecificCluster := GetAndExpectStringEnvVar(datastoreUrlSpecificToCluster)
+		var cancel context.CancelFunc
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		finder := find.NewFinder(e2eVSphere.Client.Client, false)
+		cfg, err := getConfig()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		dcList := strings.Split(cfg.Global.Datacenters, ",")
+		for _, dc := range dcList {
+			dcName := strings.TrimSpace(dc)
+			if dcName != "" {
+				datacenters = append(datacenters, dcName)
+			}
+		}
+		for _, dc := range datacenters {
+			defaultDatacenter, err = finder.Datacenter(ctx, dc)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			finder.SetDatacenter(defaultDatacenter)
+			defaultDatastore, err = getDatastoreByURL(ctx, datastoreURL, defaultDatacenter)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			DSSharedToSpecificCluster, err = getDatastoreByURL(ctx, SharedDSURLToSpecificCluster,
+				defaultDatacenter)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	})
+
+	/*
+		TESTCASE-1
+		Steps:
+		1. Create SC without specifying any topology details using volumeBindingMode
+		as WaitForFirstConsumer.
+		2. Create StatefulSet with default pod management policy with replica count 3 using above SC.
+		3. Wait for StatefulSet pods to be in up and running state.
+		4. Since there is no Topology describe on SC, volume provisioning should happen on
+		any availability zone.
+		5. Describe on the PV's and verify node affinity details.
+		5a. Verify, PV node affinity of all 5 levels should be displayed.
+		5b. Verify, If a volume is provisioned on shared datastore, pv node affinity details
+			contain all the availability zone details.
+		5c. Verify, If a volume provisioned on a datastore that is shared within
+			the specific zone then node affinity will have details of specific zone and its node labels.
+		6. Verify StatefuSet pods are created on appropriate nodes.
+		7. Bring down statefulset replica to 0.
+		8. Delete statefulset, PVC and SC.
+	*/
+
+	ginkgo.It("Provisioning volume when no topology details specified in storage class "+
+		"and using default pod management policy for statefulset", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Creating StorageClass when no topology details are specified using WFC Binding mode
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil, "",
+			bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Creating StatefulSet with replica count 3 using default pod management policy
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+
+		// Wait for StatefulSet pods to be in up and running state
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// Verify PV node affinity and that the PODS are running on appropriate nodes
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, false)
+
+		// Scale down statefulset to 0 replicas
+		replicas -= 3
+		ginkgo.By("Scale down statefulset replica count to 0")
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+	})
+
+	/*
+		TESTCASE-2
+		Steps:
+		1. Create SC without specifying any topology details using volumeBindingMode as
+		 WaitForFirstConsumer.
+		2. Create StatefulSet with parallel pod management policy with replica count 3 using above SC.
+		3. Wait for StatefulSet pods to be in up and running state.
+		4. Since there is no Topology describe on SC, volume provisioning should happen on
+		any availability zone.
+		5. Describe on the PV's and verify node affinity details.
+		5a. Verify, PV node affinity of all 5 levels should be displayed.
+		5b. Verify, If a volume is provisioned on shared datastore, pv node affinity details
+			contain all the availability zone details.
+		5c. Verify, If a volume provisioned on a datastore that is shared within the specific
+			zone then node affinity will have details of specific zone and its node labels.
+		6. Verify StatefuSet pods are created on appropriate nodes.
+		7. Scale up the StatefulSet replica count to 5.
+		8. Scale down the StatefulSet replica count to 1.
+		9. Verify scale up and scale down of StaefulSet pods are successful.
+		10. Verify newly created StatefuSet pods are created on appropriate nodes.
+		11. Describe PV and verify the node affinity details should display all 5 topology levels.
+		12. Bring down all statefulset replica to 0.
+		13. Delete statefulset, PVC and SC.
+	*/
+
+	ginkgo.It("Provisioning volume when no topology details specified in storage class "+
+		"and using parallel pod management policy for statefulset", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Creating StorageClass when no topology details are specified using WFC Binding mode
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil, "",
+			bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Creating StatefulSet with replica count 3 using parallel pod management policy
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating StatefulSet with replica count 3 using parallel pod management policy")
+		*(statefulset.Spec.Replicas) = 3
+		statefulset.Spec.PodManagementPolicy = apps.ParallelPodManagement
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Annotations["volume.beta.kubernetes.io/storage-class"] = sc.Name
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+
+		// Wait for StatefulSet pods to be in up and running state
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// Verify PV node affinity and that the PODS are running on appropriate node
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate nodes")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
+			statefulset, namespace, allowedTopologies, false)
+
+		// Scale up statefulset replica count to 5
+		replicas += 5
+		ginkgo.By("Scale up statefulset replica count to 5")
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+
+		// Scale down statefulset replica count to 1
+		replicas -= 1
+		ginkgo.By("Scale down statefulset replica count to 1")
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+
+		// Verify newly created PV node affinity details  and that the new PODS are running on appropriate nodes
+		ginkgo.By("Verify newly created PV node affinity details  and that the new PODS are running on appropriate nodes")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, false)
+
+		// Scale down statefulset replicas to 0
+		replicas = 0
+		ginkgo.By("Scale down statefulset replica count to 0")
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+	})
+
+	/*
+		TESTCASE-3
+		Steps:
+		1. Create SC with volumeBindingMode as WaitForFirstConsumer with allowed topology details.
+		(here in this case Allowed Topology specified:
+			region1 > zone1 > building1 > level1 > rack > rack3)
+		2. Create StatefulSet with parallel pod management policy with replica count 3 using above SC.
+		3. Wait for StatefulSet pods to be in up and running state.
+		4. Describe PV's and verify node affinity details of all 5 levels should be displayed.
+		5. Verify pods are created on nodes as mentioned in the storage class.
+		6. Scale up StatefulSet replica count to 5.
+		7. Verify StatefulSet scale	 up is successful.
+		8. Verify newly created StatefuSet pods are created on nodes as mentioned in the storage class.
+		9. Describe new PV and verify node affinity details of all the 5 levels should be displayed.
+		10. Bring down statefulset replica to 0.
+		11. Delete statefulset, PVC and SC.
+	*/
+
+	ginkgo.It("Provisioning volume when storage class specified with WFC Binding mode "+
+		"with allowed topologies and using parallel pod management policy for statefulset", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		/* Get allowed topologies for Storage Class
+		(region1 > zone1 > building1 > level1 > rack > rack3) */
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag2)
+
+		// Create StorageClass with allowed Topologies
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologyForSC,
+			"", bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Create StatefulSet using parallel pod management policy
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Updating replicas to 3 and podManagement Policy as Parallel")
+		*(statefulset.Spec.Replicas) = 3
+		statefulset.Spec.PodManagementPolicy = apps.ParallelPodManagement
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Annotations["volume.beta.kubernetes.io/storage-class"] = sc.Name
+		ginkgo.By("Creating statefulset")
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+
+		// Wait for StatefulSet pods to be in up and running state
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		/* Verify PV node affinity and that the PODS are running on
+		appropriate node as specified in the allowed topologies of SC */
+		ginkgo.By("Verify PV node affinity and that the PODS are running " +
+			"on appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, false)
+
+		// Scale up statefulset replicas to 5
+		replicas += 5
+		ginkgo.By("Scale up statefulset replica count to 5")
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+
+		/* Verify newly created PV node affinity and that the news PODS are running
+		on appropriate node as specified in the allowed topologies of SC */
+		ginkgo.By("Verify newly created PV node affinity and that the news PODS " +
+			"are running on appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, false)
+
+		// Scale down statefulset replicas to 0
+		replicas = 0
+		ginkgo.By("Scale down statefulset replica count to 0")
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+	})
+
+	/*
+		TESTCASE-4
+		Steps:
+		1. Create SC with Immediate BindingMode with higher level allowed topologies and use
+		shared datastore across cluster.
+		(here in this case allowed topology - region1 > zone1 > building1).
+		2. Create StatefulSet with default pod management policy with replica count 3 using above SC.
+		3. Wait for StatefulSet pods to be in up and running state.
+		4. Describe PV's and verify node affinity details of all 5 levels should be displayed.
+		4a. Verify volume provisioning can be on any rack. PV should have node affinity of all 5.
+		5. Verify pods are created on nodes as mentioned in the storage class.
+		6. Scale up StatefulSet replica count to 5.
+		7. Scale up StatefulSet replica count to 1.
+		8. Verify StatefulSet scale up and scale down is successful.
+		9. Verify newly created StatefuSet pods are created on nodes as mentioned in the storage class.
+		10. Describe newly created PV's and verify node affinity details of all the 5 levels
+		should be displayed.
+		11. Bring down statefulset replica to 0.
+		12. Delete statefulset, PVC and SC.
+	*/
+
+	ginkgo.It("Provisioning volume when storage class specified with Immediate BindingMode "+
+		"with higher level allowed topologies and using default pod management policy for statefulset", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Get allowed topologies for Storage Class (region1 > zone1 > building1)
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories, 3)
+
+		/* Create SC with Immediate BindingMode with higher level allowed topologies
+		using shared datastore across cluster */
+		scParameters := make(map[string]string)
+		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
+		scParameters["storagepolicyname"] = storagePolicyName
+		storageclass, err := createStorageClass(client, scParameters, allowedTopologyForSC, "",
+			"", false, "nginx-sc")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Creating StatefulSet with replica count 3 using default pod management policy
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+
+		// Wait for StatefulSet pods to be in up and running state
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		/* Verify PV node affinity and that the PODS are running on appropriate
+		node as specified in the allowed topologies of SC */
+		ginkgo.By("Verify PV node affinity and that the PODS are running " +
+			"on appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, false)
+
+		// Scale up statefulset replicas to 5
+		replicas += 5
+		ginkgo.By("Scale up statefulset replica count to 5")
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+
+		// Scale down statefulset replicas to 1
+		replicas -= 1
+		ginkgo.By("Scale down statefulset replica count to 1")
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+
+		/* "Verify newly created PV node affinity and that the new PODS are
+		running on appropriate node as specified in the allowed topologies of SC */
+		ginkgo.By("Verify newly created PV node affinity and that the new PODS are running " +
+			"on appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, false)
+
+		// Scale down statefulset replicas to 0
+		replicas = 0
+		ginkgo.By("Scale down statefulset replica count to 0")
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+	})
+
+	/*
+		TESTCASE-5
+		Steps:
+		1. Create SC with Immediate BindingMode with all 5 levels of allowedTopologies
+			(provide multiple labels) and shared datasore URL present only in rack2 and rack3.
+		(here in this case - region1 > zone1 > building1 > level1 > rack > (rack2 and rack3)
+		2. Create StatefulSet with parallel pod management policy with replica count 3 using above SC.
+		3. Wait for all StatefulSet Pods to be in up and running state and PVC to be in bound phase.
+		5. Describe PV's. Since the datastore mentioned in SC is specific to rack2 and rack3,
+			all the nodes should get deployed on rack2 and rack3 only. Node affinity should have
+			details of all 5 levels.
+		6. Verify that the pods are running on appropriate node.
+		7. Scale up Statefulset replica count to 5.
+		8. Scale down Statefulset replica count to 1.
+		7. Describe newly created PV's and verify volumes are provisioned on appropriate node.
+		PV should show proper node affinity details of all 5 levels.
+		8. Bring down statefulset replica to 0.
+		9. Delete statefulset , PVC, SC
+	*/
+
+	ginkgo.It("Provisioning volume when storage class specified with Immediate Bindingmode "+
+		"shared datastore url between multiple topology labels and using parallel pod management "+
+		"policy for statefulset", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		sharedDataStoreUrlBetweenClusters := GetAndExpectStringEnvVar(datstoreSharedBetweenClusters)
+
+		/* Get allowed topologies for Storage Class
+		region1 > zone1 > building1 > level1 > rack > (rack2 and rack3)
+		Taking Shared datstore between Rack2 and Rack3 */
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag1, leafNodeTag2)
+
+		/* Create SC with Immediate BindingMode with multiple topology labels and datastore
+		shared between those labels. */
+		scParameters := make(map[string]string)
+		scParameters["datastoreurl"] = sharedDataStoreUrlBetweenClusters
+		storageclass, err := createStorageClass(client, scParameters, allowedTopologyForSC,
+			"", "", false, "nginx-sc")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Create StatefulSet using parallel pod management policy
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Updating replicas to 3 and podManagement Policy as Parallel")
+		*(statefulset.Spec.Replicas) = 3
+		statefulset.Spec.PodManagementPolicy = apps.ParallelPodManagement
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+		ginkgo.By("Creating statefulset")
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+
+		// Wait for StatefulSet pods to be in up and running state
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		/* Verify PV node affinity and that the PODS are running on appropriate
+		node as specified in the allowed topologies of SC */
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
+			"node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, false)
+
+		// Scale up statefulset replicas to 5
+		replicas += 5
+		ginkgo.By("Scale up statefulset replica count to 5")
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+
+		// Scale down statefulset replicas to 1
+		replicas -= 1
+		ginkgo.By("Scale down statefulset replica count to 1")
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+
+		/* Verify newly created PV node affinity and that the new PODS are running on
+		appropriate node as specified in the allowed topologies of SC */
+		ginkgo.By("Verify newly created PV node affinity and that the new PODS are running " +
+			"on appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, false)
+
+		// Scale down statefulset replicas to 0
+		replicas = 0
+		ginkgo.By("Scale down statefulset replica count to 0")
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+	})
+
+	/*
+	   TESTCASE-7
+	   Steps:
+	   1. Create SC with Immediate BindingMode with all 5 levels of allowedTopologies and
+	   storage policy specific to rack3.
+	   (here in this case - region1 > zone1 > building1 > level1 > rack > rack3)
+	   2. Create PVC using above SC.
+	   3. Create Deployment set with replica count 1 using above created PVC.
+	   4. Vefiry Deployment pod is in up and running state and PVC in bound phase.
+	   5. Describe PV and verify pv node affinity should have allowed topology details of SC.
+	   6. Verify pod is created on the node as mentioned in the storage class.
+	   7. Delete Deployment set
+	   8. Delete PVC and SC
+	*/
+	ginkgo.It("Provisioning volume when storage class specified with "+
+		"Immediate BindingMode with multiple allowed topologies and using DeploymentSet pod", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		var lables = make(map[string]string)
+		lables["app"] = "nginx"
+		replica := 1
+
+		/* Get allowed topologies for Storage Class
+		(region1 > zone1 > building1 > level1 > rack > rack3) */
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag2)
+
+		// create SC and PVC
+		storagePolicyName := GetAndExpectStringEnvVar(storagePolicyForDatastoreSpecificToCluster)
+		scParameters := make(map[string]string)
+		scParameters["storagepolicyname"] = storagePolicyName
+
+		ginkgo.By("Create StorageClass and PVC for Deployment")
+		sc, pvclaim, err := createPVCAndStorageClass(client, namespace, nil,
+			scParameters, diskSize, allowedTopologyForSC, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Wait for PVC to be in Bound phase
+		pvclaims = append(pvclaims, pvclaim)
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims,
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
+		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pvclaim = nil
+		}()
+
+		// Create Deployment Pod with replica count 1 using above PVC
+		ginkgo.By("Create Deployments")
+		deployment, err := createDeployment(ctx, client, int32(replica), lables,
+			nil, namespace, pvclaims, "", false, nginxImage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			framework.Logf("Delete deployment set")
+			err := client.AppsV1().Deployments(namespace).Delete(ctx, deployment.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Verify PV node affinity and that the PODS are running on appropriate
+		node as specified in the allowed topologies of SC */
+		ginkgo.By("Verify PV node affinity and that the PODS are running " +
+			"on appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5(ctx, client, deployment,
+			namespace, allowedTopologyForSC, false)
+	})
+
+	/*
+		TESTCASE-11
+		Steps:
+		1. Create SC with WFC BindingMode and allowed topology set to multiple labels
+		without datastore URL.
+		(here in this case - rack > (rack1,rack2,rack3))
+		2. Create StatefulSet with default pod management policy with replica count 3 using above SC.
+		3. Wait for StatefulSet pods to be in running state and PVC to be in Bound phase.
+		4. Describe on the PV's and verify node affinity details.
+		5. Verify, PV node affinity of all 5 levels should be displayed.
+		5a. Verify, If a volume is provisioned on shared datastore, pv node affinity
+			details contain all the availability zone details.
+		5b. Verify, If a volume provisioned on a datastore that is shared within
+			 the specific zone then node affinity will have details of specific zone and its node labels.
+		6. Verify StatefuSet pods are created on nodes as mentioned in the storage class.
+		7. Bring down statefulset replica to 0.
+		8. Delete statefulset, PVC and SC.
+	*/
+
+	ginkgo.It("Provisioning volume when storage class specified with multiple labels "+
+		"without specifying datastore url and using default pod management policy "+
+		"for statefulset", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Get allowed topologies for Storage Class rack > (rack1,rack2,rack3)
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength)[4:]
+
+		// Create SC with WFC BindingMode with allowed topology details.
+		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "",
+			bindingMode, false, "nginx-sc")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Creating StatefulSet with replica count 3 using default pod management policy
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+
+		// Wait for StatefulSet pods to be in up and running state
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		/* Verify PV node affinity and that the PODS are running on appropriate node
+		as specified in the allowed topologies of SC */
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, false)
+
+		// Scale down statefulset to 0 replicas
+		replicas -= 3
+		ginkgo.By("Scale down statefulset replica count to 0")
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+	})
+
+	/*
+		TESTCASE-12
+		Steps:
+		1. Create SC with Immediate BindingMode and allowed topology set to invalid topology
+		label in any one level.
+		(here in this case - region1 > zone1 > building1 > level1 > rack > rack15)
+		2. Create PVC using above SC.
+		3. Volume Provisioning should fail with error message displayed due to incorrect topology
+		labels specified in SC
+		4. Delete PVC and SC.
+	*/
+
+	ginkgo.It("Verify volume provisioning when storage class specified with invalid topology label", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		log := logger.GetLogger(ctx)
+		// Get allowed topologies for Storage Class
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength)
+		allowedTopologyForSC[4].Values = []string{"rack15"}
+
+		/* Create SC with Immediate BindingMode and allowed topology set to
+		invalid topology label in any one level */
+		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Create PVC using above SC
+		pvc, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			if pvc != nil {
+				ginkgo.By("Delete the PVC")
+				err = fpv.DeletePersistentVolumeClaim(client, pvc.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		// Expect PVC claim to fail as invalid topology label is given in Storage Class
+		ginkgo.By("Expect claim to fail as invalid topology label is specified in Storage Class")
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
+			pvc.Namespace, pvc.Name, framework.Poll, time.Minute/2)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		if err != nil {
+			log.Errorf("Volume Provisioning Failed for PVC %s due to invalid topology "+
+				"label given in Storage Class", pvc.Name)
+		}
+	})
+
+	/*
+		TESTCASE-16
+		Verify that Topology is not supported on file volumes
+		Steps:
+		1. Create SC with Immediate BindingMode with allowed topologies.
+		(here in this case - region1 > zone1 > building1 > level1 > rack > (rack1,rack2,rack3))
+		2. Create PVC using above SC with access mode "accessModes" ReadWriteMany.
+		3. Verify PVC creation is stuck in pending state forever.
+		4. Delete PVC and SC.
+	*/
+
+	ginkgo.It("Verify volume provisioning when storage class specified with Immediate "+
+		"BindingMode and pvc specified with ReadWriteMany access mode", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		log := logger.GetLogger(ctx)
+		// Get allowed topologies for Storage Class for all 5 levels
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength)
+
+		// Create SC with Immediate BindingMode and allowed topology set to 5 levels
+		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Create PVC with accessMode as "ReadWriteMany" using above SC
+		pvc, err := createPVC(client, namespace, nil, "", storageclass, v1.ReadWriteMany)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			if pvc != nil {
+				ginkgo.By("Delete the PVC")
+				err = fpv.DeletePersistentVolumeClaim(client, pvc.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		// Expect PVC claim to fail as volume topology feature for file volumes is not supported
+		ginkgo.By("Expect PVC claim to fail as volume topology feature for file " +
+			"volumes is not supported")
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
+			pvc.Namespace, pvc.Name, framework.Poll, time.Minute/2)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		if err != nil {
+			log.Errorf("Volume Provisioning Failed %v because Topology feature for file "+
+				"volumes is not supported", err)
+		}
+	})
+
+	/*
+		TESTCASE-14
+		Create SC with one topology label with datastore URL
+		Steps:
+		1. Create SC with Immediate binding mode and one level topology detail
+		specified with Datastore URL.
+		(here in this case - rack > rack2 and datastore url specific to rack2)
+		2. Create PVC using above created SC and wait for PVC to reach bound state.
+		2. Describe PV and verify pv node affinity details should hold all the 5 levels of
+		topology details.
+		3. Create POD using above created PVC.
+		4. Verify that the pod are running on appropriate node.
+		5. Delete POD, PVC and SC
+	*/
+
+	ginkgo.It("Verify volume provisioning when storage class specified with one level "+
+		"topology along with datstore url", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Get allowed topologies for Storage Class (rack > rack2)
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag1)[4:]
+
+		/* Create SC with Immediate BindingMode with single level topology detail
+		specified with datatsoreUrl */
+		scParameters := make(map[string]string)
+		DataStoreUrlSpecificToCluster := GetAndExpectStringEnvVar(datastoreUrlSpecificToCluster)
+		scParameters["datastoreurl"] = DataStoreUrlSpecificToCluster
+		storageclass, pvclaim, err := createPVCAndStorageClass(client, namespace, nil,
+			scParameters, "", allowedTopologyForSC, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Wait for PVC to be bound
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaims = append(pvclaims, pvclaim)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims,
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pv := persistentvolumes[0]
+		volHandle := pv.Spec.CSI.VolumeHandle
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Create a Pod to use this PVC, and verify volume has been attached
+		ginkgo.By("Creating pod to attach PV to the node")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		var vmUUID string
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle,
+			pod.Spec.NodeName))
+		vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify volume is detached from the node")
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle,
+					pod.Spec.NodeName))
+		}()
+
+		/* Verify PV node affinity and that the PODS are running on appropriate node as
+		specified in the allowed topologies of SC */
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
+			"node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
+			allowedTopologies)
+	})
+
+	/*
+		TESTCASE-13
+		Crete SC with one label specified in storage class without datastore URL
+		Steps:
+		1. Create SC with Immediate BindingMode with only one level topology detail
+		specified without datastore url.
+		(here in this case - rack > rack1)
+		2. Create PVC using above SC and wait for PVC to reach bound state.
+		3. Create POD using above created PVC.
+		4. Verify that the pod are running on appropriate node.
+		5. Delete POD, PVC and SC
+	*/
+	ginkgo.It("Verify volume provisioning when storage class specified with single "+
+		"level topology without datstore url", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Get allowed topologies for Storage Class (rack > rack1)
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag0)[4:]
+
+		// Create SC with Immediate BindingMode with single level topology detail
+		storageclass, pvclaim, err := createPVCAndStorageClass(client, namespace, nil,
+			nil, "", allowedTopologyForSC, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Wait for PVC to be bound
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaims = append(pvclaims, pvclaim)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims,
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pv := persistentvolumes[0]
+		volHandle := pv.Spec.CSI.VolumeHandle
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Create a Pod to use this PVC, and verify volume has been attached
+		ginkgo.By("Creating pod to attach PV to the node")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		var vmUUID string
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify volume is detached from the node")
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle,
+					pod.Spec.NodeName))
+		}()
+
+		/* Verify PV node affinity and that the PODS are running on appropriate node as
+		specified in the allowed topologies of SC */
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
+			allowedTopologies)
+	})
+
+	/*
+		TESTCASE-6
+		Steps:
+		1. Create FCD on the datastore present in datacenter > cluster2
+		2. Create SC which points to region1 > zone1 > building1 > level1 > rack > rack2.
+		3. Create PV using the above created FCD, SC and 'nodeSelectorTerms' of SC.
+		4. Create PVC using above created SC and PV.
+		5. Wait for PV, PVC to be in bound.
+		6. Describe  PV and verify node affinity details. It should display all 5 levels.
+		7. Create POD using the above PVC.
+		8. POD should come up on the node which is present in the same zone as mentioned in
+		the storage class.
+		9. Delete POD, PVC, PV and SC.
+	*/
+	ginkgo.It("Verify static volume provisioning with FCD and storage class with allowed topologies", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		/* Get allowed topologies for Storage Class
+		region1 > zone1 > building1 > level1 > rack > rack2 */
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag1)
+
+		// Create SC with Immediate BindingMode and allowed topology set to 5 levels
+		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating FCD Disk")
+		fcdID, err := e2eVSphere.createFCD(ctx, "BasicStaticFCD", diskSizeInMb,
+			DSSharedToSpecificCluster.Reference())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow newly created FCD:%s to sync "+
+			"with pandora",
+			pandoraSyncWaitTime, fcdID))
+		time.Sleep(time.Duration(pandoraSyncWaitTime) * time.Second)
+
+		// Creating label for PV.
+		// PVC will use this label as Selector to find PV.
+		staticPVLabels := make(map[string]string)
+		staticPVLabels["fcd-id"] = fcdID
+
+		ginkgo.By("Creating the PV")
+		pv := getPersistentVolumeSpecWithStorageClassFCDNodeSelector(fcdID,
+			v1.PersistentVolumeReclaimDelete, storageclass.Name, staticPVLabels,
+			diskSize, allowedTopologyForSC)
+		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
+		if err != nil {
+			return
+		}
+		err = e2eVSphere.waitForCNSVolumeToBeCreated(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Creating the PVC")
+		pvc := getPersistentVolumeClaimSpec(namespace, staticPVLabels, pv.Name)
+		pvc.Spec.StorageClassName = &storageclass.Name
+		pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc,
+			metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Wait for PV and PVC to Bind.
+		framework.ExpectNoError(fpv.WaitOnPVandPVC(client, framework.NewTimeoutContextWithDefaults(),
+			namespace, pv, pvc))
+
+		ginkgo.By("Verifying CNS entry is present in cache")
+		_, err = e2eVSphere.queryCNSVolumeWithResult(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Deleting the PV Claim")
+			framework.ExpectNoError(fpv.DeletePersistentVolumeClaim(client, pvc.Name, namespace),
+				"Failed to delete PVC", pvc.Name)
+			pvc = nil
+
+			ginkgo.By("Verify PV should be deleted automatically")
+			framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+				pollTimeout))
+			pv = nil
+
+		}()
+
+		ginkgo.By("Creating the Pod")
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaims = append(pvclaims, pvc)
+		pod, err := createPod(client, namespace, nil, pvclaims, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle,
+			pod.Spec.NodeName))
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
+
+		ginkgo.By("Verify container volume metadata is present in CNS cache")
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolume with VolumeID: %s", pv.Spec.CSI.VolumeHandle))
+		_, err = e2eVSphere.queryCNSVolumeWithResult(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		labels := []types.KeyValue{{Key: "fcd-id", Value: fcdID}}
+		ginkgo.By("Verify container volume metadata is matching the one in CNS cache")
+		err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+			pvc.Name, pv.ObjectMeta.Name, pod.Name, labels...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Deleting the Pod")
+			framework.ExpectNoError(fpod.DeletePodWithWait(client, pod), "Failed to delete pod",
+				pod.Name)
+
+			ginkgo.By(fmt.Sprintf("Verify volume is detached from the node: %s", pod.Spec.NodeName))
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(), "Volume is not detached from the node")
+		}()
+
+		/* Verify PV node affinity and that the PODS are running on appropriate node
+		as specified in the allowed topologies of SC */
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
+			allowedTopologies)
+
+	})
+
+	/*
+		TESTCASE-15
+		Steps:
+		1. Create FCD on the datastore present in datacenter1 > cluster1/cluster2/cluster3.
+		2. Create SC which points to region1 > zone1 > building1 > level1 > rack > rack1/rack2/rack3.
+		3. Create PV using the above created FCD and SC and reclaim policy retain.
+		4. Create PVC using above created SC and PV.
+		5. Wait for PV, PVC to be in bound state.
+		6. Create POD using above PVC.
+		7. Wait for Pod to be in up and running state.
+		8. Describe  PV and verify node affinity details. It should display all 5 levels.
+		9. POD should come up on the appropriate node as mentioned in storage class.
+		10. Delete POD and PVC.
+		11. Delete claim ref from PV to bring it to available state.
+		12. Recreate PVC with the same name used in step 4.
+		13. PVC should be created and should reach bound state.
+		14. Create Pod using above created PVC. Wait for Pod to reach running state.
+		15. Describe PV and verify node affinity details. It should display all 5 levels.
+		16. Verfiy Pod is running on appropriate node as mentioned in SC.
+		17. Verify CNS metadata for PVC.
+		18. Delete POD, PVC, PV and SC.
+
+	*/
+	ginkgo.It("Verify static volume provisioning with FCD and storage class specified "+
+		"with datastore url and set of allowed topologies", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		/* Get allowed topologies for Storage Class
+		zone1 > building1 > level1 > rack > rack1/rack2/rack3 */
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength)
+
+		// Create SC with Immediate BindingMode and allowed topology set to 5 levels
+		scParameters := make(map[string]string)
+		scParameters["datastoreurl"] = datastoreURL
+		storageclass, err := createStorageClass(client, scParameters, allowedTopologyForSC, "", "",
+			false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Creating FCD disk
+		ginkgo.By("Creating FCD Disk")
+		fcdID, err := e2eVSphere.createFCD(ctx, "BasicStaticFCD", diskSizeInMb,
+			defaultDatastore.Reference())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow newly created FCD:%s to sync "+
+			"with pandora",
+			pandoraSyncWaitTime, fcdID))
+		time.Sleep(time.Duration(pandoraSyncWaitTime) * time.Second)
+
+		// Creating label for PV. PVC will use this label as Selector to find PV.
+		staticPVLabels := make(map[string]string)
+		staticPVLabels["fcd-id"] = fcdID
+
+		// Creating PV using above created SC and FCD
+		ginkgo.By("Creating the PV")
+		pv := getPersistentVolumeSpecWithStorageClassFCDNodeSelector(fcdID,
+			v1.PersistentVolumeReclaimRetain, storageclass.Name, staticPVLabels,
+			diskSize, allowedTopologyForSC)
+		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
+		if err != nil {
+			return
+		}
+		err = e2eVSphere.waitForCNSVolumeToBeCreated(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Creating PVC using above created PV
+		ginkgo.By("Creating the PVC")
+		pvc := getPersistentVolumeClaimSpec(namespace, staticPVLabels, pv.Name)
+		pvc.Spec.StorageClassName = &storageclass.Name
+		pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc,
+			metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Wait for PV and PVC to Bind.
+		framework.ExpectNoError(fpv.WaitOnPVandPVC(client, framework.NewTimeoutContextWithDefaults(),
+			namespace, pv, pvc))
+		ginkgo.By("Verifying CNS entry is present in cache")
+		_, err = e2eVSphere.queryCNSVolumeWithResult(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Deleting the PV Claim")
+			framework.ExpectNoError(fpv.DeletePersistentVolumeClaim(client, pvc.Name, namespace),
+				"Failed to delete PVC", pvc.Name)
+			pvc = nil
+
+			ginkgo.By("Deleting the PV")
+			err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}()
+
+		// Creating Pod using above created PVC
+		ginkgo.By("Creating the Pod")
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaims = append(pvclaims, pvc)
+		pod, err := createPod(client, namespace, nil, pvclaims, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle,
+			pod.Spec.NodeName))
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
+
+		ginkgo.By("Verify container volume metadata is present in CNS cache")
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolume with VolumeID: %s", pv.Spec.CSI.VolumeHandle))
+		_, err = e2eVSphere.queryCNSVolumeWithResult(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		labels := []types.KeyValue{{Key: "fcd-id", Value: fcdID}}
+		ginkgo.By("Verify container volume metadata is matching the one in CNS cache")
+		err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+			pvc.Name, pv.ObjectMeta.Name, pod.Name, labels...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Deleting the Pod")
+			framework.ExpectNoError(fpod.DeletePodWithWait(client, pod), "Failed to delete pod",
+				pod.Name)
+
+			ginkgo.By(fmt.Sprintf("Verify volume is detached from the node: %s", pod.Spec.NodeName))
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(), "Volume is not detached from the node")
+		}()
+
+		/* Verify PV node affinity and that the PODS are running on appropriate node as
+		specified in the allowed topologies of SC */
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
+			allowedTopologies)
+
+		// Deleting Pod
+		ginkgo.By("Deleting the Pod")
+		framework.ExpectNoError(fpod.DeletePodWithWait(client, pod), "Failed to delete pod", pod.Name)
+
+		ginkgo.By(fmt.Sprintf("Verify volume is detached from the node: %s", pod.Spec.NodeName))
+		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle,
+			pod.Spec.NodeName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskDetached).To(gomega.BeTrue(), "Volume is not detached from the node")
+
+		// Deleting PVC
+		ginkgo.By("Delete PVC")
+		err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name,
+			*metav1.NewDeleteOptions(0))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		framework.Logf("PVC %s is deleted successfully", pvc.Name)
+
+		// Verify PV exist and is in released status
+		ginkgo.By("Check PV exists and is released")
+		pv, err = waitForPvToBeReleased(ctx, client, pv.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		framework.Logf("PV status after deleting PVC: %s", pv.Status.Phase)
+
+		// Remove claim from PV and check its status.
+		ginkgo.By("Remove claimRef from PV")
+		pv.Spec.ClaimRef = nil
+		pv, err = client.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		framework.Logf("PV status after removing claim : %s", pv.Status.Phase)
+
+		// Recreate PVC with same name as created above
+		ginkgo.By("ReCreating the PVC")
+		pvclaim := getPersistentVolumeClaimSpec(namespace, nil, pv.Name)
+		pvclaim.Spec.StorageClassName = &storageclass.Name
+		pvclaim.Name = pvc.Name
+		pvclaim, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvclaim,
+			metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Wait for newly created PVC to bind to the existing PV
+		ginkgo.By("Wait for the PVC to bind the lingering pv")
+		err = fpv.WaitOnPVandPVC(client, framework.NewTimeoutContextWithDefaults(), namespace, pv,
+			pvclaim)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Creating POD to use this PVC, and verify volume has been attached.
+		ginkgo.By("Creating pod to attach PV to the node")
+		pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false,
+			execCommand)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isDiskAttached, err = e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle,
+			vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+
+		/* Verify PV node affinity and that the PODS are running on appropriate node as
+		specified in the allowed topologies of SC */
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
+			allowedTopologies)
+
+		// Verify volume metadata for POD, PVC and PV
+		ginkgo.By("Verify volume metadata for POD, PVC and PV")
+		err = waitAndVerifyCnsVolumeMetadata(pv.Spec.CSI.VolumeHandle, pvclaim, pv, pod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	})
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Topology automation testcases

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Yes

**Special notes for your reviewer**:
Test-cases for Topology Table2

Make check:
sipriya@sipriya-a02 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a02 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/new-topology-table2/vsphere-csi-driver /Users/sipriya/new-topology-table2 /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|imports|name|types_sizes|deps|exports_file|files) took 1m2.075699982s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 139.386925ms 
INFO [linters context/goanalysis] analyzers took 6m15.339246572s with top 10 stages: buildir: 4m30.536360475s, nilness: 26.147594558s, fact_deprecated: 9.551538855s, ctrlflow: 9.380562583s, printf: 9.308877962s, typedness: 8.212309818s, fact_purity: 7.585511371s, SA5012: 6.304097637s, inspect: 4.05468102s, misspell: 2.093591475s 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): cgo: 110/110, skip_dirs: 110/110, identifier_marker: 21/21, filename_unadjuster: 110/110, autogenerated_exclude: 21/110, exclude: 21/21, exclude-rules: 1/21, nolint: 0/1, path_prettifier: 110/110, skip_files: 110/110 
INFO [runner] processing took 30.342818ms with stages: nolint: 24.451973ms, autogenerated_exclude: 3.258649ms, path_prettifier: 1.302661ms, skip_dirs: 602.262µs, identifier_marker: 504.657µs, exclude-rules: 186.735µs, cgo: 14.508µs, filename_unadjuster: 14.036µs, max_same_issues: 1.619µs, uniq_by_line: 997ns, max_from_linter: 827ns, skip_files: 703ns, diff: 558ns, source_code: 455ns, max_per_file_from_linter: 424ns, exclude: 394ns, path_shortener: 389ns, severity-rules: 373ns, sort_results: 352ns, path_prefixer: 246ns 
INFO [runner] linters took 43.495213407s with stages: goanalysis_metalinter: 43.464686376s 
INFO File cache stats: 269 entries of total size 3.8MiB 
INFO Memory: 978 samples, avg is 636.7MB, max is 2368.6MB 
INFO Execution took 1m45.721175059s  

