### PR TITLE
update csi-node-driver-registrar config for Guest Cluster

### DIFF
--- a/manifests/guestcluster/1.21/pvcsi.yaml
+++ b/manifests/guestcluster/1.21/pvcsi.yaml
@@ -317,7 +317,6 @@ spec:
           - "--v=5"
           - "--csi-address=$(ADDRESS)"
           - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
-          - "--health-port=9809"
         env:
           - name: ADDRESS
             value: /csi/csi.sock
@@ -328,15 +327,14 @@ spec:
             mountPath: /csi
           - name: registration-dir
             mountPath: /registration
-        ports:
-          - containerPort: 9809
-            name: healthz
         livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
-          initialDelaySeconds: 5
-          timeoutSeconds: 5
+          exec:
+            command:
+              - /csi-node-driver-registrar
+              - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+              - --mode=kubelet-registration-probe
+          initialDelaySeconds: 30
+          timeoutSeconds: 15
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
         args:

--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -345,7 +345,6 @@ spec:
           - "--v=5"
           - "--csi-address=$(ADDRESS)"
           - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
-          - "--health-port=9809"
         env:
           - name: ADDRESS
             value: /csi/csi.sock
@@ -356,15 +355,14 @@ spec:
             mountPath: /csi
           - name: registration-dir
             mountPath: /registration
-        ports:
-          - containerPort: 9809
-            name: healthz
         livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
-          initialDelaySeconds: 5
-          timeoutSeconds: 5
+          exec:
+            command:
+              - /csi-node-driver-registrar
+              - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+              - --mode=kubelet-registration-probe
+          initialDelaySeconds: 30
+          timeoutSeconds: 15
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
         args:

--- a/manifests/guestcluster/1.23/pvcsi.yaml
+++ b/manifests/guestcluster/1.23/pvcsi.yaml
@@ -354,7 +354,6 @@ spec:
           - "--v=5"
           - "--csi-address=$(ADDRESS)"
           - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
-          - "--health-port=9809"
         env:
           - name: ADDRESS
             value: /csi/csi.sock
@@ -365,15 +364,14 @@ spec:
             mountPath: /csi
           - name: registration-dir
             mountPath: /registration
-        ports:
-          - containerPort: 9809
-            name: healthz
         livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
-          initialDelaySeconds: 5
-          timeoutSeconds: 5
+          exec:
+            command:
+            - /csi-node-driver-registrar
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --mode=kubelet-registration-probe
+          initialDelaySeconds: 30
+          timeoutSeconds: 15
       - name: vsphere-csi-node
         image: vmware.io/vsphere-csi:<image_tag>
         args:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We have bumped up `node-driver-registrar` version for Guest Cluster and the newer version requires changes regarding `livenessProbe`.

Refer to the example provided here - https://github.com/kubernetes-csi/node-driver-registrar#health-check-with-an-exec-probe 

**Which issue this PR fixes**
Without this change, Node Daemonset in Guest Cluster is crashing.


**Testing done**:
Applied these changes on a couple of setups and created PVC, PV, and Pod.

**Special notes for your reviewer**:
Verified Node Daemonset Pods are no longer crashing with this changes.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
update csi-node-driver-registrar config for Guest Cluster
```
