### PR TITLE
Cherrypick PR #1710 to release-2.5 branch

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -31,7 +31,6 @@ const (
 	adminPassword                              = "Admin!23"
 	busyBoxImageOnGcr                          = "gcr.io/google_containers/busybox:1.27"
 	nginxImage                                 = "k8s.gcr.io/nginx-slim:0.8"
-	cnsNewSyncFSS                              = "CNS_NEW_SYNC"
 	configSecret                               = "vsphere-config-secret"
 	crdCNSNodeVMAttachment                     = "cnsnodevmattachments"
 	crdCNSVolumeMetadatas                      = "cnsvolumemetadatas"

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1235,21 +1235,26 @@ func invokeVCenterServiceControl(command, service, host string) error {
 	return nil
 }
 
-// isFssEnabled invokes the given command to check if vCenter
-// has a particular FSS enabled or not
-func isFssEnabled(host, fss string) bool {
-	sshCmd := fmt.Sprintf("python /usr/sbin/feature-state-wrapper.py %s", fss)
-	framework.Logf("Checking if fss is enabled on vCenter host %v", host)
-	result, err := fssh.SSH(sshCmd, host, framework.TestContext.Provider)
-	fssh.LogResult(result)
-	if err == nil && result.Code == 0 {
-		return strings.TrimSpace(result.Stdout) == "enabled"
-	} else {
-		ginkgo.By(fmt.Sprintf("couldn't execute command: %s on vCenter host: %v", sshCmd, err))
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}
-	return false
-}
+/*
+	Note: As per PR #2935677, even if cns_new_sync is enabled volume expansion
+	will not work if sps-service is down.
+	Keeping this code for reference. Disabling isFssEnabled util method as we won't be using
+	this util method in testcases.
+	isFssEnabled invokes the given command to check if vCenter has a particular FSS enabled or not
+*/
+// func isFssEnabled(host, fss string) bool {
+// 	sshCmd := fmt.Sprintf("python /usr/sbin/feature-state-wrapper.py %s", fss)
+// 	framework.Logf("Checking if fss is enabled on vCenter host %v", host)
+// 	result, err := fssh.SSH(sshCmd, host, framework.TestContext.Provider)
+// 	fssh.LogResult(result)
+// 	if err == nil && result.Code == 0 {
+// 		return strings.TrimSpace(result.Stdout) == "enabled"
+// 	} else {
+// 		ginkgo.By(fmt.Sprintf("couldn't execute command: %s on vCenter host: %v", sshCmd, err))
+// 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+// 	}
+// 	return false
+// }
 
 // waitVCenterServiceToBeInState invokes the status check for the given service and waits
 // via service-control on the given vCenter host over SSH.


### PR DESCRIPTION
**What this PR does / why we need it**:
CherryPick code fix of Online/Offline volume expansion when sps-service is down to release-2.5 branch

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
CherryPick code fix of Online/Offline volume expansion when sps-service is down to release-2.5 branch


**Testing done**:
Yes

**Special notes for your reviewer**:

Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/vol-expansion-sps-pr/vsphere-csi-driver /Users/sipriya/vol-expansion-sps-pr /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|exports_file|name|compiled_files|files|imports|types_sizes) took 20.92374718s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 88.706584ms 
INFO [linters context/goanalysis] analyzers took 3m13.048604824s with top 10 stages: buildir: 2m9.595135583s, nilness: 7.838721634s, printf: 7.610190654s, ctrlflow: 7.129339866s, fact_deprecated: 7.050679232s, typedness: 5.655055864s, fact_purity: 5.379530716s, SA5012: 5.061945421s, inspect: 1.85748617s, misspell: 1.475577083s 
INFO [runner] Issues before processing: 110, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_files: 110/110, autogenerated_exclude: 21/110, cgo: 110/110, identifier_marker: 21/21, exclude: 21/21, exclude-rules: 1/21, nolint: 0/1, skip_dirs: 110/110, path_prettifier: 110/110, filename_unadjuster: 110/110 
INFO [runner] processing took 11.586675ms with stages: nolint: 8.813674ms, autogenerated_exclude: 1.91959ms, path_prettifier: 343.808µs, identifier_marker: 258.845µs, exclude-rules: 117.189µs, skip_dirs: 114.465µs, filename_unadjuster: 8.098µs, cgo: 6.902µs, max_same_issues: 1.145µs, uniq_by_line: 532ns, skip_files: 347ns, source_code: 300ns, max_from_linter: 282ns, diff: 277ns, severity-rules: 255ns, exclude: 224ns, path_shortener: 209ns, max_per_file_from_linter: 205ns, sort_results: 205ns, path_prefixer: 123ns 
INFO [runner] linters took 23.810986178s with stages: goanalysis_metalinter: 23.79931659s 
INFO File cache stats: 256 entries of total size 3.7MiB 
INFO Memory: 434 samples, avg is 636.3MB, max is 1896.6MB 
INFO Execution took 44.836341398s                 
sipriya@sipriya-a01 vsphere-csi-driver % 
