### PR TITLE
fail volume creation when zones labels not found in volume accessibilityRequirements on stretched supervisor cluster

### DIFF
--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -140,6 +140,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 
 		// CNS based CSI requires a valid cluster name.
 		config.Global.ClusterID = testClusterName
+		clusterComputeResourceMoIds = append(clusterComputeResourceMoIds, config.Global.ClusterID)
 		vcenterconfig, err := cnsvsphere.GetVirtualCenterConfig(ctx, config)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- This PR is enhancing the failure message to say we do not support volume creation on the stretched supervisor cluster (with more than 1 vSpher cluster) without having zone labels in the volume accessibility requirements.

- If the supervisor cluster is having only one vsphere cluster, we do support the creation of volume using clusterComputeResourceMoId we retrieved from the AvailabilityZone CRs or using cluster-moref set in`config.Global.ClusterID` 



**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fail volume creation when zones labels not found in volume accessibilityRequirements on stretched supervisor cluster
```
