### PR TITLE
Stretched cluster tests PART 7

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -42,6 +42,7 @@ const (
 	csiSystemNamespace                         = "vmware-system-csi"
 	csiFssCM                                   = "internal-feature-states.csi.vsphere.vmware.com"
 	csiVolAttrVolType                          = "vSphere CNS Block Volume"
+	csiDriverContainerName                     = "vsphere-csi-controller"
 	defaultFullSyncIntervalInMin               = "30"
 	defaultProvisionerTimeInSec                = "300"
 	defaultFullSyncWaitTime                    = 1800
@@ -128,6 +129,7 @@ const (
 	rqLimitScaleTest                          = "900Gi"
 	defaultrqLimit                            = "20Gi"
 	rqStorageType                             = ".storageclass.storage.k8s.io/requests.storage"
+	resizerContainerName                      = "csi-resizer"
 	scParamDatastoreURL                       = "DatastoreURL"
 	scParamFsType                             = "csi.storage.k8s.io/fstype"
 	scParamStoragePolicyID                    = "StoragePolicyId"
@@ -136,6 +138,7 @@ const (
 	sleepTimeOut                              = 30
 	oneMinuteWaitTimeInSeconds                = 60
 	spsServiceName                            = "sps"
+	snapshotterContainerName                  = "csi-snapshotter"
 	sshdPort                                  = "22"
 	svcRunningMessage                         = "Running"
 	startOperation                            = "start"


### PR DESCRIPTION
**What this PR does / why we need it**: Includes automation for 3 testcases for leader change scenarios of vsan stretched cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/480a1994720d5dd16bd681f331dbd39b

**Special notes for your reviewer**: make check output
```
(base) kai@kai-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/stretched-tests-part7/vsphere-csi-driver /Users/kai/CSI/stretched-tests-part7 /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (files|imports|types_sizes|compiled_files|deps|exports_file|name) took 1.664800429s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 88.353583ms 
INFO [linters context/goanalysis] analyzers took 6.303643685s with top 10 stages: buildir: 536.739658ms, S1038: 476.637718ms, misspell: 381.16076ms, S1039: 235.823248ms, unused: 195.07867ms, S1024: 169.579624ms, SA1012: 169.539077ms, directives: 169.32558ms, S1028: 160.483939ms, SA1013: 138.48908ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_dirs: 113/113, exclude: 24/24, skip_files: 113/113, identifier_marker: 24/24, cgo: 113/113, filename_unadjuster: 113/113, exclude-rules: 1/24, nolint: 0/1, path_prettifier: 113/113, autogenerated_exclude: 24/113 
INFO [runner] processing took 17.902543ms with stages: nolint: 15.066897ms, autogenerated_exclude: 1.592126ms, path_prettifier: 629.366µs, identifier_marker: 321.816µs, skip_dirs: 162.319µs, exclude-rules: 107.973µs, cgo: 10.341µs, filename_unadjuster: 7.65µs, max_same_issues: 975ns, uniq_by_line: 522ns, exclude: 374ns, diff: 336ns, max_from_linter: 296ns, skip_files: 288ns, source_code: 237ns, max_per_file_from_linter: 231ns, severity-rules: 228ns, sort_results: 219ns, path_shortener: 218ns, path_prefixer: 131ns 
INFO [runner] linters took 5.44953686s with stages: goanalysis_metalinter: 5.4315345s 
INFO File cache stats: 86 entries of total size 2.3MiB 
INFO Memory: 74 samples, avg is 237.7MB, max is 549.5MB 
INFO Execution took 7.213843449s 
```

