### PR TITLE
Handle PV name NotFound in PVC spec errors in CnsNodeVMAttachment controller

### DIFF
--- a/pkg/common/fault/constants.go
+++ b/pkg/common/fault/constants.go
@@ -34,6 +34,13 @@ const (
 	// CSIApiServerOperationFault is the fault type when Get(), List() and others fail on the API Server
 	CSIApiServerOperationFault = "csi.fault.ApiServerOperation"
 
+	// CSIPvNotFoundInPvcSpecFault is the fault type when PV name is not found in PVC Spec.
+	// This can happen at the time of guest cluster creation when user specifies volumes to be created
+	// in the guest cluster spec. Volume creation in such cases are typically initiated by
+	// vmoperator and an error is observed because the volume name is updated in the VM spec, even
+	// before the volume is provisioned in supervisor cluster.
+	CSIPvNotFoundInPvcSpecFault = "csi.fault.nonstorage.PvNotFoundInPvcSpec"
+
 	// CSITaskResultEmptyFault is the fault type when taskResult is empty.
 	CSITaskResultEmptyFault = "csi.fault.TaskResultEmpty"
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding fault handling for PV name not found in PVC Spec, observed during CnsNodeVmAttachment Reconciliation. CSIPVNotFoundFault is the fault type when PV name is not found in PVC Spec. This can happen at the time of guest cluster creation when user specifies volumes to be created n the guest cluster spec. Volume creation in such cases are typically initiated by vmoperator and an error is observed because the volume name is updated in the VM spec, even before the volume is provisioned in supervisor cluster.

Error observed:

```
{\"level\":\"info\",\"time\":\"2022-06-02T17:15:24.270129137Z\",\"caller\":\"cnsnodevmattachment/cnsnodevmattachment_controller.go:210\",\"msg\":\"Reconciling CnsNodeVmAttachment with Request.Name: \\\"gc-workers-dp4m7-7576fb75c8-qr8hg-gc-workers-xhmh6-4hlk5-containerd\\\" instance \\\"gc-workers-dp4m7-7576fb75c8-qr8hg-gc-workers-xhmh6-4hlk5-containerd\\\" timeout \\\"8s\\\" seconds\",\"TraceId\":\"127e394d-8f5f-4a2c-bc0d-f891083a0785\"}"}{\"level\":\"error\",\"time\":\"2022-06-02T17:15:24.276415877Z\",\"caller\":\"cnsnodevmattachment/cnsnodevmattachment_controller.go:804\",\"msg\":\"failed to get PV with name: \\\"\\\" for PVC: \\\"gc-workers-xhmh6-4hlk5-containerd\\\". Err: PersistentVolume \\\"\\\" not found\",\"TraceId\":\"127e394d-8f5f-4a2c-bc0d-f891083a0785\" {\"level\":\"error\",\"time\":\"2022-06-02T17:15:24.432814445Z\",\"caller\":\"cnsnodevmattachment/cnsnodevmattachment_controller.go:900\",\"msg\":\"failed to get volumeID from volumeName: \\\"gc-workers-xhmh6-4hlk5-containerd\\\" for CnsNodeVmAttachment request with name: \\\"gc-workers-dp4m7-7576fb75c8-qr8hg-gc-workers-xhmh6-4hlk5-containerd\\\" on namespace: \\\"shaolany-joy1101\\\". Error: PersistentVolume \\\"\\\" not found\",\"TraceId\":\"127e394d-8f5f-4a2c-bc0d-f891083a0785\"
--
```
These errors are emitted as ApiServerOperationFaults and the success rate of Attach operations come down drastically.
Hence we will be adding a unique faulttype, which will be later filtered out in the success rate computation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Below is a simulation of the scenario observed on Supervisor Cluster. The scenario is, VM spec in SV has a volumeName(PVC name) for which PV is still not created successfully(PVC is not in Bound state). This can happen when a TKC is created with some additional volumes to be added as ephemeral storage. In such cases, the VM spec is updated by vmOperator and hence the syncer will be trying to reconcile the corresponding cnsnodevmattachment and controller will be attempting to create volumes. Since the PVC may not be in Bound state, and PVC.Spec.VolumeName = "", syncer will start emitting errors as VolumeId not found. This is not an ideal PVC-Pod provisioning workflow and hence a separate nonCSI or nonStorage fault needs to be emitted in the metrics.


Add a dummy volume name in VM spec:
```kubectl edit virtualmachine -n tkc-e2e-omrvk6   tkc-e2e-tkc-e2e-omrvk6-rak-workers-dz4tv-84fb8cd594-btbrg
```
```
  - name: 7b821812-2838-44ec-aade-e7aee8f72355-59c0f5de-9153-43e3-8244-36889bab4261
    persistentVolumeClaim:
      claimName: 7b821812-2838-44ec-aade-e7aee8f72355-59c0f5de-9153-43e3-8244-36889bab4261
```


Bring down only the controller container:
```
kubectl get pods -nvmware-system-csi
NAME                                      READY   STATUS             RESTARTS      AGE
vsphere-csi-controller-56f4ccff78-j42hb   5/6     CrashLoopBackOff   5 (63s ago)   4m35s
```

Create a PVC, so that the PV name is empty:
```
kubectl get pvc -A
NAMESPACE        NAME                                                                        STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
tkc-e2e-omrvk6   7b821812-2838-44ec-aade-e7aee8f72355-59c0f5de-9153-43e3-8244-36889bab4261   Pending                                                                        wcpglobal-storage-profile   23s
```

Syncer will be making attempts to reconcile cnsnodevmattachment for the dummy volume added in vm spec:

```
kubectl get cnsnodevmattachments -A
NAMESPACE        NAME                                                                                                                                  AGE
tkc-e2e-omrvk6   tkc-e2e-tkc-e2e-omrvk6-rak-workers-dz4tv-84fb8cd594-btbrg-7b821812-2838-44ec-aade-e7aee8f72355-59c0f5de-9153-43e3-8244-36889bab4261   14m
```

Logs:
```
{"level":"error","time":"2022-06-13T15:14:27.107864599Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:805","msg":"failed to get PV with name: \"\" for PVC: \"7b821812-2838-44ec-aade-e7aee8f72355-59c0f5de-9153-43e3-8244-36889bab4261\". Err: PersistentVolume \"\" not found","TraceId":"f5a76ba7-a7b1-4ae8-b10c-0ce427ce3a00","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.getVolumeID\n\t/build/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:805\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.(*ReconcileCnsNodeVMAttachment).Reconcile.func1\n\t/build/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:324\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.(*ReconcileCnsNodeVMAttachment).Reconcile\n\t/build/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:621\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:298\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:253\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:214"}
{"level":"error","time":"2022-06-13T15:14:27.172061649Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:901","msg":"failed to get volumeID from volumeName: \"7b821812-2838-44ec-aade-e7aee8f72355-59c0f5de-9153-43e3-8244-36889bab4261\" for CnsNodeVmAttachment request with name: \"tkc-e2e-tkc-e2e-omrvk6-rak-workers-dz4tv-84fb8cd594-btbrg-7b821812-2838-44ec-aade-e7aee8f72355-59c0f5de-9153-43e3-8244-36889bab4261\" on namespace: \"tkc-e2e-omrvk6\". Error: PersistentVolume \"\" not found","TraceId":"f5a76ba7-a7b1-4ae8-b10c-0ce427ce3a00"
```


With the changes in the PR, the faulttype emitted is PvNotFoundInPvcSpec:
```
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.PvNotFoundInPvcSpec",optype="attach-volume",status="fail",voltype="block",le="10"} 2
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.PvNotFoundInPvcSpec",optype="attach-volume",status="fail",voltype="block",le="15"} 2
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.PvNotFoundInPvcSpec",optype="attach-volume",status="fail",voltype="block",le="20"} 2
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.PvNotFoundInPvcSpec",optype="attach-volume",status="fail",voltype="block",le="25"} 2
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.PvNotFoundInPvcSpec",optype="attach-volume",status="fail",voltype="block",le="30"} 2
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.PvNotFoundInPvcSpec",optype="attach-volume",status="fail",voltype="block",le="60"} 2
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.PvNotFoundInPvcSpec",optype="attach-volume",status="fail",voltype="block",le="120"} 2
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.PvNotFoundInPvcSpec",optype="attach-volume",status="fail",voltype="block",le="180"} 2
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.PvNotFoundInPvcSpec",optype="attach-volume",status="fail",voltype="block",le="+Inf"} 2
vsphere_csi_volume_ops_histogram_sum{faulttype="csi.fault.nonstorage.PvNotFoundInPvcSpec",optype="attach-volume",status="fail",voltype="block"} 0.218210379
vsphere_csi_volume_ops_histogram_count{faulttype="csi.fault.nonstorage.PvNotFoundInPvcSpec",optype="attach-volume",status="fail",voltype="block"} 2
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Handle PV name NotFound in PVC spec errors in CnsNodeVMAttachment controller
```
