### PR TITLE
[yaml] Add online-volume-extend FSS in 1.21, 1.22, 1.23 WCP and GC yamls

### DIFF
--- a/manifests/guestcluster/1.21/pvcsi.yaml
+++ b/manifests/guestcluster/1.21/pvcsi.yaml
@@ -435,6 +435,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"

--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -463,6 +463,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"

--- a/manifests/guestcluster/1.23/pvcsi.yaml
+++ b/manifests/guestcluster/1.23/pvcsi.yaml
@@ -472,6 +472,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -384,6 +384,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
   "vsan-direct-disk-decommission": "true"

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -403,6 +403,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
   "vsan-direct-disk-decommission": "true"

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -404,6 +404,7 @@ data:
   "volume-extend": "true"
   "volume-health": "true"
   "file-volume": "true"
+  "online-volume-extend": "true"
   "csi-auth-check": "true"
   "vsan-direct-disk-decommission": "true"
   "trigger-csi-fullsync": "false"


### PR DESCRIPTION
**What this PR does / why we need it**:

### What went wrong

Referring to the diagram in PR (https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1632), 

old GC/Supervisor == online-volume-extend FSS check is present, 
new GC/Supervisor == online-volume-extend FSS check is removed, and
new VC is VC >= 7.0U2

CSI 2.4 would be considered "old" in this case as it still has the FSS check. 

So, this case is where GC is old, Supervisor is new and VC is new. 

For a new Supervisor, the thinking was that GC request will be passed to Supervisor, Supervisor will check for VC version and since VC is new (>= 7.0U2), supervisor will allow the request. 

What I failed to consider was that old GC checks if the FSS exists in Supervisor. (See commit before my check-in -> https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/release-2.4/pkg/csi/service/wcpguest/controller.go#L1069)

Since my PR also removed the FSS from the csi-feature-states ConfigMap in cnscsi.yaml for 1.21, 1.22, and 1.23, GC cannot find the FSS in Supervisor's csi-feature-states ConfigMap. 

### Fix

Add online-volume-extend: "true" FSS in 1.21, 1.22, 1.23 WCP and GC yaml files

<img width="736" alt="Screen Shot 2022-06-03 at 11 28 45 AM" src="https://user-images.githubusercontent.com/21956662/171941504-16601d94-c52f-4923-9c92-baa85b8e9c69.png">


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Added online-volume-extend: "true" in WCP FSS configmap

```
root@4228e5a9189a8871b00edc294031ad2f [ ~ ]# k edit configmap -n vmware-system-csi
configmap/csi-feature-states edited
configmap/kube-root-ca.crt skipped

root@4228e5a9189a8871b00edc294031ad2f [ ~ ]# cat pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pvc-test
  namespace: volume-expansion-8081
spec:
 storageClassName: sc-hdsmd
 accessModes:
   - ReadWriteOnce
 resources:
   requests:
     storage: 1Gi

root@4228e5a9189a8871b00edc294031ad2f [ ~ ]# k create -f pvc.yaml -n volume-expansion-8081
persistentvolumeclaim/pvc-test created

root@4228e5a9189a8871b00edc294031ad2f [ ~ ]# k get pvc -n volume-expansion-8081
NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pvc-test   Bound    pvc-e8d95304-3c5f-4933-8a6f-1e7ebba4272c   1Gi        RWO            sc-hdsmd       16s

root@4228e5a9189a8871b00edc294031ad2f [ ~ ]# cat apod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  namespace: volume-expansion-8081
spec:
  containers:
    - name: test-container
      image: gcr.io/google_containers/busybox:1.27
      command: ["/bin/sh", "-c", "while true ; do sleep 2 ; done"]
      volumeMounts:
      - name: volume1
        mountPath: /mnt/volume1
  restartPolicy: Never
  volumes:
    - name: volume1
      persistentVolumeClaim:
        claimName: pvc-test


root@4228e5a9189a8871b00edc294031ad2f [ ~ ]# k create -f apod.yaml -n volume-expansion-8081
pod/test-pod created

root@4228e5a9189a8871b00edc294031ad2f [ ~ ]# k get po -n volume-expansion-8081
NAME       READY   STATUS    RESTARTS   AGE
test-pod   1/1     Running   0          18s

root@4228e5a9189a8871b00edc294031ad2f [ ~ ]# k edit pvc -n volume-expansion-8081

# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
  creationTimestamp: "2022-06-03T19:05:13Z"
  finalizers:
  - kubernetes.io/pvc-protection
  name: pvc-test
  namespace: volume-expansion-8081
  resourceVersion: "1039435"
  uid: e8d95304-3c5f-4933-8a6f-1e7ebba4272c
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  storageClassName: sc-hdsmd
  volumeMode: Filesystem
  volumeName: pvc-e8d95304-3c5f-4933-8a6f-1e7ebba4272c
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound
~
~
~
:wq!

persistentvolumeclaim/pvc-test edited

root@4228e5a9189a8871b00edc294031ad2f [ ~ ]# k get pvc -n volume-expansion-8081 -w
NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pvc-test   Bound    pvc-e8d95304-3c5f-4933-8a6f-1e7ebba4272c   1Gi        RWO            sc-hdsmd       2m53s
pvc-test   Bound    pvc-e8d95304-3c5f-4933-8a6f-1e7ebba4272c   5Gi        RWO            sc-hdsmd       3m8s

root@4228e5a9189a8871b00edc294031ad2f [ ~ ]# k get pvc -n volume-expansion-8081
NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pvc-test   Bound    pvc-e8d95304-3c5f-4933-8a6f-1e7ebba4272c   5Gi        RWO            sc-hdsmd       3m27s

```

make check

```
(~/GolandProjects/vsphere-csi-driver) $ make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.1
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/adkulkarni/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/provider sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/adkulkarni/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/adkulkarni/GolandProjects/vsphere-csi-driver /Users/adkulkarni/GolandProjects /Users/adkulkarni /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (name|deps|exports_file|files|imports|types_sizes|compiled_files) took 3.745924092s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 132.186653ms
INFO [linters context/goanalysis] analyzers took 34.76150277s with top 10 stages: buildir: 19.427567932s, misspell: 1.329472456s, S1038: 1.067401492s, printf: 609.366752ms, nilness: 587.307563ms, unused: 576.828807ms, directives: 514.294335ms, ctrlflow: 500.889619ms, S1039: 465.305696ms, typedness: 407.665869ms
INFO [runner] Issues before processing: 113, after processing: 0
INFO [runner] Processors filtering stat (out/in): path_prettifier: 113/113, skip_files: 113/113, exclude-rules: 1/24, identifier_marker: 24/24, nolint: 0/1, exclude: 24/24, cgo: 113/113, filename_unadjuster: 113/113, skip_dirs: 113/113, autogenerated_exclude: 24/113
INFO [runner] processing took 23.660745ms with stages: nolint: 16.217276ms, autogenerated_exclude: 6.030515ms, identifier_marker: 634.447µs, path_prettifier: 462.355µs, exclude-rules: 157.301µs, skip_dirs: 136.769µs, filename_unadjuster: 8.614µs, cgo: 8.424µs, max_same_issues: 1.167µs, uniq_by_line: 791ns, diff: 428ns, max_from_linter: 412ns, source_code: 344ns, exclude: 321ns, skip_files: 317ns, path_shortener: 269ns, max_per_file_from_linter: 266ns, severity-rules: 255ns, sort_results: 254ns, path_prefixer: 220ns
INFO [runner] linters took 11.527884841s with stages: goanalysis_metalinter: 11.50410728s
INFO File cache stats: 230 entries of total size 4.5MiB
INFO Memory: 156 samples, avg is 442.7MB, max is 1020.8MB
INFO Execution took 15.417637045s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
