### PR TITLE
unescape target for IsTargetInMounts

### DIFF
--- a/manifests/v2.2.4/deploy/validatingwebhook.yaml
+++ b/manifests/v2.2.4/deploy/validatingwebhook.yaml
@@ -99,7 +99,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.2.4-rc.2
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.2.4-rc.3
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/v2.2.4/deploy/vsphere-csi-controller-deployment.yaml
+++ b/manifests/v2.2.4/deploy/vsphere-csi-controller-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.2.4-rc.2
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.2.4-rc.3
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -117,7 +117,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.2.4-rc.2
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.2.4-rc.3
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/v2.2.4/deploy/vsphere-csi-node-ds.yaml
+++ b/manifests/v2.2.4/deploy/vsphere-csi-node-ds.yaml
@@ -48,7 +48,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: vsphere-csi-node
-        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.2.4-rc.2
+        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.2.4-rc.3
         args:
           - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
           - "--fss-namespace=$(CSI_NAMESPACE)"

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -188,7 +188,7 @@ func IsFileVolumeMount(ctx context.Context, target string, mnts []gofsutil.Info)
 func IsTargetInMounts(ctx context.Context, target string, mnts []gofsutil.Info) bool {
 	log := logger.GetLogger(ctx)
 	for _, m := range mnts {
-		if m.Path == target {
+		if Unescape(ctx, m.Path) == target {
 			log.Debugf("Found target %q in list of mounts", target)
 			return true
 		}
@@ -352,4 +352,24 @@ func ConvertVolumeHealthStatus(volHealthStatus string) (string, error) {
 	default:
 		return "", fmt.Errorf("cannot convert invalid volume health status %s", volHealthStatus)
 	}
+}
+
+// Unescape "\nnn" sequences in /proc/self/mounts. For example, replaces "\040" with space " ".
+func Unescape(ctx context.Context, in string) string {
+	log := logger.GetLogger(ctx)
+	out := make([]rune, 0, len(in))
+	s := in
+	for len(s) > 0 {
+		// Un-escape single character.
+		// UnquoteChar will un-escape also \r, \n, \Unnnn and other sequences, but they should not be used in /proc/mounts.
+		rune, _, tail, err := strconv.UnquoteChar(s, '"')
+		if err != nil {
+			log.Infof("Error parsing mount %q: %s", in, err)
+			// Use escaped string as a fallback
+			return in
+		}
+		out = append(out, rune)
+		s = tail
+	}
+	return string(out)
 }

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -389,4 +390,44 @@ func TestParseStorageClassParamsWithMigrationDisabled(t *testing.T) {
 		t.Errorf("error expected but not received. scParam received from ParseStorageClassParams: %v", scParam)
 	}
 	t.Logf("expected err received. err: %v", err)
+}
+
+func TestUnescape(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{
+			// Space is unescaped. This is basically the only test that can happen in reality
+			// and only when in-tree in-line volume in a Pod is used with CSI migration enabled.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+		},
+		{
+			// Multiple spaces are unescaped.
+			in:  `/var/lib/kube\040let/plug\040ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo\040bar\040baz`,
+			out: `/var/lib/kube let/plug ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo bar baz`,
+		},
+		{
+			// Too short escape sequence. Expect the same string on output.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
+		},
+		{
+			// Wrong characters in the escape sequence. Expect the same string on output.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
+		},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			out := Unescape(ctx, test.in)
+			if out != test.out {
+				t.Errorf("Expected %q to be unescaped as %q, got %q", test.in, test.out, out)
+			}
+		})
+	}
 }

--- a/pkg/csi/service/node_test.go
+++ b/pkg/csi/service/node_test.go
@@ -17,10 +17,8 @@ limitations under the License.
 package service
 
 import (
-	"context"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 )
@@ -98,44 +96,4 @@ func (fi *FakeFileInfo) IsDir() bool {
 
 func (fi *FakeFileInfo) Sys() interface{} {
 	return nil
-}
-
-func TestUnescape(t *testing.T) {
-	tests := []struct {
-		in, out string
-	}{
-		{
-			// Space is unescaped. This is basically the only test that can happen in reality
-			// and only when in-tree in-line volume in a Pod is used with CSI migration enabled.
-			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
-			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
-		},
-		{
-			// Multiple spaces are unescaped.
-			in:  `/var/lib/kube\040let/plug\040ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo\040bar\040baz`,
-			out: `/var/lib/kube let/plug ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo bar baz`,
-		},
-		{
-			// Too short escape sequence. Expect the same string on output.
-			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
-			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
-		},
-		{
-			// Wrong characters in the escape sequence. Expect the same string on output.
-			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
-			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
-		},
-	}
-
-	for i, test := range tests {
-		test := test
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			t.Parallel()
-			ctx := context.Background()
-			out := unescape(ctx, test.in)
-			if out != test.out {
-				t.Errorf("Expected %q to be unescaped as %q, got %q", test.in, test.out, out)
-			}
-		})
-	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 unescape target for IsTargetInMounts



Refer to https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1805


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
unescape target for IsTargetInMounts
```
