### PR TITLE
Update Readme to reflect the independence from CPI with 2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 This repository provides tools and scripts for building and testing the vSphere CSI provider. This driver is in a stable `GA` state and is suitable for production use. Some of the features may be in the `beta` phase. Please refer [feature matrix](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-E59B13F5-6F49-4619-9877-DF710C365A1E.html) for more details.  vSphere CSI driver requires vSphere 6.7 U3 or higher in order to operate.
 
-The CSI driver, when used on Kubernetes, also requires the use of the out-of-tree vSphere Cloud Provider Interface [CPI](https://github.com/kubernetes/cloud-provider-vsphere).
-
 ## Documentation
 
 Documentation for vSphere CSI Driver is available here:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Minor documentation change as the CSI is now decoupled from CPI.