### PR TITLE
Adding vanilla cluster related functions for listVolume API

### DIFF
--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -202,6 +202,11 @@ func (nodes *Nodes) GetAllNodes(ctx context.Context) (
 	return nodes.cnsNodeManager.GetAllNodes(ctx)
 }
 
+// GetNodeNameByVmMoID fetches the k8s name of the given node given the VM MoID
+func (nodes *Nodes) GetNodeNameByVmMoID(ctx context.Context, vmMoID string) (string, error) {
+	return nodes.cnsNodeManager.GetNodeNameByVmMoID(ctx, vmMoID)
+}
+
 // GetSharedDatastoresInTopology returns shared accessible datastores for
 // specified topologyRequirement along with the map of datastore URL and
 // array of accessibleTopology map for each datastore returned from this

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -62,6 +62,7 @@ type NodeManagerInterface interface {
 	GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error)
 	GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error)
 	GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachine, error)
+	GetNodeNameByVmMoID(ctx context.Context, vmMoID string) (string, error)
 }
 
 type controller struct {

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -281,6 +281,10 @@ func (f *FakeNodeManager) GetSharedDatastoresInTopology(ctx context.Context,
 	return nil, nil, nil
 }
 
+func (f *FakeNodeManager) GetNodeNameByVmMoID(ctx context.Context, vmMoID string) (string, error) {
+	return "", nil
+}
+
 func (f *FakeAuthManager) GetDatastoreMapForBlockVolumes(ctx context.Context) map[string]*cnsvsphere.DatastoreInfo {
 	datastoreMapForBlockVolumes := make(map[string]*cnsvsphere.DatastoreInfo)
 	fmt.Print("FakeAuthManager: GetDatastoreMapForBlockVolumes")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Output of make check
msmruthi@msmruthi-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
	To adjust and download dependencies of the current module, use 'go get -d'.
	To install using requirements of the current module, use 'go install'.
	To install ignoring the current module, use 'go install' with a version,
	like 'go install example.com/cmd@latest'.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/msmruthi/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/msmruthi/k8s/vsphere-csi-driver /Users/msmruthi/k8s /Users/msmruthi /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (types_sizes|compiled_files|name|files|imports|deps|exports_file) took 1.86595396s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 97.766394ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 110/110, autogenerated_exclude: 21/110, skip_dirs: 110/110, exclude-rules: 1/21, cgo: 110/110, exclude: 21/21, path_prettifier: 110/110, skip_files: 110/110, identifier_marker: 21/21, nolint: 0/1 
INFO [runner] processing took 11.201634ms with stages: nolint: 8.565905ms, autogenerated_exclude: 1.498984ms, path_prettifier: 617.121µs, identifier_marker: 263.334µs, skip_dirs: 128.528µs, exclude-rules: 95.584µs, cgo: 14.401µs, filename_unadjuster: 13.049µs, max_same_issues: 1.505µs, uniq_by_line: 563ns, max_per_file_from_linter: 347ns, exclude: 335ns, max_from_linter: 331ns, skip_files: 315ns, source_code: 300ns, diff: 296ns, severity-rules: 240ns, sort_results: 191ns, path_shortener: 187ns, path_prefixer: 118ns 
INFO [runner] linters took 2.648955749s with stages: goanalysis_metalinter: 2.637660744s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 48 samples, avg is 112.8MB, max is 139.6MB 
INFO Execution took 4.625810919s                  
msmruthi@msmruthi-a01 vsphere-csi-driver % 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
