### PR TITLE
unescape taret for IsTargetInMounts

### DIFF
--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -389,4 +390,44 @@ func TestParseStorageClassParamsWithMigrationDisabled(t *testing.T) {
 		t.Errorf("error expected but not received. scParam received from ParseStorageClassParams: %v", scParam)
 	}
 	t.Logf("expected err received. err: %v", err)
+}
+
+func TestUnescape(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{
+			// Space is unescaped. This is basically the only test that can happen in reality
+			// and only when in-tree in-line volume in a Pod is used with CSI migration enabled.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+		},
+		{
+			// Multiple spaces are unescaped.
+			in:  `/var/lib/kube\040let/plug\040ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo\040bar\040baz`,
+			out: `/var/lib/kube let/plug ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo bar baz`,
+		},
+		{
+			// Too short escape sequence. Expect the same string on output.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
+		},
+		{
+			// Wrong characters in the escape sequence. Expect the same string on output.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
+		},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			out := Unescape(ctx, test.in)
+			if out != test.out {
+				t.Errorf("Expected %q to be unescaped as %q, got %q", test.in, test.out, out)
+			}
+		})
+	}
 }

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -940,7 +940,7 @@ func publishMountVol(
 	if len(devMnts) > 1 {
 		// check if publish is already there
 		for _, m := range devMnts {
-			if unescape(ctx, m.Path) == params.target {
+			if common.Unescape(ctx, m.Path) == params.target {
 				// volume already published to target
 				// if mount options look good, do nothing
 				rwo := "rw"
@@ -1025,7 +1025,7 @@ func publishBlockVol(
 		log.Debugf("PublishBlockVolume: Bind mount successful to path %q", params.target)
 	} else if len(devMnts) == 1 {
 		// already mounted, make sure it's what we want
-		if unescape(ctx, devMnts[0].Path) != params.target {
+		if common.Unescape(ctx, devMnts[0].Path) != params.target {
 			return nil, logger.LogNewErrorCode(log, codes.Internal,
 				"device already in use and mounted elsewhere")
 		}
@@ -1069,7 +1069,7 @@ func publishFileVol(
 	}
 	log.Debugf("PublishFileVolume: Mounts - %+v", mnts)
 	for _, m := range mnts {
-		if unescape(ctx, m.Path) == params.target {
+		if common.Unescape(ctx, m.Path) == params.target {
 			// volume already published to target
 			// if mount options look good, do nothing
 			rwo := "rw"
@@ -1436,7 +1436,7 @@ func getDevFromMount(ctx context.Context, target string) (*Device, error) {
 	// Opts:[rw relatime]
 
 	for _, m := range mnts {
-		if unescape(ctx, m.Path) == target {
+		if common.Unescape(ctx, m.Path) == target {
 			// something is mounted to target, get underlying disk
 			d := m.Device
 			if m.Device == "udev" || m.Device == "devtmpfs" {
@@ -1452,24 +1452,4 @@ func getDevFromMount(ctx context.Context, target string) (*Device, error) {
 
 	// Did not identify a device mounted to target
 	return nil, nil
-}
-
-// un-escapes "\nnn" sequences in /proc/self/mounts. For example, replaces "\040" with space " ".
-func unescape(ctx context.Context, in string) string {
-	log := logger.GetLogger(ctx)
-	out := make([]rune, 0, len(in))
-	s := in
-	for len(s) > 0 {
-		// Un-escape single character.
-		// UnquoteChar will un-escape also \r, \n, \Unnnn and other sequences, but they should not be used in /proc/mounts.
-		rune, _, tail, err := strconv.UnquoteChar(s, '"')
-		if err != nil {
-			log.Infof("Error parsing mount %q: %s", in, err)
-			// Use escaped string as a fallback
-			return in
-		}
-		out = append(out, rune)
-		s = tail
-	}
-	return string(out)
 }

--- a/pkg/csi/service/node_test.go
+++ b/pkg/csi/service/node_test.go
@@ -17,10 +17,8 @@ limitations under the License.
 package service
 
 import (
-	"context"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 )
@@ -98,44 +96,4 @@ func (fi *FakeFileInfo) IsDir() bool {
 
 func (fi *FakeFileInfo) Sys() interface{} {
 	return nil
-}
-
-func TestUnescape(t *testing.T) {
-	tests := []struct {
-		in, out string
-	}{
-		{
-			// Space is unescaped. This is basically the only test that can happen in reality
-			// and only when in-tree in-line volume in a Pod is used with CSI migration enabled.
-			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
-			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
-		},
-		{
-			// Multiple spaces are unescaped.
-			in:  `/var/lib/kube\040let/plug\040ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo\040bar\040baz`,
-			out: `/var/lib/kube let/plug ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo bar baz`,
-		},
-		{
-			// Too short escape sequence. Expect the same string on output.
-			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
-			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
-		},
-		{
-			// Wrong characters in the escape sequence. Expect the same string on output.
-			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
-			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
-		},
-	}
-
-	for i, test := range tests {
-		test := test
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			t.Parallel()
-			ctx := context.Background()
-			out := unescape(ctx, test.in)
-			if out != test.out {
-				t.Errorf("Expected %q to be unescaped as %q, got %q", test.in, test.out, out)
-			}
-		})
-	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
unescape target for `IsTargetInMounts`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
**Created Pod with Inline-volume**

```
# kubectl create -f inlinepod.yaml 
deployment.apps/sample-inline-deployment created


# kubectl get pods -o wide
NAME                                        READY   STATUS    RESTARTS   AGE   IP            NODE                      NOMINATED NODE   READINESS GATES
sample-inline-deployment-69cbdbb5d5-ppkt7   1/1     Running   0          19s   10.244.5.30   k8s-node-560-1655194774   <none>           <none>
```


> {"level":"info","time":"2022-06-14T20:30:31.400580254Z","caller":"service/node.go:95","msg":"NodeStageVolume: called with args {VolumeId:[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk PublishContext:map[diskUUID:6000c29afe3719ebf4507cbf93a01333 type:vSphere CNS Block Volume] StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk/globalmount VolumeCapability:mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER >  Secrets:map[] VolumeContext:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"295e3ed1-f603-4ee0-93f7-8c161146d2e5"}
{"level":"info","time":"2022-06-14T20:30:31.402557332Z","caller":"service/node.go:154","msg":"nodeStageBlockVolume: Retrieved diskID as \"6000c29afe3719ebf4507cbf93a01333\"","TraceId":"295e3ed1-f603-4ee0-93f7-8c161146d2e5"}
time="2022-06-14T20:30:31Z" level=info msg="attempting to mount disk" fsType=ext4 options="[defaults]" source=/dev/disk/by-id/wwn-0x6000c29afe3719ebf4507cbf93a01333 target="/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk/globalmount"
time="2022-06-14T20:30:31Z" level=info msg="mount command" args="-t ext4 -o defaults /dev/disk/by-id/wwn-0x6000c29afe3719ebf4507cbf93a01333 /var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk/globalmount" cmd=mount
{"level":"info","time":"2022-06-14T20:30:31.820254779Z","caller":"service/node.go:237","msg":"nodeStageBlockVolume: Device mounted successfully at \"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk/globalmount\"","TraceId":"295e3ed1-f603-4ee0-93f7-8c161146d2e5"}
{"level":"info","time":"2022-06-14T20:30:31.8468556Z","caller":"service/node.go:351","msg":"NodePublishVolume: called with args {VolumeId:[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk PublishContext:map[diskUUID:6000c29afe3719ebf4507cbf93a01333 type:vSphere CNS Block Volume] StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk/globalmount TargetPath:/var/lib/kubelet/pods/0e7daf59-a788-483d-b6ad-76bf6d8e01e1/volumes/kubernetes.io~csi/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8~test-vm.vmdk/mount VolumeCapability:mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"64c965e5-58ab-4787-9d84-d8f67af66a85"}
{"level":"info","time":"2022-06-14T20:30:31.847967619Z","caller":"service/node.go:908","msg":"PublishMountVolume called with args: {volID:[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk target:/var/lib/kubelet/pods/0e7daf59-a788-483d-b6ad-76bf6d8e01e1/volumes/kubernetes.io~csi/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8~test-vm.vmdk/mount stagingTarget:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk/globalmount diskID:6000c29afe3719ebf4507cbf93a01333 volumePath:/dev/disk/by-id/wwn-0x6000c29afe3719ebf4507cbf93a01333 device:/dev/sdb ro:false}","TraceId":"64c965e5-58ab-4787-9d84-d8f67af66a85"}
{"level":"info","time":"2022-06-14T20:30:31.851404056Z","caller":"service/node.go:1276","msg":"creating directory :\"/var/lib/kubelet/pods/0e7daf59-a788-483d-b6ad-76bf6d8e01e1/volumes/kubernetes.io~csi/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8~test-vm.vmdk/mount\"","TraceId":"64c965e5-58ab-4787-9d84-d8f67af66a85"}
time="2022-06-14T20:30:31Z" level=info msg="mount command" args="-o bind /var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk/globalmount /var/lib/kubelet/pods/0e7daf59-a788-483d-b6ad-76bf6d8e01e1/volumes/kubernetes.io~csi/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8~test-vm.vmdk/mount" cmd=mount
time="2022-06-14T20:30:31Z" level=info msg="mount command" args="-o remount /var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk/globalmount /var/lib/kubelet/pods/0e7daf59-a788-483d-b6ad-76bf6d8e01e1/volumes/kubernetes.io~csi/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8~test-vm.vmdk/mount" cmd=mount
{"level":"info","time":"2022-06-14T20:30:31.870034615Z","caller":"service/node.go:976","msg":"NodePublishVolume for \"[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk\" successful to path \"/var/lib/kubelet/pods/0e7daf59-a788-483d-b6ad-76bf6d8e01e1/volumes/kubernetes.io~csi/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8~test-vm.vmdk/mount\"","TraceId":"64c965e5-58ab-4787-9d84-d8f67af66a85"}



**Deleted Pod with inline-volume**


```
# kubectl delete deployment sample-inline-deployment
deployment.apps "sample-inline-deployment" deleted

root@k8s-control-960-1655194703:~# kubectl get pods -o wide
NAME                                        READY   STATUS        RESTARTS   AGE   IP            NODE                      NOMINATED NODE   READINESS GATES
sample-inline-deployment-69cbdbb5d5-ppkt7   1/1     Terminating   0          72s   10.244.5.30   k8s-node-560-1655194774   <none>           <none>
```



```
root@k8s-control-960-1655194703:~# kubectl get pods -o wide
No resources found in default namespace.
```


>{"level":"info","time":"2022-06-14T20:32:05.076432484Z","caller":"service/node.go:423","msg":"NodeUnpublishVolume: called with args {VolumeId:[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk TargetPath:/var/lib/kubelet/pods/0e7daf59-a788-483d-b6ad-76bf6d8e01e1/volumes/kubernetes.io~csi/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8~test-vm.vmdk/mount XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"4b17d40c-b558-47f8-bb1d-b857a8be99cb"}
{"level":"info","time":"2022-06-14T20:32:05.087244342Z","caller":"service/node.go:473","msg":"NodeUnpublishVolume: Attempting to unmount target \"/var/lib/kubelet/pods/0e7daf59-a788-483d-b6ad-76bf6d8e01e1/volumes/kubernetes.io~csi/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8~test-vm.vmdk/mount\" for volume \"[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk\"","TraceId":"4b17d40c-b558-47f8-bb1d-b857a8be99cb"}
time="2022-06-14T20:32:05Z" level=info msg="unmount command" cmd=umount path="/var/lib/kubelet/pods/0e7daf59-a788-483d-b6ad-76bf6d8e01e1/volumes/kubernetes.io~csi/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8~test-vm.vmdk/mount"
{"level":"info","time":"2022-06-14T20:32:05.097885248Z","caller":"service/node.go:487","msg":"NodeUnpublishVolume successful for volume \"[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk\"","TraceId":"4b17d40c-b558-47f8-bb1d-b857a8be99cb"}
{"level":"info","time":"2022-06-14T20:32:05.189724617Z","caller":"service/node.go:247","msg":"NodeUnstageVolume: called with args {VolumeId:[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk/globalmount XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"1f49340e-01e2-487a-9f02-aa5ad5369546"}
{"level":"info","time":"2022-06-14T20:32:05.198803855Z","caller":"service/node.go:283","msg":"Attempting to unmount target \"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk/globalmount\" for volume \"[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk\"","TraceId":"1f49340e-01e2-487a-9f02-aa5ad5369546"}
time="2022-06-14T20:32:05Z" level=info msg="unmount command" cmd=umount path="/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk/globalmount"
{"level":"info","time":"2022-06-14T20:32:05.228407596Z","caller":"service/node.go:289","msg":"NodeUnstageVolume successful for target \"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk/globalmount\" for volume \"[vsanDatastore] 74d2a862-26ca-2794-dcab-02006679c9d8/test-vm.vmdk\"","TraceId":"1f49340e-01e2-487a-9f02-aa5ad5369546"}



**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
unescape taret for IsTargetInMounts
```
