### PR TITLE
add feature-gate for 256 volumes per node feature

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -155,6 +155,7 @@ data:
   "pv-to-backingdiskobjectid-mapping": "false"
   "cnsmgr-suspend-create-volume": "false"
   "topology-preferential-datastores": "false"
+  "max-pvscsi-targets-per-vm" : "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -359,4 +359,6 @@ const (
 	// TopologyPreferentialDatastores is the feature gate for preferential
 	// datastore deployment in topology aware environments.
 	TopologyPreferentialDatastores = "topology-preferential-datastores"
+	// MaxPVSCSITargetsPerVM enables support for 255 volumes per node vm
+	MaxPVSCSITargetsPerVM = "max-pvscsi-targets-per-vm"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We do not want to release 256 volume per node feature in CSI 2.6 release.
In this commit - https://github.com/kubernetes-sigs/vsphere-csi-driver/commit/008b6925359f8633e8ea8129b3a27298189eab22 we allowed the option for the customer to increase the default 59 volumes per node to 255.

This PR is adding a feature-gate `max-pvscsi-targets-per-vm` to disable users from increasing volumes per node to 255.
Later when we release vSphere 8.0 with support for 255 volumes per node, we will enable feature gate - `max-pvscsi-targets-per-vm`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add feature-gate for 256 volumes per node feature
```
