### PR TITLE
[Cherry-pick to release-2.3] Fixed parsing of /proc/self/mountinfo with spaces (#1468)

### DIFF
--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -304,7 +304,7 @@ func isBlockVolumeMounted(
 	// have created the staging path per the spec, even for BlockVolumes. Even
 	// though we don't use the staging path for block, the fact nothing will be
 	// mounted still indicates that unstaging is done.
-	dev, err := getDevFromMount(stagingTargetPath)
+	dev, err := getDevFromMount(ctx, stagingTargetPath)
 	if err != nil {
 		return false, logger.LogNewErrorCodef(log, codes.Internal,
 			"isBlockVolumeMounted: error getting block device for volume: %s, err: %s",
@@ -494,7 +494,7 @@ func isBlockVolumePublished(ctx context.Context, volID string, target string) (b
 	log := logger.GetLogger(ctx)
 
 	// Look up block device mounted to target
-	dev, err := getDevFromMount(target)
+	dev, err := getDevFromMount(ctx, target)
 	if err != nil {
 		return false, logger.LogNewErrorCodef(log, codes.Internal,
 			"error getting block device for volume: %s, err: %v", volID, err)
@@ -816,7 +816,7 @@ func (driver *vsphereCSIDriver) NodeExpandVolume(
 	}
 
 	// Look up block device mounted to staging target path
-	dev, err := getDevFromMount(volumePath)
+	dev, err := getDevFromMount(ctx, volumePath)
 	if err != nil {
 		return nil, logger.LogNewErrorCodef(log, codes.Internal,
 			"error getting block device for volume: %q, err: %v",
@@ -940,7 +940,7 @@ func publishMountVol(
 	if len(devMnts) > 1 {
 		// check if publish is already there
 		for _, m := range devMnts {
-			if m.Path == params.target {
+			if unescape(ctx, m.Path) == params.target {
 				// volume already published to target
 				// if mount options look good, do nothing
 				rwo := "rw"
@@ -1025,7 +1025,7 @@ func publishBlockVol(
 		log.Debugf("PublishBlockVolume: Bind mount successful to path %q", params.target)
 	} else if len(devMnts) == 1 {
 		// already mounted, make sure it's what we want
-		if devMnts[0].Path != params.target {
+		if unescape(ctx, devMnts[0].Path) != params.target {
 			return nil, logger.LogNewErrorCode(log, codes.Internal,
 				"device already in use and mounted elsewhere")
 		}
@@ -1069,7 +1069,7 @@ func publishFileVol(
 	}
 	log.Debugf("PublishFileVolume: Mounts - %+v", mnts)
 	for _, m := range mnts {
-		if m.Path == params.target {
+		if unescape(ctx, m.Path) == params.target {
 			// volume already published to target
 			// if mount options look good, do nothing
 			rwo := "rw"
@@ -1396,8 +1396,7 @@ func getDiskID(pubCtx map[string]string, log *zap.SugaredLogger) (string, error)
 	return diskID, nil
 }
 
-func getDevFromMount(target string) (*Device, error) {
-
+func getDevFromMount(ctx context.Context, target string) (*Device, error) {
 	// Get list of all mounts on system
 	mnts, err := gofsutil.GetMounts(context.Background())
 	if err != nil {
@@ -1437,7 +1436,7 @@ func getDevFromMount(target string) (*Device, error) {
 	// Opts:[rw relatime]
 
 	for _, m := range mnts {
-		if m.Path == target {
+		if unescape(ctx, m.Path) == target {
 			// something is mounted to target, get underlying disk
 			d := m.Device
 			if m.Device == "udev" || m.Device == "devtmpfs" {
@@ -1453,4 +1452,24 @@ func getDevFromMount(target string) (*Device, error) {
 
 	// Did not identify a device mounted to target
 	return nil, nil
+}
+
+// un-escapes "\nnn" sequences in /proc/self/mounts. For example, replaces "\040" with space " ".
+func unescape(ctx context.Context, in string) string {
+	log := logger.GetLogger(ctx)
+	out := make([]rune, 0, len(in))
+	s := in
+	for len(s) > 0 {
+		// Un-escape single character.
+		// UnquoteChar will un-escape also \r, \n, \Unnnn and other sequences, but they should not be used in /proc/mounts.
+		rune, _, tail, err := strconv.UnquoteChar(s, '"')
+		if err != nil {
+			log.Infof("Error parsing mount %q: %s", in, err)
+			// Use escaped string as a fallback
+			return in
+		}
+		out = append(out, rune)
+		s = tail
+	}
+	return string(out)
 }

--- a/pkg/csi/service/node_test.go
+++ b/pkg/csi/service/node_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -96,4 +98,44 @@ func (fi *FakeFileInfo) IsDir() bool {
 
 func (fi *FakeFileInfo) Sys() interface{} {
 	return nil
+}
+
+func TestUnescape(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{
+			// Space is unescaped. This is basically the only test that can happen in reality
+			// and only when in-tree in-line volume in a Pod is used with CSI migration enabled.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+		},
+		{
+			// Multiple spaces are unescaped.
+			in:  `/var/lib/kube\040let/plug\040ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo\040bar\040baz`,
+			out: `/var/lib/kube let/plug ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo bar baz`,
+		},
+		{
+			// Too short escape sequence. Expect the same string on output.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
+		},
+		{
+			// Wrong characters in the escape sequence. Expect the same string on output.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
+		},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			out := unescape(ctx, test.in)
+			if out != test.out {
+				t.Errorf("Expected %q to be unescaped as %q, got %q", test.in, test.out, out)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR is cherry-picking PR #1468 to release the 2.3 branch.

When a mount point contains space, it is escaped in /proc/self/mountifo as
\040:

7331 6783 8:32 / /var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount rw,relatime - ext4 /dev/sdc rw,seclabel

Un-escape this sequence (and any other \nnn sequences) before comparing the
parsed mount path.

This happens only for in-line in-tree vSphere volumes when CSI migration is
enabled. Whole '[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk'
is used as volumeHandle (and thus in global mount dir) and a fake PV name (and
thus in pod local mount dir).

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed parsing of /proc/self/mountinfo with spaces
```
