### PR TITLE
[Cherry-pick to release-2.2] Fixed parsing of /proc/self/mountinfo with spaces (#1468)

### DIFF
--- a/pkg/csi/service/node_test.go
+++ b/pkg/csi/service/node_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -96,4 +98,44 @@ func (fi *FakeFileInfo) IsDir() bool {
 
 func (fi *FakeFileInfo) Sys() interface{} {
 	return nil
+}
+
+func TestUnescape(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{
+			// Space is unescaped. This is basically the only test that can happen in reality
+			// and only when in-tree in-line volume in a Pod is used with CSI migration enabled.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+		},
+		{
+			// Multiple spaces are unescaped.
+			in:  `/var/lib/kube\040let/plug\040ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo\040bar\040baz`,
+			out: `/var/lib/kube let/plug ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo bar baz`,
+		},
+		{
+			// Too short escape sequence. Expect the same string on output.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
+		},
+		{
+			// Wrong characters in the escape sequence. Expect the same string on output.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
+		},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			out := unescape(ctx, test.in)
+			if out != test.out {
+				t.Errorf("Expected %q to be unescaped as %q, got %q", test.in, test.out, out)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR is cherry-picking PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1468 to release the 2.2 branch.

When a mount point contains space, it is escaped in /proc/self/mountifo as
\040:

7331 6783 8:32 / /var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount rw,relatime - ext4 /dev/sdc rw,seclabel

Un-escape this sequence (and any other \nnn sequences) before comparing the
parsed mount path.

This happens only for in-line in-tree vSphere volumes when CSI migration is
enabled. Whole '[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk'
is used as volumeHandle (and thus in global mount dir) and a fake PV name (and
thus in pod local mount dir).

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed parsing of /proc/self/mountinfo with spaces
```
