### PR TITLE
prefix supervisor ID with `vSphereSupervisorID-`

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -90,6 +90,9 @@ const (
 	// DefaultListVolumeThreshold specifies the default maximum number of differences in volumes between CNS
 	// and kubernetes
 	DefaultListVolumeThreshold = 50
+	// supervisorIDPrefix is added before the SupervisorID
+	// Using this CNS UI can form an appropriate URL to navigate from CNS UI to WCP UI
+	supervisorIDPrefix = "vSphereSupervisorID-"
 )
 
 // Errors
@@ -475,6 +478,9 @@ func GetCnsconfig(ctx context.Context, cfgPath string) (*Config, error) {
 		if err != nil {
 			log.Errorf("failed to parse config. Err: %v", err)
 			return cfg, err
+		}
+		if cfg.Global.SupervisorID != "" {
+			cfg.Global.SupervisorID = supervisorIDPrefix + cfg.Global.SupervisorID
 		}
 	}
 	return cfg, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is prefixing SupervisorID with "vSphereSupervisorID-".
We need to prefix this new Cluster ID for the supervisor cluster, to help UI form an appropriate URL to navigate from CNS UI to WCP UI.


**Testing done**:
Done.

Verified Creating Volume from Guest Cluster with this change.
UI is showing a prefixed supervisor ID.
![supervisorID-prefix](https://user-images.githubusercontent.com/22985595/163468022-7e10a2a4-489c-400f-828d-4cd6292d0d8c.jpg)





**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
prefix supervisor ID with vSphereSupervisorID:
```
