### PR TITLE
Code fix for Topology automation test scenario

### DIFF
--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -1316,8 +1316,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
-		vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 		isDiskAttached, err = e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle,
 			vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**
Topology automation part3
TC: Verify static volume provisioning with FCD and storage class specified with datastore url and set of allowed topologies

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Topology automation part3
TC: Verify static volume provisioning with FCD and storage class specified with datastore url and set of allowed topologies


**Testing done**:
Yes

**Special notes for your reviewer**:
Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % 
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % 
sipriya@sipriya-a01 vsphere-csi-driver % 
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/topology-pr-fix/vsphere-csi-driver /Users/sipriya/topology-pr-fix /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (types_sizes|files|imports|compiled_files|deps|exports_file|name) took 11.378287757s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 101.454448ms 
INFO [linters context/goanalysis] analyzers took 36.078411008s with top 10 stages: buildir: 12.356590144s, misspell: 1.781230081s, S1038: 1.112606777s, printf: 994.160337ms, ctrlflow: 944.034037ms, isgenerated: 828.490109ms, lll: 792.455157ms, unused: 783.597493ms, fact_deprecated: 689.945163ms, SA1012: 578.960593ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude-rules: 1/24, cgo: 113/113, filename_unadjuster: 113/113, skip_files: 113/113, skip_dirs: 113/113, nolint: 0/1, path_prettifier: 113/113, autogenerated_exclude: 24/113, exclude: 24/24, identifier_marker: 24/24 
INFO [runner] processing took 14.929917ms with stages: nolint: 12.912197ms, autogenerated_exclude: 1.066496ms, path_prettifier: 354.093µs, identifier_marker: 349.296µs, skip_dirs: 121.69µs, exclude-rules: 108.248µs, filename_unadjuster: 6.667µs, cgo: 6.569µs, max_same_issues: 1.358µs, uniq_by_line: 636ns, diff: 372ns, source_code: 362ns, max_from_linter: 287ns, skip_files: 287ns, exclude: 272ns, severity-rules: 259ns, path_shortener: 244ns, sort_results: 237ns, max_per_file_from_linter: 227ns, path_prefixer: 120ns 
INFO [runner] linters took 8.270460183s with stages: goanalysis_metalinter: 8.255428682s 
INFO File cache stats: 277 entries of total size 4.2MiB 
INFO Memory: 198 samples, avg is 269.2MB, max is 1089.3MB 
INFO Execution took 19.761331405s                 
sipriya@sipriya-a01 vsphere-csi-driver % 
