### PR TITLE
Specify QPS and Burst for csi-snapshotter

### DIFF
--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -120,6 +120,10 @@ echo -e "✅ Deployed snapshot-controller"
 
 kubectl patch deployment -n kube-system snapshot-controller --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/master": ""}, "tolerations": [{"key":"node-role.kubernetes.io/master","operator":"Exists", "effect":"NoSchedule"}]}}}}'
 
+kubectl patch deployment -n kube-system snapshot-controller \
+--type=json \
+-p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-qps=100"},{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-burst=100"}]'
+
 wait_for_deployment snapshot-controller kube-system
 
 # Deploy the snapshot validating webhook.
@@ -203,6 +207,8 @@ spec:
           image: 'k8s.gcr.io/sig-storage/csi-snapshotter:${release}'
           args:
             - '--v=4'
+            - '--kube-api-qps=100'
+            - '--kube-api-burst=100'
             - '--timeout=300s'
             - '--csi-address=\$(ADDRESS)'
             - '--leader-election'
@@ -240,4 +246,4 @@ for _ in $(seq 20); do
     sleep 10
 done
 
-echo -e "\n✅ Successfully deployed all components for CSI Snapshot feature!\n"
+echo -e "\n✅ Successfully deployed all components for CSI Snapshot feature, please wait till vSphere CSI driver deployment is updated..\n"


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the QPS and Burst for csi-snapshotter.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
dkinni@dkinni-a02 vanilla % ./deploy-csi-snapshot-components.sh
✅ Verified that block-volume-snapshot feature is enabled
Using release version: v5.0.1
customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io configured
customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io configured
customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io configured
✅ Deployed VolumeSnapshot CRDs
serviceaccount/snapshot-controller unchanged
clusterrole.rbac.authorization.k8s.io/snapshot-controller-runner unchanged
clusterrolebinding.rbac.authorization.k8s.io/snapshot-controller-role unchanged
role.rbac.authorization.k8s.io/snapshot-controller-leaderelection unchanged
rolebinding.rbac.authorization.k8s.io/snapshot-controller-leaderelection unchanged
✅ Created  RBACs for snapshot-controller
deployment.apps/snapshot-controller unchanged
✅ Deployed snapshot-controller
deployment.apps/snapshot-controller patched (no change)
✅ snapshot-controller successfully deployed!
creating certs in tmpdir /var/folders/31/y77ywvzd6lqc0g60r4xnfyd80000gp/T/tmp.xBpWLNSK6U 
Generating a 2048 bit RSA private key
...........................+++
......+++
writing new private key to '/var/folders/31/y77ywvzd6lqc0g60r4xnfyd80000gp/T/tmp.xBpWLNSK6U/ca.key'
-----
Generating RSA private key, 2048 bit long modulus
...........+++
...............................................+++
e is 65537 (0x10001)
Signature ok
subject=/CN=snapshot-validation-service.kube-system.svc
Getting CA Private Key
secret "snapshot-webhook-certs" deleted
secret/snapshot-webhook-certs created
service "snapshot-validation-service" deleted
deployment.apps "snapshot-validation-deployment" deleted
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2238  100  2238    0     0   5241      0 --:--:-- --:--:-- --:--:--  5228
service/snapshot-validation-service created
validatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook.snapshot.storage.k8s.io configured
deployment.apps/snapshot-validation-deployment created
✅ Deployed snapshot-validation-deployment
deployment.apps/snapshot-validation-deployment patched
waiting for snapshot-validation-deployment to complete..
waiting for snapshot-validation-deployment to complete..
✅ snapshot-validation-deployment successfully deployed!
creating patch file in tmpdir /var/folders/31/y77ywvzd6lqc0g60r4xnfyd80000gp/T/tmp.tQ5wYGtMDF
Scale down the vSphere CSI driver
deployment.apps/vsphere-csi-controller scaled
Patching vSphere CSI driver..
deployment.apps/vsphere-csi-controller patched
Scaling the vSphere CSI driver back to original state..
deployment.apps/vsphere-csi-controller scaled


vSphere CSI driver restored to original number of replicas before patching!


✅ Successfully deployed all components for CSI Snapshot feature!


dkinni@dkinni-a02 vanilla % kubectl get deployments vsphere-csi-controller -n vmware-system-csi -o yaml

      containers:
      - args:
        - --v=4
        - --kube-api-qps=100
        - --kube-api-burst=100
        - --timeout=300s
        - --csi-address=$(ADDRESS)
        - --leader-election
        env:
        - name: ADDRESS
          value: /csi/csi.sock
        image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
        imagePullPolicy: IfNotPresent
        name: csi-snapshotter
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /csi
          name: socket-dir


dkinni@dkinni-a02 vanilla % kubectl get deployment snapshot-controller -n kube-system -o yaml

      - args:
        - --v=5
        - --leader-election=true
        - --kube-api-qps=100
        - --kube-api-burst=100
        image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v5.0.0
        imagePullPolicy: IfNotPresent
        name: snapshot-controller

```

**Special notes for your reviewer**:

**Release note**:
```release-note
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>