### PR TITLE
Code fix for pvc health annotation

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -121,6 +121,7 @@ const (
 	pollTimeoutSixMin                         = 6 * time.Minute
 	healthStatusPollTimeout                   = 20 * time.Minute
 	healthStatusPollInterval                  = 30 * time.Second
+	healthStatusWaitTimeOut                   = 3 * time.Minute
 	psodTime                                  = "120"
 	pvcHealthAnnotation                       = "volumehealth.storage.kubernetes.io/health"
 	pvcHealthTimestampAnnotation              = "volumehealth.storage.kubernetes.io/health-timestamp"
@@ -189,6 +190,7 @@ const (
 	vmcPrdEndpoint                             = "https://vmc.vmware.com/vmc/api/orgs/"
 	authAPI                                    = "https://console.cloud.vmware.com/csp/gateway/am/api/auth" +
 		"/api-tokens/authorize"
+	volumeHealthAnnotation = "volumehealth.storage.kubernetes.io/health"
 )
 
 // The following variables are required to know cluster type to run common e2e


### PR DESCRIPTION
**What this PR does / why we need it**:
Code fix for pvc health annotation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Code fix for pvc health annotation
Removed static sleep and added polling mechanism

**Testing done**:
Yes

**Special notes for your reviewer**:
Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll 
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/wcp-nfs4/vsphere-csi-driver /Users/sipriya/wcp-nfs4 /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (types_sizes|imports|name|files|compiled_files|deps|exports_file) took 12.009750822s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 117.152469ms 
INFO [linters context/goanalysis] analyzers took 41.803251798s with top 10 stages: buildir: 15.277154515s, misspell: 1.602174247s, S1038: 1.004343918s, directives: 942.720824ms, unused: 830.138716ms, SA1012: 800.759383ms, isgenerated: 633.437707ms, nilness: 616.808073ms, typedness: 591.131591ms, printf: 583.17833ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_files: 113/113, skip_dirs: 113/113, autogenerated_exclude: 24/113, identifier_marker: 24/24, exclude: 24/24, path_prettifier: 113/113, exclude-rules: 1/24, cgo: 113/113, nolint: 0/1, filename_unadjuster: 113/113 
INFO [runner] processing took 15.263298ms with stages: nolint: 13.231962ms, autogenerated_exclude: 1.145845ms, path_prettifier: 347.345µs, identifier_marker: 293.595µs, skip_dirs: 121.62µs, exclude-rules: 105.2µs, filename_unadjuster: 6.486µs, cgo: 6.036µs, uniq_by_line: 1.342µs, max_same_issues: 1.175µs, max_from_linter: 370ns, source_code: 362ns, diff: 337ns, exclude: 293ns, severity-rules: 254ns, skip_files: 235ns, max_per_file_from_linter: 234ns, sort_results: 224ns, path_shortener: 223ns, path_prefixer: 160ns 
INFO [runner] linters took 8.911878483s with stages: goanalysis_metalinter: 8.896511686s 
INFO File cache stats: 279 entries of total size 4.4MiB 
INFO Memory: 212 samples, avg is 288.8MB, max is 1222.4MB 
INFO Execution took 21.050768461s                 
sipriya@sipriya-a01 vsphere-csi-driver % 
