### PR TITLE
Revert "Remove FSS guard for online volume expansion feature (#1632)"

### DIFF
--- a/manifests/guestcluster/1.21/pvcsi.yaml
+++ b/manifests/guestcluster/1.21/pvcsi.yaml
@@ -435,6 +435,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"

--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -463,6 +463,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"

--- a/manifests/guestcluster/1.23/pvcsi.yaml
+++ b/manifests/guestcluster/1.23/pvcsi.yaml
@@ -472,6 +472,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -384,6 +384,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
   "vsan-direct-disk-decommission": "true"

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -403,6 +403,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
   "vsan-direct-disk-decommission": "true"

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -403,6 +403,7 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
+  "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
   "vsan-direct-disk-decommission": "true"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -144,6 +144,7 @@ apiVersion: v1
 data:
   "csi-migration": "false"
   "csi-auth-check": "true"
+  "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"
   "async-query-volume": "true"
   "improved-csi-idempotency": "true"

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -309,6 +309,8 @@ const (
 	VolumeHealth = "volume-health"
 	// VolumeExtend is feature flag name for volume expansion.
 	VolumeExtend = "volume-extend"
+	// OnlineVolumeExtend guards the feature for online volume expansion.
+	OnlineVolumeExtend = "online-volume-extend"
 	// CSIMigration is feature flag for migrating in-tree vSphere volumes to CSI.
 	CSIMigration = "csi-migration"
 	// CSIAuthCheck is feature flag for auth check.

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -628,21 +628,23 @@ func (driver *vsphereCSIDriver) NodeExpandVolume(
 	}
 	log.Debugf("NodeExpandVolume: staging target path %s, getDevFromMount %+v", volumePath, *dev)
 
-	// Fetch the current block size.
-	currentBlockSizeBytes, err := driver.osUtils.GetBlockSizeBytes(ctx, dev.RealDev)
-	if err != nil {
-		return nil, logger.LogNewErrorCodef(log, codes.Internal,
-			"error when getting size of block volume at path %s: %v", dev.RealDev, err)
-	}
-	// Check if a rescan is required.
-	if currentBlockSizeBytes < reqVolSizeBytes {
-		// If a device is expanded while it is attached to a VM, we need to
-		// rescan the device on the guest OS in order to see the modified size
-		// on the Guest OS.
-		// Refer to https://kb.vmware.com/s/article/1006371
-		err = driver.osUtils.RescanDevice(ctx, dev)
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend) {
+		// Fetch the current block size.
+		currentBlockSizeBytes, err := driver.osUtils.GetBlockSizeBytes(ctx, dev.RealDev)
 		if err != nil {
-			return nil, logger.LogNewErrorCode(log, codes.Internal, err.Error())
+			return nil, logger.LogNewErrorCodef(log, codes.Internal,
+				"error when getting size of block volume at path %s: %v", dev.RealDev, err)
+		}
+		// Check if a rescan is required.
+		if currentBlockSizeBytes < reqVolSizeBytes {
+			// If a device is expanded while it is attached to a VM, we need to
+			// rescan the device on the guest OS in order to see the modified size
+			// on the Guest OS.
+			// Refer to https://kb.vmware.com/s/article/1006371
+			err = driver.osUtils.RescanDevice(ctx, dev)
+			if err != nil {
+				return nil, logger.LogNewErrorCode(log, codes.Internal, err.Error())
+			}
 		}
 	}
 

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1263,11 +1263,12 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to check if online expansion is supported due to error: %v", err)
 		}
-
-		err = validateVanillaControllerExpandVolumeRequest(ctx, req, isOnlineExpansionSupported)
+		isOnlineExpansionEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend)
+		err = validateVanillaControllerExpandVolumeRequest(ctx, req, isOnlineExpansionEnabled, isOnlineExpansionSupported)
 		if err != nil {
-			return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCodef(log, codes.Internal,
-				"validation for ExpandVolume Request: %+v has failed. Error: %v", *req, err)
+			msg := fmt.Sprintf("validation for ExpandVolume Request: %+v has failed. Error: %v", *req, err)
+			log.Error(msg)
+			return nil, csifault.CSIInternalFault, err
 		}
 		volumeType = prometheus.PrometheusBlockVolumeType
 

--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -61,32 +61,30 @@ func validateVanillaControllerUnpublishVolumeRequest(ctx context.Context,
 	return common.ValidateControllerUnpublishVolumeRequest(ctx, req)
 }
 
-// ValidateVanillaControllerExpandVolumeRequest is the helper function to
+// validateVanillaControllerExpandVolumeRequest is the helper function to
 // validate ExpandVolumeRequest for Vanilla CSI driver.
 // Function returns error if validation fails otherwise returns nil.
 func validateVanillaControllerExpandVolumeRequest(ctx context.Context,
-	req *csi.ControllerExpandVolumeRequest, isOnlineExpansionSupported bool) error {
+	req *csi.ControllerExpandVolumeRequest, isOnlineExpansionEnabled, isOnlineExpansionSupported bool) error {
 	log := logger.GetLogger(ctx)
 	if err := common.ValidateControllerExpandVolumeRequest(ctx, req); err != nil {
 		return err
 	}
 
-	// If online expansion is not supported (VC below 7.0U2),
-	// we need to determine if requested operation is online or offline.
-	if !isOnlineExpansionSupported {
-		nodeManager := node.GetManager(ctx)
-		nodes, err := nodeManager.GetAllNodes(ctx)
-		if err != nil {
-			msg := fmt.Sprintf("failed to find VirtualMachines for all registered nodes. Error: %v", err)
-			log.Error(msg)
-			return status.Error(codes.Internal, msg)
-		}
-		if err = common.IsOnlineExpansion(ctx, req.GetVolumeId(), nodes); err != nil {
-			return err
-		}
+	// Check online extend FSS and vCenter support.
+	if isOnlineExpansionEnabled && isOnlineExpansionSupported {
+		return nil
 	}
 
-	return nil
+	// Check if it is an online expansion scenario and raise error.
+	nodeManager := node.GetManager(ctx)
+	nodes, err := nodeManager.GetAllNodes(ctx)
+	if err != nil {
+		msg := fmt.Sprintf("failed to find VirtualMachines for all registered nodes. Error: %v", err)
+		log.Error(msg)
+		return status.Error(codes.Internal, msg)
+	}
+	return common.IsOnlineExpansion(ctx, req.GetVolumeId(), nodes)
 }
 
 // validateVanillaCreateSnapshotRequestRequest is the helper function to

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1313,17 +1313,8 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		// For all other cases, the faultType will be set to "csi.fault.Internal" for now.
 		// Later we may need to define different csi faults.
 
-		// WCP and VC version upgrades may not necessarily be linked,
-		// so we need this check in WCP to see if online expansion is supported.
-		// GC will also depend on this check.
-		isOnlineExpansionSupported, err := c.manager.VcenterManager.IsOnlineExtendVolumeSupported(ctx,
-			c.manager.VcenterConfig.Host)
-		if err != nil {
-			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
-				"failed to check if online expansion is supported due to error: %v", err)
-		}
-
-		err = validateWCPControllerExpandVolumeRequest(ctx, req, c.manager, isOnlineExpansionSupported)
+		isOnlineExpansionEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.OnlineVolumeExtend)
+		err := validateWCPControllerExpandVolumeRequest(ctx, req, c.manager, isOnlineExpansionEnabled)
 		if err != nil {
 			log.Errorf("validation for ExpandVolume Request: %+v has failed. Error: %v", *req, err)
 			return nil, csifault.CSIInvalidArgumentFault, err

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-
 	spv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
@@ -115,18 +114,17 @@ func validateWCPControllerUnpublishVolumeRequest(ctx context.Context, req *csi.C
 	return common.ValidateControllerUnpublishVolumeRequest(ctx, req)
 }
 
-// ValidateWCPControllerExpandVolumeRequest is the helper function to validate
-// ExpandVolumeRequest for WCP CSI driver.
+// validateWCPControllerExpandVolumeRequest is the helper function to validate
+// ExpandVolumeRequest for WCP CSI driver. Function returns error if validation
+// fails otherwise returns nil.
 func validateWCPControllerExpandVolumeRequest(ctx context.Context, req *csi.ControllerExpandVolumeRequest,
-	manager *common.Manager, isOnlineExpansionSupported bool) error {
+	manager *common.Manager, isOnlineExpansionEnabled bool) error {
 	log := logger.GetLogger(ctx)
 	if err := common.ValidateControllerExpandVolumeRequest(ctx, req); err != nil {
 		return err
 	}
 
-	// If online expansion is not supported (VC below 7.0U2),
-	// we need to determine if requested operation is online or offline.
-	if !isOnlineExpansionSupported {
+	if !isOnlineExpansionEnabled {
 		var nodes []*vsphere.VirtualMachine
 
 		// TODO: Currently we only check if disk is attached to TKG nodes

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
-
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
@@ -117,6 +116,11 @@ func validateGuestClusterControllerPublishVolumeRequest(ctx context.Context,
 func validateGuestClusterControllerUnpublishVolumeRequest(ctx context.Context,
 	req *csi.ControllerUnpublishVolumeRequest) error {
 	return common.ValidateControllerUnpublishVolumeRequest(ctx, req)
+}
+
+func validateGuestClusterControllerExpandVolumeRequest(ctx context.Context,
+	req *csi.ControllerExpandVolumeRequest) error {
+	return common.ValidateControllerExpandVolumeRequest(ctx, req)
 }
 
 // checkForSupervisorPVCCondition returns nil if the PVC condition is set as


### PR DESCRIPTION
This reverts commit f76219a3189a24ec4a89ee8db05a4fe83204f5f9.

**Need to revert ASAP for 703p05.** 

Note, #1772 is supposed to fix the bug introduced by #1632. Once CSI image is spec bumped, we can once again remove the FSS by combining #1632 and #1772. 

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

Pre-check-in tests
```
Block Vanilla - Refer to builds - 1136 (2 failures), 1137 (1 success), 1138 (1 success)
WCP - 549
GC - 410
```

Manual testing

### WCP
```
root@4204bee5645859244d762244ac57161e [ ~ ]# k create -f wcppodpvc-2.yaml -n test-gc-e2e-demo-ns
persistentvolumeclaim/aditya-2-pvc created
pod/aditya-2-pod created

root@4204bee5645859244d762244ac57161e [ ~ ]# k get pvc -n test-gc-e2e-demo-ns
NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
aditya-2-pvc                                                                Bound    pvc-64f5d4ba-59f4-4027-abe8-18db87468dce   1Gi        RWO            namespace-service-storage-profile   69s

root@4204bee5645859244d762244ac57161e [ ~ ]# k get po -n test-gc-e2e-demo-ns
NAME           READY   STATUS    RESTARTS   AGE
aditya-2-pod   1/1     Running   0          33s

root@4204bee5645859244d762244ac57161e [ ~ ]# k edit pvc aditya-2-pvc -n test-gc-e2e-demo-ns

# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
    volumehealth.storage.kubernetes.io/health: accessible
    volumehealth.storage.kubernetes.io/health-timestamp: Tue Jun  7 00:18:10 UTC 2022
  creationTimestamp: "2022-06-07T00:17:51Z"
  finalizers:
  - kubernetes.io/pvc-protection
  name: aditya-2-pvc
  namespace: test-gc-e2e-demo-ns
  resourceVersion: "9188255"
  selfLink: /api/v1/namespaces/test-gc-e2e-demo-ns/persistentvolumeclaims/aditya-2-pvc
  uid: 64f5d4ba-59f4-4027-abe8-18db87468dce
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  storageClassName: namespace-service-storage-profile
  volumeMode: Block
  volumeName: pvc-64f5d4ba-59f4-4027-abe8-18db87468dce
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound

persistentvolumeclaim/aditya-2-pvc edited


root@4204bee5645859244d762244ac57161e [ ~ ]# k get pvc -n test-gc-e2e-demo-ns
NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
aditya-2-pvc                                                                Bound    pvc-64f5d4ba-59f4-4027-abe8-18db87468dce   5Gi        RWO            namespace-service-storage-profile   2m33s


```
### GC
```

root@4204bee5645859244d762244ac57161e [ ~ ]# k create -f wcppodpvc.yaml -n default
persistentvolumeclaim/aditya-pvc created
pod/aditya-pod created

root@4204bee5645859244d762244ac57161e [ ~ ]# k get pvc
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
aditya-pvc   Bound    pvc-438c9d12-8335-411e-83f4-2cf0b788f4bf   1Gi        RWO            namespace-service-storage-profile   5s

root@4204bee5645859244d762244ac57161e [ ~ ]# k get po
NAME         READY   STATUS    RESTARTS   AGE
aditya-pod   1/1     Running   0          28s

root@4204bee5645859244d762244ac57161e [ ~ ]# k edit pvc aditya-pvc

# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
    volumehealth.storage.kubernetes.io/health: accessible
    volumehealth.storage.kubernetes.io/health-timestamp: Tue Jun  7 02:00:55 UTC 2022
  creationTimestamp: "2022-06-07T01:59:59Z"
  finalizers:
  - kubernetes.io/pvc-protection
  name: aditya-pvc
  namespace: default
  resourceVersion: "3540863"
  uid: 438c9d12-8335-411e-83f4-2cf0b788f4bf
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  storageClassName: namespace-service-storage-profile
  volumeMode: Block
  volumeName: pvc-438c9d12-8335-411e-83f4-2cf0b788f4bf
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound

persistentvolumeclaim/aditya-pvc edited

root@4204bee5645859244d762244ac57161e [ ~ ]# k get pvc
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
aditya-pvc   Bound    pvc-438c9d12-8335-411e-83f4-2cf0b788f4bf   5Gi        RWO            namespace-service-storage-profile   66s

```
### Vanilla
```

root@k8s-control-258-1654556411:~# k create -f sc.yaml
storageclass.storage.k8s.io/example-raw-block-sc created

root@k8s-control-258-1654556411:~# k create -f pvc.yaml
persistentvolumeclaim/example-raw-block-pvc created

root@k8s-control-258-1654556411:~# k create -f pod.yaml
pod/example-raw-block-pod created

root@k8s-control-258-1654556411:~# k get pvc
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
example-raw-block-pvc   Bound    pvc-2cb7176b-5d37-469a-abb0-fd5f6a8762d6   5Gi        RWO            example-raw-block-sc   9s

root@k8s-control-258-1654556411:~# k get po
NAME                    READY   STATUS    RESTARTS   AGE
example-raw-block-pod   1/1     Running   0          6s

root@k8s-control-258-1654556411:~# k edit pvc

# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
    volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
  creationTimestamp: "2022-06-07T03:19:28Z"
  finalizers:
  - kubernetes.io/pvc-protection
  name: example-raw-block-pvc
  namespace: default
  resourceVersion: "63894"
  uid: 2cb7176b-5d37-469a-abb0-fd5f6a8762d6
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 6Gi
  storageClassName: example-raw-block-sc
  volumeMode: Block
  volumeName: pvc-2cb7176b-5d37-469a-abb0-fd5f6a8762d6
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound

persistentvolumeclaim/example-raw-block-pvc edited

root@k8s-control-258-1654556411:~# k get pvc
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
example-raw-block-pvc   Bound    pvc-2cb7176b-5d37-469a-abb0-fd5f6a8762d6   6Gi        RWO            example-raw-block-sc   31s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
