### PR TITLE
[Fix-dot-import]: Fixing dot import for the importing the e2e module into cns-manager repo

### DIFF
--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -22,9 +22,9 @@ import (
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
 
-	. "github.com/onsi/ginkgo"
+	ginkgo "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
-	. "github.com/onsi/gomega"
+	gomega "github.com/onsi/gomega"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
 )
@@ -45,9 +45,10 @@ func init() {
 
 func TestE2E(t *testing.T) {
 	handleFlags()
-	RegisterFailHandler(Fail)
+	gomega.RegisterFailHandler(ginkgo.Fail)
 	junitReporter := reporters.NewJUnitReporter("junit.xml")
-	RunSpecsWithDefaultAndCustomReporters(t, "CNS CSI Driver End-to-End Tests", []Reporter{junitReporter})
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "CNS CSI Driver End-to-End Tests",
+		[]ginkgo.Reporter{junitReporter})
 }
 
 func handleFlags() {


### PR DESCRIPTION
[Fix-dot-import]: Fixing dot import for the importing the e2e module into cns-manager repo

**What this PR does / why we need it**:
[Fix-dot-import]: Fixing dot import for the importing the e2e module into cns-manager repo

**Testing done**:
Yes
https://gist.github.com/rpanduranga/6865a5ae55c51afe460a98e05af8d93e


**Special notes for your reviewer**:
NA

**Release note**:
NA
