### PR TITLE
Modify VC version check for new vSphere 8.0 releases

### DIFF
--- a/pkg/csi/service/common/common_controller_helper_test.go
+++ b/pkg/csi/service/common/common_controller_helper_test.go
@@ -174,3 +174,27 @@ func TestUseVslmAPIsFuncForVC70u1(t *testing.T) {
 		t.Fatal("Received error from UseVslmAPIs method")
 	}
 }
+
+// TestCheckAPIForVC8 tests CheckAPI method for VC version 8.
+func TestCheckAPIForVC8(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vcVersion := "8.0.0.1.0"
+	err := CheckAPI(ctx, vcVersion, MinSupportedVCenterMajor, MinSupportedVCenterMinor,
+		MinSupportedVCenterPatch)
+	if err != nil {
+		t.Fatalf("CheckAPI method failing for VC %q", vcVersion)
+	}
+}
+
+// TestCheckAPIForVC70u3 tests CheckAPI method for VC version 7.0U3.
+func TestCheckAPIForVC70u3(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vcVersion := "7.0.3.0"
+	err := CheckAPI(ctx, vcVersion, MinSupportedVCenterMajor, MinSupportedVCenterMinor,
+		MinSupportedVCenterPatch)
+	if err != nil {
+		t.Fatalf("CheckAPI method failing for VC %q", vcVersion)
+	}
+}

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -154,7 +154,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	}
 
 	// Check vCenter API Version against 6.7.3.
-	err = common.CheckAPI(vc.Client.ServiceContent.About.ApiVersion, common.MinSupportedVCenterMajor,
+	err = common.CheckAPI(ctx, vc.Client.ServiceContent.About.ApiVersion, common.MinSupportedVCenterMajor,
 		common.MinSupportedVCenterMinor, common.MinSupportedVCenterPatch)
 	if err != nil {
 		log.Errorf("checkAPI failed for vcenter API version: %s, err=%v",

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -157,7 +157,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	}
 
 	// Check vCenter API Version against 6.7.3.
-	err = common.CheckAPI(vc.Client.ServiceContent.About.ApiVersion, common.MinSupportedVCenterMajor,
+	err = common.CheckAPI(ctx, vc.Client.ServiceContent.About.ApiVersion, common.MinSupportedVCenterMajor,
 		common.MinSupportedVCenterMinor, common.MinSupportedVCenterPatch)
 	if err != nil {
 		log.Errorf("checkAPI failed for vcenter API version: %s, err=%v", vc.Client.ServiceContent.About.ApiVersion, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR removes the upper limit on VC version length to accommodate newer vSphere 8.0 releases.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before the fix:
```
root@4217951179ae76405cd4223ad8ed2f09 [ ~ ]# kc get pods -w
NAME                                      READY   STATUS              RESTARTS         AGE
vsphere-csi-controller-5f559484db-bxjvl   5/6     CrashLoopBackOff    77 (2m14s ago)   5h57m
vsphere-csi-controller-5f559484db-kpsdb   5/6     CrashLoopBackOff    82 (2m20s ago)   5h57m
vsphere-csi-controller-7f489f76bb-7c7rb   0/6     ContainerCreating   0                4s
vsphere-csi-webhook-5bf946bb66-9fpdr      1/1     Running             0                5h57m
vsphere-csi-webhook-5bf946bb66-md9cf      1/1     Running             0                5h57m
vsphere-csi-webhook-5bf946bb66-w89gs      1/1     Running             0                5h57m
```

After applying the fix:
```
root@4217951179ae76405cd4223ad8ed2f09 [ ~ ]# kc get pods -w
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-7f489f76bb-7c7rb   6/6     Running   0          115s
vsphere-csi-controller-7f489f76bb-t6n2m   6/6     Running   0          93s
vsphere-csi-controller-7f489f76bb-zxbt4   6/6     Running   0          46s
vsphere-csi-webhook-5bf946bb66-9fpdr      1/1     Running   0          5h58m
vsphere-csi-webhook-5bf946bb66-md9cf      1/1     Running   0          5h58m
vsphere-csi-webhook-5bf946bb66-w89gs      1/1     Running   0          5h58m
```

Also confirmed from the logs that the code has moved beyond the VC check.

Added 2 unit-tests:
```
=== RUN   TestCheckAPIForVC8
{"level":"info","time":"2022-06-06T17:19:46.933101-07:00","caller":"common/common_controller_helper.go:149","msg":"VC version detected as \"8.0.0.1.0\" satisfies minimum supported vcenter version 6.7.3."}
--- PASS: TestCheckAPIForVC8 (0.00s)
=== RUN   TestCheckAPIForVC70u3
{"level":"info","time":"2022-06-06T17:19:46.933767-07:00","caller":"common/common_controller_helper.go:149","msg":"VC version detected as \"7.0.3.0\" satisfies minimum supported vcenter version 6.7.3."}
--- PASS: TestCheckAPIForVC70u3 (0.00s)
```

**Special notes for your reviewer**:
AboutInfo for VC:
<img width="583" alt="Screen Shot 2022-06-06 at 5 24 13 PM" src="https://user-images.githubusercontent.com/12457217/172270611-6e2a35d7-a015-40ab-8a07-655a939bfd61.png">

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Modify VC version check for new vSphere 8.0 releases
```
