### PR TITLE
Bug fixes for CSI tests

### DIFF
--- a/tests/e2e/connection.go
+++ b/tests/e2e/connection.go
@@ -68,7 +68,7 @@ func connect(ctx context.Context, vs *vSphere) {
 	}
 	framework.Logf("Creating new client session since the existing session is not valid or not authenticated")
 	err = vs.Client.Logout(ctx)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	framework.Logf("Error from logging out from session is: %v", err)
 	vs.Client = newClient(ctx, vs)
 }
 

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -5578,10 +5578,15 @@ func waitForEventWithReason(client clientset.Interface, namespace string,
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	isFailureFound := false
-	ginkgo.By("Checking for error in events related to pvc " + name)
-	waitErr := wait.PollImmediate(poll, pollTimeoutShort, func() (bool, error) {
-		eventList, _ := client.CoreV1().Events(namespace).List(ctx,
+	waitErr := wait.PollImmediate(poll, pollTimeout, func() (bool, error) {
+		framework.Logf("Checking for error in events related to pvc " + name)
+		eventList, err := client.CoreV1().Events(namespace).List(ctx,
 			metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", name)})
+		framework.Logf("Eventlist is :%v", eventList)
+		if err != nil {
+			framework.Logf("Error is: %v", err)
+			return false, err
+		}
 		for _, item := range eventList.Items {
 			if strings.Contains(item.Reason, expectedErrMsg) {
 				framework.Logf("Expected Error msg found. EventList Reason: "+

--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -306,7 +306,8 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 	   8.  Delete statefulsets and its pvcs created in step 2
 	   9.  Bring primary site up and wait for testbed to be back to normal
 	*/
-	ginkgo.It("[primary-centric][distributed] Statefulset scale up/down while primary site goes down", func() {
+	ginkgo.It("[primary-centric][control-plane-on-primary] Statefulset scale up/down while primary"+
+		" site goes down", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -454,7 +455,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 	   10. Delete the PVCs created in step 2
 
 	*/
-	ginkgo.It("[primary-centric][distributed] Pod deletion while primary site goes down", func() {
+	ginkgo.It("[primary-centric][control-plane-on-primary] Pod deletion while primary site goes down", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass")
@@ -709,7 +710,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		6.	Re-establish primary site network and wait for testbed to be back to normal
 		7.	Delete all objects created in step 2
 	*/
-	ginkgo.It("[primary-centric][distributed][control-plane-on-primary] Primary site network isolation", func() {
+	ginkgo.It("[primary-centric][control-plane-on-primary][distributed] Primary site network isolation", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -938,7 +939,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		9.	Delete PVCs created in step 2
 
 	*/
-	ginkgo.It("[primary-centric][distributed] Pod creation while primary site goes down", func() {
+	ginkgo.It("[primary-centric][control-plane-on-primary] Pod creation while primary site goes down", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass")
@@ -1212,7 +1213,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		9.  Delete PVC created in step 3
 		10. If there is an orphan volume clean up that using cnsctl
 	*/
-	ginkgo.It("[control-plane-on-primary] PVC creation while secondary site goes down"+
+	ginkgo.It("[distributed] PVC creation while secondary site goes down"+
 		" and csi provisioner leader is in secondary site", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1316,7 +1317,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		8.  Bring secondary site up and wait for testbed to be back to normal
 
 	*/
-	ginkgo.It("[control-plane-on-primary] PVC deletion while secondary site goes down"+
+	ginkgo.It("[distributed] PVC deletion while secondary site goes down"+
 		" and csi provisioner leader is in secondary site", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1427,7 +1428,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		10.	Delete PVCs created in step 2
 
 	*/
-	ginkgo.It("[control-plane-on-primary] Pod creation while secondary site goes down"+
+	ginkgo.It("[distributed] Pod creation while secondary site goes down"+
 		" and csi attacher leader is in secondary site", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1567,7 +1568,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		12.	Delete PVCs created in step 2
 
 	*/
-	ginkgo.It("[control-plane-on-primary] Pod deletion while secondary site goes down"+
+	ginkgo.It("[distributed] Pod deletion while secondary site goes down"+
 		" and csi attacher leader is in secondary site", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1704,7 +1705,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		6.	Bring secondary site up and wait for testbed to be back to normal
 		7.	Delete all objects created in step 2 and 5
 	*/
-	ginkgo.It("[distributed] Secondary site down", func() {
+	ginkgo.It("[control-plane-on-primary] Secondary site down", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass")
@@ -1816,7 +1817,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 			volume and application lifecycle actions work fine
 		11.	Cleanup all objects created so far in the test
 	*/
-	ginkgo.It("[distributed][control-plane-on-primary] Network failure between sites", func() {
+	ginkgo.It("[control-plane-on-primary][distributed] Network failure between sites", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -1929,7 +1930,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		5.	Run volume and application lifecycle actions
 		6.	Cleanup all objects created in step 3 and 5
 	*/
-	ginkgo.It("[control-plane-on-primary] Witness failure", func() {
+	ginkgo.It("[distributed] Witness failure", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -2023,7 +2024,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 	   9.  Delete statefulsets and its pvcs created in step 2
 	   10. Bring secondary site up and wait for testbed to be back to normal
 	*/
-	ginkgo.It("[control-plane-on-primary] Statefulset scale up/down while secondary site goes down when csi provisioner"+
+	ginkgo.It("[distributed] Statefulset scale up/down while secondary site goes down when csi provisioner"+
 		" and attacher leaders are in secondary site", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2179,7 +2180,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 	   9.  Delete the PVCs created in step 2
 	   10.  Bring secondary site up and wait for testbed to be back to normal
 	*/
-	ginkgo.It("[control-plane-on-primary] Label updates to PV, PVC while primary site goes down"+
+	ginkgo.It("[distributed] Label updates to PV, PVC while primary site goes down"+
 		" when syncer pod leader is in secondary site", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2333,7 +2334,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 	   9.  Delete statefulsets and its pvcs created in step 2
 	   10. Bring secondary site up and wait for testbed to be back to normal
 	*/
-	ginkgo.It("[control-plane-on-primary] Statefulset scale up/down while secondary site goes down"+
+	ginkgo.It("[distributed] Statefulset scale up/down while secondary site goes down"+
 		" when csi driver leader is in secondary site", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2531,7 +2532,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 	   10. Delete the PVCs used by statefulsets in step 2
 	   11. Bring secondary site up and wait for testbed to be back to normal
 	*/
-	ginkgo.It("[distributed] Statefulset scale up/down while secondary site goes down", func() {
+	ginkgo.It("[control-plane-on-primary] Statefulset scale up/down while secondary site goes down", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -2683,7 +2684,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		14. Delete all PVCs
 		15. Bring secondary site up and wait for testbed to be normal
 	*/
-	ginkgo.It("[control-plane-on-primary] Operation Storm", func() {
+	ginkgo.It("[distributed] Operation Storm", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -2906,7 +2907,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		6. Restore secondary site back up and wait for testbed to be back to normal
 		7. Delete all objects created in step 2 and 5
 	*/
-	ginkgo.It("[distributed] Partial failure of secondary site", func() {
+	ginkgo.It("[control-plane-on-primary] Partial failure of secondary site", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -3021,7 +3022,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		9.  Bring secondary site up and wait for testbed to be back to normal
 
 	*/
-	ginkgo.It("[control-plane-on-primary] PV/PVC with Retain reclaim policy deletion while secondary site goes down "+
+	ginkgo.It("[distributed] PV/PVC with Retain reclaim policy deletion while secondary site goes down "+
 		"and csi provisioner and csi-syncer leaders are in secondary site", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -3168,7 +3169,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		11. Delete PVC created in step 4
 
 	*/
-	ginkgo.It("[control-plane-on-primary] Static PV/PVC creation while secondary site goes down"+
+	ginkgo.It("[distributed] Static PV/PVC creation while secondary site goes down"+
 		" and csi-syncer leader is in secondary site", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -717,6 +717,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		isSPSServiceStopped = true
 		err = invokeVCenterServiceControl(stopOperation, spsServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = waitVCenterServiceToBeInState(spsServiceName, vcAddress, svcStoppedMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
 			if isSPSServiceStopped {


### PR DESCRIPTION
**What this PR does / why we need it**:
1.  Fix for call to CNS giving error " The session is not authenticated." after failover of ESX hosts.
2.  Wait for sps to be in stoppped state before checking pvc events in online volume expansion test.
3.  Interchanging tags control-plane-on-primary and distributed in vsan stretch testing.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
https://gist.github.com/Aishwarya-Hebbar/62bf41479e53d5a163f4e731b9a251de
**Special notes for your reviewer**:
make check:
```
(base) kai@kai-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.1
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/kai/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/provider sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/cns_connection/vsphere-csi-driver /Users/kai/CSI/cns_connection /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|imports|name|files|types_sizes) took 1.705658085s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 101.678219ms 
INFO [linters context/goanalysis] analyzers took 9.056830803s with top 10 stages: buildir: 6.038567721s, misspell: 307.689902ms, S1038: 174.446813ms, unused: 156.169438ms, printf: 108.69502ms, directives: 105.96196ms, ctrlflow: 88.399144ms, S1039: 80.896689ms, nilness: 71.256262ms, SA1012: 69.05429ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): nolint: 0/1, cgo: 113/113, exclude: 24/24, filename_unadjuster: 113/113, identifier_marker: 24/24, exclude-rules: 1/24, path_prettifier: 113/113, skip_files: 113/113, skip_dirs: 113/113, autogenerated_exclude: 24/113 
INFO [runner] processing took 15.972971ms with stages: nolint: 12.952917ms, autogenerated_exclude: 1.383302ms, path_prettifier: 975.965µs, identifier_marker: 299.102µs, skip_dirs: 161.832µs, exclude-rules: 130.075µs, cgo: 43.246µs, filename_unadjuster: 22.217µs, max_same_issues: 993ns, uniq_by_line: 633ns, source_code: 378ns, max_from_linter: 373ns, diff: 314ns, skip_files: 280ns, severity-rules: 260ns, max_per_file_from_linter: 246ns, exclude: 244ns, sort_results: 236ns, path_shortener: 229ns, path_prefixer: 129ns 
INFO [runner] linters took 7.321471944s with stages: goanalysis_metalinter: 7.305396299s 
INFO File cache stats: 89 entries of total size 1.3MiB 
INFO Memory: 93 samples, avg is 301.8MB, max is 817.9MB 
INFO Execution took 9.140932383s                  
(base) kai@kai-a01 vsphere-csi-driver % 




```