### PR TITLE
Add negative scenarios for fstype and test fix for label updates

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -169,6 +169,7 @@ const (
 	cloudadminTKG                             = "test-cluster-e2e-script-1"
 	vmOperatorAPI                             = "/apis/vmoperator.vmware.com/v1alpha1/"
 	devopsUser                                = "testuser"
+	xfsFSType                                 = "xfs"
 	zoneKey                                   = "failure-domain.beta.kubernetes.io/zone"
 	tkgAPI                                    = "/apis/run.tanzu.vmware.com/v1alpha1/namespaces" +
 		"/test-gc-e2e-demo-ns/tanzukubernetesclusters/"

--- a/tests/e2e/vsphere_file_volume_basic_mount.go
+++ b/tests/e2e/vsphere_file_volume_basic_mount.go
@@ -150,6 +150,170 @@ var _ = ginkgo.Describe("[csi-file-vanilla] Verify Two Pods can read write files
 		"which is deleted, when the Pod has pvc statically provisoned on same vsan file share", func() {
 		invokeTestForCreateFileVolumeAndMount(f, client, namespace, accessMode, filePath1, filePath2, true, false, true)
 	})
+
+	/*
+		Verify mounting of volume fails for RWX PVC with xfs fstype
+
+		    1.Create StorageClass with fsType as "xfs"
+		    2.Create a PVC with "ReadWriteMany" using the SC from above
+		    3.Wait for PVC to be Bound
+		    4.Get the VolumeID from PV
+		    5.Verify using CNS Query API if VolumeID retrieved from PV is present. Also verify
+			Name, Capacity, VolumeType, Health matches
+		    6.Verify if VolumeID is created on one of the VSAN datastores from list of datacenters provided in vsphere.conf
+		    7.Create Pod using PVC created above at a mount path specified in PodSpec
+		    8.Verify for pod to not come to Running state as mount of volume with xfs fstype fails.
+		Cleanup:
+		    1. Delete all the Pods, pvcs and storage class and verify the deletion
+	*/
+	ginkgo.It("[csi-file-vanilla] Verify mounting of volume fails for RWX PVC with xfs fstype", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Create Storage class and PVC
+		ginkgo.By("Creating Storage Class and PVC with xfs fstype")
+		scParameters := map[string]string{}
+		scParameters[scParamFsType] = xfsFSType
+		storageClassName := "file-sc"
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaim, err := createPVC(client, namespace, nil, "", sc, accessMode)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pvclaims = append(pvclaims, pvclaim)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
+
+		// clean up for pvc
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pv := persistentvolumes[0]
+			err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+				pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			volumeHandle := pv.Spec.CSI.VolumeHandle
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+					"kubernetes", volumeHandle))
+		}()
+
+		// Verify various properties Capacity, VolumeType, datastore and datacenter of volume using CNS Query API
+		verifyVolPropertiesFromCnsQueryResults(e2eVSphere, volHandle)
+
+		// Create Pod
+		ginkgo.By(fmt.Sprintf("Create pod with pvc: %s", pvclaim.Name))
+		pod := fpod.MakePod(namespace, nil, []*v1.PersistentVolumeClaim{pvclaims[0]}, false, execCommand)
+		pod.Spec.Containers[0].Image = busyBoxImageOnGcr
+		pod, err = client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+		framework.Logf("Error is: %v", err)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod : %s in namespace %s", pod.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		err = fpod.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)
+		framework.Logf("Error from creating pod: %v", err)
+		// Mounting of volumes should fail with xfs fstype
+		gomega.Expect(err).To(gomega.HaveOccurred())
+
+	})
+
+	/*
+		Verify mounting of volume for RWX PVC with ext4 fstype passes
+
+		    1.Create StorageClass with fsType as "ext4"
+		    2.Create a PVC with "ReadWriteMany" using the SC from above
+		    3.Wait for PVC to be Bound
+		    4.Get the VolumeID from PV
+		    5.Verify using CNS Query API if VolumeID retrieved from PV is present. Also verify
+			Name, Capacity, VolumeType, Health matches
+		    6.Verify if VolumeID is created on one of the VSAN datastores from list of datacenters provided in vsphere.conf
+		    7.Create Pod using PVC created above at a mount path specified in PodSpec
+		    8.Verify if pod comes to Running state as CSI driver ignores the ext4 and default to nfs4 fstype
+			while mounting the file volume
+		Cleanup:
+		    1.Delete all the Pods, pvcs and storage class and verify the deletion
+	*/
+	ginkgo.It("[csi-file-vanilla] Verify mounting of volume for RWX PVC with ext4 fstype passes", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Create Storage class and PVC
+		ginkgo.By("Creating Storage Class and PVC with xfs fstype")
+		scParameters := map[string]string{}
+		scParameters[scParamFsType] = ext4FSType
+		storageClassName := "file-sc"
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaim, err := createPVC(client, namespace, nil, "", sc, accessMode)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pvclaims = append(pvclaims, pvclaim)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
+
+		// clean up for pvc
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pv := persistentvolumes[0]
+			err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+				pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			volumeHandle := pv.Spec.CSI.VolumeHandle
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+					"kubernetes", volumeHandle))
+		}()
+
+		// Verify various properties Capacity, VolumeType, datastore and datacenter of volume using CNS Query API
+		verifyVolPropertiesFromCnsQueryResults(e2eVSphere, volHandle)
+
+		// Create Pod
+		ginkgo.By(fmt.Sprintf("Create pod with pvc: %s", pvclaim.Name))
+		pod := fpod.MakePod(namespace, nil, []*v1.PersistentVolumeClaim{pvclaims[0]}, false, execCommand)
+		pod.Spec.Containers[0].Image = busyBoxImageOnGcr
+		pod, err = client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod : %s in namespace %s", pod.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		err = fpod.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)
+		framework.Logf("Error from creating pod: %v", err)
+		// CSI driver ignores the ext4 and default to nfs4 fstype while mounting the file volume.
+		// Hence, mounting of file volume should pass with ext4 fstype
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	})
+
 	/*
 		Verify File Volume is created without specifying fstype in pv spec
 


### PR DESCRIPTION
**What this PR does / why we need it**: Add negative scenarios for fstype parameter in storageclass yaml and test fix for label updates when PVC name is removed from PV entry on CNS

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/0031112892bd3dab72d4d0275036e47b

**Special notes for your reviewer**: make check output:
```
(base) kai@kai-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
go get: upgraded honnef.co/go/tools v0.0.1-2020.1.3 => v0.2.0
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/kai_fstype/vsphere-csi-driver /Users/kai/CSI/kai_fstype /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (types_sizes|compiled_files|deps|name|exports_file|files|imports) took 1.67782452s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 85.621259ms 
INFO [linters context/goanalysis] analyzers took 22.972904395s with top 10 stages: buildir: 9.389992735s, misspell: 1.079294044s, S1038: 845.115378ms, unused: 490.603087ms, printf: 480.972684ms, S1039: 471.543442ms, ctrlflow: 468.861624ms, nilness: 379.042419ms, SA1012: 378.287594ms, fact_deprecated: 345.27397ms 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): cgo: 110/110, path_prettifier: 110/110, skip_files: 110/110, nolint: 0/1, identifier_marker: 21/21, exclude-rules: 1/21, filename_unadjuster: 110/110, skip_dirs: 110/110, autogenerated_exclude: 21/110, exclude: 21/21 
INFO [runner] processing took 13.999253ms with stages: nolint: 11.345937ms, autogenerated_exclude: 1.387522ms, path_prettifier: 727.823µs, identifier_marker: 263.565µs, skip_dirs: 152.144µs, exclude-rules: 102.789µs, filename_unadjuster: 8.58µs, cgo: 6.865µs, max_same_issues: 840ns, uniq_by_line: 580ns, max_from_linter: 552ns, source_code: 310ns, diff: 279ns, severity-rules: 273ns, skip_files: 239ns, exclude: 234ns, path_shortener: 224ns, max_per_file_from_linter: 196ns, sort_results: 173ns, path_prefixer: 128ns 
INFO [runner] linters took 8.293711308s with stages: goanalysis_metalinter: 8.279625978s 
INFO File cache stats: 271 entries of total size 3.9MiB 
INFO Memory: 102 samples, avg is 408.2MB, max is 955.3MB 
INFO Execution took 10.069207386s 
```
