### PR TITLE
Error message fix for online volume expansion when sps service is down

### DIFF
--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -737,8 +737,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			framework.Logf("Expected failure message: %+q", expectedErrMsg)
 			isFailureFound, err := getEventsListAndVerifyPvcError(client, namespace, pvclaim, expectedErrMsg)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(isFailureFound).To(gomega.BeTrue(), expectedErrMsg)
-
+			gomega.Expect(isFailureFound).To(gomega.BeTrue(), "Expected error %v, to occur but did not occur", expectedErrMsg)
 			ginkgo.By("Bringup SPS service")
 			err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
Error message fix for online volume expansion when sps service is down.

**Testing done**:
Yes
GC : https://gist.githubusercontent.com/sipriyaa/bc8ab1c06609caa61da45e1f87df2ffe/raw/d85eb2b570b5f603ef856aa1248f1ce6aefaf0ec/gistfile1.txt

Make Check:

sipriya@sipriya-a01 vsphere-csi-driver % 
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/block-csi2.5/vsphere-csi-driver /Users/sipriya/block-csi2.5 /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (name|types_sizes|compiled_files|exports_file|files|deps|imports) took 48.443857562s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 89.673637ms 
INFO [linters context/goanalysis] analyzers took 3m26.252586927s with top 10 stages: buildir: 2m27.174719006s, nilness: 14.371260653s, ctrlflow: 5.910006768s, printf: 5.451672152s, fact_deprecated: 5.169263809s, fact_purity: 4.609588695s, typedness: 4.593314383s, SA5012: 3.836322259s, inspect: 3.221977572s, misspell: 1.317488425s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude: 24/24, path_prettifier: 113/113, autogenerated_exclude: 24/113, nolint: 0/1, skip_dirs: 113/113, identifier_marker: 24/24, exclude-rules: 1/24, cgo: 113/113, filename_unadjuster: 113/113, skip_files: 113/113 
INFO [runner] processing took 13.121448ms with stages: nolint: 10.80263ms, autogenerated_exclude: 1.442263ms, path_prettifier: 319.492µs, identifier_marker: 287.273µs, skip_dirs: 146.479µs, exclude-rules: 103.14µs, filename_unadjuster: 7.832µs, cgo: 7.117µs, max_same_issues: 907ns, uniq_by_line: 751ns, exclude: 657ns, sort_results: 544ns, skip_files: 484ns, diff: 388ns, max_from_linter: 385ns, source_code: 328ns, severity-rules: 243ns, max_per_file_from_linter: 222ns, path_shortener: 203ns, path_prefixer: 110ns 
INFO [runner] linters took 25.519563952s with stages: goanalysis_metalinter: 25.506358842s 
INFO File cache stats: 273 entries of total size 3.9MiB 
INFO Memory: 727 samples, avg is 571.4MB, max is 2368.6MB 
INFO Execution took 1m14.063674229s               
sipriya@sipriya-a01 vsphere-csi-driver % 