### PR TITLE
Cherry pick PR #1542 to release-2.5 branch

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -41,7 +41,12 @@ PUSH=
 LATEST=
 CSI_IMAGE_NAME=
 SYNCER_IMAGE_NAME=
-VERSION=$(git log -1 --format=%h)
+if [[ "$(git rev-parse --abbrev-ref HEAD)" =~ "master" ]]; then
+  VERSION="$(git log -1 --format=%h)"
+else
+  VERSION="$(git describe --always 2>/dev/null)"
+fi
+GIT_COMMIT="$(git log -1 --format=%H)"
 GCR_KEY_FILE="${GCR_KEY_FILE:-}"
 GOPROXY="${GOPROXY:-https://proxy.golang.org}"
 BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
@@ -126,7 +131,7 @@ function build_driver_images_windows() {
    --build-arg "VERSION=${VERSION}" \
    --build-arg "OSVERSION=${OSVERSION}" \
    --build-arg "GOPROXY=${GOPROXY}" \
-   --build-arg "GIT_COMMIT=${VERSION}" \
+   --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
    .
    docker buildx rm vsphere-csi-builder-win || echo "builder instance not found, safe to proceed"
 }
@@ -143,7 +148,7 @@ function build_driver_images_linux() {
    --build-arg ARCH=amd64 \
    --build-arg "VERSION=${VERSION}" \
    --build-arg "GOPROXY=${GOPROXY}" \
-   --build-arg "GIT_COMMIT=${VERSION}" \
+   --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
    .
 }
 
@@ -154,7 +159,7 @@ function build_syncer_image_linux() {
       -t "${SYNCER_IMAGE_NAME}":"${VERSION}" \
       --build-arg "VERSION=${VERSION}" \
       --build-arg "GOPROXY=${GOPROXY}" \
-      --build-arg "GIT_COMMIT=${VERSION}" \
+      --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
   .
 
   if [ "${LATEST}" ]; then


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**What this PR does / why we need it**:
Cherry-pick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1542 PR to release-2.5 to fix docker image tagging on release branches

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Testing complete in master branch

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherry pick PR #1542 to release-2.5 branch
```
