### PR TITLE
bump up CSI provisioner for TKGS HA

### DIFF
--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -161,7 +161,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.5
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.7
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -174,6 +174,7 @@ spec:
             - "--kube-api-burst=100"
             - "--default-fstype=ext4"
             - "--use-service-for-placement-engine=false"
+            - "--tkgs-ha=false"
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is bumping up CSI Provisioner for the TKGS HA feature in the supervisor CSI controller.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
bump up CSI provisioner for TKGS HA
```
