### PR TITLE
[TKGs-HA] Change clusterComputeResourceMoId from string to slice in AZ CR

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -288,17 +288,18 @@ func azCRAdded(obj interface{}) {
 		log.Errorf("failed to get `name` from AvailabilityZone instance: %+v, Error: %+v", obj, err)
 		return
 	}
-	// Retrieve clusterMoref from instance spec.
-	// TODO: TKGS-HA - convert to slice when appropriate
-	clusterComputeResourceMoId, found, err := unstructured.NestedString(obj.(*unstructured.Unstructured).Object,
-		"spec", "clusterComputeResourceMoId")
-	if !found || err != nil {
-		log.Errorf("failed to get `clusterComputeResourceMoId` from AvailabilityZone instance: %+v, Error: %+v",
-			obj, err)
+	// Retrieve clusterMorefs from instance spec.
+	clusterComputeResourceMoIds, found, err := unstructured.NestedStringSlice(obj.(*unstructured.Unstructured).Object,
+		"spec", "clusterComputeResourceMoIDs")
+	if len(clusterComputeResourceMoIds) == 0 || !found || err != nil {
+		log.Errorf("failed to get `clusterComputeResourceMoIds` from AvailabilityZone instance: %+v, "+
+			"Error: %+v", obj, err)
 		return
 	}
 	// Add to cache.
-	addToAZClusterMap(ctx, azName, clusterComputeResourceMoId)
+	// TODO: For VC 8.0 release, zone to CCR is a 1:1 mapping.
+	// Update this when one vSphere zone can span across multiple CCRs.
+	addToAZClusterMap(ctx, azName, clusterComputeResourceMoIds[0])
 }
 
 // azCRUpdated handles deleting AZ name in the cache.

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -382,11 +382,10 @@ func Contains(list []string, item string) bool {
 }
 
 // GetClusterComputeResourceMoIds helps find ClusterComputeResourceMoIds from
-// AvailabilityZone CRs on the supervisor cluster
+// AvailabilityZone CRs on the supervisor cluster.
 func GetClusterComputeResourceMoIds(ctx context.Context) ([]string, error) {
 	log := logger.GetLogger(ctx)
 	// Get a config to talk to the apiserver.
-	clusterComputeResourceMoIds := make([]string, 0)
 	cfg, err := config.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Kubernetes config. Err: %+v", err)
@@ -399,14 +398,14 @@ func GetClusterComputeResourceMoIds(ctx context.Context) ([]string, error) {
 	}
 	azResource := schema.GroupVersionResource{
 		Group: "topology.tanzu.vmware.com", Version: "v1alpha1", Resource: "availabilityzones"}
-	// Get AvailabilityZone list
+	// Get AvailabilityZone list.
 	azList, err := azClient.Resource(azResource).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		// If the AvailabilityZone CR is not registered in the
 		// supervisor cluster, we receive NoKindMatchError. In such cases
-		// return nil array for ClusterComputeResourceMoIds with no error
-		// AvailabilityZone CR is not registered when supervisor cluster was installed prior to vSphere 8.0
-		// Upgrading vSphere to 8.0 does not create zone CRs on existing supervisor clusters
+		// return nil array for ClusterComputeResourceMoIds with no error.
+		// AvailabilityZone CR is not registered when supervisor cluster was installed prior to vSphere 8.0.
+		// Upgrading vSphere to 8.0 does not create zone CRs on existing supervisor clusters.
 		_, ok := err.(*apiMeta.NoKindMatchError)
 		if ok {
 			log.Infof("AvailabilityZone CR is not registered on the cluster")
@@ -418,14 +417,17 @@ func GetClusterComputeResourceMoIds(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("could not find any AvailabilityZone")
 	}
 
+	var (
+		clusterComputeResourceMoIds []string
+		found                       bool
+	)
 	for _, az := range azList.Items {
-		// TODO: TKGS-HA - convert to slice when appropriate
-		clusterComputeResourceMoId, found, err := unstructured.NestedString(az.Object, "spec", "clusterComputeResourceMoId")
+		clusterComputeResourceMoIds, found, err = unstructured.NestedStringSlice(az.Object, "spec",
+			"clusterComputeResourceMoIDs")
 		if !found || err != nil {
-			return nil, fmt.Errorf("failed to get clusterComputeResourceMoId "+
+			return nil, fmt.Errorf("failed to get ClusterComputeResourceMoIDs "+
 				"from AvailabilityZone instance: %+v, err:%+v", az.Object, err)
 		}
-		clusterComputeResourceMoIds = append(clusterComputeResourceMoIds, clusterComputeResourceMoId)
 	}
 	return clusterComputeResourceMoIds, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR handles the update of `ClusterComputeResourceMoId` field in AvailabilityZone CR for a stretch supervisor cluster from a string to a slice. The new parameter is called `ClusterComputeResourceMoIds`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
PVC created with zonal SC:
```
Name:          block-pvc
Namespace:     default
StorageClass:  zonal
Status:        Bound
Volume:        pvc-95025434-668a-41d2-b0bb-2af5f90f3989
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Wed Apr 13 21:12:29 UTC 2022
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      200Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       block-pod
Events:
  Type    Reason                 Age   From                                                                                                 Message
  ----    ------                 ----  ----                                                                                                 -------
  Normal  Provisioning           28m   csi.vsphere.vmware.com_vsphere-csi-controller-85c9b9d566-d6cst_c6bf4001-31ff-45bb-b8de-b922ae36981f  External provisioner is provisioning volume for claim "default/block-pvc"
  Normal  ExternalProvisioning   28m   persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  ProvisioningSucceeded  28m   csi.vsphere.vmware.com_vsphere-csi-controller-85c9b9d566-d6cst_c6bf4001-31ff-45bb-b8de-b922ae36981f  Successfully provisioned volume pvc-95025434-668a-41d2-b0bb-2af5f90f3989
```

PV:
```
Name:              pvc-95025434-668a-41d2-b0bb-2af5f90f3989
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection external-attacher/csi-vsphere-vmware-com]
StorageClass:      zonal
Status:            Bound
Claim:             default/block-pvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          200Mi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.kubernetes.io/zone in [zone-3]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      b845ee18-041a-4c6d-92f2-918de6de2a50-95025434-668a-41d2-b0bb-2af5f90f3989
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1649883576866-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```

Pod:
```
Name:         block-pod
Namespace:    default
Priority:     0
Node:         zonal-tkc-new-cidr-nodepool-3-7fwb8-759df7f744-xlvl2/192.168.128.32
Start Time:   Wed, 13 Apr 2022 21:16:43 +0000
Labels:       <none>
Annotations:  kubernetes.io/psp: vmware-system-privileged
Status:       Running
IP:           172.16.1.2
IPs:
  IP:  172.16.1.2
Containers:
  test-container:
    Container ID:  containerd://d9e1116033210b4ce958303b295f74028550dddc2a1df9d90f40a843c1ab7940
    Image:         gcr.io/google_containers/busybox:1.24
    Image ID:      sha256:ddabeeccc3fa881b831a6dc22831db07d56876dc6f660fd017030bcef0f7de5c
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/sh
      -c
      echo 'hello' > /mnt/volume1/index.html  && chmod o+rX /mnt /mnt/volume1/index.html && while true ; do sleep 2 ; done
    State:          Running
      Started:      Wed, 13 Apr 2022 21:16:54 +0000
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /mnt/volume1 from test-volume (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-rkjhd (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  test-volume:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  block-pvc
    ReadOnly:   false
  kube-api-access-rkjhd:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason                  Age   From                     Message
  ----    ------                  ----  ----                     -------
  Normal  Scheduled               14s   default-scheduler        Successfully assigned default/block-pod to zonal-tkc-new-cidr-nodepool-3-7fwb8-759df7f744-xlvl2
  Normal  SuccessfulAttachVolume  13s   attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-95025434-668a-41d2-b0bb-2af5f90f3989"
  Normal  Pulling                 5s    kubelet                  Pulling image "gcr.io/google_containers/busybox:1.24"
  Normal  Pulled                  4s    kubelet                  Successfully pulled image "gcr.io/google_containers/busybox:1.24" in 1.359516868s
  Normal  Created                 4s    kubelet                  Created container test-container
  Normal  Started                 4s    kubelet                  Started container test-container
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Change clusterComputeResourceMoId from string to slice in AZ CR
```
