### PR TITLE
Relocate volume tests for  policy driven volume allocation

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -73,6 +73,7 @@ const (
 	envSharedVVOLDatastoreURL                  = "SHARED_VVOL_DATASTORE_URL"
 	envSharedNFSDatastoreURL                   = "SHARED_NFS_DATASTORE_URL"
 	envSharedVMFSDatastoreURL                  = "SHARED_VMFS_DATASTORE_URL"
+	envSharedVMFSDatastore2URL                 = "SHARED_VMFS_DATASTORE2_URL"
 	envStoragePolicyNameForNonSharedDatastores = "STORAGE_POLICY_FOR_NONSHARED_DATASTORES"
 	envStoragePolicyNameForSharedDatastores    = "STORAGE_POLICY_FOR_SHARED_DATASTORES"
 	envStoragePolicyNameForSharedDatastores2   = "STORAGE_POLICY_FOR_SHARED_DATASTORES_2"

--- a/tests/e2e/vcp_to_csi_attach_detach.go
+++ b/tests/e2e/vcp_to_csi_attach_detach.go
@@ -1059,7 +1059,13 @@ func createMultiplePods(ctx context.Context, client clientset.Interface,
 						gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel),
 					)
 				}
-				volHandle := getVolHandle4Pvc(ctx, client, pvc)
+				var volHandle string
+				volHandle = getVolHandle4Pvc(ctx, client, pvc)
+				if guestCluster {
+					pv := getPvFromClaim(client, pvc.Namespace, pvc.Name)
+					volHandle = getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
+					gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+				}
 				ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s, VMUUID : %s",
 					volHandle, pod.Spec.NodeName, vmUUID))
 				isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)


### PR DESCRIPTION
**What this PR does / why we need it**: Relocate volume tests for policy driven volume allocation 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/54dd6655496fd3abb15611b01ab5649c
**Special notes for your reviewer**: Please note that volume allocation for vsan direct is not enabled in latest main builds.

make check output
```
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.1
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/kai/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/provider sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/vol_allocation-part1/vsphere-csi-driver /Users/kai/vol_allocation-part1 /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (types_sizes|compiled_files|files|imports|name|deps|exports_file) took 1.655827541s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 106.983983ms 
INFO [linters context/goanalysis] analyzers took 10.525641608s with top 10 stages: S1038: 658.287547ms, buildir: 580.058472ms, misspell: 497.751521ms, S1039: 293.948762ms, unused: 260.655186ms, directives: 255.147847ms, SA1012: 250.741222ms, S1028: 243.444297ms, S1024: 215.213856ms, S1030: 171.012429ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 113/113, autogenerated_exclude: 24/113, identifier_marker: 24/24, exclude: 24/24, exclude-rules: 1/24, cgo: 113/113, path_prettifier: 113/113, skip_files: 113/113, skip_dirs: 113/113, nolint: 0/1 
INFO [runner] processing took 15.922721ms with stages: nolint: 13.283088ms, autogenerated_exclude: 1.375838ms, path_prettifier: 693.543µs, identifier_marker: 295.179µs, skip_dirs: 144.563µs, exclude-rules: 108.801µs, cgo: 9.772µs, filename_unadjuster: 8.228µs, max_same_issues: 854ns, uniq_by_line: 427ns, diff: 352ns, skip_files: 311ns, max_from_linter: 304ns, exclude: 262ns, source_code: 256ns, severity-rules: 240ns, max_per_file_from_linter: 206ns, path_shortener: 188ns, sort_results: 173ns, path_prefixer: 136ns 
INFO [runner] linters took 5.934828072s with stages: goanalysis_metalinter: 5.91881367s 
INFO File cache stats: 92 entries of total size 2.8MiB 
INFO Memory: 79 samples, avg is 260.3MB, max is 616.8MB 
INFO Execution took 7.710417952s                  
(base) kai@kai-a01 vsphere-csi-driver % 
```

