### PR TITLE
Config Secret testcases automation

### DIFF
--- a/tests/e2e/config_secret.go
+++ b/tests/e2e/config_secret.go
@@ -1,0 +1,1575 @@
+/*
+	Copyright 2022 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"golang.org/x/crypto/ssh"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+)
+
+var _ = ginkgo.Describe("[csi-config-secret] Config-Secret", func() {
+	f := framework.NewDefaultFramework("config-secret-volume-provisioning")
+	var (
+		client              clientset.Interface
+		namespace           string
+		sshClientConfig     *ssh.ClientConfig
+		vcAddress           string
+		allMasterIps        []string
+		masterIp            string
+		loginCmd            string
+		csiNamespace        string
+		testUser            string
+		dataCenter          string
+		cluster             string
+		err                 error
+		insecureFlag        bool
+		clusterId           string
+		clusterDistribution string
+		dataCenters         string
+		vCenterPort         string
+	)
+
+	ginkgo.BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		bootstrap()
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		allMasterIps = getK8sMasterIPs(ctx, client)
+		masterIp = allMasterIps[0]
+		sshClientConfig = &ssh.ClientConfig{
+			User: "root",
+			Auth: []ssh.AuthMethod{
+				ssh.Password(k8sVmPasswd),
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+		vcAddress = e2eVSphere.Config.Global.VCenterHostname
+		csiNamespace = GetAndExpectStringEnvVar(envCSINamespace)
+		// govc login command
+		loginCmd = govcLoginCmd(vcAddress)
+
+	})
+
+	/*
+		TESTCASE-1
+		Change VC user
+		Steps:
+		1. Create two users (user1 and user2) with required roles and privileges and with same password
+		2. Create csi-vsphere.conf with user1's credentials and create vsphere-config-secret in turn using that file
+		3. Install CSI driver
+		4. Verify we can create a PVC and attach it to pod
+		5. Change csi-vsphere.conf with user2's credentials and re-create vsphere-config-secret in turn using that file
+		6. Verify we can create a PVC and attach it to pod
+		7. Cleanup all objects created during the test
+	*/
+
+	ginkgo.It("Change vcenter users in vsphere config secret file having same password", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Step1: Create two users (user1 and user2) with required roles and privileges and with same password
+		ginkgo.By("Create 2 test users")
+		err = createTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser1,
+			configSecertTestUser1Password)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = createTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser2,
+			configSecertTestUser1Password)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create roles for testuser1
+		ginkgo.By("Create roles for testuser1")
+		err = createRolesForTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create roles for testuser2
+		ginkgo.By("Create roles for testuser2")
+		err = createRolesForTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Fetch DataCenter, Cluster and hosts details")
+		dataCenter, cluster, err = getDataCenterClusterHostAndVmDetails(loginCmd, sshClientConfig,
+			masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Assign required roles and privileges for testuser1 and testuser2")
+
+		// set DataCenter level permission for testuser1 and testuser2
+		ginkgo.By("Set DataCenter level permission for testuser1 and testuser2")
+		err = setDataCenterLevelPermission(loginCmd, sshClientConfig, masterIp, dataCenter,
+			configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setDataCenterLevelPermission(loginCmd, sshClientConfig, masterIp, dataCenter,
+			configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set hosts level permission for testuser1 and testuser2
+		ginkgo.By("Set hosts level permission for testuser1 and testuser2")
+		err = setHostLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setHostLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set K8s VM level permission for testuser1 and testuser2
+		ginkgo.By("Set k8s VM level permission for testuser1 and testuser2")
+		err = setK8sVMLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setK8sVMLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set cluster level permission for testuser1 and testuser2
+		ginkgo.By("Set cluster level permission for testuser1 and testuser2")
+		err = setClusterLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser1, cluster)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setClusterLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser2, cluster)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set datastore level permission for testuser1 and testuser2
+		ginkgo.By("Set datastore level permission for testuser1 and testuser2")
+		err = setDataStoreLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser1, dataCenter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setDataStoreLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser2, dataCenter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete users, its roles and permissions
+			ginkgo.By("Delete testUser1, its roles and permissions")
+			err = deleteUsersRolesAndPermissions(loginCmd, sshClientConfig, masterIp,
+				configSecretTestUser1, dataCenter, cluster)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Delete testUser2, its roles and permissions")
+			err = deleteUsersRolesAndPermissions(loginCmd, sshClientConfig, masterIp,
+				configSecretTestUser2, dataCenter, cluster)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Create csi-vsphere.conf with original vcenter user and its credentails
+			ginkgo.By("Create csi-vsphere.conf with original vcenter user and its credentails")
+			insecureFlag, clusterId, clusterDistribution,
+				dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+			err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+				vCenterUIUser, vCenterUIPassword, vCenterPort, dataCenters,
+				loginCmd, sshClientConfig, masterIp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step2 : Create csi-vsphere.conf with user1's credentials and create
+		vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testUser1
+		ginkgo.By("Create vsphere-config-secret file with testuser1 credentials")
+		testUser = configSecretTestUser1 + "@vsphere.local"
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step3: Install CSI driver
+		ginkgo.By("Install CSI driver")
+		err = installCsiDriver(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step4: Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete storage class
+			ginkgo.By("Delete Storage Class")
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating Pvc")
+		pvclaim1, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims1 []*v1.PersistentVolumeClaim
+		pvclaims1 = append(pvclaims1, pvclaim1)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims1, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim1}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod1.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step5: Change csi-vsphere.conf with user2's credentials and re-create
+		vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testUser2
+		ginkgo.By("Create vsphere-config-secret file with testuser2 credentials")
+		testUser = configSecretTestUser2 + "@vsphere.local"
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step6: Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim2, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims2 []*v1.PersistentVolumeClaim
+		pvclaims2 = append(pvclaims2, pvclaim2)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims2, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim2}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod2.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+	})
+
+	/*
+		TESTCASE-2
+		Change VC user's password
+		Steps:
+		1. Create a user, user1, with required roles and privileges
+		2. Create csi-vsphere.conf with user1's credentials and create vsphere-config-secret
+		in turn using that file
+		3. Install CSI driver
+		4. Verify we can create a PVC and attach it to pod
+		5. Change password for user1
+		6. try to create a PVC and verify it gets bound successfully
+		7. Restart CSI controller pod
+		8. Try to create a PVC verify that it is stuck in pending state
+		9. Change csi-vsphere.conf with updated user1's credentials and re-create
+		vsphere-config-secret in turn using that file
+		10. Verify we can create a PVC and attach it to pod
+		11. Verify PVC created in step 6 gets bound eventually
+		12. Cleanup all objects created during the test
+	*/
+
+	ginkgo.It("Change vcenter user and its password in vsphere config secret file", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Step1: Create a user, user1, with required roles and privileges
+		ginkgo.By("Create 2 test users")
+		err = createTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser1,
+			configSecertTestUser1Password)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = createTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser2,
+			configSecertTestUser1Password)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create roles for testuser1
+		ginkgo.By("Create roles for testuser1")
+		err = createRolesForTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create roles for testuser2
+		ginkgo.By("Create roles for testuser2")
+		err = createRolesForTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Fetch DataCenter, Cluster and hosts details")
+		dataCenter, cluster, err = getDataCenterClusterHostAndVmDetails(loginCmd, sshClientConfig,
+			masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Assign required roles and privileges for testuser1 and testuser2")
+
+		// set DataCenter level permission for testuser1 and testuser2
+		ginkgo.By("Set DataCenter level permission for testuser1 and testuser2")
+		err = setDataCenterLevelPermission(loginCmd, sshClientConfig, masterIp, dataCenter,
+			configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setDataCenterLevelPermission(loginCmd, sshClientConfig, masterIp, dataCenter,
+			configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set hosts level permission for testuser1 and testuser2
+		ginkgo.By("Set hosts level permission for testuser1 and testuser2")
+		err = setHostLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setHostLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set K8s VM level permission for testuser1 and testuser2
+		ginkgo.By("Set k8s VM level permission for testuser1 and testuser2")
+		err = setK8sVMLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setK8sVMLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set cluster level permission for testuser1 and testuser2
+		ginkgo.By("Set cluster level permission for testuser1 and testuser2")
+		err = setClusterLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser1, cluster)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setClusterLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser2, cluster)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set datastore level permission for testuser1 and testuser2
+		ginkgo.By("Set datastore level permission for testuser1 and testuser2")
+		err = setDataStoreLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser1, dataCenter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setDataStoreLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser2, dataCenter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete users, its roles and permissions
+			ginkgo.By("Delete testUser1, its roles and permissions")
+			err = deleteUsersRolesAndPermissions(loginCmd, sshClientConfig, masterIp,
+				configSecretTestUser1, dataCenter, cluster)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Delete testUser2, its roles and permissions")
+			err = deleteUsersRolesAndPermissions(loginCmd, sshClientConfig, masterIp,
+				configSecretTestUser2, dataCenter, cluster)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Create csi-vsphere.conf with original vcenter user and its credentails
+			ginkgo.By("Create csi-vsphere.conf with original vcenter user and its credentails")
+			insecureFlag, clusterId, clusterDistribution,
+				dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+			err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+				vCenterUIUser, vCenterUIPassword, vCenterPort, dataCenters,
+				loginCmd, sshClientConfig, masterIp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step2: Create csi-vsphere.conf with user1's credentials and create
+		vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testUser1
+		ginkgo.By("Create vsphere-config-secret file with testuser1 credentials")
+		testUser = configSecretTestUser1 + "@vsphere.local"
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step3: Install CSI driver
+		ginkgo.By("Install CSI driver")
+		err = installCsiDriver(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step4: Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete storage class
+			ginkgo.By("Delete Storage Class")
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating Pvc")
+		pvclaim1, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims1 []*v1.PersistentVolumeClaim
+		pvclaims1 = append(pvclaims1, pvclaim1)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims1, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim1}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod1.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Step5: Change password for user1
+		ginkgo.By("Change password for testuser1")
+		testUser1NewPassword := e2eTestPassword
+
+		// Step6: Try to create a PVC and verify it gets bound successfully
+		ginkgo.By("Try to create a PVC and verify it gets bound successfully")
+		pvc1, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims2 []*v1.PersistentVolumeClaim
+		pvclaims2 = append(pvclaims2, pvc1)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims2, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Deleting the PVC")
+			err = fpv.DeletePersistentVolumeClaim(client, pvc1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Step7: Restart CSI controller pod
+		ginkgo.By("Restart CSI controller pod")
+		csiDeployment, err := client.AppsV1().Deployments(csiNamespace).Get(
+			ctx, vSphereCSIControllerPodNamePrefix, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		csiReplicas := csiDeployment.Spec.Replicas
+		framework.Logf("Stopping CSI driver")
+		_ = updateDeploymentReplica(client, 0, vSphereCSIControllerPodNamePrefix, csiNamespace)
+		framework.Logf("Starting CSI driver")
+		_ = updateDeploymentReplica(client, *csiReplicas, vSphereCSIControllerPodNamePrefix, csiNamespace)
+
+		// Step8: Try to create a PVC verify that it is stuck in pending state
+		ginkgo.By("Try to create a PVC verify that it is stuck in pending state")
+		pvc2, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Expect claim status to be in Pending state")
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
+			pvc2.Namespace, pvc2.Name, framework.Poll, time.Minute)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+		defer func() {
+			ginkgo.By("Deleting the PVC")
+			err = fpv.DeletePersistentVolumeClaim(client, pvc2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step9: Change csi-vsphere.conf with updated user1's credentials and re-create
+		vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testUser1
+		ginkgo.By("Create vsphere-config-secret file with testuser1 credentials")
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, testUser1NewPassword, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step10: Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim2, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims3 []*v1.PersistentVolumeClaim
+		pvclaims3 = append(pvclaims3, pvclaim2)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims3, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim2}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod2.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Step11: Verify the PVC which was stuck in Pening state should gets bound eventually
+		ginkgo.By("Verify the PVC which was stuck in Pening state should gets bound eventually")
+		pvc2, err = client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvc2.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvc2.Status.Phase == v1.ClaimBound).To(gomega.BeTrue())
+
+	})
+
+	/*
+		TESTCASE-3
+		Change VC user and password
+		Steps:
+		1. Create two users (user1 and user2) with required roles and privileges and with different passwords
+		2. Create csi-vsphere.conf with user1's credentials and create vsphere-config-secret
+		 in turn using that file
+		3. Install CSI driver
+		4. Verify we can create a PVC and attach it to pod
+		5. Change csi-vsphere.conf with user2's credentials and re-create vsphere-config-secret
+		in turn using that file
+		6. Verify we can create a PVC and attach it to pod
+		7. Cleanup all objects created during the test
+	*/
+
+	ginkgo.It("Change vcenter users in vsphere config secret file having different password", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		/* Step1: Create two users (user1 and user2) with required roles and
+		privileges and with different passwords */
+		ginkgo.By("Create 2 test users")
+		err = createTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser1,
+			configSecertTestUser1Password)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = createTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser2,
+			configSecertTestUser2Password)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create roles for testuser1
+		ginkgo.By("Create roles for testuser1")
+		err = createRolesForTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create roles for testuser2
+		ginkgo.By("Create roles for testuser2")
+		err = createRolesForTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Fetch DataCenter, Cluster and hosts details")
+		dataCenter, cluster, err = getDataCenterClusterHostAndVmDetails(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Assign required roles and privileges for testuser1 and testuser2")
+
+		// set DataCenter level permission for testuser1 and testuser2
+		ginkgo.By("Set DataCenter level permission for testuser1 and testuser2")
+		err = setDataCenterLevelPermission(loginCmd, sshClientConfig, masterIp, dataCenter,
+			configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setDataCenterLevelPermission(loginCmd, sshClientConfig, masterIp, dataCenter,
+			configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set hosts level permission for testuser1 and testuser2
+		ginkgo.By("Set hosts level permission for testuser1 and testuser2")
+		err = setHostLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setHostLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set K8s VM level permission for testuser1 and testuser2
+		ginkgo.By("Set k8s VM level permission for testuser1 and testuser2")
+		err = setK8sVMLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setK8sVMLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set cluster level permission for testuser1 and testuser2
+		ginkgo.By("Set cluster level permission for testuser1 and testuser2")
+		err = setClusterLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser1, cluster)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setClusterLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser2, cluster)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set datastore level permission for testuser1 and testuser2
+		ginkgo.By("Set datastore level permission for testuser1 and testuser2")
+		err = setDataStoreLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser1, dataCenter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setDataStoreLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser2, dataCenter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete users, its roles and permissions
+			ginkgo.By("Delete testUser1, its roles and permissions")
+			err = deleteUsersRolesAndPermissions(loginCmd, sshClientConfig, masterIp,
+				configSecretTestUser1, dataCenter, cluster)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Delete testUser2, its roles and permissions")
+			err = deleteUsersRolesAndPermissions(loginCmd, sshClientConfig, masterIp,
+				configSecretTestUser2, dataCenter, cluster)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Create csi-vsphere.conf with original vcenter user and its credentails
+			ginkgo.By("Create csi-vsphere.conf with original vcenter user and its credentails")
+			insecureFlag, clusterId, clusterDistribution,
+				dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+			err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+				vCenterUIUser, vCenterUIPassword, vCenterPort, dataCenters,
+				loginCmd, sshClientConfig, masterIp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step2: Create csi-vsphere.conf with user1's credentials and create
+		vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testUser1
+		ginkgo.By("Create vsphere-config-secret file with testuser1 credentials")
+		testUser = configSecretTestUser1 + "@vsphere.local"
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step3: Install CSI driver
+		ginkgo.By("Install CSI driver")
+		err = installCsiDriver(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step4: Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete storage class
+			ginkgo.By("Delete Storage Class")
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating Pvc")
+		pvclaim1, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims1 []*v1.PersistentVolumeClaim
+		pvclaims1 = append(pvclaims1, pvclaim1)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims1, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim1}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod1.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step5: Change csi-vsphere.conf with user2's credentials and re-create
+		vsphere-config-secret in turn using that file */
+		// delete csi vsphere conf file
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testUser1
+		ginkgo.By("Create vsphere-config-secret file with testuser2 credentials")
+		testUser = configSecretTestUser2 + "@vsphere.local"
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser2Password, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step6: Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim2, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims2 []*v1.PersistentVolumeClaim
+		pvclaims2 = append(pvclaims2, pvclaim2)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims2, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim2}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod2.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+	})
+
+	/*
+		TESTCASE-4
+		Change IP to host name and vice versa
+		Steps:
+		1. Create two users (user1 and user2) with required roles and privileges and with different passwords
+		2. Create csi-vsphere.conf with user1's credentials and VC IP and then
+		create vsphere-config-secret in turn using that file
+		3. Install CSI driver
+		4. Verify we can create a PVC and attach it to pod
+		5. Change csi-vsphere.conf to use VC hostname instead of VC IP and re-create
+		vsphere-config-secret in turn using that file
+		6. Verify we can create a PVC and attach it to pod
+		7. Change csi-vsphere.conf to use VC IP instead of VC hostname and re-create
+		vsphere-config-secret in turn using that file
+		8. Verify we can create a PVC and attach it to pod
+		9. Cleanup all objects created during the test
+	*/
+
+	ginkgo.It("Change vcenter user, ip and hostname in vsphere config secret file", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		/* Step1: Create two users (user1 and user2) with required roles and privileges
+		and with different passwords */
+		ginkgo.By("Create 2 test users")
+		err = createTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser1,
+			configSecertTestUser1Password)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = createTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser2,
+			configSecertTestUser2Password)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create roles for testuser1
+		ginkgo.By("Create roles for testuser1")
+		err = createRolesForTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create roles for testuser2
+		ginkgo.By("Create roles for testuser2")
+		err = createRolesForTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Fetch DataCenter, Cluster and hosts details")
+		dataCenter, cluster, err = getDataCenterClusterHostAndVmDetails(loginCmd, sshClientConfig,
+			masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Assign required roles and privileges for testuser1 and testuser2")
+
+		// set DataCenter level permission for testuser1 and testuser2
+		ginkgo.By("Set DataCenter level permission for testuser1 and testuser2")
+		err = setDataCenterLevelPermission(loginCmd, sshClientConfig, masterIp, dataCenter,
+			configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setDataCenterLevelPermission(loginCmd, sshClientConfig, masterIp, dataCenter,
+			configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set hosts level permission for testuser1 and testuser2
+		ginkgo.By("Set hosts level permission for testuser1 and testuser2")
+		err = setHostLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setHostLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set K8s VM level permission for testuser1 and testuser2
+		ginkgo.By("Set k8s VM level permission for testuser1 and testuser2")
+		err = setK8sVMLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setK8sVMLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set cluster level permission for testuser1 and testuser2
+		ginkgo.By("Set cluster level permission for testuser1 and testuser2")
+		err = setClusterLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser1,
+			cluster)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setClusterLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser2,
+			cluster)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set datastore level permission for testuser1 and testuser2
+		ginkgo.By("Set datastore level permission for testuser1 and testuser2")
+		err = setDataStoreLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser1,
+			dataCenter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setDataStoreLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser2,
+			dataCenter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete users, its roles and permissions
+			ginkgo.By("Delete testUser1, its roles and permissions")
+			err = deleteUsersRolesAndPermissions(loginCmd, sshClientConfig, masterIp,
+				configSecretTestUser1, dataCenter, cluster)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Delete testUser2, its roles and permissions")
+			err = deleteUsersRolesAndPermissions(loginCmd, sshClientConfig, masterIp,
+				configSecretTestUser2, dataCenter, cluster)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Create csi-vsphere.conf with original vcenter user and its credentails
+			ginkgo.By("Create csi-vsphere.conf with original vcenter user and its credentails")
+			insecureFlag, clusterId, clusterDistribution,
+				dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+			err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+				vCenterUIUser, vCenterUIPassword, vCenterPort, dataCenters,
+				loginCmd, sshClientConfig, masterIp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step2: Create csi-vsphere.conf with user1's credentials and VC IP and then
+		create vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testUser1
+		ginkgo.By("Create vsphere-config-secret file with testuser1 credentials " +
+			"and by providing vcenter IP")
+		testUser = configSecretTestUser1 + "@vsphere.local"
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step3 : Install CSI driver
+		ginkgo.By("Install CSI driver")
+		err = installCsiDriver(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step4 : Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete storage class
+			ginkgo.By("Delete Storage Class")
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating Pvc")
+		pvclaim1, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims1 []*v1.PersistentVolumeClaim
+		pvclaims1 = append(pvclaims1, pvclaim1)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims1, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim1}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod1.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step5: Change csi-vsphere.conf to use VC hostname instead of VC IP and
+		re-create vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// Get vcenter hotsname
+		ginkgo.By("Get vcenter hotsname")
+		vCenterHostName, err := getVcenterHostName(sshClientConfig, masterIp, vCenterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testUser1
+		ginkgo.By("Create vsphere-config-secret file with testuser1 credentials " +
+			"and by providing vcenter hostname")
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vCenterHostName, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step6 : Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim2, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims2 []*v1.PersistentVolumeClaim
+		pvclaims2 = append(pvclaims2, pvclaim2)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims2, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim2}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod2.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step7: Change csi-vsphere.conf to use VC IP instead of VC hostname and
+		re-create vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testUser1
+		ginkgo.By("Create vsphere-config-secret file with testuser1 credentials " +
+			"and reverting vcenter hostname to vcenter IP")
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step8 : Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim3, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims3 []*v1.PersistentVolumeClaim
+		pvclaims3 = append(pvclaims3, pvclaim3)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims3, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim3.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod3, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim3}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod3.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod3)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+	})
+
+	/*
+		TESTCASE-6
+		Add wrong user and switch back to correct user
+		Steps:
+		1. Create a user, user1, with required roles and privileges
+		2. Create csi-vsphere.conf with user1's credentials and create vsphere-config-secret
+		in turn using that file
+		3. Install CSI driver
+		4. Verify we can create a PVC and attach it to pod
+		5. Change csi-vsphere.conf and add a dummy user and re-create vsphere-config-secret in turn using that file
+		6. Try to create a PVC verify that it is stuck in pending state
+		(Note: PVC will go to bound state with the dummy user who does not have any privilege
+			to login to VC, This is because CSI will continue with the previous session ID
+		7. Change csi-vsphere.conf with updated user1's credentials and re-create vsphere-config-secret
+		in turn using that file
+		8. Verify we can create a PVC and attach it to pod
+		9. Cleanup all objects created during the test
+	*/
+
+	ginkgo.It("Change vcenter user to wrong user and switch back to correct user "+
+		"in vsphere config secret file", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Step1: Create a user, user1, with required roles and privileges
+		ginkgo.By("Create 2 test users")
+		err = createTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser1,
+			configSecertTestUser1Password)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = createTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser2,
+			configSecertTestUser2Password)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create roles for testuser1
+		ginkgo.By("Create roles for testuser1")
+		err = createRolesForTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create roles for testuser2
+		ginkgo.By("Create roles for testuser2")
+		err = createRolesForTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Fetch DataCenter, Cluster and hosts details")
+		dataCenter, cluster, err = getDataCenterClusterHostAndVmDetails(loginCmd, sshClientConfig,
+			masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Assign required roles and privileges for testuser1 and testuser2")
+
+		// set DataCenter level permission for testuser1 and testuser2
+		ginkgo.By("Set DataCenter level permission for testuser1 and testuser2")
+		err = setDataCenterLevelPermission(loginCmd, sshClientConfig, masterIp, dataCenter,
+			configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setDataCenterLevelPermission(loginCmd, sshClientConfig, masterIp, dataCenter,
+			configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set hosts level permission for testuser1 and testuser2
+		ginkgo.By("Set hosts level permission for testuser1 and testuser2")
+		err = setHostLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setHostLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set K8s VM level permission for testuser1 and testuser2
+		ginkgo.By("Set k8s VM level permission for testuser1 and testuser2")
+		err = setK8sVMLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setK8sVMLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set cluster level permission for testuser1 and testuser2
+		ginkgo.By("Set cluster level permission for testuser1 and testuser2")
+		err = setClusterLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser1, cluster)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setClusterLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser2, cluster)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set datastore level permission for testuser1 and testuser2
+		ginkgo.By("Set datastore level permission for testuser1 and testuser2")
+		err = setDataStoreLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser1, dataCenter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setDataStoreLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser2, dataCenter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete users, its roles and permissions
+			ginkgo.By("Delete testUser1, its roles and permissions")
+			err = deleteUsersRolesAndPermissions(loginCmd, sshClientConfig, masterIp,
+				configSecretTestUser1, dataCenter, cluster)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Delete testUser2, its roles and permissions")
+			err = deleteUsersRolesAndPermissions(loginCmd, sshClientConfig, masterIp,
+				configSecretTestUser2, dataCenter, cluster)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Create csi-vsphere.conf with original vcenter user and its credentails
+			ginkgo.By("Create csi-vsphere.conf with original vcenter user and its credentails")
+			insecureFlag, clusterId, clusterDistribution,
+				dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+			err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+				vCenterUIUser, vCenterUIPassword, vCenterPort, dataCenters,
+				loginCmd, sshClientConfig, masterIp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step2 : Create csi-vsphere.conf with user1's credentials and
+		create vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testUser1
+		ginkgo.By("Create vsphere-config-secret file with testuser1 credentials")
+		testUser = configSecretTestUser1 + "@vsphere.local"
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step3: Install CSI driver
+		ginkgo.By("Install CSI driver")
+		err = installCsiDriver(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step4: Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete storage class
+			ginkgo.By("Delete Storage Class")
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating Pvc")
+		pvclaim1, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims1 []*v1.PersistentVolumeClaim
+		pvclaims1 = append(pvclaims1, pvclaim1)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims1, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim1}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod1.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step5: Change csi-vsphere.conf and add a dummy user and re-create
+		vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with dummy user
+		ginkgo.By("Create vsphere-config-secret file with dummy user credentials")
+		testUser = "dummyUser@vsphere.local"
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step6: Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim2, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims2 []*v1.PersistentVolumeClaim
+		pvclaims2 = append(pvclaims2, pvclaim2)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims2, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim2}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod2.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step7: Change csi-vsphere.conf with updated user1's credentials and
+		re-create vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testuser1
+		ginkgo.By("Create vsphere-config-secret file with testuser1 credentials")
+		testUser = configSecretTestUser1 + "@vsphere.local"
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step8: Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim3, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims3 []*v1.PersistentVolumeClaim
+		pvclaims3 = append(pvclaims3, pvclaim3)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims3, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim3.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod3, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim3}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod3.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod3)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+	})
+
+	/*
+		TESTCASE-10
+		Add the wrong datacenter and switch back to the correct datacenter
+		Steps:
+		1. Create a user, user1, with required roles and privileges
+		2. Create csi-vsphere.conf with user1's credentials and create vsphere-config-secret
+		in turn using that file
+		3. Install CSI driver
+		4. Verify we can create a PVC and attach it to pod
+		5.  Change csi-vsphere.conf and add a dummy datacentre and re-create vsphere-config-secret
+		in turn using that file
+		6. Try to create a PVC verify that it is stuck in pending state
+		7. Change csi-vsphere.conf with updated datacentre and re-create vsphere-config-secret
+		in turn using that file
+		8. Verify we can create a PVC and attach it to pod
+		9. Verify PVC created in step 6 gets bound eventually
+		10. Cleanup all objects created during the test
+	*/
+
+	ginkgo.It("Change vcenter datacenter to dummy value and switch back to correct datacenter "+
+		"in vsphere config secret file", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// Step1: Create a user, user1, with required roles and privileges
+		ginkgo.By("Create 2 test users")
+		err = createTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser1,
+			configSecertTestUser1Password)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = createTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser2,
+			configSecertTestUser2Password)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create roles for testuser1
+		ginkgo.By("Create roles for testuser1")
+		err = createRolesForTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create roles for testuser2
+		ginkgo.By("Create roles for testuser2")
+		err = createRolesForTestUser(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Fetch DataCenter, Cluster and hosts details")
+		dataCenter, cluster, err = getDataCenterClusterHostAndVmDetails(loginCmd, sshClientConfig,
+			masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Assign required roles and privileges for testuser1 and testuser2")
+
+		// set DataCenter level permission for testuser1 and testuser2
+		ginkgo.By("Set DataCenter level permission for testuser1 and testuser2")
+		err = setDataCenterLevelPermission(loginCmd, sshClientConfig, masterIp, dataCenter,
+			configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setDataCenterLevelPermission(loginCmd, sshClientConfig, masterIp, dataCenter,
+			configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set hosts level permission for testuser1 and testuser2
+		ginkgo.By("Set hosts level permission for testuser1 and testuser2")
+		err = setHostLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setHostLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set K8s VM level permission for testuser1 and testuser2
+		ginkgo.By("Set k8s VM level permission for testuser1 and testuser2")
+		err = setK8sVMLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setK8sVMLevelPermission(loginCmd, sshClientConfig, masterIp, configSecretTestUser2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set cluster level permission for testuser1 and testuser2
+		ginkgo.By("Set cluster level permission for testuser1 and testuser2")
+		err = setClusterLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser1, cluster)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setClusterLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser2, cluster)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// set datastore level permission for testuser1 and testuser2
+		ginkgo.By("Set datastore level permission for testuser1 and testuser2")
+		err = setDataStoreLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser1, dataCenter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = setDataStoreLevelPermission(loginCmd, sshClientConfig, masterIp,
+			configSecretTestUser2, dataCenter)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete users, its roles and permissions
+			ginkgo.By("Delete testUser1, its roles and permissions")
+			err = deleteUsersRolesAndPermissions(loginCmd, sshClientConfig, masterIp,
+				configSecretTestUser1, dataCenter, cluster)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Delete testUser2, its roles and permissions")
+			err = deleteUsersRolesAndPermissions(loginCmd, sshClientConfig, masterIp,
+				configSecretTestUser2, dataCenter, cluster)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Create csi-vsphere.conf with original vcenter user and its credentails
+			ginkgo.By("Create csi-vsphere.conf with original vcenter user and its credentails")
+			insecureFlag, clusterId, clusterDistribution,
+				dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+			err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+				vCenterUIUser, vCenterUIPassword, vCenterPort, dataCenters,
+				loginCmd, sshClientConfig, masterIp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step2 : Create csi-vsphere.conf with user1's credentials and
+		create vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+		correctDataCenter := dataCenter
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testUser1
+		ginkgo.By("Create vsphere-config-secret file with testuser1 credentials " +
+			"and provide correct datacenter details")
+		testUser = configSecretTestUser1 + "@vsphere.local"
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, dataCenters,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step3: Install CSI driver
+		ginkgo.By("Install CSI driver")
+		err = installCsiDriver(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step4: Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete storage class
+			ginkgo.By("Delete Storage Class")
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating Pvc")
+		pvclaim1, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims1 []*v1.PersistentVolumeClaim
+		pvclaims1 = append(pvclaims1, pvclaim1)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims1, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim1}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod1.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step5: Change csi-vsphere.conf and add a dummy datacenter and
+		re-create vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with dummy dataCenter
+		ginkgo.By("Create vsphere-config-secret file with dummy datacenter")
+		dummyDataCenter := "dummy-data-center"
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, dummyDataCenter,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step6: Try to create a PVC verify that it is stuck in pending state
+		ginkgo.By("Try to create a PVC verify that it is stuck in pending state")
+		pvc1, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Expect claim status to be in Pending state")
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
+			pvc1.Namespace, pvc1.Name, framework.Poll, time.Minute)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvc1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		/* Step7: Change csi-vsphere.conf with updated datacenter and
+		re-create vsphere-config-secret in turn using that file */
+		ginkgo.By("Fetch vsphere-config-secret file details")
+		insecureFlag, clusterId, clusterDistribution,
+			dataCenters, vCenterPort = getConfigSecretFileValues(client, ctx)
+
+		// delete csi vsphere conf file
+		ginkgo.By("Delete previously created vsphere-config-secret file")
+		err = deleteCsiVsphereConfFile(loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// create csi vsphere conf file with testuser1 and with correct data center
+		ginkgo.By("Create vsphere-config-secret file with correct data center details")
+		err = createCsiVsphereConfFile(clusterId, clusterDistribution, vcAddress, insecureFlag,
+			testUser, configSecertTestUser1Password, vCenterPort, correctDataCenter,
+			loginCmd, sshClientConfig, masterIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Step8: Verify we can create a PVC and attach it to pod
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim2, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Waiting for PVC to be bound.
+		var pvclaims2 []*v1.PersistentVolumeClaim
+		pvclaims2 = append(pvclaims2, pvclaim2)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims2, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			// delete pvc
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim2}, false, "")
+		defer func() {
+			// delete pod
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod2.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Step9: Verify the PVC which was stuck in Pening state should gets bound eventually
+		ginkgo.By("Verify the PVC which was stuck in Pening state should gets bound eventually")
+		pvc1, err = client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvc1.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvc1.Status.Phase == v1.ClaimBound).To(gomega.BeTrue())
+	})
+})

--- a/tests/e2e/config_secret_utils.go
+++ b/tests/e2e/config_secret_utils.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"golang.org/x/crypto/ssh"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fssh "k8s.io/kubernetes/test/e2e/framework/ssh"
+)
+
+var insecureFlag bool
+var clusterId string
+var clusterDistribution string
+var dataCenters string
+var vCenterPort string
+var user string
+var password string
+var vCenterIp string
+
+func govcLoginCmd(vcAddress string) string {
+	loginCmd := "export GOVC_INSECURE=1;"
+	loginCmd += fmt.Sprintf("export GOVC_URL='https://administrator@vsphere.local:Admin!23@%s';", vcAddress)
+	framework.Logf(loginCmd)
+	return loginCmd
+}
+
+func createTestUser(loginCmd string, sshClientConfig *ssh.ClientConfig, masterIp string,
+	testUser string, testUserPassword string) error {
+	// create 2 test users
+	createUser := loginCmd + "govc sso.user.create -p " + testUserPassword + " " + testUser
+	framework.Logf(createUser)
+	result, err := sshExec(sshClientConfig, masterIp, createUser)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			createUser, masterIp, err)
+	}
+	return nil
+}
+
+func deleteUsersRolesAndPermissions(loginCmd string, sshClientConfig *ssh.ClientConfig,
+	masterIp string, testUser string,
+	dataCenter string, cluster string) error {
+	// delete Permissions
+	deletePermissions := loginCmd + "govc permissions.remove -principal " + testUser +
+		"@vsphere.local " + dataCenter + ";" +
+		"while read i; do govc permissions.remove -principal " + testUser + "@vsphere.local $i;done </root/hosts.txt;" +
+		"while read i; do govc permissions.remove -principal " + testUser + "@vsphere.local $i;done </root/k8s_vm.txt;" +
+		"govc permissions.remove -principal " + testUser + "@vsphere.local " + cluster + ";" +
+		"govc permissions.remove -principal " + testUser + "@vsphere.local /" + dataCenter + "/datastore/vsanDatastore;" +
+		"govc permissions.remove -principal " + testUser + "@vsphere.local /" + dataCenter + "/datastore/local-0;" +
+		"govc permissions.remove -principal " + testUser + "@vsphere.local /" + dataCenter + "'/datastore/local-0 (1)';" +
+		"govc permissions.remove -principal " + testUser + "@vsphere.local "
+	framework.Logf(deletePermissions)
+	result, err := sshExec(sshClientConfig, masterIp, deletePermissions)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			deletePermissions, masterIp, err)
+	}
+
+	// delete roles of testusers
+	deleteRoles := loginCmd + "govc role.remove CNS-DATASTORE-" + testUser + ";" +
+		"govc role.remove CNS-HOST-CONFIG-STORAGE-" + testUser + ";" +
+		"govc role.remove CNS-VM-" + testUser + ";" +
+		"govc role.remove CNS-SEARCH-AND-SPBM-" + testUser
+	framework.Logf(deleteRoles)
+	result, err = sshExec(sshClientConfig, masterIp, deleteRoles)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			deleteRoles, masterIp, err)
+	}
+
+	// delete test user
+	deleteUser := loginCmd + "govc sso.user.rm " + testUser
+	framework.Logf(deleteUser)
+	result, err = sshExec(sshClientConfig, masterIp, deleteUser)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			deleteUser, masterIp, err)
+	}
+	return nil
+}
+
+func createRolesForTestUser(loginCmd string, sshClientConfig *ssh.ClientConfig,
+	masterIp string, testUser string) error {
+	createRoleCmdFortestUser := loginCmd + "govc role.create CNS-DATASTORE-" + testUser +
+		" Datastore.FileManagement;" +
+		"govc role.create CNS-HOST-CONFIG-STORAGE-" + testUser +
+		" Host.Config.Storage;" +
+		"govc role.create CNS-VM-" + testUser +
+		" VirtualMachine.Config.AddExistingDisk VirtualMachine.Config.AddRemoveDevice;" +
+		"govc role.create CNS-SEARCH-AND-SPBM-" + testUser +
+		" Cns.Searchable StorageProfile.View"
+	framework.Logf(createRoleCmdFortestUser)
+	result, err := sshExec(sshClientConfig, masterIp, createRoleCmdFortestUser)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			createRoleCmdFortestUser, masterIp, err)
+	}
+	return nil
+}
+
+func getDataCenterClusterHostAndVmDetails(loginCmd string, sshClientConfig *ssh.ClientConfig,
+	masterIp string) (string, string, error) {
+	// fetch datacenter details
+	ginkgo.By("Executing command for fetching data center details")
+	dataCenter := loginCmd + "govc datacenter.info | grep -i Name | awk '{print $2}' | tr -d '\n'"
+	framework.Logf(dataCenter)
+	dcResult, err := sshExec(sshClientConfig, masterIp, dataCenter)
+	if err != nil && dcResult.Code != 0 {
+		fssh.LogResult(dcResult)
+		return "", "", fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			dataCenter, masterIp, err)
+	}
+
+	// fetch cluster details
+	ginkgo.By("Executing command for fetching cluster details")
+	cluster := loginCmd + "govc ls /" + dcResult.Stdout + "/host | tr -d '\n'"
+	framework.Logf(cluster)
+	clusterResult, err := sshExec(sshClientConfig, masterIp, cluster)
+	if err != nil && clusterResult.Code != 0 {
+		fssh.LogResult(clusterResult)
+		return "", "", fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			cluster, masterIp, err)
+	}
+
+	// Get all esxi hosts details
+	ginkgo.By("Executing command for fetching esxi host details")
+	hosts := loginCmd + "govc ls " + clusterResult.Stdout + " " + " | grep 10. > /root/hosts.txt | tr -d '\n'"
+	framework.Logf(hosts)
+	hostsResult, err := sshExec(sshClientConfig, masterIp, hosts)
+	if err != nil && hostsResult.Code != 0 {
+		fssh.LogResult(hostsResult)
+		return "", "", fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			hosts, masterIp, err)
+	}
+
+	// Get all k8s vm details
+	ginkgo.By("Executing command for fetching k8s vm details")
+	vms := loginCmd + "govc ls /" + dcResult.Stdout + "/vm" + " " + "| grep k8s > /root/k8s_vm.txt | tr -d '\n'"
+	framework.Logf(vms)
+	vMsResult, err := sshExec(sshClientConfig, masterIp, hosts)
+	if err != nil && vMsResult.Code != 0 {
+		fssh.LogResult(vMsResult)
+		return "", "", fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			vms, masterIp, err)
+	}
+	return dcResult.Stdout, clusterResult.Stdout, nil
+}
+
+func setDataCenterLevelPermission(loginCmd string, sshClientConfig *ssh.ClientConfig,
+	masterIp string, dataCenter string, testUser string) error {
+	setPermissionForDataCenter := loginCmd + "govc permissions.set -principal " + testUser +
+		"@vsphere.local -propagate=false -role ReadOnly " + dataCenter + " | tr -d '\n'"
+	framework.Logf(setPermissionForDataCenter)
+	result, err := sshExec(sshClientConfig, masterIp, setPermissionForDataCenter)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			setPermissionForDataCenter, masterIp, err)
+	}
+	return nil
+}
+
+func setHostLevelPermission(loginCmd string, sshClientConfig *ssh.ClientConfig,
+	masterIp string, testUser string) error {
+	setPermissionForHosts := loginCmd + "while read i; do govc permissions.set -principal " +
+		testUser + "@vsphere.local -propagate=false -role ReadOnly $i;done </root/hosts.txt | tr -d '\n'"
+	framework.Logf(setPermissionForHosts)
+	result, err := sshExec(sshClientConfig, masterIp, setPermissionForHosts)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			setPermissionForHosts, masterIp, err)
+	}
+	return nil
+}
+
+func setK8sVMLevelPermission(loginCmd string, sshClientConfig *ssh.ClientConfig,
+	masterIp string, testUser string) error {
+	setPermissionForK8sVms := loginCmd + "while read i; do govc permissions.set -principal " +
+		testUser + "@vsphere.local -propagate=false -role CNS-VM-" + testUser +
+		" $i;done </root/k8s_vm.txt | tr -d '\n'"
+	framework.Logf(setPermissionForK8sVms)
+	result, err := sshExec(sshClientConfig, masterIp, setPermissionForK8sVms)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			setPermissionForK8sVms, masterIp, err)
+	}
+	return nil
+}
+
+func setClusterLevelPermission(loginCmd string, sshClientConfig *ssh.ClientConfig,
+	masterIp string, testUser string, cluster string) error {
+	setPermissionForCluster := loginCmd + "govc permissions.set -principal " +
+		testUser + "@vsphere.local " +
+		"-propagate=false -role CNS-HOST-CONFIG-STORAGE-" + testUser + " " + cluster + " | tr -d '\n'"
+	framework.Logf(setPermissionForCluster)
+	result, err := sshExec(sshClientConfig, masterIp, setPermissionForCluster)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			setPermissionForCluster, masterIp, err)
+	}
+	return nil
+}
+
+func setDataStoreLevelPermission(loginCmd string, sshClientConfig *ssh.ClientConfig,
+	masterIp string, testUser string, dataCenter string) error {
+	setPermissionForDataStore := loginCmd + "govc permissions.set -principal " + testUser + "@vsphere.local " +
+		"-propagate=false -role  CNS-DATASTORE-" + testUser + " " + "/" + dataCenter + "/datastore/vsanDatastore;" +
+		"govc permissions.set -principal " + testUser + "@vsphere.local -propagate=false -role " +
+		"CNS-DATASTORE-" + testUser + " " + "/" + dataCenter + "/datastore/local-0;" +
+		"govc permissions.set -principal " + testUser + "@vsphere.local -propagate=false -role " +
+		"CNS-DATASTORE-" + testUser + " " + "/" + dataCenter + "'/datastore/local-0 (1)';" +
+		"govc permissions.set -principal " + testUser + "@vsphere.local " +
+		"-propagate=false -role  CNS-SEARCH-AND-SPBM-" + testUser + " /"
+	framework.Logf(setPermissionForDataStore)
+	result, err := sshExec(sshClientConfig, masterIp, setPermissionForDataStore)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			setPermissionForDataStore, masterIp, err)
+	}
+	return nil
+}
+
+func createCsiVsphereConfFile(clusterName string, clusterDistribution string, vCenterIP string,
+	inSecureFlag bool, testUser string, password string, vCenterPort string,
+	dataCenter string, loginCmd string, sshClientConfig *ssh.ClientConfig,
+	masterIp string) error {
+	conf := (fmt.Sprintf("tee csi-vsphere.conf >/dev/null <<EOF\n[Global]\ncluster-id = \"%s\"\n"+
+		"cluster-distribution = \"%s\"\n\n[VirtualCenter \"%s\"]\n"+
+		"insecure-flag = \"%t\"\nuser = \"%s\"\npassword = \"%s\"\nport = \"%s\"\n"+
+		"datacenters = \"%s\"\nEOF",
+		clusterName, clusterDistribution, vCenterIP, inSecureFlag, testUser, password,
+		vCenterPort, dataCenter))
+	framework.Logf(conf)
+	result, err := sshExec(sshClientConfig, masterIp, conf)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			conf, masterIp, err)
+	}
+	applyConf := "kubectl create secret generic vsphere-config-secret --from-file=csi-vsphere.conf " +
+		"-n vmware-system-csi"
+	framework.Logf(applyConf)
+	result, err = sshExec(sshClientConfig, masterIp, applyConf)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			applyConf, masterIp, err)
+	}
+	return nil
+
+}
+
+func deleteCsiVsphereConfFile(loginCmd string, sshClientConfig *ssh.ClientConfig,
+	masterIp string) error {
+	deleteConf := "kubectl delete secret vsphere-config-secret --namespace=vmware-system-csi"
+	framework.Logf(deleteConf)
+	result, err := sshExec(sshClientConfig, masterIp, deleteConf)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			deleteConf, masterIp, err)
+	}
+	return nil
+}
+
+func installCsiDriver(loginCmd string, sshClientConfig *ssh.ClientConfig,
+	masterIp string) error {
+	deleteCsiPods := "kubectl delete pods -n vmware-system-csi --all"
+	framework.Logf(deleteCsiPods)
+	result, err := sshExec(sshClientConfig, masterIp, deleteCsiPods)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			deleteCsiPods, masterIp, err)
+	}
+	time.Sleep(60 * time.Second)
+	return nil
+}
+
+func getVcenterHostName(sshClientConfig *ssh.ClientConfig, masterIp string, vcenterIp string) (string, error) {
+	getVcenterHostName := "nslookup " + vcenterIp + "| grep name |  awk '{print $4}' | tr -d '\n'"
+	framework.Logf(getVcenterHostName)
+	vCenterRes, err := sshExec(sshClientConfig, masterIp, getVcenterHostName)
+	if err != nil && vCenterRes.Code != 0 {
+		fssh.LogResult(vCenterRes)
+		return "", fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			getVcenterHostName, masterIp, err)
+	}
+	return vCenterRes.Stdout, nil
+
+}
+
+func getConfigSecretFileValues(client clientset.Interface, ctx context.Context) (bool, string, string, string, string) {
+	currentSecret, err := client.CoreV1().Secrets(csiSystemNamespace).Get(ctx, configSecret, metav1.GetOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	originalConf := string(currentSecret.Data[vSphereCSIConf])
+	vsphereCfg, err := readConfigFromSecretString(originalConf)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	insecureFlag = vsphereCfg.Global.InsecureFlag
+	clusterId = vsphereCfg.Global.ClusterID
+	clusterDistribution = vsphereCfg.Global.ClusterDistribution
+	dataCenters = vsphereCfg.Global.Datacenters
+	vCenterPort = vsphereCfg.Global.VCenterPort
+	user = vsphereCfg.Global.User
+	password = vsphereCfg.Global.Password
+	vCenterIp = vsphereCfg.Global.VCenterHostname
+	framework.Logf("cluster-id: %s"+"  "+"cluster-distribution: %s"+"  "+
+		"VirtualCenter: %s"+"  "+"insecure-flag: %t"+"  "+
+		"user: %s"+"  "+"password: %s"+"  "+"vCenterPort: %s"+"  "+"dataCenters: %s", clusterId,
+		clusterDistribution, vCenterIp, insecureFlag, user, password, vCenterPort, dataCenters)
+	return insecureFlag, clusterId, clusterDistribution, dataCenters, vCenterPort
+}

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -186,6 +186,12 @@ const (
 	datastoreUrlSpecificToCluster              = "DATASTORE_URL_SPECIFIC_TO_CLUSTER"
 	storagePolicyForDatastoreSpecificToCluster = "STORAGE_POLICY_FOR_DATASTORE_SPECIFIC_TO_CLUSTER"
 	topologyCluster                            = "TOPOLOGY_CLUSTERS"
+	configSecertTestUser1Password              = "VMware!23"
+	configSecertTestUser2Password              = "Admin!23"
+	configSecretTestUser1                      = "testuser1"
+	configSecretTestUser2                      = "testuser2"
+	vCenterUIUser                              = "administrator@vsphere.local"
+	vCenterUIPassword                          = "Admin!23"
 	vmcPrdEndpoint                             = "https://vmc.vmware.com/vmc/api/orgs/"
 	authAPI                                    = "https://console.cloud.vmware.com/csp/gateway/am/api/auth" +
 		"/api-tokens/authorize"


### PR DESCRIPTION
**What this PR does / why we need it**:
Config Secret testcases automation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Config Secret testcases automation

**Testing done**:
Yes
TC1 - https://gist.githubusercontent.com/sipriyaa/93befec77ac1eeeda79ddb2aaa02ab99/raw/2f92a80787965a1e82f927fc2b5fe73bec2c844e/gistfile1.txt

TC2 - https://gist.githubusercontent.com/sipriyaa/bc66501a5affb305490a869466d5306d/raw/a8861d7836a28e1680d44ee0d2c043c2e145f8c8/gistfile1.txt

TC3 - https://gist.githubusercontent.com/sipriyaa/08dd36bec682a7e5dab097084620f4d3/raw/2e94e15ed84019c7a2d4ea2d03d6aa411fae69c5/gistfile1.txt

TC4 - https://gist.githubusercontent.com/sipriyaa/ddb711de7ee864d35464535cedd8953b/raw/82c65c7ca3374a981bf7c837bf829073e2c1bd90/gistfile1.txt

TC6- https://gist.githubusercontent.com/sipriyaa/871e4077c88d70072c99f76bb464b63b/raw/f350eabadab94ba77f7b1f1b3c6199e445f3985d/gistfile1.txt

TC10 -https://gist.githubusercontent.com/sipriyaa/2b6ad536b78f379788cfbbab71117438/raw/64a5ee97fa18ff8a0ae34f0cfb1d8dc812da6bf8/gistfile1.txt

**Special notes for your reviewer**:
Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint 
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/config-secret-automation/vsphere-csi-driver /Users/sipriya/config-secret-automation /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|imports|name|types_sizes|exports_file|files) took 12.367921176s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 110.667927ms 
INFO [linters context/goanalysis] analyzers took 43.8781397s with top 10 stages: buildir: 13.424471303s, misspell: 2.209169173s, S1038: 1.511229575s, printf: 954.03393ms, SA1012: 942.494795ms, ctrlflow: 906.717217ms, isgenerated: 903.717057ms, fact_deprecated: 899.782784ms, lll: 893.186788ms, directives: 804.391457ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 24/113, skip_dirs: 113/113, identifier_marker: 24/24, exclude: 24/24, cgo: 113/113, path_prettifier: 113/113, nolint: 0/1, filename_unadjuster: 113/113, skip_files: 113/113, exclude-rules: 1/24 
INFO [runner] processing took 14.95407ms with stages: nolint: 12.969324ms, autogenerated_exclude: 1.043388ms, path_prettifier: 352.824µs, identifier_marker: 322.919µs, exclude-rules: 129.951µs, skip_dirs: 115.882µs, filename_unadjuster: 7.479µs, cgo: 6.559µs, max_same_issues: 1.429µs, uniq_by_line: 877ns, max_from_linter: 771ns, diff: 535ns, source_code: 429ns, max_per_file_from_linter: 316ns, sort_results: 309ns, severity-rules: 254ns, skip_files: 236ns, exclude: 235ns, path_shortener: 231ns, path_prefixer: 122ns 
INFO [runner] linters took 8.861674391s with stages: goanalysis_metalinter: 8.846600502s 
INFO File cache stats: 283 entries of total size 4.6MiB 
INFO Memory: 213 samples, avg is 271.0MB, max is 1155.9MB 
INFO Execution took 21.351458524s                 
sipriya@sipriya-a01 vsphere-csi-driver % 

