### PR TITLE
Add non storage fault for CSI attach and handle vm not found in CSI Attach for WCP 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/elazarl/goproxy v0.0.0-20200710112657-153946a5f232 // indirect
 	github.com/fsnotify/fsnotify v1.4.9
+	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.2.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 // indirect

--- a/pkg/common/fault/constants.go
+++ b/pkg/common/fault/constants.go
@@ -19,6 +19,9 @@ const (
 	// CSITaskInfoEmptyFault is the fault type when taskInfo is empty.
 	CSITaskInfoEmptyFault = "csi.fault.TaskInfoEmpty"
 
+	// CSIVmUuidNotFoundFault is the fault type when Pod VMs do not have the vmware-system-vm-uuid annotation.
+	CSIVmUuidNotFoundFault = "csi.fault.nonstorage.VmUuidNotFound"
+
 	// CSITaskResultEmptyFault is the fault type when taskResult is empty.
 	CSITaskResultEmptyFault = "csi.fault.TaskResultEmpty"
 

--- a/pkg/common/prometheus/metrics.go
+++ b/pkg/common/prometheus/metrics.go
@@ -118,7 +118,7 @@ var (
 		// Possible voltype - "unknown", "block", "file"
 		// Possible optype - "create-volume", "delete-volume", "attach-volume", "detach-volume", "expand-volume"
 		// Possible status - "pass", "fail"
-		[]string{"voltype", "optype", "status", "namespace"})
+		[]string{"voltype", "optype", "status", "namespace", "faulttype"})
 
 	// CnsControlOpsHistVec is a histogram vector metric to observe various control
 	// operations on CNS. Note that this captures the time taken by CNS into a bucket

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -862,10 +862,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	log.Debugf("createVolumeInternal: returns fault %q", faultType)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -978,10 +978,10 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	log.Debugf("deleteVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1106,10 +1106,10 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	log.Debugf("controllerPublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1223,10 +1223,10 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	log.Debugf("controllerUnpublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1330,10 +1330,10 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	if err != nil {
 		log.Debugf("controllerExpandVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1544,10 +1544,10 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 	resp, err := createSnapshotInternal()
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateSnapshotOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, "NotComputed").Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateSnapshotOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, "").Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1594,10 +1594,10 @@ func (c *controller) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshot
 	resp, err := deleteSnapshotInternal()
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteSnapshotOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, "NotComputed").Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteSnapshotOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, "").Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 
@@ -1654,10 +1654,10 @@ func (c *controller) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRe
 	resp, err := listSnapshotsInternal()
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusListSnapshotsOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, "NotComputed").Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusListSnapshotsOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, "").Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -378,10 +378,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	log.Debugf("createVolumeInternal: returns fault %q", faultType)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	}
 	log.Debugf("CreateVolume response: %+v", resp)
 	return resp, err
@@ -451,10 +451,10 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	log.Debugf("deleteVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -509,10 +509,10 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	if err != nil {
 		log.Debugf("controllerPublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -854,10 +854,10 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	log.Debugf("controllerUnpublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1222,10 +1222,10 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	log.Debugf("controllerExpandVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -502,10 +502,10 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 		// When reconciler returns reconcile.Result{RequeueAfter: timeout}, the err will be set to nil,
 		// for this case, we need count it as an attach/detach failure
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, volumeOpType,
-			prometheus.PrometheusFailStatus, request.Namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, request.Namespace, "NotComputed").Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, volumeOpType,
-			prometheus.PrometheusPassStatus, request.Namespace).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, request.Namespace, "").Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is enhancing the k8scloudoperator.go to return VMUuidNotFound error which will be verified by WCP CNS CSI controller to emit non storage related faulttypes in AttachVolume

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

1. **Induce VMuuidNotFound fault**

Create a PVC
Run a script to look for a specific podName `example-block-pod` and remove vm-uuid annotation on the podVM
```
 cat script.sh 
for ((i = 1; i <= 200; i++)); do
  sleep 0.1 &
  kubectl annotate pod example-block-pod vmware-system-vm-uuid- -n test-e2e
  wait # for sleep
done
```
While the above script is running, create a Pod using the above PVC:
```
kubectl create -f pod.yaml -n test-e2e
pod/example-block-pod created
```
The script removes the annotation before CSI Attach is even invoked. This was observed in the attach volume errors:

```
2022-03-08T18:44:59.808Z	ERROR	wcp/controller.go:806	failed to find the pod vmuuid annotation from the k8sCloudOperator service when processing attach for volumeID: 7d9562ad-e751-4da9-8540-67a4acb1333e on node: wdc-10-180-192-214.eng.vmware.com. Error: rpc error: code = NotFound desc = Unable to find vmware-system-vm-uuid annotation in pod with name: example-block-pod on namespace: test-e2e.	{"TraceId": "e68d6b15-ba7f-410c-9d34-3b12699c9e5b"}
```
RPC error code = NotFound and hence ControllerPublishVolume emits the expected nonstorage faulttype

```
2022-03-08T18:44:59.808Z	DEBUG	wcp/controller.go:904	controllerPublishVolumeInternal: returns fault "csi.fault.nonstorage.VmUuidNotFound" for volume "7d9562ad-e751-4da9-8540-67a4acb1333e"	{"TraceId": "e68d6b15-ba7f-410c-9d34-3b12699c9e5b"}
```

When we check the prometheus metrics, we can clearly see the faulttype label added : 
> curl 10.180.193.235:2112/metrics
```
vsphere_csi_volume_ops_histogram_sum{faulttype="csi.fault.nonstorage.VmUuidNotFound",namespace="unknown",optype="attach-volume",status="fail",voltype="block"} 19.567546573999998
vsphere_csi_volume_ops_histogram_count{faulttype="csi.fault.nonstorage.VmUuidNotFound",namespace="unknown",optype="attach-volume",status="fail",voltype="block"} 9
```

**2. Simulate other errors (not VMuuidNotFound errors)**

Edit the cluster role to remove permissions to list pods and restart the driver
Create Pod with a PVC
CSI logs contains internal fault types & RPC error code is different
```
2022-03-08T19:15:37.598Z	ERROR	wcp/controller_helper.go:247	Failed to get the pod vmuuid annotation from the k8s cloud operator service. Error: rpc error: code = Unknown desc = Cannot find pod with namespace: test-e2e running on node: wdc-10-180-192-214.eng.vmware.com with error pods is forbidden: User "system:serviceaccount:vmware-system-csi:vsphere-csi-controller" cannot list resource "pods" in API group "" in the namespace "test-e2e"
...
2022-03-08T19:15:37.598Z	DEBUG	wcp/controller.go:904	controllerPublishVolumeInternal: returns fault "csi.fault.Internal" for volume "7d9562ad-e751-4da9-8540-67a4acb1333e"	{"TraceId": "c1ebb925-c9a2-4371-8a48-580243b57605"}
```
Metrics with labels:

```
vsphere_csi_volume_ops_histogram_sum{faulttype="csi.fault.Internal",namespace="unknown",optype="attach-volume",status="fail",voltype="block"} 0.14740892
vsphere_csi_volume_ops_histogram_count{faulttype="csi.fault.Internal",namespace="unknown",optype="attach-volume",status="fail",voltype="block"} 8
```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add non storage fault for CSI attach and handle vm not found in CSI detach for WCP
```
