### PR TITLE
Update restrictions on filevolume creation in a tkgs ha setup

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -279,7 +279,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			if errors.IsNotFound(err) {
 				diskSize := strconv.FormatInt(volSizeMB, 10) + "Mi"
 				var annotations map[string]string
-				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
+				if !isFileVolumeRequest && commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
 					req.AccessibilityRequirements != nil {
 					// generate new annotations.
 					annotations = make(map[string]string)
@@ -334,7 +334,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			attributes[common.AttributeDiskType] = common.DiskTypeBlockVolume
 		}
 		var accessibleTopology []*csi.Topology
-		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
+		if !isFileVolumeRequest && commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
 			req.AccessibilityRequirements != nil {
 			// Retrieve the latest version of the PVC
 			pvc, err = c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
@@ -361,7 +361,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				VolumeContext: attributes,
 			},
 		}
-		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
+		if !isFileVolumeRequest && commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
 			req.AccessibilityRequirements != nil {
 			resp.Volume.AccessibleTopology = accessibleTopology
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Do not set "csi.vsphere.guest-cluster-requested-topology" annotation on the Supervisor PVC requested for file volume from TKG.
2. Do not expect "csi.vsphere.volumeAccessibleTopology"  annotation on the Supervisor PVC requested for file volume from TKG.
3. Do not set Node Affinity Rules for file volume requested from TKG cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran Unit tests.

**Special notes for your reviewer**:

**Release note**:
```release-note

Update restrictions on filevolume creation in a tkgs ha setup
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>