### PR TITLE
Remove FSS guard for online volume expansion feature

### DIFF
--- a/manifests/guestcluster/1.21/pvcsi.yaml
+++ b/manifests/guestcluster/1.21/pvcsi.yaml
@@ -435,7 +435,6 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"

--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -463,7 +463,6 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"

--- a/manifests/guestcluster/1.23/pvcsi.yaml
+++ b/manifests/guestcluster/1.23/pvcsi.yaml
@@ -463,7 +463,6 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -347,7 +347,6 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
   "vsan-direct-disk-decommission": "false"

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -351,7 +351,6 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
   "vsan-direct-disk-decommission": "false"

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -351,7 +351,6 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
   "vsan-direct-disk-decommission": "false"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -144,7 +144,6 @@ apiVersion: v1
 data:
   "csi-migration": "false"
   "csi-auth-check": "true"
-  "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"
   "async-query-volume": "true"
   "improved-csi-idempotency": "true"

--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -26,6 +26,7 @@ import (
 	vim25types "github.com/vmware/govmomi/vim25/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus"

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -302,8 +302,6 @@ const (
 	VolumeHealth = "volume-health"
 	// VolumeExtend is feature flag name for volume expansion.
 	VolumeExtend = "volume-extend"
-	// OnlineVolumeExtend guards the feature for online volume expansion.
-	OnlineVolumeExtend = "online-volume-extend"
 	// CSIMigration is feature flag for migrating in-tree vSphere volumes to CSI.
 	CSIMigration = "csi-migration"
 	// CSIAuthCheck is feature flag for auth check.

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -616,23 +616,21 @@ func (driver *vsphereCSIDriver) NodeExpandVolume(
 	}
 	log.Debugf("NodeExpandVolume: staging target path %s, getDevFromMount %+v", volumePath, *dev)
 
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend) {
-		// Fetch the current block size.
-		currentBlockSizeBytes, err := driver.osUtils.GetBlockSizeBytes(ctx, dev.RealDev)
+	// Fetch the current block size.
+	currentBlockSizeBytes, err := driver.osUtils.GetBlockSizeBytes(ctx, dev.RealDev)
+	if err != nil {
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"error when getting size of block volume at path %s: %v", dev.RealDev, err)
+	}
+	// Check if a rescan is required.
+	if currentBlockSizeBytes < reqVolSizeBytes {
+		// If a device is expanded while it is attached to a VM, we need to
+		// rescan the device on the guest OS in order to see the modified size
+		// on the Guest OS.
+		// Refer to https://kb.vmware.com/s/article/1006371
+		err = driver.osUtils.RescanDevice(ctx, dev)
 		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
-				"error when getting size of block volume at path %s: %v", dev.RealDev, err)
-		}
-		// Check if a rescan is required.
-		if currentBlockSizeBytes < reqVolSizeBytes {
-			// If a device is expanded while it is attached to a VM, we need to
-			// rescan the device on the guest OS in order to see the modified size
-			// on the Guest OS.
-			// Refer to https://kb.vmware.com/s/article/1006371
-			err = driver.osUtils.RescanDevice(ctx, dev)
-			if err != nil {
-				return nil, logger.LogNewErrorCode(log, codes.Internal, err.Error())
-			}
+			return nil, logger.LogNewErrorCode(log, codes.Internal, err.Error())
 		}
 	}
 

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -18,7 +18,6 @@ package vanilla
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -1262,12 +1261,11 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to check if online expansion is supported due to error: %v", err)
 		}
-		isOnlineExpansionEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend)
-		err = validateVanillaControllerExpandVolumeRequest(ctx, req, isOnlineExpansionEnabled, isOnlineExpansionSupported)
+
+		err = validateVanillaControllerExpandVolumeRequest(ctx, req, isOnlineExpansionSupported)
 		if err != nil {
-			msg := fmt.Sprintf("validation for ExpandVolume Request: %+v has failed. Error: %v", *req, err)
-			log.Error(msg)
-			return nil, csifault.CSIInternalFault, err
+			return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCodef(log, codes.Internal,
+				"validation for ExpandVolume Request: %+v has failed. Error: %v", *req, err)
 		}
 		volumeType = prometheus.PrometheusBlockVolumeType
 

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1074,8 +1074,17 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		// For all other cases, the faultType will be set to "csi.fault.Internal" for now.
 		// Later we may need to define different csi faults.
 
-		isOnlineExpansionEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend)
-		err := validateWCPControllerExpandVolumeRequest(ctx, req, c.manager, isOnlineExpansionEnabled)
+		// WCP and VC version upgrades may not necessarily be linked,
+		// so we need this check in WCP to see if online expansion is supported.
+		// GC will also depend on this check.
+		isOnlineExpansionSupported, err := c.manager.VcenterManager.IsOnlineExtendVolumeSupported(ctx,
+			c.manager.VcenterConfig.Host)
+		if err != nil {
+			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
+				"failed to check if online expansion is supported due to error: %v", err)
+		}
+
+		err = validateWCPControllerExpandVolumeRequest(ctx, req, c.manager, isOnlineExpansionSupported)
 		if err != nil {
 			log.Errorf("validation for ExpandVolume Request: %+v has failed. Error: %v", *req, err)
 			return nil, csifault.CSIInvalidArgumentFault, err

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
 	spv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
@@ -111,17 +112,18 @@ func validateWCPControllerUnpublishVolumeRequest(ctx context.Context, req *csi.C
 	return common.ValidateControllerUnpublishVolumeRequest(ctx, req)
 }
 
-// validateWCPControllerExpandVolumeRequest is the helper function to validate
-// ExpandVolumeRequest for WCP CSI driver. Function returns error if validation
-// fails otherwise returns nil.
+// ValidateWCPControllerExpandVolumeRequest is the helper function to validate
+// ExpandVolumeRequest for WCP CSI driver.
 func validateWCPControllerExpandVolumeRequest(ctx context.Context, req *csi.ControllerExpandVolumeRequest,
-	manager *common.Manager, isOnlineExpansionEnabled bool) error {
+	manager *common.Manager, isOnlineExpansionSupported bool) error {
 	log := logger.GetLogger(ctx)
 	if err := common.ValidateControllerExpandVolumeRequest(ctx, req); err != nil {
 		return err
 	}
 
-	if !isOnlineExpansionEnabled {
+	// If online expansion is not supported (VC below 7.0U2),
+	// we need to determine if requested operation is online or offline.
+	if !isOnlineExpansionSupported {
 		var nodes []*vsphere.VirtualMachine
 
 		// TODO: Currently we only check if disk is attached to TKG nodes

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator"
 	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
@@ -1106,7 +1107,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		// For all other cases, the faultType will be set to "csi.fault.Internal" for now.
 		// Later we may need to define different csi faults.
 
-		err := validateGuestClusterControllerExpandVolumeRequest(ctx, req)
+		err := common.ValidateControllerExpandVolumeRequest(ctx, req)
 		if err != nil {
 			return nil, csifault.CSIInvalidArgumentFault, err
 		}
@@ -1115,27 +1116,6 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 
 		volumeID := req.GetVolumeId()
 		volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
-
-		if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend) {
-			vmList := &vmoperatortypes.VirtualMachineList{}
-			err = c.vmOperatorClient.List(ctx, vmList, client.InNamespace(c.supervisorNamespace))
-			if err != nil {
-				msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
-				log.Error(msg)
-				return nil, csifault.CSIInternalFault, status.Error(codes.Internal, msg)
-			}
-
-			for _, vmInstance := range vmList.Items {
-				for _, vmVolume := range vmInstance.Status.Volumes {
-					if vmVolume.Name == volumeID && vmVolume.Attached {
-						msg := fmt.Sprintf("failed to expand volume: %q. Volume is attached to pod. "+
-							"Only offline volume expansion is supported", volumeID)
-						log.Error(msg)
-						return nil, csifault.CSIInvalidArgumentFault, status.Error(codes.FailedPrecondition, msg)
-					}
-				}
-			}
-		}
 
 		// Retrieve Supervisor PVC
 		svPVC, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
+
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
@@ -105,11 +106,6 @@ func validateGuestClusterControllerPublishVolumeRequest(ctx context.Context,
 func validateGuestClusterControllerUnpublishVolumeRequest(ctx context.Context,
 	req *csi.ControllerUnpublishVolumeRequest) error {
 	return common.ValidateControllerUnpublishVolumeRequest(ctx, req)
-}
-
-func validateGuestClusterControllerExpandVolumeRequest(ctx context.Context,
-	req *csi.ControllerExpandVolumeRequest) error {
-	return common.ValidateControllerExpandVolumeRequest(ctx, req)
 }
 
 // checkForSupervisorPVCCondition returns nil if the PVC condition is set as


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is part of an effort to remove FSS code guards put in place for feature states that have already been enabled in previous releases. This PR specifically removes the FSS guard for `online-volume-extend`. 

Background:
- Online Volume Extend was enabled from VC/ESX 7.0U2 and above. 
- Vanilla, GC, SVC and VC version upgrades are not linked. 

Thus, while removing the FSS, we need to ensure for all cases that request for expansion doesn't go to a VC version that doesn't support the feature. 

The following matrix denotes how things work with Guest/Supervisor clusters wrt. VC and k8s versions. 

New VC: 7.0U2 and above
New Supervisor: release which will include this commit. 
New Guest: release which will include this commit. 

<img width="798" alt="online volume expansion matrix" src="https://user-images.githubusercontent.com/21956662/160206889-f7ead2a2-a5a2-4963-a476-7123a044d689.png">
@shalini-b 

<!-- **Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # -->


**Testing done**:
<!-- A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.-->

Manual tests performed until now. 

Block Vanilla

```
{"level":"info","time":"2022-03-28T22:26:40.534652106Z","caller":"vanilla/controller.go:1244","msg":"ControllerExpandVolume: called with args {VolumeId:2aebbd42-409b-4fa0-8087-507ebf689095 CapacityRange:required_bytes:17179869184  Secrets:map[] VolumeCapability:block:<> access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"8b3aa749-f5f1-46ac-88b0-edbfe9f72b9d"}

{"level":"info","time":"2022-03-28T22:26:40.601704628Z","caller":"vanilla/controller.go:1292","msg":"The volume 2aebbd42-409b-4fa0-8087-507ebf689095 can be safely expanded as no CNS snapshots were found.","TraceId":"8b3aa749-f5f1-46ac-88b0-edbfe9f72b9d"}
{"level":"info","time":"2022-03-28T22:26:40.615301185Z","caller":"volume/manager.go:1295","msg":"Calling CnsClient.ExtendVolume: VolumeID [\"2aebbd42-409b-4fa0-8087-507ebf689095\"] Size [16384] cnsExtendSpecList [[]types.CnsVolumeExtendSpec{types.CnsVolumeExtendSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:\"2aebbd42-409b-4fa0-8087-507ebf689095\"}, CapacityInMb:16384}}]","TraceId":"8b3aa749-f5f1-46ac-88b0-edbfe9f72b9d"}
{"level":"info","time":"2022-03-28T22:26:42.823273683Z","caller":"volume/manager.go:1344","msg":"ExpandVolume: volumeID: \"2aebbd42-409b-4fa0-8087-507ebf689095\", opId: \"178f1d42\"","TraceId":"8b3aa749-f5f1-46ac-88b0-edbfe9f72b9d"}
{"level":"info","time":"2022-03-28T22:26:42.824147628Z","caller":"volume/manager.go:1382","msg":"ExpandVolume: Volume expanded successfully to size 16384. volumeID: \"2aebbd42-409b-4fa0-8087-507ebf689095\", opId: \"178f1d42\"","TraceId":"8b3aa749-f5f1-46ac-88b0-edbfe9f72b9d"}
{"level":"info","time":"2022-03-28T22:26:42.846742974Z","caller":"common/vsphereutil.go:671","msg":"Successfully expanded volume for volumeID \"2aebbd42-409b-4fa0-8087-507ebf689095\" to new size 16384 Mb.","TraceId":"8b3aa749-f5f1-46ac-88b0-edbfe9f72b9d"}
```

Supervisor Cluster

vsphere-csi-controller

```
ControllerExpandVolume: called with args {VolumeId:0f3a0a23-5cfd-4f10-99f6-24071897e0a4 CapacityRange:required_bytes:8589934592  Secrets:map[] VolumeCapability:block:<> access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "5ac2bf63-822d-4cfd-821c-fc4cdc562061"}
2022-03-28T22:22:58.104Z	DEBUG	common/vsphereutil.go:638	vSphere CSI driver expanding volume "0f3a0a23-5cfd-4f10-99f6-24071897e0a4" to new size 8192 Mb.	{"TraceId": "5ac2bf63-822d-4cfd-821c-fc4cdc562061"}
2022-03-28T22:22:58.117Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:131	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/expand-0f3a0a23-5cfd-4f10-99f6-24071897e0a4	{"TraceId": "5ac2bf63-822d-4cfd-821c-fc4cdc562061"}
2022-03-28T22:22:58.131Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:138	Found CnsVolumeOperationRequest instance (*v1alpha1.CnsVolumeOperationRequest)(0xc000ce0960)({
 TypeMeta: (v1.TypeMeta) &TypeMeta{Kind:,APIVersion:,},
 ObjectMeta: (v1.ObjectMeta) &ObjectMeta{Name:expand-0f3a0a23-5cfd-4f10-99f6-24071897e0a4,GenerateName:,Namespace:vmware-system-csi,SelfLink:/apis/cns.vmware.com/v1alpha1/namespaces/vmware-system-csi/cnsvolumeoperationrequests/expand-0f3a0a23-5cfd-4f10-99f6-24071897e0a4,UID:27f7fa51-cdc3-4ced-87c9-fd107e2ce3a7,ResourceVersion:13300680,Generation:2,CreationTimestamp:2022-03-28 21:37:32 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{},Annotations:map[string]string{},OwnerReferences:[]OwnerReference{},Finalizers:[],ClusterName:,ManagedFields:[]ManagedFieldsEntry{ManagedFieldsEntry{Manager:vsphere-csi,Operation:Update,APIVersion:cns.vmware.com/v1alpha1,Time:2022-03-28 21:37:34 +0000 UTC,FieldsType:FieldsV1,FieldsV1:{"f:spec":{".":{},"f:name":{}},"f:status":{".":{},"f:capacity":{},"f:firstOperationDetails":{".":{},"f:opId":{},"f:taskId":{},"f:taskInvocationTimestamp":{},"f:taskStatus":{}},"f:latestOperationDetails":{}}},},},},
 Spec: (v1alpha1.CnsVolumeOperationRequestSpec) {
  Name: (string) (len=43) "expand-0f3a0a23-5cfd-4f10-99f6-24071897e0a4"
 },
 Status: (v1alpha1.CnsVolumeOperationRequestStatus) {
  VolumeID: (string) "",
  SnapshotID: (string) "",
  Capacity: (int64) 7168,
  ErrorCount: (int) 0,
  FirstOperationDetails: (v1alpha1.OperationDetails) {
   TaskInvocationTimestamp: (v1.Time) 2022-03-28 21:37:32 +0000 UTC,
   TaskID: (string) (len=10) "task-39038",
   OpID: (string) (len=8) "056ad1e4",
   TaskStatus: (string) (len=7) "Success",
   Error: (string) ""
  },
  LatestOperationDetails: ([]v1alpha1.OperationDetails) (len=1 cap=1) {
   (v1alpha1.OperationDetails) {
    TaskInvocationTimestamp: (v1.Time) 2022-03-28 21:37:32 +0000 UTC,
    TaskID: (string) (len=10) "task-39038",
    OpID: (string) (len=8) "056ad1e4",
    TaskStatus: (string) (len=7) "Success",
    Error: (string) ""
   }
  }
 }
})
	{"TraceId": "5ac2bf63-822d-4cfd-821c-fc4cdc562061"}
2022-03-28T22:22:58.132Z	INFO	volume/manager.go:1295	Calling CnsClient.ExtendVolume: VolumeID ["0f3a0a23-5cfd-4f10-99f6-24071897e0a4"] Size [8192] cnsExtendSpecList [[]types.CnsVolumeExtendSpec{types.CnsVolumeExtendSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:"0f3a0a23-5cfd-4f10-99f6-24071897e0a4"}, CapacityInMb:8192}}]	{"TraceId": "5ac2bf63-822d-4cfd-821c-fc4cdc562061"}
2022-03-28T22:22:58.161Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:165	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc0004b7140)({
 Name: (string) (len=43) "expand-0f3a0a23-5cfd-4f10-99f6-24071897e0a4",
 VolumeID: (string) "",
 SnapshotID: (string) "",
 Capacity: (int64) 8192,
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc000207860)({
  TaskInvocationTimestamp: (v1.Time) 2022-03-28 22:22:58.161811932 +0000 UTC m=+2799.395163755,
  TaskID: (string) (len=10) "task-39239",
  OpID: (string) "",
  TaskStatus: (string) (len=10) "InProgress",
  Error: (string) ""
 })
})
	{"TraceId": "5ac2bf63-822d-4cfd-821c-fc4cdc562061"}
2022-03-28T22:22:58.207Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:272	Updated CnsVolumeOperationRequest instance vmware-system-csi/expand-0f3a0a23-5cfd-4f10-99f6-24071897e0a4 with latest information for task with ID: task-39239	{"TraceId": "5ac2bf63-822d-4cfd-821c-fc4cdc562061"}
2022-03-28T22:22:59.517Z	INFO	volume/manager.go:1344	ExpandVolume: volumeID: "0f3a0a23-5cfd-4f10-99f6-24071897e0a4", opId: "056ae718"	{"TraceId": "5ac2bf63-822d-4cfd-821c-fc4cdc562061"}
2022-03-28T22:22:59.518Z	INFO	volume/manager.go:1382	ExpandVolume: Volume expanded successfully to size 8192. volumeID: "0f3a0a23-5cfd-4f10-99f6-24071897e0a4", opId: "056ae718"	{"TraceId": "5ac2bf63-822d-4cfd-821c-fc4cdc562061"}
```

GC

vsphere-csi-controller

```
2022-03-28T22:16:02.165Z	INFO	wcp/controller.go:1069	ControllerExpandVolume: called with args {VolumeId:e4430062-99da-41d7-8ab3-e1def1db858d CapacityRange:required_bytes:7516192768  Secrets:map[] VolumeCapability:block:<> access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "4f07348e-b4b7-444e-8ff7-1739a7c9cb0a"}
2022-03-28T22:16:02.165Z	DEBUG	common/vsphereutil.go:638	vSphere CSI driver expanding volume "e4430062-99da-41d7-8ab3-e1def1db858d" to new size 7168 Mb.	{"TraceId": "4f07348e-b4b7-444e-8ff7-1739a7c9cb0a"}
2022-03-28T22:16:02.182Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:131	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/expand-e4430062-99da-41d7-8ab3-e1def1db858d	{"TraceId": "4f07348e-b4b7-444e-8ff7-1739a7c9cb0a"}
2022-03-28T22:16:02.192Z	INFO	volume/manager.go:1295	Calling CnsClient.ExtendVolume: VolumeID ["e4430062-99da-41d7-8ab3-e1def1db858d"] Size [7168] cnsExtendSpecList [[]types.CnsVolumeExtendSpec{types.CnsVolumeExtendSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:"e4430062-99da-41d7-8ab3-e1def1db858d"}, CapacityInMb:7168}}]	{"TraceId": "4f07348e-b4b7-444e-8ff7-1739a7c9cb0a"}
2022-03-28T22:16:02.227Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:165	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc0000bc780)({
 Name: (string) (len=43) "expand-e4430062-99da-41d7-8ab3-e1def1db858d",
 VolumeID: (string) "",
 SnapshotID: (string) "",
 Capacity: (int64) 7168,
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc000156780)({
  TaskInvocationTimestamp: (v1.Time) 2022-03-28 22:16:02.226861555 +0000 UTC m=+2383.460213381,
  TaskID: (string) (len=10) "task-39202",
  OpID: (string) "",
  TaskStatus: (string) (len=10) "InProgress",
  Error: (string) ""
 })
})
	{"TraceId": "4f07348e-b4b7-444e-8ff7-1739a7c9cb0a"}
2022-03-28T22:16:02.297Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:204	Created CnsVolumeOperationRequest instance vmware-system-csi/expand-e4430062-99da-41d7-8ab3-e1def1db858d with latest information for task with ID: task-39202	{"TraceId": "4f07348e-b4b7-444e-8ff7-1739a7c9cb0a"}
2022-03-28T22:16:03.693Z	INFO	volume/manager.go:1344	ExpandVolume: volumeID: "e4430062-99da-41d7-8ab3-e1def1db858d", opId: "056adce8"	{"TraceId": "4f07348e-b4b7-444e-8ff7-1739a7c9cb0a"}
2022-03-28T22:16:03.693Z	INFO	volume/manager.go:1382	ExpandVolume: Volume expanded successfully to size 7168. volumeID: "e4430062-99da-41d7-8ab3-e1def1db858d", opId: "056adce8"	{"TraceId": "4f07348e-b4b7-444e-8ff7-1739a7c9cb0a"}
```

**Special notes for your reviewer**:

pre-checkin tests

For block vanilla, kindly refer to bot comments for Build ID: 941 (3 failures). 942, 943 and 944 passed those 3 failures. 

For WCP, kindly refer to bot comments for Build ID: 430 and 431. 

Out of 5 failures from 430, 2 succeeded in 431.

The remaining 3 failures, 

`Verify health annotation is not updated to unknown status from accessible`
`Verify health annotation added on the pvc is accessible`
`Verify health annotaiton is not added on the PV`

are related to health annotations and seem to be caused by a mismatch in the testbed creation and the e2e tests for which there is an internal bug under investigation. 

GC

Build: 295

```make check```

```
(~/GolandProjects/vsphere-csi-driver) $ make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@master
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/adkulkarni/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/provider sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/adkulkarni/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/adkulkarni/GolandProjects/vsphere-csi-driver /Users/adkulkarni/GolandProjects /Users/adkulkarni /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (types_sizes|compiled_files|deps|name|exports_file|files|imports) took 2.339144607s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 249.314468ms
INFO [linters context/goanalysis] analyzers took 38.898367123s with top 10 stages: buildir: 16.553226905s, nilness: 4.067960415s, ctrlflow: 1.888154682s, printf: 1.831313292s, fact_deprecated: 1.721326605s, SA5012: 1.459172664s, fact_purity: 1.444639155s, typedness: 1.442543918s, inspect: 603.002418ms, S1038: 565.065897ms
INFO [runner] Issues before processing: 113, after processing: 0
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 113/113, autogenerated_exclude: 24/113, skip_dirs: 113/113, identifier_marker: 24/24, nolint: 0/1, cgo: 113/113, path_prettifier: 113/113, skip_files: 113/113, exclude: 24/24, exclude-rules: 1/24
INFO [runner] processing took 15.041379ms with stages: nolint: 12.60762ms, autogenerated_exclude: 1.505421ms, path_prettifier: 360.224µs, identifier_marker: 306.063µs, skip_dirs: 119.41µs, exclude-rules: 115.341µs, cgo: 13.098µs, filename_unadjuster: 9.361µs, max_same_issues: 1.272µs, uniq_by_line: 651ns, severity-rules: 498ns, max_from_linter: 408ns, diff: 349ns, skip_files: 333ns, source_code: 330ns, max_per_file_from_linter: 229ns, path_shortener: 223ns, exclude: 213ns, sort_results: 206ns, path_prefixer: 129ns
INFO [runner] linters took 10.247142117s with stages: goanalysis_metalinter: 10.232003046s
INFO File cache stats: 86 entries of total size 2.3MiB
INFO Memory: 130 samples, avg is 623.9MB, max is 1151.4MB
INFO Execution took 12.847250243s
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
