### PR TITLE
[Test PR] VCP-CSI migration regression tests for release 2.5 branch

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -3464,6 +3464,15 @@ func toggleCSIMigrationFeatureGatesOnKubeControllerManager(ctx context.Context,
 			fssh.LogResult(result)
 			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s", sshCmd, k8sMasterIP, err)
 		}
+		restartKubeletCmd := "systemctl restart kubelet"
+		framework.Logf("Invoking command '%v' on host %v", restartKubeletCmd, k8sMasterIP)
+		result, err = sshExec(sshClientConfig, k8sMasterIP, restartKubeletCmd)
+		if err != nil && result.Code != 0 {
+			fssh.LogResult(result)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				fmt.Sprintf("command failed/couldn't execute command: %s on host: %v", restartKubeletCmd,
+					k8sMasterIP))
+		}
 	}
 	// Sleeping for two seconds so that the change made to manifest file is
 	// recognised.


### PR DESCRIPTION
**What this PR does / why we need it**:
VCP-CSI migration regression tests for release 2.5 branch 
Note: Using only for Test PR's.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
VCP-CSI migration regression tests for release 2.5 branch 

**Testing done**:
Yes

