### PR TITLE
Bump up liveness-probe for WCP

### DIFF
--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -317,7 +317,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.6.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
           volumeMounts:

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -321,7 +321,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.6.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
           volumeMounts:

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -321,7 +321,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.3.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.6.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
           volumeMounts:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Bump up liveness-probe to 2.6 for WCP

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Testing will be done by integrating CSI driver builds with vSphere & WCP builds.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump up liveness-probe to 2.6 for WCP
```
