### PR TITLE
stretched Test fix for leader change scenarios

### DIFF
--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -384,7 +384,8 @@ func updatePvcLabelsInParallel(ctx context.Context, client clientset.Interface, 
 			labels, pvc.Name, namespace))
 		pvc.Labels = labels
 		_, err := client.CoreV1().PersistentVolumeClaims(namespace).Update(ctx, pvc, metav1.UpdateOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			"Error on updating pvc labels is: %v", err)
 	}
 }
 
@@ -397,7 +398,8 @@ func updatePvLabelsInParallel(ctx context.Context, client clientset.Interface, n
 			labels, pv.Name, namespace))
 		pv.Labels = labels
 		_, err := client.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			"Error on updating pv labels is: %v", err)
 	}
 }
 
@@ -470,7 +472,7 @@ func changeLeaderOfContainerToComeUpOnMaster(ctx context.Context, client clients
 		// Check if leader of csi container comes up on master node of secondary site
 		_, masterIp, err := getK8sMasterNodeIPWhereContainerLeaderIsRunning(ctx, client, sshClientConfig,
 			csiContainerName)
-		framework.Logf("%s container leader is %s on %s ", csiContainerName, masterIp)
+		framework.Logf("%s container leader is on a master node with IP %s ", csiContainerName, masterIp)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: Test fix for leader change scenarios in stretched cluster automation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/fb1c2b659550dd665e49594003e95ac9
**Special notes for your reviewer**:
make check output:
```
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/test-fix/vsphere-csi-driver /Users/kai/CSI/test-fix /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|files|name|imports|types_sizes) took 1.788018028s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 118.031443ms 
INFO [linters context/goanalysis] analyzers took 27.733549691s with top 10 stages: buildir: 9.930255843s, misspell: 1.217732786s, S1038: 1.024536418s, directives: 572.663799ms, S1039: 567.553617ms, unused: 502.750064ms, ctrlflow: 448.65846ms, lll: 399.245351ms, SA1012: 387.424325ms, nilness: 380.626871ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude: 24/24, skip_files: 113/113, skip_dirs: 113/113, autogenerated_exclude: 24/113, exclude-rules: 1/24, cgo: 113/113, nolint: 0/1, filename_unadjuster: 113/113, identifier_marker: 24/24, path_prettifier: 113/113 
INFO [runner] processing took 14.736654ms with stages: nolint: 12.058646ms, autogenerated_exclude: 1.349425ms, path_prettifier: 697.119µs, identifier_marker: 300.297µs, skip_dirs: 205.876µs, exclude-rules: 107.648µs, filename_unadjuster: 7.287µs, cgo: 6.239µs, max_same_issues: 885ns, uniq_by_line: 500ns, diff: 391ns, source_code: 350ns, skip_files: 310ns, exclude: 307ns, path_shortener: 300ns, max_from_linter: 259ns, max_per_file_from_linter: 242ns, sort_results: 223ns, severity-rules: 222ns, path_prefixer: 128ns 
INFO [runner] linters took 8.850399547s with stages: goanalysis_metalinter: 8.835577655s 
INFO File cache stats: 273 entries of total size 4.0MiB 
INFO Memory: 109 samples, avg is 420.9MB, max is 1089.9MB 
INFO Execution took 10.769333766s

```