### PR TITLE
staticcheck fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/hack/check-staticcheck.sh
+++ b/hack/check-staticcheck.sh
@@ -17,12 +17,13 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 # Change directories to the parent directory of the one in which this
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-go get honnef.co/go/tools/cmd/staticcheck@v0.2.0
+go install honnef.co/go/tools/cmd/staticcheck@master
 
 # shellcheck disable=SC2046
 # shellcheck disable=SC1083

--- a/hack/run-e2e-test.sh
+++ b/hack/run-e2e-test.sh
@@ -21,9 +21,9 @@ set -o pipefail
 # Fetching ginkgo for running the test
 export GO111MODULE=on
 export ACK_GINKGO_DEPRECATIONS=1.16.4
-if ! (go mod vendor && go get -u github.com/onsi/ginkgo/ginkgo@v1.16.4)
+if ! (go mod vendor && go install github.com/onsi/ginkgo/ginkgo@v1.16.4)
 then
-    echo "go mod vendor or go get ginkgo error"
+    echo "go mod vendor or go install ginkgo error"
     exit 1
 fi
 

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -634,7 +634,7 @@ func TestExtendVolume(t *testing.T) {
 		},
 		VolumeCapability: capabilities[0],
 	}
-	t.Log(fmt.Sprintf("ControllerExpandVolume will be called with req +%v", *reqExpand))
+	t.Logf("ControllerExpandVolume will be called with req +%v", *reqExpand)
 	respExpand, err := ct.controller.ControllerExpandVolume(ctx, reqExpand)
 	if err != nil {
 		t.Fatal(err)
@@ -643,7 +643,7 @@ func TestExtendVolume(t *testing.T) {
 		t.Fatalf("newly expanded volume size %d is smaller than requested size %d for volume with ID: %s",
 			respExpand.CapacityBytes, newSize, volID)
 	}
-	t.Log(fmt.Sprintf("ControllerExpandVolume succeeded: volume is expanded to requested size %d", newSize))
+	t.Logf("ControllerExpandVolume succeeded: volume is expanded to requested size %d", newSize)
 
 	// Query volume after expand volume.
 	queryFilter = cnstypes.CnsQueryFilter{
@@ -692,7 +692,7 @@ func TestMigratedExtendVolume(t *testing.T) {
 			RequiredBytes: 1024,
 		},
 	}
-	t.Log(fmt.Sprintf("ControllerExpandVolume will be called with req +%v", *reqExpand))
+	t.Logf("ControllerExpandVolume will be called with req +%v", *reqExpand)
 	_, err := ct.controller.ControllerExpandVolume(ctx, reqExpand)
 	if err != nil {
 		t.Logf("Expected error received. migrated volume with VMDK path can not be expanded")
@@ -781,20 +781,20 @@ func TestCompleteControllerFlow(t *testing.T) {
 		VolumeCapability: capabilities[0],
 		Readonly:         false,
 	}
-	t.Log(fmt.Sprintf("ControllerPublishVolume will be called with req +%v", *reqControllerPublishVolume))
+	t.Logf("ControllerPublishVolume will be called with req +%v", *reqControllerPublishVolume)
 	respControllerPublishVolume, err := ct.controller.ControllerPublishVolume(ctx, reqControllerPublishVolume)
 	if err != nil {
 		t.Fatal(err)
 	}
 	diskUUID := respControllerPublishVolume.PublishContext[common.AttributeFirstClassDiskUUID]
-	t.Log(fmt.Sprintf("ControllerPublishVolume succeed, diskUUID %s is returned", diskUUID))
+	t.Logf("ControllerPublishVolume succeed, diskUUID %s is returned", diskUUID)
 
 	// Detach.
 	reqControllerUnpublishVolume := &csi.ControllerUnpublishVolumeRequest{
 		VolumeId: volID,
 		NodeId:   NodeID,
 	}
-	t.Log(fmt.Sprintf("ControllerUnpublishVolume will be called with req +%v", *reqControllerUnpublishVolume))
+	t.Logf("ControllerUnpublishVolume will be called with req +%v", *reqControllerUnpublishVolume)
 	_, err = ct.controller.ControllerUnpublishVolume(ctx, reqControllerUnpublishVolume)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Replace `go get` with `go install` to install `staticcheck`.
- Replace usage of `honnef.co/go/tools/cmd/staticcheck@v0.2.0` with `honnef.co/go/tools/cmd/staticcheck@master` which seems compatible with latest go. Refer to https://github.com/dominikh/go-tools/issues/1200#issuecomment-1068846403  
- fixd staticcheck failures for `S1038` reported by newer version of staticcheck in `pkg/csi/service/vanilla/controller_test.go`


**Testing done**:
```
 % make staticcheck                                                
hack/check-staticcheck.sh
```

**Special notes for your reviewer**:
I am trying to fix issue with `pull-vsphere-csi-driver-verify-staticcheck` - https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_vsphere-csi-driver/1558/pull-vsphere-csi-driver-verify-staticcheck/1506606438208770048/build-log.txt

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
use go install in place of deprecated go get
```
