### PR TITLE
unbound variable fix

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -54,7 +54,7 @@ BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 # CUSTOM_REPO_FOR_GOLANG can be used to pass custom repository for golang builder image.
 # Please ensure it ends with a '/'.
 # Example: CUSTOM_REPO_FOR_GOLANG=harbor-repo.vmware.com/dockerhub-proxy-cache/library/
-GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG}golang:1.16
+GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.16
 
 ARCH=amd64
 OSVERSION=1809


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: unbound variable fix

**Testing done**:
Before fix
```bash
17:25:42  + make -C /home/worker/workspace/vcp-to-csi-migration-BR/Results/26/vsphere-csi-driver push-images
17:25:45  which: no controller-gen in (/usr/local/bin:/usr/bin:/usr/local/go/bin:/home/worker/go/bin:/home/worker/.rvm/bin)
17:25:45  make: Entering directory `/home/worker/workspace/vcp-to-csi-migration-BR/Results/26/vsphere-csi-driver'
17:25:45  hack/release.sh -p -r vcsidev/
17:25:45  hack/release.sh: line 57: CUSTOM_REPO_FOR_GOLANG: unbound variable
17:25:45  make: *** [push-images] Error 1
```

after fix
```bash
22:26:55  + make -C /home/worker/workspace/Block-Vanilla/Results/1070/vsphere-csi-driver push-images

22:26:57  which: no controller-gen in (/usr/local/bin:/usr/bin:/usr/local/go/bin:/home/worker/go/bin:/home/worker/.rvm/bin)
22:26:57  make: Entering directory `/home/worker/workspace/Block-Vanilla/Results/1070/vsphere-csi-driver'
22:26:57  hack/release.sh -p -r vcsidev/
22:26:57  building gcr.io/cloud-provider-vsphere/csi/ci/driver:v2.1.0-rc.1-1223-g7a5d3ad for linux
22:26:57  error: no builder "vsphere-csi-builder-win" found
22:26:57  builder instance not found, safe to proceed
22:26:57  #1 [internal] load build definition from Dockerfile
```

