### PR TITLE
Add volumeAttachement listeners

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -50,6 +50,7 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 				"file-volume":           "true",
 				"block-volume-snapshot": "true",
 				"tkgs-ha":               "true",
+				"list-volumes":          "true",
 			},
 		}
 		return fakeCO, nil
@@ -209,4 +210,10 @@ func (f *fakeVolumeOperationRequestInterface) StoreRequestDetails(
 ) error {
 	f.volumeOperationRequestMap[instance.Name] = instance
 	return nil
+}
+
+// GetNodesForVolumes returns nodeNames to which the given volumeIDs are attached
+func (c *FakeK8SOrchestrator) GetNodesForVolumes(ctx context.Context, volumeID []string) map[string][]string {
+	nodeNames := make(map[string][]string)
+	return nodeNames
 }

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -51,6 +51,8 @@ type COCommonInterface interface {
 	// InitTopologyServiceInNode initializes the necessary resources
 	// required for topology related functionality in the nodes.
 	InitTopologyServiceInNode(ctx context.Context) (types.NodeTopologyService, error)
+	// GetNodesForVolumes returns a map of volumeID to list of node names
+	GetNodesForVolumes(ctx context.Context, volumeIds []string) map[string][]string
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given

--- a/pkg/kubernetes/informers.go
+++ b/pkg/kubernetes/informers.go
@@ -171,6 +171,19 @@ func (im *InformerManager) AddPodListener(
 	})
 }
 
+// AddVolumeAttachmentListener hooks up add, update, delete callbacks.
+func (im *InformerManager) AddVolumeAttachmentListener(
+	add func(obj interface{}), remove func(obj interface{})) {
+	if im.volumeAttachmentInformer == nil {
+		im.volumeAttachmentInformer = im.informerFactory.Storage().V1().VolumeAttachments().Informer()
+	}
+
+	im.volumeAttachmentInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    add,
+		DeleteFunc: remove,
+	})
+}
+
 // GetPVLister returns PV Lister for the calling informer manager.
 func (im *InformerManager) GetPVLister() corelisters.PersistentVolumeLister {
 	return im.informerFactory.Core().V1().PersistentVolumes().Lister()

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -80,4 +80,7 @@ type InformerManager struct {
 	podInformer cache.SharedInformer
 	// Function to determine if podInformer has been synced
 	podSynced cache.InformerSynced
+
+	// volume attachment informer
+	volumeAttachmentInformer cache.SharedInformer
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

This PR adds:

1. VolumeAttachment add/delete callback functions which update the volumeIDsToNodeName map
2. Implementation of GetNodesForVolumes function which returns a map containing the volumeID to node names map for the given list of volumeIDs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Make check output:
```
msmruthi@msmruthi-a01 vsphere-csi-driver % git status
On branch CNAS-3822
Your branch is ahead of 'origin/master' by 1 commit.
  (use "git push" to publish your local commits)

nothing to commit, working tree clean
msmruthi@msmruthi-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
	To adjust and download dependencies of the current module, use 'go get -d'.
	To install using requirements of the current module, use 'go install'.
	To install ignoring the current module, use 'go install' with a version,
	like 'go install example.com/cmd@latest'.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/msmruthi/devel/src/wcp-sample-persistentservice/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/msmruthi/k8s/vsphere-csi-driver /Users/msmruthi/k8s /Users/msmruthi /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (exports_file|files|imports|name|compiled_files|deps|types_sizes) took 2.086212673s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 102.255327ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): cgo: 110/110, filename_unadjuster: 110/110, exclude: 21/21, exclude-rules: 1/21, autogenerated_exclude: 21/110, identifier_marker: 21/21, nolint: 0/1, path_prettifier: 110/110, skip_files: 110/110, skip_dirs: 110/110 
INFO [runner] processing took 10.40779ms with stages: nolint: 8.506374ms, autogenerated_exclude: 991.403µs, path_prettifier: 450.437µs, identifier_marker: 226.602µs, skip_dirs: 114.399µs, exclude-rules: 91.741µs, cgo: 11.615µs, filename_unadjuster: 10.63µs, max_same_issues: 1.176µs, uniq_by_line: 582ns, diff: 469ns, max_from_linter: 415ns, path_shortener: 375ns, exclude: 302ns, source_code: 289ns, max_per_file_from_linter: 233ns, skip_files: 231ns, severity-rules: 227ns, sort_results: 176ns, path_prefixer: 114ns 
INFO [runner] linters took 673.783254ms with stages: goanalysis_metalinter: 663.291547ms 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 30 samples, avg is 89.9MB, max is 140.1MB 
INFO Execution took 2.875675303s                  
```
Manually tested to ensure volume create calls the volumeAttachment add handler and similarly delete calls the volumeAttachment delete handler.
Volume create:
`
2022-03-10T08:57:52.918902796Z 2022-03-10T08:57:52.918Z	DEBUG	k8sorchestrator/k8sorchestrator.go:1015	volumeAttachmentAdded: volume=&VolumeAttachment{ObjectMeta:{csi-a6ad0a50f240d31fe97b5f10cd6c3fcf153603643104a7dcdd3f188812a5f1c5   /apis/storage.k8s.io/v1/volumeattachments/csi-a6ad0a50f240d31fe97b5f10cd6c3fcf153603643104a7dcdd3f188812a5f1c5 162575ab-6e18-4d2a-9dc9-611e75fbdecc 3402130 0 2022-03-10 07:03:51 +0000 UTC <nil> <nil> map[] map[csi.alpha.kubernetes.io/node-id:sc1-10-182-56-62.eng.vmware.com] [] [external-attacher/csi-vsphere-vmware-com]  [{kube-controller-manager Update storage.k8s.io/v1 2022-03-10 07:03:51 +0000 UTC FieldsV1 {"f:spec":{"f:attacher":{},"f:nodeName":{},"f:source":{"f:persistentVolumeName":{}}}}} {csi-attacher Update storage.k8s.io/v1 2022-03-10 07:04:01 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{".":{},"f:csi.alpha.kubernetes.io/node-id":{}},"f:finalizers":{".":{},"v:\"external-attacher/csi-vsphere-vmware-com\"":{}}},"f:status":{"f:attached":{},"f:attachmentMetadata":{".":{},"f:diskUUID":{},"f:type":{}}}}}]},Spec:VolumeAttachmentSpec{Attacher:csi.vsphere.vmware.com,Source:VolumeAttachmentSource{PersistentVolumeName:*pvc-ae741462-b44e-4e03-bda3-bb9469681e81,InlineVolumeSpec:nil,},NodeName:sc1-10-182-56-62.eng.vmware.com,},Status:VolumeAttachmentStatus{Attached:true,AttachmentMetadata:map[string]string{diskUUID: 6000c29614c07a0b9c1a01be24c3d72b,type: vSphere CNS Block Volume,},AttachError:nil,DetachError:nil,},}
2022-03-10T08:57:52.918907338Z 2022-03-10T08:57:52.918Z	DEBUG	k8sorchestrator/k8sorchestrator.go:1029	volumeAttachmentAdded: Adding nodeName sc1-10-182-56-62.eng.vmware.com to volumeID pvc-ae741462-b44e-4e03-bda3-bb9469681e81:[sc1-10-182-56-62.eng.vmware.com] map
`
volume attachment deleted
`
2022-03-10T08:59:34.512080542Z 2022-03-10T08:59:34.511Z	DEBUG	k8sorchestrator/k8sorchestrator.go:1046	volumeAttachmentDeleted: volume attachment deleted: volume=&VolumeAttachment{ObjectMeta:{csi-a6ad0a50f240d31fe97b5f10cd6c3fcf153603643104a7dcdd3f188812a5f1c5   /apis/storage.k8s.io/v1/volumeattachments/csi-a6ad0a50f240d31fe97b5f10cd6c3fcf153603643104a7dcdd3f188812a5f1c5 162575ab-6e18-4d2a-9dc9-611e75fbdecc 3472599 0 2022-03-10 07:03:51 +0000 UTC 2022-03-10 08:59:34 +0000 UTC 0xc0002ce5e0 map[] map[csi.alpha.kubernetes.io/node-id:sc1-10-182-56-62.eng.vmware.com] [] [external-attacher/csi-vsphere-vmware-com]  [{kube-controller-manager Update storage.k8s.io/v1 2022-03-10 07:03:51 +0000 UTC FieldsV1 {"f:spec":{"f:attacher":{},"f:nodeName":{},"f:source":{"f:persistentVolumeName":{}}}}} {csi-attacher Update storage.k8s.io/v1 2022-03-10 08:59:34 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{".":{},"f:csi.alpha.kubernetes.io/node-id":{}},"f:finalizers":{".":{},"v:\"external-attacher/csi-vsphere-vmware-com\"":{}}},"f:status":{"f:attached":{}}}}]},Spec:VolumeAttachmentSpec{Attacher:csi.vsphere.vmware.com,Source:VolumeAttachmentSource{PersistentVolumeName:*pvc-ae741462-b44e-4e03-bda3-bb9469681e81,InlineVolumeSpec:nil,},NodeName:sc1-10-182-56-62.eng.vmware.com,},Status:VolumeAttachmentStatus{Attached:false,AttachmentMetadata:map[string]string{},AttachError:nil,DetachError:nil,},}
2022-03-10T08:59:34.512106356Z 2022-03-10T08:59:34.511Z	DEBUG	k8sorchestrator/k8sorchestrator.go:1059	volumeAttachmentDeleted: Deleting nodeName sc1-10-182-56-62.eng.vmware.com to volumeID pvc-ae741462-b44e-4e03-bda3-bb9469681e81 map
`
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
