### PR TITLE
Topology test-fix

### DIFF
--- a/tests/e2e/invalid_topology_values.go
+++ b/tests/e2e/invalid_topology_values.go
@@ -96,13 +96,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		// Get the event list and verify if it contains expected error message
 		eventList, _ := client.CoreV1().Events(pvclaim.Namespace).List(ctx, metav1.ListOptions{})
 		gomega.Expect(eventList.Items).NotTo(gomega.BeEmpty())
-		actualErrMsg := eventList.Items[len(eventList.Items)-1].Message
-		framework.Logf(fmt.Sprintf("Actual failure message: %+q", actualErrMsg))
 		expectedErrMsg := "failed to get shared datastores for topology requirement"
-		framework.Logf(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
-		gomega.Expect(strings.Contains(actualErrMsg, expectedErrMsg)).To(gomega.BeTrue(),
-			fmt.Sprintf("actualErrMsg: %q does not contain expectedErrMsg: %q", actualErrMsg, expectedErrMsg))
-
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
 	})
 
 	/*
@@ -141,12 +137,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		// Get the event list and verify if it contains expected error message
 		eventList, _ := client.CoreV1().Events(pvclaim.Namespace).List(ctx, metav1.ListOptions{})
 		gomega.Expect(eventList.Items).NotTo(gomega.BeEmpty())
-		actualErrMsg := eventList.Items[len(eventList.Items)-1].Message
-		framework.Logf(fmt.Sprintf("Actual failure message: %+q", actualErrMsg))
 		expectedErrMsg := "failed to get shared datastores for topology requirement"
-		framework.Logf(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
-		gomega.Expect(strings.Contains(actualErrMsg, expectedErrMsg)).To(gomega.BeTrue(),
-			fmt.Sprintf("actualErrMsg: %q does not contain expectedErrMsg: %q", actualErrMsg, expectedErrMsg))
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
 	})
 
 	/*
@@ -182,14 +175,10 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		framework.ExpectError(fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
 			pvclaim.Namespace, pvclaim.Name, pollTimeoutShort, framework.PollShortTimeout))
 		// Get the event list and verify if it contains expected error message
-
 		eventList, _ := client.CoreV1().Events(pvclaim.Namespace).List(ctx, metav1.ListOptions{})
 		gomega.Expect(eventList.Items).NotTo(gomega.BeEmpty())
-		actualErrMsg := eventList.Items[len(eventList.Items)-1].Message
-		framework.Logf(fmt.Sprintf("Actual failure message: %+q", actualErrMsg))
 		expectedErrMsg := "failed to get shared datastores for topology requirement"
-		framework.Logf(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
-		gomega.Expect(strings.Contains(actualErrMsg, expectedErrMsg)).To(gomega.BeTrue(),
-			fmt.Sprintf("actualErrMsg: %q does not contain expectedErrMsg: %q", actualErrMsg, expectedErrMsg))
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error %q", expectedErrMsg))
 	})
 })


### PR DESCRIPTION
What this PR does / why we need it:
fixed failed topology testcases

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #
Failure in the error message validation code is fixed 

Testing done:
Yes

Special notes for your reviewer:
```
make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kramachandra/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kramachandra/github/2ndSet/vsphere-csi-driver /Users/kramachandra/github/2ndSet /Users/kramachandra/github /Users/kramachandra /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|imports|name|exports_file|files|types_sizes) took 1m12.454548778s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 144.975474ms 
INFO [linters context/goanalysis] analyzers took 7m45.380743114s with top 10 stages: buildir: 5m9.265767964s, nilness: 29.352790433s, printf: 12.998402921s, ctrlflow: 12.462078851s, fact_deprecated: 12.213423779s, typedness: 10.835520264s, fact_purity: 9.971113679s, SA5012: 8.730898834s, misspell: 4.976247472s, inspect: 4.931335745s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude-rules: 1/24, cgo: 113/113, skip_files: 113/113, skip_dirs: 113/113, identifier_marker: 24/24, nolint: 0/1, filename_unadjuster: 113/113, path_prettifier: 113/113, exclude: 24/24, autogenerated_exclude: 24/113 
INFO [runner] processing took 86.0227ms with stages: nolint: 70.85441ms, autogenerated_exclude: 10.113689ms, path_prettifier: 3.339269ms, identifier_marker: 924.038µs, skip_dirs: 432.582µs, exclude-rules: 281.316µs, cgo: 45.07µs, filename_unadjuster: 22.48µs, max_same_issues: 1.873µs, uniq_by_line: 1.144µs, source_code: 1.04µs, skip_files: 951ns, max_per_file_from_linter: 926ns, diff: 837ns, max_from_linter: 682ns, exclude: 565ns, path_shortener: 512ns, severity-rules: 506ns, sort_results: 485ns, path_prefixer: 325ns 
INFO [runner] linters took 59.74858824s with stages: goanalysis_metalinter: 59.662191615s 
INFO File cache stats: 278 entries of total size 4.5MiB 
INFO Memory: 1230 samples, avg is 784.5MB, max is 2369.0MB 
INFO Execution took 2m12.360902768s    
```
