### PR TITLE
wcp secure connection improvement

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -261,6 +261,9 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 	if vc.Client == nil {
 		if vc.Client, err = vc.newClient(ctx); err != nil {
 			log.Errorf("failed to create govmomi client with err: %v", err)
+			if !vc.Config.Insecure {
+				log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
+			}
 			return err
 		}
 		return nil
@@ -282,6 +285,9 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 	log.Warnf("Creating a new client session as the existing one isn't valid or not authenticated")
 	if vc.Client, err = vc.newClient(ctx); err != nil {
 		log.Errorf("failed to create govmomi client with err: %v", err)
+		if !vc.Config.Insecure {
+			log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
+		}
 		return err
 	}
 	// Recreate PbmClient if created using timed out VC Client.

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -94,7 +94,11 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Infof("Initializing WCP CSI controller")
 	var err error
-
+	if !config.Global.InsecureFlag && config.Global.CAFile != cnsconfig.SupervisorCAFilePath {
+		log.Warnf("Invalid CA file: %q is set in the vSphere Config Secret. "+
+			"Setting correct CA file: %q", config.Global.CAFile, cnsconfig.SupervisorCAFilePath)
+		config.Global.CAFile = cnsconfig.SupervisorCAFilePath
+	}
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
 		clusterComputeResourceMoIds, err = common.GetClusterComputeResourceMoIds(ctx)
 		if err != nil {
@@ -287,6 +291,12 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 	if err != nil {
 		log.Errorf("failed to read config. Error: %+v", err)
 		return err
+	}
+
+	if !cfg.Global.InsecureFlag && cfg.Global.CAFile != cnsconfig.SupervisorCAFilePath {
+		log.Warnf("Invalid CA file: %q is set in the vSphere Config Secret. "+
+			"Setting correct CA file: %q", cfg.Global.CAFile, cnsconfig.SupervisorCAFilePath)
+		cfg.Global.CAFile = cnsconfig.SupervisorCAFilePath
 	}
 	newVCConfig, err := cnsvsphere.GetVirtualCenterConfig(ctx, cfg)
 	if err != nil {

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -177,6 +177,11 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 	metadataSyncer.clusterFlavor = clusterFlavor
 	clusterIDforVolumeMetadata = configInfo.Cfg.Global.ClusterID
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		if !configInfo.Cfg.Global.InsecureFlag && configInfo.Cfg.Global.CAFile != cnsconfig.SupervisorCAFilePath {
+			log.Warnf("Invalid CA file: %q is set in the vSphere Config Secret. "+
+				"Setting correct CA file: %q", configInfo.Cfg.Global.CAFile, cnsconfig.SupervisorCAFilePath)
+			configInfo.Cfg.Global.CAFile = cnsconfig.SupervisorCAFilePath
+		}
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
 			clusterComputeResourceMoIds, err = common.GetClusterComputeResourceMoIds(ctx)
 			if err != nil {
@@ -554,6 +559,14 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to read config. Error: %+v", err)
 	}
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		if !cfg.Global.InsecureFlag && cfg.Global.CAFile != cnsconfig.SupervisorCAFilePath {
+			log.Warnf("Invalid CA file: %q is set in the vSphere Config Secret. "+
+				"Setting correct CA file: %q", cfg.Global.CAFile, cnsconfig.SupervisorCAFilePath)
+			cfg.Global.CAFile = cnsconfig.SupervisorCAFilePath
+		}
+	}
+
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		var err error
 		restClientConfig := k8s.GetRestClientConfigForSupervisor(ctx,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Set default CAFile to `/etc/vmware/wcp/tls/vmca.pem` when `config.Global.InsecureFlag` is set to false in WCP supervisor 
- print CA file used to connect to vCenter when unable to connect to vCenter and config.Global.InsecureFlag is set to false.

**Testing done**:

Verified setting following secret config
Note: ca-file is not mentioned in the vSphere secret config
```
[Global]
insecure-flag = "false"
cluster-id = "domain-c9"
supervisor-id = "dfa6e33e-464f-48c4-93e2-037c64dab94b"
cnsregistervolumes-cleanup-intervalinmin = 720
cluster-distribution = "SupervisorCluster"
[VirtualCenter "******.eng.vmware.com"]
user = "workload_storage_management-c4db3817-2226-4415-a315-9312bbb79d12@vsphere.local"
password = "W}7x}xf2-{ImclK~trJ$"
datacenters = "datacenter-4"
port = "443"
targetvSANFileShareClusters = ""
```

Logs

```
2022-05-25T22:46:44.850Z	WARN	wcp/controller.go:297	Invalid CA file: "" is set in the vSphere Config Secret. Setting correct CA file: "/etc/vmware/wcp/tls/vmca.pem"	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).ReloadConfiguration
	/build/pkg/csi/service/wcp/controller.go:297
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).Init.func2
	/build/pkg/csi/service/wcp/controller.go:223
2022-05-25T22:46:44.851Z	INFO	vsphere/utils.go:189	Defaulting timeout for vCenter Client to 5 minutes	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.852Z	DEBUG	vsphere/utils.go:217	Setting the queryLimit = 10000, ListVolumeThreshold = 50	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.853Z	INFO	vsphere/virtualcenter.go:524	Initializing new vCenterInstance.	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.853Z	DEBUG	vsphere/utils.go:217	Setting the queryLimit = 10000, ListVolumeThreshold = 50	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.854Z	INFO	vsphere/pbm.go:76	PbmClient wasn't connected, ignoring	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.895Z	INFO	vsphere/cns.go:59	CnsClient wasn't connected, ignoring	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.895Z	INFO	vsphere/virtualcentermanager.go:144	Successfully unregistered VC sc2-10-186-130-12.eng.vmware.com	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.896Z	INFO	vsphere/virtualcentermanager.go:122	Successfully registered VC "sc2-10-186-130-12.eng.vmware.com"	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.898Z	DEBUG	vsphere/virtualcenter.go:158	Setting vCenter soap client timeout to 5m0s	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.965Z	INFO	vsphere/virtualcenter.go:183	New session ID for 'VSPHERE.LOCAL\workload_storage_management-c4db3817-2226-4415-a315-9312bbb79d12' = 52ee20bd-9892-2d2e-8411-2b0f8e545903	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.965Z	INFO	vsphere/virtualcenter.go:558	vCenterInstance initialized	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.966Z	INFO	wcp/controller.go:339	CSI Volume manager idempotency handling feature flag is enabled.	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.967Z	INFO	volume/manager.go:242	Re-initializing defaultManager.virtualCenter	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.970Z	INFO	volume/manager.go:246	VC client timeout is set to 5m0s	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.970Z	INFO	volume/manager.go:248	Done resetting volume.defaultManager	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.970Z	INFO	volume/manager.go:170	Retrieving existing defaultManager...	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.970Z	INFO	common/authmanager.go:127	Resetting vCenter Instance in the AuthManager	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.971Z	DEBUG	wcp/controller.go:356	Updated vCenter in auth manager	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.971Z	DEBUG	wcp/controller.go:361	Updated manager.CnsConfig	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.971Z	INFO	wcp/controller.go:363	Successfully reloaded configuration	{"TraceId": "4a198674-3869-43c9-b1f3-47ff8d549dba"}
2022-05-25T22:46:44.971Z	INFO	wcp/controller.go:225	Successfully reloaded configuration from: "/etc/vmware/wcp/vsphere-cloud-provider.conf"	{"TraceId": "f026d939-9cc4-426b-aa47-08a00275cc82"}
2022-05-25T22:46:44.971Z	DEBUG	wcp/controller.go:260	fsnotify event processed	{"TraceId": "f026d939-9cc4-426b-aa47-08a00275cc82"}
2022-05-25T22:46:44.971Z	DEBUG	wcp/controller.go:212	Waiting for event on fsnotify watcher	{"TraceId": "f026d939-9cc4-426b-aa47-08a00275cc82"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
wcp secure connection improvement
```
