### PR TITLE
Always report CREATE_DELETE_SNAPSHOT and LIST_SNAPSHOTS capabilities

### DIFF
--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -101,26 +101,6 @@ func ValidateControllerUnpublishVolumeRequest(ctx context.Context, req *csi.Cont
 	return nil
 }
 
-// CheckSnapshotSupport internally checks if the vCenter version is 7.0.3
-func CheckSnapshotSupport(ctx context.Context, manager *Manager) bool {
-	log := logger.GetLogger(ctx)
-	vc, err := GetVCenter(ctx, manager)
-	if err != nil {
-		log.Errorf("failed to get vCenter while checking for Snapshot support on vCenter. err=%v", err)
-		return false
-	}
-	currentVcVersion := vc.Client.ServiceContent.About.ApiVersion
-	err = CheckAPI(currentVcVersion, SnapshotSupportedVCenterMajor, SnapshotSupportedVCenterMinor,
-		SnapshotSupportedVCenterPatch)
-	if err != nil {
-		log.Errorf("checkAPI failed for snapshot support on vCenter API version: %s, err=%v", currentVcVersion, err)
-		return false
-	}
-	// vCenter version supported.
-	log.Infof("vCenter API version: %s supports CNS snapshots.", currentVcVersion)
-	return true
-}
-
 // CheckAPI checks if specified version against the specified minimum support version.
 func CheckAPI(versionToCheck string,
 	minSupportedVCenterMajor int,

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -40,6 +40,7 @@ import (
 	pbmsim "github.com/vmware/govmomi/pbm/simulator"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/simulator/vpx"
 	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -100,6 +101,13 @@ func configFromSim() (*config.Config, func()) {
 func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.Config, func()) {
 	cfg := &config.Config{}
 	model := simulator.VPX()
+	// Currently the simulated vc has a version of 6.5.0, modifying service content to 7.0.3
+	// TODO: update in govmomi
+	serviceContent := vpx.ServiceContent
+	serviceContent.About.Version = "7.0.3"
+	serviceContent.About.ApiVersion = "7.0"
+	model.ServiceContent = serviceContent
+
 	defer model.Remove()
 
 	err := model.Create()


### PR DESCRIPTION
**What this PR does / why we need it**:
In existing code when `ControllerGetCapabilities` is called, a VC call is made to determine if it supports snapshots, if the VC is unreachable for some reason, we assume that it does not support snapshots and do not report snapshot capabilities from the csi driver.

The change always reports the snapshot-related capabilities. The version checks are triggered in individual APIs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran Unit Tests with no failure

**Special notes for your reviewer**:

**Release note**:
```release-note
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>