### PR TITLE
Cherry-pick - Add a check for custom attributes to filter out datastores which are suspended

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/yaml.v2 v2.4.0
+	honnef.co/go/tools v0.2.0 // indirect
 	k8s.io/api v0.21.1
 	k8s.io/apiextensions-apiserver v0.21.1
 	k8s.io/apimachinery v0.21.1

--- a/go.sum
+++ b/go.sum
@@ -783,6 +783,7 @@ golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1105,6 +1106,8 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
+honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 k8s.io/api v0.21.1 h1:94bbZ5NTjdINJEdzOkpS4vdPhkb1VFpTYC9zh43f75c=
 k8s.io/api v0.21.1/go.mod h1:FstGROTmsSHBarKc8bylzXih8BLNYTiS3TZcsoEDg2s=
 k8s.io/apiextensions-apiserver v0.21.1 h1:AA+cnsb6w7SZ1vD32Z+zdgfXdXY8X9uGX5bN6EoPEIo=

--- a/manifests/guestcluster/1.20/pvcsi.yaml
+++ b/manifests/guestcluster/1.20/pvcsi.yaml
@@ -435,6 +435,7 @@ data:
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.21/pvcsi.yaml
+++ b/manifests/guestcluster/1.21/pvcsi.yaml
@@ -437,6 +437,7 @@ data:
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -466,6 +466,7 @@ data:
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"
   "tkgs-ha": "false"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -357,6 +357,8 @@ data:
   "block-volume-snapshot": "false"
   "sibling-replica-bound-pvc-check": "true"
   "tkgs-ha": "false"
+  "list-volumes": "false"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -356,6 +356,7 @@ data:
   "improved-csi-idempotency": "false"
   "block-volume-snapshot": "false"
   "sibling-replica-bound-pvc-check": "true"
+  "cnsmgr-suspend-create-volume": "false"
   "tkgs-ha": "false"
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -360,6 +360,8 @@ data:
   "block-volume-snapshot": "false"
   "sibling-replica-bound-pvc-check": "true"
   "tkgs-ha": "false"
+  "list-volumes": "false"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -153,6 +153,7 @@ data:
   "csi-windows-support": "false"
   "use-csinode-id": "false"
   "pv-to-backingdiskobjectid-mapping": "false"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/common/cns-lib/vsphere/datastore.go
+++ b/pkg/common/cns-lib/vsphere/datastore.go
@@ -38,7 +38,8 @@ type Datastore struct {
 // DatastoreInfo is a structure to store the Datastore and it's Info.
 type DatastoreInfo struct {
 	*Datastore
-	Info *types.DatastoreInfo
+	Info         *types.DatastoreInfo
+	CustomValues []types.BaseCustomFieldValue
 }
 
 func (di DatastoreInfo) String() string {

--- a/pkg/common/cns-lib/vsphere/hostsystem.go
+++ b/pkg/common/cns-lib/vsphere/hostsystem.go
@@ -51,7 +51,7 @@ func (host *HostSystem) GetAllAccessibleDatastores(ctx context.Context) ([]*Data
 
 	var dsMoList []mo.Datastore
 	pc := property.DefaultCollector(host.Client())
-	properties := []string{"info"}
+	properties := []string{"info", "customValue"}
 	err = pc.Retrieve(ctx, dsRefList, properties, &dsMoList)
 	if err != nil {
 		log.Errorf("failed to get datastore managed objects from datastore objects %v with properties %v: %v",
@@ -64,7 +64,7 @@ func (host *HostSystem) GetAllAccessibleDatastores(ctx context.Context) ([]*Data
 			&DatastoreInfo{
 				&Datastore{object.NewDatastore(host.Client(), dsMo.Reference()),
 					nil},
-				dsMo.Info.GetDatastoreInfo()})
+				dsMo.Info.GetDatastoreInfo(), dsMo.CustomValue})
 	}
 	return dsObjList, nil
 }

--- a/pkg/common/cns-lib/vsphere/utils_test.go
+++ b/pkg/common/cns-lib/vsphere/utils_test.go
@@ -1,0 +1,60 @@
+package vsphere
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestFilterSuspendedDatastoresWhenDatastoreIsSuspended(t *testing.T) {
+
+	customValue := []types.CustomFieldValue{
+		{Key: 101},
+	}
+	CustomFieldStringValue := []types.CustomFieldStringValue{
+		{Value: cnsMgrDatastoreSuspended, CustomFieldValue: customValue[0]},
+	}
+	customValue2 := (types.CustomFieldStringValue)(CustomFieldStringValue[0])
+	baseCustomFieldValue := (types.BaseCustomFieldValue)(&customValue2)
+
+	datastoreMoref := types.ManagedObjectReference{Type: "datastore", Value: "datastore-1"}
+	datastore := &Datastore{Datastore: object.NewDatastore(nil, datastoreMoref)}
+	dsInfo := []*DatastoreInfo{
+		{
+			Datastore: datastore,
+			Info: &types.DatastoreInfo{
+				Name: "test-ds",
+			},
+			CustomValues: []types.BaseCustomFieldValue{baseCustomFieldValue},
+		},
+	}
+
+	outputDsInfo := FilterSuspendedDatastores(context.TODO(), dsInfo)
+	assert.Equal(t, 0, len(outputDsInfo))
+}
+func TestFilterSuspendedDatastoresWhenDatastoreIsNotSuspended(t *testing.T) {
+
+	customValue := []types.CustomFieldValue{
+		{Key: 101},
+	}
+	CustomFieldStringValue := []types.CustomFieldStringValue{
+		{Value: "randomValue", CustomFieldValue: customValue[0]},
+	}
+	customValue2 := (types.CustomFieldStringValue)(CustomFieldStringValue[0])
+	baseCustomFieldValue := (types.BaseCustomFieldValue)(&customValue2)
+
+	dsInfo := []*DatastoreInfo{
+		{
+			Info: &types.DatastoreInfo{
+				Name: "test-ds",
+			},
+			CustomValues: []types.BaseCustomFieldValue{baseCustomFieldValue},
+		},
+	}
+
+	outputDsInfo := FilterSuspendedDatastores(context.TODO(), dsInfo)
+	assert.Equal(t, 1, len(outputDsInfo))
+}

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -437,7 +437,7 @@ func (vc *VirtualCenter) GetVsanDatastores(ctx context.Context,
 		}
 		var dsMoList []mo.Datastore
 		pc := property.DefaultCollector(dc.Client())
-		properties := []string{"summary", "info"}
+		properties := []string{"summary", "info", "customValue"}
 		err = pc.Retrieve(ctx, dsMorList, properties, &dsMoList)
 		if err != nil {
 			log.Errorf("failed to get Datastore managed objects from datastore objects."+
@@ -450,7 +450,7 @@ func (vc *VirtualCenter) GetVsanDatastores(ctx context.Context,
 				vsanDsURLInfoMap[dsMo.Info.GetDatastoreInfo().Url] = &DatastoreInfo{
 					&Datastore{object.NewDatastore(dc.Client(), dsMo.Reference()),
 						dc},
-					dsMo.Info.GetDatastoreInfo()}
+					dsMo.Info.GetDatastoreInfo(), dsMo.CustomValue}
 			}
 		}
 	}

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -242,12 +242,13 @@ func GetDatastoreRefByURLFromGivenDatastoreList(
 	var candidateDsObj *cnsvsphere.Datastore
 	// traverse each datacenter and find the datastore with the specified dsURL
 	for _, datacenter := range datacenters {
-		candidateDsObj, err = datacenter.GetDatastoreByURL(ctx, dsURL)
+		candidateDsInfoObj, err := datacenter.GetDatastoreInfoByURL(ctx, dsURL)
 		if err != nil {
 			log.Errorf("failed to find datastore with URL %q in datacenter %q from VC %q, Error: %+v",
 				dsURL, datacenter.InventoryPath, vc.Config.Host, err)
 			continue
 		}
+		candidateDsObj = candidateDsInfoObj.Datastore
 		break
 	}
 

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -535,7 +535,7 @@ func getDatastoreMOsFromCluster(ctx context.Context, vc *cnsvsphere.VirtualCente
 
 	// Get datastore properties.
 	pc := property.DefaultCollector(vc.Client.Client)
-	properties := []string{"info", "summary"}
+	properties := []string{"info", "summary", "customValue"}
 	var dsList []vim25types.ManagedObjectReference
 	var dsMoList []mo.Datastore
 	for _, datastore := range datastores {

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -339,4 +339,6 @@ const (
 	TKGsHA = "tkgs-ha"
 	// PVtoBackingDiskObjectIdMapping is the feature to support pv to backingDiskObjectId mapping on vSphere CSI driver.
 	PVtoBackingDiskObjectIdMapping = "pv-to-backingdiskobjectid-mapping"
+	// Block Create Volume for datastores that are in suspended mode
+	CnsMgrSuspendCreateVolume = "cnsmgr-suspend-create-volume"
 )

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -559,8 +559,10 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		// Filter datastores which in datastoreMap from sharedDatastores.
 		sharedDatastores = c.filterDatastores(ctx, sharedDatastores)
 	}
+
+	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 	volumeInfo, faultType, err := common.CreateBlockVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
-		c.manager, &createVolumeSpec, sharedDatastores)
+		c.manager, &createVolumeSpec, sharedDatastores, filterSuspendedDatastores)
 	if err != nil {
 		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to create volume. Error: %+v", err)
@@ -770,6 +772,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 	}
 	var volumeID string
 	var faultType string
+	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIAuthCheck) {
 		fsEnabledClusterToDsInfoMap := c.authMgr.GetFsEnabledClusterToDsMap(ctx)
 
@@ -783,14 +786,14 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 				"no datastores found to create file volume")
 		}
 		volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
-			c.manager, &createVolumeSpec, filteredDatastores)
+			c.manager, &createVolumeSpec, filteredDatastores, filterSuspendedDatastores)
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to create volume. Error: %+v", err)
 		}
 	} else {
 		volumeID, faultType, err = common.CreateFileVolumeUtilOld(ctx, cnstypes.CnsClusterFlavorVanilla,
-			c.manager, &createVolumeSpec)
+			c.manager, &createVolumeSpec, filterSuspendedDatastores)
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to create volume. Error: %+v", err)

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -218,7 +218,8 @@ func (f *FakeNodeManager) GetSharedDatastoresInK8SCluster(ctx context.Context) (
 			Datastore: &cnsvsphere.Datastore{
 				Datastore:  object.NewDatastore(nil, sharedDatastoreManagedObject.Reference()),
 				Datacenter: nil},
-			Info: sharedDatastoreManagedObject.Info.GetDatastoreInfo(),
+			Info:         sharedDatastoreManagedObject.Info.GetDatastoreInfo(),
+			CustomValues: []types.BaseCustomFieldValue{},
 		},
 	}, nil
 }

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -439,9 +439,10 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			"failed finding candidate datastores to place volume. Error: %v", err)
 	}
 
+	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 	candidateDatastores := append(sharedDatastores, vsanDirectDatastores...)
 	volumeInfo, faultType, err := common.CreateBlockVolumeUtil(ctx, cnstypes.CnsClusterFlavorWorkload,
-		c.manager, &createVolumeSpec, candidateDatastores)
+		c.manager, &createVolumeSpec, candidateDatastores, filterSuspendedDatastores)
 	if err != nil {
 		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to create volume. Error: %+v", err)
@@ -529,8 +530,9 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 		return nil, csifault.CSIInternalFault, logger.LogNewErrorCode(log, codes.Internal,
 			"no datastores found to create file volume")
 	}
+	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 	volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorWorkload,
-		c.manager, &createVolumeSpec, filteredDatastores)
+		c.manager, &createVolumeSpec, filteredDatastores, filterSuspendedDatastores)
 	if err != nil {
 		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to create volume. Error: %+v", err)

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -249,14 +249,16 @@ func getFakeDatastores(ctx context.Context, vc *cnsvsphere.VirtualCenter,
 				Datastore: &cnsvsphere.Datastore{
 					Datastore:  object.NewDatastore(nil, sharedDatastoreManagedObject.Reference()),
 					Datacenter: nil},
-				Info: sharedDatastoreManagedObject.Info.GetDatastoreInfo(),
+				Info:         sharedDatastoreManagedObject.Info.GetDatastoreInfo(),
+				CustomValues: []types.BaseCustomFieldValue{},
 			},
 		}, []*cnsvsphere.DatastoreInfo{
 			{
 				Datastore: &cnsvsphere.Datastore{
 					Datastore:  object.NewDatastore(nil, vsanDirectDatastoreManagedObject.Reference()),
 					Datacenter: nil},
-				Info: vsanDirectDatastoreManagedObject.Info.GetDatastoreInfo(),
+				Info:         vsanDirectDatastoreManagedObject.Info.GetDatastoreInfo(),
+				CustomValues: []types.BaseCustomFieldValue{},
 			},
 		}, nil
 }

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -237,13 +237,13 @@ func TestSyncerWorkflows(t *testing.T) {
 		return
 	}
 
-	datastoreObj, err := dc[0].GetDatastoreByURL(ctx, sharedDatastore)
+	datastoreInfoObj, err := dc[0].GetDatastoreInfoByURL(ctx, sharedDatastore)
 	if err != nil {
 		t.Errorf("failed to get datastore with URL: %s. Error: %v", sharedDatastore, err)
 		t.Fatal(err)
 		return
 	}
-	dsList = append(dsList, datastoreObj.Reference())
+	dsList = append(dsList, datastoreInfoObj.Datastore.Reference())
 
 	runTestMetadataSyncInformer(t)
 	runTestFullSyncWorkflows(t)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry picks PR #1549  where we're filtering out datastores during create volume if they're suspended.


**Testing done**:
1. FSS is disabled. - volume gets provisioned successfully.
2. Suspended all compatible datastores - failed to get created volume. After this, changed custom value to cns.vmware.com/datstoreNotSuspended and the volume got created eventually.
3. Ran make check and make test

Example of a failed volumes that could not provisioned:

```
root@k8s-control-822-1645575351:~# kubectl describe pvc example-vanilla-block-pvc1
Name:          example-vanilla-block-pvc1
Namespace:     default
StorageClass:  example-vanilla-block-sc
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age                From                                                                                                 Message
  ----     ------                ----               ----                                                                                                 -------
  Normal   Provisioning          21s (x7 over 86s)  csi.vsphere.vmware.com_vsphere-csi-controller-6d8d8dcdc5-svr7l_a815e548-b7a0-4219-815c-cc2f862588d4  External provisioner is provisioning volume for claim "default/example-vanilla-block-pvc1"
  Warning  ProvisioningFailed    21s (x7 over 85s)  csi.vsphere.vmware.com_vsphere-csi-controller-6d8d8dcdc5-svr7l_a815e548-b7a0-4219-815c-cc2f862588d4  failed to provision volume with StorageClass "example-vanilla-block-sc": rpc error: code = Internal desc = failed to create volume. Error: ServerFaultCode: createSpecs.datastores is empty
  Normal   ExternalProvisioning  9s (x7 over 86s)   persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
``` 
