### PR TITLE
Remove deprecated --health-port from csi node driver registrar container args

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -564,7 +564,6 @@ spec:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
-            - "--health-port=9809"
           env:
             - name: ADDRESS
               value: 'unix://C:\\csi\\csi.sock'
@@ -576,7 +575,6 @@ spec:
             - name: registration-dir
               mountPath: /registration
           livenessProbe:
-            livenessProbe:
             exec:
               command:
               - /csi-node-driver-registrar.exe


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

As per https://github.com/kubernetes-csi/node-driver-registrar/blob/master/CHANGELOG/CHANGELOG-2.1.md, the --health-port is deprecated since v2.1. pvcsi.yamls for 1.21 and up have already removed this port from arguments. pvcsi.yamls for 1.20 and below were shipped with registrar versions less than v2.1 so there they don't need a backport. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

```
root@k8s-control-825-1650935284:~# k edit daemonset vsphere-csi-node
-            - "--health-port=9809" (removed port arg)
daemonset.apps/vsphere-csi-node skipped
daemonset.apps/vsphere-csi-node-windows edited
```

Also, deleted pods and confirmed they restarted without errors. 
```
root@k8s-control-825-1650935284:~# k get po
NAME                                      READY   STATUS    RESTARTS         AGE
vsphere-csi-controller-57d9f8c4cf-mjhx6   7/7     Running   42 (3h14m ago)   16h
vsphere-csi-controller-57d9f8c4cf-s4dm5   7/7     Running   30 (31m ago)     16h
vsphere-csi-controller-57d9f8c4cf-wjmdz   7/7     Running   32 (70m ago)     16h
vsphere-csi-node-bk2zx                    3/3     Running   0                25s
vsphere-csi-node-gsnrj                    3/3     Running   0                25s
vsphere-csi-node-gtmrc                    3/3     Running   0                24s
vsphere-csi-node-kd5w5                    3/3     Running   0                25s
vsphere-csi-node-sjh6f                    3/3     Running   0                24s
vsphere-csi-node-wjgtx                    3/3     Running   0                24s
```

E2E tests 1029 (2 failures). 1030 and 1031 pass those 2 failures respectively. 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
