### PR TITLE
Release vSphere CSI driver v2.5.0

### DIFF
--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -131,7 +131,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.5.0-rc.5
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.5.0
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -261,7 +261,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.0-rc.5
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -318,7 +318,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.5.0-rc.5
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.5.0
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
@@ -437,7 +437,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.0-rc.5
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -584,7 +584,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.0-rc.5
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Release vSphere CSI driver v2.5.0 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Linter checks passed:
```
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sbhaskara/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sbhaskara/github-csi/vsphere-csi-driver /Users/sbhaskara/github-csi /Users/sbhaskara /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|files|compiled_files|exports_file|imports|name|types_sizes) took 3.87537955s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 90.39126ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 52, after processing: 0 
INFO [runner] Processors filtering stat (out/in): cgo: 52/52, identifier_marker: 21/21, nolint: 0/1, filename_unadjuster: 52/52, path_prettifier: 52/52, skip_dirs: 52/52, autogenerated_exclude: 21/52, skip_files: 52/52, exclude-rules: 1/21, exclude: 21/21 
INFO [runner] processing took 12.198183ms with stages: nolint: 10.236425ms, autogenerated_exclude: 937.027µs, path_prettifier: 495.617µs, identifier_marker: 258.244µs, skip_dirs: 151.68µs, exclude-rules: 101.402µs, cgo: 7.451µs, filename_unadjuster: 6.099µs, max_same_issues: 850ns, uniq_by_line: 525ns, path_shortener: 500ns, max_from_linter: 362ns, exclude: 354ns, skip_files: 313ns, diff: 271ns, source_code: 266ns, severity-rules: 241ns, max_per_file_from_linter: 212ns, sort_results: 208ns, path_prefixer: 136ns 
INFO [runner] linters took 2.705580729s with stages: goanalysis_metalinter: 2.693297956s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 68 samples, avg is 101.6MB, max is 140.9MB 
INFO Execution took 6.683631341s         
```

E2E - TBD

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Release vSphere CSI driver v2.5.0
```
