### PR TITLE
Cherry-pick : Read UUID from product_serial in node daemonset (#1637)

### DIFF
--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -352,11 +352,6 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to get system uuid for node VM with error: %v", err)
 		}
-		nodeID, err = driver.osUtils.ConvertUUID(nodeID)
-		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
-				"convertUUID failed with error: %v", err)
-		}
 	} else {
 		nodeID = nodeName
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick request for https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1637

```release-note
Fix for CSI Node daemon set to work with BIOS version less than 2.7.
```
