### PR TITLE
use correct context instead of context.TODO()

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -127,7 +127,7 @@ func main() {
 		run = initSyncerComponents(ctx, clusterFlavor, &syncer.COInitParams)
 
 		if !*enableLeaderElection {
-			run(context.TODO())
+			run(ctx)
 		} else {
 			k8sClient, err := k8s.NewClient(ctx)
 			if err != nil {

--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -195,7 +195,7 @@ func (m *defaultManager) GetNode(ctx context.Context,
 		var vm *vsphere.VirtualMachine
 		var err error
 		if dc != nil {
-			vm, err = dc.GetVirtualMachineByUUID(context.TODO(), nodeUUID, false)
+			vm, err = dc.GetVirtualMachineByUUID(ctx, nodeUUID, false)
 			if err != nil {
 				log.Errorf("failed to find node with nodeUUID %s on datacenter: %+v with err: %v", nodeUUID, dc, err)
 				return nil, err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
context.TODO() should be avoided and only used when we are not sure about which context we need to supply to the function.
Supplying the right context improves traceability when things go wrong.


**Testing done**:
[Testing Result](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1727#issuecomment-1112775189)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
use correct context instead of context.TODO()
```
