### PR TITLE
Relocate volume tests using cnsRelocateVolume API

### DIFF
--- a/tests/e2e/policy_driven_vol_allocation.go
+++ b/tests/e2e/policy_driven_vol_allocation.go
@@ -63,7 +63,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		bootstrap()
 		if guestCluster {
 			svcClient, svNamespace := getSvcClientAndNamespace()
-			setResourceQuota(svcClient, svNamespace, rqLimit)
+			setResourceQuota(svcClient, svNamespace, rqLimitScaleTest)
 		}
 		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
 		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")

--- a/tests/e2e/svmotion_detached_volume.go
+++ b/tests/e2e/svmotion_detached_volume.go
@@ -19,6 +19,8 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -26,12 +28,15 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	pbmtypes "github.com/vmware/govmomi/pbm/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 /*
@@ -47,6 +52,7 @@ import (
 
 var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Relocate detached volume ", func() {
 	f := framework.NewDefaultFramework("svmotion-detached-disk")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
 		client          clientset.Interface
 		namespace       string
@@ -162,5 +168,277 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Re
 			err = fmt.Errorf("disk is relocated on the wrong datastore")
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/* Online relocation of volume using cnsRelocate Volume API
+	STEPS:
+	1. Create a tag based policy with 2 shared vmfs datastores(sharedVmfs-0 and sharedVmfs-1).
+	2. Create SC with storage policy created in step 1.
+	3. Create a PVC with sc created in step 2 and wait for it to come to bound state.
+	4. Create a pod with the pvc created in step 3 and wait for it to come to Running state.
+	5. Relocate volume from one shared datastore to another datastore using
+	   CnsRelocateVolume API and verify the datastore of fcd after migration and volume compliance.
+	6. Delete pod,pvc and sc.
+	*/
+	ginkgo.It("Online relocation of volume using cnsRelocate Volume API", func() {
+		ginkgo.By("Invoking Test for offline relocation")
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sharedvmfsURL := os.Getenv(envSharedVMFSDatastoreURL)
+		if sharedvmfsURL == "" {
+			ginkgo.Skip(fmt.Sprintf("Env %v is missing", envSharedVMFSDatastoreURL))
+		}
+
+		sharedvmfs2URL := os.Getenv(envSharedVMFSDatastore2URL)
+		if sharedvmfs2URL == "" {
+			ginkgo.Skip(fmt.Sprintf("Env %v is missing", envSharedVMFSDatastore2URL))
+		}
+		datastoreUrls := []string{sharedvmfsURL, sharedvmfs2URL}
+
+		govmomiClient := newClient(ctx, &e2eVSphere)
+		pc := newPbmClient(ctx, govmomiClient)
+		scParameters := make(map[string]string)
+		pvcs := []*v1.PersistentVolumeClaim{}
+
+		ginkgo.By("Creating tag and category to tag datastore")
+
+		rand.Seed(time.Now().UnixNano())
+		suffix := fmt.Sprintf("-%v-%v", time.Now().UnixNano(), rand.Intn(10000))
+		categoryName := "category" + suffix
+		tagName := "tag" + suffix
+
+		catID, tagID := createCategoryNTag(ctx, categoryName, tagName)
+		defer func() {
+			deleteCategoryNTag(ctx, catID, tagID)
+		}()
+
+		ginkgo.By("Attaching tag to shared vmfs datastores")
+
+		attachTagToDS(ctx, tagID, sharedvmfsURL)
+		defer func() {
+			detachTagFromDS(ctx, tagID, sharedvmfsURL)
+		}()
+
+		attachTagToDS(ctx, tagID, sharedvmfs2URL)
+		defer func() {
+			detachTagFromDS(ctx, tagID, sharedvmfs2URL)
+		}()
+
+		policyID, policyName := createTagBasedPolicy(
+			ctx, pc, map[string]string{categoryName: tagName})
+		defer func() {
+			deleteStoragePolicy(ctx, pc, policyID)
+		}()
+		scParameters[scParamStoragePolicyName] = policyName
+		storageclass, pvclaim, err := createPVCAndStorageClass(client,
+			namespace, nil, scParameters, "", nil, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pvcs = append(pvcs, pvclaim)
+
+		defer func() {
+			ginkgo.By("Delete the SCs created")
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Deleted the SPBM polices created")
+			_, err = pc.DeleteProfile(ctx, []pbmtypes.PbmProfileId{*policyID})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify the PVCs created in step 3 are bound")
+		pvs, err := fpv.WaitForPVClaimBoundPhase(client, pvcs, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volumeID := pvs[0].Spec.CSI.VolumeHandle
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pvs[0].Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify that the created CNS volumes are compliant and have correct policy id")
+		storagePolicyExists, err := e2eVSphere.VerifySpbmPolicyOfVolume(volumeID, policyName)
+		e2eVSphere.verifyVolumeCompliance(volumeID, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(storagePolicyExists).To(gomega.BeTrue(), "storage policy verification failed")
+
+		ginkgo.By("Creating a pod")
+		pod, err := createPod(client, namespace, nil, pvcs, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		filePath := "/mnt/volume1/file1.txt"
+		filePath2 := "/mnt/volume1/file2.txt"
+
+		//Write data on file.txt on Pod
+		data := "This file is written by Pod"
+		ginkgo.By("write to a file in pod")
+		writeDataOnFileFromPod(namespace, pod.Name, filePath, data)
+
+		defer func() {
+			ginkgo.By("Delete the pod created")
+			err := fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify if VolumeID is created on the given datastores")
+		dsUrlWhereVolumeIsPresent := fetchDsUrl4CnsVol(e2eVSphere, volumeID)
+		framework.Logf("Volume is present on %s", dsUrlWhereVolumeIsPresent)
+		e2eVSphere.verifyDatastoreMatch(volumeID, datastoreUrls)
+
+		// Get the destination ds url where the volume will get relocated
+		destDsUrl := ""
+		for _, dsurl := range datastoreUrls {
+			if dsurl != dsUrlWhereVolumeIsPresent {
+				destDsUrl = dsurl
+			}
+		}
+
+		ginkgo.By("Relocate volume from one shared datastore to another datastore using" +
+			"CnsRelocateVolume API")
+		dsRefDest := getDsMoRefFromURL(ctx, destDsUrl)
+		err = e2eVSphere.cnsRelocateVolume(e2eVSphere, ctx, volumeID, dsRefDest)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		e2eVSphere.verifyDatastoreMatch(volumeID, []string{destDsUrl})
+
+		ginkgo.By("Verify that the relocated CNS volumes are compliant and have correct policy id")
+		storagePolicyExists, err = e2eVSphere.VerifySpbmPolicyOfVolume(volumeID, policyName)
+		e2eVSphere.verifyVolumeCompliance(volumeID, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(storagePolicyExists).To(gomega.BeTrue(), "storage policy verification failed")
+
+		//Read file1.txt created from Pod
+		ginkgo.By("Read file.txt from Pod created by Pod")
+		output := readFileFromPod(namespace, pod.Name, filePath)
+		ginkgo.By(fmt.Sprintf("File contents from file.txt are: %s", output))
+		data = data + "\n"
+		gomega.Expect(output == data).To(gomega.BeTrue(), "data verification failed after relocation")
+
+		data = "Writing some data to pod post relocation"
+		ginkgo.By("writing to a file in pod post relocation")
+		writeDataOnFileFromPod(namespace, pod.Name, filePath2, data)
+
+		ginkgo.By("Read file.txt created by Pod")
+		output = readFileFromPod(namespace, pod.Name, filePath2)
+		ginkgo.By(fmt.Sprintf("File contents from file.txt are: %s", output))
+		data = data + "\n"
+		gomega.Expect(output == data).To(gomega.BeTrue(), "data verification failed after relocation")
+
+	})
+
+	/* Offline relocation of volume using cnsRelocate Volume API
+	STEPS:
+	1. Create a tag based policy with 2 shared vmfs datastores(sharedVmfs-0 and sharedVmfs-1).
+	2. Create SC with storage policy created in step 1.
+	3. Create a PVC with sc created in step 2 and wait for it to come to bound state.
+	4. Relocate volume from one shared datastore to another datastore
+	   using CnsRelocateVolume API and verify the datastore of fcd after migration and volume compliance.
+	5. Delete pvc and sc.
+	*/
+	ginkgo.It("Offline relocation of volume using cnsRelocate Volume API", func() {
+		ginkgo.By("Invoking Test for offline relocation")
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sharedvmfsURL := os.Getenv(envSharedVMFSDatastoreURL)
+		if sharedvmfsURL == "" {
+			ginkgo.Skip(fmt.Sprintf("Env %v is missing", envSharedVMFSDatastoreURL))
+		}
+
+		sharedvmfs2URL := os.Getenv(envSharedVMFSDatastore2URL)
+		if sharedvmfs2URL == "" {
+			ginkgo.Skip(fmt.Sprintf("Env %v is missing", envSharedVMFSDatastore2URL))
+		}
+		datastoreUrls := []string{sharedvmfsURL, sharedvmfs2URL}
+
+		govmomiClient := newClient(ctx, &e2eVSphere)
+		pc := newPbmClient(ctx, govmomiClient)
+		scParameters := make(map[string]string)
+		pvcs := []*v1.PersistentVolumeClaim{}
+
+		rand.Seed(time.Now().UnixNano())
+		suffix := fmt.Sprintf("-%v-%v", time.Now().UnixNano(), rand.Intn(10000))
+		categoryName := "category" + suffix
+		tagName := "tag" + suffix
+
+		ginkgo.By("Creating tag and category to tag datastore")
+
+		catID, tagID := createCategoryNTag(ctx, categoryName, tagName)
+		defer func() {
+			deleteCategoryNTag(ctx, catID, tagID)
+		}()
+
+		ginkgo.By("Attaching tag to shared vmfs datastores")
+
+		attachTagToDS(ctx, tagID, sharedvmfsURL)
+		defer func() {
+			detachTagFromDS(ctx, tagID, sharedvmfsURL)
+		}()
+
+		attachTagToDS(ctx, tagID, sharedvmfs2URL)
+		defer func() {
+			detachTagFromDS(ctx, tagID, sharedvmfs2URL)
+		}()
+
+		policyID, policyName := createTagBasedPolicy(
+			ctx, pc, map[string]string{categoryName: tagName})
+		defer func() {
+			deleteStoragePolicy(ctx, pc, policyID)
+		}()
+		scParameters[scParamStoragePolicyName] = policyName
+		storageclass, pvclaim, err := createPVCAndStorageClass(client,
+			namespace, nil, scParameters, "", nil, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pvcs = append(pvcs, pvclaim)
+
+		defer func() {
+			ginkgo.By("Delete the SCs created")
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify the PVCs created in step 3 are bound")
+		pvs, err := fpv.WaitForPVClaimBoundPhase(client, pvcs, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volumeID := pvs[0].Spec.CSI.VolumeHandle
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pvs[0].Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify that the created CNS volumes are compliant and have correct policy id")
+		storagePolicyExists, err := e2eVSphere.VerifySpbmPolicyOfVolume(volumeID, policyName)
+		e2eVSphere.verifyVolumeCompliance(volumeID, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(storagePolicyExists).To(gomega.BeTrue(), "storage policy verification failed")
+
+		ginkgo.By("Verify if VolumeID is created on the given datastores")
+		dsUrlWhereVolumeIsPresent := fetchDsUrl4CnsVol(e2eVSphere, volumeID)
+		framework.Logf("Volume is present on %s", dsUrlWhereVolumeIsPresent)
+		e2eVSphere.verifyDatastoreMatch(volumeID, datastoreUrls)
+
+		// Get the destination ds url where the volume will get relocated
+		destDsUrl := ""
+		for _, dsurl := range datastoreUrls {
+			if dsurl != dsUrlWhereVolumeIsPresent {
+				destDsUrl = dsurl
+			}
+		}
+
+		dsRefDest := getDsMoRefFromURL(ctx, destDsUrl)
+		err = e2eVSphere.cnsRelocateVolume(e2eVSphere, ctx, volumeID, dsRefDest)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		e2eVSphere.verifyDatastoreMatch(volumeID, []string{destDsUrl})
+
+		ginkgo.By("Verify that the relocated CNS volumes are compliant and have correct policy id")
+		storagePolicyExists, err = e2eVSphere.VerifySpbmPolicyOfVolume(volumeID, policyName)
+		e2eVSphere.verifyVolumeCompliance(volumeID, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(storagePolicyExists).To(gomega.BeTrue(), "storage policy verification failed")
+
 	})
 })

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -5782,7 +5782,7 @@ func assignPolicyToWcpNamespace(client clientset.Interface, ctx context.Context,
 
 	curlStr := ""
 	policyNamesArrLength := len(policyNames)
-	defRqLimit := strings.Split(defaultrqLimit, "Gi")[0]
+	defRqLimit := strings.Split(rqLimit, "Gi")[0]
 	limit, err := strconv.Atoi(defRqLimit)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	limit *= 953 //to convert gb to mebibytes


### PR DESCRIPTION
**What this PR does / why we need it**: Relocate volume tests using cnsRelocateVolume API

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/44cfd3404a7917aff78bd65f3fd00f85
**Special notes for your reviewer**: make check output:
```
(base) kai@kai-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.1
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/kai/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/provider sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/cnsrelocate/vsphere-csi-driver /Users/kai/cnsrelocate /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (types_sizes|compiled_files|imports|files|name|deps|exports_file) took 2.205574458s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 142.454ms 
INFO [linters context/goanalysis] analyzers took 3m7.270949555s with top 10 stages: buildir: 2m3.106491644s, nilness: 14.963901011s, printf: 7.27347798s, ctrlflow: 7.105652489s, fact_deprecated: 6.667743892s, typedness: 5.623834834s, fact_purity: 5.360497448s, SA5012: 4.9744816s, inspect: 2.251130404s, S1038: 885.396405ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 113/113, skip_files: 113/113, skip_dirs: 113/113, identifier_marker: 24/24, nolint: 0/1, path_prettifier: 113/113, autogenerated_exclude: 24/113, exclude-rules: 1/24, cgo: 113/113, exclude: 24/24 
INFO [runner] processing took 23.636841ms with stages: nolint: 19.644383ms, autogenerated_exclude: 2.260211ms, path_prettifier: 830.116µs, identifier_marker: 468.686µs, skip_dirs: 207.326µs, exclude-rules: 192.876µs, cgo: 15.143µs, filename_unadjuster: 12.384µs, max_same_issues: 1.429µs, uniq_by_line: 728ns, skip_files: 500ns, max_from_linter: 438ns, diff: 435ns, source_code: 386ns, sort_results: 325ns, exclude: 325ns, max_per_file_from_linter: 321ns, path_shortener: 315ns, severity-rules: 311ns, path_prefixer: 203ns 
INFO [runner] linters took 23.284557438s with stages: goanalysis_metalinter: 23.260785906s 
INFO File cache stats: 93 entries of total size 2.8MiB 
INFO Memory: 249 samples, avg is 1500.5MB, max is 2702.7MB 
INFO Execution took 25.648780026s                 
(base) kai@kai-a01 vsphere-csi-driver % 
```
