### PR TITLE
 Driver packages dependency removal from e2e topology code

### DIFF
--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -42,7 +42,7 @@ import (
 	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
 )
 
-var _ = ginkgo.Describe("[csi-topology-vanilla-level5] Topology-Aware-Provisioning-With-Statefulset-Level5", func() {
+var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Statefulset-Level5", func() {
 	f := framework.NewDefaultFramework("e2e-vsphere-topology-aware-provisioning")
 	var (
 		client                    clientset.Interface

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -40,7 +40,6 @@ import (
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 )
 
 var _ = ginkgo.Describe("[csi-topology-vanilla-level5] Topology-Aware-Provisioning-With-Statefulset-Level5", func() {
@@ -735,7 +734,6 @@ var _ = ginkgo.Describe("[csi-topology-vanilla-level5] Topology-Aware-Provisioni
 	ginkgo.It("Verify volume provisioning when storage class specified with invalid topology label", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		log := logger.GetLogger(ctx)
 		// Get allowed topologies for Storage Class
 		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
 			topologyLength)
@@ -768,7 +766,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla-level5] Topology-Aware-Provisioni
 			pvc.Namespace, pvc.Name, framework.Poll, time.Minute/2)
 		gomega.Expect(err).To(gomega.HaveOccurred())
 		if err != nil {
-			log.Errorf("Volume Provisioning Failed for PVC %s due to invalid topology "+
+			framework.Logf("Volume Provisioning Failed for PVC %s due to invalid topology "+
 				"label given in Storage Class", pvc.Name)
 		}
 	})
@@ -788,7 +786,6 @@ var _ = ginkgo.Describe("[csi-topology-vanilla-level5] Topology-Aware-Provisioni
 		"BindingMode and pvc specified with ReadWriteMany access mode", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		log := logger.GetLogger(ctx)
 		// Get allowed topologies for Storage Class for all 5 levels
 		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
 			topologyLength)
@@ -820,7 +817,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla-level5] Topology-Aware-Provisioni
 			pvc.Namespace, pvc.Name, framework.Poll, time.Minute/2)
 		gomega.Expect(err).To(gomega.HaveOccurred())
 		if err != nil {
-			log.Errorf("Volume Provisioning Failed %v because Topology feature for file "+
+			framework.Logf("Volume Provisioning Failed %v because Topology feature for file "+
 				"volumes is not supported", err)
 		}
 	})

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -765,10 +765,8 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
 			pvc.Namespace, pvc.Name, framework.Poll, time.Minute/2)
 		gomega.Expect(err).To(gomega.HaveOccurred())
-		if err != nil {
-			framework.Logf("Volume Provisioning Failed for PVC %s due to invalid topology "+
-				"label given in Storage Class", pvc.Name)
-		}
+		framework.Logf("Volume Provisioning Failed for PVC %s due to invalid topology "+
+			"label given in Storage Class", pvc.Name)
 	})
 
 	/*
@@ -816,10 +814,8 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
 			pvc.Namespace, pvc.Name, framework.Poll, time.Minute/2)
 		gomega.Expect(err).To(gomega.HaveOccurred())
-		if err != nil {
-			framework.Logf("Volume Provisioning Failed %v because Topology feature for file "+
-				"volumes is not supported", err)
-		}
+		framework.Logf("Volume Provisioning Failed %v because Topology feature for file "+
+			"volumes is not supported", err)
 	})
 
 	/*


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
 Driver packages dependency removal from e2e topology code

**Testing done**:
Yes

**Special notes for your reviewer**:
Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % 
sipriya@sipriya-a01 vsphere-csi-driver % 
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint 
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/dev-driver-removal/vsphere-csi-driver /Users/sipriya/dev-driver-removal /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (exports_file|types_sizes|compiled_files|deps|files|imports|name) took 9.173049718s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 86.973479ms 
INFO [linters context/goanalysis] analyzers took 32.653130444s with top 10 stages: buildir: 11.100217534s, misspell: 1.428685997s, S1038: 960.665492ms, unused: 861.853287ms, directives: 668.228728ms, SA1012: 628.463569ms, S1039: 552.055128ms, printf: 549.000277ms, fact_deprecated: 520.021419ms, inspect: 491.564631ms 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_dirs: 110/110, nolint: 0/1, cgo: 110/110, exclude: 21/21, identifier_marker: 21/21, skip_files: 110/110, autogenerated_exclude: 21/110, exclude-rules: 1/21, filename_unadjuster: 110/110, path_prettifier: 110/110 
INFO [runner] processing took 12.291786ms with stages: nolint: 10.343183ms, autogenerated_exclude: 1.050377ms, path_prettifier: 355.303µs, identifier_marker: 245.653µs, skip_dirs: 175.506µs, exclude-rules: 99.817µs, cgo: 11.918µs, filename_unadjuster: 6.219µs, max_same_issues: 827ns, uniq_by_line: 639ns, diff: 337ns, max_from_linter: 316ns, skip_files: 291ns, source_code: 231ns, exclude: 215ns, severity-rules: 213ns, max_per_file_from_linter: 212ns, sort_results: 203ns, path_shortener: 171ns, path_prefixer: 155ns 
INFO [runner] linters took 8.017448614s with stages: goanalysis_metalinter: 8.005075563s 
INFO File cache stats: 271 entries of total size 3.9MiB 
INFO Memory: 174 samples, avg is 295.8MB, max is 1089.4MB 
INFO Execution took 17.287675791s                 
