### PR TITLE
Filter out datastores that are in suspended mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/yaml.v2 v2.4.0
+	honnef.co/go/tools v0.2.0 // indirect
 	k8s.io/api v0.21.1
 	k8s.io/apiextensions-apiserver v0.21.1
 	k8s.io/apimachinery v0.21.1

--- a/go.sum
+++ b/go.sum
@@ -783,6 +783,7 @@ golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1105,6 +1106,8 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
+honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 k8s.io/api v0.21.1 h1:94bbZ5NTjdINJEdzOkpS4vdPhkb1VFpTYC9zh43f75c=
 k8s.io/api v0.21.1/go.mod h1:FstGROTmsSHBarKc8bylzXih8BLNYTiS3TZcsoEDg2s=
 k8s.io/apiextensions-apiserver v0.21.1 h1:AA+cnsb6w7SZ1vD32Z+zdgfXdXY8X9uGX5bN6EoPEIo=

--- a/manifests/guestcluster/1.20/pvcsi.yaml
+++ b/manifests/guestcluster/1.20/pvcsi.yaml
@@ -437,6 +437,7 @@ data:
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.21/pvcsi.yaml
+++ b/manifests/guestcluster/1.21/pvcsi.yaml
@@ -439,6 +439,7 @@ data:
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -468,6 +468,7 @@ data:
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"
   "tkgs-ha": "false"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -360,6 +360,7 @@ data:
   "sibling-replica-bound-pvc-check": "true"
   "tkgs-ha": "false"
   "list-volumes": "false"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -358,6 +358,7 @@ data:
   "improved-csi-idempotency": "false"
   "block-volume-snapshot": "false"
   "sibling-replica-bound-pvc-check": "true"
+  "cnsmgr-suspend-create-volume": "false"
   "tkgs-ha": "false"
   "list-volumes": "false"
 kind: ConfigMap

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -364,6 +364,7 @@ data:
   "sibling-replica-bound-pvc-check": "true"
   "tkgs-ha": "false"
   "list-volumes": "false"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -154,6 +154,7 @@ data:
   "use-csinode-id": "false"
   "list-volumes": "false"
   "pv-to-backingdiskobjectid-mapping": "false"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/common/cns-lib/vsphere/datastore.go
+++ b/pkg/common/cns-lib/vsphere/datastore.go
@@ -38,7 +38,8 @@ type Datastore struct {
 // DatastoreInfo is a structure to store the Datastore and it's Info.
 type DatastoreInfo struct {
 	*Datastore
-	Info *types.DatastoreInfo
+	Info         *types.DatastoreInfo
+	CustomValues []types.BaseCustomFieldValue
 }
 
 func (di DatastoreInfo) String() string {

--- a/pkg/common/cns-lib/vsphere/hostsystem.go
+++ b/pkg/common/cns-lib/vsphere/hostsystem.go
@@ -51,7 +51,7 @@ func (host *HostSystem) GetAllAccessibleDatastores(ctx context.Context) ([]*Data
 
 	var dsMoList []mo.Datastore
 	pc := property.DefaultCollector(host.Client())
-	properties := []string{"info"}
+	properties := []string{"info", "customValue"}
 	err = pc.Retrieve(ctx, dsRefList, properties, &dsMoList)
 	if err != nil {
 		log.Errorf("failed to get datastore managed objects from datastore objects %v with properties %v: %v",
@@ -64,7 +64,7 @@ func (host *HostSystem) GetAllAccessibleDatastores(ctx context.Context) ([]*Data
 			&DatastoreInfo{
 				&Datastore{object.NewDatastore(host.Client(), dsMo.Reference()),
 					nil},
-				dsMo.Info.GetDatastoreInfo()})
+				dsMo.Info.GetDatastoreInfo(), dsMo.CustomValue})
 	}
 	return dsObjList, nil
 }

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -28,6 +28,7 @@ import (
 const (
 	vsanDType                       = "vsanD"
 	defaultVCClientTimeoutInMinutes = 5
+	cnsMgrDatastoreSuspended        = "cns.vmware.com/datastoreSuspended"
 	// VSphere70u3Version is a 3 digit value to indicate the minimum vSphere
 	// version to use query volume async API.
 	VSphere70u3Version int = 703
@@ -468,4 +469,35 @@ func IsvSphereVersion70U3orAbove(ctx context.Context, aboutInfo types.AboutInfo)
 	}
 	// For all other versions.
 	return false, nil
+}
+
+// IsVolumeCreationSuspended checks whether a given Datastore has cns.vmware.com/datastoreSuspended customValue
+func IsVolumeCreationSuspended(ctx context.Context, datastoreInfo *DatastoreInfo) bool {
+	log := logger.GetLogger(ctx)
+
+	for _, customValField := range datastoreInfo.CustomValues {
+		customVal := customValField.(*types.CustomFieldStringValue)
+		if customVal.Value == cnsMgrDatastoreSuspended {
+			log.Infof("Ignoring datastore %v as it is suspended. Datastore moref: %v", datastoreInfo.Info.Name,
+				datastoreInfo.Datastore.Reference())
+			return true
+		}
+	}
+
+	return false
+}
+
+// FilterSuspendedDatastores filters out datastores which cns.vmware.com/datastoreSuspended customValue
+func FilterSuspendedDatastores(ctx context.Context, datastoreInfoList []*DatastoreInfo) []*DatastoreInfo {
+	log := logger.GetLogger(ctx)
+
+	var filteredList []*DatastoreInfo
+	for _, ds := range datastoreInfoList {
+		if !IsVolumeCreationSuspended(ctx, ds) {
+			filteredList = append(filteredList, ds)
+		}
+	}
+
+	log.Infof("Updated filtered list of datastores %+v", filteredList)
+	return filteredList
 }

--- a/pkg/common/cns-lib/vsphere/utils_test.go
+++ b/pkg/common/cns-lib/vsphere/utils_test.go
@@ -1,0 +1,60 @@
+package vsphere
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestFilterSuspendedDatastoresWhenDatastoreIsSuspended(t *testing.T) {
+
+	customValue := []types.CustomFieldValue{
+		{Key: 101},
+	}
+	CustomFieldStringValue := []types.CustomFieldStringValue{
+		{Value: cnsMgrDatastoreSuspended, CustomFieldValue: customValue[0]},
+	}
+	customValue2 := (types.CustomFieldStringValue)(CustomFieldStringValue[0])
+	baseCustomFieldValue := (types.BaseCustomFieldValue)(&customValue2)
+
+	datastoreMoref := types.ManagedObjectReference{Type: "datastore", Value: "datastore-1"}
+	datastore := &Datastore{Datastore: object.NewDatastore(nil, datastoreMoref)}
+	dsInfo := []*DatastoreInfo{
+		{
+			Datastore: datastore,
+			Info: &types.DatastoreInfo{
+				Name: "test-ds",
+			},
+			CustomValues: []types.BaseCustomFieldValue{baseCustomFieldValue},
+		},
+	}
+
+	outputDsInfo := FilterSuspendedDatastores(context.TODO(), dsInfo)
+	assert.Equal(t, 0, len(outputDsInfo))
+}
+func TestFilterSuspendedDatastoresWhenDatastoreIsNotSuspended(t *testing.T) {
+
+	customValue := []types.CustomFieldValue{
+		{Key: 101},
+	}
+	CustomFieldStringValue := []types.CustomFieldStringValue{
+		{Value: "randomValue", CustomFieldValue: customValue[0]},
+	}
+	customValue2 := (types.CustomFieldStringValue)(CustomFieldStringValue[0])
+	baseCustomFieldValue := (types.BaseCustomFieldValue)(&customValue2)
+
+	dsInfo := []*DatastoreInfo{
+		{
+			Info: &types.DatastoreInfo{
+				Name: "test-ds",
+			},
+			CustomValues: []types.BaseCustomFieldValue{baseCustomFieldValue},
+		},
+	}
+
+	outputDsInfo := FilterSuspendedDatastores(context.TODO(), dsInfo)
+	assert.Equal(t, 1, len(outputDsInfo))
+}

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -440,7 +440,7 @@ func (vc *VirtualCenter) GetVsanDatastores(ctx context.Context,
 		}
 		var dsMoList []mo.Datastore
 		pc := property.DefaultCollector(dc.Client())
-		properties := []string{"summary", "info"}
+		properties := []string{"summary", "info", "customValue"}
 		err = pc.Retrieve(ctx, dsMorList, properties, &dsMoList)
 		if err != nil {
 			log.Errorf("failed to get Datastore managed objects from datastore objects."+
@@ -453,7 +453,7 @@ func (vc *VirtualCenter) GetVsanDatastores(ctx context.Context,
 				vsanDsURLInfoMap[dsMo.Info.GetDatastoreInfo().Url] = &DatastoreInfo{
 					&Datastore{object.NewDatastore(dc.Client(), dsMo.Reference()),
 						dc},
-					dsMo.Info.GetDatastoreInfo()}
+					dsMo.Info.GetDatastoreInfo(), dsMo.CustomValue}
 			}
 		}
 	}

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -242,12 +242,13 @@ func GetDatastoreRefByURLFromGivenDatastoreList(
 	var candidateDsObj *cnsvsphere.Datastore
 	// traverse each datacenter and find the datastore with the specified dsURL
 	for _, datacenter := range datacenters {
-		candidateDsObj, err = datacenter.GetDatastoreByURL(ctx, dsURL)
+		candidateDsInfoObj, err := datacenter.GetDatastoreInfoByURL(ctx, dsURL)
 		if err != nil {
 			log.Errorf("failed to find datastore with URL %q in datacenter %q from VC %q, Error: %+v",
 				dsURL, datacenter.InventoryPath, vc.Config.Host, err)
 			continue
 		}
+		candidateDsObj = candidateDsInfoObj.Datastore
 		break
 	}
 

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -535,7 +535,7 @@ func getDatastoreMOsFromCluster(ctx context.Context, vc *cnsvsphere.VirtualCente
 
 	// Get datastore properties.
 	pc := property.DefaultCollector(vc.Client.Client)
-	properties := []string{"info", "summary"}
+	properties := []string{"info", "summary", "customValue"}
 	var dsList []vim25types.ManagedObjectReference
 	var dsMoList []mo.Datastore
 	for _, datastore := range datastores {

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -346,4 +346,6 @@ const (
 	ListVolumes = "list-volumes"
 	// PVtoBackingDiskObjectIdMapping is the feature to support pv to backingDiskObjectId mapping on vSphere CSI driver.
 	PVtoBackingDiskObjectIdMapping = "pv-to-backingdiskobjectid-mapping"
+	// Block Create Volume for datastores that are in suspended mode
+	CnsMgrSuspendCreateVolume = "cnsmgr-suspend-create-volume"
 )

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -549,8 +549,10 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		// Filter datastores which in datastoreMap from sharedDatastores.
 		sharedDatastores = c.filterDatastores(ctx, sharedDatastores)
 	}
+
+	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 	volumeInfo, faultType, err := common.CreateBlockVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
-		c.manager, &createVolumeSpec, sharedDatastores)
+		c.manager, &createVolumeSpec, sharedDatastores, filterSuspendedDatastores)
 	if err != nil {
 		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to create volume. Error: %+v", err)
@@ -764,6 +766,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 	}
 	var volumeID string
 	var faultType string
+	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIAuthCheck) {
 		fsEnabledClusterToDsInfoMap := c.authMgr.GetFsEnabledClusterToDsMap(ctx)
 
@@ -777,14 +780,14 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 				"no datastores found to create file volume")
 		}
 		volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
-			c.manager, &createVolumeSpec, filteredDatastores)
+			c.manager, &createVolumeSpec, filteredDatastores, filterSuspendedDatastores)
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to create volume. Error: %+v", err)
 		}
 	} else {
 		volumeID, faultType, err = common.CreateFileVolumeUtilOld(ctx, cnstypes.CnsClusterFlavorVanilla,
-			c.manager, &createVolumeSpec)
+			c.manager, &createVolumeSpec, filterSuspendedDatastores)
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to create volume. Error: %+v", err)

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -210,7 +210,8 @@ func (f *FakeNodeManager) GetSharedDatastoresInK8SCluster(ctx context.Context) (
 			Datastore: &cnsvsphere.Datastore{
 				Datastore:  object.NewDatastore(nil, sharedDatastoreManagedObject.Reference()),
 				Datacenter: nil},
-			Info: sharedDatastoreManagedObject.Info.GetDatastoreInfo(),
+			Info:         sharedDatastoreManagedObject.Info.GetDatastoreInfo(),
+			CustomValues: []types.BaseCustomFieldValue{},
 		},
 	}, nil
 }

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -398,6 +398,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	}
 	// Fetch the accessibility requirements from the request.
 	topologyRequirement = req.GetAccessibilityRequirements()
+	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
 		// Identify the topology keys in Accessibility requirements.
 		hostnameLabelPresent, zoneLabelPresent = checkTopologyKeysFromAccessibilityReqs(topologyRequirement)
@@ -499,7 +500,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	}
 	candidateDatastores := append(sharedDatastores, vsanDirectDatastores...)
 	volumeInfo, faultType, err := common.CreateBlockVolumeUtil(ctx, cnstypes.CnsClusterFlavorWorkload,
-		c.manager, &createVolumeSpec, candidateDatastores)
+		c.manager, &createVolumeSpec, candidateDatastores, filterSuspendedDatastores)
 	if err != nil {
 		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to create volume. Error: %+v", err)
@@ -627,8 +628,9 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 		return nil, csifault.CSIInternalFault, logger.LogNewErrorCode(log, codes.Internal,
 			"no datastores found to create file volume")
 	}
+	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 	volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorWorkload,
-		c.manager, &createVolumeSpec, filteredDatastores)
+		c.manager, &createVolumeSpec, filteredDatastores, filterSuspendedDatastores)
 	if err != nil {
 		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to create volume. Error: %+v", err)

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -249,14 +249,16 @@ func getFakeDatastores(ctx context.Context, vc *cnsvsphere.VirtualCenter,
 				Datastore: &cnsvsphere.Datastore{
 					Datastore:  object.NewDatastore(nil, sharedDatastoreManagedObject.Reference()),
 					Datacenter: nil},
-				Info: sharedDatastoreManagedObject.Info.GetDatastoreInfo(),
+				Info:         sharedDatastoreManagedObject.Info.GetDatastoreInfo(),
+				CustomValues: []types.BaseCustomFieldValue{},
 			},
 		}, []*cnsvsphere.DatastoreInfo{
 			{
 				Datastore: &cnsvsphere.Datastore{
 					Datastore:  object.NewDatastore(nil, vsanDirectDatastoreManagedObject.Reference()),
 					Datacenter: nil},
-				Info: vsanDirectDatastoreManagedObject.Info.GetDatastoreInfo(),
+				Info:         vsanDirectDatastoreManagedObject.Info.GetDatastoreInfo(),
+				CustomValues: []types.BaseCustomFieldValue{},
 			},
 		}, nil
 }

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -237,13 +237,13 @@ func TestSyncerWorkflows(t *testing.T) {
 		return
 	}
 
-	datastoreObj, err := dc[0].GetDatastoreByURL(ctx, sharedDatastore)
+	datastoreInfoObj, err := dc[0].GetDatastoreInfoByURL(ctx, sharedDatastore)
 	if err != nil {
 		t.Errorf("failed to get datastore with URL: %s. Error: %v", sharedDatastore, err)
 		t.Fatal(err)
 		return
 	}
-	dsList = append(dsList, datastoreObj.Reference())
+	dsList = append(dsList, datastoreInfoObj.Datastore.Reference())
 
 	runTestMetadataSyncInformer(t)
 	runTestFullSyncWorkflows(t)


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of CNS manager, we are exposing APIs to suspend creation of new volumes on a given datastore. A suspended datastore is identified by a custom attribute field (cns.vmware.com/datstoreSuspensionState) having value as (cns.vmware.com/datstoreSuspended or cns.vmware.com/datastoreNotSuspended).

As part of this change, we are removing those datastores from CreateVolumeSpec's candidate datastores list which have customAttribute's value same as cns.vmware.com/datstoreSuspended, that is datastore is suspended.

This applies to new volumes being created on WCP as well.

**Testing done**:
All unit tests are passing.

Tested the following scenarios:
1. FSS is disabled. - volume gets provisioned successfully.
2. Added custom attribute to suspend vsan Datastore - volume got provisioned on another datastore which was not suspended.
3. Suspended all compatible datastores - failed to get created volume. After this, changed custom value to `cns.vmware.com/datstoreNotSuspended` and the volume got created eventually. 

Example of a failed that could not provisioned:
```
root@k8s-control-932-1643699929:~# kubectl describe pvc example-vanilla-block-pvc50
Name:          example-vanilla-block-pvc50
Namespace:     default
StorageClass:  example-vanilla-block-sc
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age               From                                                                                                 Message
  ----     ------                ----              ----                                                                                                 -------
  Normal   Provisioning          4s (x6 over 37s)  csi.vsphere.vmware.com_vsphere-csi-controller-5d77b85cc8-th8xk_36a78eb0-672b-42ef-b036-c69140b8eee1  External provisioner is provisioning volume for claim "default/example-vanilla-block-pvc50"
  Warning  ProvisioningFailed    4s (x6 over 36s)  csi.vsphere.vmware.com_vsphere-csi-controller-5d77b85cc8-th8xk_36a78eb0-672b-42ef-b036-c69140b8eee1  failed to provision volume with StorageClass "example-vanilla-block-sc": rpc error: code = Internal desc = failed to create volume. Error: ServerFaultCode: createSpecs.datastores is empty
  Normal   ExternalProvisioning  1s (x4 over 37s)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
```


Output of make check after running go clean -modcache

```
go: downloading github.com/rexray/gocsi v1.2.2
go: downloading google.golang.org/grpc v1.27.1
go: downloading go.uber.org/zap v1.17.0
go: downloading github.com/google/uuid v1.2.0
go: downloading github.com/vmware/govmomi v0.27.4
go: downloading github.com/container-storage-interface/spec v1.4.0
go: downloading gopkg.in/gcfg.v1 v1.2.3
go: downloading k8s.io/api v0.21.1
go: downloading golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading k8s.io/apimachinery v0.21.1
go: downloading k8s.io/client-go v0.21.1
go: downloading sigs.k8s.io/controller-runtime v0.9.0
go: downloading google.golang.org/protobuf v1.26.0
go: downloading github.com/akutz/gofsutil v0.1.2
go: downloading k8s.io/kubernetes v1.21.1
go: downloading k8s.io/mount-utils v0.21.1
go: downloading github.com/fsnotify/fsnotify v1.4.9
go: downloading github.com/prometheus/client_golang v1.11.0
go: downloading github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae
go: downloading github.com/sirupsen/logrus v1.7.0
go: downloading github.com/golang/protobuf v1.5.2
go: downloading go.uber.org/atomic v1.7.0
go: downloading go.uber.org/multierr v1.6.0
go: downloading gopkg.in/warnings.v0 v0.1.1
go: downloading google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a
go: downloading k8s.io/klog/v2 v2.8.0
go: downloading github.com/gogo/protobuf v1.3.2
go: downloading github.com/google/gofuzz v1.1.0
go: downloading sigs.k8s.io/structured-merge-diff/v4 v4.1.0
go: downloading k8s.io/klog v1.0.0
go: downloading github.com/kubernetes-csi/external-snapshotter/client/v4 v4.1.0
go: downloading k8s.io/apiextensions-apiserver v0.21.1
go: downloading k8s.io/sample-controller v0.21.1
go: downloading k8s.io/utils v0.0.0-20210527160623-6fdb442a123b
go: downloading gopkg.in/inf.v0 v0.9.1
go: downloading github.com/akutz/gosync v0.1.0
go: downloading github.com/evanphx/json-patch v4.11.0+incompatible
go: downloading github.com/coreos/etcd v3.3.13+incompatible
go: downloading golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/prometheus/common v0.26.0
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/cespare/xxhash/v2 v2.1.1
go: downloading github.com/prometheus/procfs v0.6.0
go: downloading github.com/google/go-cmp v0.5.5
go: downloading github.com/json-iterator/go v1.1.11
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading sigs.k8s.io/yaml v1.2.0
go: downloading github.com/go-logr/logr v0.3.0
go: downloading github.com/cespare/xxhash v1.1.0
go: downloading golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
go: downloading github.com/imdario/mergo v0.3.12
go: downloading github.com/spf13/pflag v1.0.5
go: downloading golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
go: downloading k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
go: downloading github.com/modern-go/reflect2 v1.0.1
go: downloading github.com/googleapis/gnostic v0.4.1
go: downloading golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
go: downloading github.com/hashicorp/golang-lru v0.5.4
go: downloading golang.org/x/text v0.3.6
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: downloading k8s.io/apiserver v0.21.1
go: downloading k8s.io/component-base v0.21.1
go: downloading k8s.io/cloud-provider v0.21.1
go: downloading github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
go: downloading github.com/spf13/cobra v1.1.3
go: downloading github.com/spf13/viper v1.7.1
go: downloading gopkg.in/ini.v1 v1.51.0
go: downloading github.com/hashicorp/hcl v1.0.0
go: downloading github.com/spf13/afero v1.2.2
go: downloading github.com/spf13/jwalterweatherman v1.1.0
go: downloading github.com/mitchellh/mapstructure v1.1.2
go: downloading github.com/spf13/cast v1.3.0
go: downloading github.com/pelletier/go-toml v1.2.0
go: downloading github.com/magiconair/properties v1.8.1
go: downloading github.com/subosito/gotenv v1.2.0
go: downloading github.com/kubernetes-csi/csi-lib-utils v0.7.0
go: downloading golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
go: downloading gomodules.xyz/jsonpatch/v2 v2.2.0
hack/check-format.sh
go: downloading golang.org/x/tools v0.1.1
go: downloading golang.org/x/sys v0.0.0-20210510120138-977fb7262007
go: downloading golang.org/x/mod v0.4.2
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go: downloading honnef.co/go/tools v0.2.0
go: downloading github.com/BurntSushi/toml v0.3.1
go get: installing executables with 'go get' in module mode is deprecated.
	To adjust and download dependencies of the current module, use 'go get -d'.
	To install using requirements of the current module, use 'go install'.
	To install ignoring the current module, use 'go install' with a version,
	like 'go install example.com/cmd@latest'.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
go: downloading github.com/onsi/ginkgo v1.16.4
go: downloading github.com/onsi/gomega v1.13.0
go: downloading golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
go: downloading k8s.io/kubectl v0.21.1
go: downloading github.com/aws/aws-sdk-go v1.35.24
go: downloading k8s.io/kubelet v0.21.1
go: downloading github.com/moby/spdystream v0.2.0
go: downloading github.com/blang/semver v3.5.1+incompatible
go: downloading sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
go: downloading k8s.io/component-helpers v0.21.1
go: downloading github.com/docker/distribution v2.7.1+incompatible
go: downloading github.com/nxadm/tail v1.4.8
go: downloading github.com/opencontainers/go-digest v1.0.0
go: downloading gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: downloading k8s.io/cli-runtime v0.21.1
go: downloading github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
go: downloading github.com/russross/blackfriday v1.5.2
go: downloading github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
go: downloading github.com/go-openapi/spec v0.19.5
go: downloading github.com/mitchellh/go-wordwrap v1.0.0
go: downloading github.com/moby/term v0.0.0-20201216013528-df9cb8a40635
go: downloading github.com/go-openapi/jsonpointer v0.19.3
go: downloading github.com/go-openapi/jsonreference v0.19.3
go: downloading github.com/go-openapi/swag v0.19.5
go: downloading github.com/PuerkitoBio/purell v1.1.1
go: downloading github.com/mailru/easyjson v0.7.0
go: downloading sigs.k8s.io/kustomize/api v0.8.8
go: downloading github.com/peterbourgon/diskv v2.0.1+incompatible
go: downloading github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
go: downloading github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
go: downloading github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
go: downloading github.com/google/btree v1.0.0
go: downloading sigs.k8s.io/kustomize/kyaml v0.10.17
go: downloading github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
go: downloading github.com/go-errors/errors v1.0.1
go: downloading go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5
go: downloading github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca
go: downloading github.com/stretchr/testify v1.7.0
go: downloading github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00
go: downloading gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading github.com/jmespath/go-jmespath v0.4.0
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/skogta/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/skogta/go/src/github.com/skogta/vsphere-csi-driver /Users/skogta/go/src/github.com/skogta /Users/skogta/go/src/github.com /Users/skogta/go/src /Users/skogta/go /Users/skogta /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (files|imports|name|types_sizes|compiled_files|deps|exports_file) took 2.264483824s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 122.910427ms 
INFO [linters context/goanalysis] analyzers took 26.740446772s with top 10 stages: buildir: 11.173640646s, misspell: 1.301260545s, S1038: 1.066823037s, unused: 670.913876ms, S1039: 587.039033ms, directives: 557.822359ms, SA1012: 530.246505ms, S1024: 383.991342ms, S1028: 362.899917ms, printf: 347.293744ms 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 110/110, autogenerated_exclude: 21/110, nolint: 0/1, skip_files: 110/110, skip_dirs: 110/110, cgo: 110/110, filename_unadjuster: 110/110, identifier_marker: 21/21, exclude: 21/21, exclude-rules: 1/21 
INFO [runner] processing took 20.635036ms with stages: nolint: 17.27434ms, autogenerated_exclude: 1.658558ms, path_prettifier: 1.135062ms, identifier_marker: 265.449µs, skip_dirs: 178.748µs, exclude-rules: 100.874µs, filename_unadjuster: 9.336µs, cgo: 7.447µs, max_same_issues: 1.018µs, uniq_by_line: 769ns, source_code: 590ns, max_from_linter: 461ns, path_shortener: 436ns, diff: 348ns, skip_files: 341ns, max_per_file_from_linter: 335ns, severity-rules: 319ns, exclude: 271ns, sort_results: 213ns, path_prefixer: 121ns 
INFO [runner] linters took 6.099640423s with stages: goanalysis_metalinter: 6.07887978s 
INFO File cache stats: 198 entries of total size 3.7MiB 
INFO Memory: 87 samples, avg is 475.1MB, max is 1020.0MB 
INFO Execution took 8.503334178s
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
