### PR TITLE
[cherry-pick-release-2.5] protect migrated volume from vm deletion (#1762)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae
-	github.com/vmware/govmomi v0.27.4
+	github.com/vmware/govmomi v0.27.5
 	go.uber.org/zap v1.17.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
@@ -36,7 +36,6 @@ require (
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/yaml.v2 v2.4.0
-	honnef.co/go/tools v0.2.0 // indirect
 	k8s.io/api v0.21.1
 	k8s.io/apiextensions-apiserver v0.21.1
 	k8s.io/apimachinery v0.21.1

--- a/go.sum
+++ b/go.sum
@@ -688,8 +688,8 @@ github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1
 github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae h1:R7ukgIC/uN4vULAvwWJxuq2XLcUEJkR4psxdRNssqSI=
 github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/vmware/govmomi v0.27.4 h1:5kY8TAkhB20lsjzrjE073eRb8+HixBI29PVMG5lxq6I=
-github.com/vmware/govmomi v0.27.4/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
+github.com/vmware/govmomi v0.27.5 h1:/F8S4YfsLHy8J2e1X3rIl/Lup7R67zjTW9bXLv/q3ic=
+github.com/vmware/govmomi v0.27.5/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
@@ -783,7 +783,6 @@ golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1106,8 +1105,6 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
-honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 k8s.io/api v0.21.1 h1:94bbZ5NTjdINJEdzOkpS4vdPhkb1VFpTYC9zh43f75c=
 k8s.io/api v0.21.1/go.mod h1:FstGROTmsSHBarKc8bylzXih8BLNYTiS3TZcsoEDg2s=
 k8s.io/apiextensions-apiserver v0.21.1 h1:AA+cnsb6w7SZ1vD32Z+zdgfXdXY8X9uGX5bN6EoPEIo=

--- a/pkg/apis/migration/config/cns.vmware.com_cnsvspherevolumemigrations.yaml
+++ b/pkg/apis/migration/config/cns.vmware.com_cnsvspherevolumemigrations.yaml
@@ -45,6 +45,9 @@ spec:
               volumepath:
                 description: VolumePath is the vmdk path of the vSphere Volume
                 type: string
+              protectvolumefromvmdelete:
+                description: protect volume from vm deletion after vmdk is migrated to CSI
+                type: boolean
             required:
             - volumeid
             - volumepath

--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -73,6 +73,10 @@ type VolumeMigrationService interface {
 	// DeleteVolumeInfo helps delete mapping of volumePath to VolumeID for
 	// specified volumeID.
 	DeleteVolumeInfo(ctx context.Context, volumeID string) error
+
+	// ProtectVolumeFromVMDeletion sets keepAfterDeleteVm control flag on the migrated volume
+	// Returns an error if not able to set keepAfterDeleteVm control flag on the volume
+	ProtectVolumeFromVMDeletion(ctx context.Context, volumeID string) error
 }
 
 // volumeMigration holds migrated volume information and provides functionality
@@ -235,6 +239,39 @@ func (volumeMigration *volumeMigration) GetVolumeID(ctx context.Context, volumeS
 	return "", ErrVolumeIDNotFound
 }
 
+// ProtectVolumeFromVMDeletion sets keepAfterDeleteVm control flag on the migrated volume
+// Returns an error if not able to set keepAfterDeleteVm control flag on the volume
+func (volumeMigration *volumeMigration) ProtectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	log := logger.GetLogger(ctx)
+	volumeMigrationResource := &migrationv1alpha1.CnsVSphereVolumeMigration{}
+	var err error
+	err = volumeMigration.k8sClient.Get(ctx, client.ObjectKey{Name: volumeID}, volumeMigrationResource)
+	if err != nil {
+		log.Errorf("error while getting CnsVSphereVolumeMigration CR for VolumeID: %q, err: %v", volumeID, err)
+		return err
+	}
+	if !volumeMigrationResource.Spec.ProtectVolumeFromVMDelete {
+		log.Info("Set keepAfterDeleteVm control flag using Vslm APIs")
+		err = (*volumeMigration.volumeManager).ProtectVolumeFromVMDeletion(ctx, volumeID)
+		if err != nil {
+			log.Errorf("failed to protect migrated volume from vm deletion. Volume ID: %q, err: %v", volumeID, err)
+			return err
+		}
+		log.Infof("Migrated Volume with ID: %q is protected from VM deletion", volumeID)
+	} else {
+		log.Infof("Migrated volume with ID: %q is already protected from vm deletion", volumeID)
+		return nil
+	}
+	volumeMigrationResource.Spec.ProtectVolumeFromVMDelete = true
+	err = volumeMigration.k8sClient.Update(ctx, volumeMigrationResource)
+	if err != nil {
+		log.Errorf("error happened while updating volumeMigration CR to set ProtectVolumeFromVMDelete true "+
+			"for VolumeID: %q, err: %v", volumeID, err)
+		return err
+	}
+	return nil
+}
+
 // GetVolumePath returns VolumePath for given VolumeID.
 // Returns an error if not able to retrieve VolumePath.
 func (volumeMigration *volumeMigration) GetVolumePath(ctx context.Context, volumeID string) (string, error) {
@@ -255,7 +292,7 @@ func (volumeMigration *volumeMigration) GetVolumePath(ctx context.Context, volum
 	err := volumeMigration.k8sClient.Get(ctx, client.ObjectKey{Name: volumeID}, volumeMigrationResource)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			log.Errorf("error happened while getting CR for volumeMigration for VolumeID: %q, err: %v", volumeID, err)
+			log.Errorf("error while getting CnsVSphereVolumeMigration CR for VolumeID: %q, err: %v", volumeID, err)
 			return "", err
 		}
 	} else {

--- a/pkg/apis/migration/v1alpha1/types.go
+++ b/pkg/apis/migration/v1alpha1/types.go
@@ -37,6 +37,8 @@ type CnsVSphereVolumeMigrationSpec struct {
 	VolumePath string `json:"volumepath"`
 	// VolumeID is the FCD ID obtained after register volume with CNS.
 	VolumeID string `json:"volumeid"`
+	// ProtectVolumeFromVMDelete true means migrated volumes is protected from Node VM deletion
+	ProtectVolumeFromVMDelete bool `json:"protectvolumefromvmdelete"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -109,6 +109,8 @@ type Manager interface {
 	RegisterDisk(ctx context.Context, path string, name string) (string, error)
 	// RetrieveVStorageObject helps in retreiving virtual disk information for a given volume id.
 	RetrieveVStorageObject(ctx context.Context, volumeID string) (*vim25types.VStorageObject, error)
+	// ProtectVolumeFromVMDeletion sets keepAfterDeleteVm control flag on migrated volume
+	ProtectVolumeFromVMDeletion(ctx context.Context, volumeID string) error
 	// CreateSnapshot helps create a snapshot for a block volume
 	CreateSnapshot(ctx context.Context, volumeID string, desc string) (*CnsSnapshotInfo, error)
 	// DeleteSnapshot helps delete a snapshot for a block volume
@@ -2228,4 +2230,29 @@ func (m *defaultManager) DeleteSnapshot(ctx context.Context, volumeID string, sn
 			prometheus.PrometheusPassStatus).Observe(time.Since(start).Seconds())
 	}
 	return err
+}
+
+// ProtectVolumeFromVMDeletion helps set keepAfterDeleteVm control flag for given volumeID
+func (m *defaultManager) ProtectVolumeFromVMDeletion(ctx context.Context, volumeID string) error {
+	log := logger.GetLogger(ctx)
+	err := validateManager(ctx, m)
+	if err != nil {
+		log.Errorf("failed to validate volume manager with err: %+v", err)
+		return err
+	}
+	// Set up the VC connection
+	err = m.virtualCenter.ConnectVslm(ctx)
+	if err != nil {
+		log.Errorf("ConnectVslm failed with err: %+v", err)
+		return err
+	}
+	globalObjectManager := vslm.NewGlobalObjectManager(m.virtualCenter.VslmClient)
+	err = globalObjectManager.SetControlFlags(ctx, vim25types.ID{Id: volumeID}, []string{
+		string(vim25types.VslmVStorageObjectControlFlagKeepAfterDeleteVm)})
+	if err != nil {
+		log.Errorf("failed to set control flag keepAfterDeleteVm  for volumeID %q with err: %v", volumeID, err)
+		return err
+	}
+	log.Infof("Successfully set keepAfterDeleteVm control flag for volumeID: %q", volumeID)
+	return nil
 }

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1071,6 +1071,11 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 						"failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
 				}
+				err = volumeMigrationService.ProtectVolumeFromVMDeletion(ctx, req.VolumeId)
+				if err != nil {
+					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
+						"failed to set keepAfterDeleteVm control flag for VolumeID %q", req.VolumeId)
+				}
 			}
 			var node *cnsvsphere.VirtualMachine
 			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry Pick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1762 to release 2.5 branch.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
protect migrated volume from vm deletion
```
