### PR TITLE
Stretched cluster tests PART 6

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	adminPassword                              = "Admin!23"
+	attacherContainerName                      = "csi-attacher"
 	busyBoxImageOnGcr                          = "gcr.io/google_containers/busybox:1.27"
 	nginxImage                                 = "k8s.gcr.io/nginx-slim:0.8"
 	cnsNewSyncFSS                              = "CNS_NEW_SYNC"


### PR DESCRIPTION
**What this PR does / why we need it**:  Includes automation for 3 testcases  for leader change scenarios of vsan stretched cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/d405771c6a6a16f634a90ce439f5ac8b

**Special notes for your reviewer**: make check output:
```
(base) kai@kai-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/stretch-part6/vsphere-csi-driver /Users/kai/CSI/stretch-part6 /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|files|name|types_sizes|imports) took 1.721179134s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 88.023519ms 
INFO [linters context/goanalysis] analyzers took 28.150512686s with top 10 stages: buildir: 10.762107505s, misspell: 1.472528093s, S1038: 862.554498ms, isgenerated: 628.228699ms, printf: 619.73189ms, lll: 605.76231ms, ctrlflow: 597.885374ms, unused: 547.432801ms, directives: 498.463803ms, SA1012: 494.843425ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 24/113, skip_dirs: 113/113, exclude: 24/24, cgo: 113/113, skip_files: 113/113, identifier_marker: 24/24, nolint: 0/1, path_prettifier: 113/113, exclude-rules: 1/24, filename_unadjuster: 113/113 
INFO [runner] processing took 17.782981ms with stages: nolint: 15.191614ms, autogenerated_exclude: 1.328901ms, path_prettifier: 662.061µs, identifier_marker: 318.349µs, skip_dirs: 152.738µs, exclude-rules: 108.346µs, filename_unadjuster: 7.476µs, cgo: 5.931µs, uniq_by_line: 3.111µs, max_same_issues: 1.219µs, max_from_linter: 642ns, exclude: 384ns, severity-rules: 380ns, source_code: 345ns, diff: 341ns, path_shortener: 268ns, skip_files: 262ns, sort_results: 250ns, max_per_file_from_linter: 241ns, path_prefixer: 122ns 
INFO [runner] linters took 9.034180244s with stages: goanalysis_metalinter: 9.016298389s 
INFO File cache stats: 273 entries of total size 4.0MiB 
INFO Memory: 110 samples, avg is 402.1MB, max is 1087.7MB 
INFO Execution took 10.855441177s
```
