### PR TITLE
tag v2.2.3 release

### DIFF
--- a/manifests/v2.2.3/deploy/validatingwebhook.yaml
+++ b/manifests/v2.2.3/deploy/validatingwebhook.yaml
@@ -99,7 +99,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.2.3-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.2.3
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/v2.2.3/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.2.3/deploy/vsphere-csi-controller-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.2.3-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.2.3
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -117,7 +117,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.2.3-rc.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.2.3
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/v2.2.3/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.2.3/deploy/vsphere-csi-node-ds.yaml
@@ -48,7 +48,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: vsphere-csi-node
-        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.2.3-rc.1
+        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.2.3
         args:
           - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
           - "--fss-namespace=$(CSI_NAMESPACE)"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
tag v2.2.3 release


**Special notes for your reviewer**:
FVT has validated https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1471 with `v2.2.3-rc.1`


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
tag v2.2.3 release
```
