### PR TITLE
Support storage-provisioner GA annotation for k8s 1.23

### DIFF
--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -230,15 +230,17 @@ func isValidvSphereVolumeClaim(ctx context.Context, pvcMetadata metav1.ObjectMet
 	// Checking if the migrated-to annotation is found in the PVC metadata.
 	if annotation, annMigratedToFound := pvcMetadata.Annotations[common.AnnMigratedTo]; annMigratedToFound {
 		if annotation == csitypes.Name &&
-			pvcMetadata.Annotations[common.AnnBetaStorageProvisioner] == common.InTreePluginName {
+			(pvcMetadata.Annotations[common.AnnBetaStorageProvisioner] == common.InTreePluginName ||
+				pvcMetadata.Annotations[common.AnnStorageProvisioner] == common.InTreePluginName) {
 			log.Debugf("%v annotation found with value %q for PVC: %q",
 				common.AnnMigratedTo, csitypes.Name, pvcMetadata.Name)
 			return true
 		}
 	} else { // Checking if the PVC was provisioned by CSI.
-		if pvcMetadata.Annotations[common.AnnBetaStorageProvisioner] == csitypes.Name {
-			log.Debugf("%v annotation found with value %q for PVC: %q",
-				common.AnnBetaStorageProvisioner, csitypes.Name, pvcMetadata.Name)
+		if pvcMetadata.Annotations[common.AnnBetaStorageProvisioner] == csitypes.Name ||
+			pvcMetadata.Annotations[common.AnnStorageProvisioner] == csitypes.Name {
+			log.Debugf("%v or %v annotation found with value %q for PVC: %q",
+				common.AnnBetaStorageProvisioner, common.AnnStorageProvisioner, csitypes.Name, pvcMetadata.Name)
 			return true
 		}
 	}

--- a/pkg/syncer/util_test.go
+++ b/pkg/syncer/util_test.go
@@ -14,12 +14,14 @@ import (
 )
 
 var (
-	validMigratedPVCMetadata   metav1.ObjectMeta
-	validMigratedPVMetadata    metav1.ObjectMeta
-	validLegacyPVCMetadata     metav1.ObjectMeta
-	validLegacyPVMetadata      metav1.ObjectMeta
-	invalidMigratedPVCMetadata metav1.ObjectMeta
-	invalidMigratedPVMetadata  metav1.ObjectMeta
+	validMigratedPVCMetadata                            metav1.ObjectMeta
+	validMigratedPVCMetadataWithGAStorageProvisionerAnn metav1.ObjectMeta
+	validMigratedPVMetadata                             metav1.ObjectMeta
+	validLegacyPVCMetadata                              metav1.ObjectMeta
+	validLegacyPVCMetadataWithGAStorageProvisionerAnn   metav1.ObjectMeta
+	validLegacyPVMetadata                               metav1.ObjectMeta
+	invalidMigratedPVCMetadata                          metav1.ObjectMeta
+	invalidMigratedPVMetadata                           metav1.ObjectMeta
 )
 
 func init() {
@@ -30,10 +32,23 @@ func init() {
 			"volume.beta.kubernetes.io/storage-provisioner": "kubernetes.io/vsphere-volume",
 		},
 	}
+	validMigratedPVCMetadataWithGAStorageProvisionerAnn = metav1.ObjectMeta{
+		Name: "migrated-vcppvc",
+		Annotations: map[string]string{
+			"pv.kubernetes.io/migrated-to":             "csi.vsphere.vmware.com",
+			"volume.kubernetes.io/storage-provisioner": "kubernetes.io/vsphere-volume",
+		},
+	}
 	validLegacyPVCMetadata = metav1.ObjectMeta{
 		Name: "vcppvcProvisionedByCSI",
 		Annotations: map[string]string{
 			"volume.beta.kubernetes.io/storage-provisioner": "csi.vsphere.vmware.com",
+		},
+	}
+	validLegacyPVCMetadataWithGAStorageProvisionerAnn = metav1.ObjectMeta{
+		Name: "vcppvcProvisionedByCSI",
+		Annotations: map[string]string{
+			"volume.kubernetes.io/storage-provisioner": "csi.vsphere.vmware.com",
 		},
 	}
 	validMigratedPVMetadata = metav1.ObjectMeta{
@@ -72,7 +87,13 @@ func TestValidMigratedAndLegacyVolume(t *testing.T) {
 	if !isValidvSphereVolumeClaim(ctx, validMigratedPVCMetadata) {
 		t.Errorf("Expected: isValidvSphereVolumeClaim to return True\n Actual: isValidvSphereVolumeClaim returned False")
 	}
+	if !isValidvSphereVolumeClaim(ctx, validMigratedPVCMetadataWithGAStorageProvisionerAnn) {
+		t.Errorf("Expected: isValidvSphereVolumeClaim to return True\n Actual: isValidvSphereVolumeClaim returned False")
+	}
 	if !isValidvSphereVolumeClaim(ctx, validLegacyPVCMetadata) {
+		t.Errorf("Expected: isValidvSphereVolumeClaim to return True\n Actual: isValidvSphereVolumeClaim returned False")
+	}
+	if !isValidvSphereVolumeClaim(ctx, validLegacyPVCMetadataWithGAStorageProvisionerAnn) {
 		t.Errorf("Expected: isValidvSphereVolumeClaim to return True\n Actual: isValidvSphereVolumeClaim returned False")
 	}
 	if isValidvSphereVolumeClaim(ctx, invalidMigratedPVCMetadata) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/pull/104590 has a change to add `volume.kubernetes.io/storage-provisioner` annotation for dynamic provisioning PVC. `volume.beta.kubernetes.io/storage-provisioner` annotation is deprecated.

We have a VCP to CSI Migration workflow dependent on `volume.beta.kubernetes.io/storage-provisioner`. This PR is making a change in the driver to support `volume.kubernetes.io/storage-provisioner` annotation.


**Testing done**:
Executed unit tests and linter tests locally 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support storage-provisioner GA annotation for k8s 1.23
```
