### PR TITLE
Change scope of TriggerCsiFullSync CRD from Namespaced to Cluster

### DIFF
--- a/pkg/internalapis/cnsoperator/config/triggercsifullsync_crd.yaml
+++ b/pkg/internalapis/cnsoperator/config/triggercsifullsync_crd.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: TriggerCsiFullSyncList
     plural: triggercsifullsyncs
     singular: triggercsifullsync
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
 	cnsoperatorconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config"
 	internalapiscnsoperatorconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config"
 	csinodetopologyconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config"
@@ -234,6 +235,10 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 	}
 	if err = csinodetopologyv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Errorf("failed to add CSINodeTopology to scheme with error: %+v", err)
+		return err
+	}
+	if err = internalapis.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Errorf("failed to add internalapis to scheme with error: %+v", err)
 		return err
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

TriggerCsiFullSync CRD scope should always be `Cluster`. It was mistakenly changed to `Namespaced` during a previous change which led to an error when the `trigger-csi-fullsync` flag was enabled. 

The PR changes the CRD scope back to `Cluster` while adding the Kind to the scheme. 

**Which issue this PR fixes** : 
fixes the bug `Vsphere-syncer crashing with error "Error: an empty namespace may not be set when a resource name is provided "  when "trigger-csi-fullsync" is enabled`

**Testing done**:
<!-- A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.-->

Only changing scope from Namespaced to Cluster

flag disabled

1. correct log seen

```
{"level":"info","time":"2022-02-25T21:42:24.783751318Z","caller":"triggercsifullsync/triggercsifullsync_controller.go:82","msg":"Not initializing the TriggerCsiFullSync Controller as this feature is disabled on the cluster","TraceId":"dabd8aad-160d-4d54-b772-94dda30053fd"}
```

2. no fullsync crd created

```
root@k8s-control-518-1645052707:\~/adkulkarni# k get crd
NAME                                        CREATED AT
cnsvolumeoperationrequests.cns.vmware.com   2022-02-16T23:14:37Z
csinodetopologies.cns.vmware.com            2022-02-16T23:14:46Z
root@k8s-control-518-1645052707:~/adkulkarni#
```

flag enabled

1. incorrect log seen

```
{"level":"info","time":"2022-02-25T22:24:12.851513632Z","caller":"manager/init.go:278","msg":"Triggerfullsync feature enabled","TraceId":"f5ce612f-eb43-4ab3-9b40-4ee96fb7479c"}

{"level":"info","time":"2022-02-25T22:24:12.892303721Z","caller":"kubernetes/kubernetes.go:455","msg":"\"triggercsifullsyncs.cns.vmware.com\" CRD created successfully","TraceId":"f5ce612f-eb43-4ab3-9b40-4ee96fb7479c"}
{"level":"info","time":"2022-02-25T22:24:18.211110299Z","caller":"manager/init.go:310","msg":"Created the a new instance of \"csifullsync\" TriggerCsiFullSync instance as it was not found.","TraceId":"f5ce612f-eb43-4ab3-9b40-4ee96fb7479c"}

{"level":"info","time":"2022-02-25T22:24:18.213634669Z","caller":"syncer/metadatasyncer.go:157","msg":"Initializing MetadataSyncer"}
{"level":"info","time":"2022-02-25T22:24:18.214551294Z","caller":"manager/init.go:70","msg":"Initializing CNS Operator"}

{"level":"info","time":"2022-02-25T22:24:18.447766294Z","caller":"syncer/metadatasyncer.go:372","msg":"\"trigger-csi-fullsync\" feature flag is enabled. Using TriggerCsiFullSync API to trigger full sync"}

{"level":"info","time":"2022-02-25T22:24:18.683294183Z","caller":"manager/init.go:247","msg":"Starting Cns Operator"}
{"level":"error","time":"2022-02-25T22:24:18.691618687Z","caller":"manager/init.go:251","msg":"failed to start Cns operator. Err: failed to wait for triggercsifullsync-controller caches to sync: no kind is registered for the type v1alpha1.TriggerCsiFullSync in scheme \"pkg/runtime/scheme.go:100\"","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager.InitCnsOperator\n\t/build/pkg/syncer/cnsoperator/manager/init.go:251\nmain.initSyncerComponents.func1.2\n\t/build/cmd/syncer/main.go:180"}
{"level":"error","time":"2022-02-25T22:24:18.6921101Z","caller":"syncer/main.go:181","msg":"Error initializing Cns Operator. Error: failed to wait for triggercsifullsync-controller caches to sync: no kind is registered for the type v1alpha1.TriggerCsiFullSync in scheme \"pkg/runtime/scheme.go:100\"","stacktrace":"main.initSyncerComponents.func1.2\n\t/build/cmd/syncer/main.go:181"}
```


2. fullsync crd and instance created

```
root@k8s-control-518-1645052707:\~/adkulkarni# k get crd
NAME                                        CREATED AT
cnsvolumeoperationrequests.cns.vmware.com   2022-02-16T23:14:37Z
csinodetopologies.cns.vmware.com            2022-02-16T23:14:46Z
triggercsifullsyncs.cns.vmware.com          2022-02-25T22:24:12Z

root@k8s-control-518-1645052707:\~/adkulkarni# k get triggercsifullsyncs.cns.vmware.com
NAME          AGE
csifullsync   5m9s
```


Changed scope and registered the Kind, we get the correct log and crd instance creation

```
{"level":"info","time":"2022-02-28T17:45:34.631395442Z","caller":"manager/init.go:251","msg":"Starting Cns Operator"}
{"level":"info","time":"2022-02-28T17:45:34.737409891Z","caller":"triggercsifullsync/triggercsifullsync_controller.go:231","msg":"Reconciling trigger full sync with triggerSyncID: 1"}
{"level":"info","time":"2022-02-28T17:45:34.747442419Z","caller":"syncer/fullsync.go:41","msg":"FullSync: start"}
```

```
root@k8s-control-518-1645052707:\~/adkulkarni# k get crd
NAME                                        CREATED AT
cnsvolumeoperationrequests.cns.vmware.com   2022-02-16T23:14:37Z
csinodetopologies.cns.vmware.com            2022-02-16T23:14:46Z
triggercsifullsyncs.cns.vmware.com          2022-02-28T17:45:28Z

root@k8s-control-518-1645052707:\~/adkulkarni# k get triggercsifullsyncs.cns.vmware.com
NAME          AGE
csifullsync   19s
```

make check 

```
(~/GolandProjects/vsphere-csi-driver) $ make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
	To adjust and download dependencies of the current module, use 'go get -d'.
	To install using requirements of the current module, use 'go install'.
	To install ignoring the current module, use 'go install' with a version,
	like 'go install example.com/cmd@latest'.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/adkulkarni/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/adkulkarni/GolandProjects/vsphere-csi-driver /Users/adkulkarni/GolandProjects /Users/adkulkarni /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (types_sizes|imports|name|files|compiled_files|deps|exports_file) took 1.517843582s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 92.767932ms
INFO [linters context/goanalysis] analyzers took 16.008312857s with top 10 stages: buildir: 6.135639566s, S1038: 807.134864ms, misspell: 696.701428ms, unused: 370.452012ms, S1039: 349.44008ms, directives: 312.615986ms, SA1012: 251.301377ms, S1028: 199.071559ms, S1024: 195.961965ms, S1025: 184.280467ms
INFO [runner] Issues before processing: 113, after processing: 0
INFO [runner] Processors filtering stat (out/in): cgo: 113/113, skip_files: 113/113, autogenerated_exclude: 24/113, identifier_marker: 24/24, skip_dirs: 113/113, path_prettifier: 113/113, exclude: 24/24, nolint: 0/1, filename_unadjuster: 113/113, exclude-rules: 1/24
INFO [runner] processing took 13.351745ms with stages: nolint: 11.323891ms, autogenerated_exclude: 1.13743ms, path_prettifier: 352.081µs, identifier_marker: 292.256µs, skip_dirs: 118.862µs, exclude-rules: 107.956µs, filename_unadjuster: 7.851µs, cgo: 7.552µs, max_same_issues: 929ns, uniq_by_line: 480ns, max_from_linter: 365ns, diff: 328ns, source_code: 292ns, max_per_file_from_linter: 269ns, exclude: 261ns, skip_files: 237ns, path_shortener: 218ns, severity-rules: 208ns, sort_results: 161ns, path_prefixer: 118ns
INFO [runner] linters took 6.71387003s with stages: goanalysis_metalinter: 6.700434267s
INFO File cache stats: 169 entries of total size 3.4MiB
INFO Memory: 85 samples, avg is 403.6MB, max is 1088.2MB
INFO Execution took 8.335666298s
```

**Special notes for your reviewer**:

Block Vanilla e2e tests: 
Build ID: 832 - 36 Passed | 4 Failed. 
Build ID: 834, 835, 836, 839: those 4 failures passed when run individually. 

File Vanilla e2e tests: 
Build ID: 203 - 27 Passed | 1 Failed. 
Build ID: 204 - 1 failure passed when run individually. 

WCP is not mentioned in the bug report but performed manual tests and confirmed the same logs for crd and instance creation when flag is enabled, as seen above. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
