### PR TITLE
Return non storage fault when VM is not found is VC during CnsNodeVmAttachment detach workflow

### DIFF
--- a/pkg/common/fault/constants.go
+++ b/pkg/common/fault/constants.go
@@ -21,6 +21,8 @@ const (
 
 	// CSIVmUuidNotFoundFault is the fault type when Pod VMs do not have the vmware-system-vm-uuid annotation.
 	CSIVmUuidNotFoundFault = "csi.fault.nonstorage.VmUuidNotFound"
+	// CSIVmNotFoundFault is the fault type when VM object is not found in the VC
+	CSIVmNotFoundFault = "csi.fault.nonstorage.VmNotFound"
 
 	// CSITaskResultEmptyFault is the fault type when taskResult is empty.
 	CSITaskResultEmptyFault = "csi.fault.TaskResultEmpty"

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -413,7 +413,7 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 				// Now that VM on VC is not found, check VirtualMachine CRD instance exists.
 				// This check is needed in scenarios where VC inventory is stale due
 				// to upgrade or back-up and restore.
-				isPresent, err := isVmCrPresent(ctx, r.vmOperatorClient, nodeUUID,
+				isPresent, vmInstance, err := isVmCrPresent(ctx, r.vmOperatorClient, nodeUUID,
 					request.Namespace)
 				if err != nil {
 					msg = fmt.Sprintf("failed to verify is VM CR is present with UUID: %s "+
@@ -427,10 +427,18 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 						"returning success since the deletion timestamp is set.",
 						nodeUUID, request.Namespace, request.Name)
 				} else {
-					msg = fmt.Sprintf("VM on VC not found but VM CR with UUID: %s "+
-						"is still present in namespace: %s. Returning success since "+
-						"the deletion timestamp is set.", nodeUUID, request.Namespace)
-					recordEvent(ctx, r, instance, v1.EventTypeNormal, msg)
+					if vmInstance.DeletionTimestamp != nil {
+						msg = fmt.Sprintf("VM on VC not found but VM CR with UUID: %s "+
+							"is still present in namespace: %s. Returning success since "+
+							"the deletion timestamp is set on VM CR.", nodeUUID, request.Namespace)
+						recordEvent(ctx, r, instance, v1.EventTypeNormal, msg)
+					} else {
+						msg = fmt.Sprintf("VM on VC not found but VM CR with UUID: %s "+
+							"is still present in namespace: %s. Returning failure since "+
+							"the deletion timestamp is not set on VM CR.", nodeUUID, request.Namespace)
+						recordEvent(ctx, r, instance, v1.EventTypeWarning, msg)
+						return reconcile.Result{RequeueAfter: timeout}, csifault.CSIVmNotFoundFault, nil
+					}
 				}
 				removeFinalizerFromCRDInstance(ctx, instance, request)
 				err = updateCnsNodeVMAttachment(ctx, r.client, instance)
@@ -527,29 +535,30 @@ func removeFinalizerFromCRDInstance(ctx context.Context,
 }
 
 // isVmCrPresent checks whether VM CR is present in SV namespace
-// with given vmuuid.
+// with given vmuuid and returns true or false along with the
+// VirtualMachine CR object if it is found
 func isVmCrPresent(ctx context.Context, vmOperatorClient client.Client,
-	vmuuid string, namespace string) (bool, error) {
+	vmuuid string, namespace string) (bool, *vmoperatortypes.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
 	vmList := &vmoperatortypes.VirtualMachineList{}
 	err := vmOperatorClient.List(ctx, vmList, client.InNamespace(namespace))
 	if err != nil {
 		msg := fmt.Sprintf("failed to list virtualmachines with error: %+v", err)
 		log.Error(msg)
-		return false, err
+		return false, nil, err
 	}
 	for _, vmInstance := range vmList.Items {
 		if vmInstance.Status.BiosUUID == vmuuid {
 			msg := fmt.Sprintf("VM CR with BiosUUID: %s found in namespace: %s",
 				vmuuid, namespace)
 			log.Infof(msg)
-			return true, nil
+			return true, &vmInstance, nil
 		}
 	}
 	msg := fmt.Sprintf("VM CR with BiosUUID: %s not found in namespace: %s",
 		vmuuid, namespace)
 	log.Error(msg)
-	return false, nil
+	return false, nil, nil
 }
 
 // getVCDatacenterFromConfig returns datacenter registered for each vCenter


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is enhancing CnsNodeVmAttachment detach workflow to set a non-storage fault since the VM is not found in the VC but the VM CR is present in the SV Namespace.
With these changes CSI metrics will emit `VmNotFound` fault during such scenarios which can later be marked as non-Storage related fault.
  
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
$kubectl create -f pvc.yaml -n  testing
persistentvolumeclaim/example-rwo-pvc created
```
```
$kubectl create -f pod.yaml -n  testing
pod/example-block-pod created
```
```
$kubectl get pods -n testing
NAME                        READY   STATUS    RESTARTS   AGE
example-block-pod   1/1     Running   0          2m22s
```
```
$kubectl get cnsnodevmattachment -A
NAMESPACE             NAME                                                                       
tkc-e2e-i1bvby        tkc-e2e-tkc-e2e-i1bvby-xbh-workers-nbrqp-6b5b78d6-8w2fv-78e34eb2-8bae-45df-ab6c-70055273f297-b25dee2e-1fd7-47ac-832b-003b04e421ce   7m12s
```

Bring down tkc worker count to zero
```
$kubectl edit tkc -n tkc-e2e-i1bvby        tkc-e2e-tkc-e2e-i1bvby-xbh
tanzukubernetescluster.run.tanzu.vmware.com/tkc-e2e-tkc-e2e-i1bvby-xbh edited
```

Check the CNS-CSI syncer logs:
```
2022-05-12T20:48:46.861Z	INFO	cnsnodevmattachment/cnsnodevmattachment_controller.go:210	Reconciling CnsNodeVmAttachment with Request.Name: "tkc-e2e-tkc-e2e-i1bvby-xbh-workers-nbrqp-6b5b78d6-8w2fv-78e34eb2-8bae-45df-ab6c-70055273f297-b25dee2e-1fd7-47ac-832b-003b04e421ce" instance "tkc-e2e-tkc-e2e-i1bvby-xbh-workers-nbrqp-6b5b78d6-8w2fv-78e34eb2-8bae-45df-ab6c-70055273f297-b25dee2e-1fd7-47ac-832b-003b04e421ce" timeout "8s" seconds	{"TraceId": "8386cb5a-4110-45ce-a325-394d22f712cc"}
2022-05-12T20:48:46.997Z	ERROR	cnsnodevmattachment/cnsnodevmattachment_controller.go:403	failed to find the VM on VC with UUID: 423299c9-a586-e8ed-e57c-73d9ca807354 for CnsNodeVmAttachment request with name: "tkc-e2e-tkc-e2e-i1bvby-xbh-workers-nbrqp-6b5b78d6-8w2fv-78e34eb2-8bae-45df-ab6c-70055273f297-b25dee2e-1fd7-47ac-832b-003b04e421ce" on namespace: tkc-e2e-i1bvby. Err: virtual machine wasn't found	{"TraceId": "8386cb5a-4110-45ce-a325-394d22f712cc"}
2022-05-12T20:48:46.998Z	INFO	cnsnodevmattachment/cnsnodevmattachment_controller.go:655	VM on VC with UUID: 423299c9-a586-e8ed-e57c-73d9ca807354 not found when processing CnsNodeVmAttachment request with name: "tkc-e2e-tkc-e2e-i1bvby-xbh-workers-nbrqp-6b5b78d6-8w2fv-78e34eb2-8bae-45df-ab6c-70055273f297-b25dee2e-1fd7-47ac-832b-003b04e421ce" on namespace: "tkc-e2e-i1bvby". Returning success since the deletion timestamp is set.	{"TraceId": "8386cb5a-4110-45ce-a325-394d22f712cc"}
```


Check the CNS-CSI syncer logs to verify that detach operation is returned as success:
```
2022-05-12T20:48:46.861Z	INFO	cnsnodevmattachment/cnsnodevmattachment_controller.go:210	Reconciling CnsNodeVmAttachment with Request.Name: "tkc-e2e-tkc-e2e-i1bvby-xbh-workers-nbrqp-6b5b78d6-8w2fv-78e34eb2-8bae-45df-ab6c-70055273f297-b25dee2e-1fd7-47ac-832b-003b04e421ce" instance "tkc-e2e-tkc-e2e-i1bvby-xbh-workers-nbrqp-6b5b78d6-8w2fv-78e34eb2-8bae-45df-ab6c-70055273f297-b25dee2e-1fd7-47ac-832b-003b04e421ce" timeout "8s" seconds	{"TraceId": "8386cb5a-4110-45ce-a325-394d22f712cc"}
2022-05-12T20:48:46.997Z	ERROR	cnsnodevmattachment/cnsnodevmattachment_controller.go:403	failed to find the VM on VC with UUID: 423299c9-a586-e8ed-e57c-73d9ca807354 for CnsNodeVmAttachment request with name: "tkc-e2e-tkc-e2e-i1bvby-xbh-workers-nbrqp-6b5b78d6-8w2fv-78e34eb2-8bae-45df-ab6c-70055273f297-b25dee2e-1fd7-47ac-832b-003b04e421ce" on namespace: tkc-e2e-i1bvby. Err: virtual machine wasn't found	{"TraceId": "8386cb5a-4110-45ce-a325-394d22f712cc"}
2022-05-12T20:48:46.998Z	INFO	cnsnodevmattachment/cnsnodevmattachment_controller.go:655	VM on VC with UUID: 423299c9-a586-e8ed-e57c-73d9ca807354 not found when processing CnsNodeVmAttachment request with name: "tkc-e2e-tkc-e2e-i1bvby-xbh-workers-nbrqp-6b5b78d6-8w2fv-78e34eb2-8bae-45df-ab6c-70055273f297-b25dee2e-1fd7-47ac-832b-003b04e421ce" on namespace: "tkc-e2e-i1bvby". Returning success since the deletion timestamp is set.	{"TraceId": "8386cb5a-4110-45ce-a325-394d22f712cc"}
```

Simulate VM not present and VM CR does not have deletionTimestamp scenario by deleting vm in VC(Simulate non storage related error).

```
2022-05-12T20:48:46.997Z	ERROR	cnsnodevmattachment/cnsnodevmattachment_controller.go:655	failed to find the VM on VC with UUID: 423299c9-a586-e8ed-e57c-45c1de134790 for CnsNodeVmAttachment request with name: "tkc-e2e-tkc-e2e-i1bvby-xbh-workers-nbrqp-6b5b78d6-8w2fv-78e34eb2-8bae-45df-ab6c-70055273f297-b25dee2e-1fd7-47ac-832b-423299c910ab" on namespace: tkc-e2e-i1bvby. Err: virtual machine wasn't found	{"TraceId": "423299c9-4110-45ce-a325-423299c910ab"}
```

Verify if the fault is capture in the metrics:

```
$curl 192.168.123.1:2113/metrics
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block",le="2"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block",le="5"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block",le="10"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block",le="15"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block",le="20"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block",le="25"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block",le="30"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block",le="60"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block",le="120"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block",le="180"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block",le="+Inf"} 12
vsphere_csi_volume_ops_histogram_sum{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block"} 2.43044905
vsphere_csi_volume_ops_histogram_count{faulttype="csi.fault.nonstorage.VmNotFound",optype="detach-volume",status="fail",voltype="block"} 12
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Return non storage fault when VM is not found is VC during CnsNodeVmAttachment detach workflow
```
