### PR TITLE
Add privileges for Administrator group users on CnsRegisterVolume/PVC…

### DIFF
--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -104,6 +104,34 @@ subjects:
     kind: Group
     name: system:serviceaccounts:vmware-system-csi
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-admin-csi-role
+rules:
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsregistervolumes"]
+    verbs: ["get", "list", "create", "delete", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["update", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wcp:administrators:cluster-edit-csirole
+subjects:
+- kind: Group
+  name: sso:Administrators@<sso_domain>
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: vsphere-admin-csi-role
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -104,6 +104,34 @@ subjects:
     kind: Group
     name: system:serviceaccounts:vmware-system-csi
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-admin-csi-role
+rules:
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsregistervolumes"]
+    verbs: ["get", "list", "create", "delete", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["update", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wcp:administrators:cluster-edit-csirole
+subjects:
+- kind: Group
+  name: sso:Administrators@<sso_domain>
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: vsphere-admin-csi-role
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -107,6 +107,34 @@ subjects:
     kind: Group
     name: system:serviceaccounts:vmware-system-csi
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-admin-csi-role
+rules:
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsregistervolumes"]
+    verbs: ["get", "list", "create", "delete", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["update", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wcp:administrators:cluster-edit-csirole
+subjects:
+- kind: Group
+  name: sso:Administrators@<sso_domain>
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: vsphere-admin-csi-role
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -107,6 +107,34 @@ subjects:
     kind: Group
     name: system:serviceaccounts:vmware-system-csi
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-admin-csi-role
+rules:
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsregistervolumes"]
+    verbs: ["get", "list", "create", "delete", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["update", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wcp:administrators:cluster-edit-csirole
+subjects:
+- kind: Group
+  name: sso:Administrators@<sso_domain>
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: vsphere-admin-csi-role
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds privileges for Administrator group users on CnsRegisterVolume/PV/PVC API. This is required for the TKGu migration which imports existing volumes from TKGm clusters to TKGs clusters on WCP.

TKGu migration which requires migrating TKGm workloads to TKGs. As part of migration, it would need to import existing volumes from TKGm cluster into TKGs cluster via CnsRegisterVolume API.
For this, Admin needs permission on certain API objects like CnsRegisterVolume/PVC/PV for this to work. This PR adds the permissions for Admin on those objects as part of this PR.

**Testing done**:
Currently verifying this on WCP cluster using the Admin account.

```
$ export KUBECONFIG=/tmp/sample.txt

$ kubectl vsphere login --server=10.78.141.163 --insecure-skip-tls-verify -v20

$ kubectl auth can-i create cnsregistervolumes
yes

$ kubectl auth can-i delete persistentvolumes
yes

$ kubectl auth can-i delete persistentvolumeclaims
yes
```

cc @deepakkinni @shalini-b 


**Release note**:
```release-note
Add privileges for Administrator group users on CnsRegisterVolume API
```
