### PR TITLE
set timeout for GetPodVMUUIDAnnotation to 4 minutes

### DIFF
--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -109,7 +109,7 @@ func (k8sCloudOperator *k8sCloudOperator) GetPodVMUUIDAnnotation(ctx context.Con
 	var (
 		vmuuid   string
 		err      error
-		timeout  = 5 * time.Minute
+		timeout  = 4 * time.Minute
 		pollTime = time.Duration(getPodPollIntervalInSecs(ctx)) * time.Second
 		volumeID = req.VolumeID
 		nodeName = req.NodeName


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is setting timeout for GetPodVMUUIDAnnotation to 4 minutes.
We are calling GetPodVMUUIDAnnotation from ControllerPublishVolume. csi-attacher in WCP is started with `"--timeout=300s"`. We want to make sure we return the response back to csi-attacher before 5 minutes timeout to avoid seeing failure regarding `context deadline exceeded`.




**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
set timeout for GetPodVMUUIDAnnotation to 4 minutes
```
