### PR TITLE
Topology - Operation Strom testcases

### DIFF
--- a/tests/e2e/topology_operation_strom_cases.go
+++ b/tests/e2e/topology_operation_strom_cases.go
@@ -1,0 +1,547 @@
+/*
+	Copyright 2019 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"golang.org/x/crypto/ssh"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+)
+
+var _ = ginkgo.Describe("[csi-topology-vanilla-level5] Topology-Aware-Provisioning-With-SiteDown-Cases", func() {
+	f := framework.NewDefaultFramework("e2e-vsphere-topology-aware-provisioning")
+	var (
+		client                  clientset.Interface
+		namespace               string
+		bindingMode             storagev1.VolumeBindingMode
+		allowedTopologies       []v1.TopologySelectorLabelRequirement
+		topologyAffinityDetails map[string][]string
+		topologyCategories      []string
+		topologyLength          int
+		sts_count               int
+		statefulSetReplicaCount int32
+		nodeList                *v1.NodeList
+		err                     error
+		topologyClusterList     []string
+		powerOffHostsList       []string
+		sshClientConfig         *ssh.ClientConfig
+	)
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		bootstrap()
+		nodeList, err = fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+		bindingMode = storagev1.VolumeBindingWaitForFirstConsumer
+		topologyLength = 5
+		topologyMap := GetAndExpectStringEnvVar(topologyMap)
+		topologyAffinityDetails, topologyCategories = createTopologyMapLevel5(topologyMap, topologyLength)
+		allowedTopologies = createAllowedTopolgies(topologyMap, topologyLength)
+		topologyCluster := "cluster-1,cluster-2,cluster-3"
+		topologyClusterList = ListTopologyClusterNames(topologyCluster)
+		readVcEsxIpsViaTestbedInfoJson(GetAndExpectStringEnvVar(envTestbedInfoJsonPath))
+		sshClientConfig = &ssh.ClientConfig{
+			User: "root",
+			Auth: []ssh.AuthMethod{
+				ssh.Password(k8sVmPasswd),
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+	})
+
+	/*
+		TESTCASE-1
+		Distribute Multiple PV's across all the zones (50 Pv's)
+		As per the deployment , Below assumptions are made
+		cluster 1 - > 2 ESX in site A , 2 ESX in site B
+		Cluster 2 - > Site A
+		Cluster 3 → Site B
+
+		Steps//
+		1. Create SC with volumeBindingMode as WaitForFirstConsumer and has parallel pod
+		management policy(SC example 1)
+		2. Use the above created storageclass and create 3 stateful with parallel pod-management
+		policy and each with replica 20and NodeSelector Terms set to all three countries
+		3. Create Stateful set and wait for some time for Pod's to create and to be in running state
+		4. Once the POD is in running state verify that POD's are created on all countries as specified in
+		nodeAffinity entry
+		5. Describe on the PV's and Verify node affinity details
+		6. Bring down site B
+		7. Wait for some time and verify that all the POD's that were on cluster3 are in
+		Terminating state, and nodes that are on cluster 1 comes up on different ESX's in the same
+		cluster1 and respective POD's are back to running state .
+		8. Scale up First stateful set to 55 replica's and scaledown second stateful set to 5 Replicas
+		9. Since 2nd stateful set is scaled down , there will be 5 PVC's without POD linking to it.
+		Delete those PVC's
+		10. Bring Up Site B
+		11. wait for  site B VMs to come up and k8s to be healthy
+		12. Verify First stateful set is up with 55 replica's , and 2nd  stateful sets is
+		scaled down to 5 succesffully
+		13. Bring all ESX's in cluster 2 down
+		14. Wait for some time and verify that all the POD's that were on cluster2 are in Terminating state
+		15. Scale down First stateful set to 10 replica's
+		16. Scale up second stateful set to 55 replica's
+		17. Wait for some time for new pod's to get created and few POD's which were in cluster 2
+		goes to terminating state.
+		18. Verify the node affinity details of PV should be proper
+		19. Bring up ESX's in cluster 2
+		20. Randomly pick few PVC and check CNS metadata data details
+		21. Delete all stateful sets
+		22. Delete PVC's and SC
+	*/
+
+	ginkgo.It("Volume provisioning when multiple statefulsets creation is in "+
+		"progress and in between hosts are down", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		sts_count = 3
+		statefulSetReplicaCount = 20
+		var ssPods *v1.PodList
+
+		// Get allowed topologies for Storage Class
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength)
+
+		// Create SC with WFC BindingMode
+		ginkgo.By("Creating Storage Class with WFC Binding Mode and allowed topolgies of 5 levels")
+		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "",
+			bindingMode, false, "nginx-sc")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Creating StatefulSet service
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Create multiple StatefulSets Specs in parallel
+		ginkgo.By("Creating multiple StatefulSets specs in parallel")
+		statefulSets := createParallelStatefulSetSpec(namespace, sts_count)
+
+		// Trigger multiple StatefulSets creation in parallel.
+		ginkgo.By("Trigger multiple StatefulSets creation in parallel")
+		var wg sync.WaitGroup
+		wg.Add(3)
+		for i := 0; i < len(statefulSets); i++ {
+			go createParallelStatefulSets(client, namespace, statefulSets[i],
+				statefulSetReplicaCount, &wg)
+		}
+		wg.Wait()
+
+		// Waiting for StatefulSets Pods to be in Ready State
+		ginkgo.By("Waiting for StatefulSets Pods to be in Ready State")
+		time.Sleep(pollTimeoutSixMin)
+
+		// Verify that all parallel triggered StatefulSets Pods creation should be in up and running state
+		ginkgo.By("Verify that all parallel triggered StatefulSets Pods creation should be in up and running state")
+		for i := 0; i < len(statefulSets); i++ {
+			// verify that the StatefulSets pods are in ready state
+			fss.WaitForStatusReadyReplicas(client, statefulSets[i], statefulSetReplicaCount)
+			gomega.Expect(CheckMountForStsPods(client, statefulSets[i], mountPath)).NotTo(gomega.HaveOccurred())
+
+			// Get list of Pods in each StatefulSet and verify the replica count
+			ssPods = GetListOfPodsInSts(client, statefulSets[i])
+			gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+				fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulSets[i].Name))
+			gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+				"Number of Pods in the statefulset should match with number of replicas")
+		}
+
+		/* Verify PV nde affinity and that the pods are running on appropriate nodes
+		for each StatefulSet pod */
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		for i := 0; i < len(statefulSets); i++ {
+			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
+				statefulSets[i], namespace, allowedTopologies, true)
+		}
+
+		// Bring down ESXi hosts that belongs to Cluster3
+		ginkgo.By("Bring down ESXi hosts that belongs to Cluster3")
+		HostsList := getListOfHostsInCluster(ctx, &e2eVSphere, topologyClusterList[2])
+		powerOffHostsList = powerOffEsxiHostByCluster(ctx, &e2eVSphere, topologyClusterList[2],
+			(len(HostsList) - 1))
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify all the workload Pods are in up and running state
+		ginkgo.By("Verify all the workload Pods are in up and running state")
+		ssPods = fss.GetPodList(client, statefulSets[1])
+		for _, pod := range ssPods.Items {
+			err := fpod.WaitForPodRunningInNamespace(client, &pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		// Scale up statefulSets replicas count
+		ginkgo.By("Scaleup any one StatefulSets replica")
+		statefulSetReplicaCount = 10
+		ginkgo.By("Scale down statefulset replica and verify the replica count")
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// Scale down statefulSets replica count
+		statefulSetReplicaCount = 5
+		ginkgo.By("Scale down statefulset replica count")
+		scaleDownStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount, true)
+		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulSets[1])
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// Bring up
+		ginkgo.By("Bring up all ESXi host which were powered off")
+		for i := 0; i < len(powerOffHostsList); i++ {
+			powerOnEsxiHostByCluster(powerOffHostsList[i])
+		}
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Bring down ESXi hosts that belongs to Cluster2
+		ginkgo.By("Bring down ESXi hosts that belongs to Cluster2")
+		HostsList = getListOfHostsInCluster(ctx, &e2eVSphere, topologyClusterList[1])
+		powerOffHostsList = powerOffEsxiHostByCluster(ctx, &e2eVSphere, topologyClusterList[1],
+			(len(HostsList) - 1))
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Scale up statefulSets replicas count
+		ginkgo.By("Scaleup any one StatefulSets replica")
+		statefulSetReplicaCount = 10
+		ginkgo.By("Scale down statefulset replica and verify the replica count")
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulSets[0])
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// Scale down statefulSets replica count
+		statefulSetReplicaCount = 5
+		ginkgo.By("Scale down statefulset replica count")
+		scaleDownStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount, true)
+		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulSets[1])
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		/* Verify PV nde affinity and that the pods are running on appropriate nodes
+		for each StatefulSet pod */
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		for i := 0; i < len(statefulSets); i++ {
+			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
+				statefulSets[i], namespace, allowedTopologies, true)
+		}
+
+		// Bring up
+		ginkgo.By("Bring up all ESXi host which were powered off")
+		for i := 0; i < len(powerOffHostsList); i++ {
+			powerOnEsxiHostByCluster(powerOffHostsList[i])
+		}
+
+		// verifyVolumeMetadataInCNS
+		ginkgo.By("Verify pod entry in CNS volume-metadata for the volumes associated with the PVC")
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulSets[1])
+		for _, pod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range pod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, pod.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					// Verify the attached volume match the one in CNS cache
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, pod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By("Verify k8s cluster is healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Scale down statefulSets replica count
+		statefulSetReplicaCount = 0
+		ginkgo.By("Scale down statefulset replica count")
+		for i := 0; i < len(statefulSets); i++ {
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
+			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+				"Number of Pods in the statefulset should match with number of replicas")
+		}
+	})
+
+	/*
+		TESTCASE-2
+		Delete one of the containernode + bring down few esx's
+
+		Steps//
+		1. Identify the Pod where CSI Provisioner is the leader.
+		2. Create Storage class with Wait for first consumer
+		3. Bring down all esx in cluster2
+		4. Using the above created SC , Create 5 statefulset with parallel POD management policy
+		each with 10 replica's
+		5. While the Statefulsets is creating PVCs and Pods, kill CSI Provisioner container
+		identified in the step 1, where CSI provisioner is the leader.
+		6. csi-provisioner in other replica should take the leadership to help provisioning of the volume.
+		7. Wait until all PVCs and Pods are created for Statefulsets . Since all esx's down in
+		cluster 2 POD's should come up on cluster 1 and cluster 3
+		8. Expect all PVCs for Statefulsets to be in the bound state.
+		9. Expect all Pods for Statefulsets to be in the running state
+		10. Describe PV and Verify the node affinity rule . Make sure node affinity should
+		contain all 5 levels of topology details
+		11. POD should be running in the appropriate nodes
+		12. Bring up ESX's in cluster 2
+		13. Identify the Pod where CSI Attacher is the leader
+		14. Scale down the Statefulsets replica count to 5,
+		15. While the Statefulsets is scaling down Pods, kill CSI Attacher container
+		identified in the step 11, where CSI Attacher is the leader.
+		16. Wait until the POD count goes down to 5
+		17. Delete the PVC's which are not used by POD's
+		18. Scale up replica count 20
+		19. PVC's, POD's should come up on all three clusters (labeled as countries)
+		20. verify node affinity details on PV's should be proper with all 5 level details
+		21. Delete statefulset
+		22. Delete PVC's and SC
+	*/
+
+	ginkgo.It("Volume provisioning when multiple statefulsets creation in progress and in "+
+		"between hosts and container nodes are down", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		sts_count = 3
+		statefulSetReplicaCount = 10
+		var ssPods *v1.PodList
+		controller_name := "csi-provisioner"
+
+		/* Get current leader Csi-Controller-Pod where CSI Provisioner is running and " +
+		find the master node IP where this Csi-Controller-Pod is running */
+		ginkgo.By("Get current leader Csi-Controller-Pod name where CSI Provisioner is running and " +
+			"find the master node IP where this Csi-Controller-Pod is running")
+		csi_controller_pod, k8sMasterIP, err := getK8sMasterNodeIPWhereControllerLeaderIsRunning(ctx,
+			client, sshClientConfig, controller_name)
+		framework.Logf("CSI-Provisioner is running on Leader Pod %s "+
+			"which is running on master node %s", csi_controller_pod, k8sMasterIP)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Get allowed topologies for Storage Class
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength)
+
+		// Create SC with WFC BindingMode
+		ginkgo.By("Creating Storage Class with WFC Binding Mode and allowed topolgies of 5 levels")
+		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "",
+			bindingMode, false, "nginx-sc")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Bring down ESXi hosts that belongs to Cluster3
+		ginkgo.By("Bring down ESXi hosts that belongs to Cluster3")
+		HostsList := getListOfHostsInCluster(ctx, &e2eVSphere, topologyClusterList[2])
+		powerOffHostsList = powerOffEsxiHostByCluster(ctx, &e2eVSphere, topologyClusterList[2],
+			(len(HostsList) - 1))
+
+		// Creating StatefulSet service
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Create multiple StatefulSets Specs in parallel
+		ginkgo.By("Creating multiple StatefulSets specs in parallel")
+		statefulSets := createParallelStatefulSetSpec(namespace, sts_count)
+
+		/* Trigger multiple StatefulSets creation in parallel.
+		During StatefulSets creation, kill CSI Provisioner container in between */
+		ginkgo.By("Trigger multiple StatefulSets creation in parallel. During StatefulSets " +
+			"creation, kill CSI Provisioner container in between ")
+		var wg sync.WaitGroup
+		wg.Add(3)
+		for i := 0; i < len(statefulSets); i++ {
+			go createParallelStatefulSets(client, namespace, statefulSets[i],
+				statefulSetReplicaCount, &wg)
+			if i == 2 {
+				/* Kill container CSI-Provisioner on the master node where elected leader CSi-Controller-Pod
+				is running */
+				ginkgo.By("Kill container CSI-Provisioner on the master node where elected leader " +
+					"CSi-Controller-Pod is running")
+				err = executeDockerPauseKillCmd(sshClientConfig, k8sMasterIP, controller_name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+		wg.Wait()
+
+		/* Get newly elected leader Csi-Controller-Pod where CSI Provisioner is running" +
+		find new master node IP where this Csi-Controller-Pod is running */
+		ginkgo.By("Get newly Leader Csi-Controller-Pod where CSI Provisioner is running and " +
+			"find the master node IP where this Csi-Controller-Pod is running")
+		csi_controller_pod, k8sMasterIP, err = getK8sMasterNodeIPWhereControllerLeaderIsRunning(ctx,
+			client, sshClientConfig, controller_name)
+		framework.Logf("CSI-Provisioner is running on newly elected Leader Pod %s "+
+			"which is running on master node %s", csi_controller_pod, k8sMasterIP)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Waiting for StatefulSets Pods to be in Ready State
+		ginkgo.By("Waiting for StatefulSets Pods to be in Ready State")
+		time.Sleep(pollTimeoutSixMin)
+
+		// Verify that all parallel triggered StatefulSets Pods creation should be in up and running state
+		ginkgo.By("Verify that all parallel triggered StatefulSets Pods creation should be in up and running state")
+		for i := 0; i < len(statefulSets); i++ {
+			// verify that the StatefulSets pods are in ready state
+			fss.WaitForStatusReadyReplicas(client, statefulSets[i], statefulSetReplicaCount)
+			gomega.Expect(CheckMountForStsPods(client, statefulSets[i], mountPath)).NotTo(gomega.HaveOccurred())
+
+			// Get list of Pods in each StatefulSet and verify the replica count
+			ssPods = GetListOfPodsInSts(client, statefulSets[i])
+			gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+				fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulSets[i].Name))
+			gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+				"Number of Pods in the statefulset should match with number of replicas")
+		}
+
+		/* Verify PV nde affinity and that the pods are running on appropriate nodes
+		for each StatefulSet pod */
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		for i := 0; i < len(statefulSets); i++ {
+			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
+				statefulSets[i], namespace, allowedTopologies, true)
+		}
+
+		// Bring up
+		ginkgo.By("Bring up all ESXi host which were powered off")
+		for i := 0; i < len(powerOffHostsList); i++ {
+			powerOnEsxiHostByCluster(powerOffHostsList[i])
+		}
+
+		/* Get current leader Csi-Controller-Pod where CSI Attacher is running and " +
+		find the master node IP where this Csi-Controller-Pod is running */
+		controller_name = "CSI-Attacher"
+		ginkgo.By("Get current leader Csi-Controller-Pod name where CSI Attacher is running and " +
+			"find the master node IP where this Csi-Controller-Pod is running")
+		csi_controller_pod, k8sMasterIP, err = getK8sMasterNodeIPWhereControllerLeaderIsRunning(ctx,
+			client, sshClientConfig, controller_name)
+		framework.Logf("CSI-Attacher is running on Leader Pod %s "+
+			"which is running on master node %s", csi_controller_pod, k8sMasterIP)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify all the workload Pods are in up and running state
+		ginkgo.By("Verify all the workload Pods are in up and running state")
+		ssPods = fss.GetPodList(client, statefulSets[1])
+		for _, pod := range ssPods.Items {
+			err := fpod.WaitForPodRunningInNamespace(client, &pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		// Scale down statefulSets replicas count
+		ginkgo.By("Scaledown StatefulSets replica in parallel. During StatefulSets replica scaledown " +
+			"kill CSI Attacher container in between")
+		statefulSetReplicaCount = 5
+		ginkgo.By("Scale down statefulset replica and verify the replica count")
+		for i := 0; i < len(statefulSets); i++ {
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
+			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+				"Number of Pods in the statefulset should match with number of replicas")
+			if i == 2 {
+				/* Kill container CSI-Attacher on the master node where elected leader CSi-Controller-Pod
+				is running */
+				ginkgo.By("Kill container CSI-Attacher on the master node where elected leader CSi-Controller-Pod " +
+					"is running")
+				err = executeDockerPauseKillCmd(sshClientConfig, k8sMasterIP, controller_name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		/* Get newly elected leader Csi-Controller-Pod where CSI Provisioner is running" +
+		   find new master node IP where this Csi-Controller-Pod is running */
+		ginkgo.By("Get newly elected leader Csi-Controller-Pod where CSI Provisioner is running and " +
+			"find the master node IP where this Csi-Controller-Pod is running")
+		controller_name = "csi-provisioner"
+		csi_controller_pod, k8sMasterIP, err = getK8sMasterNodeIPWhereControllerLeaderIsRunning(ctx,
+			client, sshClientConfig, controller_name)
+		framework.Logf("CSI-Provisioner is running on elected Leader Pod %s "+
+			"which is running on master node %s", csi_controller_pod, k8sMasterIP)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		for i := 0; i < len(statefulSets); i++ {
+			// Scale up statefulSets replicas count
+			ginkgo.By("Scaleup any one StatefulSets replica")
+			statefulSetReplicaCount = 15
+			ginkgo.By("Scale down statefulset replica and verify the replica count")
+			scaleUpStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
+			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+				"Number of Pods in the statefulset should match with number of replicas")
+		}
+
+		/* Verify PV nde affinity and that the pods are running on appropriate nodes
+		for each StatefulSet pod */
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		for i := 0; i < len(statefulSets); i++ {
+			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
+				statefulSets[i], namespace, allowedTopologies, true)
+		}
+
+		// Scale down statefulSets replica count
+		statefulSetReplicaCount = 0
+		ginkgo.By("Scale down statefulset replica count")
+		for i := 0; i < len(statefulSets); i++ {
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
+			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+				"Number of Pods in the statefulset should match with number of replicas")
+		}
+	})
+
+})

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -5106,3 +5106,222 @@ func waitForVolumeSnapshotContentToBeDeleted(client snapclient.Clientset, ctx co
 	})
 	return waitErr
 }
+
+// CheckMount checks that the mount at mountPath is valid for all Pods in ss.
+func CheckMountForStsPods(c clientset.Interface, ss *appsv1.StatefulSet, mountPath string) error {
+	for _, cmd := range []string{
+		// Print inode, size etc
+		fmt.Sprintf("ls -idlh %v", mountPath),
+		// Print subdirs
+		fmt.Sprintf("find %v", mountPath),
+		// Try writing
+		fmt.Sprintf("touch %v", filepath.Join(mountPath, fmt.Sprintf("%v", time.Now().UnixNano()))),
+	} {
+		if err := ExecInStsPodsInNs(c, ss, cmd); err != nil {
+			return fmt.Errorf("failed to execute %v, error: %v", cmd, err)
+		}
+	}
+	return nil
+}
+
+/* ExecInStsPodsInNs executes cmd in all Pods in ss. If a error occurs it is returned and
+cmd is not execute in any subsequent Pods. */
+func ExecInStsPodsInNs(c clientset.Interface, ss *appsv1.StatefulSet, cmd string) error {
+	podList := GetListOfPodsInSts(c, ss)
+	StatefulSetPoll := 10 * time.Second
+	StatefulPodTimeout := 5 * time.Minute
+	for _, statefulPod := range podList.Items {
+		stdout, err := framework.RunHostCmdWithRetries(statefulPod.Namespace, statefulPod.Name,
+			cmd, StatefulSetPoll, StatefulPodTimeout)
+		framework.Logf("stdout of %v on %v: %v", cmd, statefulPod.Name, stdout)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ListTopologyClusterNames(topologyCluster string) []string {
+	topologyClusterList := strings.Split(topologyCluster, ",")
+	return topologyClusterList
+}
+
+func createParallelStatefulSetSpec(namespace string, no_of_sts int) []*appsv1.StatefulSet {
+	stss := []*appsv1.StatefulSet{}
+	var statefulset *appsv1.StatefulSet
+	for i := 0; i < no_of_sts; i++ {
+		statefulset = GetStatefulSetFromManifest(namespace)
+		statefulset.Name = "thread-" + strconv.Itoa(i) + "-" + statefulset.Name
+		statefulset.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Annotations["volume.beta.kubernetes.io/storage-class"] = "nginx-sc"
+		stss = append(stss, statefulset)
+	}
+	return stss
+}
+
+func createParallelStatefulSets(client clientset.Interface, namespace string,
+	statefulset *appsv1.StatefulSet, replicas int32, wg *sync.WaitGroup) {
+	defer wg.Done()
+	ginkgo.By("Creating statefulset")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	framework.Logf(fmt.Sprintf("Creating statefulset %v/%v with %d replicas and selector %+v",
+		statefulset.Namespace, statefulset.Name, *(statefulset.Spec.Replicas), statefulset.Spec.Selector))
+	_, err := client.AppsV1().StatefulSets(namespace).Create(ctx, statefulset, metav1.CreateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func powerOffEsxiHostByCluster(ctx context.Context, vs *vSphere, clusterName string,
+	esxCount int) []string {
+	var powerOffHostsList []string
+	var clusterHostlist []*object.ClusterComputeResource
+	var hostsInCluster []*object.HostSystem
+	clusterLists, _, err := getClusterName(ctx, &e2eVSphere)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	for i := 0; i < len(clusterLists); i++ {
+		if strings.Contains(clusterLists[i].ComputeResource.Common.InventoryPath, clusterName) {
+			clusterHostlist = append(clusterHostlist, clusterLists[i])
+			hostsInCluster = getHosts(ctx, clusterHostlist)
+		}
+	}
+	for i := 0; i < esxCount; i++ {
+		for _, esxInfo := range tbinfo.esxHosts {
+			host := hostsInCluster[i].Common.InventoryPath
+			hostIp := strings.Split(host, "/")
+			if hostIp[6] == esxInfo["ip"] {
+				esxHostName := esxInfo["vmName"]
+				powerOffHostsList = append(powerOffHostsList, esxHostName)
+				err = vMPowerMgmt(tbinfo.user, tbinfo.location, esxHostName, false)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = waitForHostToBeDown(esxInfo["ip"])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+	}
+	return powerOffHostsList
+}
+
+func powerOnEsxiHostByCluster(hostToPowerOn string) {
+	var esxHostIp string = ""
+	for _, esxInfo := range tbinfo.esxHosts {
+		if hostToPowerOn == esxInfo["vmName"] {
+			esxHostIp = esxInfo["ip"]
+			err := vMPowerMgmt(tbinfo.user, tbinfo.location, hostToPowerOn, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}
+	}
+	err := waitForHostToBeUp(esxHostIp)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func getListOfHostsInCluster(ctx context.Context, vs *vSphere, clusterName string) []*object.HostSystem {
+	var clusterHostlist []*object.ClusterComputeResource
+	var hostsInCluster []*object.HostSystem
+	clusterLists, _, err := getClusterName(ctx, &e2eVSphere)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	for i := 0; i < len(clusterLists); i++ {
+		if strings.Contains(clusterLists[i].ComputeResource.Common.InventoryPath, clusterName) {
+			clusterHostlist = append(clusterHostlist, clusterLists[i])
+			hostsInCluster = getHosts(ctx, clusterHostlist)
+		}
+	}
+	return hostsInCluster
+}
+
+/*
+This method will kill container on the master node IP where controller is running
+*/
+func executeDockerPauseKillCmd(sshClientConfig *ssh.ClientConfig, k8sMasterNodeIP string,
+	controller_name string) error {
+	grepCmdForGettingDockerContainerId := "docker ps | grep " + controller_name + " | " +
+		"awk '{print $1}' |  tr -d '\n'"
+	framework.Logf("Invoking command '%v' on host %v", grepCmdForGettingDockerContainerId,
+		k8sMasterNodeIP)
+	DockerContainerInfo, err := sshExec(sshClientConfig, k8sMasterNodeIP,
+		grepCmdForGettingDockerContainerId)
+	if err != nil || DockerContainerInfo.Code != 0 {
+		fssh.LogResult(DockerContainerInfo)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			grepCmdForGettingDockerContainerId, k8sMasterNodeIP, err)
+	}
+	grepCmdForPausingDockerContainer := "docker pause " + DockerContainerInfo.Stdout
+	framework.Logf("Invoking command '%v' on host %v", grepCmdForPausingDockerContainer,
+		k8sMasterNodeIP)
+	DockerContainerPauseInfo, err := sshExec(sshClientConfig, k8sMasterNodeIP,
+		grepCmdForPausingDockerContainer)
+	if err != nil || DockerContainerPauseInfo.Code != 0 {
+		fssh.LogResult(DockerContainerPauseInfo)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			grepCmdForPausingDockerContainer, k8sMasterNodeIP, err)
+	}
+	grepCmdForKillingDockerContainer := "docker kill " + DockerContainerInfo.Stdout
+	framework.Logf("Invoking command '%v' on host %v", grepCmdForKillingDockerContainer,
+		k8sMasterNodeIP)
+	DockerContainerKillInfo, err := sshExec(sshClientConfig, k8sMasterNodeIP,
+		grepCmdForKillingDockerContainer)
+	if err != nil || DockerContainerKillInfo.Code != 0 {
+		fssh.LogResult(DockerContainerKillInfo)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			grepCmdForKillingDockerContainer, k8sMasterNodeIP, err)
+	}
+	return nil
+}
+
+/*
+This method will fetch the master node IP where controller is running
+*/
+func getK8sMasterNodeIPWhereControllerLeaderIsRunning(ctx context.Context,
+	client clientset.Interface, sshClientConfig *ssh.ClientConfig,
+	controller_name string) (string, string, error) {
+	ignoreLabels := make(map[string]string)
+	var k8sMasterNodeIP string
+	var csi_controller_pod string
+	list_of_pods, err := fpod.GetPodsInNamespace(client, csiSystemNamespace, ignoreLabels)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	for i := 0; i < len(list_of_pods); i++ {
+		if strings.Contains(list_of_pods[i].Name, vSphereCSIControllerPodNamePrefix) {
+			k8sMasterIPs := getK8sMasterIPs(ctx, client)
+			for _, k8sMasterIP := range k8sMasterIPs {
+				grepCmdForFindingCurrentLeader := "kubectl logs " + list_of_pods[i].Name + " -n " +
+					"vmware-system-csi " + controller_name + " | grep 'new leader detected, current leader:' " +
+					" | tail -1 | awk '{print $10}' | tr -d '\n'"
+				framework.Logf("Invoking command '%v' on host %v", grepCmdForFindingCurrentLeader,
+					k8sMasterIP)
+				RunningLeaderInfo, err := sshExec(sshClientConfig, k8sMasterIP,
+					grepCmdForFindingCurrentLeader)
+				csi_controller_pod = RunningLeaderInfo.Stdout
+				if err != nil || RunningLeaderInfo.Code != 0 {
+					fssh.LogResult(RunningLeaderInfo)
+					return "", "", fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+						grepCmdForFindingCurrentLeader, k8sMasterIP, err)
+				}
+				grepCmdForFindingMasterNodeName := "kubectl get pods -owide -n " +
+					"vmware-system-csi | grep " + RunningLeaderInfo.Stdout + "| awk '{print $(NF-2)}' | tr -d '\n'"
+				framework.Logf("Invoking command '%v' on host %v", grepCmdForFindingMasterNodeName,
+					k8sMasterIP)
+				K8sMasterNodeNameInfo, err := sshExec(sshClientConfig, k8sMasterIP,
+					grepCmdForFindingMasterNodeName)
+				if err != nil || K8sMasterNodeNameInfo.Code != 0 {
+					fssh.LogResult(K8sMasterNodeNameInfo)
+					return "", "", fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+						grepCmdForFindingMasterNodeName, k8sMasterIP, err)
+				}
+				grepCmdForFindingMasterNodeIP := "kubectl get nodes -owide | " +
+					"grep " + K8sMasterNodeNameInfo.Stdout + " | awk '{print $6}' |  tr -d '\n'"
+				framework.Logf("Invoking command '%v' on host %v", grepCmdForFindingMasterNodeIP,
+					k8sMasterIP)
+				K8sMasterNodeIPInfo, err := sshExec(sshClientConfig, k8sMasterIP,
+					grepCmdForFindingMasterNodeIP)
+				k8sMasterNodeIP = K8sMasterNodeIPInfo.Stdout
+				if err != nil || K8sMasterNodeIPInfo.Code != 0 {
+					fssh.LogResult(K8sMasterNodeIPInfo)
+					return "", "", fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+						grepCmdForFindingMasterNodeIP, k8sMasterIP, err)
+				}
+			}
+		}
+	}
+	return csi_controller_pod, k8sMasterNodeIP, nil
+}


### PR DESCRIPTION

**What this PR does / why we need it**:
Testcase coverage for Topology  Operation Strom testcases


**Testing done**:
Yes

Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/table-4-topology-OStorm/vsphere-csi-driver /Users/sipriya/table-4-topology-OStorm /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|name|compiled_files|files|imports|types_sizes|exports_file) took 10.576064982s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 103.741902ms 
INFO [linters context/goanalysis] analyzers took 38.332345154s with top 10 stages: buildir: 13.095941412s, misspell: 1.569027379s, S1038: 1.048910736s, directives: 805.793238ms, printf: 640.979512ms, SA1012: 622.872801ms, unused: 612.555722ms, S1039: 601.481622ms, SA1013: 537.982385ms, isgenerated: 498.669731ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 113/113, identifier_marker: 24/24, path_prettifier: 113/113, exclude: 24/24, cgo: 113/113, skip_files: 113/113, autogenerated_exclude: 24/113, exclude-rules: 1/24, nolint: 0/1, skip_dirs: 113/113 
INFO [runner] processing took 15.237871ms with stages: nolint: 12.679931ms, autogenerated_exclude: 1.627578ms, path_prettifier: 370.267µs, identifier_marker: 309.318µs, skip_dirs: 119.147µs, exclude-rules: 113.791µs, cgo: 6.936µs, filename_unadjuster: 6.521µs, max_same_issues: 957ns, uniq_by_line: 682ns, max_from_linter: 417ns, source_code: 334ns, diff: 292ns, path_shortener: 290ns, skip_files: 288ns, max_per_file_from_linter: 252ns, exclude: 243ns, severity-rules: 223ns, sort_results: 211ns, path_prefixer: 193ns 
INFO [runner] linters took 8.215187498s with stages: goanalysis_metalinter: 8.199847422s 
INFO File cache stats: 274 entries of total size 4.0MiB 
INFO Memory: 190 samples, avg is 273.8MB, max is 1088.4MB 
INFO Execution took 18.905335012s 
