### PR TITLE
change node-role.kubernetes.io/master to node-role.kubernetes.io/control-plane

### DIFF
--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -164,7 +164,7 @@ deploy_snapshot_controller(){
 	# The released yaml for v5.0.1 does not have v5.0.1 image for snapshot-controller, explicitly updating it.
 	snapshot_controller_image="gcr.io/k8s-staging-sig-storage/snapshot-controller:"${qualified_version}
 	kubectl -n kube-system set image deployment/snapshot-controller snapshot-controller=$snapshot_controller_image
-	kubectl patch deployment -n kube-system snapshot-controller --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/control-plane": ""}, "tolerations": [{"key":"node-role.kubernetes.io/control-plane","operator":"Exists", "effect":"NoSchedule"}]}}}}'
+	kubectl patch deployment -n kube-system snapshot-controller --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/control-plane": ""}, "tolerations": [{"key":"node-role.kubernetes.io/master","operator":"Exists", "effect":"NoSchedule"},{"key":"node-role.kubernetes.io/control-plane","operator":"Exists", "effect":"NoSchedule"}]}}}}'
 	kubectl patch deployment -n kube-system snapshot-controller --type=json \
 	-p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-qps=100"},{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-burst=100"}]'
 	kubectl -n kube-system rollout status deploy/snapshot-controller
@@ -225,7 +225,7 @@ EOF
 	kubectl delete deployment snapshot-validation-deployment --namespace "${namespace}" 2>/dev/null || true
 	# patch csi-snapshot-validatingwebhook.yaml with CA_BUNDLE and create service and validatingwebhookconfiguration
 	curl https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/vanilla/csi-snapshot-validatingwebhook.yaml | sed "s/caBundle: .*$/caBundle: ${CA_BUNDLE}/g" | kubectl apply -f -
-	kubectl patch deployment -n kube-system snapshot-validation-deployment --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/control-plane": ""}, "tolerations": [{"key":"node-role.kubernetes.io/control-plane","operator":"Exists", "effect":"NoSchedule"}]}}}}'
+	kubectl patch deployment -n kube-system snapshot-validation-deployment --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/control-plane": ""}, "tolerations": [{"key":"node-role.kubernetes.io/master","operator":"Exists", "effect":"NoSchedule"},{"key":"node-role.kubernetes.io/control-plane","operator":"Exists", "effect":"NoSchedule"}]}}}}'
 	kubectl -n kube-system rollout status deploy/snapshot-validation-deployment
 	echo -e "\n✅ Successfully deployed snapshot-validation-deployment\n"
 }

--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -164,7 +164,7 @@ deploy_snapshot_controller(){
 	# The released yaml for v5.0.1 does not have v5.0.1 image for snapshot-controller, explicitly updating it.
 	snapshot_controller_image="gcr.io/k8s-staging-sig-storage/snapshot-controller:"${qualified_version}
 	kubectl -n kube-system set image deployment/snapshot-controller snapshot-controller=$snapshot_controller_image
-	kubectl patch deployment -n kube-system snapshot-controller --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/master": ""}, "tolerations": [{"key":"node-role.kubernetes.io/master","operator":"Exists", "effect":"NoSchedule"}]}}}}'
+	kubectl patch deployment -n kube-system snapshot-controller --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/control-plane": ""}, "tolerations": [{"key":"node-role.kubernetes.io/control-plane","operator":"Exists", "effect":"NoSchedule"}]}}}}'
 	kubectl patch deployment -n kube-system snapshot-controller --type=json \
 	-p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-qps=100"},{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-burst=100"}]'
 	kubectl -n kube-system rollout status deploy/snapshot-controller
@@ -225,7 +225,7 @@ EOF
 	kubectl delete deployment snapshot-validation-deployment --namespace "${namespace}" 2>/dev/null || true
 	# patch csi-snapshot-validatingwebhook.yaml with CA_BUNDLE and create service and validatingwebhookconfiguration
 	curl https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/vanilla/csi-snapshot-validatingwebhook.yaml | sed "s/caBundle: .*$/caBundle: ${CA_BUNDLE}/g" | kubectl apply -f -
-	kubectl patch deployment -n kube-system snapshot-validation-deployment --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/master": ""}, "tolerations": [{"key":"node-role.kubernetes.io/master","operator":"Exists", "effect":"NoSchedule"}]}}}}'
+	kubectl patch deployment -n kube-system snapshot-validation-deployment --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/control-plane": ""}, "tolerations": [{"key":"node-role.kubernetes.io/control-plane","operator":"Exists", "effect":"NoSchedule"}]}}}}'
 	kubectl -n kube-system rollout status deploy/snapshot-validation-deployment
 	echo -e "\n✅ Successfully deployed snapshot-validation-deployment\n"
 }

--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -115,6 +115,9 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule

--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -113,9 +113,9 @@ spec:
     spec:
       serviceAccountName: vsphere-csi-webhook
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
         # uncomment below toleration if you need an aggressive pod eviction in case when

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -212,9 +212,9 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       serviceAccountName: vsphere-csi-controller
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
         # uncomment below toleration if you need an aggressive pod eviction in case when

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -214,6 +214,9 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Refer to https://github.com/kubernetes/kubernetes/pull/107533 and https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint


**Testing done**:
Deployed K8s 1.23 release cluster with nodes having labels `node-role.kubernetes.io/control-plane`

```
root@k8s-control-227-1653523650:~# kubectl describe nodes | grep node-role.kubernetes.io/control-plane
                    node-role.kubernetes.io/control-plane=
                    node-role.kubernetes.io/control-plane=
                    node-role.kubernetes.io/control-plane=
```

Installed CSI Driver with the change made in this PR

```
% kubectl create -f vsphere-csi-driver.yaml
csidriver.storage.k8s.io/csi.vsphere.vmware.com created
serviceaccount/vsphere-csi-controller created
clusterrole.rbac.authorization.k8s.io/vsphere-csi-controller-role created
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-controller-binding created
serviceaccount/vsphere-csi-node created
clusterrole.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role created
clusterrolebinding.rbac.authorization.k8s.io/vsphere-csi-node-cluster-role-binding created
role.rbac.authorization.k8s.io/vsphere-csi-node-role created
rolebinding.rbac.authorization.k8s.io/vsphere-csi-node-binding created
configmap/internal-feature-states.csi.vsphere.vmware.com created
service/vsphere-csi-controller created
deployment.apps/vsphere-csi-controller created
daemonset.apps/vsphere-csi-node created
daemonset.apps/vsphere-csi-node-windows created


% kubectl get pods --namespace=vmware-system-csi
NAME                                     READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-c8bfcfdbb-bw74w   7/7     Running   0          29s
vsphere-csi-controller-c8bfcfdbb-pkl47   7/7     Running   0          29s
vsphere-csi-controller-c8bfcfdbb-xv6bl   7/7     Running   0          29s
vsphere-csi-node-7tph2                   3/3     Running   0          29s
vsphere-csi-node-8cnw7                   3/3     Running   0          29s
vsphere-csi-node-9nsbq                   3/3     Running   0          29s
vsphere-csi-node-bp7lz                   3/3     Running   0          29s
vsphere-csi-node-tr2bq                   3/3     Running   0          29s
vsphere-csi-node-zfn6t                   3/3     Running   0          29s

```

Deployed CSI snapshot components

```
./deploy-csi-snapshot-components.sh 
✅ Verified that block-volume-snapshot feature is enabled
Checking CRDs...
Supported version v1 of crd volumesnapshotclasses.snapshot.storage.k8s.io present
Supported version v1 of crd volumesnapshotcontents.snapshot.storage.k8s.io present
Supported version v1 of crd volumesnapshots.snapshot.storage.k8s.io present

✅ Deployed VolumeSnapshot CRDs

No existing snapshot-controller Deployment found, deploying it now..
Start snapshot-controller deployment...
serviceaccount/snapshot-controller unchanged
clusterrole.rbac.authorization.k8s.io/snapshot-controller-runner unchanged
clusterrolebinding.rbac.authorization.k8s.io/snapshot-controller-role unchanged
role.rbac.authorization.k8s.io/snapshot-controller-leaderelection unchanged
rolebinding.rbac.authorization.k8s.io/snapshot-controller-leaderelection unchanged
✅ Created  RBACs for snapshot-controller
deployment.apps/snapshot-controller created
deployment.apps/snapshot-controller image updated
deployment.apps/snapshot-controller patched
deployment.apps/snapshot-controller patched
Waiting for deployment spec update to be observed...
Waiting for deployment "snapshot-controller" rollout to finish: 0 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 0 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 0 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 of 2 updated replicas are available...
Waiting for deployment "snapshot-controller" rollout to finish: 1 of 2 updated replicas are available...
deployment "snapshot-controller" successfully rolled out

✅ Successfully deployed snapshot-controller

No existing snapshot-validation-deployment Deployment found, deploying it now..
creating certs in tmpdir /var/folders/vy/_6dvxx7j5db9sq9n38qjymwr002gzv/T/tmp.vtkb0rs4 
Generating a 2048 bit RSA private key
.+++
........................+++
writing new private key to '/var/folders/vy/_6dvxx7j5db9sq9n38qjymwr002gzv/T/tmp.vtkb0rs4/ca.key'
-----
Generating RSA private key, 2048 bit long modulus
......+++
.............................................+++
e is 65537 (0x10001)
Signature ok
subject=/CN=snapshot-validation-service.kube-system.svc
Getting CA Private Key
secret "snapshot-webhook-certs" deleted
secret/snapshot-webhook-certs created
service "snapshot-validation-service" deleted
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2238  100  2238    0     0  50107      0 --:--:-- --:--:-- --:--:-- 62166
service/snapshot-validation-service created
validatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook.snapshot.storage.k8s.io configured
deployment.apps/snapshot-validation-deployment created
deployment.apps/snapshot-validation-deployment patched
Waiting for deployment spec update to be observed...
Waiting for deployment "snapshot-validation-deployment" rollout to finish: 0 out of 3 new replicas have been updated...
Waiting for deployment "snapshot-validation-deployment" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "snapshot-validation-deployment" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "snapshot-validation-deployment" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "snapshot-validation-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "snapshot-validation-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "snapshot-validation-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "snapshot-validation-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "snapshot-validation-deployment" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "snapshot-validation-deployment" rollout to finish: 1 old replicas are pending termination...
deployment "snapshot-validation-deployment" successfully rolled out

✅ Successfully deployed snapshot-validation-deployment

✅ vSphere CSI Driver already running the qualified version of csi-snapshotter.

✅ Successfully deployed all components for CSI Snapshot feature!
```

```
% kubectl get pods --namespace=kube-system | grep snapshot
snapshot-controller-7f88dc89f6-s9d8v                 1/1     Running   0               39s
snapshot-controller-7f88dc89f6-zps44                 1/1     Running   0               61s
snapshot-validation-deployment-56d48f7956-97q6w      1/1     Running   0               12s
snapshot-validation-deployment-56d48f7956-rq2dm      1/1     Running   0               14s
snapshot-validation-deployment-56d48f7956-zbbmd      1/1     Running   0               8s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
change node-role.kubernetes.io/master to node-role.kubernetes.io/control-plane
```
