### PR TITLE
Perform snapshot queries only on Block volumes during delete

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -105,6 +105,9 @@ const (
 	// FileVolumeType is the VolumeType for CNS File Share Volume.
 	FileVolumeType = "FILE"
 
+	// UnknownVolumeType is assigned to CNS volumes whose type couldn't be determined.
+	UnknownVolumeType = "UNKNOWN"
+
 	// Nfsv4AccessPointKey is the key for NFSv4 access point.
 	Nfsv4AccessPointKey = "NFSv4.1"
 

--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 )
@@ -125,4 +126,14 @@ func validateVanillaListSnapshotRequest(ctx context.Context, req *csi.ListSnapsh
 		}
 	}
 	return nil
+}
+
+func convertCnsVolumeType(ctx context.Context, cnsVolumeType string) string {
+	volumeType := prometheus.PrometheusUnknownVolumeType
+	if cnsVolumeType == common.BlockVolumeType {
+		volumeType = prometheus.PrometheusBlockVolumeType
+	} else if cnsVolumeType == common.FileVolumeType {
+		volumeType = prometheus.PrometheusFileVolumeType
+	}
+	return volumeType
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This change performs snapshot checks only for block volumes during delete volume call.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Unit Tests

**Special notes for your reviewer**:

**Release note**:
```release-note
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>