### PR TITLE
Check if vm and disk association exists in detach volume for supervisor

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -23,9 +23,9 @@ import (
 	"sync"
 
 	"google.golang.org/grpc/codes"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration"
-
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
@@ -229,4 +229,10 @@ func (c *FakeK8SOrchestrator) GetNodeIDtoNameMap(ctx context.Context) map[string
 func (c *FakeK8SOrchestrator) GetFakeAttachedVolumes(ctx context.Context, volumeID []string) map[string]bool {
 	fakeAttachedVolumes := make(map[string]bool)
 	return fakeAttachedVolumes
+}
+
+// GetVolumeAttachment returns the VA object by using the given volumeId & nodeName
+func (c *FakeK8SOrchestrator) GetVolumeAttachment(ctx context.Context, volumeId string, nodeName string) (
+	*storagev1.VolumeAttachment, error) {
+	return nil, nil
 }

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	storagev1 "k8s.io/api/storage/v1"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
 
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
@@ -58,6 +59,8 @@ type COCommonInterface interface {
 	// GetFakeAttachedVolumes returns a map of volumeIDs to a bool, which is set
 	// to true if volumeID key is fake attached else false
 	GetFakeAttachedVolumes(ctx context.Context, volumeIDs []string) map[string]bool
+	//GetVolumeAttachment is used to fetch the VA object from the cluster.
+	GetVolumeAttachment(ctx context.Context, volumeId string, nodeName string) (*storagev1.VolumeAttachment, error)
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -95,6 +95,9 @@ const (
 	// AttributeFirstClassDiskUUID is the SCSI Disk Identifier.
 	AttributeFirstClassDiskUUID = "diskUUID"
 
+	// AttributeVmUUID is the vmUUID to which volume is attached to.
+	AttributeVmUUID = "vmUUID"
+
 	// AttributeFakeAttached is the flag that indicates if a volume is fake
 	// attached.
 	AttributeFakeAttached = "fake-attach"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making changes to WCP detach volume method to check if vm and disk association exists before sending a successful response for ControllerPublishVolume. This is needed because DetachVolume is currently a no-op for CSI in WCP and there is a need for checking if vm-volumeid association does not exist in CNS.

Here is the overview of the changes this PR is bringing in:
* vmuuid is added in the VA object status.Metadata field during AttachVolume.
* The association between vm & volumeId is checked, by fetching the vmuuid from VA object during DetachVolume. 
* Once the vmuuid is found, we will check if the volumeid still exist in vm devices. 
With these changes DeleteVolume resource in use errors will not be observed when PVC is deleted after Pod is deleted

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Captured logs & run basic e2e tests


```
2022-03-29T08:14:09.325Z	DEBUG	wcp/controller.go:969	Found PV: {TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:pvc-5fe29e12-943b-4fab-a463-9ced73203681 GenerateName: Namespace: SelfLink:/api/v1/persistentvolumes/pvc-5fe29e12-943b-4fab-a463-9ced73203681 UID:bab17926-8178-4a67-8e75-b96443f7b65f ResourceVersion:30996123 Generation:0 CreationTimestamp:2022-03-23 06:10:48 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[pv.kubernetes.io/provisioned-by:csi.vsphere.vmware.com] OwnerReferences:[] Finalizers:[kubernetes.io/pv-protection external-attacher/csi-vsphere-vmware-com] ClusterName: ManagedFields:[{Manager:csi-provisioner Operation:Update APIVersion:v1 Time:2022-03-23 06:10:48 +0000 UTC FieldsType:FieldsV1 FieldsV1:{"f:metadata":{"f:annotations":{".":{},"f:pv.kubernetes.io/provisioned-by":{}}},"f:spec":{"f:accessModes":{},"f:capacity":{".":{},"f:storage":{}},"f:claimRef":{".":{},"f:apiVersion":{},"f:kind":{},"f:name":{},"f:namespace":{},"f:resourceVersion":{},"f:uid":{}},"f:csi":{".":{},"f:driver":{},"f:fsType":{},"f:volumeAttributes":{".":{},"f:storage.kubernetes.io/csiProvisionerIdentity":{},"f:type":{}},"f:volumeHandle":{}},"f:persistentVolumeReclaimPolicy":{},"f:storageClassName":{},"f:volumeMode":{}}}} {Manager:kube-controller-manager Operation:Update APIVersion:v1 Time:2022-03-23 06:10:48 +0000 UTC FieldsType:FieldsV1 FieldsV1:{"f:status":{"f:phase":{}}}} {Manager:csi-attacher Operation:Update APIVersion:v1 Time:2022-03-23 06:11:03 +0000 UTC FieldsType:FieldsV1 FieldsV1:{"f:metadata":{"f:finalizers":{"v:\"external-attacher/csi-vsphere-vmware-com\"":{}}}}}]} Spec:{Capacity:map[storage:{i:{value:1048576 scale:0} d:{Dec:<nil>} s:1Mi Format:BinarySI}] PersistentVolumeSource:{GCEPersistentDisk:nil AWSElasticBlockStore:nil HostPath:nil Glusterfs:nil NFS:nil RBD:nil ISCSI:nil Cinder:nil CephFS:nil FC:nil Flocker:nil FlexVolume:nil AzureFile:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil PortworxVolume:nil ScaleIO:nil Local:nil StorageOS:nil CSI:&CSIPersistentVolumeSource{Driver:csi.vsphere.vmware.com,VolumeHandle:0f3930c5-7192-4eef-a7a8-3b3f061b7f3e,ReadOnly:false,FSType:ext4,VolumeAttributes:map[string]string{storage.kubernetes.io/csiProvisionerIdentity: 1648015817797-8081-csi.vsphere.vmware.com,type: vSphere CNS Block Volume,},ControllerPublishSecretRef:nil,NodeStageSecretRef:nil,NodePublishSecretRef:nil,ControllerExpandSecretRef:nil,}} AccessModes:[ReadWriteOnce] ClaimRef:&ObjectReference{Kind:PersistentVolumeClaim,Namespace:test-gc-e2e-demo-ns,Name:example-vanilla-block-pvc,UID:5fe29e12-943b-4fab-a463-9ced73203681,APIVersion:v1,ResourceVersion:30995944,FieldPath:,} PersistentVolumeReclaimPolicy:Delete StorageClassName:gc-storage-profile MountOptions:[] VolumeMode:0xc0008f7840 NodeAffinity:nil} Status:{Phase:Bound Message: Reason:}} referring to volume ID: 0f3930c5-7192-4eef-a7a8-3b3f061b7f3e	{"TraceId": "29d35ce4-4052-4e45-b2e1-2622aa66e90e"}
2022-03-29T08:14:09.353Z	INFO	wcp/controller.go:995	controllerUnpublishVolumeInternal: VA : (*v1.VolumeAttachment)(0xc0007f6a80)(&VolumeAttachment{ObjectMeta:{csi-32c0a19a3916fe68c19050f486e58101fdb2660909e70ffb81fe09d9fdf2b7d8   /apis/storage.k8s.io/v1/volumeattachments/csi-32c0a19a3916fe68c19050f486e58101fdb2660909e70ffb81fe09d9fdf2b7d8 1adcca03-2c2a-42e4-9ef4-e4d7a344da63 35846930 0 2022-03-29 08:13:01 +0000 UTC 2022-03-29 08:14:09 +0000 UTC 0xc000c00410 map[] map[csi.alpha.kubernetes.io/node-id:sc1-10-78-187-113.eng.vmware.com] [] [external-attacher/csi-vsphere-vmware-com]  [{kube-controller-manager Update storage.k8s.io/v1 2022-03-29 08:13:01 +0000 UTC FieldsV1 {"f:spec":{"f:attacher":{},"f:nodeName":{},"f:source":{"f:persistentVolumeName":{}}}}} {csi-attacher Update storage.k8s.io/v1 2022-03-29 08:13:12 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{".":{},"f:csi.alpha.kubernetes.io/node-id":{}},"f:finalizers":{".":{},"v:\"external-attacher/csi-vsphere-vmware-com\"":{}}},"f:status":{"f:attached":{},"f:attachmentMetadata":{".":{},"f:diskUUID":{},"f:type":{},"f:vmuuid":{}}}}}]},Spec:VolumeAttachmentSpec{Attacher:csi.vsphere.vmware.com,Source:VolumeAttachmentSource{PersistentVolumeName:*pvc-5fe29e12-943b-4fab-a463-9ced73203681,InlineVolumeSpec:nil,},NodeName:sc1-10-78-187-113.eng.vmware.com,},Status:VolumeAttachmentStatus{Attached:true,AttachmentMetadata:map[string]string{diskUUID: 6000c29332ed3143b90dfe60e7c8a288,type: vSphere CNS Block Volume,vmuuid: 50010140-a614-94eb-d893-9147a7b8cea0,},AttachError:nil,DetachError:nil,},})
	{"TraceId": "29d35ce4-4052-4e45-b2e1-2622aa66e90e"}
2022-03-29T08:14:09.353Z	INFO	wcp/controller.go:997	controllerUnpublishVolumeInternal: VA AttachmentMetadata key: vmuuid	{"TraceId": "29d35ce4-4052-4e45-b2e1-2622aa66e90e"}
2022-03-29T08:14:09.353Z	INFO	wcp/controller.go:997	controllerUnpublishVolumeInternal: VA AttachmentMetadata key: diskUUID	{"TraceId": "29d35ce4-4052-4e45-b2e1-2622aa66e90e"}
2022-03-29T08:14:09.353Z	INFO	wcp/controller.go:997	controllerUnpublishVolumeInternal: VA AttachmentMetadata key: type	{"TraceId": "29d35ce4-4052-4e45-b2e1-2622aa66e90e"}

```



```
root@421ad32bc09922e3bce5b1a7c1e0a7f4 [ ~ ]# kubectl get pvc -n  storage-policy-test
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
example-vanilla-rwo-pvc   Bound    pvc-ead5f35b-349b-4fbf-a6fb-f6eee0933da6   1Mi        RWO            wcpglobal-storage-profile   63m

root@421ad32bc09922e3bce5b1a7c1e0a7f4 [ ~ ]# kubectl create -f pod.yaml -n storage-policy-test
pod/example-vanilla-block-pod created

root@421ad32bc09922e3bce5b1a7c1e0a7f4 [ ~ ]# kubectl get pods -n  storage-policy-test
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   0/1     Pending   0          72s

root@421ad32bc09922e3bce5b1a7c1e0a7f4 [ ~ ]# kubectl get pods -n  storage-policy-test
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   1/1     Running   0          102s

kubectl get volumeattachment
NAME                                                                   ATTACHER                 PV                                         NODE                                ATTACHED   AGE
csi-20a0a6b32474284fbfc68910de203dc27fb58f3a0e1f9f901c30392c27789f57   csi.vsphere.vmware.com   pvc-ead5f35b-349b-4fbf-a6fb-f6eee0933da6   wdc-10-180-206-99.eng.vmware.com    false      3s

root@421ad32bc09922e3bce5b1a7c1e0a7f4 [ ~ ]# kubectl describe volumeattachment csi-20a0a6b32474284fbfc68910de203dc27fb58f3a0e1f9f901c30392c27789f57
Name:         csi-20a0a6b32474284fbfc68910de203dc27fb58f3a0e1f9f901c30392c27789f57
...
...
Status:
  Attached:  true
  Attachment Metadata:
    Disk UUID:  6000c29a4599f0c547154508a42c06db
    Type:       vSphere CNS Block Volume
    Vm UUID:    501a7a97-f804-d771-0610-341faf009f36
Events:         <none>


root@421ad32bc09922e3bce5b1a7c1e0a7f4 [ ~ ]# kubectl delete -f pod.yaml -n storage-policy-test
pod "example-vanilla-block-pod" deleted
```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Check if vm and disk association exists in detach volume for supervisor
```
