### PR TITLE
Avoid setting provisioner annotation

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -253,12 +253,6 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			volumeType = prometheus.PrometheusBlockVolumeType
 		}
 
-		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) && isFileVolumeRequest &&
-			req.AccessibilityRequirements != nil {
-			msg := "File Volumes are currently not supported with TKGS HA feature"
-			log.Error(msg)
-			return nil, csifault.CSIUnimplementedFault, status.Errorf(codes.Unimplemented, msg)
-		}
 		// Get PVC name and disk size for the supervisor cluster
 		// We use default prefix 'pvc-' for pvc created in the guest cluster, it is mandatory.
 		supervisorPVCName := c.tanzukubernetesClusterUID + "-" + req.Name[4:]
@@ -297,8 +291,6 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 						return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
 					}
 					annotations[common.AnnGuestClusterRequestedTopology] = topologyAnnotation
-					annotations[common.AnnBetaStorageProvisioner] = common.VSphereCSIDriverName
-					annotations[common.AnnStorageProvisioner] = common.VSphereCSIDriverName
 				}
 				claim := getPersistentVolumeClaimSpecWithStorageClass(supervisorPVCName, c.supervisorNamespace,
 					diskSize, supervisorStorageClass, getAccessMode(accessMode), annotations)


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Do not set the storage provisioner as an annotation on the PVC.
2. Remove checks that prevent volume creation when file volume is requested and tkgs-ha is enabled.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
make test

Ran all unit tests and they PASS
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>