### PR TITLE
fail-fast when storage topology type is unset while zonal label is present

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -411,6 +411,11 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			return nil, csifault.CSIUnimplementedFault, logger.LogNewErrorCodef(log, codes.Unimplemented,
 				"support for topology requirement with both zone and hostname labels is not yet implemented.")
 		} else if zoneLabelPresent {
+			// StorageTopologyType should be set if topology label is present
+			if storageTopologyType == "" {
+				return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCode(log, codes.InvalidArgument,
+					"StorageTopologyType is unset while topology label is present")
+			}
 			// topologyMgr can be nil if the AZ CR was not registered
 			// at the time of controller init. Handling that case in CreateVolume calls.
 			if c.topologyMgr == nil {

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -38,6 +39,7 @@ import (
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+	v1 "k8s.io/api/core/v1"
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
@@ -372,5 +374,102 @@ func TestWCPCreateVolumeWithStoragePolicy(t *testing.T) {
 
 	if len(queryResult.Volumes) != 0 {
 		t.Fatalf("Volume should not exist after deletion with ID: %s", volID)
+	}
+}
+
+// TestWCPCreateVolumeWithZonalLabelPresentButNoStorageTopoType creates volume with zonal label present
+// but not storage topology type. It is a negative case.
+func TestWCPCreateVolumeWithZonalLabelPresentButNoStorageTopoType(t *testing.T) {
+	ct := getControllerTest(t)
+
+	// Create.
+	params := make(map[string]string)
+
+	profileID := os.Getenv("VSPHERE_STORAGE_POLICY_ID")
+	if profileID == "" {
+		storagePolicyName := os.Getenv("VSPHERE_STORAGE_POLICY_NAME")
+		if storagePolicyName == "" {
+			// PBM simulator defaults.
+			storagePolicyName = "vSAN Default Storage Policy"
+		}
+
+		// Verify the volume has been create with corresponding storage policy ID.
+		pc, err := pbm.NewClient(ctx, ct.vcenter.Client.Client)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		profileID, err = pc.ProfileIDByName(ctx, storagePolicyName)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	params[common.AttributeStoragePolicyID] = profileID
+
+	capabilities := []*csi.VolumeCapability{
+		{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters:         params,
+		VolumeCapabilities: capabilities,
+		AccessibilityRequirements: &csi.TopologyRequirement{
+			Requisite: []*csi.Topology{},
+			Preferred: []*csi.Topology{
+				{
+					Segments: map[string]string{
+						v1.LabelTopologyZone: "zone1",
+					},
+				},
+			},
+		},
+	}
+
+	getCandidateDatastores = getFakeDatastores
+	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
+	if err != nil && strings.Contains(err.Error(), "InvalidArgument") {
+		t.Logf("expected error is thrown: %v", err)
+	} else {
+		defer func() {
+			if respCreate == nil {
+				t.Log("Skip cleaning up the volume as it might never been successfully created")
+				return
+			}
+
+			volID := respCreate.Volume.VolumeId
+			// Delete volume.
+			reqDelete := &csi.DeleteVolumeRequest{
+				VolumeId: volID,
+			}
+			_, err = ct.controller.DeleteVolume(ctx, reqDelete)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Verify the volume has been deleted.
+			queryFilter := cnstypes.CnsQueryFilter{
+				VolumeIds: []cnstypes.CnsVolumeId{
+					{
+						Id: volID,
+					},
+				},
+			}
+			queryResult, err := ct.vcenter.CnsClient.QueryVolume(ctx, queryFilter)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(queryResult.Volumes) != 0 {
+				t.Fatalf("volume should not exist after deletion with ID: %s", volID)
+			}
+		}()
+		t.Fatal("expected error is not thrown")
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

we should error out if storage topology type is unset while zonal label is present

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Unit Test: Passed

```
$ PKGS_WITH_TESTS=./pkg/csi/service/wcp/... TEST_FLAGS='-count=1 -run=TestWCPCreateVolumeWithZonalLabelPresentButNoStorageTopoType' make test
```
```
=== RUN   TestWCPCreateVolumeWithZonalLabelPresentButNoStorageTopoType
...
    controller_test.go:438: expected error is thrown: rpc error: code = InvalidArgument desc = StorageTopologyType is unset while topology label is present
--- PASS: TestWCPCreateVolumeWithZonalLabelPresentButNoStorageTopoType (0.41s)
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fail fast the volume creation when storage topology type is unset while zonal label is present
```
