### PR TITLE
Prevent filevolume creation on a stretched cluster setup

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -681,6 +681,12 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				return nil, csifault.CSIUnimplementedFault, logger.LogNewErrorCode(log, codes.Unimplemented,
 					"file volume feature is disabled on the cluster")
 			}
+			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
+				if len(clusterComputeResourceMoIds) > 1 {
+					return nil, csifault.CSIUnimplementedFault, logger.LogNewErrorCode(log, codes.Unimplemented,
+						"file volume provisioning is not supported on a stretched supervisor cluster")
+				}
+			}
 			return c.createFileVolume(ctx, req)
 		}
 		return c.createBlockVolume(ctx, req)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Prevents creation of filevolumes on a stretched supervisor cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran Unit tests. 

**Special notes for your reviewer**:

**Release note**:
```release-note
Prevent filevolume creation on a stretched cluster setup
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>