### PR TITLE
Removed CNS_NEW_SYNC FSS logic from online volume expansion testcode

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -32,7 +32,6 @@ const (
 	attacherContainerName                      = "csi-attacher"
 	busyBoxImageOnGcr                          = "gcr.io/google_containers/busybox:1.27"
 	nginxImage                                 = "k8s.gcr.io/nginx-slim:0.8"
-	cnsNewSyncFSS                              = "CNS_NEW_SYNC"
 	configSecret                               = "vsphere-config-secret"
 	crdCNSNodeVMAttachment                     = "cnsnodevmattachments"
 	crdCNSVolumeMetadatas                      = "cnsvolumemetadatas"

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1355,6 +1355,27 @@ func invokeVCenterServiceControl(command, service, host string) error {
 	return nil
 }
 
+/*
+	Note: As per PR #2935677, even if cns_new_sync is enabled volume expansion
+	will not work if sps-service is down.
+	Keeping this code for reference. Disabling isFssEnabled util method as we won't be using
+	this util method in testcases.
+	isFssEnabled invokes the given command to check if vCenter has a particular FSS enabled or not
+*/
+// func isFssEnabled(host, fss string) bool {
+// 	sshCmd := fmt.Sprintf("python /usr/sbin/feature-state-wrapper.py %s", fss)
+// 	framework.Logf("Checking if fss is enabled on vCenter host %v", host)
+// 	result, err := fssh.SSH(sshCmd, host, framework.TestContext.Provider)
+// 	fssh.LogResult(result)
+// 	if err == nil && result.Code == 0 {
+// 		return strings.TrimSpace(result.Stdout) == "enabled"
+// 	} else {
+// 		ginkgo.By(fmt.Sprintf("couldn't execute command: %s on vCenter host: %v", sshCmd, err))
+// 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+// 	}
+// 	return false
+// }
+
 // waitVCenterServiceToBeInState invokes the status check for the given service and waits
 // via service-control on the given vCenter host over SSH.
 func waitVCenterServiceToBeInState(serviceName string, host string, state string) error {

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1355,22 +1355,6 @@ func invokeVCenterServiceControl(command, service, host string) error {
 	return nil
 }
 
-// isFssEnabled invokes the given command to check if vCenter
-// has a particular FSS enabled or not
-func isFssEnabled(host, fss string) bool {
-	sshCmd := fmt.Sprintf("python /usr/sbin/feature-state-wrapper.py %s", fss)
-	framework.Logf("Checking if fss is enabled on vCenter host %v", host)
-	result, err := fssh.SSH(sshCmd, host, framework.TestContext.Provider)
-	fssh.LogResult(result)
-	if err == nil && result.Code == 0 {
-		return strings.TrimSpace(result.Stdout) == "enabled"
-	} else {
-		ginkgo.By(fmt.Sprintf("couldn't execute command: %s on vCenter host: %v", sshCmd, err))
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}
-	return false
-}
-
 // waitVCenterServiceToBeInState invokes the status check for the given service and waits
 // via service-control on the given vCenter host over SSH.
 func waitVCenterServiceToBeInState(serviceName string, host string, state string) error {

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -724,6 +724,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 				err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				isSPSServiceStopped = false
+				err = waitVCenterServiceToBeInState(spsServiceName, vcAddress, svcRunningMessage)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
 
@@ -748,6 +750,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isSPSServiceStopped = false
+		err = waitVCenterServiceToBeInState(spsServiceName, vcAddress, svcRunningMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Waiting for file system resize to finish")
 		pvclaim, err = waitForFSResize(pvclaim, client)
@@ -1480,6 +1484,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 				err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				isSPSServiceStopped = false
+				err = waitVCenterServiceToBeInState(spsServiceName, vcAddress, svcRunningMessage)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
 
@@ -1504,6 +1510,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isSPSServiceStopped = false
+		err = waitVCenterServiceToBeInState(spsServiceName, vcAddress, svcRunningMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		pvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
 		if pvcSize.Cmp(newSize) != 0 {

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -663,6 +663,13 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		var expectedErrMsg string
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 
+		/*
+			Note: As per PR #2935677, even if cns_new_sync is enabled volume expansion
+			will not work if sps-service is down.
+			Keeping the below disabled line of code for reference. Here, cnsNewSyncFSS = "CNS_NEW_SYNC"
+		*/
+		//featureEnabled := isFssEnabled(vcAddress, cnsNewSyncFSS)
+
 		volHandle, pvclaim, pv, storageclass := createSCwithVolumeExpansionTrueAndDynamicPVC(
 			f, client, "", storagePolicyName, namespace)
 		defer func() {

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -723,9 +723,9 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 				framework.Logf("Bringing sps up before terminating the test")
 				err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				isSPSServiceStopped = false
 				err = waitVCenterServiceToBeInState(spsServiceName, vcAddress, svcRunningMessage)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				isSPSServiceStopped = false
 			}
 		}()
 
@@ -749,9 +749,9 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		ginkgo.By("Bringup SPS service")
 		err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		isSPSServiceStopped = false
 		err = waitVCenterServiceToBeInState(spsServiceName, vcAddress, svcRunningMessage)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isSPSServiceStopped = false
 
 		ginkgo.By("Waiting for file system resize to finish")
 		pvclaim, err = waitForFSResize(pvclaim, client)
@@ -1483,9 +1483,9 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 				framework.Logf("Bringing sps up before terminating the test")
 				err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				isSPSServiceStopped = false
 				err = waitVCenterServiceToBeInState(spsServiceName, vcAddress, svcRunningMessage)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				isSPSServiceStopped = false
 			}
 		}()
 
@@ -1509,9 +1509,9 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		ginkgo.By("Bringup SPS service")
 		err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		isSPSServiceStopped = false
 		err = waitVCenterServiceToBeInState(spsServiceName, vcAddress, svcRunningMessage)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isSPSServiceStopped = false
 
 		pvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
 		if pvcSize.Cmp(newSize) != 0 {

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -1548,11 +1548,13 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		var vmUUID string
 		var exists bool
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volHandle, pod.Spec.NodeName))
-
-		annotations := pod.Annotations
-		vmUUID, exists = annotations[vmUUIDLabel]
-		gomega.Expect(exists).To(gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
-
+		if supervisorCluster {
+			annotations := pod.Annotations
+			vmUUID, exists = annotations[vmUUIDLabel]
+			gomega.Expect(exists).To(gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+		} else {
+			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
+		}
 		framework.Logf("VMUUID : %s", vmUUID)
 		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed CNS_NEW_SYNC FSS logic from online volume expansion testcode


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Removed CNS_NEW_SYNC FSS logic from online volume expansion testcode

**Testing done**:
Yes

**Special notes for your reviewer**:
Make Check:
sipriya@sipriya-a01 vsphere-csi-driver %  golangci-lint run --enable=lll       
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint                        
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/vol-expansion-sps-pr/vsphere-csi-driver /Users/sipriya/vol-expansion-sps-pr /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|files|types_sizes|compiled_files|imports|name|exports_file) took 3.464988345s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 104.883568ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 24/113, path_prettifier: 113/113, identifier_marker: 24/24, skip_dirs: 113/113, skip_files: 113/113, exclude-rules: 1/24, nolint: 0/1, filename_unadjuster: 113/113, exclude: 24/24, cgo: 113/113 
INFO [runner] processing took 15.648694ms with stages: nolint: 13.771441ms, autogenerated_exclude: 996.293µs, identifier_marker: 314.822µs, path_prettifier: 311.089µs, skip_dirs: 111.882µs, exclude-rules: 98.818µs, cgo: 35.149µs, filename_unadjuster: 5.37µs, max_same_issues: 1.007µs, uniq_by_line: 473ns, max_from_linter: 345ns, diff: 286ns, exclude: 248ns, max_per_file_from_linter: 241ns, severity-rules: 233ns, source_code: 229ns, path_shortener: 217ns, skip_files: 213ns, sort_results: 206ns, path_prefixer: 132ns 
INFO [runner] linters took 1.929645236s with stages: goanalysis_metalinter: 1.913908832s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 57 samples, avg is 98.6MB, max is 140.9MB 
INFO Execution took 5.51026515s   
