### PR TITLE
Adding wcp related functions for listVolume API

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -217,3 +217,16 @@ func (c *FakeK8SOrchestrator) GetNodesForVolumes(ctx context.Context, volumeID [
 	nodeNames := make(map[string][]string)
 	return nodeNames
 }
+
+// GetNodeIDtoNameMap returns a map containing the nodeID to node name
+func (c *FakeK8SOrchestrator) GetNodeIDtoNameMap(ctx context.Context) map[string]string {
+	nodeIDToNamesMap := make(map[string]string)
+	return nodeIDToNamesMap
+}
+
+// GetFakeAttachedVolumes returns a map of volumeIDs to a bool, which is set
+// to true if volumeID key is fake attached else false
+func (c *FakeK8SOrchestrator) GetFakeAttachedVolumes(ctx context.Context, volumeID []string) map[string]bool {
+	fakeAttachedVolumes := make(map[string]bool)
+	return fakeAttachedVolumes
+}

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -53,6 +53,11 @@ type COCommonInterface interface {
 	InitTopologyServiceInNode(ctx context.Context) (types.NodeTopologyService, error)
 	// GetNodesForVolumes returns a map of volumeID to list of node names
 	GetNodesForVolumes(ctx context.Context, volumeIds []string) map[string][]string
+	// GetNodeIDtoNameMap returns a map of node ID  to node names
+	GetNodeIDtoNameMap(ctx context.Context) map[string]string
+	// GetFakeAttachedVolumes returns a map of volumeIDs to a bool, which is set
+	// to true if volumeID key is fake attached else false
+	GetFakeAttachedVolumes(ctx context.Context, volumeIDs []string) map[string]bool
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Adding wcp related changes for listVolume API. It includes addition of callback functions for node annotation changes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Make check output:
```
msmruthi@msmruthi-a01 vsphere-csi-driver % make check                                                            
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
	To adjust and download dependencies of the current module, use 'go get -d'.
	To install using requirements of the current module, use 'go install'.
	To install ignoring the current module, use 'go install' with a version,
	like 'go install example.com/cmd@latest'.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/msmruthi/devel/src/wcp-sample-persistentservice/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/msmruthi/k8s/vsphere-csi-driver /Users/msmruthi/k8s /Users/msmruthi /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (files|imports|name|compiled_files|deps|exports_file|types_sizes) took 2.140762366s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 89.938329ms 
INFO [linters context/goanalysis] analyzers took 12.419475452s with top 10 stages: buildir: 8.244688806s, misspell: 416.953204ms, directives: 275.327915ms, S1038: 243.352173ms, fact_deprecated: 208.633432ms, lll: 208.344557ms, S1039: 164.45877ms, unused: 148.42017ms, printf: 147.325138ms, ctrlflow: 114.410996ms 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude: 21/21, path_prettifier: 110/110, filename_unadjuster: 110/110, skip_files: 110/110, cgo: 110/110, identifier_marker: 21/21, exclude-rules: 1/21, nolint: 0/1, skip_dirs: 110/110, autogenerated_exclude: 21/110 
INFO [runner] processing took 11.090947ms with stages: nolint: 9.080991ms, autogenerated_exclude: 1.069016ms, path_prettifier: 459.684µs, identifier_marker: 249.844µs, skip_dirs: 121.424µs, exclude-rules: 94.017µs, cgo: 5.974µs, filename_unadjuster: 5.822µs, max_same_issues: 971ns, uniq_by_line: 653ns, max_from_linter: 386ns, diff: 350ns, skip_files: 287ns, source_code: 241ns, exclude: 237ns, max_per_file_from_linter: 230ns, severity-rules: 226ns, path_shortener: 207ns, sort_results: 201ns, path_prefixer: 186ns 
INFO [runner] linters took 5.71757936s with stages: goanalysis_metalinter: 5.706396439s 
INFO File cache stats: 68 entries of total size 1002.4KiB 
INFO Memory: 81 samples, avg is 339.9MB, max is 815.4MB 
INFO Execution took 7.961697723s                  
```
Manual testing done to show nodeAdd/nodeRemove callback functions called to populate the nodeIDToNameMap:
```
root@4238a049a493a40236d202fe6cea38e5 [ ~ ]# kubectl -n vmware-system-csi logs vsphere-csi-controller-7b5c8d7b87-7wmdx vsphere-csi-controller |grep -e 'node add:' -e 'node remove:'
2022-02-18T00:38:11.692Z	DEBUG	k8sorchestrator/k8sorchestrator.go:1013	node add: node=sc2-10-186-96-73.eng.vmware.com, modID=host-18
2022-02-18T00:38:11.693Z	DEBUG	k8sorchestrator/k8sorchestrator.go:1013	node add: node=sc2-10-186-97-91.eng.vmware.com, modID=host-21
2022-02-18T00:38:11.707Z	DEBUG	k8sorchestrator/k8sorchestrator.go:1013	node add: node=sc2-10-186-101-101.eng.vmware.com, modID=host-15
2022-02-18T00:38:11.708Z	DEBUG	k8sorchestrator/k8sorchestrator.go:1013	node add: node=sc2-10-186-111-98.eng.vmware.com, modID=host-12
2022-02-18T00:38:11.708Z	DEBUG	k8sorchestrator/k8sorchestrator.go:1013	node add: node=sc2-10-186-96-210.eng.vmware.com, modID=host-24
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
