### PR TITLE
pvCSI support for uTKGS

### DIFF
--- a/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
+++ b/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1/cnsvolumemetadata_types.go
@@ -21,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
-	cnsoperatortypes "sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types"
 )
 
 // CnsVolumeMetadataSpec defines the desired state of CnsVolumeMetadata
@@ -142,8 +141,8 @@ func CreateCnsVolumeMetadataSpec(volumeHandle []string, gcConfig config.GCConfig
 	return &CnsVolumeMetadata{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: GetCnsVolumeMetadataName(gcConfig.TanzuKubernetesClusterUID, uid),
-			OwnerReferences: []metav1.OwnerReference{GetCnsVolumeMetadataOwnerReference(cnsoperatortypes.GCAPIVersion,
-				cnsoperatortypes.GCKind, gcConfig.TanzuKubernetesClusterName, gcConfig.TanzuKubernetesClusterUID)},
+			OwnerReferences: []metav1.OwnerReference{GetCnsVolumeMetadataOwnerReference(gcConfig.ClusterAPIVersion,
+				gcConfig.ClusterKind, gcConfig.TanzuKubernetesClusterName, gcConfig.TanzuKubernetesClusterUID)},
 		},
 		Spec: CnsVolumeMetadataSpec{
 			VolumeNames:         volumeHandle,

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -96,6 +96,10 @@ const (
 	// supervisorIDPrefix is added before the SupervisorID
 	// Using this CNS UI can form an appropriate URL to navigate from CNS UI to WCP UI
 	supervisorIDPrefix = "vSphereSupervisorID-"
+	// TKCKind refers to the kind of TKC cluster being used.
+	TKCKind = "TanzuKubernetesCluster"
+	// TKCAPIVersion refers to the version of TanzuKubernetesCluster object currently being used.
+	TKCAPIVersion = "run.tanzu.vmware.com/v1alpha1"
 )
 
 // Errors
@@ -585,6 +589,15 @@ func validateGCConfig(ctx context.Context, cfg *Config) error {
 	if cfg.GC.TanzuKubernetesClusterUID == "" {
 		log.Error(ErrMissingTanzuKubernetesClusterUID)
 		return ErrMissingTanzuKubernetesClusterUID
+	}
+	// ClusterAPIVersion and ClusterKind parameters have been introduced for the uTKGS effort.
+	// To maintain backward compatibility with GCs created with TKC objects,
+	// we will default to the old configuration if these values are not present.
+	if cfg.GC.ClusterAPIVersion == "" {
+		cfg.GC.ClusterAPIVersion = TKCAPIVersion
+	}
+	if cfg.GC.ClusterKind == "" {
+		cfg.GC.ClusterKind = TKCKind
 	}
 	return nil
 }

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -163,6 +163,10 @@ type GCConfig struct {
 	TanzuKubernetesClusterName string `gcfg:"tanzukubernetescluster-name"`
 	// Cluster Distribution Name
 	ClusterDistribution string `gcfg:"cluster-distribution"`
+	// ClusterAPIVersion refers to the API version of the object guest cluster is created from.
+	ClusterAPIVersion string `gcfg:"cluster-api-version"`
+	// ClusterKind refers to the kind of object guest cluster is created from.
+	ClusterKind string `gcfg:"cluster-kind"`
 }
 
 // SnapshotConfig contains snapshot configuration.

--- a/pkg/syncer/cnsoperator/types/types.go
+++ b/pkg/syncer/cnsoperator/types/types.go
@@ -24,12 +24,6 @@ const (
 	// to avoid Detach-Delete race which in-turn avoids ResourceInUse errors
 	CNSPvcFinalizer = "cns.vmware.com/pvc-protection"
 
-	// GCAPIVersion is the APIVersion for TanzuKubernetes Cluster
-	GCAPIVersion = "run.tanzu.vmware.com/v1alpha1"
-
-	// GCKind is the Kind value for TanzuKubernetes Cluster
-	GCKind = "TanzuKubernetesCluster"
-
 	// VSphereCSIDriverName is the vsphere CSI driver name
 	VSphereCSIDriverName = "csi.vsphere.vmware.com"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: As part of the uTKGS effort, we plan to create guest clusters using a Cluster object instead of a TKC object. This PR contains the modifications required in the GC config to be able to do so while simultaneously maintaining backward compatibility.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: uTKG team has used this branch to complete internal testing. They have given a sign-off for the code changes.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
pvCSI support for uTKGS
```
