### PR TITLE
Fixed the VC login failure in CSI during WCP password rotation

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -315,6 +315,9 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 func (vc *VirtualCenter) ListDatacenters(ctx context.Context) (
 	[]*Datacenter, error) {
 	log := logger.GetLogger(ctx)
+	if vc.Client == nil {
+		return nil, logger.LogNewError(log, "failed to list datacenters due to VC client is not set")
+	}
 	finder := find.NewFinder(vc.Client.Client, false)
 	dcList, err := finder.DatacenterList(ctx, "*")
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

During the WCP password rotation, we could observe ops failures due to VC login failure. Even though this issue is automatic ally recoverable, it could result CSI service unavailability up to around 5 mins, which might break CSI SLA.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixed the VC login failure in CSI during WCP password rotation

**Testing done**:
Regression Test: TODO

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed the VC login failure in CSI during WCP password rotation
```
