### PR TITLE
Fix image tag and commit for release branches

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -41,7 +41,12 @@ PUSH=
 LATEST=
 CSI_IMAGE_NAME=
 SYNCER_IMAGE_NAME=
-VERSION=$(git log -1 --format=%h)
+if [[ "$(git rev-parse --abbrev-ref HEAD)" =~ "master" ]]; then
+  VERSION="$(git log -1 --format=%h)"
+else
+  VERSION="$(git describe --always 2>/dev/null)"
+fi
+GIT_COMMIT="$(git log -1 --format=%H)"
 GCR_KEY_FILE="${GCR_KEY_FILE:-}"
 GOPROXY="${GOPROXY:-https://proxy.golang.org}"
 BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
@@ -126,7 +131,7 @@ function build_driver_images_windows() {
    --build-arg "VERSION=${VERSION}" \
    --build-arg "OSVERSION=${OSVERSION}" \
    --build-arg "GOPROXY=${GOPROXY}" \
-   --build-arg "GIT_COMMIT=${VERSION}" \
+   --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
    .
    docker buildx rm vsphere-csi-builder-win || echo "builder instance not found, safe to proceed"
 }
@@ -143,7 +148,7 @@ function build_driver_images_linux() {
    --build-arg ARCH=amd64 \
    --build-arg "VERSION=${VERSION}" \
    --build-arg "GOPROXY=${GOPROXY}" \
-   --build-arg "GIT_COMMIT=${VERSION}" \
+   --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
    .
 }
 
@@ -154,7 +159,7 @@ function build_syncer_image_linux() {
       -t "${SYNCER_IMAGE_NAME}":"${VERSION}" \
       --build-arg "VERSION=${VERSION}" \
       --build-arg "GOPROXY=${GOPROXY}" \
-      --build-arg "GIT_COMMIT=${VERSION}" \
+      --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
   .
 
   if [ "${LATEST}" ]; then


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing image tag and commit ID for release branches
Previously, git commit ID was being added for all images pushed to registry. Release tag was not considered for tagging images built from release branches

For master branch,
```
❯ make images
hack/release.sh
building gcr.io/cloud-provider-vsphere/csi/ci/driver:edbe68f7 for linux
error: no builder "vsphere-csi-builder-win" found
builder instance not found, safe to proceed
[+] Building 1673.7s (13/15)
[+] Building 2309.8s (16/16) FINISHED
 => [internal] load build definition from Dockerfile                                                                                             0.5s
 => => transferring dockerfile: 3.09kB
 ..
 ..
building gcr.io/cloud-provider-vsphere/csi/ci/syncer:edbe68f7 for linux
[+] Building 1596.7s (11/13)
..
```

For release branches,
```
❯ make images
hack/release.sh
building gcr.io/cloud-provider-vsphere/csi/ci/driver:v2.5.0-rc.1 for linux
[+] Building 338.5s (16/16) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.4s
 => => transferring dockerfile: 32B                                                                                                                                                                                                      0.0s
 => [internal] load .dockerignore
 ..
 ..
building gcr.io/cloud-provider-vsphere/csi/ci/syncer:v2.5.0-rc.1 for linux
[+] Building 7.3s (14/14) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.4s
 => => transferring dockerfile: 37B
 ..
 ..
```

Locally built images and tags assigned
```
❯ docker images | grep -i 'driver\|syncer'
gcr.io/cloud-provider-vsphere/csi/ci/driver-linux-amd64   v2.5.0-rc.1       4d92f4335879   30 minutes ago      300MB
gcr.io/cloud-provider-vsphere/csi/ci/syncer               latest            d42b1e237cac   About an hour ago   95.1MB
gcr.io/cloud-provider-vsphere/csi/ci/syncer               v2.5.0-rc.1       d42b1e237cac   About an hour ago   95.1MB
gcr.io/cloud-provider-vsphere/csi/ci/syncer               edbe68f7          d0f9151ae913   4 hours ago         95.1MB
gcr.io/cloud-provider-vsphere/csi/ci/driver-linux-amd64   edbe68f7          00edec1492f8   5 hours ago         300MB
```

Commit ID retained as image label for debug purposes
```
❯ docker inspect gcr.io/cloud-provider-vsphere/csi/ci/driver-linux-amd64:v2.5.0-rc.1 | grep commit
                "git_commit": "7caa8eee",
❯ docker inspect gcr.io/cloud-provider-vsphere/csi/ci/syncer:v2.5.0-rc.1 | grep -i commit
                "git_commit": "7caa8eee",
❯ docker inspect gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest | grep -i commit
                "git_commit": "7caa8eee",

```



**Testing done**:
Yes generated image locally with this change and inspected git commit from the image.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix image tag and commit for release branches
```
