### PR TITLE
get feature-gates status during webhook server initialization

### DIFF
--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -54,8 +54,10 @@ var (
 	cfg    *config
 	// COInitParams stores the input params required for initiating the
 	// CO agnostic orchestrator in the admission handler package.
-	COInitParams                 *interface{}
-	containerOrchestratorUtility commonco.COCommonInterface
+	COInitParams                          *interface{}
+	featureGateCsiMigrationEnabled        bool
+	featureGateBlockVolumeSnapshotEnabled bool
+	featureGateTKGSHaEnabled              bool
 )
 
 // watchConfigChange watches on the webhook configuration directory for changes
@@ -121,22 +123,21 @@ func StartWebhookServer(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
 	var err error
 	var clusterFlavor cnstypes.CnsClusterFlavor
-
-	if containerOrchestratorUtility == nil {
-		clusterFlavor, err = cnsconfig.GetClusterFlavor(ctx)
-		if err != nil {
-			log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
-			return err
-		}
-		containerOrchestratorUtility, err = commonco.GetContainerOrchestratorInterface(ctx,
-			common.Kubernetes, clusterFlavor, *COInitParams)
-		if err != nil {
-			log.Errorf("failed to get k8s interface. err: %v", err)
-			return err
-		}
+	var containerOrchestratorUtility commonco.COCommonInterface
+	clusterFlavor, err = cnsconfig.GetClusterFlavor(ctx)
+	if err != nil {
+		log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
+		return err
+	}
+	containerOrchestratorUtility, err = commonco.GetContainerOrchestratorInterface(ctx,
+		common.Kubernetes, clusterFlavor, *COInitParams)
+	if err != nil {
+		log.Errorf("failed to get k8s interface. err: %v", err)
+		return err
 	}
 
 	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		featureGateTKGSHaEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
 		startCNSCSIWebhookManager(ctx)
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		if cfg == nil {
@@ -147,9 +148,10 @@ func StartWebhookServer(ctx context.Context) error {
 			}
 			log.Debugf("webhook config: %v", cfg)
 		}
+		featureGateCsiMigrationEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration)
+		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 
-		if containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) ||
-			containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot) {
+		if featureGateCsiMigrationEnabled || featureGateBlockVolumeSnapshotEnabled {
 			certs, err := tls.LoadX509KeyPair(cfg.WebHookConfig.CertFile, cfg.WebHookConfig.KeyFile)
 			if err != nil {
 				log.Errorf("failed to load key pair. certFile: %q, keyFile: %q err: %v",

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -13,7 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 )
 
@@ -85,12 +84,11 @@ func (h *CSISupervisorWebhook) Handle(ctx context.Context, req admission.Request
 	log.Debugf("CNS-CSI validation webhook handler called with request: %+v", req)
 
 	resp = admission.Allowed("")
-	if containerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
+	if featureGateTKGSHaEnabled {
 		if req.Kind.Kind == "PersistentVolumeClaim" {
 			resp = validatePVCAnnotation(ctx, req)
 		}
 	}
-
 	log.Debugf("CNS-CSI validation webhook handler completed for the request: %+v", req)
 	return
 }

--- a/pkg/syncer/admissionhandler/validatepvc.go
+++ b/pkg/syncer/admissionhandler/validatepvc.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes"
 )
@@ -23,7 +22,7 @@ const (
 
 // validatePVC helps validate AdmissionReview requests for PersistentVolumeClaim.
 func validatePVC(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-	if containerOrchestratorUtility != nil && !containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot) {
+	if !featureGateBlockVolumeSnapshotEnabled {
 		// If CSI block volume snapshot is disabled and webhook is running,
 		// skip validation for PersistentVolumeClaim.
 		return &admissionv1.AdmissionResponse{

--- a/pkg/syncer/admissionhandler/validatepvc_test.go
+++ b/pkg/syncer/admissionhandler/validatepvc_test.go
@@ -105,7 +105,7 @@ func getPVCAdmissionTest(t *testing.T) *pvcAdmissionTest {
 
 func TestValidatePVC(t *testing.T) {
 	testInstance := getPVCAdmissionTest(t)
-
+	featureGateBlockVolumeSnapshotEnabled = true
 	tests := []struct {
 		name             string
 		kubeObjs         []runtime.Object

--- a/pkg/syncer/admissionhandler/validatestorageclass.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass.go
@@ -50,7 +50,7 @@ const (
 
 // validateStorageClass helps validate AdmissionReview requests for StroageClass.
 func validateStorageClass(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-	if containerOrchestratorUtility != nil && !containerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
+	if !featureGateCsiMigrationEnabled {
 		// If CSI migration is disabled and webhook is running,
 		// skip validation for StorageClass.
 		return &admissionv1.AdmissionResponse{

--- a/pkg/syncer/admissionhandler/validatestorageclass_test.go
+++ b/pkg/syncer/admissionhandler/validatestorageclass_test.go
@@ -40,6 +40,7 @@ var admissionReview = v1.AdmissionReview{
 func TestValidateStorageClassForAllowVolumeExpansion(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	featureGateCsiMigrationEnabled = true
 	admissionReview.Request.Object = runtime.RawExtension{
 		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": " +
 			"{\n    \"name\": \"sc\",\n    \"uid\": \"e5d6b37e-db23-4c1d-9aed-e38cdd0f9ec6\",\n    " +
@@ -64,6 +65,7 @@ func TestValidateStorageClassForAllowVolumeExpansion(t *testing.T) {
 func TestValidateStorageClassForMigrationParameter(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	featureGateCsiMigrationEnabled = true
 	admissionReview.Request.Object = runtime.RawExtension{
 		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": " +
 			"{\n    \"name\": \"sc\",\n    \"uid\": \"a9ed134e-aab1-4624-8de4-b9d961cad861\",\n    " +
@@ -101,6 +103,7 @@ func TestValidateStorageClassForMigrationParameter(t *testing.T) {
 func TestValidateStorageClassForValidStorageClass(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	featureGateCsiMigrationEnabled = true
 	admissionReview.Request.Object = runtime.RawExtension{
 		Raw: []byte("{\n  \"kind\": \"StorageClass\",\n  \"apiVersion\": \"storage.k8s.io/v1\",\n  \"metadata\": " +
 			"{\n    \"name\": \"sc\",\n    \"uid\": \"a896f427-929a-4fc5-be95-078d99d57774\",\n    " +


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is removing feature gate check upon every request that comes to the webhook admission handler.

During the initialization of the webhook server, we can cache feature-gate status and use cached value in the admission handler.

admission handler is getting every request reaching to API server, and it is very expensive to make API call to check the feature gate status in the config-map in the admission handler. The admission handler should be very quick and should mostly do in-memory operations.


**Testing done**:
In progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
get feature-gates status during webhook server initialization
```
