### PR TITLE
Read UUID from product_serial in node daemonset instead of product_uuid file

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -577,9 +577,16 @@ func (volTopology *nodeVolumeTopology) GetNodeTopologyLabels(ctx context.Context
 				return nil, logger.LogNewErrorCodef(log, codes.Internal, msg)
 			}
 		} else {
-			if csiNodeTopology.Spec.NodeUUID == "" {
-				log.Infof("CSINodeTopology instance: %q with empty nodeUUID found. "+
-					"Patching the instance with nodeUUID", nodeInfo.NodeName)
+			if csiNodeTopology.Spec.NodeUUID == "" ||
+				csiNodeTopology.Spec.NodeUUID != nodeInfo.NodeID {
+				if csiNodeTopology.Spec.NodeUUID == "" {
+					log.Infof("CSINodeTopology instance: %q with empty nodeUUID found. "+
+						"Patching the instance with nodeUUID", nodeInfo.NodeName)
+				} else {
+					log.Infof("CSINodeTopology instance: %q with different "+
+						"nodeUUID: %s found. Patching the instance with nodeUUID: %s",
+						nodeInfo.NodeName, csiNodeTopology.Spec.NodeUUID, nodeInfo.NodeID)
+				}
 				patch := []byte(fmt.Sprintf(`{"spec":{"nodeID":"%s","nodeuuid":"%s"}}`, nodeInfo.NodeName, nodeInfo.NodeID))
 				// Patch the CSINodeTopology instance with nodeUUID
 				err = volTopology.csiNodeTopologyK8sClient.Patch(ctx,
@@ -590,8 +597,9 @@ func (volTopology *nodeVolumeTopology) GetNodeTopologyLabels(ctx context.Context
 					},
 					client.RawPatch(types.MergePatchType, patch))
 				if err != nil {
-					msg := fmt.Sprintf("Fail to patch CsiNodeTopology for the node: %q. Error: %+v",
-						nodeInfo.NodeName, err)
+					msg := fmt.Sprintf("Fail to patch CsiNodeTopology for the node: %q "+
+						"with nodeUUID: %s. Error: %+v",
+						nodeInfo.NodeName, nodeInfo.NodeID, err)
 					return nil, logger.LogNewErrorCodef(log, codes.Internal, msg)
 				}
 				log.Infof("Successfully patched CSINodeTopology instance: %q with Uuid: %q",

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -352,11 +352,6 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to get system uuid for node VM with error: %v", err)
 		}
-		nodeID, err = driver.osUtils.ConvertUUID(nodeID)
-		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
-				"convertUUID failed with error: %v", err)
-		}
 	} else {
 		nodeID = nodeName
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently CSI Node daemonset reads the `product_uuid` file - https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/csi/service/node.go#L350 and converts the read value  - https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/csi/service/node.go#L355.

This works for BIOS versions 2.7 and greater and doesn't work for the lower BIOS versions.

With lower BIOS version, the syncer container will not be able to reconcile the CsiNodeTopology instance and hence all the Kubernetes nodes fail to come up.

Inorder to solve this problem, we read from the `product_serial` file which will ensure that it will be correct VM UUID. The only thing is that VM configured for Kubernetes should have DMI enabled and use original long UUID. Both of these are default when you configure a VM and we would need the customer to stick to these and not deviate from these defaults. We will also document this is in out documentation when we release a patch version of CSI.

Fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/1629

**Testing done**:
**Upgrade from 2.5 to 2.5.1**
1. Patched existing CSINodeTopology instance with new VM UUID.
```
2022-03-15T00:33:49.255Z	INFO	k8sorchestrator/topology.go:605	Successfully patched CSINodeTopology instance: "k8s-node-852-1646948770" with Uuid: "420329f1-f052-ed4d-30e7-7307ddd15eea"	{"TraceId": "2d7cb8df-7c7e-4713-bf5f-d962206f42d4"}
2022-03-15T00:33:49.255Z	INFO	k8sorchestrator/topology.go:738	Timeout is set to 1 minute(s)	{"TraceId": "2d7cb8df-7c7e-4713-bf5f-d962206f42d4"}
```

2. Syncer container reconciling the csinodetopology instance to fetch the topology labels correctly.

```
2022-03-15T00:34:41.481Z	INFO	csinodetopology/csinodetopology_controller.go:335	Successfully updated topology labels for nodeVM "k8s-node-852-1646948770"
```

3. CSINodeTopology instances reconciled properly now.
```
Name:         k8s-node-852-1646948770
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-03-10T21:52:23Z
  Generation:          6
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"a4f5896e-79d8-4c23-b183-5bec7df812bf"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2022-03-15T00:33:49Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2022-03-15T00:34:41Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-852-1646948770
    UID:             a4f5896e-79d8-4c23-b183-5bec7df812bf
  Resource Version:  1081618
  UID:               a8b2b705-d1f8-49b6-86a6-7ad399384916
Spec:
  Node ID:   k8s-node-852-1646948770
  Nodeuuid:  420329f1-f052-ed4d-30e7-7307ddd15eea
Status:
  Status:  Success
Events:
  Type     Reason                      Age                   From            Message
  ----     ------                      ----                  ----            -------
  Warning  TopologyRetrievalFailed     4m7s (x8 over 6m14s)  cns.vmware.com  failed to retrieve nodeVM "420329f1-f052-ed4d-30e7-7307ddd15eea1" using the node manager. Error: virtual machine wasn't found
  Normal   TopologyRetrievalSucceeded  119s                  cns.vmware.com  Not a topology aware cluster.
```


**A new CSI 2.5.1 deployment**

1. Describe CSINodes and all nodes initialized.

```
root@k8s-control-759-1646948726:~# kubectl describe csinodes
Name:               k8s-control-759-1646948726
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/cinder,kubernetes.io/gce-pd
CreationTimestamp:  Thu, 10 Mar 2022 21:48:08 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  4203daeb-60ec-193a-c697-18ef1aaaac45
      Allocatables:
        Count:  59
Events:         <none>


Name:               k8s-node-213-1646948789
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/cinder,kubernetes.io/gce-pd
CreationTimestamp:  Thu, 10 Mar 2022 21:50:22 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  4203449a-97c3-d05e-48dd-2b5853ea5128
      Allocatables:
        Count:  59
Events:         <none>


Name:               k8s-node-753-1646948748
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/cinder,kubernetes.io/gce-pd
CreationTimestamp:  Thu, 10 Mar 2022 21:49:27 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  4203942f-ce98-3f27-455c-463d34b8af41
      Allocatables:
        Count:  59
Events:         <none>


Name:               k8s-node-852-1646948770
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins: kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/cinder,kubernetes.io/gce-pd
CreationTimestamp:  Thu, 10 Mar 2022 21:49:53 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:  420329f1-f052-ed4d-30e7-7307ddd15eea
      Allocatables:
        Count:  59
Events:         <none>
```

2. CSINodeTopology instances reconciled properly.
```
root@k8s-control-759-1646948726:~# kubectl describe csinodetopology
Name:         k8s-control-759-1646948726
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-03-15T00:41:17Z
  Generation:          2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"89510224-b1f9-490e-9255-6beea12b6b87"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2022-03-15T00:41:17Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2022-03-15T00:41:43Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-control-759-1646948726
    UID:             89510224-b1f9-490e-9255-6beea12b6b87
  Resource Version:  1083051
  UID:               5420ec67-430c-444b-b06f-5f04616843f8
Spec:
  Node ID:   k8s-control-759-1646948726
  Nodeuuid:  4203daeb-60ec-193a-c697-18ef1aaaac45
Status:
  Status:  Success
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  5s    cns.vmware.com  Not a topology aware cluster.


Name:         k8s-node-213-1646948789
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-03-15T00:41:17Z
  Generation:          2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"ff242c94-c707-4c68-bd59-053c49a0e9b2"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2022-03-15T00:41:17Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2022-03-15T00:41:43Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-213-1646948789
    UID:             ff242c94-c707-4c68-bd59-053c49a0e9b2
  Resource Version:  1083046
  UID:               697feff9-83ac-4808-a250-7c641d983bfa
Spec:
  Node ID:   k8s-node-213-1646948789
  Nodeuuid:  4203449a-97c3-d05e-48dd-2b5853ea5128
Status:
  Status:  Success
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  5s    cns.vmware.com  Not a topology aware cluster.


Name:         k8s-node-753-1646948748
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-03-15T00:41:16Z
  Generation:          2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"3af3fcb9-6aec-460f-b1b3-593bdc3aebb7"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2022-03-15T00:41:16Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2022-03-15T00:41:43Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-753-1646948748
    UID:             3af3fcb9-6aec-460f-b1b3-593bdc3aebb7
  Resource Version:  1083039
  UID:               dc89faa6-bdc1-4490-a6a9-14f93f7f992e
Spec:
  Node ID:   k8s-node-753-1646948748
  Nodeuuid:  4203942f-ce98-3f27-455c-463d34b8af41
Status:
  Status:  Success
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  5s    cns.vmware.com  Not a topology aware cluster.


Name:         k8s-node-852-1646948770
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-03-15T00:41:17Z
  Generation:          2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"a4f5896e-79d8-4c23-b183-5bec7df812bf"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:      vsphere-csi
    Operation:    Update
    Time:         2022-03-15T00:41:17Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2022-03-15T00:41:43Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            k8s-node-852-1646948770
    UID:             a4f5896e-79d8-4c23-b183-5bec7df812bf
  Resource Version:  1083041
  UID:               fc160a78-228c-4b4d-8e05-4d961d561d8e
Spec:
  Node ID:   k8s-node-852-1646948770
  Nodeuuid:  420329f1-f052-ed4d-30e7-7307ddd15eea
Status:
  Status:  Success
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  TopologyRetrievalSucceeded  5s    cns.vmware.com  Not a topology aware cluster.
```

3. node daemonset logs
```
2022-03-15T00:41:16.121Z	INFO	service/node.go:334	NodeGetInfo: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "68155596-9984-4c47-babc-291ef445b456"}
2022-03-15T00:41:16.121Z	DEBUG	osutils/linux_os_utils.go:829	product_serial in string: VMware-42 03 94 2f ce 98 3f 27-45 5c 46 3d 34 b8 af 41	{"TraceId": "68155596-9984-4c47-babc-291ef445b456"}
2022-03-15T00:41:16.122Z	INFO	osutils/linux_os_utils.go:843	UUID is 4203942f-ce98-3f27-455c-463d34b8af41	{"TraceId": "68155596-9984-4c47-babc-291ef445b456"}
2022-03-15T00:41:16.122Z	INFO	service/node.go:371	NodeGetInfo: MAX_VOLUMES_PER_NODE is set to 59	{"TraceId": "68155596-9984-4c47-babc-291ef445b456"}
2022-03-15T00:41:16.122Z	INFO	kubernetes/kubernetes.go:86	k8s client using in-cluster config	{"TraceId": "68155596-9984-4c47-babc-291ef445b456"}
2022-03-15T00:41:16.123Z	INFO	kubernetes/kubernetes.go:375	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "68155596-9984-4c47-babc-291ef445b456"}
2022-03-15T00:41:16.123Z	INFO	kubernetes/kubernetes.go:86	k8s client using in-cluster config	{"TraceId": "68155596-9984-4c47-babc-291ef445b456"}
2022-03-15T00:41:16.123Z	INFO	kubernetes/kubernetes.go:375	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "68155596-9984-4c47-babc-291ef445b456"}
2022-03-15T00:41:16.147Z	INFO	k8sorchestrator/topology.go:547	Topology service initiated successfully	{"TraceId": "68155596-9984-4c47-babc-291ef445b456"}
2022-03-15T00:41:16.233Z	INFO	k8sorchestrator/topology.go:713	Successfully created a CSINodeTopology instance for NodeName: "k8s-node-753-1646948748"	{"TraceId": "68155596-9984-4c47-babc-291ef445b456"}
2022-03-15T00:41:16.234Z	INFO	k8sorchestrator/topology.go:738	Timeout is set to 1 minute(s)	{"TraceId": "68155596-9984-4c47-babc-291ef445b456"}
2022-03-15T00:41:43.707Z	INFO	service/node.go:461	NodeGetInfo response: node_id:"4203942f-ce98-3f27-455c-463d34b8af41" max_volumes_per_node:59 accessible_topology:<> 	{"TraceId": "68155596-9984-4c47-babc-291ef445b456"}
```

Tested on OS/BIOS version
```
root@k8s-control-759-1646948726:~# sudo dmidecode -t 0
# dmidecode 3.2
Getting SMBIOS data from sysfs.
SMBIOS 2.7 present.

Handle 0x0000, DMI type 0, 24 bytes
BIOS Information
	Vendor: Phoenix Technologies LTD
	Version: 6.00
	Release Date: 11/12/2020
	Address: 0xEA480
	Runtime Size: 88960 bytes
	ROM Size: 64 kB
	Characteristics:
		ISA is supported
		PCI is supported
		PC Card (PCMCIA) is supported
		PNP is supported
		APM is supported
		BIOS is upgradeable
		BIOS shadowing is allowed
		ESCD support is available
		Boot from CD is supported
		Selectable boot is supported
		EDD is supported
		Print screen service is supported (int 5h)
		8042 keyboard services are supported (int 9h)
		Serial services are supported (int 14h)
		Printer services are supported (int 17h)
		CGA/mono video services are supported (int 10h)
		ACPI is supported
		Smart battery is supported
		BIOS boot specification is supported
		Function key-initiated network boot is supported
		Targeted content distribution is supported
	BIOS Revision: 4.6
	Firmware Revision: 0.0
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix for CSI Node daemon set to work with BIOS version less than 2.7.
```
