### PR TITLE
[TKGs-HA] Cleanup when CreateVolume fails after volume is created

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -111,11 +111,11 @@ var (
 	// define any vCenters.
 	ErrMissingVCenter = errors.New("no Virtual Center hosts defined")
 
-	// ErrClusterIdCharLimit is returned when the provided cluster id is more
+	// ErrClusterIDCharLimit is returned when the provided cluster id is more
 	// than 64 characters.
 	ErrClusterIDCharLimit = errors.New("cluster id must not exceed 64 characters")
 
-	// ErrSupervisorIdCharLimit is returned when the provided supervisor id is more
+	// ErrSupervisorIDCharLimit is returned when the provided supervisor id is more
 	// than 64 characters.
 	ErrSupervisorIDCharLimit = errors.New("supervisor id must not exceed 64 characters")
 

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -212,6 +212,16 @@ func (f *fakeVolumeOperationRequestInterface) StoreRequestDetails(
 	return nil
 }
 
+// DeleteRequestDetails deletes the VolumeOperationRequestDetails for the given
+// name, if any, stored by the fake VolumeOperationRequest interface.
+func (f *fakeVolumeOperationRequestInterface) DeleteRequestDetails(
+	ctx context.Context,
+	name string,
+) error {
+	delete(f.volumeOperationRequestMap, name)
+	return nil
+}
+
 // GetNodesForVolumes returns nodeNames to which the given volumeIDs are attached
 func (c *FakeK8SOrchestrator) GetNodesForVolumes(ctx context.Context, volumeID []string) map[string][]string {
 	nodeNames := make(map[string][]string)

--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -30,6 +30,16 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 )
 
+// InvalidTopologyProvisioningError is raised when volume provisioning
+// fails on a topology aware setup due to an invalid setting.
+type InvalidTopologyProvisioningError struct {
+	ErrMsg string
+}
+
+func (e *InvalidTopologyProvisioningError) Error() string {
+	return e.ErrMsg
+}
+
 // ValidateCreateVolumeRequest is the helper function to validate
 // CreateVolumeRequest for all block controllers.
 // Function returns error if validation fails otherwise returns nil.

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"reflect"
 	"strconv"
@@ -1107,7 +1106,7 @@ func (volTopology *wcpControllerVolumeTopology) GetTopologyInfoFromNodes(ctx con
 					datastores, err := params.Vc.GetDatastoresByCluster(ctx, clusterMoref)
 					if err != nil {
 						return nil, logger.LogNewErrorf(log,
-							"Failed to fetch datastores associated with cluster %q", clusterMoref)
+							"failed to fetch datastores associated with cluster %q", clusterMoref)
 					}
 					for _, ds := range datastores {
 						if ds.Info.Url == params.DatastoreURL {
@@ -1125,23 +1124,19 @@ func (volTopology *wcpControllerVolumeTopology) GetTopologyInfoFromNodes(ctx con
 					"could not find the topology of the volume provisioned on datastore %q", params.DatastoreURL)
 			case numSelectedSegments > 1:
 				// This situation will arise when datastore belongs to multiple zones but the
-				// storageTopologyType is `zonal`. In such cases, we will choose a random zone among
-				// the retrieved zones and use it as node affinity for the PV.
-				rand.Seed(time.Now().Unix())
-				topologySegments = append(topologySegments, selectedSegments[rand.Intn(len(selectedSegments))])
-				log.Infof("Selected topology %+v from possible selections %+v", topologySegments,
-					selectedSegments)
+				// storageTopologyType is `zonal`. This seems like a configuration error.
+				return nil, &common.InvalidTopologyProvisioningError{ErrMsg: fmt.Sprintf(
+					"zonal volume is provisioned on %q datastore which is accessible from multiple zones: %+v. "+
+						"Kindly check the configuration of the storage policy used in the StorageClass.",
+					params.DatastoreURL, selectedSegments)}
 			default:
 				topologySegments = selectedSegments
 			}
 		}
-	case "crosszonal":
-		// TODO: TKGS-HA : Implement the node affinity logic for crossZonal
-		return nil, logger.LogNewErrorf(log,
-			"Node Affinity logic for crossZonal storageTopologyType not implemented yet.")
 	default:
-		return nil, logger.LogNewErrorf(log, "Unrecognised storageTopologyType found: %q",
-			params.StorageTopologyType)
+		// This is considered a configuration error.
+		return nil, &common.InvalidTopologyProvisioningError{ErrMsg: fmt.Sprintf("unrecognised "+
+			"storageTopologyType found: %q", params.StorageTopologyType)}
 	}
 	log.Infof("Topology of the provisioned volume detected as %+v", topologySegments)
 	return topologySegments, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR adds in minor corrections and validations. It also handles the case where the customer requests for a zonal volume and the volume provisioned is on a datastore which is accessible from more than one vSphere zone.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
**Positive case**
GC PVC:
```
Name:          zonal-pvc
Namespace:     default
StorageClass:  zonal
Status:        Bound
Volume:        pvc-2bb455ee-f434-4d36-9e94-193a9fe54fd7
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      100Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                From                                                                                                 Message
  ----    ------                 ----               ----                                                                                                 -------
  Normal  Provisioning           11s                csi.vsphere.vmware.com_vsphere-csi-controller-66c5cdf558-lrp2j_8e051834-4376-4a41-bccb-644028b9eccc  External provisioner is provisioning volume for claim "default/zonal-pvc"
  Normal  ExternalProvisioning   10s (x2 over 11s)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  ProvisioningSucceeded  9s                 csi.vsphere.vmware.com_vsphere-csi-controller-66c5cdf558-lrp2j_8e051834-4376-4a41-bccb-644028b9eccc  Successfully provisioned volume pvc-2bb455ee-f434-4d36-9e94-193a9fe54fd7
```

SV PVC:
```
Name:          6a95bb4e-e9bd-4bbc-9ae7-84d96cbeb20b-2bb455ee-f434-4d36-9e94-193a9fe54fd7
Namespace:     new-gc
StorageClass:  zonal
Status:        Bound
Volume:        pvc-0225e0fb-226f-4266-81fc-7cdfac91fca7
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"zone-1"}]
               csi.vsphere.volume-requested-topology:
                 [{"topology.kubernetes.io/zone":"zone-1"},{"topology.kubernetes.io/zone":"zone-2"},{"topology.kubernetes.io/zone":"zone-3"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Thu Apr 28 22:48:10 UTC 2022
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      100Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                   From                                                                                          Message
  ----    ------                 ----                  ----                                                                                          -------
  Normal  Provisioning           5m10s                 csi.vsphere.vmware.com_420374ca3dc499cc6bc10615d8606387_264003db-6797-4f97-a955-f66ebeca8514  External provisioner is provisioning volume for claim "new-gc/6a95bb4e-e9bd-4bbc-9ae7-84d96cbeb20b-2bb455ee-f434-4d36-9e94-193a9fe54fd7"
  Normal  ExternalProvisioning   5m8s (x3 over 5m10s)  persistentvolume-controller                                                                   waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  ProvisioningSucceeded  5m8s                  csi.vsphere.vmware.com_420374ca3dc499cc6bc10615d8606387_264003db-6797-4f97-a955-f66ebeca8514  Successfully provisioned volume pvc-0225e0fb-226f-4266-81fc-7cdfac91fca7
```

SV logs:
```
{"level":"info","time":"2022-04-28T22:44:26.970179864Z","caller":"wcp/controller.go:725","msg":"CreateVolume: called with args {Name:pvc-0225e0fb-226f-4266-81fc-7cdfac91fca7 CapacityRange:required_bytes:104857600  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[StorageTopologyType:Zonal storagePolicyID:99498346-fd55-4226-a268-692c9f0fb7e2] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"f2498929-6e97-44b9-aecb-2bb231758b3d"}
{"level":"info","time":"2022-04-28T22:44:26.978515702Z","caller":"wcp/controller.go:422","msg":"Topology aware environment detected with requirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > ","TraceId":"f2498929-6e97-44b9-aecb-2bb231758b3d"}
{"level":"info","time":"2022-04-28T22:44:26.978700276Z","caller":"k8sorchestrator/topology.go:1077","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-1] are [domain-c71]","TraceId":"f2498929-6e97-44b9-aecb-2bb231758b3d"}
{"level":"info","time":"2022-04-28T22:44:27.062863105Z","caller":"vsphere/utils.go:391","msg":"Found shared datastores: [Datastore: Datastore:datastore-170, datastore URL: ds:///vmfs/volumes/a9495f19-066274b7/ Datastore: Datastore:datastore-67, datastore URL: ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/] and vSAN Direct datastores: []","TraceId":"f2498929-6e97-44b9-aecb-2bb231758b3d"}
{"level":"info","time":"2022-04-28T22:44:27.062980532Z","caller":"k8sorchestrator/topology.go:1077","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-2] are [domain-c73]","TraceId":"f2498929-6e97-44b9-aecb-2bb231758b3d"}
{"level":"info","time":"2022-04-28T22:44:27.136034567Z","caller":"vsphere/utils.go:391","msg":"Found shared datastores: [Datastore: Datastore:datastore-168, datastore URL: ds:///vmfs/volumes/ce20238d-ce3cfc80/ Datastore: Datastore:datastore-67, datastore URL: ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/] and vSAN Direct datastores: []","TraceId":"f2498929-6e97-44b9-aecb-2bb231758b3d"}
{"level":"info","time":"2022-04-28T22:44:27.136146151Z","caller":"k8sorchestrator/topology.go:1077","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-3] are [domain-c79]","TraceId":"f2498929-6e97-44b9-aecb-2bb231758b3d"}
{"level":"info","time":"2022-04-28T22:44:27.225535668Z","caller":"vsphere/utils.go:391","msg":"Found shared datastores: [Datastore: Datastore:datastore-169, datastore URL: ds:///vmfs/volumes/c53dbce2-461eb4ff/ Datastore: Datastore:datastore-67, datastore URL: ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/] and vSAN Direct datastores: []","TraceId":"f2498929-6e97-44b9-aecb-2bb231758b3d"}
{"level":"info","time":"2022-04-28T22:44:27.929082117Z","caller":"volume/manager.go:408","msg":"CreateVolume: VolumeName: \"pvc-0225e0fb-226f-4266-81fc-7cdfac91fca7\", opId: \"66ca73d2\"","TraceId":"f2498929-6e97-44b9-aecb-2bb231758b3d"}
{"level":"info","time":"2022-04-28T22:44:27.932723083Z","caller":"volume/util.go:322","msg":"Volume created successfully. VolumeName: \"pvc-0225e0fb-226f-4266-81fc-7cdfac91fca7\", volumeID: \"d05dd512-41e2-4bf1-984a-2e40e075f100\"","TraceId":"f2498929-6e97-44b9-aecb-2bb231758b3d"}
{"level":"info","time":"2022-04-28T22:44:28.029872258Z","caller":"k8sorchestrator/topology.go:1145","msg":"Topology of the provisioned volume detected as [map[topology.kubernetes.io/zone:zone-1]]","TraceId":"f2498929-6e97-44b9-aecb-2bb231758b3d"}
```


**Negative case**
SV PVC:
```
Name:          6a95bb4e-e9bd-4bbc-9ae7-84d96cbeb20b-d814465f-7420-446b-a0e8-817425a62e70
Namespace:     new-gc
StorageClass:  zonal
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   csi.vsphere.volume-requested-topology:
                 [{"topology.kubernetes.io/zone":"zone-1"},{"topology.kubernetes.io/zone":"zone-2"},{"topology.kubernetes.io/zone":"zone-3"}]
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age                From                                                                                          Message
  ----     ------                ----               ----                                                                                          -------
  Warning  ProvisioningFailed    39s                csi.vsphere.vmware.com_420374ca3dc499cc6bc10615d8606387_264003db-6797-4f97-a955-f66ebeca8514  failed to provision volume with StorageClass "zonal": rpc error: code = Internal desc = encountered an error while fetching accessible topologies for volume "a603275c-e644-4610-aa88-d39cc123acdd". Error: zonal volume is provisioned on "ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/" datastore which is accessible from multiple zones: [map[topology.kubernetes.io/zone:zone-1] map[topology.kubernetes.io/zone:zone-2] map[topology.kubernetes.io/zone:zone-3]]. Kindly check the configuration of the storage policy used in the StorageClass.
  Warning  ProvisioningFailed    33s                csi.vsphere.vmware.com_420374ca3dc499cc6bc10615d8606387_264003db-6797-4f97-a955-f66ebeca8514  failed to provision volume with StorageClass "zonal": rpc error: code = Internal desc = encountered an error while fetching accessible topologies for volume "a6b5a389-5bc1-4a18-a0e5-16c1eda2dfdf". Error: zonal volume is provisioned on "ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/" datastore which is accessible from multiple zones: [map[topology.kubernetes.io/zone:zone-1] map[topology.kubernetes.io/zone:zone-2] map[topology.kubernetes.io/zone:zone-3]]. Kindly check the configuration of the storage policy used in the StorageClass.
  Warning  ProvisioningFailed    24s                csi.vsphere.vmware.com_420374ca3dc499cc6bc10615d8606387_264003db-6797-4f97-a955-f66ebeca8514  failed to provision volume with StorageClass "zonal": rpc error: code = Internal desc = encountered an error while fetching accessible topologies for volume "828dd417-a29d-47c8-84c0-0c8c1154d773". Error: zonal volume is provisioned on "ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/" datastore which is accessible from multiple zones: [map[topology.kubernetes.io/zone:zone-1] map[topology.kubernetes.io/zone:zone-2] map[topology.kubernetes.io/zone:zone-3]]. Kindly check the configuration of the storage policy used in the StorageClass.
  Warning  ProvisioningFailed    16s                csi.vsphere.vmware.com_420374ca3dc499cc6bc10615d8606387_264003db-6797-4f97-a955-f66ebeca8514  failed to provision volume with StorageClass "zonal": rpc error: code = Internal desc = encountered an error while fetching accessible topologies for volume "efcbff52-2abe-4092-ba72-3e917968d0df". Error: zonal volume is provisioned on "ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/" datastore which is accessible from multiple zones: [map[topology.kubernetes.io/zone:zone-1] map[topology.kubernetes.io/zone:zone-2] map[topology.kubernetes.io/zone:zone-3]]. Kindly check the configuration of the storage policy used in the StorageClass.
  Normal   ExternalProvisioning  15s (x4 over 42s)  persistentvolume-controller                                                                   waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   Provisioning          8s (x5 over 42s)   csi.vsphere.vmware.com_420374ca3dc499cc6bc10615d8606387_264003db-6797-4f97-a955-f66ebeca8514  External provisioner is provisioning volume for claim "new-gc/6a95bb4e-e9bd-4bbc-9ae7-84d96cbeb20b-d814465f-7420-446b-a0e8-817425a62e70"
  Warning  ProvisioningFailed    2s                 csi.vsphere.vmware.com_420374ca3dc499cc6bc10615d8606387_264003db-6797-4f97-a955-f66ebeca8514  failed to provision volume with StorageClass "zonal": rpc error: code = Internal desc = encountered an error while fetching accessible topologies for volume "f849b91b-5f29-4638-bb5d-0097984dc280". Error: zonal volume is provisioned on "ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/" datastore which is accessible from multiple zones: [map[topology.kubernetes.io/zone:zone-1] map[topology.kubernetes.io/zone:zone-2] map[topology.kubernetes.io/zone:zone-3]]. Kindly check the configuration of the storage policy used in the StorageClass.
```

GC PVC:
```
Name:          zonal-pvc
Namespace:     default
StorageClass:  zonal
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                Age                From                                                                                                 Message
  ----    ------                ----               ----                                                                                                 -------
  Normal  Provisioning          49s                csi.vsphere.vmware.com_vsphere-csi-controller-66c5cdf558-lrp2j_8e051834-4376-4a41-bccb-644028b9eccc  External provisioner is provisioning volume for claim "default/zonal-pvc"
  Normal  ExternalProvisioning  15s (x4 over 49s)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
```


SV Logs with one retry:
```
{"level":"info","time":"2022-04-28T22:40:09.183875755Z","caller":"wcp/controller.go:725","msg":"CreateVolume: called with args {Name:pvc-6de43b08-f330-406a-90bb-7b26258239fa CapacityRange:required_bytes:104857600  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[StorageTopologyType:Zonal storagePolicyID:99498346-fd55-4226-a268-692c9f0fb7e2] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e"}
{"level":"info","time":"2022-04-28T22:40:09.235040854Z","caller":"wcp/controller.go:422","msg":"Topology aware environment detected with requirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > ","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e"}
{"level":"info","time":"2022-04-28T22:40:09.235215379Z","caller":"k8sorchestrator/topology.go:1077","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-1] are [domain-c71]","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e"}
{"level":"info","time":"2022-04-28T22:40:09.378942567Z","caller":"vsphere/utils.go:391","msg":"Found shared datastores: [Datastore: Datastore:datastore-170, datastore URL: ds:///vmfs/volumes/a9495f19-066274b7/ Datastore: Datastore:datastore-67, datastore URL: ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/] and vSAN Direct datastores: []","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e"}
{"level":"info","time":"2022-04-28T22:40:09.379107632Z","caller":"k8sorchestrator/topology.go:1077","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-2] are [domain-c73]","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e"}
{"level":"info","time":"2022-04-28T22:40:09.472453534Z","caller":"vsphere/utils.go:391","msg":"Found shared datastores: [Datastore: Datastore:datastore-168, datastore URL: ds:///vmfs/volumes/ce20238d-ce3cfc80/ Datastore: Datastore:datastore-67, datastore URL: ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/] and vSAN Direct datastores: []","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e"}
{"level":"info","time":"2022-04-28T22:40:09.472621492Z","caller":"k8sorchestrator/topology.go:1077","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-3] are [domain-c79]","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e"}
{"level":"info","time":"2022-04-28T22:40:09.587840526Z","caller":"vsphere/utils.go:391","msg":"Found shared datastores: [Datastore: Datastore:datastore-169, datastore URL: ds:///vmfs/volumes/c53dbce2-461eb4ff/ Datastore: Datastore:datastore-67, datastore URL: ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/] and vSAN Direct datastores: []","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e"}
{"level":"info","time":"2022-04-28T22:40:11.047684336Z","caller":"volume/manager.go:408","msg":"CreateVolume: VolumeName: \"pvc-6de43b08-f330-406a-90bb-7b26258239fa\", opId: \"66ca7329\"","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e"}
{"level":"info","time":"2022-04-28T22:40:11.058925915Z","caller":"volume/util.go:322","msg":"Volume created successfully. VolumeName: \"pvc-6de43b08-f330-406a-90bb-7b26258239fa\", volumeID: \"a603275c-e644-4610-aa88-d39cc123acdd\"","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e"}
{"level":"info","time":"2022-04-28T22:40:11.959639513Z","caller":"volume/manager.go:1012","msg":"DeleteVolume: volumeID: \"a603275c-e644-4610-aa88-d39cc123acdd\", opId: \"66ca732c\"","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e"}
{"level":"info","time":"2022-04-28T22:40:11.959788506Z","caller":"volume/manager.go:1037","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"a603275c-e644-4610-aa88-d39cc123acdd\", opId: \"66ca732c\"","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e"}
{"level":"error","time":"2022-04-28T22:40:12.001703451Z","caller":"wcp/controller.go:587","msg":"encountered an error while fetching accessible topologies for volume \"a603275c-e644-4610-aa88-d39cc123acdd\". Error: zonal volume is provisioned on \"ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/\" datastore which is accessible from multiple zones: [map[topology.kubernetes.io/zone:zone-1] map[topology.kubernetes.io/zone:zone-2] map[topology.kubernetes.io/zone:zone-3]]. Kindly check the configuration of the storage policy used in the StorageClass.","TraceId":"12f225ba-8149-4fd5-ae28-5acd4171ec8e","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).createBlockVolume\n\t/build/pkg/csi/service/wcp/controller.go:587\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).CreateVolume.func1\n\t/build/pkg/csi/service/wcp/controller.go:761\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).CreateVolume\n\t/build/pkg/csi/service/wcp/controller.go:763\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler\n\t/go/pkg/mod/github.com/container-storage-interface/spec@v1.4.0/lib/go/csi/csi.pb.go:5589\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.27.1/server.go:1024\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.27.1/server.go:1313\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.1\n\t/go/pkg/mod/google.golang.org/grpc@v1.27.1/server.go:722"}
{"level":"info","time":"2022-04-28T22:40:13.054723603Z","caller":"wcp/controller.go:725","msg":"CreateVolume: called with args {Name:pvc-6de43b08-f330-406a-90bb-7b26258239fa CapacityRange:required_bytes:104857600  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[StorageTopologyType:Zonal storagePolicyID:99498346-fd55-4226-a268-692c9f0fb7e2] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1"}
{"level":"info","time":"2022-04-28T22:40:13.060544041Z","caller":"wcp/controller.go:422","msg":"Topology aware environment detected with requirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > ","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1"}
{"level":"info","time":"2022-04-28T22:40:13.060675255Z","caller":"k8sorchestrator/topology.go:1077","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-1] are [domain-c71]","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1"}
{"level":"info","time":"2022-04-28T22:40:13.137897603Z","caller":"vsphere/utils.go:391","msg":"Found shared datastores: [Datastore: Datastore:datastore-170, datastore URL: ds:///vmfs/volumes/a9495f19-066274b7/ Datastore: Datastore:datastore-67, datastore URL: ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/] and vSAN Direct datastores: []","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1"}
{"level":"info","time":"2022-04-28T22:40:13.139761189Z","caller":"k8sorchestrator/topology.go:1077","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-2] are [domain-c73]","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1"}
{"level":"info","time":"2022-04-28T22:40:13.200243737Z","caller":"vsphere/utils.go:391","msg":"Found shared datastores: [Datastore: Datastore:datastore-168, datastore URL: ds:///vmfs/volumes/ce20238d-ce3cfc80/ Datastore: Datastore:datastore-67, datastore URL: ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/] and vSAN Direct datastores: []","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1"}
{"level":"info","time":"2022-04-28T22:40:13.200330752Z","caller":"k8sorchestrator/topology.go:1077","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-3] are [domain-c79]","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1"}
{"level":"info","time":"2022-04-28T22:40:13.257956452Z","caller":"vsphere/utils.go:391","msg":"Found shared datastores: [Datastore: Datastore:datastore-169, datastore URL: ds:///vmfs/volumes/c53dbce2-461eb4ff/ Datastore: Datastore:datastore-67, datastore URL: ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/] and vSAN Direct datastores: []","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1"}
{"level":"info","time":"2022-04-28T22:40:14.449350439Z","caller":"volume/manager.go:408","msg":"CreateVolume: VolumeName: \"pvc-6de43b08-f330-406a-90bb-7b26258239fa\", opId: \"66ca7331\"","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1"}
{"level":"info","time":"2022-04-28T22:40:14.455045811Z","caller":"volume/util.go:322","msg":"Volume created successfully. VolumeName: \"pvc-6de43b08-f330-406a-90bb-7b26258239fa\", volumeID: \"a6b5a389-5bc1-4a18-a0e5-16c1eda2dfdf\"","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1"}
{"level":"info","time":"2022-04-28T22:40:18.83622476Z","caller":"volume/manager.go:1012","msg":"DeleteVolume: volumeID: \"a6b5a389-5bc1-4a18-a0e5-16c1eda2dfdf\", opId: \"66ca7334\"","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1"}
{"level":"info","time":"2022-04-28T22:40:18.836336069Z","caller":"volume/manager.go:1037","msg":"DeleteVolume: Volume deleted successfully. volumeID: \"a6b5a389-5bc1-4a18-a0e5-16c1eda2dfdf\", opId: \"66ca7334\"","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1"}
{"level":"error","time":"2022-04-28T22:40:18.898139739Z","caller":"wcp/controller.go:587","msg":"encountered an error while fetching accessible topologies for volume \"a6b5a389-5bc1-4a18-a0e5-16c1eda2dfdf\". Error: zonal volume is provisioned on \"ds:///vmfs/volumes/625e549c-30dd8395-5da9-020079cd2391/\" datastore which is accessible from multiple zones: [map[topology.kubernetes.io/zone:zone-1] map[topology.kubernetes.io/zone:zone-2] map[topology.kubernetes.io/zone:zone-3]]. Kindly check the configuration of the storage policy used in the StorageClass.","TraceId":"5b37596b-1594-4063-8dcb-e3113ff92fd1","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).createBlockVolume\n\t/build/pkg/csi/service/wcp/controller.go:587\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).CreateVolume.func1\n\t/build/pkg/csi/service/wcp/controller.go:761\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).CreateVolume\n\t/build/pkg/csi/service/wcp/controller.go:763\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler\n\t/go/pkg/mod/github.com/container-storage-interface/spec@v1.4.0/lib/go/csi/csi.pb.go:5589\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.27.1/server.go:1024\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.27.1/server.go:1313\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.1\n\t/go/pkg/mod/google.golang.org/grpc@v1.27.1/server.go:722"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
TKGs-HA: Cleanup when CreateVolume fails after volume is created
```
