### PR TITLE
Remove namespace label from CsiControlOpsHistVec

### DIFF
--- a/pkg/common/prometheus/metrics.go
+++ b/pkg/common/prometheus/metrics.go
@@ -29,9 +29,6 @@ const (
 	// PrometheusUnknownVolumeType is used in situation when the volume type could not be found.
 	PrometheusUnknownVolumeType = "unknown"
 
-	// PrometheusUnknownNamespace is used when namespace isn't set by sidecars for a volume operation.
-	PrometheusUnknownNamespace = "unknown"
-
 	// CSI operation types
 
 	// PrometheusCreateVolumeOpType represents the CreateVolume operation.
@@ -118,7 +115,7 @@ var (
 		// Possible voltype - "unknown", "block", "file"
 		// Possible optype - "create-volume", "delete-volume", "attach-volume", "detach-volume", "expand-volume"
 		// Possible status - "pass", "fail"
-		[]string{"voltype", "optype", "status", "namespace", "faulttype"})
+		[]string{"voltype", "optype", "status", "faulttype"})
 
 	// CnsControlOpsHistVec is a histogram vector metric to observe various control
 	// operations on CNS. Note that this captures the time taken by CNS into a bucket

--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -25,11 +25,8 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	vim25types "github.com/vmware/govmomi/vim25/types"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
-
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 )
 
@@ -245,18 +242,6 @@ func IsOnlineExpansion(ctx context.Context, volumeID string, nodes []*cnsvsphere
 	}
 
 	return nil
-}
-
-// GetNamespaceFromContext returns the namespace set as grpc metadata in context by the sidecars.
-// Returns unknown if it's not set.
-func GetNamespaceFromContext(ctx context.Context) string {
-	var values []string
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		if values = md.Get("namespace"); len(values) > 0 {
-			return values[0]
-		}
-	}
-	return prometheus.PrometheusUnknownNamespace
 }
 
 // IsvSphere8AndAbove returns true if vSphere version if 8.0 and above

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -825,7 +825,6 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	volumeType := prometheus.PrometheusUnknownVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 	createVolumeInternal := func() (
 		*csi.CreateVolumeResponse, string, error) {
 		log.Infof("CreateVolume: called with args %+v", *req)
@@ -861,10 +860,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	log.Debugf("createVolumeInternal: returns fault %q", faultType)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -877,7 +876,6 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	log := logger.GetLogger(ctx)
 	volumeType := prometheus.PrometheusUnknownVolumeType
 	cnsVolumeType := common.UnknownVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 
 	deleteVolumeInternal := func() (
 		*csi.DeleteVolumeResponse, string, error) {
@@ -977,10 +975,10 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	log.Debugf("deleteVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -993,7 +991,6 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	volumeType := prometheus.PrometheusUnknownVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 
 	controllerPublishVolumeInternal := func() (
 		*csi.ControllerPublishVolumeResponse, string, error) {
@@ -1105,10 +1102,10 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	log.Debugf("controllerPublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1121,7 +1118,6 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	volumeType := prometheus.PrometheusUnknownVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 
 	controllerUnpublishVolumeInternal := func() (
 		*csi.ControllerUnpublishVolumeResponse, string, error) {
@@ -1222,10 +1218,10 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	log.Debugf("controllerUnpublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1238,7 +1234,6 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	volumeType := prometheus.PrometheusUnknownVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 	controllerExpandVolumeInternal := func() (
 		*csi.ControllerExpandVolumeResponse, string, error) {
 		log.Infof("ControllerExpandVolume: called with args %+v", *req)
@@ -1328,10 +1323,10 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	if err != nil {
 		log.Debugf("controllerExpandVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1437,7 +1432,6 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 			"VC version does not support snapshot operations")
 	}
 	volumeType := prometheus.PrometheusUnknownVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 	createSnapshotInternal := func() (*csi.CreateSnapshotResponse, error) {
 		// Validate CreateSnapshotRequest
 		if err := validateVanillaCreateSnapshotRequestRequest(ctx, req); err != nil {
@@ -1542,10 +1536,10 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 	resp, err := createSnapshotInternal()
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateSnapshotOpType,
-			prometheus.PrometheusFailStatus, namespace, "NotComputed").Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, "NotComputed").Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateSnapshotOpType,
-			prometheus.PrometheusPassStatus, namespace, "").Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1587,15 +1581,14 @@ func (c *controller) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshot
 	}
 
 	volumeType := prometheus.PrometheusBlockVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 	start := time.Now()
 	resp, err := deleteSnapshotInternal()
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteSnapshotOpType,
-			prometheus.PrometheusFailStatus, namespace, "NotComputed").Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, "NotComputed").Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteSnapshotOpType,
-			prometheus.PrometheusPassStatus, namespace, "").Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 
@@ -1607,7 +1600,6 @@ func (c *controller) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRe
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	volumeType := prometheus.PrometheusBlockVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 
 	isCnsSnapshotSupported, err := c.manager.VcenterManager.IsCnsSnapshotSupported(ctx,
 		c.manager.VcenterConfig.Host)
@@ -1652,10 +1644,10 @@ func (c *controller) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRe
 	resp, err := listSnapshotsInternal()
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusListSnapshotsOpType,
-			prometheus.PrometheusFailStatus, namespace, "NotComputed").Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, "NotComputed").Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusListSnapshotsOpType,
-			prometheus.PrometheusPassStatus, namespace, "").Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -713,19 +713,12 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	resp, faultType, err := createVolumeInternal()
 	log.Debugf("createVolumeInternal: returns fault %q", faultType)
 
-	namespace := common.GetNamespaceFromContext(ctx)
-	if namespace == prometheus.PrometheusUnknownNamespace {
-		log.Warnf("Namespace not set in context metadata. Setting it as unknown in Prometheus.")
-	} else {
-		log.Debugf("Namespace from context metadata: %s", namespace)
-	}
-
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -767,19 +760,12 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	resp, faultType, err := deleteVolumeInternal()
 	log.Debugf("deleteVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 
-	namespace := common.GetNamespaceFromContext(ctx)
-	if namespace == prometheus.PrometheusUnknownNamespace {
-		log.Warnf("Namespace not set in context metadata. Setting it as unknown in Prometheus.")
-	} else {
-		log.Debugf("Namespace from context metadata: %s", namespace)
-	}
-
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -913,19 +899,12 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	resp, faultType, err := controllerPublishVolumeInternal()
 	log.Debugf("controllerPublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 
-	namespace := common.GetNamespaceFromContext(ctx)
-	if namespace == prometheus.PrometheusUnknownNamespace {
-		log.Warnf("Namespace not set in context metadata. Setting it as unknown in Prometheus.")
-	} else {
-		log.Debugf("Namespace from context metadata: %s", namespace)
-	}
-
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -969,19 +948,12 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	resp, faultType, err := controllerUnpublishVolumeInternal()
 	log.Debugf("controllerUnpublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 
-	namespace := common.GetNamespaceFromContext(ctx)
-	if namespace == prometheus.PrometheusUnknownNamespace {
-		log.Warnf("Namespace not set in context metadata. Setting it as unknown in Prometheus.")
-	} else {
-		log.Debugf("Namespace from context metadata: %s", namespace)
-	}
-
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1133,19 +1105,12 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	resp, faultType, err := controllerExpandVolumeInternal()
 	log.Debugf("controllerExpandVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 
-	namespace := common.GetNamespaceFromContext(ctx)
-	if namespace == prometheus.PrometheusUnknownNamespace {
-		log.Warnf("Namespace not set in context metadata. Setting it as unknown in Prometheus.")
-	} else {
-		log.Debugf("Namespace from context metadata: %s", namespace)
-	}
-
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -230,7 +230,6 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	volumeType := prometheus.PrometheusUnknownVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 	createVolumeInternal := func() (
 		*csi.CreateVolumeResponse, string, error) {
 
@@ -379,10 +378,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	log.Debugf("createVolumeInternal: returns fault %q", faultType)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	log.Debugf("CreateVolume response: %+v", resp)
 	return resp, err
@@ -396,7 +395,6 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	volumeType := prometheus.PrometheusUnknownVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 
 	deleteVolumeInternal := func() (
 		*csi.DeleteVolumeResponse, string, error) {
@@ -452,10 +450,10 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	log.Debugf("deleteVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -468,7 +466,6 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	volumeType := prometheus.PrometheusUnknownVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 
 	controllerPublishVolumeInternal := func() (
 		*csi.ControllerPublishVolumeResponse, string, error) {
@@ -510,10 +507,10 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	if err != nil {
 		log.Debugf("controllerPublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusAttachVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -806,7 +803,6 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	volumeType := prometheus.PrometheusUnknownVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 
 	controllerUnpublishVolumeInternal := func() (
 		*csi.ControllerUnpublishVolumeResponse, string, error) {
@@ -855,10 +851,10 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	log.Debugf("controllerUnpublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDetachVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }
@@ -1090,7 +1086,6 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
 	volumeType := prometheus.PrometheusUnknownVolumeType
-	namespace := prometheus.PrometheusUnknownNamespace
 
 	controllerExpandVolumeInternal := func() (
 		*csi.ControllerExpandVolumeResponse, string, error) {
@@ -1202,10 +1197,10 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	log.Debugf("controllerExpandVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusFailStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, faultType).Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusExpandVolumeOpType,
-			prometheus.PrometheusPassStatus, namespace, faultType).Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -502,10 +502,10 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 		// When reconciler returns reconcile.Result{RequeueAfter: timeout}, the err will be set to nil,
 		// for this case, we need count it as an attach/detach failure
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, volumeOpType,
-			prometheus.PrometheusFailStatus, request.Namespace, "NotComputed").Observe(time.Since(start).Seconds())
+			prometheus.PrometheusFailStatus, "NotComputed").Observe(time.Since(start).Seconds())
 	} else {
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, volumeOpType,
-			prometheus.PrometheusPassStatus, request.Namespace, "").Observe(time.Since(start).Seconds())
+			prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
 	}
 	return resp, err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR reverts the changes introduced in #1389 for adding namespace in CsiControlOpsHistVec.
We have seen that having namespace label in metrics introduces a high cardinality and it doesn't scale well while pushing the metrics to an analytics engine (Wavefront, for instance).


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
1. Created a PVC with existing CSI driver image and observed it prints `namespace` in the metrics.
```
root@420d7643abb2183e43cc3f3e913e0178 [ ~/manifests ]# kubectl exec -it vsphere-csi-controller-fdcdd8755-jr7kw -n vmware-system-csi -c vsphere-csi-controller -- curl localhost:2112/metrics | grep vsphere_csi_volume_ops
# HELP vsphere_csi_volume_ops_histogram Histogram vector for CSI volume operations.
# TYPE vsphere_csi_volume_ops_histogram histogram
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="1"} 0
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="2"} 0
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="3"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="4"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="5"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="7"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="10"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="12"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="15"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="18"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="20"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="25"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="30"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="60"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="120"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="180"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="300"} 1
vsphere_csi_volume_ops_histogram_bucket{namespace="playground-ns",optype="create-volume",status="pass",voltype="block",le="+Inf"} 1
vsphere_csi_volume_ops_histogram_sum{namespace="playground-ns",optype="create-volume",status="pass",voltype="block"} 2.754985328
vsphere_csi_volume_ops_histogram_count{namespace="playground-ns",optype="create-volume",status="pass",voltype="block"} 1
```

2. Replaced the CSI driver image containing this change, and deleted the PVC.
Confirmed that the `namespace` label is removed from the metrics.
```
root@420d7643abb2183e43cc3f3e913e0178 [ ~/manifests ]# kubectl -n vmware-system-csi exec -it vsphere-csi-controller-7b75dc4cd9-hsjfc -c vsphere-csi-controller -- curl localhost:2112/metrics | grep vsphere_csi_volume_ops
# HELP vsphere_csi_volume_ops_histogram Histogram vector for CSI volume operations.
# TYPE vsphere_csi_volume_ops_histogram histogram
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="1"} 0
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="2"} 0
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="3"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="4"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="5"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="7"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="10"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="12"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="15"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="18"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="20"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="25"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="30"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="60"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="120"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="180"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="300"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="delete-volume",status="pass",voltype="unknown",le="+Inf"} 1
vsphere_csi_volume_ops_histogram_sum{faulttype="",optype="delete-volume",status="pass",voltype="unknown"} 2.771587096
vsphere_csi_volume_ops_histogram_count{faulttype="",optype="delete-volume",status="pass",voltype="unknown"} 1
```

**Special notes for your reviewer**:

**Release note**:
```
Remove namespace label from CsiControlOpsHistVec
```

E2E Test Results
-----------------
WCP:

```
Build ID: 440
WCP build status: FAILURE
Stage before exit: null
Jenkins E2E Test Results:
Ran 3 of 327 Specs in 4.979 seconds
FAIL! -- 0 Passed | 3 Failed | 0 Pending | 324 Skipped
--- FAIL: TestE2E (5.16s)
FAIL
```

The 3 tests failed are from volume health annotation suite, and not related to this change. They're failing while waiting for all hosts to be up before each test. Summarizing 3 failures:
```
[Fail] Volume health check [BeforeEach] [csi-supervisor] Verify health annotaiton is not added on the PV  
/home/worker/workspace/csi-wcp-pre-check-in/Results/440/vsphere-csi-driver/tests/e2e/util.go:3210

[Fail] Volume health check [BeforeEach] [csi-supervisor] [csi-guest] Verify health annotation added on the pvc is accessible 
/home/worker/workspace/csi-wcp-pre-check-in/Results/440/vsphere-csi-driver/tests/e2e/util.go:3210

[Fail] Volume health check [BeforeEach] [csi-supervisor] [csi-guest] Verify health annotation is not updated to unknown status from accessible 
/home/worker/workspace/csi-wcp-pre-check-in/Results/440/vsphere-csi-driver/tests/e2e/util.go:3210
```


Vanilla:
```
Build ID: 952
Block vanilla build status: FAILURE 
Stage before exit: e2e-tests 
Jenkins E2E Test Results: 
JUnit report was created: /home/worker/workspace/csi-block-vanilla-pre-check-in/952/vsphere-csi-driver/tests/e2e/junit.xml

Ran 1 of 305 Specs in 407.023 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 304 Skipped
PASS

Ginkgo ran 1 suite in 8m12.324457159s
Test Suite Passed
--
JUnit report was created: /home/worker/workspace/csi-block-vanilla-pre-check-in/952/vsphere-csi-driver/tests/e2e/junit.xml

Ran 12 of 305 Specs in 5346.148 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 293 Skipped
PASS

Ginkgo ran 1 suite in 1h29m20.836100581s
Test Suite Passed
--
/home/worker/workspace/csi-block-vanilla-pre-check-in/952/vsphere-csi-driver/tests/e2e/csi_cns_telemetry.go:203

Ran 40 of 305 Specs in 1049.794 seconds
FAIL! -- 34 Passed | 6 Failed | 0 Pending | 265 Skipped


Ginkgo ran 1 suite in 17m46.914914535s
Test Suite Failed
```
Can confirm the failures are not related to this change.


GC:
```
Build ID: 299
GC build status: FAILURE
Stage before exit: e2e-tests
Jenkins E2E Test Results:
Ran 17 of 327 Specs in 2988.556 seconds
FAIL! -- 16 Passed | 1 Failed | 0 Pending | 310 Skipped
--- FAIL: TestE2E (2988.72s)
FAIL
```

The 1 failure is not related to this change.
```
Summarizing 1 Failure:

[Fail] Volume Expansion Test [It] [csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] Verify volume expansion with no filesystem before expansion 
/home/worker/workspace/gc-csi-pre-checkin/Results/299/vsphere-csi-driver/tests/e2e/vsphere_volume_expansion.go:2784
```