### PR TITLE
Refactor  controllerpublishForBlockVolume and controllerUnpublishForBlockVolume for Guest Cluster

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -521,75 +521,71 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest, c *controller) (
 	*csi.ControllerPublishVolumeResponse, string, error) {
 	log := logger.GetLogger(ctx)
+	var isVolumePresentInSpec, isVolumeAttached bool
+	var diskUUID string
+	var err error
+
 	virtualMachine := &vmoperatortypes.VirtualMachine{}
 	vmKey := types.NamespacedName{
 		Namespace: c.supervisorNamespace,
 		Name:      req.NodeId,
 	}
 
-	var err error
-	if err = c.vmOperatorClient.Get(ctx, vmKey, virtualMachine); err != nil {
-		msg := fmt.Sprintf("failed to get VirtualMachines for the node: %q. Error: %+v", req.NodeId, err)
-		log.Error(msg)
-		return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
-	}
-	// Check if volume is already present in the virtualMachine.Spec.Volumes
-	var isVolumePresentInSpec, isVolumeAttached bool
-	var diskUUID string
-	for _, volume := range virtualMachine.Spec.Volumes {
-		if volume.PersistentVolumeClaim != nil && volume.Name == req.VolumeId {
-			log.Infof("Volume %q is already present in the virtualMachine.Spec.Volumes", volume.Name)
-			isVolumePresentInSpec = true
-			break
-		}
-	}
 	timeoutSeconds := int64(getAttacherTimeoutInMin(ctx) * 60)
-	// if volume is present in the virtualMachine.Spec.Volumes check if volume's status is attached and DiskUuid is set
-	if isVolumePresentInSpec {
-		for _, volume := range virtualMachine.Status.Volumes {
-			if volume.Name == req.VolumeId && volume.Attached && volume.DiskUuid != "" {
-				diskUUID = volume.DiskUuid
-				isVolumeAttached = true
-				log.Infof("Volume %q is already attached in the virtualMachine.Spec.Volumes. Disk UUID: %q",
-					volume.Name, volume.DiskUuid)
-				break
-			}
-		}
-	} else {
-		timeout := time.Now().Add(time.Duration(timeoutSeconds) * time.Second)
-		for {
-			// Volume is not present in the virtualMachine.Spec.Volumes, so adding
-			// volume in the spec and patching virtualMachine instance.
-			vmvolumes := vmoperatortypes.VirtualMachineVolume{
-				Name: req.VolumeId,
-				PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
-					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: req.VolumeId,
-					},
-				},
-			}
-			virtualMachineLock.Lock()
-			virtualMachine.Spec.Volumes = append(virtualMachine.Spec.Volumes, vmvolumes)
-			err := c.vmOperatorClient.Update(ctx, virtualMachine)
-			virtualMachineLock.Unlock()
-			if err == nil || time.Now().After(timeout) {
-				break
-			}
-			virtualMachine = &vmoperatortypes.VirtualMachine{}
-			if err := c.vmOperatorClient.Get(ctx, vmKey, virtualMachine); err != nil {
-				msg := fmt.Sprintf("failed to get VirtualMachines for the node: %q. Error: %+v", req.NodeId, err)
-				log.Error(msg)
-				return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
-			}
-			log.Debugf("Found virtualMachine instance for node: %q", req.NodeId)
-		}
-		if err != nil {
-			msg := fmt.Sprintf("Time out to update VirtualMachines %q with Error: %+v", virtualMachine.Name, err)
+	timeout := time.Now().Add(time.Duration(timeoutSeconds) * time.Second)
+	for {
+		if err = c.vmOperatorClient.Get(ctx, vmKey, virtualMachine); err != nil {
+			msg := fmt.Sprintf("failed to get VirtualMachines for the node: %q. Error: %+v", req.NodeId, err)
 			log.Error(msg)
 			return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
 		}
+		// Check if volume is already present in the virtualMachine.Spec.Volumes
+		for _, volume := range virtualMachine.Spec.Volumes {
+			if volume.PersistentVolumeClaim != nil && volume.Name == req.VolumeId {
+				log.Infof("Volume %q is already present in the virtualMachine.Spec.Volumes", volume.Name)
+				isVolumePresentInSpec = true
+				break
+			}
+		}
+		if isVolumePresentInSpec {
+			break
+		}
+		// Volume is not present in the virtualMachine.Spec.Volumes, so adding
+		// volume in the spec and patching virtualMachine instance.
+		vmvolumes := vmoperatortypes.VirtualMachineVolume{
+			Name: req.VolumeId,
+			PersistentVolumeClaim: &vmoperatortypes.PersistentVolumeClaimVolumeSource{
+				PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: req.VolumeId,
+				},
+			},
+		}
+		virtualMachineLock.Lock()
+		virtualMachine.Spec.Volumes = append(virtualMachine.Spec.Volumes, vmvolumes)
+		err = c.vmOperatorClient.Update(ctx, virtualMachine)
+		virtualMachineLock.Unlock()
+		if err == nil {
+			break
+		} else {
+			log.Errorf("failed to update virtualmachine. Err: %v", err)
+		}
+		if time.Now().After(timeout) {
+			msg := fmt.Sprintf("timedout to update VirtualMachines %q", virtualMachine.Name)
+			log.Error(msg)
+			return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
+		}
+		virtualMachine = &vmoperatortypes.VirtualMachine{}
 	}
 
+	for _, volume := range virtualMachine.Status.Volumes {
+		if volume.Name == req.VolumeId && volume.Attached && volume.DiskUuid != "" {
+			diskUUID = volume.DiskUuid
+			isVolumeAttached = true
+			log.Infof("Volume %q is already attached in the virtualMachine.Spec.Volumes. Disk UUID: %q",
+				volume.Name, volume.DiskUuid)
+			break
+		}
+	}
 	// volume is not attached, so wait until volume is attached and DiskUuid is set
 	if !isVolumeAttached {
 		watchVirtualMachine, err := c.vmWatcher.Watch(metav1.ListOptions{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making sure `c.vmOperatorClient.Update(ctx, virtualMachine)` only when virtualMachine.Status.Volumes  does not have the volume we want to add to virtualMachine.

This will help avoid erroring  `c.vmOperatorClient.Update(ctx, virtualMachine)` in the loop when virtualMachine already has the volume in the spec due to prior timedout `controllerPublishForBlockVolume` call.

This PR is also removing the lock between `controllerpublishForBlockVolume` and `controllerUnpublishForBlockVolume`.
and simplifying logic of  `controllerpublishForBlockVolume` and `controllerUnpublishForBlockVolume`

This PR is fixing the following issue observed while creating VM services VM by Guest Cluster CSI controller

```
I0511 14:46:23.860076       1 response.go:42] vmware-system-vmop-controller-manager-7466c8c54d-sslrr/default-validate-vmoperator-vmware-com-v1alpha1-virtualmachine/tkgha37/tkgha37-cluster37-nodepool-2-z5chx-7649d84689-6ct6m "msg"="validation denied"  "code"=422 "reason"="spec.volumes[1].name: Duplicate value: \"8875df5c-e0b0-4445-82a8-bc803abe1368-06c67733-ebbc-43a4-8471-0642696cad72\"
```

**Testing done**:
Created statefulset with parallel pod management policy and performed scale up and scale down.

```
root@420a0ced914125e81ebbb50e53297a60 [ ~ ]# kubectl get sts
NAME   READY   AGE
web    30/30   20m
root@420a0ced914125e81ebbb50e53297a60 [ ~ ]# kubectl get pods
NAME     READY   STATUS    RESTARTS   AGE
web-0    1/1     Running   0          20m
web-1    1/1     Running   0          20m
web-10   1/1     Running   0          20m
web-11   1/1     Running   0          20m
web-12   1/1     Running   0          20m
web-13   1/1     Running   0          20m
web-14   1/1     Running   0          20m
web-15   1/1     Running   0          20m
web-16   1/1     Running   0          20m
web-17   1/1     Running   0          20m
web-18   1/1     Running   0          20m
web-19   1/1     Running   0          20m
web-2    1/1     Running   0          99s
web-20   1/1     Running   0          20m
web-21   1/1     Running   0          20m
web-22   1/1     Running   0          20m
web-23   1/1     Running   0          20m
web-24   1/1     Running   0          20m
web-25   1/1     Running   0          20m
web-26   1/1     Running   0          20m
web-27   1/1     Running   0          20m
web-28   1/1     Running   0          20m
web-29   1/1     Running   0          20m
web-3    1/1     Running   0          20m
web-4    1/1     Running   0          20m
web-5    1/1     Running   0          20m
web-6    1/1     Running   0          20m
web-7    1/1     Running   0          20m
web-8    1/1     Running   0          20m
web-9    1/1     Running   0          20m


# kubectl scale sts web --replicas=10
statefulset.apps/web scaled


# kubectl get sts
NAME   READY   AGE
web    10/10   23m


# kubectl get pods
NAME    READY   STATUS    RESTARTS   AGE
web-0   1/1     Running   0          23m
web-1   1/1     Running   0          23m
web-2   1/1     Running   0          5m1s
web-3   1/1     Running   0          23m
web-4   1/1     Running   0          23m
web-5   1/1     Running   0          23m
web-6   1/1     Running   0          23m
web-7   1/1     Running   0          23m
web-8   1/1     Running   0          23m
web-9   1/1     Running   0          23m


# kubectl scale sts web --replicas=25
statefulset.apps/web scaled


# kubectl get sts
NAME   READY   AGE
web    25/25   24m


# kubectl get pods
NAME     READY   STATUS    RESTARTS   AGE
web-0    1/1     Running   0          25m
web-1    1/1     Running   0          25m
web-10   1/1     Running   0          62s
web-11   1/1     Running   0          62s
web-12   1/1     Running   0          62s
web-13   1/1     Running   0          62s
web-14   1/1     Running   0          62s
web-15   1/1     Running   0          61s
web-16   1/1     Running   0          61s
web-17   1/1     Running   0          61s
web-18   1/1     Running   0          60s
web-19   1/1     Running   0          59s
web-2    1/1     Running   0          6m31s
web-20   1/1     Running   0          59s
web-21   1/1     Running   0          59s
web-22   1/1     Running   0          59s
web-23   1/1     Running   0          58s
web-24   1/1     Running   0          58s
web-3    1/1     Running   0          25m
web-4    1/1     Running   0          25m
web-5    1/1     Running   0          25m
web-6    1/1     Running   0          25m
web-7    1/1     Running   0          25m
web-8    1/1     Running   0          25m
web-9    1/1     Running   0          25m



# kubectl scale sts web --replicas=0
statefulset.apps/web scaled

# kubectl get sts
NAME   READY   AGE
web    0/0     27m

# kubectl get pods
No resources found in default namespace.
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Refactor controllerpublishForBlockVolume and controllerUnpublishForBlockVolume for Guest Cluster
```
