### PR TITLE
Update sidecar containers to latest releases

### DIFF
--- a/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
+++ b/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
@@ -55,7 +55,7 @@ spec:
     spec:
       containers:
         - name: snapshot-validation
-          image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v5.0.1 # change the image if you wish to use your own custom validation server image
+          image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.0.1 # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/run/secrets/tls/tls.crt', '--tls-private-key-file=/run/secrets/tls/tls.key']
           ports:

--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -59,7 +59,7 @@ else
         exit 1
 fi
 
-qualified_version="v5.0.1"
+qualified_version="v6.0.1"
 volumesnapshotclasses_crd="volumesnapshotclasses.snapshot.storage.k8s.io"
 volumesnapshotcontents_crd="volumesnapshotcontents.snapshot.storage.k8s.io"
 volumesnapshots_crd="volumesnapshots.snapshot.storage.k8s.io"
@@ -161,7 +161,7 @@ deploy_snapshot_controller(){
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/"${qualified_version}"/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml 2>/dev/null || true
 	echo -e "✅ Created  RBACs for snapshot-controller"
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/"${qualified_version}"/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml 2>/dev/null || true
-	# The released yaml for v5.0.1 does not have v5.0.1 image for snapshot-controller, explicitly updating it.
+	# The released yaml for v6.0.1 does not have v6.0.1 image for snapshot-controller, explicitly updating it.
 	snapshot_controller_image="gcr.io/k8s-staging-sig-storage/snapshot-controller:"${qualified_version}
 	kubectl -n kube-system set image deployment/snapshot-controller snapshot-controller=$snapshot_controller_image
 	kubectl patch deployment -n kube-system snapshot-controller --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/control-plane": ""}, "tolerations": [{"key":"node-role.kubernetes.io/master","operator":"Exists", "effect":"NoSchedule"},{"key":"node-role.kubernetes.io/control-plane","operator":"Exists", "effect":"NoSchedule"}]}}}}'

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -236,7 +236,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -251,7 +251,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -354,7 +354,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -373,7 +373,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
           args:
             - "--v=4"
             - "--kube-api-qps=100"
@@ -565,7 +565,7 @@ spec:
       serviceAccountName: vsphere-csi-node
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -645,7 +645,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update csi-provisioner to 3.2.0
https://github.com/kubernetes-csi/external-provisioner/releases/tag/v3.2.0

Update csi-attacher to 3.5.0
https://github.com/kubernetes-csi/external-attacher/releases/tag/v3.5.0

Update csi-resizer to 1.5.0
https://github.com/kubernetes-csi/external-resizer/releases/tag/v1.5.0


**Testing done**:
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1812#issuecomment-1159136943

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update sidecar containers to latest releases
```
