### PR TITLE
Config secret - Util methods along with testcase - updating vsphere conf file with different testuser credentials

### DIFF
--- a/tests/e2e/config_secret.go
+++ b/tests/e2e/config_secret.go
@@ -1,0 +1,264 @@
+/*
+	Copyright 2022 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/vmware/govmomi/object"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = ginkgo.Describe("Config-Secret", func() {
+	f := framework.NewDefaultFramework("config-secret-changes")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		client                    clientset.Interface
+		namespace                 string
+		allMasterIps              []string
+		masterIp                  string
+		dataCenters               []*object.Datacenter
+		clusters                  []string
+		hosts                     []string
+		vms                       []string
+		datastores                []string
+		configSecretUser1Alias    string
+		configSecretUser2Alias    string
+		csiNamespace              string
+		csiReplicas               int32
+		vCenterUIUser             string
+		vCenterUIPassword         string
+		propagateVal              string
+		revertOriginalvCenterUser bool
+	)
+
+	ginkgo.BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		bootstrap()
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		// fetching required parameters
+		allMasterIps = getK8sMasterIPs(ctx, client)
+		masterIp = allMasterIps[0]
+		vCenterUIUser = e2eVSphere.Config.Global.User
+		vCenterUIPassword = e2eVSphere.Config.Global.Password
+		propagateVal = "false"
+		revertOriginalvCenterUser = false
+		configSecretUser1Alias = configSecretTestUser1 + "@vsphere.local"
+		configSecretUser2Alias = configSecretTestUser2 + "@vsphere.local"
+
+		// fetching datacenter, cluster, host details
+		dataCenters, clusters, hosts, vms, datastores = getDataCenterClusterHostAndVmDetails(ctx, masterIp)
+
+		ginkgo.By("Delete roles, permissions for testuser1 if already exist")
+		deleteTestUserAndRemoveRolesPrivileges(masterIp, configSecretTestUser1,
+			configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+			dataCenters, clusters, hosts, vms, datastores)
+
+		ginkgo.By("Delete roles, permissions for testuser2 if already exist")
+		deleteTestUserAndRemoveRolesPrivileges(masterIp, configSecretTestUser2,
+			configSecretTestUser1Password, configSecretUser2Alias, propagateVal,
+			dataCenters, clusters, hosts, vms, datastores)
+
+		csiNamespace = GetAndExpectStringEnvVar(envCSINamespace)
+		csiDeployment, err := client.AppsV1().Deployments(csiNamespace).Get(
+			ctx, vSphereCSIControllerPodNamePrefix, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		csiReplicas = *csiDeployment.Spec.Replicas
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		if !revertOriginalvCenterUser {
+			ginkgo.By("Reverting back csi-vsphere.conf with its original vcenter user " +
+				"and its credentials")
+			createCsiVsphereSecret(client, ctx, vCenterUIUser, vCenterUIPassword, csiNamespace)
+
+			ginkgo.By("Restart CSI driver")
+			restartSuccess, err := restartCSIDriver(ctx, client, namespace, csiReplicas)
+			gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+	})
+
+	/*
+		TESTCASE-1
+		Change VC user
+		Steps:
+		1. Create two users (user1 and user2) with required roles and privileges and with same password
+		2. Create csi-vsphere.conf with user1's credentials and create vsphere-config-secret in turn using that file
+		3. Install CSI driver
+		4. Verify we can create a PVC and attach it to pod
+		5. Change csi-vsphere.conf with user2's credentials and re-create vsphere-config-secret in turn using that file
+		6. Verify we can create a PVC and attach it to pod
+		7. Cleanup all objects created during the test
+	*/
+
+	ginkgo.It("[csi-config-secret-block][csi-config-secret-file] Update user credentials in vsphere config "+
+		"secret keeping password same for both test users", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ginkgo.By("Create testuser1 and assign required roles and privileges to testuser1")
+		createTestUserAndAssignRolesPrivileges(masterIp, configSecretTestUser1,
+			configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+			dataCenters, clusters, hosts, vms, datastores)
+		defer func() {
+			ginkgo.By("Delete testuser1 and remove assigned roles and privileges to testuser1")
+			deleteTestUserAndRemoveRolesPrivileges(masterIp, configSecretTestUser1,
+				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+				dataCenters, clusters, hosts, vms, datastores)
+		}()
+
+		ginkgo.By("Create testuser2 and assign required roles and privileges to testuser2")
+		createTestUserAndAssignRolesPrivileges(masterIp, configSecretTestUser2,
+			configSecretTestUser1Password, configSecretUser2Alias, propagateVal,
+			dataCenters, clusters, hosts, vms, datastores)
+		defer func() {
+			ginkgo.By("Delete testuser2 and remove assigned roles and privileges to testuser2")
+			deleteTestUserAndRemoveRolesPrivileges(masterIp, configSecretTestUser2,
+				configSecretTestUser1Password, configSecretUser2Alias, propagateVal,
+				dataCenters, clusters, hosts, vms, datastores)
+		}()
+
+		ginkgo.By("Create vsphere-config-secret file with testuser1 credentials")
+		createCsiVsphereSecret(client, ctx, configSecretUser1Alias, configSecretTestUser1Password, csiNamespace)
+
+		ginkgo.By("Restart CSI driver")
+		restartSuccess, err := restartCSIDriver(ctx, client, namespace, csiReplicas)
+		gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Delete Storage Class")
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating PVC")
+		pvclaim1, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvclaims1 []*v1.PersistentVolumeClaim
+		pvclaims1 = append(pvclaims1, pvclaim1)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		pvs1, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims1, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs1).NotTo(gomega.BeEmpty())
+		pv1 := pvs1[0]
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv1.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}()
+
+		ginkgo.By("Creating pod")
+		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim1}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod1.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume metadata for POD, PVC and PV")
+		err = waitAndVerifyCnsVolumeMetadata(pv1.Spec.CSI.VolumeHandle, pvclaim1, pv1, pod1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Create vsphere-config-secret file with testuser2 credentials")
+		createCsiVsphereSecret(client, ctx, configSecretUser2Alias, configSecretTestUser1Password, csiNamespace)
+		defer func() {
+			ginkgo.By("Reverting back csi-vsphere.conf with its original vcenter user " +
+				"and its credentials")
+			createCsiVsphereSecret(client, ctx, vCenterUIUser, vCenterUIPassword, csiNamespace)
+			revertOriginalvCenterUser = true
+
+			ginkgo.By("Restart CSI driver")
+			restartSuccess, err = restartCSIDriver(ctx, client, namespace, csiReplicas)
+			gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Restart CSI driver")
+		restartSuccess, err = restartCSIDriver(ctx, client, namespace, csiReplicas)
+		gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim2, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvclaims2 []*v1.PersistentVolumeClaim
+		pvclaims2 = append(pvclaims2, pvclaim2)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		pvs2, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims2, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs2).NotTo(gomega.BeEmpty())
+		pv2 := pvs2[0]
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			err = fpv.WaitForPersistentVolumeDeleted(client, pv2.Name, poll, pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv2.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				"Volume: %s should not be present in the CNS after it is deleted from "+
+					"kubernetes", pv2.Spec.CSI.VolumeHandle)
+		}()
+
+		ginkgo.By("Creating pod")
+		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim2}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod2.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume metadata for POD, PVC and PV")
+		err = waitAndVerifyCnsVolumeMetadata(pv2.Spec.CSI.VolumeHandle, pvclaim2, pv2, pod2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})

--- a/tests/e2e/config_secret_utils.go
+++ b/tests/e2e/config_secret_utils.go
@@ -1,0 +1,656 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega"
+	"github.com/vmware/govmomi/object"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fssh "k8s.io/kubernetes/test/e2e/framework/ssh"
+)
+
+// createTestUser util method is used for creating test users
+func createTestUser(masterIp string, testUser string, testUserPassword string) error {
+	createUser := govcLoginCmd() + "govc sso.user.create -p " + testUserPassword + " " + testUser
+	framework.Logf("Create testuser: %s ", createUser)
+	result, err := sshExec(sshClientConfig, masterIp, createUser)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			createUser, masterIp, err)
+	}
+	return nil
+}
+
+// deleteUsersRolesAndPermissions method is used to delete roles and permissions of a test users
+func deleteUsersRolesAndPermissions(masterIp string, testUser string, testUserAlias string,
+	dataCenter []*object.Datacenter, cluster []string, hosts []string, vms []string, datastores []string) {
+	framework.Logf("Delete user permissions")
+	deleteUserPermissions(masterIp, testUserAlias, dataCenter, cluster, hosts, vms, datastores)
+
+	framework.Logf("Delete user roles")
+	err := deleteUserRoles(masterIp, testUser)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			framework.Logf("No test user roles exist")
+		} else {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+				masterIp, err)
+		}
+	}
+}
+
+// deleteUserPermissions method is used to delete permissions of a test user
+func deleteUserPermissions(masterIp string, testUser string, dataCenter []*object.Datacenter, clusters []string,
+	hosts []string, vms []string, datastores []string) {
+	err := deleteDataCenterPermissions(masterIp, testUser, dataCenter)
+	if err != nil {
+		if strings.Contains(err.Error(), "The object or item referred to could not be found") {
+			framework.Logf("No datacenter level permissions exist for a testuser")
+		} else {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+				masterIp, err)
+		}
+	}
+
+	err = deleteHostsLevelPermission(masterIp, testUser, hosts)
+	if err != nil {
+		if strings.Contains(err.Error(), "The object or item referred to could not be found") {
+			framework.Logf("No host level permissions exist for a testuser")
+		} else {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+				masterIp, err)
+		}
+	}
+
+	err = deleteVMsLevelPermission(masterIp, testUser, vms)
+	if err != nil {
+		if strings.Contains(err.Error(), "The object or item referred to could not be found") {
+			framework.Logf("No vm level permissions exist for a testuser")
+		} else {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+				masterIp, err)
+		}
+	}
+
+	err = deleteClusterLevelPermission(masterIp, testUser, clusters)
+	if err != nil {
+		if strings.Contains(err.Error(), "The object or item referred to could not be found") {
+			framework.Logf("No cluster level permissions exist for a testuser")
+		} else {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+				masterIp, err)
+		}
+	}
+
+	for i := 0; i < len(dataCenter); i++ {
+		err = deleteDataStoreLevelPermission(masterIp, testUser, dataCenter[i].InventoryPath, datastores)
+		if err != nil {
+			if strings.Contains(err.Error(), "The object or item referred to could not be found") {
+				framework.Logf("No datastore level permissions exist for a testuser")
+			} else {
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+					masterIp, err)
+			}
+		}
+	}
+	err = deleteOtherPermissionsFromTestUser(masterIp, testUser)
+	if err != nil {
+		if strings.Contains(err.Error(), "The object or item referred to could not be found") {
+			framework.Logf("No search level permissions exist for a testuser")
+		} else {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+				masterIp, err)
+		}
+	}
+}
+
+// deleteDataCenterPermissions method is used to delete DataCenter Permissions from a test user
+func deleteDataCenterPermissions(masterIp string, testUser string, dataCenter []*object.Datacenter) error {
+	for i := 0; i < len(dataCenter); i++ {
+		deleteDataCenterPermissions := govcLoginCmd() +
+			"govc permissions.remove -principal " + testUser + " " + dataCenter[i].InventoryPath
+		framework.Logf("delete datacenter level permissions %s", deleteDataCenterPermissions)
+		result, err := sshExec(sshClientConfig, masterIp, deleteDataCenterPermissions)
+		if err != nil && result.Code != 0 {
+			fssh.LogResult(result)
+			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				deleteDataCenterPermissions, masterIp, err)
+		}
+	}
+	return nil
+}
+
+// deleteHostsLevelPermission method is used to delete hosts level permissions from a test user
+func deleteHostsLevelPermission(masterIp string, testUser string, hosts []string) error {
+	for i := 0; i < len(hosts); i++ {
+		deleteHostsLevelPermissions := govcLoginCmd() +
+			"govc permissions.remove -principal " + testUser + " " + hosts[i]
+		framework.Logf("delete host level permissions %s", deleteHostsLevelPermissions)
+		result, err := sshExec(sshClientConfig, masterIp, deleteHostsLevelPermissions)
+		if err != nil && result.Code != 0 {
+			fssh.LogResult(result)
+			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				deleteHostsLevelPermissions, masterIp, err)
+		}
+	}
+	return nil
+}
+
+// deleteVMsLevelPermission method is used to delete vm level permissions from a test user
+func deleteVMsLevelPermission(masterIp string, testUser string, vms []string) error {
+	for i := 0; i < len(vms); i++ {
+		deleteVmsLevelPermissions := govcLoginCmd() + "govc permissions.remove -principal " + testUser +
+			" " + vms[i]
+		framework.Logf("delete vm level permissions %s", deleteVmsLevelPermissions)
+		result, err := sshExec(sshClientConfig, masterIp, deleteVmsLevelPermissions)
+		if err != nil && result.Code != 0 {
+			fssh.LogResult(result)
+			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				deleteVmsLevelPermissions, masterIp, err)
+		}
+	}
+	return nil
+}
+
+// deleteClusterLevelPermission method is used to delete cluster level permissions from a test user
+func deleteClusterLevelPermission(masterIp string, testUser string, clusters []string) error {
+	for i := 0; i < len(clusters); i++ {
+		deleteClusterLevelPermissions := govcLoginCmd() +
+			"govc permissions.remove -principal " + testUser + " " + clusters[i]
+		framework.Logf("delete cluster level permissions %s", deleteClusterLevelPermissions)
+		result, err := sshExec(sshClientConfig, masterIp, deleteClusterLevelPermissions)
+		if err != nil && result.Code != 0 {
+			fssh.LogResult(result)
+			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				deleteClusterLevelPermissions, masterIp, err)
+		}
+	}
+	return nil
+}
+
+// deleteDataStoreLevelPermission method is used to delete datastore level permissions from a test user
+func deleteDataStoreLevelPermission(masterIp string, testUser string, dataCenter string, datastores []string) error {
+	for i := 0; i < len(datastores); i++ {
+		deleteDataStoreLevelPermissions := govcLoginCmd() + "govc permissions.remove -principal " +
+			testUser + " '" + datastores[i] + "'"
+		framework.Logf("delete datastore level permissions %s", deleteDataStoreLevelPermissions)
+		result, err := sshExec(sshClientConfig, masterIp, deleteDataStoreLevelPermissions)
+		if err != nil && result.Code != 0 {
+			fssh.LogResult(result)
+			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				deleteDataStoreLevelPermissions, masterIp, err)
+		}
+	}
+	return nil
+}
+
+// deleteOtherPermissionsFromTestUser method is used to remove permissions from a test user
+func deleteOtherPermissionsFromTestUser(masterIp string, testUser string) error {
+	deleteOtherPermissions := govcLoginCmd() + "govc permissions.remove -principal " +
+		testUser
+	framework.Logf("delete other permissions %s", deleteOtherPermissions)
+	result, err := sshExec(sshClientConfig, masterIp, deleteOtherPermissions)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			deleteOtherPermissions, masterIp, err)
+	}
+	return nil
+}
+
+// deleteUserRoles method is used to delete roles of a test user
+func deleteUserRoles(masterIp string, testUser string) error {
+	roleMap := userRoleMap()
+	for key := range roleMap {
+		if key != "ReadOnly" {
+			deleteRoles := govcLoginCmd() + "govc role.remove " + key + "-" + testUser
+			framework.Logf("delete user roles %s", deleteRoles)
+			result, err := sshExec(sshClientConfig, masterIp, deleteRoles)
+			if err != nil && result.Code != 0 {
+				fssh.LogResult(result)
+				return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+					deleteRoles, masterIp, err)
+			}
+		}
+	}
+	return nil
+}
+
+// deleteTestUser method is used to delete config secret test users
+func deleteTestUser(masterIp string, testUser string) error {
+	deleteUser := govcLoginCmd() + "govc sso.user.rm " + testUser
+	framework.Logf("delete test user %s", deleteUser)
+	result, err := sshExec(sshClientConfig, masterIp, deleteUser)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			deleteUser, masterIp, err)
+	}
+	return nil
+}
+
+// createRolesForTestUser method is used to create roles for a test user
+func createRolesForTestUser(masterIp string, testUser string) error {
+	roleMap := userRoleMap()
+	for key, val := range roleMap {
+		if key != "ReadOnly" {
+			createRoleCmdFortestUser := govcLoginCmd() + "govc role.create " + key + "-" + testUser + " " + val
+			framework.Logf("Create roles for test user %s", createRoleCmdFortestUser)
+			result, err := sshExec(sshClientConfig, masterIp, createRoleCmdFortestUser)
+			if err != nil && result.Code != 0 {
+				fssh.LogResult(result)
+				return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+					createRoleCmdFortestUser, masterIp, err)
+			}
+		}
+	}
+	return nil
+}
+
+/*
+getDataCenterClusterHostAndVmDetails method is used to fetch data center details, cluster
+details, host details and vm details
+*/
+func getDataCenterClusterHostAndVmDetails(ctx context.Context, masterIp string) ([]*object.Datacenter,
+	[]string, []string, []string, []string) {
+	// fetch datacenter details
+	dataCenters, err := e2eVSphere.getAllDatacenters(ctx)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// fetch cluster details
+	clusters, err := getClusterNames(masterIp, dataCenters)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+		masterIp, err)
+
+	// fetch esxi hosts details
+	hosts, err := getEsxiHostNames(masterIp, clusters)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+		masterIp, err)
+
+	// fetch vm details
+	vms, err := getVmNames(masterIp, dataCenters)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+		masterIp, err)
+
+	// fetch datastore details
+	datastores, err := getDatastoreNames(masterIp, dataCenters)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+		masterIp, err)
+
+	return dataCenters, clusters, hosts, vms, datastores
+}
+
+// getClusterNames method is used to fetch cluster list
+func getClusterNames(masterIp string, dataCenter []*object.Datacenter) ([]string, error) {
+	var clusDetails, clusterList, clusterNames []string
+	framework.Logf("Fetching cluster details")
+	for i := 0; i < len(dataCenter); i++ {
+		clusterFolder := govcLoginCmd() + "govc ls " + dataCenter[i].InventoryPath
+		clusterFolderNameResult, err := sshExec(sshClientConfig, masterIp, clusterFolder)
+		if err != nil && clusterFolderNameResult.Code != 0 {
+			fssh.LogResult(clusterFolderNameResult)
+			return nil, fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				clusterFolder, masterIp, err)
+		}
+		if clusterFolderNameResult.Stdout != "" {
+			clusDetails = strings.Split(clusterFolderNameResult.Stdout, "\n")
+		}
+		clusterPathName := ""
+		for i := 0; i < len(clusDetails)-1; i++ {
+			if strings.Contains(clusDetails[i], "host") {
+				clusterPathName = clusDetails[i]
+				break
+			}
+		}
+		clusterGroup := govcLoginCmd() + "govc ls " + clusterPathName
+		clusterGroupResult, err := sshExec(sshClientConfig, masterIp, clusterGroup)
+		if err != nil && clusterGroupResult.Code != 0 {
+			fssh.LogResult(clusterGroupResult)
+			return nil, fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				clusterGroup, masterIp, err)
+		}
+		if clusterGroupResult.Stdout != "" {
+			clusterNames = strings.Split(clusterGroupResult.Stdout, "\n")
+		}
+		cluster := govcLoginCmd() + "govc ls " + clusterNames[0] + " | sort"
+		clusterResult, err := sshExec(sshClientConfig, masterIp, cluster)
+		if err != nil && clusterResult.Code != 0 {
+			fssh.LogResult(clusterResult)
+			return nil, fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				cluster, masterIp, err)
+		}
+		clusDetails = nil
+		if !strings.Contains(clusterResult.Stdout, "10.") {
+			if clusterResult.Stdout != "" {
+				clusListTemp := strings.Split(clusterResult.Stdout, "\n")
+				clusDetails = append(clusDetails, clusListTemp...)
+			}
+			for i := 0; i < len(clusDetails)-1; i++ {
+				clusterList = append(clusterList, clusDetails[i])
+			}
+			clusDetails = nil
+		} else {
+			for i := 0; i < len(clusterNames)-1; i++ {
+				clusterList = append(clusterList, clusterNames[i])
+			}
+			clusDetails = nil
+		}
+	}
+	return clusterList, nil
+}
+
+// getEsxiHostNames method is used to fetch esxi hosts details
+func getEsxiHostNames(masterIp string, cluster []string) ([]string, error) {
+	var hostsList, hostList []string
+	framework.Logf("Fetching ESXi host details")
+	for i := 0; i < len(cluster); i++ {
+		hosts := govcLoginCmd() + "govc ls " + cluster[i] + " " + " | grep 10."
+		hostsResult, err := sshExec(sshClientConfig, masterIp, hosts)
+		if err != nil && hostsResult.Code != 0 {
+			fssh.LogResult(hostsResult)
+			return nil, fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				hosts, masterIp, err)
+		}
+		if hostsResult.Stdout != "" {
+			hostListTemp := strings.Split(hostsResult.Stdout, "\n")
+			hostList = append(hostList, hostListTemp...)
+		}
+		for i := 0; i < len(hostList)-1; i++ {
+			hostsList = append(hostsList, hostList[i])
+		}
+		hostList = nil
+	}
+	return hostsList, nil
+}
+
+// getVmNames method is used to fetch vm details
+func getVmNames(masterIp string, dataCenter []*object.Datacenter) ([]string, error) {
+	var vmsList, vmList []string
+	framework.Logf("Fetching VM details")
+	for i := 0; i < len(dataCenter); i++ {
+		vms := govcLoginCmd() + "govc ls " + dataCenter[i].InventoryPath + "/vm" + " " + "| grep 'k8s\\|haproxy'"
+		vMsResult, err := sshExec(sshClientConfig, masterIp, vms)
+		if err != nil && vMsResult.Code != 0 {
+			fssh.LogResult(vMsResult)
+			return nil, fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				vms, masterIp, err)
+		}
+		if vMsResult.Stdout != "" {
+			vmListTemp := strings.Split(vMsResult.Stdout, "\n")
+			vmList = append(vmList, vmListTemp...)
+		}
+		for i := 0; i < len(vmList)-1; i++ {
+			vmsList = append(vmsList, vmList[i])
+		}
+		vmList = nil
+	}
+	return vmsList, nil
+}
+
+// getDatastoreNames method is used to fetch datastore details
+func getDatastoreNames(masterIp string, dataCenter []*object.Datacenter) ([]string, error) {
+	var dsList, datastores []string
+	framework.Logf("Fetching datastore details")
+	for i := 0; i < len(dataCenter); i++ {
+		ds := govcLoginCmd() + "govc ls " + dataCenter[i].InventoryPath + "/datastore"
+		dsResult, err := sshExec(sshClientConfig, masterIp, ds)
+		if err != nil && dsResult.Code != 0 {
+			fssh.LogResult(dsResult)
+			return nil, fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				ds, masterIp, err)
+		}
+		if dsResult.Stdout != "" {
+			dsListTemp := strings.Split(dsResult.Stdout, "\n")
+			dsList = append(dsList, dsListTemp...)
+		}
+		for i := 0; i < len(dsList)-1; i++ {
+			datastores = append(datastores, dsList[i])
+		}
+		dsList = nil
+	}
+	return datastores, nil
+}
+
+// setDataCenterLevelPermission is used to set data center level permissions for test user
+func setDataCenterLevelPermission(masterIp string, dataCenter string, testUser string,
+	propagateVal string, readOnlyRole string) error {
+	setPermissionForDataCenter := govcLoginCmd() + "govc permissions.set -principal " + testUser +
+		" -propagate=" + propagateVal + " -role " + readOnlyRole + " " + dataCenter + " | tr -d '\n'"
+	result, err := sshExec(sshClientConfig, masterIp, setPermissionForDataCenter)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			setPermissionForDataCenter, masterIp, err)
+	}
+
+	return nil
+}
+
+// setHostLevelPermission is used to set host level permissions for test user
+func setHostLevelPermission(masterIp string, testUser string, hosts []string, propagateVal string,
+	readOnlyRole string) error {
+	for i := 0; i < len(hosts); i++ {
+		setPermissionForHosts := govcLoginCmd() + "govc permissions.set -principal " +
+			testUser + " -propagate=" + propagateVal + " -role " + readOnlyRole + " " + hosts[i] + "| tr -d '\n'"
+		result, err := sshExec(sshClientConfig, masterIp, setPermissionForHosts)
+		if err != nil && result.Code != 0 {
+			fssh.LogResult(result)
+			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				setPermissionForHosts, masterIp, err)
+		}
+	}
+
+	return nil
+}
+
+// setVMLevelPermission is used to set vm level permissions for test user
+func setVMLevelPermission(masterIp string, testUserAlias string, testUser string, vms []string,
+	propagateVal string, vmRole string) error {
+	for i := 0; i < len(vms); i++ {
+		setPermissionForK8sVms := govcLoginCmd() + "govc permissions.set -principal " +
+			testUserAlias + " -propagate=" + propagateVal + " -role " + vmRole + "-" + testUser +
+			" " + vms[i] + " | tr -d '\n'"
+		result, err := sshExec(sshClientConfig, masterIp, setPermissionForK8sVms)
+		framework.Logf("Vm level permissions %s", setPermissionForK8sVms)
+		if err != nil && result.Code != 0 {
+			fssh.LogResult(result)
+			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				setPermissionForK8sVms, masterIp, err)
+		}
+	}
+	return nil
+}
+
+// setClusterLevelPermission is used to set cluster level permissions for test user
+func setClusterLevelPermission(masterIp string, testUserAlias string, testUser string, cluster string,
+	propagateVal string, hostRole string) error {
+	setPermissionForCluster := govcLoginCmd() + "govc permissions.set -principal " +
+		testUserAlias + " -propagate=" + propagateVal + " -role " + hostRole + "-" +
+		testUser + " " + cluster + " | tr -d '\n'"
+	framework.Logf("Cluster level permissions %s", setPermissionForCluster)
+	result, err := sshExec(sshClientConfig, masterIp, setPermissionForCluster)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			setPermissionForCluster, masterIp, err)
+	}
+	return nil
+}
+
+// setDataStoreLevelPermission is used to set datastore level permissions for test user
+func setDataStoreLevelPermission(masterIp string, testUserAlias string, testUser string, dataCenter string,
+	datastores []string, propagateVal string, datastoreRole string) error {
+	for i := 0; i < len(datastores); i++ {
+		setPermissionForDataStore := govcLoginCmd() + "govc permissions.set -principal " +
+			testUserAlias + " " + "-propagate=" + propagateVal + " -role " + datastoreRole + "-" + testUser + " '" +
+			datastores[i] + "'"
+		framework.Logf("Datastore level permissions %s", setPermissionForDataStore)
+		result, err := sshExec(sshClientConfig, masterIp, setPermissionForDataStore)
+		if err != nil && result.Code != 0 {
+			fssh.LogResult(result)
+			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				setPermissionForDataStore, masterIp, err)
+		}
+	}
+	return nil
+}
+
+// setSearchlevelPermission method is used to set search level permissions
+func setSearchlevelPermission(masterIp string, testUserAlias string, testUser string,
+	propagateVal string, searchRole string) error {
+	setSearchLevelPermission := govcLoginCmd() + "govc permissions.set -principal " + testUserAlias +
+		" -propagate=" + propagateVal + " -role " + searchRole + "-" + testUser + " /"
+	framework.Logf("Search level permissions %s", setSearchLevelPermission)
+	result, err := sshExec(sshClientConfig, masterIp, setSearchLevelPermission)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			setSearchLevelPermission, masterIp, err)
+	}
+	return nil
+}
+
+// createCsiVsphereSecret method is used to create csi vsphere secret file
+func createCsiVsphereSecret(client clientset.Interface, ctx context.Context, testUser string,
+	password string, csiNamespace string) {
+	currentSecret, err := client.CoreV1().Secrets(csiNamespace).Get(ctx, configSecret, metav1.GetOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	originalConf := string(currentSecret.Data[vSphereCSIConf])
+	vsphereCfg, err := readConfigFromSecretString(originalConf)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	vsphereCfg.Global.User = testUser
+	vsphereCfg.Global.Password = password
+	modifiedConf, err := writeConfigToSecretString(vsphereCfg)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	framework.Logf("Updating the secret to reflect new conf credentials")
+	currentSecret.Data[vSphereCSIConf] = []byte(modifiedConf)
+	_, err = client.CoreV1().Secrets(csiNamespace).Update(ctx, currentSecret, metav1.UpdateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+/*
+createTestUserAndAssignRolesPrivileges method is used to create test user, assign
+roles and privileges to test user
+*/
+func createTestUserAndAssignRolesPrivileges(masterIp string, configSecretTestUser string,
+	configSecretTestUserPassword string, configSecretTestUserAlias string, propagateVal string,
+	dataCenters []*object.Datacenter, clusters []string, hosts []string,
+	vms []string, datastores []string) {
+	roleMap := userRoleMap()
+
+	framework.Logf("Create TestUser")
+	err := createTestUser(masterIp, configSecretTestUser, configSecretTestUserPassword)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+		masterIp, err)
+
+	framework.Logf("Create roles for TestUser")
+	err = createRolesForTestUser(masterIp, configSecretTestUser)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+		masterIp, err)
+
+	for key := range roleMap {
+		if strings.Contains(key, "VM") {
+			framework.Logf("Assign vm level permissions")
+			err = setVMLevelPermission(masterIp, configSecretTestUserAlias, configSecretTestUser, vms,
+				propagateVal, key)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+				masterIp, err)
+		}
+		if strings.Contains(key, "HOST") {
+			framework.Logf("Assign cluster level permissions")
+			for i := 0; i < len(clusters); i++ {
+				err = setClusterLevelPermission(masterIp, configSecretTestUserAlias, configSecretTestUser,
+					clusters[i], propagateVal, key)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+					masterIp, err)
+			}
+		}
+		if strings.Contains(key, "DATASTORE") {
+			framework.Logf("Assign datastores level permissions")
+			for i := 0; i < len(dataCenters); i++ {
+				err = setDataStoreLevelPermission(masterIp, configSecretTestUserAlias, configSecretTestUser,
+					dataCenters[i].InventoryPath, datastores, propagateVal, key)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+					masterIp, err)
+			}
+		}
+		if strings.Contains(key, "SEARCH") {
+			framework.Logf("Assign search level permissions")
+			err = setSearchlevelPermission(masterIp, configSecretTestUserAlias, configSecretTestUser,
+				propagateVal, key)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+				masterIp, err)
+		}
+		if strings.Contains(key, "ReadOnly") {
+			framework.Logf("Assign datacenter level read-only permissions")
+			for i := 0; i < len(dataCenters); i++ {
+				err = setDataCenterLevelPermission(masterIp, dataCenters[i].InventoryPath, configSecretTestUserAlias,
+					propagateVal, key)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+					masterIp, err)
+			}
+
+			framework.Logf("Assign host level read-only permissions")
+			err = setHostLevelPermission(masterIp, configSecretTestUserAlias, hosts, propagateVal, key)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+				masterIp, err)
+		}
+	}
+}
+
+/*
+deleteTestUserAndRemoveRolesPrivileges method is used to delete test user and to remove assigned
+roles and privileges to test user
+*/
+func deleteTestUserAndRemoveRolesPrivileges(masterIp string, configSecretTestUser string,
+	configSecretTestUserPassword string, configSecretTestUserAlias string, propagateVal string,
+	dataCenters []*object.Datacenter, clusters []string, hosts []string,
+	vms []string, datastores []string) {
+	framework.Logf("Delete users roles and permissions")
+	deleteUsersRolesAndPermissions(masterIp, configSecretTestUser, configSecretTestUserAlias, dataCenters,
+		clusters, hosts, vms, datastores)
+
+	framework.Logf("Delete Test user")
+	err := deleteTestUser(masterIp, configSecretTestUser)
+	if err != nil {
+		if strings.Contains(err.Error(), "doesn't exist") {
+			framework.Logf("test user doesn't exist")
+		} else {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
+				masterIp, err)
+		}
+	}
+}
+
+// userRoleMap util method returns a map of roles required for a test user
+func userRoleMap() map[string]string {
+	roleMap := make(map[string]string)
+	roleMap["CNS-DATASTORE"] = "Datastore.FileManagement"
+	roleMap["CNS-HOST-CONFIG-STORAGE"] = "Host.Config.Storage"
+	roleMap["CNS-VM"] = "VirtualMachine.Config.AddExistingDisk VirtualMachine.Config.AddRemoveDevice"
+	roleMap["CNS-SEARCH-AND-SPBM"] = "Cns.Searchable StorageProfile.View"
+	roleMap["ReadOnly"] = "ReadOnly"
+
+	return roleMap
+}

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -249,6 +249,13 @@ var (
 	envTestbedInfoJsonPath = "TESTBEDINFO_JSON"
 )
 
+// Config secret testuser credentials
+var (
+	configSecretTestUser1Password = "VMware!23"
+	configSecretTestUser1         = "testuser1"
+	configSecretTestUser2         = "testuser2"
+)
+
 // CSI Internal FSSs
 var (
 	useCsiNodeID = "use-csinode-id"


### PR DESCRIPTION
**What this PR does / why we need it**:
Config secret automation 

Part1 of this review - This PR consists of set of util/wrapper methods required for updating vsphere conf file with different user credentials and later verifying the volume creation and attachment with different user credentials.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Testing done**:
Yes

Testcase1 - https://gist.githubusercontent.com/sipriyaa/93befec77ac1eeeda79ddb2aaa02ab99/raw/2f92a80787965a1e82f927fc2b5fe73bec2c844e/gistfile1.txt

Special notes for your reviewer:

Release note:
-->
Config secret - Util methods along with testcase "updating vsphere conf file with different testuser credentials

Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint 
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/config-secret-part1/vsphere-csi-driver /Users/sipriya/config-secret-part1 /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (files|name|compiled_files|deps|exports_file|imports|types_sizes) took 14.984900079s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 113.656634ms 
INFO [linters context/goanalysis] analyzers took 2m57.886424992s with top 10 stages: buildir: 2m2.46025757s, nilness: 6.152616367s, printf: 5.954271202s, ctrlflow: 5.748861574s, fact_deprecated: 4.836142805s, fact_purity: 3.670024276s, typedness: 3.556831s, SA5012: 3.260623103s, misspell: 2.121718061s, inspect: 1.918346598s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude-rules: 1/24, path_prettifier: 113/113, skip_files: 113/113, identifier_marker: 24/24, filename_unadjuster: 113/113, autogenerated_exclude: 24/113, exclude: 24/24, nolint: 0/1, cgo: 113/113, skip_dirs: 113/113 
INFO [runner] processing took 15.245112ms with stages: nolint: 13.064929ms, autogenerated_exclude: 1.315278ms, path_prettifier: 352.836µs, identifier_marker: 274.882µs, skip_dirs: 116.481µs, exclude-rules: 100.665µs, cgo: 7.582µs, filename_unadjuster: 7.513µs, max_same_issues: 1.373µs, uniq_by_line: 930ns, max_from_linter: 387ns, source_code: 364ns, diff: 343ns, skip_files: 303ns, exclude: 270ns, max_per_file_from_linter: 235ns, severity-rules: 212ns, path_shortener: 210ns, sort_results: 201ns, path_prefixer: 118ns 
INFO [runner] linters took 21.986160685s with stages: goanalysis_metalinter: 21.970825273s 
INFO File cache stats: 284 entries of total size 4.6MiB 
INFO Memory: 359 samples, avg is 792.4MB, max is 1963.5MB 
INFO Execution took 37.095787165s                 
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint            
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/config-secret-part1/vsphere-csi-driver /Users/sipriya/config-secret-part1 /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (exports_file|types_sizes|imports|name|compiled_files|deps|files) took 3.585686559s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 127.746358ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 113/113, autogenerated_exclude: 24/113, cgo: 113/113, skip_dirs: 113/113, exclude-rules: 1/24, path_prettifier: 113/113, identifier_marker: 24/24, skip_files: 113/113, nolint: 0/1, exclude: 24/24 
INFO [runner] processing took 14.136991ms with stages: nolint: 11.931427ms, autogenerated_exclude: 1.212911ms, path_prettifier: 445.349µs, identifier_marker: 282.234µs, skip_dirs: 115.285µs, exclude-rules: 96.962µs, filename_unadjuster: 32.238µs, cgo: 15.904µs, max_same_issues: 1.192µs, max_from_linter: 648ns, source_code: 597ns, uniq_by_line: 511ns, diff: 308ns, skip_files: 287ns, exclude: 226ns, severity-rules: 225ns, max_per_file_from_linter: 195ns, path_shortener: 193ns, sort_results: 188ns, path_prefixer: 111ns 
INFO [runner] linters took 2.022114876s with stages: goanalysis_metalinter: 2.007892754s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 59 samples, avg is 97.6MB, max is 140.9MB 
INFO Execution took 5.74771753s                   
sipriya@sipriya-a01 vsphere-csi-driver % 
sipriya@sipriya-a01 vsphere-csi-driver % 
sipriya@sipriya-a01 vsphere-csi-driver % git status
