### PR TITLE
Topology testcases when invalid topology labels specified

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -75,7 +75,7 @@ const (
 	envSupervisorClusterNamespaceToDelete      = "SVC_NAMESPACE_TO_DELETE"
 	envTopologyWithOnlyOneNode                 = "TOPOLOGY_WITH_ONLY_ONE_NODE"
 	envTopologyWithInvalidTagInvalidCat        = "TOPOLOGY_WITH_INVALID_TAG_INVALID_CAT"
-	envTopologyWithInvalidTagvalidCat          = "TOPOLOGY_WITH_INVALID_TAG_VALID_CAT"
+	envTopologyWithInvalidTagValidCat          = "TOPOLOGY_WITH_INVALID_TAG_VALID_CAT"
 	envNumberOfGoRoutines                      = "NUMBER_OF_GO_ROUTINES"
 	envWorkerPerRoutine                        = "WORKER_PER_ROUTINE"
 	envVmdkDiskURL                             = "DISK_URL_PATH"

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -74,6 +74,8 @@ const (
 	envSupervisorClusterNamespace              = "SVC_NAMESPACE"
 	envSupervisorClusterNamespaceToDelete      = "SVC_NAMESPACE_TO_DELETE"
 	envTopologyWithOnlyOneNode                 = "TOPOLOGY_WITH_ONLY_ONE_NODE"
+	envTopologyWithInvalidTagInvalidCat        = "TOPOLOGY_WITH_INVALID_TAG_INVALID_CAT"
+	envTopologyWithInvalidTagvalidCat          = "TOPOLOGY_WITH_INVALID_TAG_VALID_CAT"
 	envNumberOfGoRoutines                      = "NUMBER_OF_GO_ROUTINES"
 	envWorkerPerRoutine                        = "WORKER_PER_ROUTINE"
 	envVmdkDiskURL                             = "DISK_URL_PATH"

--- a/tests/e2e/topology_add_node_with_different_labels.go
+++ b/tests/e2e/topology_add_node_with_different_labels.go
@@ -1,0 +1,173 @@
+/*
+	Copyright 2019 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+)
+
+var _ = ginkgo.Describe("[csi-topology-for-new-node] Topology-Provisioning-For-New-Node-With-Diff-Labels", func() {
+	f := framework.NewDefaultFramework("e2e-vsphere-topology-aware-provisioning")
+	var (
+		client            clientset.Interface
+		namespace         string
+		allowedTopologies []v1.TopologySelectorLabelRequirement
+		nodeList          *v1.NodeList
+		pvclaim           *v1.PersistentVolumeClaim
+		storageclass      *storagev1.StorageClass
+		err               error
+		regionZoneValue   string
+	)
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		bootstrap()
+		nodeList, err = fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+	})
+
+	/*
+		In the existing setup add a node with different tag and category and
+		create a SC by mentioning that tag
+
+		Steps
+		1. Create SC with the tag that is newly added on the existing node
+		2. Create PVC using the above created SC
+		3. Volume provisioning should fail since NodeVM does not belong to a label
+		from all the categories mentioned under `topology-categories`
+	*/
+
+	ginkgo.It("Verify volume provisioning when storage class created with different tag and category", func() {
+		var cancel context.CancelFunc
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		regionZoneValue = GetAndExpectStringEnvVar(envTopologyWithInvalidTagInvalidCat)
+		_, _, allowedTopologies = topologyParameterForStorageClass(regionZoneValue)
+		regionZone := strings.Split(regionZoneValue, ":")
+		topologyNonExistingRegionZone := regionZone[0] + ":" + regionZone[1]
+		_, _, allowedTopologies = topologyParameterForStorageClass(topologyNonExistingRegionZone)
+		storageclass, pvclaim, err = createPVCAndStorageClass(client,
+			namespace, nil, nil, "", allowedTopologies, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Expect claim to fail provisioning volume within the topology")
+		framework.ExpectError(fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound,
+			client, pvclaim.Namespace, pvclaim.Name, pollTimeoutShort, framework.PollShortTimeout))
+		// Get the event list and verify if it contains expected error message
+		eventList, _ := client.CoreV1().Events(pvclaim.Namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(eventList.Items).NotTo(gomega.BeEmpty())
+		actualErrMsg := eventList.Items[len(eventList.Items)-1].Message
+		framework.Logf(fmt.Sprintf("Actual failure message: %+q", actualErrMsg))
+		expectedErrMsg := "failed to get shared datastores for topology requirement"
+		framework.Logf(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
+		gomega.Expect(strings.Contains(actualErrMsg, expectedErrMsg)).To(gomega.BeTrue(),
+			fmt.Sprintf("actualErrMsg: %q does not contain expectedErrMsg: %q", actualErrMsg, expectedErrMsg))
+	})
+
+	/*
+		Add a new node with a different tag under a known category
+
+		Steps
+		1. To an existing set create a new node and add a new tag to a known category
+		2. Create SC which allows provisioning of volume on the specific node
+		3. Create PVC using the above SC
+		4. Wait for PVC and PV to bound
+		5. Describe on the PV and validate node affinity details
+		6. Create POD using above created PVC
+		7. Write some data on to POD
+		8. Delete POD, PVC,SC
+	*/
+
+	ginkgo.It("Verify volume provisioning when storage class created with different tag under a known category", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// nonSharedDataStoreUrl := GetAndExpectStringEnvVar(envInaccessibleZoneDatastoreURL)
+		// scParameters := make(map[string]string)
+		// scParameters[scParamDatastoreURL] = nonSharedDataStoreUrl
+		regionZoneValue = GetAndExpectStringEnvVar(envTopologyWithInvalidTagvalidCat)
+		regionZone := strings.Split(regionZoneValue, ":")
+		topologyInvalidTagValidCat := regionZone[0] + ":" + regionZone[1]
+		regionValues, zoneValues, allowedTopologies := topologyParameterForStorageClass(topologyInvalidTagValidCat)
+		storageclass, pvclaim, err = createPVCAndStorageClass(client,
+			namespace, nil, nil, "", allowedTopologies, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Expect claim to pass provisioning volume")
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, pollTimeoutShort)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
+
+		ginkgo.By("Verify if volume is provisioned in specified region")
+		pv := getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)
+		pvRegion, pvZone, err = verifyVolumeTopology(pv, zoneValues, regionValues)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Creating a pod")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Deleting the pod and wait for disk to detach")
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+
+		ginkgo.By("Verify Pod is scheduled on a node belonging to same topology as the PV it is attached to")
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+		err = verifyPodLocation(pod, nodeList, "", pvRegion)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+})

--- a/tests/e2e/topology_add_node_with_different_labels.go
+++ b/tests/e2e/topology_add_node_with_different_labels.go
@@ -117,15 +117,15 @@ var _ = ginkgo.Describe("[csi-topology-for-new-node] Topology-Provisioning-For-N
 	ginkgo.It("Verify volume provisioning when storage class created with different tag under a known category", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		// nonSharedDataStoreUrl := GetAndExpectStringEnvVar(envInaccessibleZoneDatastoreURL)
-		// scParameters := make(map[string]string)
-		// scParameters[scParamDatastoreURL] = nonSharedDataStoreUrl
+		StoragePolicyName := GetAndExpectStringEnvVar(envStoragePolicyNameForNonSharedDatastores)
+		scParameters := make(map[string]string)
+		scParameters[scParamStoragePolicyName] = StoragePolicyName
 		regionZoneValue = GetAndExpectStringEnvVar(envTopologyWithInvalidTagvalidCat)
 		regionZone := strings.Split(regionZoneValue, ":")
 		topologyInvalidTagValidCat := regionZone[0] + ":" + regionZone[1]
 		regionValues, zoneValues, allowedTopologies := topologyParameterForStorageClass(topologyInvalidTagValidCat)
 		storageclass, pvclaim, err = createPVCAndStorageClass(client,
-			namespace, nil, nil, "", allowedTopologies, "", false, "")
+			namespace, nil, scParameters, "", allowedTopologies, "", false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
@@ -166,7 +166,7 @@ var _ = ginkgo.Describe("[csi-topology-for-new-node] Topology-Provisioning-For-N
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
-		err = verifyPodLocation(pod, nodeList, "", pvRegion)
+		err = verifyPodLocation(pod, nodeList, pvZone, pvRegion)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Topology testcases when invalid topology labels specified

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Topology testcases when invalid topology labels specified

**Testing done**:
Yes
TC1: https://gist.githubusercontent.com/sipriyaa/5a3e471d9f0ac35152980cade9fdc09f/raw/1cca0ae21fb4d7142331586e07bfce55136934c6/gistfile1.txt

TC2: https://gist.githubusercontent.com/sipriyaa/34b81b43c634b9ce7bcef6221ad3d268/raw/57ca017148f20f6dd5d6a9e13531edd5fe601f47/gistfile1.txt

**Special notes for your reviewer**:
Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/topology-table2-worker-node/vsphere-csi-driver /Users/sipriya/topology-table2-worker-node /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (files|imports|name|types_sizes|compiled_files|deps|exports_file) took 9.359557772s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 89.379666ms 
INFO [linters context/goanalysis] analyzers took 28.836872397s with top 10 stages: buildir: 12.41503657s, misspell: 1.531587446s, S1038: 1.122815808s, unused: 676.462975ms, directives: 637.053775ms, lll: 607.961581ms, SA1012: 534.404266ms, S1039: 486.386663ms, printf: 426.974322ms, isgenerated: 410.463973ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): nolint: 0/1, cgo: 113/113, skip_dirs: 113/113, filename_unadjuster: 113/113, skip_files: 113/113, autogenerated_exclude: 24/113, exclude: 24/24, path_prettifier: 113/113, identifier_marker: 24/24, exclude-rules: 1/24 
INFO [runner] processing took 15.06392ms with stages: nolint: 12.792534ms, autogenerated_exclude: 1.280528ms, identifier_marker: 403.397µs, path_prettifier: 350.053µs, skip_dirs: 109.744µs, exclude-rules: 107.326µs, cgo: 8.596µs, filename_unadjuster: 6.314µs, max_same_issues: 1.107µs, uniq_by_line: 788ns, exclude: 712ns, source_code: 616ns, diff: 442ns, max_from_linter: 393ns, skip_files: 349ns, max_per_file_from_linter: 230ns, sort_results: 230ns, path_shortener: 224ns, severity-rules: 212ns, path_prefixer: 125ns 
INFO [runner] linters took 8.226579961s with stages: goanalysis_metalinter: 8.211425109s 
INFO File cache stats: 277 entries of total size 4.0MiB 
INFO Memory: 177 samples, avg is 291.7MB, max is 1155.3MB 
INFO Execution took 17.686540414s   