### PR TITLE
Bump up sidecars & configure leader election args to avoid too many restarts

### DIFF
--- a/manifests/guestcluster/1.23/pvcsi.yaml
+++ b/manifests/guestcluster/1.23/pvcsi.yaml
@@ -163,6 +163,9 @@ spec:
             - "--leader-election"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS
@@ -273,6 +276,9 @@ spec:
             - "--default-fstype=ext4"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: ADDRESS
@@ -290,6 +296,9 @@ spec:
             - "--leader-election"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -189,7 +189,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v2.2.2_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.1.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -203,6 +203,9 @@ spec:
             - "--default-fstype=ext4"
             - "--use-service-for-placement-engine=false"
             - "--tkgs-ha=false"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -221,7 +224,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.2.1_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v3.4.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -229,6 +232,9 @@ spec:
             - "--leader-election"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -241,7 +247,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.2.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.4.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -251,6 +257,9 @@ spec:
             - --leader-election
             - --kube-api-qps=100
             - --kube-api-burst=100
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is bumping up sidecars for WCP & also configures lease-duration args without which the CSI containers restart too many times during lease renewal.
The args added in this PR will help bring down the restart count for CSI containers which happen lease renewal wait timeout

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified the new sidecar images with the customized args manually on WCP & GC testbeds 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump up sidecars & configure leader election args to avoid too many restarts
```
