### PR TITLE
Stretched tests PART 8

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -36,6 +36,7 @@ const (
 	crdCNSNodeVMAttachment                     = "cnsnodevmattachments"
 	crdCNSVolumeMetadatas                      = "cnsvolumemetadatas"
 	crdCNSFileAccessConfig                     = "cnsfileaccessconfigs"
+	crdtriggercsifullsyncsName                 = "csifullsync"
 	crdGroup                                   = "cns.vmware.com"
 	crdVersion                                 = "v1alpha1"
 	csiSystemNamespace                         = "vmware-system-csi"
@@ -95,6 +96,7 @@ const (
 	ext4FSType                                = "ext4"
 	fcdName                                   = "BasicStaticFCD"
 	fileSizeInMb                              = int64(2048)
+	fullSyncFss                               = "trigger-csi-fullsync"
 	healthGreen                               = "green"
 	healthRed                                 = "red"
 	healthStatusAccessible                    = "accessible"

--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -44,6 +44,8 @@ import (
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
 
 var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", func() {
@@ -51,22 +53,23 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 	const defaultVolumeOpsScale = 30
 	const operationStormScale = 50
 	var (
-		client                 clientset.Interface
-		namespace              string
-		nodeList               *v1.NodeList
-		storagePolicyName      string
-		scParameters           map[string]string
-		storageClassName       string
-		csiNs                  string
-		fullSyncWaitTime       int
-		volumeOpsScale         int
-		storageThickPolicyName string
-		labelKey               string
-		labelValue             string
-		sshClientConfig        *ssh.ClientConfig
-		pandoraSyncWaitTime    int
-		defaultDatacenter      *object.Datacenter
-		defaultDatastore       *object.Datastore
+		client                     clientset.Interface
+		namespace                  string
+		nodeList                   *v1.NodeList
+		storagePolicyName          string
+		scParameters               map[string]string
+		storageClassName           string
+		csiNs                      string
+		fullSyncWaitTime           int
+		volumeOpsScale             int
+		storageThickPolicyName     string
+		labelKey                   string
+		labelValue                 string
+		sshClientConfig            *ssh.ClientConfig
+		pandoraSyncWaitTime        int
+		defaultDatacenter          *object.Datacenter
+		defaultDatastore           *object.Datastore
+		isVsanHealthServiceStopped bool
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -80,6 +83,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		readVcEsxIpsViaTestbedInfoJson(GetAndExpectStringEnvVar(envTestbedInfoJsonPath))
 
 		csiNs = GetAndExpectStringEnvVar(envCSINamespace)
+		isVsanHealthServiceStopped = false
 
 		initialiseFdsVar(ctx)
 		err = waitForAllNodes2BeReady(ctx, client)
@@ -167,6 +171,14 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		}
 		err = client.StorageV1().StorageClasses().Delete(ctx, storageClassName, *metav1.NewDeleteOptions(0))
 		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		if isVsanHealthServiceStopped {
+			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+			ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
+			err := invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 	})
@@ -3289,5 +3301,676 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		// wait for the VMs to move back
 		err = waitForAllNodes2BeReady(ctx, client)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/*
+			Site failover during full sync
+			Steps:
+			1.  Configure a vanilla multi-master K8s cluster with inter and intra site replication
+			2.	Create 6 PVCs with reclaim policy Delete and 8 with reclaim policy Retain
+				and wait for them to be bound
+			3.	Delete four PVCs with reclaim policy Retain
+			4.	Delete two PVs reclaim policy Retain related to PVC used in step 3
+			5.	Create two pods using PVCs with reclaim policy Delete
+			6.	Bring vsan-health service down
+			7.	Create two pods with two PVCs each
+			8.	Create two static PVs with disk left after step 4
+			9.	Create two PVCs to bind to PVs with reclaim policy Retain
+			10. Delete four PVCs with reclaim policy Retain different from the ones used in step 3 and 9
+			11. Delete two PVs reclaim policy Retain related to PVC used in step 10
+			12. Add labels to all PVs, PVCs
+			13. Bring vsan-health service up when full sync is triggered
+			14. Bring down primary site
+			15. Verify that the VMs on the primary site are started up on the other esx servers
+		        in the secondary site
+			16. Wait for full sync
+			17. Verify CNS entries
+			18. Delete all pods, PVCs and PVs
+			19. Bring primary site up and wait for testbed to be back to normal
+
+	*/
+	ginkgo.It("[primary-centric][distributed] Primary site failover during full sync when syncer"+
+		" pod leader is in primary site", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass")
+		// decide which test setup is available to run
+		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+		scParameters = map[string]string{}
+		scParameters["StoragePolicyName"] = storagePolicyName
+		storageClassName = "nginx-sc-delete"
+		var pods []*v1.Pod
+		var pvclaimsWithDelete, pvclaimsWithRetain []*v1.PersistentVolumeClaim
+		var volHandles []string
+
+		framework.Logf("Ensuring %s leader is in primary site", syncerContainerName)
+		err := changeLeaderOfContainerToComeUpOnMaster(ctx, client, sshClientConfig, syncerContainerName, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		scRetain, err := createStorageClass(client, scParameters, nil, v1.PersistentVolumeReclaimRetain, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		scDelete, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, scRetain.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = client.StorageV1().StorageClasses().Delete(ctx, scDelete.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		for i := 0; i < 6; i++ {
+			framework.Logf("Creating pvc %v with reclaim policy Delete", i)
+			pvc, err := createPVC(client, namespace, nil, diskSize, scDelete, "")
+			pvclaimsWithDelete = append(pvclaimsWithDelete, pvc)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		for i := 0; i < 8; i++ {
+			framework.Logf("Creating pvc %v with reclaim policy Retain", i)
+			pvc, err := createPVC(client, namespace, nil, diskSize, scRetain, "")
+			pvclaimsWithRetain = append(pvclaimsWithRetain, pvc)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		persistentvolumesRetain, err := fpv.WaitForPVClaimBoundPhase(client, pvclaimsWithRetain,
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for i := 0; i < 8; i++ {
+			volHandle := persistentvolumesRetain[i].Spec.CSI.VolumeHandle
+			gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		}
+
+		persistentvolumesDelete, err := fpv.WaitForPVClaimBoundPhase(client, pvclaimsWithDelete,
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for i := 0; i < 6; i++ {
+			volHandle := persistentvolumesDelete[i].Spec.CSI.VolumeHandle
+			gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		}
+
+		defer func() {
+			for _, claim := range pvclaimsWithDelete {
+				err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			for _, claim := range pvclaimsWithRetain {
+				err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			for _, pv := range persistentvolumesDelete {
+				err := fpv.WaitForPersistentVolumeDeleted(client, pv.Name, framework.Poll,
+					framework.PodDeleteTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volumeHandle := pv.Spec.CSI.VolumeHandle
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			for _, pv := range persistentvolumesRetain {
+				err = fpv.DeletePersistentVolume(client, pv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err := fpv.WaitForPersistentVolumeDeleted(client, pv.Name, framework.Poll,
+					framework.PodDeleteTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volumeHandle := pv.Spec.CSI.VolumeHandle
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		for i := 0; i < 4; i++ {
+			if i == 0 || i == 1 {
+				pv := getPvFromClaim(client, namespace, pvclaimsWithRetain[i].Name)
+				framework.Logf("Deleting pvc %v with reclaim policy Retain", pvclaimsWithRetain[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(client, pvclaimsWithRetain[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				framework.Logf("Deleting pv %s from pvc: %s", pv.Name, pvclaimsWithRetain[i].Name)
+				volHandle := pv.Spec.CSI.VolumeHandle
+				volHandles = append(volHandles, volHandle)
+				err = fpv.DeletePersistentVolume(client, pv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			} else {
+				framework.Logf("Deleting pvc %v with reclaim policy Retain", pvclaimsWithRetain[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(client, pvclaimsWithRetain[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		for i := 0; i < 2; i++ {
+			pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaimsWithDelete[i]}, false, execCommand)
+			framework.Logf("Created pod %s", pod.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pods = append(pods, pod)
+		}
+		framework.Logf("Stopping vsan-health on the vCenter host")
+		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcStoppedMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isVsanHealthServiceStopped = true
+
+		for i := 2; i < 4; i++ {
+			pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaimsWithDelete[i]}, false, execCommand)
+			framework.Logf("Created pod %s", pod.Name)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			pods = append(pods, pod)
+		}
+
+		// Creating label for PV.
+		// PVC will use this label as Selector to find PV
+		staticPVLabels := make(map[string]string)
+		var staticPvcs []*v1.PersistentVolumeClaim
+		var staticPvs []*v1.PersistentVolume
+		for i := 0; i < 2; i++ {
+			staticPVLabels["fcd-id"] = volHandles[i]
+
+			ginkgo.By("Creating static PV")
+			pv := getPersistentVolumeSpec(volHandles[i], v1.PersistentVolumeReclaimDelete, staticPVLabels)
+			pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			staticPvs = append(staticPvs, pv)
+
+			ginkgo.By("Creating PVC from static PV")
+			pvc := getPersistentVolumeClaimSpec(namespace, staticPVLabels, pv.Name)
+			pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			staticPvcs = append(staticPvcs, pvc)
+
+			framework.ExpectNoError(fpv.WaitOnPVandPVC(client, framework.NewTimeoutContextWithDefaults(), namespace, pv, pvc))
+
+		}
+
+		defer func() {
+			ginkgo.By("Deleting static pvcs and pvs")
+			for _, pvc := range staticPvcs {
+				err := fpv.DeletePersistentVolumeClaim(client, pvc.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			for _, pv := range staticPvs {
+				err := fpv.DeletePersistentVolume(client, pv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+					pollTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volumeHandle := pv.Spec.CSI.VolumeHandle
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+
+		}()
+
+		for i := 4; i < 8; i++ {
+			if i == 4 || i == 5 {
+				pv := getPvFromClaim(client, namespace, pvclaimsWithRetain[i].Name)
+				framework.Logf("Deleting pvc %v with reclaim policy Retain", pvclaimsWithRetain[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(client, pvclaimsWithRetain[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fpv.DeletePersistentVolume(client, pv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			} else {
+				framework.Logf("Deleting pvc %v with reclaim policy Retain", pvclaimsWithRetain[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(client, pvclaimsWithRetain[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		labels := make(map[string]string)
+		labels[labelKey] = labelValue
+
+		allPvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, pvc := range allPvcs.Items {
+			framework.Logf("Updating labels %+v for pvc %s in namespace %s",
+				labels, pvc.Name, namespace)
+			pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pvc.Labels = labels
+			_, err = client.CoreV1().PersistentVolumeClaims(namespace).Update(ctx, pvc, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				"Error on updating pvc labels is: %v", err)
+		}
+
+		allPvs, err := client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, pv := range allPvs.Items {
+			framework.Logf("Updating labels %+v for pv %s in namespace %s",
+				labels, pv.Name, namespace)
+			pv, err := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pv.Labels = labels
+			_, err = client.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				"Error on updating pv labels is: %v", err)
+		}
+
+		framework.Logf("Starting vsan-health on the vCenter host")
+		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+		err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isVsanHealthServiceStopped = false
+
+		framework.Logf("Sleeping full-sync interval for vsan health service " +
+			"to be fully up")
+		time.Sleep(time.Duration(60) * time.Second)
+
+		csipods, err := client.CoreV1().Pods(csiSystemNamespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Get restConfig.
+		restConfig := getRestConfigClient()
+		cnsOperatorClient, err := k8s.NewClientForGroup(ctx, restConfig, cnsoperatorv1alpha1.GroupName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		enableFullSyncTriggerFss(ctx, client, csiSystemNamespace, fullSyncFss)
+		ginkgo.By("Bring down the primary site while full sync is going on")
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go triggerFullSyncInParallel(ctx, client, cnsOperatorClient, &wg)
+		go siteFailureInParallel(true, &wg)
+		wg.Wait()
+
+		defer func() {
+			ginkgo.By("Bring up the primary site before terminating the test")
+			if len(fds.hostsDown) > 0 {
+				siteRestore(true)
+				fds.hostsDown = []string{}
+			}
+		}()
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Check if csi pods are running fine after site failure
+		err = fpod.WaitForPodsRunningReady(client, csiNs, int32(csipods.Size()), 0, pollTimeout, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Trigger 2 full syncs as full sync might be interrupted during site failover")
+		triggerFullSync(ctx, client, cnsOperatorClient)
+
+		ginkgo.By("Checking whether pods are in Running state")
+		for _, pod := range pods {
+			framework.Logf("Pod is %s", pod.Name)
+			err = fpod.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		for _, pvc := range allPvcs.Items {
+			ginkgo.By(fmt.Sprintf("Verifying labels %+v are updated for pvc %s in namespace %s",
+				labels, pvc.Name, namespace))
+			pv := getPvFromClaim(client, namespace, pvc.Name)
+			err = e2eVSphere.verifyLabelsAreUpdated(pv.Spec.CSI.VolumeHandle, labels,
+				string(cnstypes.CnsKubernetesEntityTypePVC), pvc.Name, pvc.Namespace, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		for _, pv := range allPvs.Items {
+			ginkgo.By(fmt.Sprintf("Verifying labels %+v are updated for pv %s",
+				labels, pv.Name))
+			err = e2eVSphere.verifyLabelsAreUpdated(pv.Spec.CSI.VolumeHandle, labels,
+				string(cnstypes.CnsKubernetesEntityTypePV), pv.Name, pv.Namespace, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		// Deleting all the pods in the namespace
+		for _, pod := range pods {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By("Bring up the primary site")
+		if len(fds.hostsDown) > 0 {
+			siteRestore(true)
+			fds.hostsDown = []string{}
+		}
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		// wait for the VMs to move back
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	})
+
+	/*
+		Secondary site failover during full sync when syncer pod leader is in secondary site
+		Steps:
+		1.  Configure a vanilla multi-master K8s cluster with inter and intra site replication
+		2.	Ensure syncer leader is in secondary site
+		3.	Create 6 PVCs with reclaim policy Delete and 8 with reclaim policy Retain
+			and wait for them to be bound
+		4.	Delete four PVCs with reclaim policy Retain
+		5.	Delete two PVs reclaim policy Retain related to PVC used in step 3
+		6.	Create two pods using PVCs with reclaim policy Delete
+		7.	Bring vsan-health service down
+		8.	Create two pods with two PVCs each
+		9.	Create two static PVs with disk left after step 4
+		10.	Create two PVCs to bind to PVs with reclaim policy Retain
+		11. Delete four PVCs with reclaim policy Retain different from the ones used in step 3 and 9
+		12. Delete two PVs reclaim policy Retain related to PVC used in step 10
+		13. Add labels to all PVs, PVCs
+		14. Bring vsan-health service up when full sync is triggered
+		15. Bring down secondary site
+		16. Verify that the VMs on the secondary site are started up on the other esx servers
+			in the primary site
+		17. Wait for full sync
+		18. Verify CNS entries
+		19. Delete all pods, PVCs and PVs
+		19. Bring secondary site up and wait for testbed to be back to normal
+
+	*/
+	ginkgo.It("[distributed] Secondary site failover during full sync when syncer"+
+		" pod leader is in secondary site", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass")
+		// decide which test setup is available to run
+		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+		scParameters = map[string]string{}
+		scParameters["StoragePolicyName"] = storagePolicyName
+		storageClassName = "nginx-sc-delete"
+		var pods []*v1.Pod
+		var pvclaimsWithDelete, pvclaimsWithRetain []*v1.PersistentVolumeClaim
+		var volHandles []string
+
+		framework.Logf("Ensuring %s leader is in secondary site", syncerContainerName)
+		err := changeLeaderOfContainerToComeUpOnMaster(ctx, client, sshClientConfig, syncerContainerName, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		scRetain, err := createStorageClass(client, scParameters, nil, v1.PersistentVolumeReclaimRetain, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		scDelete, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, scRetain.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = client.StorageV1().StorageClasses().Delete(ctx, scDelete.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		for i := 0; i < 6; i++ {
+			framework.Logf("Creating pvc %v with reclaim policy Delete", i)
+			pvc, err := createPVC(client, namespace, nil, diskSize, scDelete, "")
+			pvclaimsWithDelete = append(pvclaimsWithDelete, pvc)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		for i := 0; i < 8; i++ {
+			framework.Logf("Creating pvc %v with reclaim policy Retain", i)
+			pvc, err := createPVC(client, namespace, nil, diskSize, scRetain, "")
+			pvclaimsWithRetain = append(pvclaimsWithRetain, pvc)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		persistentvolumesRetain, err := fpv.WaitForPVClaimBoundPhase(client, pvclaimsWithRetain,
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for i := 0; i < 8; i++ {
+			volHandle := persistentvolumesRetain[i].Spec.CSI.VolumeHandle
+			gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		}
+
+		persistentvolumesDelete, err := fpv.WaitForPVClaimBoundPhase(client, pvclaimsWithDelete,
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for i := 0; i < 6; i++ {
+			volHandle := persistentvolumesDelete[i].Spec.CSI.VolumeHandle
+			gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		}
+
+		defer func() {
+			for _, claim := range pvclaimsWithDelete {
+				err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			for _, claim := range pvclaimsWithRetain {
+				err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			for _, pv := range persistentvolumesDelete {
+				err := fpv.WaitForPersistentVolumeDeleted(client, pv.Name, framework.Poll,
+					framework.PodDeleteTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volumeHandle := pv.Spec.CSI.VolumeHandle
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			for _, pv := range persistentvolumesRetain {
+				err = fpv.DeletePersistentVolume(client, pv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err := fpv.WaitForPersistentVolumeDeleted(client, pv.Name, framework.Poll,
+					framework.PodDeleteTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volumeHandle := pv.Spec.CSI.VolumeHandle
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		for i := 0; i < 4; i++ {
+			if i == 0 || i == 1 {
+				pv := getPvFromClaim(client, namespace, pvclaimsWithRetain[i].Name)
+				framework.Logf("Deleting pvc %v with reclaim policy Retain", pvclaimsWithRetain[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(client, pvclaimsWithRetain[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				framework.Logf("Deleting pv %s from pvc: %s", pv.Name, pvclaimsWithRetain[i].Name)
+				volHandle := pv.Spec.CSI.VolumeHandle
+				volHandles = append(volHandles, volHandle)
+				err = fpv.DeletePersistentVolume(client, pv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			} else {
+				framework.Logf("Deleting pvc %v with reclaim policy Retain", pvclaimsWithRetain[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(client, pvclaimsWithRetain[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		for i := 0; i < 2; i++ {
+			pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaimsWithDelete[i]}, false, execCommand)
+			framework.Logf("Created pod %s", pod.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pods = append(pods, pod)
+		}
+		framework.Logf("Stopping vsan-health on the vCenter host")
+		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcStoppedMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isVsanHealthServiceStopped = true
+
+		for i := 2; i < 4; i++ {
+			pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaimsWithDelete[i]}, false, execCommand)
+			framework.Logf("Created pod %s", pod.Name)
+			pods = append(pods, pod)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		}
+
+		// Creating label for PV.
+		// PVC will use this label as Selector to find PV
+		staticPVLabels := make(map[string]string)
+		var staticPvcs []*v1.PersistentVolumeClaim
+		var staticPvs []*v1.PersistentVolume
+
+		for i := 0; i < 2; i++ {
+			staticPVLabels["fcd-id"] = volHandles[i]
+
+			ginkgo.By("Creating static PV")
+			pv := getPersistentVolumeSpec(volHandles[i], v1.PersistentVolumeReclaimDelete, staticPVLabels)
+			pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			staticPvs = append(staticPvs, pv)
+
+			ginkgo.By("Creating PVC from static PV")
+			pvc := getPersistentVolumeClaimSpec(namespace, staticPVLabels, pv.Name)
+			pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			staticPvcs = append(staticPvcs, pvc)
+
+			framework.ExpectNoError(fpv.WaitOnPVandPVC(client, framework.NewTimeoutContextWithDefaults(), namespace, pv, pvc))
+
+		}
+
+		defer func() {
+			ginkgo.By("Deleting static pvcs and pvs")
+			for _, pvc := range staticPvcs {
+				err := fpv.DeletePersistentVolumeClaim(client, pvc.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			for _, pv := range staticPvs {
+				err := fpv.DeletePersistentVolume(client, pv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+					pollTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volumeHandle := pv.Spec.CSI.VolumeHandle
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+
+		}()
+
+		for i := 4; i < 8; i++ {
+			if i == 4 || i == 5 {
+				pv := getPvFromClaim(client, namespace, pvclaimsWithRetain[i].Name)
+				framework.Logf("Deleting pvc %v with reclaim policy Retain", pvclaimsWithRetain[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(client, pvclaimsWithRetain[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fpv.DeletePersistentVolume(client, pv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			} else {
+				framework.Logf("Deleting pvc %v with reclaim policy Retain", pvclaimsWithRetain[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(client, pvclaimsWithRetain[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		labels := make(map[string]string)
+		labels[labelKey] = labelValue
+
+		allPvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, pvc := range allPvcs.Items {
+			framework.Logf("Updating labels %+v for pvc %s in namespace %s",
+				labels, pvc.Name, namespace)
+			pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pvc.Labels = labels
+			_, err = client.CoreV1().PersistentVolumeClaims(namespace).Update(ctx, pvc, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				"Error on updating pvc labels is: %v", err)
+		}
+
+		allPvs, err := client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, pv := range allPvs.Items {
+			framework.Logf("Updating labels %+v for pv %s in namespace %s",
+				labels, pv.Name, namespace)
+			pv, err := client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pv.Labels = labels
+			_, err = client.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				"Error on updating pv labels is: %v", err)
+		}
+
+		framework.Logf("Starting vsan-health on the vCenter host")
+		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+		err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isVsanHealthServiceStopped = false
+
+		framework.Logf("Sleeping full-sync interval for vsan health service " +
+			"to be fully up")
+		time.Sleep(time.Duration(60) * time.Second)
+
+		csipods, err := client.CoreV1().Pods(csiSystemNamespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Get restConfig.
+		restConfig := getRestConfigClient()
+		cnsOperatorClient, err := k8s.NewClientForGroup(ctx, restConfig, cnsoperatorv1alpha1.GroupName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		enableFullSyncTriggerFss(ctx, client, csiSystemNamespace, fullSyncFss)
+		ginkgo.By("Bring down the secondary site while full sync is going on")
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go triggerFullSyncInParallel(ctx, client, cnsOperatorClient, &wg)
+		go siteFailureInParallel(false, &wg)
+		wg.Wait()
+
+		defer func() {
+			ginkgo.By("Bring up the secondary site before terminating the test")
+			if len(fds.hostsDown) > 0 {
+				siteRestore(false)
+				fds.hostsDown = nil
+			}
+		}()
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		wait4AllK8sNodesToBeUp(ctx, client, nodeList)
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Check if csi pods are running fine after site failure
+		err = fpod.WaitForPodsRunningReady(client, csiNs, int32(csipods.Size()), 0, pollTimeout, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Trigger 2 full syncs as full sync might be interrupted during site failover")
+		triggerFullSync(ctx, client, cnsOperatorClient)
+
+		ginkgo.By("Checking whether pods are in Running state")
+		for _, pod := range pods {
+			framework.Logf("Pod is %s", pod.Name)
+			err = waitForPodsToBeInErrorOrRunning(client, pod.Name, namespace, pollTimeout*4)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		for _, pvc := range allPvcs.Items {
+			ginkgo.By(fmt.Sprintf("Verifying labels %+v are updated for pvc %s in namespace %s",
+				labels, pvc.Name, namespace))
+			pv := getPvFromClaim(client, namespace, pvc.Name)
+			err = e2eVSphere.verifyLabelsAreUpdated(pv.Spec.CSI.VolumeHandle, labels,
+				string(cnstypes.CnsKubernetesEntityTypePVC), pvc.Name, pvc.Namespace, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}
+
+		for _, pv := range allPvs.Items {
+			ginkgo.By(fmt.Sprintf("Verifying labels %+v are updated for pv %s",
+				labels, pv.Name))
+			err = e2eVSphere.verifyLabelsAreUpdated(pv.Spec.CSI.VolumeHandle, labels,
+				string(cnstypes.CnsKubernetesEntityTypePV), pv.Name, pv.Namespace, true)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}
+
+		// Deleting all pods in namespace
+		for _, pod := range pods {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By("Bring up the secondary site")
+		if len(fds.hostsDown) > 0 {
+			siteRestore(false)
+			fds.hostsDown = []string{}
+		}
+
+		ginkgo.By("Wait for k8s cluster to be healthy")
+		// wait for the VMs to move back
+		err = waitForAllNodes2BeReady(ctx, client, pollTimeout*4)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 	})
 })

--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -36,6 +36,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgtypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -44,6 +45,8 @@ import (
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	triggercsifullsyncv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1"
 )
 
 type FaultDomains struct {
@@ -912,4 +915,74 @@ func createStaticPvAndPvcInParallel(client clientset.Interface, ctx context.Cont
 		ch <- pvc
 
 	}
+}
+
+// triggerFullSyncInParallel triggers full sync on demand in parallel. Here, we are
+// ignoring full sync failures due to site failover/failback. Hence, we are not
+// using triggerFullSync() here
+func triggerFullSyncInParallel(ctx context.Context, client clientset.Interface,
+	cnsOperatorClient client.Client, wg *sync.WaitGroup) {
+	defer wg.Done()
+	err := waitForFullSyncToFinish(client, ctx, cnsOperatorClient)
+	if err != nil {
+		framework.Logf("Full sync did not finish in given time, ignoring this error: %v", err)
+	}
+
+	crd := getTriggerFullSyncCrd(ctx, client, cnsOperatorClient)
+	framework.Logf("INFO: full sync crd details: %v", crd)
+	updateTriggerFullSyncCrd(ctx, cnsOperatorClient, *crd)
+	err = waitForFullSyncToFinish(client, ctx, cnsOperatorClient)
+	if err != nil {
+		framework.Logf("Full sync did not finish in given time, ignoring this error: %v", err)
+	}
+	crd = getTriggerFullSyncCrd(ctx, client, cnsOperatorClient)
+	framework.Logf("INFO: full sync crd details: %v", crd)
+	updateTriggerFullSyncCrd(ctx, cnsOperatorClient, *crd)
+	err = waitForFullSyncToFinish(client, ctx, cnsOperatorClient)
+	if err != nil {
+		framework.Logf("Full sync did not finish in given time, ignoring this error: %v", err)
+	}
+}
+
+// getTriggerFullSyncCrd fetches full sync crd from the list of crds in k8s cluster
+func getTriggerFullSyncCrd(ctx context.Context, client clientset.Interface,
+	cnsOperatorClient client.Client) *triggercsifullsyncv1alpha1.TriggerCsiFullSync {
+	fullSyncCrd := &triggercsifullsyncv1alpha1.TriggerCsiFullSync{}
+	err := cnsOperatorClient.Get(ctx,
+		pkgtypes.NamespacedName{Name: crdtriggercsifullsyncsName}, fullSyncCrd)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(fullSyncCrd).NotTo(gomega.BeNil(), "couldn't find full sync crd: %s", crdtriggercsifullsyncsName)
+	return fullSyncCrd
+}
+
+// updateTriggerFullSyncCrd triggers full sync by updating TriggerSyncID
+// value to  LastTriggerSyncID +1 in full sync crd
+func updateTriggerFullSyncCrd(ctx context.Context, cnsOperatorClient client.Client,
+	crd triggercsifullsyncv1alpha1.TriggerCsiFullSync) {
+	framework.Logf("instance is %v before update", crd)
+	lastSyncId := crd.Status.LastTriggerSyncID
+	triggerSyncID := lastSyncId + 1
+	crd.Spec.TriggerSyncID = triggerSyncID
+	err := cnsOperatorClient.Update(ctx, &crd)
+	framework.Logf("Error is %v", err)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	framework.Logf("instance is %v after update", crd)
+}
+
+// waitForFullSyncToFinish waits for a given full sync to finish by checking
+// InProgress field in trigger full sync crd
+func waitForFullSyncToFinish(client clientset.Interface, ctx context.Context,
+	cnsOperatorClient client.Client) error {
+	waitErr := wait.PollImmediate(poll, pollTimeoutShort, func() (bool, error) {
+		crd := getTriggerFullSyncCrd(ctx, client, cnsOperatorClient)
+		framework.Logf("crd is: %v", crd)
+		if !crd.Status.InProgress {
+			return true, nil
+		}
+		if crd.Status.Error != "" {
+			return false, fmt.Errorf("full sync failed with error: %s", crd.Status.Error)
+		}
+		return false, nil
+	})
+	return waitErr
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Full sync tests automation for vsan stretched cluster feature

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/8a0e4b795f446d7f051cb68ea7c2b29e
**Special notes for your reviewer**: make check output
```
(base) kai@kai-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.1
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/kai/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/provider sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/stretched-part8/vsphere-csi-driver /Users/kai/CSI/stretched-part8 /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|files|name|deps|exports_file|imports|types_sizes) took 1.652440339s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 105.716442ms 
INFO [linters context/goanalysis] analyzers took 9.741809656s with top 10 stages: buildir: 608.658415ms, S1038: 594.997902ms, misspell: 483.923669ms, S1039: 313.208679ms, SA1012: 270.130113ms, unused: 258.100455ms, S1028: 228.300947ms, S1024: 221.17047ms, S1019: 209.700174ms, directives: 203.148842ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude: 24/24, path_prettifier: 113/113, skip_files: 113/113, skip_dirs: 113/113, nolint: 0/1, cgo: 113/113, filename_unadjuster: 113/113, autogenerated_exclude: 24/113, identifier_marker: 24/24, exclude-rules: 1/24 
INFO [runner] processing took 15.21348ms with stages: nolint: 12.735323ms, autogenerated_exclude: 1.291152ms, path_prettifier: 618.57µs, identifier_marker: 293.625µs, skip_dirs: 143.534µs, exclude-rules: 109.196µs, cgo: 10.41µs, filename_unadjuster: 7.939µs, max_same_issues: 860ns, uniq_by_line: 513ns, max_from_linter: 329ns, diff: 309ns, source_code: 272ns, skip_files: 268ns, exclude: 231ns, max_per_file_from_linter: 227ns, severity-rules: 220ns, sort_results: 173ns, path_prefixer: 171ns, path_shortener: 158ns 
INFO [runner] linters took 5.574445696s with stages: goanalysis_metalinter: 5.559151931s 
INFO File cache stats: 93 entries of total size 2.8MiB 
INFO Memory: 75 samples, avg is 250.0MB, max is 617.3MB 
INFO Execution took 7.34409666s                   
(base) kai@kai-a01 vsphere-csi-driver % 
``` 
