### PR TITLE
Optional custom repository support for golang docker builder image

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -51,6 +51,11 @@ GCR_KEY_FILE="${GCR_KEY_FILE:-}"
 GOPROXY="${GOPROXY:-https://proxy.golang.org}"
 BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 
+# CUSTOM_REPO_FOR_GOLANG can be used to pass custom repository for golang builder image.
+# Please ensure it ends with a '/'.
+# Example: CUSTOM_REPO_FOR_GOLANG=harbor-repo.vmware.com/dockerhub-proxy-cache/library/
+GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG}golang:1.16
+
 ARCH=amd64
 OSVERSION=1809
 # OS Version for the Windows images: 1809, 1903, 1909 2004, 20H2, ltsc2022
@@ -132,6 +137,7 @@ function build_driver_images_windows() {
    --build-arg "OSVERSION=${OSVERSION}" \
    --build-arg "GOPROXY=${GOPROXY}" \
    --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
+   --build-arg "GOLANG_IMAGE=${GOLANG_IMAGE}" \
    .
    docker buildx rm vsphere-csi-builder-win || echo "builder instance not found, safe to proceed"
 }
@@ -149,6 +155,7 @@ function build_driver_images_linux() {
    --build-arg "VERSION=${VERSION}" \
    --build-arg "GOPROXY=${GOPROXY}" \
    --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
+   --build-arg "GOLANG_IMAGE=${GOLANG_IMAGE}" \
    .
 }
 
@@ -160,6 +167,7 @@ function build_syncer_image_linux() {
       --build-arg "VERSION=${VERSION}" \
       --build-arg "GOPROXY=${GOPROXY}" \
       --build-arg "GIT_COMMIT=${GIT_COMMIT}" \
+      --build-arg "GOLANG_IMAGE=${GOLANG_IMAGE}" \
   .
 
   if [ "${LATEST}" ]; then


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Add support for passing a custom repository for golang docker builder image. So, that we can work around dockerhub pull rate limits.

**Testing done**:
https://gist.github.com/sashrith/48076f9a97ee6306708e4b45201b7b11

**Special notes for your reviewer**:
```zsh
sashrith@sashrith-a02 vsphere-csi-driver % ./hack/check-shell.sh
sashrith@sashrith-a02 vsphere-csi-driver %
```

