### PR TITLE
Add privileges for Administrator group users on PVC and PV for WCP cl…

### DIFF
--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -114,10 +114,10 @@ rules:
     verbs: ["get", "list", "create", "delete", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "update", "delete"]
+    verbs: ["get", "list", "update", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["update", "get"]
+    verbs: ["get", "list", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -114,10 +114,10 @@ rules:
     verbs: ["get", "list", "create", "delete", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "update", "delete"]
+    verbs: ["get", "list", "update", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["update", "get"]
+    verbs: ["get", "list", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -117,10 +117,10 @@ rules:
     verbs: ["get", "list", "create", "delete", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "update", "delete"]
+    verbs: ["get", "list", "update", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["update", "get"]
+    verbs: ["get", "list", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -117,10 +117,10 @@ rules:
     verbs: ["get", "list", "create", "delete", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "update", "delete"]
+    verbs: ["get", "list", "update", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["update", "get"]
+    verbs: ["get", "list", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds more privileges for Administrator group users on PV and PVC API. This is required for the TKGu migration which imports existing volumes from TKGm clusters to TKGs clusters on WCP.

TKGu migration which requires migrating TKGm workloads to TKGs. As part of migration, it would need to import existing volumes from TKGm cluster into TKGs cluster via CnsRegisterVolume API.
For this, Admin needs permission on certain API objects like PVC/PV for this to work. This PR adds the permissions for Admin on those objects as part of this PR.

**Testing done**:
Currently verifying this on WCP cluster using the Admin account.
```
$ export KUBECONFIG=/tmp/sample.txt

$ kubectl vsphere login --server=10.78.141.163 --insecure-skip-tls-verify -v20

$ kubectl auth can-i list persistentvolumes
yes

$ kubectl auth can-i delete persistentvolumes
yes
```

cc @deepakkinni @shalini-b 


**Release note**:
```release-note
Add privileges for Administrator group users on CnsRegisterVolume API
```