### PR TITLE
Code fix for static sleep while checking csi pods running state

### DIFF
--- a/tests/e2e/file_volume_statefulsets.go
+++ b/tests/e2e/file_volume_statefulsets.go
@@ -570,16 +570,18 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		// Fetch the number of CSI pods running before restart
 		list_of_pods, err := fpod.GetPodsInNamespace(client, csiSystemNamespace, ignoreLabels)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		num_csi_pods := len(list_of_pods)
 
 		// Restart CSI daemonset
+		ginkgo.By("Restart Daemonset")
 		cmd := []string{"rollout", "restart", "daemonset/vsphere-csi-node", "--namespace=" + csiSystemNamespace}
 		framework.RunKubectlOrDie(csiSystemNamespace, cmd...)
 
-		// Wait for the CSI Pods to be up and Running
-		// If the status of the pods checked immediately after the some rolling update, they will be running always
-		// so wait for a min or so and check pods status
-		time.Sleep(pollTimeoutShort)
-		num_csi_pods := len(list_of_pods)
+		ginkgo.By("Waiting for daemon set rollout status to finish")
+		statusCheck := []string{"rollout", "status", "daemonset/vsphere-csi-node", "--namespace=" + csiSystemNamespace}
+		framework.RunKubectlOrDie(csiSystemNamespace, statusCheck...)
+
+		// wait for csi Pods to be in running ready state
 		err = fpod.WaitForPodsRunningReady(client, csiSystemNamespace, int32(num_csi_pods), 0, pollTimeout, ignoreLabels)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Code fix for static sleep while checking csi pods running state
Removed static sleep and added polling

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Code fix for node daemon restart and csi pods to be in running state
Removed static sleep and added polling

**Testing done**:
Yes
https://gist.githubusercontent.com/sipriyaa/7da07ca1ec0d42ea1233803adfa422fd/raw/6f1e6dc364a2a2a95cf6480592795aed8da3bb36/gistfile1.txt

**Special notes for your reviewer**:

**Release note**:
Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % 
sipriya@sipriya-a01 vsphere-csi-driver %  golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint 
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/file-vanilla-test-fix/vsphere-csi-driver /Users/sipriya/file-vanilla-test-fix /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|types_sizes|files|imports|name) took 14.614751362s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 115.535727ms 
INFO [linters context/goanalysis] analyzers took 44.891397538s with top 10 stages: buildir: 15.039585775s, misspell: 2.091373421s, S1038: 1.554237353s, printf: 951.627047ms, ctrlflow: 930.703098ms, S1039: 908.077628ms, fact_deprecated: 841.233746ms, directives: 737.743689ms, unused: 705.487564ms, S1024: 700.282437ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): cgo: 113/113, nolint: 0/1, skip_dirs: 113/113, identifier_marker: 24/24, filename_unadjuster: 113/113, path_prettifier: 113/113, skip_files: 113/113, exclude: 24/24, exclude-rules: 1/24, autogenerated_exclude: 24/113 
INFO [runner] processing took 15.344879ms with stages: nolint: 12.929522ms, autogenerated_exclude: 1.48806ms, path_prettifier: 370.638µs, identifier_marker: 305.178µs, skip_dirs: 121.424µs, exclude-rules: 109.661µs, cgo: 9.146µs, filename_unadjuster: 7.05µs, max_same_issues: 1.047µs, uniq_by_line: 521ns, max_from_linter: 366ns, skip_files: 356ns, diff: 334ns, source_code: 273ns, exclude: 238ns, severity-rules: 234ns, max_per_file_from_linter: 221ns, sort_results: 221ns, path_shortener: 211ns, path_prefixer: 178ns 
INFO [runner] linters took 9.949468646s with stages: goanalysis_metalinter: 9.934040136s 
INFO File cache stats: 281 entries of total size 4.5MiB 
INFO Memory: 246 samples, avg is 269.2MB, max is 1021.7MB 
INFO Execution took 24.691613557s       
