### PR TITLE
fix fstype validation

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -79,6 +79,12 @@ const (
 	// Ext4FsType represents the default filesystem type for block volume.
 	Ext4FsType = "ext4"
 
+	// Ext3FsType represents the ext4 filesystem type for block volume.
+	Ext3FsType = "ext3"
+
+	// XFSType represents the xfs filesystem type for block volume.
+	XFSType = "xfs"
+
 	// NfsV4FsType represents nfs4 mount type.
 	NfsV4FsType = "nfs4"
 

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -83,7 +83,7 @@ func (driver *vsphereCSIDriver) NodeStageVolume(
 		// Mount Volume.
 		// Extract mount volume details.
 		log.Debug("NodeStageVolume: Volume detected as a mount volume")
-		params.FsType, params.MntFlags, err = driver.osUtils.EnsureMountVol(ctx, log, volCap)
+		params.FsType, params.MntFlags, err = driver.osUtils.EnsureMountVol(ctx, volCap)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/csi/service/osutils/windows_os_utils.go
+++ b/pkg/csi/service/osutils/windows_os_utils.go
@@ -333,22 +333,29 @@ func (osUtils *OsUtils) IsTargetInMounts(ctx context.Context, path string) (bool
 }
 
 // GetVolumeCapabilityFsType retrieves fstype from VolumeCapability.
-// Defaults to nfs4 for file volume and ntfs for block volume when empty string
-// is observed. This function also ignores default ext4 fstype supplied by
+// Defaults to ntfs for block volume when empty fstype is observed
+// This function also ignores default ext4 fstype supplied by
 // external-provisioner when none is specified in the StorageClass
-func (osUtils *OsUtils) GetVolumeCapabilityFsType(ctx context.Context, capability *csi.VolumeCapability) string {
+func (osUtils *OsUtils) GetVolumeCapabilityFsType(ctx context.Context,
+	capability *csi.VolumeCapability) (string, error) {
 	log := logger.GetLogger(ctx)
 	fsType := strings.ToLower(capability.GetMount().GetFsType())
-	log.Debugf("FsType received from Volume Capability: %q", fsType)
+	log.Infof("FsType received from Volume Capability: %q", fsType)
 	isFileVolume := common.IsFileVolumeRequest(ctx, []*csi.VolumeCapability{capability})
-	if isFileVolume && (fsType == "" || fsType == "ext4") {
-		log.Infof("empty string or ext4 fstype observed for file volume. Defaulting to: %s", common.NfsV4FsType)
-		fsType = common.NfsV4FsType
-	} else if !isFileVolume && fsType == "" {
-		log.Infof("empty string fstype observed for block volume. Defaulting to: %s", common.NTFSFsType)
-		fsType = common.NTFSFsType
+	if isFileVolume {
+		return "", logger.LogNewErrorCode(log, codes.FailedPrecondition,
+			"vSAN file service volume can not be mounted on windows node")
 	}
-	return fsType
+	if fsType == common.NTFSFsType {
+		return fsType, nil
+	} else if fsType == "" || fsType == "ext4" {
+		log.Infof("replacing fsType: %q received from volume "+
+			"capability with %q", fsType, common.NTFSFsType)
+		return common.NTFSFsType, nil
+	} else {
+		return "", logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+			"unsupported fsType %q observed", fsType)
+	}
 }
 
 // ResizeVolume resizes the volume


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR adds the following fstype validation
- For Windows Node
  - return failure if attempting to mount vSAN file service volume on windows node. Error message `vSAN file service volume can not be mounted on windows node`
  - return failure if unsupported fstype is observed while mounting volume on windoes node.

- For Linux Node
  - return failure if unsupported fstype is observed for vsan file share volume.
  - return failure if unsupported fstype (nfs, nfs4, ntfs) is observed for block volume.


**Testing done**:
In progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix fstype validation
```
