### PR TITLE
Return faulttype for failure paths in CnsNodeVmAttachment controller

### DIFF
--- a/pkg/common/fault/constants.go
+++ b/pkg/common/fault/constants.go
@@ -24,6 +24,16 @@ const (
 	// CSIVmNotFoundFault is the fault type when VM object is not found in the VC
 	CSIVmNotFoundFault = "csi.fault.nonstorage.VmNotFound"
 
+	// CSIDatacenterNotFoundFault is the fault type when Datacenter are not found in the VC
+	CSIDatacenterNotFoundFault = "csi.fault.DatacenterNotFound"
+	// CSIVCenterNotFoundFault is the fault type when VC instance is not found
+	CSIVCenterNotFoundFault = "csi.fault.VCenterNotFound"
+	// CSIFindVmByUUIDFault is the fault type when FindByUUID method fails to find the VM
+	CSIFindVmByUUIDFault = "csi.fault.FindVmByUUIDFault"
+
+	// CSIApiServerOperationFault is the fault type when Get(), List() and others fail on the API Server
+	CSIApiServerOperationFault = "csi.fault.ApiServerOperation"
+
 	// CSITaskResultEmptyFault is the fault type when taskResult is empty.
 	CSITaskResultEmptyFault = "csi.fault.TaskResultEmpty"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is introducing granular faulttypes in CnsNodeVmAttachment  controller.
This is a follow up to https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1744#discussion_r875863521

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1753#issuecomment-1130737056

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Return faulttype for failure paths in CnsNodeVmAttachment controller
```
