### PR TITLE
Stretched tests Part 5

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -119,6 +119,7 @@ const (
 	psodTime                                  = "120"
 	pvcHealthAnnotation                       = "volumehealth.storage.kubernetes.io/health"
 	pvcHealthTimestampAnnotation              = "volumehealth.storage.kubernetes.io/health-timestamp"
+	provisionerContainerName                  = "csi-provisioner"
 	quotaName                                 = "cns-test-quota"
 	regionKey                                 = "failure-domain.beta.kubernetes.io/region"
 	resizePollInterval                        = 2 * time.Second
@@ -144,6 +145,7 @@ const (
 	svClusterDistribution                     = "SupervisorCluster"
 	svOperationTimeout                        = 240 * time.Second
 	svStorageClassName                        = "SVStorageClass"
+	syncerContainerName                       = "vsphere-syncer"
 	totalResizeWaitPeriod                     = 10 * time.Minute
 	tkgClusterDistribution                    = "TKGService"
 	vanillaClusterDistribution                = "CSI-Vanilla"


### PR DESCRIPTION
**What this PR does / why we need it**: Includes automation for 2 testcases and utils for leader change scenarios of vsan stretched cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/4a6b8589e2c6d7c0d5e452369807ee02
**Special notes for your reviewer**:
make check output:
```
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/vsan-stretch-part5/vsphere-csi-driver /Users/kai/CSI/vsan-stretch-part5 /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (imports|name|types_sizes|deps|files|compiled_files|exports_file) took 1.905915088s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 101.912019ms 
INFO [linters context/goanalysis] analyzers took 9.427277378s with top 10 stages: buildir: 593.488275ms, S1038: 530.927176ms, misspell: 462.994509ms, S1039: 286.54021ms, SA1012: 247.199582ms, S1024: 246.257373ms, S1028: 193.929593ms, unused: 182.910515ms, S1012: 177.454706ms, directives: 175.811739ms 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 110/110, autogenerated_exclude: 21/110, nolint: 0/1, identifier_marker: 21/21, exclude-rules: 1/21, filename_unadjuster: 110/110, exclude: 21/21, cgo: 110/110, skip_files: 110/110, skip_dirs: 110/110 
INFO [runner] processing took 20.444907ms with stages: nolint: 14.771648ms, autogenerated_exclude: 2.314436ms, identifier_marker: 1.745471ms, path_prettifier: 1.19208ms, skip_dirs: 196.085µs, exclude-rules: 194.149µs, cgo: 14.298µs, filename_unadjuster: 12.345µs, max_same_issues: 1.017µs, uniq_by_line: 546ns, exclude: 430ns, diff: 392ns, max_from_linter: 350ns, skip_files: 307ns, source_code: 283ns, max_per_file_from_linter: 227ns, severity-rules: 226ns, path_shortener: 220ns, sort_results: 216ns, path_prefixer: 181ns 
INFO [runner] linters took 6.786703247s with stages: goanalysis_metalinter: 6.766141397s 
INFO File cache stats: 85 entries of total size 2.2MiB 
INFO Memory: 90 samples, avg is 258.6MB, max is 549.3MB 
INFO Execution took 8.814224503s
```
