### PR TITLE
replace cluster-id with new supervisor-id with CSI full sync

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -562,7 +562,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 
 	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 	volumeInfo, faultType, err := common.CreateBlockVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
-		c.manager, &createVolumeSpec, sharedDatastores, filterSuspendedDatastores)
+		c.manager, &createVolumeSpec, sharedDatastores, filterSuspendedDatastores, false)
 	if err != nil {
 		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to create volume. Error: %+v", err)
@@ -790,14 +790,14 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 				"no datastores found to create file volume")
 		}
 		volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
-			c.manager, &createVolumeSpec, filteredDatastores, filterSuspendedDatastores)
+			c.manager, &createVolumeSpec, filteredDatastores, filterSuspendedDatastores, false)
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to create volume. Error: %+v", err)
 		}
 	} else {
 		volumeID, faultType, err = common.CreateFileVolumeUtilOld(ctx, cnstypes.CnsClusterFlavorVanilla,
-			c.manager, &createVolumeSpec, filterSuspendedDatastores)
+			c.manager, &createVolumeSpec, filterSuspendedDatastores, false)
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to create volume. Error: %+v", err)

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -163,6 +163,7 @@ type ReconcileCnsRegisterVolume struct {
 func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 	request reconcile.Request) (reconcile.Result, error) {
 	log := logger.GetLogger(ctx)
+	isTKGSHAEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
 	// Fetch the CnsRegisterVolume instance.
 	instance := &cnsregistervolumev1alpha1.CnsRegisterVolume{}
 	err := r.client.Get(ctx, request.NamespacedName, instance)
@@ -225,7 +226,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		pvName   string
 	)
 	// Create Volume for the input CnsRegisterVolume instance.
-	createSpec := constructCreateSpecForInstance(r, instance, vc.Config.Host)
+	createSpec := constructCreateSpecForInstance(r, instance, vc.Config.Host, isTKGSHAEnabled)
 	log.Infof("Creating CNS volume: %+v for CnsRegisterVolume request with name: %q on namespace: %q",
 		instance, instance.Name, instance.Namespace)
 	log.Debugf("CNS Volume create spec is: %+v", createSpec)

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -65,7 +65,8 @@ func isDatastoreAccessibleToCluster(ctx context.Context, vc *vsphere.VirtualCent
 
 // constructCreateSpecForInstance creates CNS CreateVolume spec.
 func constructCreateSpecForInstance(r *ReconcileCnsRegisterVolume,
-	instance *cnsregistervolumev1alpha1.CnsRegisterVolume, host string) *cnstypes.CnsVolumeCreateSpec {
+	instance *cnsregistervolumev1alpha1.CnsRegisterVolume,
+	host string, useSupervisorId bool) *cnstypes.CnsVolumeCreateSpec {
 	var volumeName string
 	if instance.Spec.VolumeID != "" {
 		volumeName = staticPvNamePrefix + instance.Spec.VolumeID
@@ -73,7 +74,13 @@ func constructCreateSpecForInstance(r *ReconcileCnsRegisterVolume,
 		id, _ := uuid.NewUUID()
 		volumeName = staticPvNamePrefix + id.String()
 	}
-	containerCluster := vsphere.GetContainerCluster(r.configInfo.Cfg.Global.ClusterID,
+	var clusterIDForVolumeMetadata string
+	if useSupervisorId {
+		clusterIDForVolumeMetadata = r.configInfo.Cfg.Global.SupervisorID
+	} else {
+		clusterIDForVolumeMetadata = r.configInfo.Cfg.Global.ClusterID
+	}
+	containerCluster := vsphere.GetContainerCluster(clusterIDForVolumeMetadata,
 		r.configInfo.Cfg.VirtualCenter[host].User,
 		cnstypes.CnsClusterFlavorWorkload, r.configInfo.Cfg.Global.ClusterDistribution)
 	createSpec := &cnstypes.CnsVolumeCreateSpec{

--- a/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsvolumemetadata/cnsvolumemetadata_controller.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	commonconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 
 	"github.com/davecgh/go-spew/spew"
@@ -182,7 +184,7 @@ type ReconcileCnsVolumeMetadata struct {
 func (r *ReconcileCnsVolumeMetadata) Reconcile(ctx context.Context,
 	request reconcile.Request) (reconcile.Result, error) {
 	log := logger.GetLogger(ctx)
-
+	isTKGSHAEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
 	instance := &cnsv1alpha1.CnsVolumeMetadata{}
 	err := r.client.Get(ctx, request.NamespacedName, instance)
 	if err != nil {
@@ -220,7 +222,7 @@ func (r *ReconcileCnsVolumeMetadata) Reconcile(ctx context.Context,
 	// If the operation succeeds, remove the finalizer.
 	// If the operation fails, requeue the request.
 	if instance.DeletionTimestamp != nil {
-		if !r.updateCnsMetadata(ctx, instance, true) {
+		if !r.updateCnsMetadata(ctx, instance, true, isTKGSHAEnabled) {
 			// Failed to update CNS.
 			msg := fmt.Sprintf("ReconcileCnsVolumeMetadata: Failed to delete entry in CNS for instance "+
 				"with name %q and entity type %q in the guest cluster %q. Requeuing request.",
@@ -279,7 +281,7 @@ func (r *ReconcileCnsVolumeMetadata) Reconcile(ctx context.Context,
 		}
 	} else {
 		// Update CNS volume entry with instance's metadata.
-		if !r.updateCnsMetadata(ctx, instance, false) {
+		if !r.updateCnsMetadata(ctx, instance, false, isTKGSHAEnabled) {
 			// Failed to update CNS.
 			msg := fmt.Sprintf("ReconcileCnsVolumeMetadata: Failed to update entry in CNS for instance "+
 				"with name %q and entity type %q in the guest cluster %q. Requeueing request.",
@@ -310,7 +312,7 @@ func (r *ReconcileCnsVolumeMetadata) Reconcile(ctx context.Context,
 // If deleteFlag is true, metadata is deleted for the given instance.
 // Returns true if all updates on CNS succeeded, otherwise return false.
 func (r *ReconcileCnsVolumeMetadata) updateCnsMetadata(ctx context.Context,
-	instance *cnsv1alpha1.CnsVolumeMetadata, deleteFlag bool) bool {
+	instance *cnsv1alpha1.CnsVolumeMetadata, deleteFlag bool, useSupervisorID bool) bool {
 	log := logger.GetLogger(ctx)
 	log.Debugf("ReconcileCnsVolumeMetadata: Calling updateCnsMetadata for instance %q with delete flag %v",
 		instance.Name, deleteFlag)
@@ -327,12 +329,16 @@ func (r *ReconcileCnsVolumeMetadata) updateCnsMetadata(ctx context.Context,
 
 	var entityReferences []cnstypes.CnsKubernetesEntityReference
 	for _, reference := range instance.Spec.EntityReferences {
-		clusterid := reference.ClusterID
+		clusterID := reference.ClusterID
 		if instance.Spec.EntityType == cnsv1alpha1.CnsOperatorEntityTypePV {
-			clusterid = r.configInfo.Cfg.Global.ClusterID
+			if useSupervisorID {
+				clusterID = r.configInfo.Cfg.Global.SupervisorID
+			} else {
+				clusterID = r.configInfo.Cfg.Global.ClusterID
+			}
 		}
 		entityReferences = append(entityReferences, cnsvsphere.CreateCnsKuberenetesEntityReference(
-			reference.EntityType, reference.EntityName, reference.Namespace, clusterid))
+			reference.EntityType, reference.EntityName, reference.Namespace, clusterID))
 	}
 
 	var volumeStatus []*cnsv1alpha1.CnsVolumeMetadataVolumeStatus

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -68,6 +68,7 @@ var (
 
 	// Contains list of clusterComputeResourceMoIds on which supervisor cluster is deployed.
 	clusterComputeResourceMoIds = make([]string, 0)
+	clusterIDforVolumeMetadata  string
 )
 
 // newInformer returns uninitialized metadataSyncInformer.
@@ -173,7 +174,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		return err
 	}
 	metadataSyncer.clusterFlavor = clusterFlavor
-
+	clusterIDforVolumeMetadata = configInfo.Cfg.Global.ClusterID
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
 			clusterComputeResourceMoIds, err = common.GetClusterComputeResourceMoIds(ctx)
@@ -182,17 +183,13 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				return err
 			}
 			if len(clusterComputeResourceMoIds) > 0 {
-				if configInfo.Cfg.Global.SupervisorID != "" {
-					// Use new SupervisorID for Volume Metadata when AvailabilityZone CR is present and
-					// config.Global.SupervisorID is not empty string
-					configInfo.Cfg.Global.ClusterID = configInfo.Cfg.Global.SupervisorID
-				} else {
+				if configInfo.Cfg.Global.SupervisorID == "" {
 					return logger.LogNewError(log, "supervisor-id is not set in the vsphere-config-secret")
 				}
 			}
+			clusterIDforVolumeMetadata = configInfo.Cfg.Global.SupervisorID
 		}
 	}
-	metadataSyncer.configInfo = configInfo
 
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		// Initialize client to supervisor cluster, if metadata syncer is being
@@ -615,19 +612,6 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 			metadataSyncer.host = newVCConfig.Host
 		}
 		if cfg != nil {
-			if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
-				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
-					if len(clusterComputeResourceMoIds) > 0 {
-						if cfg.Global.SupervisorID != "" {
-							// Use new SupervisorID for Volume Metadata when AvailabilityZone CR is present and
-							// config.Global.SupervisorID is not empty string
-							cfg.Global.ClusterID = cfg.Global.SupervisorID
-						} else {
-							return logger.LogNewError(log, "supervisor-id is not set in the vsphere-config-secret")
-						}
-					}
-				}
-			}
 			metadataSyncer.configInfo = &cnsconfig.ConfigurationInfo{Cfg: cfg}
 			log.Infof("updated metadataSyncer.configInfo")
 		}
@@ -1049,13 +1033,13 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 	// Create updateSpec.
 	var metadataList []cnstypes.BaseCnsEntityMetadata
 	entityReference := cnsvsphere.CreateCnsKuberenetesEntityReference(string(cnstypes.CnsKubernetesEntityTypePV),
-		pv.Name, "", metadataSyncer.configInfo.Cfg.Global.ClusterID)
+		pv.Name, "", clusterIDforVolumeMetadata)
 	pvcMetadata := cnsvsphere.GetCnsKubernetesEntityMetaData(pvc.Name, pvc.Labels, false,
-		string(cnstypes.CnsKubernetesEntityTypePVC), pvc.Namespace, metadataSyncer.configInfo.Cfg.Global.ClusterID,
+		string(cnstypes.CnsKubernetesEntityTypePVC), pvc.Namespace, clusterIDforVolumeMetadata,
 		[]cnstypes.CnsKubernetesEntityReference{entityReference})
 
 	metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(pvcMetadata))
-	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID,
+	containerCluster := cnsvsphere.GetContainerCluster(clusterIDforVolumeMetadata,
 		metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor,
 		metadataSyncer.configInfo.Cfg.Global.ClusterDistribution)
 
@@ -1091,7 +1075,7 @@ func csiPVCDeleted(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 	var metadataList []cnstypes.BaseCnsEntityMetadata
 	pvcMetadata := cnsvsphere.GetCnsKubernetesEntityMetaData(pvc.Name, nil, true,
 		string(cnstypes.CnsKubernetesEntityTypePVC), pvc.Namespace,
-		metadataSyncer.configInfo.Cfg.Global.ClusterID, nil)
+		clusterIDforVolumeMetadata, nil)
 	metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(pvcMetadata))
 
 	var volumeHandle string
@@ -1114,7 +1098,7 @@ func csiPVCDeleted(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 	} else {
 		volumeHandle = pv.Spec.CSI.VolumeHandle
 	}
-	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID,
+	containerCluster := cnsvsphere.GetContainerCluster(clusterIDforVolumeMetadata,
 		metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User,
 		metadataSyncer.clusterFlavor, metadataSyncer.configInfo.Cfg.Global.ClusterDistribution)
 	updateSpec := &cnstypes.CnsVolumeMetadataUpdateSpec{
@@ -1142,11 +1126,11 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 	log := logger.GetLogger(ctx)
 	var metadataList []cnstypes.BaseCnsEntityMetadata
 	pvMetadata := cnsvsphere.GetCnsKubernetesEntityMetaData(newPv.Name, newPv.GetLabels(), false,
-		string(cnstypes.CnsKubernetesEntityTypePV), "", metadataSyncer.configInfo.Cfg.Global.ClusterID, nil)
+		string(cnstypes.CnsKubernetesEntityTypePV), "", clusterIDforVolumeMetadata, nil)
 	metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(pvMetadata))
 	var volumeHandle string
 	var err error
-	containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID,
+	containerCluster := cnsvsphere.GetContainerCluster(clusterIDforVolumeMetadata,
 		metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User, metadataSyncer.clusterFlavor,
 		metadataSyncer.configInfo.Cfg.Global.ClusterDistribution)
 	if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) && newPv.Spec.VsphereVolume != nil {
@@ -1291,10 +1275,10 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 			"delete volume metadata references for PV: %q", pv.Name)
 		var metadataList []cnstypes.BaseCnsEntityMetadata
 		pvMetadata := cnsvsphere.GetCnsKubernetesEntityMetaData(pv.Name, nil, true,
-			string(cnstypes.CnsKubernetesEntityTypePV), "", metadataSyncer.configInfo.Cfg.Global.ClusterID, nil)
+			string(cnstypes.CnsKubernetesEntityTypePV), "", clusterIDforVolumeMetadata, nil)
 		metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(pvMetadata))
 
-		containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID,
+		containerCluster := cnsvsphere.GetContainerCluster(clusterIDforVolumeMetadata,
 			metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User,
 			metadataSyncer.clusterFlavor, metadataSyncer.configInfo.Cfg.Global.ClusterDistribution)
 		updateSpec := &cnstypes.CnsVolumeMetadataUpdateSpec{
@@ -1395,16 +1379,16 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 					// as an entity reference.
 					entityReference := cnsvsphere.CreateCnsKuberenetesEntityReference(
 						string(cnstypes.CnsKubernetesEntityTypePVC), pvc.Name, pvc.Namespace,
-						metadataSyncer.configInfo.Cfg.Global.ClusterID)
+						clusterIDforVolumeMetadata)
 					podMetadata = cnsvsphere.GetCnsKubernetesEntityMetaData(pod.Name, nil,
 						deleteFlag, string(cnstypes.CnsKubernetesEntityTypePOD), pod.Namespace,
-						metadataSyncer.configInfo.Cfg.Global.ClusterID,
+						clusterIDforVolumeMetadata,
 						[]cnstypes.CnsKubernetesEntityReference{entityReference})
 				} else {
 					// Deleting the pod metadata.
 					podMetadata = cnsvsphere.GetCnsKubernetesEntityMetaData(pod.Name, nil, deleteFlag,
 						string(cnstypes.CnsKubernetesEntityTypePOD), pod.Namespace,
-						metadataSyncer.configInfo.Cfg.Global.ClusterID, nil)
+						clusterIDforVolumeMetadata, nil)
 				}
 				metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(podMetadata))
 				var err error
@@ -1442,7 +1426,7 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 					// No entity reference is supplied for inline volumes.
 					podMetadata = cnsvsphere.GetCnsKubernetesEntityMetaData(pod.Name, nil, deleteFlag,
 						string(cnstypes.CnsKubernetesEntityTypePOD), pod.Namespace,
-						metadataSyncer.configInfo.Cfg.Global.ClusterID, nil)
+						clusterIDforVolumeMetadata, nil)
 					metadataList = append(metadataList, cnstypes.BaseCnsEntityMetadata(podMetadata))
 					var err error
 					// In case if feature state switch is enabled after syncer is
@@ -1475,7 +1459,7 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 				continue
 			}
 		}
-		containerCluster := cnsvsphere.GetContainerCluster(metadataSyncer.configInfo.Cfg.Global.ClusterID,
+		containerCluster := cnsvsphere.GetContainerCluster(clusterIDforVolumeMetadata,
 			metadataSyncer.configInfo.Cfg.VirtualCenter[metadataSyncer.host].User,
 			metadataSyncer.clusterFlavor, metadataSyncer.configInfo.Cfg.Global.ClusterDistribution)
 		updateSpec := &cnstypes.CnsVolumeMetadataUpdateSpec{

--- a/pkg/syncer/pv_to_backingdiskobjectid_mapping.go
+++ b/pkg/syncer/pv_to_backingdiskobjectid_mapping.go
@@ -37,7 +37,7 @@ func csiGetPVtoBackingDiskObjectIdMapping(ctx context.Context, k8sclient clients
 	// Call CNS QueryAll to get container volumes by cluster ID.
 	queryFilter := cnstypes.CnsQueryFilter{
 		ContainerClusterIds: []string{
-			metadataSyncer.configInfo.Cfg.Global.ClusterID,
+			clusterIDforVolumeMetadata,
 		},
 	}
 

--- a/pkg/syncer/volume_health.go
+++ b/pkg/syncer/volume_health.go
@@ -39,7 +39,7 @@ func csiGetVolumeHealthStatus(ctx context.Context, k8sclient clientset.Interface
 	// Call CNS QueryAll to get container volumes by cluster ID.
 	queryFilter := cnstypes.CnsQueryFilter{
 		ContainerClusterIds: []string{
-			metadataSyncer.configInfo.Cfg.Global.ClusterID,
+			clusterIDforVolumeMetadata,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- delete volume metadata with the old `cluster-id` and add the same volume metadata back with the new `supervisor-id`.
- removed previous logic to replace  `config.Global.ClusterID` with  `config.Global.SupervisorID` and using `config.Global.ClusterID` to push metadata using new SupervisorID
- updated other supervisor services to use the new `SupervisorID` to push volume metadata.


**Testing done**:
[Test logs](https://gist.github.com/divyenpatel/e408cf2faaa31914bf9a899f974aa2db)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
replace cluster-id with new supervisor-id with CSI full sync
```
