### PR TITLE
Reduce number of histogram buckets for CSI metrics

### DIFF
--- a/pkg/common/prometheus/metrics.go
+++ b/pkg/common/prometheus/metrics.go
@@ -113,7 +113,7 @@ var (
 		// Creating more buckets for operations that takes few seconds and less buckets
 		// for those that are taking a long time. A CSI operation taking a long time is
 		// unexpected and we don't have to be accurate(just approximation is fine).
-		Buckets: []float64{1, 2, 3, 4, 5, 7, 10, 12, 15, 18, 20, 25, 30, 60, 120, 180, 300},
+		Buckets: []float64{2, 5, 10, 15, 20, 25, 30, 60, 120, 180},
 	},
 		// Possible voltype - "unknown", "block", "file"
 		// Possible optype - "create-volume", "delete-volume", "attach-volume", "detach-volume", "expand-volume"
@@ -129,7 +129,7 @@ var (
 		// Creating more buckets for operations that takes few seconds and less buckets
 		// for those that are taking a long time. A CNS operation taking a long time is
 		// unexpected and we don't have to be accurate(just approximation is fine).
-		Buckets: []float64{1, 2, 3, 4, 5, 7, 10, 12, 15, 18, 20, 25, 30, 60, 120, 180, 300},
+		Buckets: []float64{2, 5, 10, 15, 20, 25, 30, 60, 120, 180},
 	},
 		// Possible optype - "create-volume", "delete-volume", "attach-volume", "detach-volume", "expand-volume", etc
 		// Possible status - "pass", "fail"
@@ -150,7 +150,7 @@ var (
 		// Creating more buckets for operations that takes few seconds and less buckets
 		// for those that are taking a long time. A Full Sync operation taking a long time is
 		// unexpected and we don't have to be accurate(just approximation is fine).
-		Buckets: []float64{1, 2, 3, 4, 5, 7, 10, 12, 15, 18, 20, 25, 30, 60, 120, 180, 300},
+		Buckets: []float64{2, 5, 10, 15, 20, 25, 30, 60, 120, 180},
 	},
 		// Possible status - "pass", "fail"
 		[]string{"status"})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR reduces number of histogram buckets in CSI metrics from 18 to 11.
The buckets are in the range {2, 5, 10, 15, 20, 25, 30, 60, 120, 180} which seems to be a good bin size given CSI operations are expected to finish in a few seconds.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
We have seen that having more buckets in metrics increases the metric size and it doesn't scale well while pushing the metrics to an analytics engine (Wavefront, for instance).


**Testing done**:
1. Created a PVC with new CSI driver image. Verified the number of buckets are reduced to 11.
```
root@k8s-control-498-1647465493:~# kubectl exec -it vsphere-csi-controller-fbccfbf5f-k6r2q -n vmware-system-csi -c vsphere-csi-controller -- curl localhost:2112/metrics | grep vsphere_csi_volume_ops
# HELP vsphere_csi_volume_ops_histogram Histogram vector for CSI volume operations.
# TYPE vsphere_csi_volume_ops_histogram histogram
vsphere_csi_volume_ops_histogram_bucket{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block",le="2"} 0
vsphere_csi_volume_ops_histogram_bucket{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block",le="5"} 0
vsphere_csi_volume_ops_histogram_bucket{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block",le="10"} 0
vsphere_csi_volume_ops_histogram_bucket{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block",le="15"} 0
vsphere_csi_volume_ops_histogram_bucket{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block",le="20"} 0
vsphere_csi_volume_ops_histogram_bucket{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block",le="25"} 0
vsphere_csi_volume_ops_histogram_bucket{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block",le="30"} 0
vsphere_csi_volume_ops_histogram_bucket{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block",le="60"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block",le="120"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block",le="180"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block",le="+Inf"} 1
vsphere_csi_volume_ops_histogram_sum{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block"} 32.134754187
vsphere_csi_volume_ops_histogram_count{faulttype="",namespace="unknown",optype="create-volume",status="pass",voltype="block"} 1
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Reduce number of histogram buckets for CSI metrics
```


E2E Test Results
-----------------
WCP:

```
Build ID: 440
WCP build status: FAILURE
Stage before exit: null
Jenkins E2E Test Results:
Ran 3 of 327 Specs in 4.979 seconds
FAIL! -- 0 Passed | 3 Failed | 0 Pending | 324 Skipped
--- FAIL: TestE2E (5.16s)
FAIL
```

The 3 tests failed are from volume health annotation suite, and not related to this change. They're failing while waiting for all hosts to be up before each test. Summarizing 3 failures:
```
[Fail] Volume health check [BeforeEach] [csi-supervisor] Verify health annotaiton is not added on the PV  
/home/worker/workspace/csi-wcp-pre-check-in/Results/440/vsphere-csi-driver/tests/e2e/util.go:3210

[Fail] Volume health check [BeforeEach] [csi-supervisor] [csi-guest] Verify health annotation added on the pvc is accessible 
/home/worker/workspace/csi-wcp-pre-check-in/Results/440/vsphere-csi-driver/tests/e2e/util.go:3210

[Fail] Volume health check [BeforeEach] [csi-supervisor] [csi-guest] Verify health annotation is not updated to unknown status from accessible 
/home/worker/workspace/csi-wcp-pre-check-in/Results/440/vsphere-csi-driver/tests/e2e/util.go:3210
```


Vanilla:
```
Build ID: 952
Block vanilla build status: FAILURE 
Stage before exit: e2e-tests 
Jenkins E2E Test Results: 
JUnit report was created: /home/worker/workspace/csi-block-vanilla-pre-check-in/952/vsphere-csi-driver/tests/e2e/junit.xml

Ran 1 of 305 Specs in 407.023 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 304 Skipped
PASS

Ginkgo ran 1 suite in 8m12.324457159s
Test Suite Passed
--
JUnit report was created: /home/worker/workspace/csi-block-vanilla-pre-check-in/952/vsphere-csi-driver/tests/e2e/junit.xml

Ran 12 of 305 Specs in 5346.148 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 293 Skipped
PASS

Ginkgo ran 1 suite in 1h29m20.836100581s
Test Suite Passed
--
/home/worker/workspace/csi-block-vanilla-pre-check-in/952/vsphere-csi-driver/tests/e2e/csi_cns_telemetry.go:203

Ran 40 of 305 Specs in 1049.794 seconds
FAIL! -- 34 Passed | 6 Failed | 0 Pending | 265 Skipped


Ginkgo ran 1 suite in 17m46.914914535s
Test Suite Failed
```
Can confirm the failures are not related to this change.


GC:
```
Build ID: 299
GC build status: FAILURE
Stage before exit: e2e-tests
Jenkins E2E Test Results:
Ran 17 of 327 Specs in 2988.556 seconds
FAIL! -- 16 Passed | 1 Failed | 0 Pending | 310 Skipped
--- FAIL: TestE2E (2988.72s)
FAIL
```

The 1 failure is not related to this change.
```
Summarizing 1 Failure:

[Fail] Volume Expansion Test [It] [csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] Verify volume expansion with no filesystem before expansion 
/home/worker/workspace/gc-csi-pre-checkin/Results/299/vsphere-csi-driver/tests/e2e/vsphere_volume_expansion.go:2784
```