### PR TITLE
Volume health check  testcases - code fix when injecting psod on esxi hosts

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -3378,6 +3378,18 @@ func runCommandOnESX(username string, addr string, cmd string) (string, error) {
 			if code = exiterr.ExitStatus(); code != 0 {
 				err = nil
 			}
+		}
+		if exiterr, ok := err.(*ssh.ExitMissingError); ok {
+			/* If we got an  ExitMissingError and the exit code is zero, we'll
+			consider the SSH itself successful and cmd executed successfully on the host.
+			If  exit code is non zero we'll consider the SSH is successful but
+			cmd failed on the host. */
+			framework.Logf(exiterr.Error())
+			if code == 0 {
+				err = nil
+			} else {
+				err = fmt.Errorf("failed running `%s` on %s@%s: '%v'", cmd, config.User, addr, err)
+			}
 		} else {
 			err = fmt.Errorf("failed running `%s` on %s@%s: '%v'", cmd, config.User, addr, err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Code fix for injecting psod on esxi host for Volume health testcases

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Code fix for injecting psod on esxi host for Volume health testcases

**Testing done**:
Yes

**Special notes for your reviewer**:
Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % 
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/gc-pr-fixes/vsphere-csi-driver /Users/sipriya/gc-pr-fixes /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (exports_file|files|imports|name|compiled_files|deps|types_sizes) took 1m4.023123724s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 98.614181ms 
INFO [linters context/goanalysis] analyzers took 5m33.9037904s with top 10 stages: buildir: 3m56.58684581s, nilness: 21.974215891s, ctrlflow: 11.515913618s, fact_deprecated: 11.266006934s, printf: 10.695524444s, fact_purity: 7.898943982s, typedness: 7.551733563s, SA5012: 6.856942721s, inspect: 4.259774528s, misspell: 1.929504655s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): cgo: 113/113, filename_unadjuster: 113/113, path_prettifier: 113/113, exclude: 24/24, nolint: 0/1, skip_dirs: 113/113, exclude-rules: 1/24, skip_files: 113/113, autogenerated_exclude: 24/113, identifier_marker: 24/24 
INFO [runner] processing took 15.954552ms with stages: nolint: 13.403818ms, autogenerated_exclude: 1.663813ms, path_prettifier: 339.373µs, identifier_marker: 299.67µs, skip_dirs: 114.035µs, exclude-rules: 112.665µs, filename_unadjuster: 8.848µs, cgo: 7.328µs, max_same_issues: 1.379µs, uniq_by_line: 670ns, diff: 545ns, skip_files: 366ns, max_from_linter: 359ns, source_code: 347ns, exclude: 283ns, path_shortener: 267ns, max_per_file_from_linter: 224ns, severity-rules: 223ns, sort_results: 212ns, path_prefixer: 127ns 
INFO [runner] linters took 37.395863131s with stages: goanalysis_metalinter: 37.379809297s 
INFO File cache stats: 281 entries of total size 4.5MiB 
INFO Memory: 950 samples, avg is 572.4MB, max is 2435.0MB 
INFO Execution took 1m41.529675791s               

