### PR TITLE
static provisioning - import VMDK testFix

### DIFF
--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -1861,7 +1861,10 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 			pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			pv := getPvFromClaim(client, namespace, pvcName)
-			verifyBidirectionalReferenceOfPVandPVC(ctx, client, pvc, pv, fcdID)
+			pvName := pvc.Spec.VolumeName
+			//pvName will be like static-pv-<volumeID> This volumeID Should be same as in PV volumeHandle
+			volumeID := strings.ReplaceAll(pvName, "static-pv-", "")
+			verifyBidirectionalReferenceOfPVandPVC(ctx, client, pvc, pv, volumeID)
 
 			// TODO: need to add code to delete VMDK hard disk and to create POD.
 


### PR DESCRIPTION
What this PR does / why we need it:
test fix

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes # 

Testing done:
Yes


make checck
golangci/golangci-lint info installed /Users/kramachandra/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kramachandra/github/2ndSet/vsphere-csi-driver /Users/kramachandra/github/2ndSet /Users/kramachandra/github /Users/kramachandra /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|types_sizes|compiled_files|exports_file|files|imports|name) took 59.502554589s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 102.793705ms 
INFO [linters context/goanalysis] analyzers took 4m57.54692897s with top 10 stages: buildir: 3m33.180750715s, nilness: 21.065367296s, ctrlflow: 8.921312299s, printf: 8.694624348s, fact_deprecated: 8.435200973s, typedness: 6.917459879s, fact_purity: 6.56823398s, SA5012: 5.992932944s, inspect: 3.908641039s, misspell: 1.777818854s 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 110/110, skip_files: 110/110, autogenerated_exclude: 21/110, cgo: 110/110, filename_unadjuster: 110/110, skip_dirs: 110/110, identifier_marker: 21/21, exclude-rules: 1/21, nolint: 0/1, exclude: 21/21 
INFO [runner] processing took 20.874041ms with stages: nolint: 16.358236ms, autogenerated_exclude: 2.883582ms, path_prettifier: 798.577µs, identifier_marker: 460.682µs, skip_dirs: 174.645µs, exclude-rules: 172.398µs, cgo: 10.495µs, filename_unadjuster: 9.861µs, max_same_issues: 1.375µs, uniq_by_line: 711ns, max_from_linter: 444ns, source_code: 436ns, diff: 428ns, exclude: 373ns, skip_files: 368ns, path_shortener: 358ns, sort_results: 330ns, max_per_file_from_linter: 289ns, severity-rules: 276ns, path_prefixer: 177ns 
INFO [runner] linters took 35.125093885s with stages: goanalysis_metalinter: 35.104096877s 
INFO File cache stats: 272 entries of total size 3.9MiB 
INFO Memory: 892 samples, avg is 571.8MB, max is 2368.3MB 
INFO Execution took 1m34.744772271s           

