### PR TITLE
Code fix for Topology disruptive scenario - added new argument nimbus "podname" for running power-on/off on ESXi

### DIFF
--- a/tests/e2e/nimbus_utils.go
+++ b/tests/e2e/nimbus_utils.go
@@ -34,18 +34,20 @@ type TestbedBasicInfo struct {
 	vcIp     string
 	vcVmName string
 	esxHosts []map[string]string
+	podname  string
 }
 
 var tbinfo TestbedBasicInfo
 
 //vMPowerMgmt power on/off given nimbus VMs (space separated list)
-func vMPowerMgmt(user string, location string, hostList string, shouldBePoweredOn bool) error {
+func vMPowerMgmt(user string, location string, podname string, hostList string, shouldBePoweredOn bool) error {
 	var err error
 	op := "off"
 	if shouldBePoweredOn {
 		op = "on"
 	}
-	nimbusCmd := fmt.Sprintf("USER=%s /mts/git/bin/nimbus-ctl --nimbusLocation %s %s %s", user, location, op, hostList)
+	nimbusCmd := fmt.Sprintf("USER=%s /mts/git/bin/nimbus-ctl --nimbusLocation %s --nimbus %s %s %s", user,
+		location, podname, op, hostList)
 	framework.Logf("Running command: %s", nimbusCmd)
 	cmd := exec.Command("/bin/bash", "-c", nimbusCmd)
 	err = cmd.Start()
@@ -90,6 +92,7 @@ func readVcEsxIpsViaTestbedInfoJson(filePath string) {
 	tbinfo.name = tb["name"].(string)
 	tbinfo.user = tb["user_name"].(string)
 	tbinfo.location = tb["nimbusLocation"].(string)
+	tbinfo.podname = tb["podname"].(string)
 
 	framework.Logf("Basic testbed info:\n%s\n", spew.Sdump(tbinfo))
 }

--- a/tests/e2e/topology_site_down_cases.go
+++ b/tests/e2e/topology_site_down_cases.go
@@ -577,6 +577,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		sts_count = 3
 		statefulSetReplicaCount = 7
 		var ssPods *v1.PodList
+		noOfHostToBringDown = 1
 
 		// Get allowed topologies for Storage Class
 		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -5499,7 +5499,7 @@ func powerOnEsxiHostByCluster(hostToPowerOn string) {
 	for _, esxInfo := range tbinfo.esxHosts {
 		if hostToPowerOn == esxInfo["vmName"] {
 			esxHostIp = esxInfo["ip"]
-			err := vMPowerMgmt(tbinfo.user, tbinfo.location, hostToPowerOn, true)
+			err := vMPowerMgmt(tbinfo.user, tbinfo.location, tbinfo.podname, hostToPowerOn, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		}
@@ -5523,7 +5523,7 @@ func powerOffEsxiHostByCluster(ctx context.Context, vs *vSphere, clusterName str
 			if hostIp[6] == esxInfo["ip"] {
 				esxHostName := esxInfo["vmName"]
 				powerOffHostsList = append(powerOffHostsList, esxHostName)
-				err = vMPowerMgmt(tbinfo.user, tbinfo.location, esxHostName, false)
+				err = vMPowerMgmt(tbinfo.user, tbinfo.location, tbinfo.podname, esxHostName, false)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = waitForHostToBeDown(esxInfo["ip"])
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -105,7 +105,7 @@ func powerOffHostParallel(hostsToPowerOff []string) {
 		fds.hostsDown = append(fds.hostsDown, host)
 	}
 
-	err := vMPowerMgmt(tbinfo.user, tbinfo.location, hostlist, false)
+	err := vMPowerMgmt(tbinfo.user, tbinfo.location, tbinfo.podname, hostlist, false)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	for _, host := range hostsToPowerOff {
@@ -135,7 +135,7 @@ func powerOnHostParallel(hostsToPowerOn []string) {
 		}
 		fds.hostsDown = append(fds.hostsDown, host)
 	}
-	err := vMPowerMgmt(tbinfo.user, tbinfo.location, hostlist, true)
+	err := vMPowerMgmt(tbinfo.user, tbinfo.location, tbinfo.podname, hostlist, true)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	for _, host := range hostsToPowerOn {
 		err = waitForHostToBeUp(host)


### PR DESCRIPTION
**What this PR does / why we need it**:
Code fix for Topology disruptive scenario - added new argument nimbus "podname" for running power-on/off on ESXi

**Which issue this PR fixes** *
Code fix for Topology disruptive scenario - added new argument nimbus "podname" for running power-on/off on ESXi

**Testing done**:
Yes
[vsan-stretch-jenkins-logs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/8784824/vsan-stretch-jenkins-logs.txt)
[topology-jenkins-logs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/8784843/topology-jenkins-logs.txt)
[topology-jenkins-logs-1.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/8784845/topology-jenkins-logs-1.txt)


**Special notes for your reviewer**:

**Release note**:
Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/topology-disruptive-code-fix/vsphere-csi-driver /Users/sipriya/topology-disruptive-code-fix /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (types_sizes|compiled_files|files|imports|name|deps|exports_file) took 15.046620153s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 99.273593ms 
INFO [linters context/goanalysis] analyzers took 43.069267559s with top 10 stages: buildir: 14.957565487s, misspell: 1.880811117s, unused: 1.085766306s, S1038: 1.045030376s, directives: 840.172524ms, printf: 737.857313ms, ctrlflow: 656.066847ms, lll: 601.102958ms, S1025: 547.472972ms, S1039: 535.328437ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): cgo: 113/113, exclude: 24/24, path_prettifier: 113/113, autogenerated_exclude: 24/113, identifier_marker: 24/24, nolint: 0/1, exclude-rules: 1/24, filename_unadjuster: 113/113, skip_files: 113/113, skip_dirs: 113/113 
INFO [runner] processing took 15.259391ms with stages: nolint: 12.795466ms, autogenerated_exclude: 1.480074ms, path_prettifier: 389.241µs, identifier_marker: 319.176µs, skip_dirs: 134.109µs, exclude-rules: 110.16µs, filename_unadjuster: 19.48µs, cgo: 7.088µs, max_same_issues: 1.111µs, max_from_linter: 675ns, uniq_by_line: 609ns, source_code: 346ns, exclude: 303ns, skip_files: 295ns, diff: 267ns, max_per_file_from_linter: 241ns, path_shortener: 216ns, severity-rules: 208ns, sort_results: 204ns, path_prefixer: 122ns 
INFO [runner] linters took 9.264382138s with stages: goanalysis_metalinter: 9.249033959s 
INFO File cache stats: 281 entries of total size 4.5MiB 
INFO Memory: 245 samples, avg is 269.6MB, max is 1424.3MB 
INFO Execution took 24.421696815s                 
sipriya@sipriya-a01 vsphere-csi-driver % 
