### PR TITLE
[webhook] make volume health annotation immutable by non-csi serviceaccount users

### DIFF
--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -58,6 +58,7 @@ var (
 	featureGateCsiMigrationEnabled        bool
 	featureGateBlockVolumeSnapshotEnabled bool
 	featureGateTKGSHaEnabled              bool
+	featureGateVolumeHealthEnabled        bool
 )
 
 // watchConfigChange watches on the webhook configuration directory for changes
@@ -138,6 +139,7 @@ func StartWebhookServer(ctx context.Context) error {
 
 	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		featureGateTKGSHaEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
+		featureGateVolumeHealthEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.VolumeHealth)
 		startCNSCSIWebhookManager(ctx)
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		if cfg == nil {

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 )
 
@@ -82,13 +83,19 @@ type CSISupervisorWebhook struct {
 func (h *CSISupervisorWebhook) Handle(ctx context.Context, req admission.Request) (resp admission.Response) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("CNS-CSI validation webhook handler called with request: %+v", req)
+	defer log.Debugf("CNS-CSI validation webhook handler completed for the request: %+v", req)
 
 	resp = admission.Allowed("")
-	if featureGateTKGSHaEnabled {
-		if req.Kind.Kind == "PersistentVolumeClaim" {
-			resp = validatePVCAnnotation(ctx, req)
+	if req.Kind.Kind == "PersistentVolumeClaim" {
+		if featureGateTKGSHaEnabled {
+			resp = validatePVCAnnotationForTKGSHA(ctx, req)
+			if !resp.Allowed {
+				return
+			}
+		}
+		if featureGateVolumeHealthEnabled {
+			resp = validatePVCAnnotationForVolumeHealth(ctx, req)
 		}
 	}
-	log.Debugf("CNS-CSI validation webhook handler completed for the request: %+v", req)
 	return
 }

--- a/pkg/syncer/admissionhandler/validatepvcannotationfortkgsha.go
+++ b/pkg/syncer/admissionhandler/validatepvcannotationfortkgsha.go
@@ -7,6 +7,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 )
@@ -18,9 +19,9 @@ const (
 	RemovePVCAnnotation            = "Remove the PVC Annotation"
 )
 
-func validatePVCAnnotation(ctx context.Context, request admission.Request) admission.Response {
+func validatePVCAnnotationForTKGSHA(ctx context.Context, request admission.Request) admission.Response {
 	log := logger.GetLogger(ctx)
-	log.Debugf("validatePVCAnnotation called with the request %v", request)
+	log.Debugf("validatePVCAnnotationForTKGSHA called with the request %v", request)
 
 	newPVC := corev1.PersistentVolumeClaim{}
 	if err := json.Unmarshal(request.Object.Raw, &newPVC); err != nil {
@@ -81,6 +82,6 @@ func validatePVCAnnotation(ctx context.Context, request admission.Request) admis
 		}
 	}
 
-	log.Debugf("validatePVCAnnotation completed for the request %v", request)
+	log.Debugf("validatePVCAnnotationForTKGSHA completed for the request %v", request)
 	return admission.Allowed("")
 }

--- a/pkg/syncer/admissionhandler/validatepvcannotationfortkgsha_test.go
+++ b/pkg/syncer/admissionhandler/validatepvcannotationfortkgsha_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -144,7 +145,7 @@ func getPVCAnnotationAdmissionTest(t *testing.T) *pvcAnnotationAdmissionTest {
 	return pvcAnnotationAdmissionTestInstance
 }
 
-func TestValidatePVCAnnotation(t *testing.T) {
+func TestValidatePVCAnnotationForTKGSHA(t *testing.T) {
 	testValidatePVCAnnotationInstance := getPVCAnnotationAdmissionTest(t)
 
 	tests := []struct {
@@ -329,8 +330,9 @@ func TestValidatePVCAnnotation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := validatePVCAnnotation(context.TODO(), tt.admissionReview); !reflect.DeepEqual(got, tt.expectedResponse) {
-				t.Errorf("validatePVCAnnotation() = %v, want %v", got, tt.expectedResponse)
+			got := validatePVCAnnotationForTKGSHA(context.TODO(), tt.admissionReview)
+			if !reflect.DeepEqual(got, tt.expectedResponse) {
+				t.Errorf("validatePVCAnnotationForTKGSHA() = %v, want %v", got, tt.expectedResponse)
 			}
 		})
 	}

--- a/pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth.go
+++ b/pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth.go
@@ -1,0 +1,78 @@
+package admissionhandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
+)
+
+const (
+	NonUpdatablePVCAnnotation = "PVC Annotation %s is not mutable by user %s"
+	NonCreatablePVCAnnotation = "PVC Annotation %s cannot be created by user %s"
+	CSIServiceAccountPrefix   = "system:serviceaccount:vmware-system-csi"
+)
+
+// Disallow editing PVC Volume Health annotation for non cns-csi service account users.
+func validatePVCAnnotationForVolumeHealth(ctx context.Context, request admission.Request) admission.Response {
+	log := logger.GetLogger(ctx)
+	username := request.UserInfo.Username
+	isCSIServiceAccount := validateCSIServiceAccount(request.UserInfo.Username)
+	log.Debugf("validatePVCAnnotationForVolumeHealth called with the request %v by user: %v", request, username)
+	newPVC := corev1.PersistentVolumeClaim{}
+	if err := json.Unmarshal(request.Object.Raw, &newPVC); err != nil {
+		reason := "skipped validation when failed to deserialize PVC from new request object"
+		log.Warn(reason)
+		return admission.Allowed(reason)
+	}
+
+	if request.Operation == admissionv1.Create {
+		_, ok := newPVC.Annotations[common.AnnVolumeHealth]
+		if ok && !isCSIServiceAccount {
+			return admission.Denied(fmt.Sprintf(NonCreatablePVCAnnotation, common.AnnVolumeHealth, username))
+		}
+	} else if request.Operation == admissionv1.Update {
+		oldPVC := corev1.PersistentVolumeClaim{}
+		if err := json.Unmarshal(request.OldObject.Raw, &oldPVC); err != nil {
+			reason := "skipped validation when failed to deserialize PVC from old request object"
+			log.Warn(reason)
+			return admission.Allowed(reason)
+		}
+
+		if !isCSIServiceAccount {
+			oldAnnVolumeHealthValue, oldOk := oldPVC.Annotations[common.AnnVolumeHealth]
+			newAnnVolumeHealthValue, newOk := newPVC.Annotations[common.AnnVolumeHealth]
+
+			// We only need to prevent updates to volume health annotation.
+			// Other PVC edit requests should go through.
+
+			if oldOk && newOk {
+				// Disallow updating the annotation of AnnVolumeHealth in an existing PVC.
+				if oldAnnVolumeHealthValue != newAnnVolumeHealthValue {
+					return admission.Denied(fmt.Sprintf(NonUpdatablePVCAnnotation, common.AnnVolumeHealth, username))
+				}
+			} else if oldOk || newOk {
+				// Disallow adding/removing the annotation of AnnVolumeHealth in an existing PVC.
+				return admission.Denied(fmt.Sprintf(NonUpdatablePVCAnnotation, common.AnnVolumeHealth, username))
+			}
+		}
+	}
+
+	log.Debugf("validatePVCAnnotationForVolumeHealth completed for the request %v", request)
+	return admission.Allowed("")
+}
+
+func validateCSIServiceAccount(username string) bool {
+	csiServiceAccountRegex, err := regexp.Compile(CSIServiceAccountPrefix)
+	if err != nil {
+		return true // fail open
+	}
+	return csiServiceAccountRegex.MatchString(username)
+}

--- a/pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth_test.go
+++ b/pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth_test.go
@@ -1,0 +1,287 @@
+package admissionhandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
+)
+
+const (
+	nonCSIServiceAccountExample = "nonCSIServiceAccount"
+	csiServiceAccountExample    = "system:serviceaccount:vmware-system-csi:vsphere-csi-controller"
+)
+
+var (
+	pvcHealthAnnotationAdmissionTestInstance *pvcHealthAnnotationAdmissionTest
+	onceForPVCHealthAnnotationAdmissionTest  sync.Once
+)
+
+type pvcHealthAnnotationAdmissionTest struct {
+	pvcWithNonExistentAnnVolumeHealth  []byte
+	pvcWithEmptyAnnVolumeHealthValue   []byte
+	pvcWithAccessibleAnnVolumeHealth   []byte
+	pvcWithInaccessibleAnnVolumeHealth []byte
+	pvcWithRandomAnnVolumeHealth       []byte
+}
+
+func TestValidatePVCAnnotationForVolumeHealth(t *testing.T) {
+
+	testValidatePVCHealthAnnotationInstance := getPVCHealthAnnotationTest(t)
+
+	tests := []struct {
+		name             string
+		admissionReview  admission.Request
+		expectedResponse admission.Response
+	}{
+		{
+			name: "TestCreatePVCWithNonEmptyAnnVolumeHealthByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: v1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithAccessibleAnnVolumeHealth,
+					},
+				},
+			},
+			expectedResponse: admission.Denied(fmt.Sprintf(NonCreatablePVCAnnotation,
+				common.AnnVolumeHealth, nonCSIServiceAccountExample)),
+		},
+		{
+			name: "TestCreatePVCWithAbsentAnnVolumeHealthByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: v1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithNonExistentAnnVolumeHealth,
+					},
+				},
+			},
+			expectedResponse: admission.Allowed(""),
+		},
+		{
+			name: "TestCreatePVCWithNonEmptyAnnVolumeHealthByCSIServiceAccount",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: v1.UserInfo{Username: csiServiceAccountExample},
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithAccessibleAnnVolumeHealth,
+					},
+				},
+			},
+			expectedResponse: admission.Allowed(""),
+		},
+		{
+			name: "TestUpdatePVCAnnVolumeHealthToInaccessibleByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: v1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithAccessibleAnnVolumeHealth,
+					},
+					Object: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithInaccessibleAnnVolumeHealth,
+					},
+				},
+			},
+			expectedResponse: admission.Denied(fmt.Sprintf(NonUpdatablePVCAnnotation,
+				common.AnnVolumeHealth, nonCSIServiceAccountExample)),
+		},
+		{
+			name: "TestUpdatePVCAnnVolumeHealthToRandomByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: v1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithAccessibleAnnVolumeHealth,
+					},
+					Object: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithRandomAnnVolumeHealth,
+					},
+				},
+			},
+			expectedResponse: admission.Denied(fmt.Sprintf(NonUpdatablePVCAnnotation,
+				common.AnnVolumeHealth, nonCSIServiceAccountExample)),
+		},
+		{
+			name: "TestUpdatePVCAnnVolumeHealthToInaccessibleByCSIServiceAccount",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: v1.UserInfo{Username: csiServiceAccountExample},
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithAccessibleAnnVolumeHealth,
+					},
+					Object: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithInaccessibleAnnVolumeHealth,
+					},
+				},
+			},
+			expectedResponse: admission.Allowed(""),
+		},
+		{
+			name: "TestUpdatePVCAnnVolumeHealthToAccessibleByCSIServiceAccount",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: v1.UserInfo{Username: csiServiceAccountExample},
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithInaccessibleAnnVolumeHealth,
+					},
+					Object: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithAccessibleAnnVolumeHealth,
+					},
+				},
+			},
+			expectedResponse: admission.Allowed(""),
+		},
+		{
+			name: "TestUpdatePVCRemoveAnnVolumeHealthByDevopsUser",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: v1.UserInfo{Username: nonCSIServiceAccountExample},
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithAccessibleAnnVolumeHealth,
+					},
+					Object: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithNonExistentAnnVolumeHealth,
+					},
+				},
+			},
+			expectedResponse: admission.Denied(fmt.Sprintf(NonUpdatablePVCAnnotation,
+				common.AnnVolumeHealth, nonCSIServiceAccountExample)),
+		},
+		{
+			name: "TestUpdatePVCRemoveAnnVolumeHealthByCSIServiceAccount",
+			admissionReview: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: v1.UserInfo{Username: csiServiceAccountExample},
+					Kind: metav1.GroupVersionKind{
+						Kind: "PersistentVolumeClaim",
+					},
+					Operation: admissionv1.Update,
+					OldObject: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithAccessibleAnnVolumeHealth,
+					},
+					Object: runtime.RawExtension{
+						Raw: testValidatePVCHealthAnnotationInstance.pvcWithNonExistentAnnVolumeHealth,
+					},
+				},
+			},
+			expectedResponse: admission.Allowed(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validatePVCAnnotationForVolumeHealth(context.TODO(), tt.admissionReview)
+			if !reflect.DeepEqual(got, tt.expectedResponse) {
+				t.Errorf("validatePVCAnnotationForVolumeHealth() = %v, want %v", got, tt.expectedResponse)
+			}
+		})
+	}
+}
+
+func getPVCHealthAnnotationTest(t *testing.T) *pvcHealthAnnotationAdmissionTest {
+
+	onceForPVCHealthAnnotationAdmissionTest.Do(func() {
+		// cases for pvc volume health annotation validation
+
+		pvcWithNonExistentAnnVolumeHealth := pvcWithoutAnnotation.DeepCopy()
+		pvcWithNonExistentAnnVolumeHealthRaw, err := json.Marshal(pvcWithNonExistentAnnVolumeHealth)
+		if err != nil {
+			t.Fatalf("Failed to marshall the pvcWithNonExistentAnnVolumeHealth, %v: %v",
+				pvcWithNonExistentAnnVolumeHealth, err)
+		}
+
+		pvcWithEmptyAnnVolumeHealthValue := pvcWithoutAnnotation.DeepCopy()
+		pvcWithEmptyAnnVolumeHealthValue.Annotations = make(map[string]string)
+		pvcWithEmptyAnnVolumeHealthValue.Annotations[common.AnnVolumeHealth] = ""
+
+		pvcWithEmptyAnnVolumeHealthValueRaw, err := json.Marshal(pvcWithEmptyAnnVolumeHealthValue)
+		if err != nil {
+			t.Fatalf("Failed to marshall the pvcWithEmptyAnnVolumeHealthValue, %v: %v",
+				pvcWithEmptyAnnVolumeHealthValue, err)
+		}
+
+		pvcWithAccessibleAnnVolumeHealth := pvcWithoutAnnotation.DeepCopy()
+		pvcWithAccessibleAnnVolumeHealth.Annotations = make(map[string]string)
+		pvcWithAccessibleAnnVolumeHealth.Annotations[common.AnnVolumeHealth] = common.VolHealthStatusAccessible
+
+		pvcWithAccessibleAnnVolumeHealthRaw, err := json.Marshal(pvcWithAccessibleAnnVolumeHealth)
+		if err != nil {
+			t.Fatalf("Failed to marshall the pvcWithAccessibleAnnVolumeHealth, %v: %v",
+				pvcWithAccessibleAnnVolumeHealth, err)
+		}
+
+		pvcWithInaccessibleAnnVolumeHealth := pvcWithoutAnnotation.DeepCopy()
+		pvcWithInaccessibleAnnVolumeHealth.Annotations = make(map[string]string)
+		pvcWithInaccessibleAnnVolumeHealth.Annotations[common.AnnVolumeHealth] = common.VolHealthStatusInaccessible
+
+		pvcWithInaccessibleAnnVolumeHealthRaw, err := json.Marshal(pvcWithInaccessibleAnnVolumeHealth)
+		if err != nil {
+			t.Fatalf("Failed to marshall the pvcWithInaccessibleAnnVolumeHealth, %v: %v",
+				pvcWithInaccessibleAnnVolumeHealth, err)
+		}
+
+		pvcWithRandomAnnVolumeHealth := pvcWithoutAnnotation.DeepCopy()
+		pvcWithRandomAnnVolumeHealth.Annotations = make(map[string]string)
+		pvcWithRandomAnnVolumeHealth.Annotations[common.AnnVolumeHealth] = "RandomValue"
+
+		pvcWithRandomAnnVolumeHealthRaw, err := json.Marshal(pvcWithRandomAnnVolumeHealth)
+		if err != nil {
+			t.Fatalf("Failed to marshall the pvcWithRandomAnnVolumeHealth, %v: %v",
+				pvcWithRandomAnnVolumeHealth, err)
+		}
+
+		pvcHealthAnnotationAdmissionTestInstance = &pvcHealthAnnotationAdmissionTest{
+			pvcWithNonExistentAnnVolumeHealth:  pvcWithNonExistentAnnVolumeHealthRaw,
+			pvcWithEmptyAnnVolumeHealthValue:   pvcWithEmptyAnnVolumeHealthValueRaw,
+			pvcWithAccessibleAnnVolumeHealth:   pvcWithAccessibleAnnVolumeHealthRaw,
+			pvcWithInaccessibleAnnVolumeHealth: pvcWithInaccessibleAnnVolumeHealthRaw,
+			pvcWithRandomAnnVolumeHealth:       pvcWithRandomAnnVolumeHealthRaw,
+		}
+	})
+	return pvcHealthAnnotationAdmissionTestInstance
+
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

What: This PR prevents Supervisor Devops user from modifying volume health annotation. Only system csi service account will be allowed to create/update the volume health annotation. 

How: Uses existing validating admission webhook for pvc annotations written by @lintongj. Adds a new method to perform the above check. 

<!-- **Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # --> 

**Testing done**:
<!--
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject. -->

### Unit tests
covering create/update scenarios by csi service accounts and non-csi service accounts
### Manual testing

#### By a Devops user with 'Can Edit' permissions

```
(~) $ kubectl-vsphere login --server=10.186.226.169 -u vol-health-ann@vsphere.local --insecure-skip-tls-verify
Test !@
Login_BannerKlüft
KUBECTL_VSPHERE_PASSWORD environment variable is not set. Please enter the password below
Password:

(~) $ kubectl edit pvc aditya-gc-pvc -n test-gc-e2e-demo-ns
# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
    volumehealth.storage.kubernetes.io/health: inaccessible
    volumehealth.storage.kubernetes.io/health-timestamp: Thu Mar 31 20:33:38 UTC 2022
  creationTimestamp: "2022-03-31T20:33:14Z"
  finalizers:
  - kubernetes.io/pvc-protection
  name: aditya-gc-pvc
  namespace: test-gc-e2e-demo-ns
  resourceVersion: "2068522"
  uid: 9c7b9c65-bbbf-44c3-9f9b-2fd062d50a38
...
...

error: persistentvolumeclaims "aditya-gc-pvc" could not be patched: admission webhook "validation.csi.vsphere.vmware.com" denied the request: PVC Annotation volumehealth.storage.kubernetes.io/health is not mutable by user sso:vol-health-ann@vsphere.local
You can run `kubectl replace -f /var/folders/3l/b_3x45hx0fz5gy60xrg02mcw0000gp/T/kubectl-edit-1088456168.yaml` to try this update again.
```

#### By kubernetes-admin

```
root@4219d1aadc35632e55066cda62d25519 [ ~ ]# k describe pvc aditya-gc-pvc -n test-gc-e2e-demo-ns
Name:          aditya-gc-pvc
Namespace:     test-gc-e2e-demo-ns
StorageClass:  gc-storage-profile
Status:        Bound
Volume:        pvc-9c7b9c65-bbbf-44c3-9f9b-2fd062d50a38
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Thu Mar 31 20:33:38 UTC 2022
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      5Gi
Access Modes:  RWO
VolumeMode:    Block
Used By:       aditya-gc-pvc-block-pod


root@4219d1aadc35632e55066cda62d25519 [ ~ ]# k edit pvc aditya-gc-pvc -n test-gc-e2e-demo-ns

# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
    volumehealth.storage.kubernetes.io/health: inaccessible
    volumehealth.storage.kubernetes.io/health-timestamp: Thu Mar 31 20:33:38 UTC 2022
  creationTimestamp: "2022-03-31T20:33:14Z"
  finalizers:
  - kubernetes.io/pvc-protection
  name: aditya-gc-pvc
  namespace: test-gc-e2e-demo-ns
  resourceVersion: "2068522"
  uid: 9c7b9c65-bbbf-44c3-9f9b-2fd062d50a38

...
...

error: persistentvolumeclaims "aditya-gc-pvc" could not be patched: admission webhook "validation.csi.vsphere.vmware.com" denied the request: PVC Annotation volumehealth.storage.kubernetes.io/health is not mutable by user kubernetes-admin
You can run `kubectl replace -f /tmp/kubectl-edit-4201101003.yaml` to try this update again.
```

**Special notes for your reviewer**:

`make check`

```
(~/GolandProjects/vsphere-csi-driver) $ make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.1
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/adkulkarni/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/provider sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/adkulkarni/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/adkulkarni/GolandProjects/vsphere-csi-driver /Users/adkulkarni/GolandProjects /Users/adkulkarni /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (files|name|types_sizes|compiled_files|deps|exports_file|imports) took 1.890896438s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 108.107276ms
INFO [linters context/goanalysis] analyzers took 12.379726104s with top 10 stages: buildir: 7.242187453s, misspell: 478.892448ms, printf: 264.236556ms, ctrlflow: 244.947649ms, fact_deprecated: 237.310555ms, lll: 229.146646ms, isgenerated: 216.79111ms, S1038: 212.699397ms, unused: 175.328379ms, directives: 121.034517ms
INFO [runner] Issues before processing: 113, after processing: 0
INFO [runner] Processors filtering stat (out/in): path_prettifier: 113/113, exclude: 24/24, filename_unadjuster: 113/113, skip_dirs: 113/113, exclude-rules: 1/24, nolint: 0/1, cgo: 113/113, skip_files: 113/113, autogenerated_exclude: 24/113, identifier_marker: 24/24
INFO [runner] processing took 14.639435ms with stages: nolint: 12.553761ms, autogenerated_exclude: 1.211563ms, path_prettifier: 331.802µs, identifier_marker: 304.606µs, skip_dirs: 111.386µs, exclude-rules: 108.333µs, filename_unadjuster: 7.14µs, cgo: 6.599µs, max_same_issues: 1.001µs, max_from_linter: 670ns, uniq_by_line: 507ns, diff: 279ns, source_code: 273ns, exclude: 245ns, path_shortener: 237ns, severity-rules: 227ns, skip_files: 222ns, sort_results: 212ns, max_per_file_from_linter: 198ns, path_prefixer: 174ns
INFO [runner] linters took 6.665579705s with stages: goanalysis_metalinter: 6.650853834s
INFO File cache stats: 97 entries of total size 1.5MiB
INFO Memory: 88 samples, avg is 305.2MB, max is 816.3MB
INFO Execution took 8.675756863s
```


`make unit`
```
/usr/local/go/bin/go test -c -o /private/var/folders/3l/b_3x45hx0fz5gy60xrg02mcw0000gp/T/GoLand/___TestValidatePVCAnnotationForVolumeHealth_in_sigs_k8s_io_vsphere_csi_driver_v2_pkg_syncer_admissionhandler.test sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/3l/b_3x45hx0fz5gy60xrg02mcw0000gp/T/GoLand/___TestValidatePVCAnnotationForVolumeHealth_in_sigs_k8s_io_vsphere_csi_driver_v2_pkg_syncer_admissionhandler.test -test.v -test.paniconexit0 -test.run ^\QTestValidatePVCAnnotationForVolumeHealth\E$
=== RUN   TestValidatePVCAnnotationForVolumeHealth
=== RUN   TestValidatePVCAnnotationForVolumeHealth/TestCreatePVCWithNonEmptyAnnVolumeHealthByDevopsUser
=== RUN   TestValidatePVCAnnotationForVolumeHealth/TestCreatePVCWithAbsentAnnVolumeHealthByDevopsUser
=== RUN   TestValidatePVCAnnotationForVolumeHealth/TestCreatePVCWithNonEmptyAnnVolumeHealthByCSIServiceAccount
=== RUN   TestValidatePVCAnnotationForVolumeHealth/TestUpdatePVCAnnVolumeHealthToInaccessibleByDevopsUser
=== RUN   TestValidatePVCAnnotationForVolumeHealth/TestUpdatePVCAnnVolumeHealthToRandomByDevopsUser
=== RUN   TestValidatePVCAnnotationForVolumeHealth/TestUpdatePVCAnnVolumeHealthToInaccessibleByCSIServiceAccount
=== RUN   TestValidatePVCAnnotationForVolumeHealth/TestUpdatePVCAnnVolumeHealthToAccessibleByCSIServiceAccount
=== RUN   TestValidatePVCAnnotationForVolumeHealth/TestUpdatePVCRemoveAnnVolumeHealthByDevopsUser
=== RUN   TestValidatePVCAnnotationForVolumeHealth/TestUpdatePVCRemoveAnnVolumeHealthByCSIServiceAccount
--- PASS: TestValidatePVCAnnotationForVolumeHealth (0.00s)
    --- PASS: TestValidatePVCAnnotationForVolumeHealth/TestCreatePVCWithNonEmptyAnnVolumeHealthByDevopsUser (0.00s)
    --- PASS: TestValidatePVCAnnotationForVolumeHealth/TestCreatePVCWithAbsentAnnVolumeHealthByDevopsUser (0.00s)
    --- PASS: TestValidatePVCAnnotationForVolumeHealth/TestCreatePVCWithNonEmptyAnnVolumeHealthByCSIServiceAccount (0.00s)
    --- PASS: TestValidatePVCAnnotationForVolumeHealth/TestUpdatePVCAnnVolumeHealthToInaccessibleByDevopsUser (0.00s)
    --- PASS: TestValidatePVCAnnotationForVolumeHealth/TestUpdatePVCAnnVolumeHealthToRandomByDevopsUser (0.00s)
    --- PASS: TestValidatePVCAnnotationForVolumeHealth/TestUpdatePVCAnnVolumeHealthToInaccessibleByCSIServiceAccount (0.00s)
    --- PASS: TestValidatePVCAnnotationForVolumeHealth/TestUpdatePVCAnnVolumeHealthToAccessibleByCSIServiceAccount (0.00s)
    --- PASS: TestValidatePVCAnnotationForVolumeHealth/TestUpdatePVCRemoveAnnVolumeHealthByDevopsUser (0.00s)
    --- PASS: TestValidatePVCAnnotationForVolumeHealth/TestUpdatePVCRemoveAnnVolumeHealthByCSIServiceAccount (0.00s)
PASS

Process finished with the exit code 0

```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
