### PR TITLE
fix syncer crash

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -158,6 +158,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 	log.Infof("Initializing MetadataSyncer")
 	metadataSyncer := newInformer()
 	MetadataSyncer = metadataSyncer
+	metadataSyncer.configInfo = configInfo
 
 	// Create the kubernetes client from config.
 	k8sClient, err := k8s.NewClient(ctx)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
syncer container was crashing because we missed assigning `configInfo` to `metadataSyncer.configInfo`.
This is a regression caused by https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1682

**Testing done**:
Built a new image with this change and made sure syncer is no longer crashing.
Thanks @adikul30 for helping to validate this fix.

**Special notes for your reviewer**:
This is a blocker for the build recommendation pipeline and needs to be merged immediately.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix syncer crash
```
