### PR TITLE
Fix overwriting of clusterComputeResourceMoIds for TKGS-HA

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -419,15 +419,15 @@ func GetClusterComputeResourceMoIds(ctx context.Context) ([]string, error) {
 
 	var (
 		clusterComputeResourceMoIds []string
-		found                       bool
 	)
 	for _, az := range azList.Items {
-		clusterComputeResourceMoIds, found, err = unstructured.NestedStringSlice(az.Object, "spec",
+		clusterComputeResourceMoIdSlice, found, err := unstructured.NestedStringSlice(az.Object, "spec",
 			"clusterComputeResourceMoIDs")
 		if !found || err != nil {
 			return nil, fmt.Errorf("failed to get ClusterComputeResourceMoIDs "+
 				"from AvailabilityZone instance: %+v, err:%+v", az.Object, err)
 		}
+		clusterComputeResourceMoIds = append(clusterComputeResourceMoIds, clusterComputeResourceMoIdSlice...)
 	}
 	return clusterComputeResourceMoIds, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixes a bug in #1689 where clusterComputeResourceMoIds from individual `AvailabilityZone`s were overwritten instead of being appended to the slice. As a result, we were only retrieving a single clusterComputeResourceMoId irrespective of the AZs and their respective clusterComputeResourceMoIds. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Testing done**:

Stretched supervisor with 3 `AvailabilityZone`s 
```
root@422a14df75f818dd1259aadc029ecd81 [ ~ ]# k get az -n gc-ns
NAME     AGE
zone-1   25h
zone-2   25h
zone-3   25h
```

TKGS-HA is enabled on Supervisor. 

```
k edit configmap -n vmware-system-csi

apiVersion: v1
items:
- apiVersion: v1
  data:
    async-query-volume: "true"
    block-volume-snapshot: "false"
    cnsmgr-suspend-create-volume: "false"
    csi-auth-check: "true"
    csi-sv-feature-states-replication: "true"
    fake-attach: "true"
    file-volume: "true"
    improved-csi-idempotency: "true"
    list-volumes: "false"
    sibling-replica-bound-pvc-check: "true"
    tkgs-ha: "true"
    trigger-csi-fullsync: "false"
    volume-extend: "true"
    volume-health: "true"
    vsan-direct-disk-decommission: "true"
  kind: ConfigMap
```

When we attempt to create a File Volume, we get this expected error. 

```
root@422a14df75f818dd1259aadc029ecd81 [ ~ ]# k describe pvc -n gc-ns
Name:          aditya-pvc
Namespace:     gc-ns
StorageClass:  zonal-profile
Status:        Pending
Volume:
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:
Access Modes:
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age              From                                                                                          Message
  ----     ------                ----             ----                                                                                          -------
  Normal   ExternalProvisioning  9s               persistentvolume-controller                                                                   waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal   Provisioning          1s (x4 over 9s)  csi.vsphere.vmware.com_422a14df75f818dd1259aadc029ecd81_79f1a4b8-cfa1-494c-8518-dd64cc7963e0  External provisioner is provisioning volume for claim "gc-ns/aditya-pvc"
  Warning  ProvisioningFailed    1s (x4 over 9s)  csi.vsphere.vmware.com_422a14df75f818dd1259aadc029ecd81_79f1a4b8-cfa1-494c-8518-dd64cc7963e0  failed to provision volume with StorageClass "zonal-profile": rpc error: code = Unimplemented desc = file volume provisioning is not supported on a stretched supervisor cluster
```

We will only get this error when for more than 1 AZs present (3 in the testbed), `clusterComputeResourceMoIds` slice length is more than 1 (3 in this case). With #1689 present, we were only getting a length of 1 as a result of overwriting and thus, not hitting this expected error. 
```
if len(clusterComputeResourceMoIds) > 1 {
	return nil, csifault.CSIUnimplementedFault, logger.LogNewErrorCode(log, codes.Unimplemented,
	"file volume provisioning is not supported on a stretched supervisor cluster")
}
```

`make check`

```
(~/GolandProjects/vsphere-csi-driver) $ make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.1
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/adkulkarni/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/provider sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/adkulkarni/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/adkulkarni/GolandProjects/vsphere-csi-driver /Users/adkulkarni/GolandProjects /Users/adkulkarni /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|imports|name|exports_file|files|types_sizes) took 1.583273873s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 106.392656ms
INFO [linters context/goanalysis] analyzers took 38.244223849s with top 10 stages: buildir: 10.676209792s, misspell: 1.225949327s, S1038: 1.128547544s, unused: 708.504178ms, directives: 663.786517ms, SA1012: 654.674466ms, SA1013: 602.885789ms, S1019: 594.550043ms, S1024: 567.86415ms, S1039: 561.324189ms
INFO [runner] Issues before processing: 113, after processing: 0
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 24/113, exclude: 24/24, filename_unadjuster: 113/113, path_prettifier: 113/113, skip_dirs: 113/113, identifier_marker: 24/24, cgo: 113/113, skip_files: 113/113, exclude-rules: 1/24, nolint: 0/1
INFO [runner] processing took 15.084285ms with stages: nolint: 13.048052ms, autogenerated_exclude: 1.130207ms, path_prettifier: 335.92µs, identifier_marker: 301.716µs, exclude-rules: 129.912µs, skip_dirs: 115.414µs, cgo: 11.751µs, filename_unadjuster: 6.988µs, max_same_issues: 1.022µs, uniq_by_line: 668ns, max_from_linter: 367ns, source_code: 364ns, diff: 287ns, skip_files: 275ns, exclude: 268ns, max_per_file_from_linter: 241ns, severity-rules: 239ns, path_shortener: 239ns, sort_results: 216ns, path_prefixer: 139ns
INFO [runner] linters took 7.80266105s with stages: goanalysis_metalinter: 7.787483446s
INFO File cache stats: 209 entries of total size 4.3MiB
INFO Memory: 97 samples, avg is 444.2MB, max is 1222.9MB
INFO Execution took 9.502298559s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
