### PR TITLE
Fix duplicate volume additions to VirtualMachine Custom Resource

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -572,6 +572,7 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 			if err == nil || time.Now().After(timeout) {
 				break
 			}
+			virtualMachine = &vmoperatortypes.VirtualMachine{}
 			if err := c.vmOperatorClient.Get(ctx, vmKey, virtualMachine); err != nil {
 				msg := fmt.Sprintf("failed to get VirtualMachines for the node: %q. Error: %+v", req.NodeId, err)
 				log.Error(msg)
@@ -900,6 +901,7 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 		if err == nil || time.Now().After(timeout) {
 			break
 		}
+		virtualMachine = &vmoperatortypes.VirtualMachine{}
 		if err := c.vmOperatorClient.Get(ctx, vmKey, virtualMachine); err != nil {
 			if errors.IsNotFound(err) {
 				log.Infof("VirtualMachine %s/%s not found. Assuming volume %s was detached.",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Issue**: This code block (https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/csi/service/wcpguest/controller.go#L557-L580) performs an `Update()` operation to add a volume to the `VirtualMachine` custom resource. 

In case of an update failure, volume does not get added to the `VirtualMachine` custom resource in the cluster. After a failure, we loop till the retry succeeds or a timeout occurs. In every iteration, we construct a new `VirtualMachineVolume` object to the VM CR. 

The subsequent `Get()` operation should ensure that we have the most up-to-date VM custom resource present in the cluster for retry operations. However, we are currently re-using the same struct for both Update and Get operations. This creates a situation where the in-memory struct for the CR and the cluster CR get merged during the Get operation. The end result is that we end up with a VM spec that is not the same as the one in the cluster. 

**Fix**: Re-initialize the in-memory struct before every Get() operation. This way, there's no chance of merging or need of deepcopy. 

**Testing done**:

csibench program gave 100% success rate three times with this change,

```
2022/04/29 02:47:12.800447 Ran 4935 operations (4935 successful)
2022/04/29 02:47:12.800458 Success rate: 100.00
2022/04/29 02:47:12.800462 csibench finished

2022/04/29 03:14:46.476402 Ran 4370 operations (4370 successful)
2022/04/29 03:14:46.476409 Success rate: 100.00
2022/04/29 03:14:46.476412 csibench finished

2022/04/29 03:41:56.820469 Ran 4857 operations (4857 successful)
2022/04/29 03:41:56.820480 Success rate: 100.00
2022/04/29 03:41:56.820488 csibench finished
```

GC pipeline testing started

**Special notes for your reviewer**:

`make check`

```
(~/GolandProjects/vsphere-csi-driver) $ make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.1
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/adkulkarni/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/provider sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/adkulkarni/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/adkulkarni/GolandProjects/vsphere-csi-driver /Users/adkulkarni/GolandProjects /Users/adkulkarni /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (imports|types_sizes|compiled_files|deps|exports_file|files|name) took 1.719058626s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 111.384361ms
INFO [linters context/goanalysis] analyzers took 715.969647ms with top 10 stages: buildir: 528.806203ms, misspell: 17.557757ms, S1038: 13.165289ms, unused: 12.087027ms, directives: 7.492285ms, nilness: 6.810335ms, S1039: 5.664288ms, typedness: 5.585932ms, printf: 4.936635ms, ctrlflow: 4.815416ms
INFO [runner] Issues before processing: 113, after processing: 0
INFO [runner] Processors filtering stat (out/in): exclude-rules: 1/24, skip_dirs: 113/113, cgo: 113/113, skip_files: 113/113, identifier_marker: 24/24, exclude: 24/24, nolint: 0/1, filename_unadjuster: 113/113, path_prettifier: 113/113, autogenerated_exclude: 24/113
INFO [runner] processing took 14.820063ms with stages: nolint: 12.709457ms, autogenerated_exclude: 1.207838ms, path_prettifier: 368.394µs, identifier_marker: 290.473µs, exclude-rules: 109.804µs, skip_dirs: 107.635µs, cgo: 14.987µs, filename_unadjuster: 6.934µs, uniq_by_line: 968ns, max_same_issues: 921ns, max_from_linter: 397ns, source_code: 378ns, diff: 306ns, skip_files: 286ns, path_shortener: 276ns, max_per_file_from_linter: 229ns, exclude: 228ns, sort_results: 222ns, severity-rules: 205ns, path_prefixer: 125ns
INFO [runner] linters took 4.972553838s with stages: goanalysis_metalinter: 4.957629792s
INFO File cache stats: 9 entries of total size 121.2KiB
INFO Memory: 70 samples, avg is 204.6MB, max is 410.5MB
INFO Execution took 6.819027916s
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
