### PR TITLE
Add finalizer to SV PVC using CNSNodeVmAttachment controller

### DIFF
--- a/pkg/syncer/cnsoperator/types/types.go
+++ b/pkg/syncer/cnsoperator/types/types.go
@@ -20,6 +20,10 @@ const (
 	// CNSFinalizer is the finalizer on CNSNodeVmAttachment and CnsVolumeMetadata controllers
 	CNSFinalizer = "cns.vmware.com"
 
+	// CNSPvcFinalizer is the finalizer on Supervisor PVC managed by CNsNodeVMAttachment controller
+	// to avoid Detach-Delete race which in-turn avoids ResourceInUse errors
+	CNSPvcFinalizer = "cns.vmware.com/pvc-protection"
+
 	// GCAPIVersion is the APIVersion for TanzuKubernetes Cluster
 	GCAPIVersion = "run.tanzu.vmware.com/v1alpha1"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making changes to CnsNodeVMAttachment controller to add/remove finalizer on SV PVC to prevent volume deletion until the detach volume succeeds. By adding the finalizer after a successful attach operation, it ensures that deleteVolume will not be invoked in the CSI driver until the detach operation succeeds. This will prevent deleteVolume to repeatedly emit ResourceInUse error.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

- **GC namespace deletion test:**

Create Namespace, PVC, Pod in a GC
```
 export KUBECONFIG=tkc
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl create ns test
Created namespace test
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-798759c664-5zp6w   6/6     Running   0          6m59s
vsphere-csi-node-5wrxv                    3/3     Running   0          7m4s
vsphere-csi-node-hgf7v                    3/3     Running   0          6m15s
vsphere-csi-node-sf4zf                    3/3     Running   0          4m45s
vsphere-csi-node-x7nkw                    3/3     Running   0          5m30s
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl get pods -n test
No resources found in test namespace.
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl create -f pvc.yaml -n test
persistentvolumeclaim/example-vanilla-rwo-pvc created
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl get pvc -n test
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
example-vanilla-rwo-pvc   Bound    pvc-4b105651-0656-4ad5-b7f7-bcdbd2d8c211   1Mi        RWO            gc-storage-profile   6s
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl create -f pod.yaml -n test
pod/example-vanilla-block-pod created
```

Switch to SVC
```
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# export KUBECONFIG=
```

Verify CNsNodeVmAttachment is created
```
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl get cnsnodevmattachment -A
NAMESPACE             NAME                                                                                                                               AGE
test-gc-e2e-demo-ns   test-cluster-e2e-script-workers-94m4t-68f76c64b4-mfxvl-04b837b3-b35c-49bd-8657-112fee97ba7f-4b105651-0656-4ad5-b7f7-bcdbd2d8c211   12s
```

Describe PVC in SV to verify finalizer is added
```
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl get pvc -A
NAMESPACE             NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
test-gc-e2e-demo-ns   04b837b3-b35c-49bd-8657-112fee97ba7f-4b105651-0656-4ad5-b7f7-bcdbd2d8c211   Bound    pvc-0216880c-75b9-4fad-a93a-ac88a0b6877e   1Mi        RWO            gc-storage-profile   22m
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl describe pvc -A
Name:          04b837b3-b35c-49bd-8657-112fee97ba7f-4b105651-0656-4ad5-b7f7-bcdbd2d8c211
Namespace:     test-gc-e2e-demo-ns
StorageClass:  gc-storage-profile
Status:        Bound
Volume:        pvc-0216880c-75b9-4fad-a93a-ac88a0b6877e
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Thu May 19 17:17:43 UTC 2022
Finalizers:    [kubernetes.io/pvc-protection cns.vmware.com/pvc-protection]        <<<<<<<<<<<<<<<#############
Capacity:      1Mi
```

Switch to GC
```
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# export KUBECONFIG=tkc
```
Delete Namespace in GC
```
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl delete ns test
namespace "test" deleted
```
Switch to supervisor cluster
```
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# export KUBECONFIG=
```

```root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl get pvc -A
No resources found
```


**- SV Namespace deletion test:**

Create namespace, PVC, Pod in a GC
```

root@423926f702fa39cae5900099e5f18a79 [ ~ ]# export KUBECONFIG=tkc-2

root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl create ns test
namespace/test created

root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl create -f pvc.yaml -n test
persistentvolumeclaim/example-vanilla-rwo-pvc created

root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl get pvc -n test
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
example-vanilla-rwo-pvc   Bound    pvc-f5e4fb7e-8130-4ab3-b110-8c0adaccf89c   1Mi        RWO            gc-storage-profile   11s

root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl create -f pod.yaml -n test
pod/example-vanilla-block-pod created
```

Delete SV namespace
```
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# export KUBECONFIG=
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl get cnsnodevmattachment -A
NAMESPACE   NAME                                                                                                                        AGE
test        test-cluster-e2e-workers-schqq-565974957f-65gb5-ca446c4c-10d5-4674-8640-c4d09284897e-f5e4fb7e-8130-4ab3-b110-8c0adaccf89c   108s
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl delete namespace test
namespace "test" deleted

```
cns.vmware.com/pvc-protection finalizer is on the PVC and is not removed until detach volume succeeds
```
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl get pvc -A
NAMESPACE   NAME                                                                        STATUS        VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
test        ca446c4c-10d5-4674-8640-c4d09284897e-f5e4fb7e-8130-4ab3-b110-8c0adaccf89c   Terminating   pvc-33a80745-4c63-4e0a-ab8c-5b6c0fa596f8   1Mi        RWO            gc-storage-profile   4m55s
root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl describe pvc -n test
Name:          ca446c4c-10d5-4674-8640-c4d09284897e-f5e4fb7e-8130-4ab3-b110-8c0adaccf89c
Namespace:     test
StorageClass:  gc-storage-profile
Status:        Terminating (lasts 19s)
Volume:        pvc-33a80745-4c63-4e0a-ab8c-5b6c0fa596f8
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Fri May 20 21:07:25 UTC 2022
Finalizers:    [cns.vmware.com/pvc-protection]          <<<<<<<<<<<<<<<<<<<#########################
Capacity:      1Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:        <none>

PVC in terminating state

root@423926f702fa39cae5900099e5f18a79 [ ~ ]# kubectl get pvc -A
NAMESPACE   NAME                                                                        STATUS        VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
test        ca446c4c-10d5-4674-8640-c4d09284897e-f5e4fb7e-8130-4ab3-b110-8c0adaccf89c   Terminating   pvc-33a80745-4c63-4e0a-ab8c-5b6c0fa596f8   1Mi        RWO            gc-storage-profile   5m29s
```

Verified that PVC gets deleted after few seconds

```
 kubectl get pvc -A
No resources found

```

Cnsnodevmattachment_controller removes the finalizer on the PVC, this can be seen in the logs:
```
2022-05-20T22:49:41.539Z	DEBUG	cnsnodevmattachment/cnsnodevmattachment_controller.go:602	Removing "cns.vmware.com/pvc-protection" finalizer from PersistentVolumeClaim: "4ca30099-20ee-4349-8afb-fa851e0e7be7-bd67522b-b618-4708-9ea0-9974d4d63aec" on namespace: "testing"	{"TraceId": "8b79c09b-78c7-4b77-a8d7-cdd4755d2054"}

```

Volume gets deleted after detach volume (can be confirmed by the timelines above and below):

```
2022-05-20T22:49:42.482Z	DEBUG	common/vsphereutil.go:633	vSphere CSI driver is deleting volume: 5eafdf56-23d8-4fa6-bcd5-2db5c4d93f7a with deleteDisk flag: true	{"TraceId": "04a66ae7-a469-4cd1-8b4a-8544fa80c953"}
...
...
2022-05-20T22:49:44.914Z	INFO	wcp/controller.go:829	Volume "5eafdf56-23d8-4fa6-bcd5-2db5c4d93f7a" deleted successfully.	{"TraceId": "04a66ae7-a469-4cd1-8b4a-8544fa80c953"}
```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add finalizer to SV PVC using CNSNodeVmAttachment controller
```
