### PR TITLE
Topology automation testcode fix for password rotation and full sync

### DIFF
--- a/tests/e2e/topology_multi_replica.go
+++ b/tests/e2e/topology_multi_replica.go
@@ -870,6 +870,8 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Bringup vsanhealth service")
 			err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			isVsanhealthServiceStopped = false
 
 			/* Get current leader Csi-Controller-Pod where CSI Resizer is running" +
@@ -1327,6 +1329,8 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 					framework.Logf("Bringing sps up before terminating the test")
 					err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					err = waitVCenterServiceToBeInState(spsServiceName, vcAddress, svcRunningMessage)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					isSPSServiceStopped = false
 				}
 			}()
@@ -1377,6 +1381,8 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			if isSPSServiceStopped {
 				framework.Logf("Bringing SPS service")
 				err = invokeVCenterServiceControl(startOperation, spsServiceName, vcAddress)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = waitVCenterServiceToBeInState(spsServiceName, vcAddress, svcRunningMessage)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -1665,6 +1671,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			scParameters := make(map[string]string)
 			var pvclaimsList []*v1.PersistentVolumeClaim
 			var podList []*v1.Pod
+			var pvclaims []*v1.PersistentVolumeClaim
 
 			// Get allowed topologies for Storage Class
 			allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
@@ -2085,11 +2092,11 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
 			defer func() {
 				ginkgo.By("Deleting the Pod")
-				framework.ExpectNoError(fpod.DeletePodWithWait(client, StaticPod), "Failed to delete pod",
-					StaticPod.Name)
-				ginkgo.By(fmt.Sprintf("Verify volume is detached from the node: %s", StaticPod.Spec.NodeName))
+				framework.ExpectNoError(fpod.DeletePodWithWait(client, newstaticPod), "Failed to delete pod",
+					newstaticPod.Name)
+				ginkgo.By(fmt.Sprintf("Verify volume is detached from the node: %s", newstaticPod.Spec.NodeName))
 				isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
-					staticPv.Spec.CSI.VolumeHandle, StaticPod.Spec.NodeName)
+					staticPv.Spec.CSI.VolumeHandle, newstaticPod.Spec.NodeName)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(isDiskDetached).To(gomega.BeTrue(), "Volume is not detached from the node")
 			}()
@@ -2106,11 +2113,11 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
 			defer func() {
 				ginkgo.By("Deleting the Pod")
-				framework.ExpectNoError(fpod.DeletePodWithWait(client, StaticPod), "Failed to delete pod",
-					StaticPod.Name)
-				ginkgo.By(fmt.Sprintf("Verify volume is detached from the node: %s", StaticPod.Spec.NodeName))
+				framework.ExpectNoError(fpod.DeletePodWithWait(client, newDynamicPod), "Failed to delete pod",
+					newDynamicPod.Name)
+				ginkgo.By(fmt.Sprintf("Verify volume is detached from the node: %s", newDynamicPod.Spec.NodeName))
 				isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
-					staticPv.Spec.CSI.VolumeHandle, StaticPod.Spec.NodeName)
+					staticPv.Spec.CSI.VolumeHandle, newDynamicPod.Spec.NodeName)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(isDiskDetached).To(gomega.BeTrue(), "Volume is not detached from the node")
 			}()

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -591,6 +591,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		var lables = make(map[string]string)
 		lables["app"] = "nginx"
 		replica := 1
+		var pvclaims []*v1.PersistentVolumeClaim
 
 		/* Get allowed topologies for Storage Class
 		(region1 > zone1 > building1 > level1 > rack > rack3) */


### PR DESCRIPTION
**What this PR does / why we need it**:
Topology automation testcode fix for password rotation and full sync testcase

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Topology automation testcode fix for password rotation and full sync

**Testing done**:
Yes

**Special notes for your reviewer**:
Make Check:

sipriya@sipriya-a01 vsphere-csi-driver % 
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/topology-jenkins-fixes/vsphere-csi-driver /Users/sipriya/topology-jenkins-fixes /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (files|compiled_files|exports_file|name|types_sizes|deps|imports) took 12.127995409s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 112.537428ms 
INFO [linters context/goanalysis] analyzers took 1m11.588110585s with top 10 stages: buildir: 32.40764798s, misspell: 1.781052296s, ctrlflow: 1.6994958s, printf: 1.636565228s, S1038: 1.603567593s, typedness: 1.438167635s, directives: 1.34480451s, nilness: 1.264410565s, unused: 1.161022367s, fact_deprecated: 1.141853256s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 113/113, exclude: 24/24, exclude-rules: 1/24, nolint: 0/1, identifier_marker: 24/24, cgo: 113/113, skip_files: 113/113, skip_dirs: 113/113, path_prettifier: 113/113, autogenerated_exclude: 24/113 
INFO [runner] processing took 15.195682ms with stages: nolint: 12.579752ms, autogenerated_exclude: 1.694449ms, path_prettifier: 374.3µs, identifier_marker: 308.308µs, exclude-rules: 110.671µs, skip_dirs: 110.361µs, filename_unadjuster: 6.676µs, cgo: 6.301µs, max_same_issues: 1.63µs, uniq_by_line: 561ns, diff: 418ns, max_from_linter: 371ns, source_code: 347ns, skip_files: 280ns, exclude: 257ns, path_shortener: 224ns, max_per_file_from_linter: 220ns, sort_results: 218ns, severity-rules: 218ns, path_prefixer: 120ns 
INFO [runner] linters took 11.184450714s with stages: goanalysis_metalinter: 11.169167702s 
INFO File cache stats: 279 entries of total size 4.4MiB 
INFO Memory: 229 samples, avg is 356.6MB, max is 1224.9MB 
INFO Execution took 23.435302414s 
