### PR TITLE
[release-2.5] upgrade go to 1.17 and tag manifests for v2.5.2-rc.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,15 @@
 module sigs.k8s.io/vsphere-csi-driver/v2
 
-go 1.16
+go 1.17
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.3.1
 	github.com/akutz/gofsutil v0.1.2
 	github.com/container-storage-interface/spec v1.4.0
 	github.com/davecgh/go-spew v1.1.1
-	github.com/elazarl/goproxy v0.0.0-20200710112657-153946a5f232 // indirect
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.2.0
-	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway v1.14.5 // indirect
 	github.com/kubernetes-csi/csi-lib-utils v0.7.0
 	github.com/kubernetes-csi/csi-proxy/client v1.0.1
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.1.0
@@ -23,15 +20,12 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
-	github.com/thecodeteam/gofsutil v0.1.2 // indirect
 	github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae
 	github.com/vmware/govmomi v0.27.5
 	go.uber.org/zap v1.17.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
-	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/tools v0.1.1 // indirect
 	google.golang.org/grpc v1.27.1
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/gcfg.v1 v1.2.3
@@ -46,6 +40,107 @@ require (
 	k8s.io/sample-controller v0.21.1
 	k8s.io/utils v0.0.0-20210527160623-6fdb442a123b
 	sigs.k8s.io/controller-runtime v0.9.0
+)
+
+require (
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
+	github.com/Microsoft/go-winio v0.4.16 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/akutz/gosync v0.1.0 // indirect
+	github.com/aws/aws-sdk-go v1.35.24 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/coreos/etcd v3.3.13+incompatible // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/elazarl/goproxy v0.0.0-20200710112657-153946a5f232 // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/spec v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/google/btree v1.0.0 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.14.5 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/russross/blackfriday v1.5.2 // indirect
+	github.com/sirupsen/logrus v1.7.0 // indirect
+	github.com/spf13/afero v1.2.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/thecodeteam/gofsutil v0.1.2 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
+	golang.org/x/tools v0.1.1 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.51.0 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/warnings.v0 v0.1.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/apiserver v0.21.1 // indirect
+	k8s.io/cli-runtime v0.21.1 // indirect
+	k8s.io/cloud-provider v0.21.1 // indirect
+	k8s.io/component-base v0.21.1 // indirect
+	k8s.io/component-helpers v0.21.1 // indirect
+	k8s.io/klog v1.0.0 // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
+	k8s.io/kubelet v0.0.0 // indirect
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15 // indirect
+	sigs.k8s.io/kustomize/api v0.8.8 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.10.17 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 replace (

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -17,7 +17,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.16
+ARG GOLANG_IMAGE=golang:1.17
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.16
+ARG GOLANG_IMAGE=golang:1.17
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.16
+ARG GOLANG_IMAGE=golang:1.17
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest

--- a/images/windows/driver/Dockerfile
+++ b/images/windows/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.16
+ARG GOLANG_IMAGE=golang:1.17
 ARG OSVERSION
 ARG ARCH=amd64
 

--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -131,7 +131,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.5.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.5.2-rc.1
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -261,7 +261,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.2-rc.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -318,7 +318,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.5.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.5.2-rc.1
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
@@ -437,7 +437,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.2-rc.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -584,7 +584,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.2-rc.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- upgrade go to 1.17
- create manifests for v2.5.2-rc.1


**Special notes for your reviewer**:

```
% make images
hack/release.sh
building gcr.io/cloud-provider-vsphere/csi/ci/driver:v2.5.1-4-g7e49ecb9 for linux
error: no builder "vsphere-csi-builder-win" found
builder instance not found, safe to proceed
[+] Building 73.8s (17/17) FINISHED                                                                                                                                                                            
 => [internal] load build definition from Dockerfile                                                                                                                                                      0.0s
 => => transferring dockerfile: 3.09kB                                                                                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                                                           0.0s
 => [internal] load metadata for gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/golang:1.16                                                                                                                                            1.9s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                                             0.0s
 => [builder 1/6] FROM docker.io/library/golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e                                                                             17.0s
 => => resolve docker.io/library/golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e                                                                                      0.0s
 => => sha256:ff5b10aec998344606441aec43a335ab6326f32aae331aab27da16a6bb4ec2be 10.87MB / 10.87MB                                                                                                          0.8s
 => => sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e 2.35kB / 2.35kB                                                                                                            0.0s
 => => sha256:35fa3cfd4ec01a520f6986535d8f70a5eeef2d40fb8019ff626da24989bdd4f1 1.80kB / 1.80kB                                                                                                            0.0s
 => => sha256:972d8c0bc0fc7d67045f744b6949c2884e6c64bc6b262d511a853b4b5aeb0d23 7.05kB / 7.05kB                                                                                                            0.0s
 => => sha256:e4d61adff2077d048c6372d73c41b0bd68f525ad41f5530af05098a876683055 54.92MB / 54.92MB                                                                                                          1.9s
 => => sha256:4ff1945c672b08a1791df62afaaf8aff14d3047155365f9c3646902937f7ffe6 5.15MB / 5.15MB                                                                                                            0.4s
 => => sha256:12de8c754e45686ace9e25d11bee372b070eed5b5ab20aa3b4fab8c936496d02 54.58MB / 54.58MB                                                                                                          2.2s
 => => sha256:8c86ff77a3175ed4d7958578d141a96b5da005855d60ea24067de33cd62e4c36 85.81MB / 85.81MB                                                                                                          4.3s
 => => sha256:0395a1c478ba68635e5d1bc9349b8fddba5584adc454cec751cd3f29af9080aa 129.16MB / 129.16MB                                                                                                        5.8s
 => => extracting sha256:e4d61adff2077d048c6372d73c41b0bd68f525ad41f5530af05098a876683055                                                                                                                 3.2s
 => => sha256:245345d44ed8225f5d3f80fb591b72fddeb8e40e1020926849fcaf0aac1ed060 156B / 156B                                                                                                                2.4s
 => => extracting sha256:4ff1945c672b08a1791df62afaaf8aff14d3047155365f9c3646902937f7ffe6                                                                                                                 0.2s
 => => extracting sha256:ff5b10aec998344606441aec43a335ab6326f32aae331aab27da16a6bb4ec2be                                                                                                                 0.2s
 => => extracting sha256:12de8c754e45686ace9e25d11bee372b070eed5b5ab20aa3b4fab8c936496d02                                                                                                                 2.2s
 => => extracting sha256:8c86ff77a3175ed4d7958578d141a96b5da005855d60ea24067de33cd62e4c36                                                                                                                 3.2s
 => => extracting sha256:0395a1c478ba68635e5d1bc9349b8fddba5584adc454cec751cd3f29af9080aa                                                                                                                 5.0s
 => => extracting sha256:245345d44ed8225f5d3f80fb591b72fddeb8e40e1020926849fcaf0aac1ed060                                                                                                                 0.0s
 => CACHED [stage-1 1/4] FROM gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest                                                                                                                  0.0s
 => [internal] load build context                                                                                                                                                                         0.1s
 => => transferring context: 2.02MB                                                                                                                                                                       0.1s
 => [stage-1 2/4] RUN tdnf -y install   nfs-utils   util-linux   e2fsprogs   xfsprogs                                                                                                                    27.4s
 => [builder 2/6] WORKDIR /build                                                                                                                                                                          3.9s
 => [builder 3/6] COPY go.mod go.sum ./                                                                                                                                                                   0.0s
 => [builder 4/6] COPY pkg/    pkg/                                                                                                                                                                       0.1s
 => [builder 5/6] COPY cmd/    cmd/                                                                                                                                                                       0.0s
 => [builder 6/6] RUN go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service.Version=v2.5.1-4-g7e49ecb9" -o vsphere-csi ./cmd/vsphere-csi                   49.6s
 => [stage-1 3/4] RUN tdnf clean all                                                                                                                                                                      0.4s
 => [stage-1 4/4] COPY --from=builder /build/vsphere-csi /bin/vsphere-csi                                                                                                                                 0.1s
 => exporting to image                                                                                                                                                                                    1.0s
 => => exporting layers                                                                                                                                                                                   0.9s
 => => writing image sha256:443c2a5eb379baeba2605adbce7b8a78aab044ebaade75631b6480f8caea4856                                                                                                              0.0s
 => => naming to gcr.io/cloud-provider-vsphere/csi/ci/driver-linux-amd64:v2.5.1-4-g7e49ecb9                                                                                                               0.0s
building gcr.io/cloud-provider-vsphere/csi/ci/syncer:v2.5.1-4-g7e49ecb9 for linux
[+] Building 50.0s (15/15) FINISHED                                                                                                                                                                            
 => [internal] load build definition from Dockerfile                                                                                                                                                      0.0s
 => => transferring dockerfile: 2.26kB                                                                                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                                                           0.0s
 => [internal] load metadata for gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/golang:1.16                                                                                                                                            1.2s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                                             0.0s
 => [builder 1/6] FROM docker.io/library/golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e                                                                              0.0s
 => [internal] load build context                                                                                                                                                                         0.1s
 => => transferring context: 1.97MB                                                                                                                                                                       0.1s
 => CACHED [stage-1 1/2] FROM gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest                                                                                                                  0.0s
 => CACHED [builder 2/6] WORKDIR /build                                                                                                                                                                   0.0s
 => CACHED [builder 3/6] COPY go.mod go.sum ./                                                                                                                                                            0.0s
 => CACHED [builder 4/6] COPY pkg/    pkg/                                                                                                                                                                0.0s
 => CACHED [builder 5/6] COPY cmd/    cmd/                                                                                                                                                                0.0s
 => [builder 6/6] RUN go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer.Version=v2.5.1-4-g7e49ecb9" -o vsphere-syncer ./cmd/syncer                          48.1s
 => [stage-1 2/2] COPY --from=builder /build/vsphere-syncer /bin/vsphere-syncer                                                                                                                           0.1s 
 => exporting to image                                                                                                                                                                                    0.2s 
 => => exporting layers                                                                                                                                                                                   0.2s 
 => => writing image sha256:640c57d0a7d674666087f24a22cd9ed0c848e043b75dec4ecfcd4191f15a87a1                                                                                                              0.0s 
 => => naming to gcr.io/cloud-provider-vsphere/csi/ci/syncer:v2.5.1-4-g7e49ecb9                                                                                                                           0.0s 
tagging image gcr.io/cloud-provider-vsphere/csi/ci/syncer:v2.5.1-4-g7e49ecb9 as latest                                                                                                                         
error: failed to find instance "vsphere-csi-builder-win": open /Users/divyenp/.docker/buildx/instances/vsphere-csi-builder-win: no such file or directory
vsphere-csi-builder-win
building gcr.io/cloud-provider-vsphere/csi/ci/driver:v2.5.1-4-g7e49ecb9 for windows
[+] Building 80.5s (19/19) FINISHED                                                                                                                                                                            
 => [internal] booting buildkit                                                                                                                                                                           5.7s
 => => pulling image moby/buildkit:buildx-stable-1                                                                                                                                                        4.8s
 => => creating container buildx_buildkit_vsphere-csi-builder-win0                                                                                                                                        0.9s
 => [internal] load .dockerignore                                                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                                                           0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                      0.0s
 => => transferring dockerfile: 2.56kB                                                                                                                                                                    0.0s
 => [internal] load metadata for mcr.microsoft.com/windows/nanoserver:1809                                                                                                                                0.6s
 => [internal] load metadata for docker.io/library/golang:1.16                                                                                                                                            1.8s
 => [internal] load metadata for gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809                                                                                         1.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                                             0.0s
 => [builder 1/6] FROM docker.io/library/golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e                                                                             13.7s
 => => resolve docker.io/library/golang:1.16@sha256:5f6a4662de3efc6d6bb812d02e9de3d8698eea16b8eb7281f03e6f3e8383018e                                                                                      0.0s
 => => sha256:245345d44ed8225f5d3f80fb591b72fddeb8e40e1020926849fcaf0aac1ed060 156B / 156B                                                                                                                0.1s
 => => sha256:0395a1c478ba68635e5d1bc9349b8fddba5584adc454cec751cd3f29af9080aa 129.16MB / 129.16MB                                                                                                        4.6s
 => => sha256:8c86ff77a3175ed4d7958578d141a96b5da005855d60ea24067de33cd62e4c36 85.81MB / 85.81MB                                                                                                          3.3s
 => => sha256:12de8c754e45686ace9e25d11bee372b070eed5b5ab20aa3b4fab8c936496d02 54.58MB / 54.58MB                                                                                                          2.8s
 => => sha256:ff5b10aec998344606441aec43a335ab6326f32aae331aab27da16a6bb4ec2be 10.87MB / 10.87MB                                                                                                          2.7s
 => => sha256:4ff1945c672b08a1791df62afaaf8aff14d3047155365f9c3646902937f7ffe6 5.15MB / 5.15MB                                                                                                            0.5s
 => => sha256:e4d61adff2077d048c6372d73c41b0bd68f525ad41f5530af05098a876683055 54.92MB / 54.92MB                                                                                                          1.7s
 => => extracting sha256:e4d61adff2077d048c6372d73c41b0bd68f525ad41f5530af05098a876683055                                                                                                                 1.8s
 => => extracting sha256:4ff1945c672b08a1791df62afaaf8aff14d3047155365f9c3646902937f7ffe6                                                                                                                 0.2s
 => => extracting sha256:ff5b10aec998344606441aec43a335ab6326f32aae331aab27da16a6bb4ec2be                                                                                                                 0.2s
 => => extracting sha256:12de8c754e45686ace9e25d11bee372b070eed5b5ab20aa3b4fab8c936496d02                                                                                                                 1.6s
 => => extracting sha256:8c86ff77a3175ed4d7958578d141a96b5da005855d60ea24067de33cd62e4c36                                                                                                                 1.9s
 => => extracting sha256:0395a1c478ba68635e5d1bc9349b8fddba5584adc454cec751cd3f29af9080aa                                                                                                                 3.2s
 => => extracting sha256:245345d44ed8225f5d3f80fb591b72fddeb8e40e1020926849fcaf0aac1ed060                                                                                                                 0.0s
 => [core 1/1] FROM gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809@sha256:b8cffb37a7271347163c3bb82148f179d0c0dce0816069dbc6ecc71a5975107d                              0.6s
 => => resolve gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809@sha256:b8cffb37a7271347163c3bb82148f179d0c0dce0816069dbc6ecc71a5975107d                                   0.0s
 => => sha256:04d7ffafd23f70c19dba922b567f42f4194209c253f7a87ff876a45042d10b52 62.03kB / 62.03kB                                                                                                          0.3s
 => => sha256:3de831824b21b40e3ef52526565f867ce7fc74967d00d6fd944f018510dacbf3 47.88kB / 47.88kB                                                                                                          0.4s
 => => sha256:6d5fd6689b72acc9789f4c3451d51a85a186217f5bfd1605a591c7dacf7276b3 144.42kB / 144.42kB                                                                                                        0.3s
 => => sha256:e228aa7c18b09449f182c0d28f27f6e728e3eca1a7aedbbe8cb57dba0aeea3ec 5.97kB / 5.97kB                                                                                                            0.3s
 => => extracting sha256:e228aa7c18b09449f182c0d28f27f6e728e3eca1a7aedbbe8cb57dba0aeea3ec                                                                                                                 0.0s
 => => extracting sha256:6d5fd6689b72acc9789f4c3451d51a85a186217f5bfd1605a591c7dacf7276b3                                                                                                                 0.0s
 => => extracting sha256:3de831824b21b40e3ef52526565f867ce7fc74967d00d6fd944f018510dacbf3                                                                                                                 0.0s
 => => extracting sha256:04d7ffafd23f70c19dba922b567f42f4194209c253f7a87ff876a45042d10b52                                                                                                                 0.0s
 => [internal] load build context                                                                                                                                                                         0.2s
 => => transferring context: 2.02MB                                                                                                                                                                       0.1s
 => [stage-2 1/3] FROM mcr.microsoft.com/windows/nanoserver:1809@sha256:fb16d42712f3599c849723d365a7ddc5fb95e8bf1674d97e9f9cbcb726e7525d                                                                  8.9s
 => => resolve mcr.microsoft.com/windows/nanoserver:1809@sha256:fb16d42712f3599c849723d365a7ddc5fb95e8bf1674d97e9f9cbcb726e7525d                                                                          0.0s
 => => sha256:6626f490e738e10ea5e31ff2643e3a8c372e076d9030c77fac37537dbf12b73c 103.13MB / 103.13MB                                                                                                        6.7s
 => => extracting sha256:6626f490e738e10ea5e31ff2643e3a8c372e076d9030c77fac37537dbf12b73c                                                                                                                 2.1s
 => [stage-2 2/3] COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll                                                                                                          0.7s
 => [builder 2/6] WORKDIR /build                                                                                                                                                                          0.8s
 => [builder 3/6] COPY go.mod go.sum ./                                                                                                                                                                   0.0s
 => [builder 4/6] COPY pkg/    pkg/                                                                                                                                                                       0.0s
 => [builder 5/6] COPY cmd/    cmd/                                                                                                                                                                       0.0s
 => [builder 6/6] RUN GOOS=windows GOARCH=amd64 go build -a -ldflags="-w -s -extldflags=static -X sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service.Version=v2.5.1-4-g7e49ecb9" -o ./bin/vsphere-csi.wi  54.5s
 => [stage-2 3/3] COPY --from=builder /build/bin/vsphere-csi.windows_amd64 ./csi.exe                                                                                                                      0.1s
 => exporting to client                                                                                                                                                                                   3.3s
 => => sending tarball   
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
upgrade go to 1.17 and tag manifests for v2.5.2-rc.1
```
