### PR TITLE
remove error message compare for ErrVMNotFound

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1040,7 +1040,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 					}
 					podVM, err := getVMByInstanceUUIDInDatacenter(ctx, vc, dcMorefValue, v)
 					if err != nil {
-						if strings.Contains(err.Error(), cnsvsphere.ErrVMNotFound.Error()) {
+						if err == cnsvsphere.ErrVMNotFound {
 							log.Infof("virtual machine not found for vmUUID %q. "+
 								"Thus, assuming the volume is detached.", v)
 							break


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making a minor fix to follow the practice of not comparing error messages.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
remove error message compare for ErrVMNotFound
```
