### PR TITLE
Validate storageTopologyType in GC

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -242,8 +242,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		// Later we may need to define different csi faults.
 		err := validateGuestClusterCreateVolumeRequest(ctx, req)
 		if err != nil {
-			msg := fmt.Sprintf("Validation for CreateVolume Request: %+v has failed. Error: %+v", *req, err)
-			log.Error(msg)
+			log.Errorf("validation for CreateVolume Request: %+v has failed. Error: %+v", *req, err)
 			return nil, csifault.CSIInvalidArgumentFault, err
 		}
 		isFileVolumeRequest := common.IsFileVolumeRequest(ctx, req.GetVolumeCapabilities())

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -28,7 +28,6 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,31 +57,43 @@ const (
 // CreateVolumeRequest for Guest Cluster CSI driver.
 // Function returns error if validation fails otherwise returns nil.
 func validateGuestClusterCreateVolumeRequest(ctx context.Context, req *csi.CreateVolumeRequest) error {
+	log := logger.GetLogger(ctx)
 	// Validate Name length of volumeName is > 4, eg: pvc-xxxxx
 	if len(req.Name) <= 4 {
-		msg := fmt.Sprintf("Volume name %s is not valid", req.Name)
-		return status.Error(codes.InvalidArgument, msg)
+		return logger.LogNewErrorCodef(log, codes.InvalidArgument, "Volume name %s is not valid", req.Name)
 	}
+	tkgsHAEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
 	// Get create params
-	var supervisorStorageClass string
-	params := req.GetParameters()
-	for param := range params {
-		paramName := strings.ToLower(param)
-		if paramName != common.AttributeSupervisorStorageClass {
-			msg := fmt.Sprintf("Volume parameter %s is not a valid GC CSI parameter", param)
-			return status.Error(codes.InvalidArgument, msg)
+	for param, val := range req.GetParameters() {
+		switch strings.ToLower(param) {
+		case common.AttributeSupervisorStorageClass:
+			// Validate if the req contains non-empty common.AttributeSupervisorStorageClass
+			if val == "" {
+				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+					"volume parameter %s is not set in the CreateVolume request",
+					common.AttributeSupervisorStorageClass)
+			}
+		case common.AttributeStorageTopologyType:
+			if tkgsHAEnabled {
+				storageTopologyTypeVal := strings.ToLower(val)
+				if storageTopologyTypeVal != "" && storageTopologyTypeVal != "zonal" {
+					return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+						"invalid value %q received for %q parameter.", val, param)
+				}
+			} else {
+				return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+					"Volume parameter %s is not a valid GC CSI parameter", param)
+			}
+		default:
+			return logger.LogNewErrorCodef(log, codes.InvalidArgument,
+				"Volume parameter %s is not a valid GC CSI parameter", param)
 		}
-		supervisorStorageClass = req.Parameters[param]
 	}
-	// Validate if the req contains non-empty common.AttributeSupervisorStorageClass
-	if supervisorStorageClass == "" {
-		msg := fmt.Sprintf("Volume parameter %s is not set in the req", common.AttributeSupervisorStorageClass)
-		return status.Error(codes.InvalidArgument, msg)
-	}
+
 	// Fail file volume creation if file volume feature gate is disabled
 	if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.FileVolume) &&
 		common.IsFileVolumeRequest(ctx, req.GetVolumeCapabilities()) {
-		return status.Error(codes.InvalidArgument, "File volume not supported.")
+		return logger.LogNewErrorCode(log, codes.InvalidArgument, "File volume provisioning is not supported.")
 	}
 	return common.ValidateCreateVolumeRequest(ctx, req)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR validates the newly added storage class parameter called storageTopologyType in GC.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
With StorageTopologyType: Zonal 
```
Name:          block-pvc
Namespace:     default
StorageClass:  zonal
Status:        Bound
Volume:        pvc-f94c7e68-d3cd-459d-b8cf-201761dda54f
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      100Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age   From                                                                                                 Message
  ----    ------                 ----  ----                                                                                                 -------
  Normal  Provisioning           7s    csi.vsphere.vmware.com_vsphere-csi-controller-5bd6f5ddcf-29djb_51d3eee6-6f0c-4bef-8594-00f26ea0c46d  External provisioner is provisioning volume for claim "default/block-pvc"
  Normal  ExternalProvisioning   7s    persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  ProvisioningSucceeded  5s    csi.vsphere.vmware.com_vsphere-csi-controller-5bd6f5ddcf-29djb_51d3eee6-6f0c-4bef-8594-00f26ea0c46d  Successfully provisioned volume pvc-f94c7e68-d3cd-459d-b8cf-201761dda54f
```

Without StorageTopologyType mentioned in SC:
```
Name:          block-pvc
Namespace:     default
StorageClass:  without-zonal
Status:        Bound
Volume:        pvc-01a12c93-bde0-43a7-86a5-356ba0feb7fa
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      100Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age   From                                                                                                 Message
  ----    ------                 ----  ----                                                                                                 -------
  Normal  ExternalProvisioning   5s    persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  Provisioning           5s    csi.vsphere.vmware.com_vsphere-csi-controller-5bd6f5ddcf-29djb_3f3f40d3-0c38-4f1c-a168-56cda6b47588  External provisioner is provisioning volume for claim "default/block-pvc"
  Normal  ProvisioningSucceeded  3s    csi.vsphere.vmware.com_vsphere-csi-controller-5bd6f5ddcf-29djb_3f3f40d3-0c38-4f1c-a168-56cda6b47588  Successfully provisioned volume pvc-01a12c93-bde0-43a7-86a5-356ba0feb7fa
```

With StorageTopologyType: ""
```
Name:          block-pvc
Namespace:     default
StorageClass:  without-zonal
Status:        Bound
Volume:        pvc-3c9e209e-e8ec-4175-a1c9-c612d1d9e9a7
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      100Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age              From                                                                                                 Message
  ----    ------                 ----             ----                                                                                                 -------
  Normal  ExternalProvisioning   7s (x2 over 7s)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  Provisioning           7s               csi.vsphere.vmware.com_vsphere-csi-controller-5bd6f5ddcf-29djb_3f3f40d3-0c38-4f1c-a168-56cda6b47588  External provisioner is provisioning volume for claim "default/block-pvc"
  Normal  ProvisioningSucceeded  3s               csi.vsphere.vmware.com_vsphere-csi-controller-5bd6f5ddcf-29djb_3f3f40d3-0c38-4f1c-a168-56cda6b47588  Successfully provisioned volume pvc-3c9e209e-e8ec-4175-a1c9-c612d1d9e9a7
```

With StorageTopologyType: CrossZonal
```
Name:          block-pvc
Namespace:     default
StorageClass:  cross-zonal
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age              From                                                                                                 Message
  ----     ------                ----             ----                                                                                                 -------
  Normal   ExternalProvisioning  4s (x2 over 4s)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   Provisioning          1s (x3 over 4s)  csi.vsphere.vmware.com_vsphere-csi-controller-5bd6f5ddcf-29djb_3f3f40d3-0c38-4f1c-a168-56cda6b47588  External provisioner is provisioning volume for claim "default/block-pvc"
  Warning  ProvisioningFailed    1s (x3 over 4s)  csi.vsphere.vmware.com_vsphere-csi-controller-5bd6f5ddcf-29djb_3f3f40d3-0c38-4f1c-a168-56cda6b47588  failed to provision volume with StorageClass "cross-zonal": rpc error: code = InvalidArgument desc = invalid value "CrossZonal" received for "StorageTopologyType" parameter.
```

With StorageTopologyType: "invalid"
```
Name:          block-pvc
Namespace:     default
StorageClass:  invalid-sc
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age              From                                                                                                 Message
  ----     ------                ----             ----                                                                                                 -------
  Normal   ExternalProvisioning  3s (x2 over 3s)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   Provisioning          0s (x3 over 3s)  csi.vsphere.vmware.com_vsphere-csi-controller-5bd6f5ddcf-29djb_3f3f40d3-0c38-4f1c-a168-56cda6b47588  External provisioner is provisioning volume for claim "default/block-pvc"
  Warning  ProvisioningFailed    0s (x3 over 3s)  csi.vsphere.vmware.com_vsphere-csi-controller-5bd6f5ddcf-29djb_3f3f40d3-0c38-4f1c-a168-56cda6b47588  failed to provision volume with StorageClass "invalid-sc": rpc error: code = InvalidArgument desc = invalid value "invalid" received for "StorageTopologyType" parameter.
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Validate storageTopologyType in GC
```
