### PR TITLE
Bump up external provisioner version

### DIFF
--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -158,7 +158,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.5
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.2.2_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -158,7 +158,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.5
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.2.2_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -161,7 +161,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.1.0_vmware.7
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.2.2_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Due to a CVE in golang version used by external provisioner 2.1.0, we had to bump the version to 2.2.2 which uses golang 1.16. All the vDPP and CSI customized changes have been moved to the 2.2.2 branch.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
TBD

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump up external provisioner version to 2.2.2
```
