### PR TITLE
Fix for syncer crash - Connect to Pbm client before invoking pbm methods

### DIFF
--- a/pkg/common/cns-lib/vsphere/pbm.go
+++ b/pkg/common/cns-lib/vsphere/pbm.go
@@ -24,6 +24,7 @@ import (
 	pbmmethods "github.com/vmware/govmomi/pbm/methods"
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 )
 
@@ -100,6 +101,14 @@ func (vc *VirtualCenter) GetStoragePolicyIDByName(ctx context.Context, storagePo
 // with the given datastores.
 func (vc *VirtualCenter) PbmCheckCompatibility(ctx context.Context,
 	datastores []vimtypes.ManagedObjectReference, profileID string) (pbm.PlacementCompatibilityResult, error) {
+
+	log := logger.GetLogger(ctx)
+	err := vc.ConnectPbm(ctx)
+	if err != nil {
+		log.Errorf("Error occurred while connecting to PBM, err: %+v", err)
+		return nil, err
+	}
+
 	hubs := make([]pbmtypes.PbmPlacementHub, 0)
 	for _, ds := range datastores {
 		hubs = append(hubs, pbmtypes.PbmPlacementHub{
@@ -125,6 +134,13 @@ func (vc *VirtualCenter) PbmCheckCompatibility(ctx context.Context,
 
 // PbmRetrieveContent fetches the policy content of all given policies from SPBM.
 func (vc *VirtualCenter) PbmRetrieveContent(ctx context.Context, policyIds []string) ([]SpbmPolicyContent, error) {
+
+	log := logger.GetLogger(ctx)
+	err := vc.ConnectPbm(ctx)
+	if err != nil {
+		log.Errorf("Error occurred while connecting to PBM, err: %+v", err)
+		return nil, err
+	}
 	pbmPolicyIds := make([]pbmtypes.PbmProfileId, 0)
 	for _, policyID := range policyIds {
 		pbmPolicyIds = append(pbmPolicyIds, pbmtypes.PbmProfileId{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix for the bug 2797177. 
syncer container was crashing due to NPE in in pbm.go. Stacktrace is in comment 33 of the above bug.
getDatastoreToPolicyCompatibility calls w.vc.PbmCheckCompatibility. 
The offending line was in PbmCheckCompatibility, where vc.PbmClient.ServiceContent.PlacementSolver was throwing the NPE. 
We need to connect to the Pbm client to populate the client before trying to access anything on the PbmClient instance.

**Testing done**:
Controller pods are running fine, and there is no panic or NPE in either the vsphere-csi-controller or vsphere-syncer containers.

NAME                                      READY   STATUS    RESTARTS        AGE
vsphere-csi-controller-7ff9c5dc5f-6bvb8   6/6     Running   2 (18h ago)     23h
vsphere-csi-controller-7ff9c5dc5f-ff998   6/6     Running   0               23h
vsphere-csi-controller-7ff9c5dc5f-hhv2q   6/6     Running   2 (7h14m ago)   23h
vsphere-csi-webhook-6899997f68-5sr8g      1/1     Running   2 (21d ago)     21d
vsphere-csi-webhook-6899997f68-hpdtv      1/1     Running   1 (14d ago)     21d
vsphere-csi-webhook-6899997f68-l65w7      1/1     Running   0               21d

Test: 
1. VC -> Monitor -> Sessions -> Terminated all the sessions.

![image](https://user-images.githubusercontent.com/99905372/175121283-ef47739a-582c-45ab-86de-23456516f4d3.png)

2. Saw that the sessions were automatically created.
```
2022-06-22T18:50:30.091406463Z 2022-06-22T18:50:30.090Z WARN    vsphere/virtualcenter.go:285    Creating a new client session as the existing one isn't valid or not authenticated      {"TraceId": "e00c930d-ff1b-413b-a0a2-10a2b8205fa5"}
2022-06-22T18:50:30.091532743Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*VirtualCenter).connect
2022-06-22T18:50:30.091542421Z  /build/pkg/common/cns-lib/vsphere/virtualcenter.go:285
2022-06-22T18:50:30.091546569Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*VirtualCenter).Connect
2022-06-22T18:50:30.091550271Z  /build/pkg/common/cns-lib/vsphere/virtualcenter.go:237
2022-06-22T18:50:30.091553863Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*VirtualCenter).ConnectPbm
2022-06-22T18:50:30.091557890Z  /build/pkg/common/cns-lib/vsphere/pbm.go:59
2022-06-22T18:50:30.091562498Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*VirtualCenter).PbmCheckCompatibility
2022-06-22T18:50:30.091565878Z  /build/pkg/common/cns-lib/vsphere/pbm.go:106
2022-06-22T18:50:30.091573563Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool.(*StorageClassWatch).getDatastoreToPolicyCompatibility
2022-06-22T18:50:30.091647047Z  /build/pkg/syncer/storagepool/storageclasswatch.go:417
2022-06-22T18:50:30.091654495Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool.newIntendedState
2022-06-22T18:50:30.091658252Z  /build/pkg/syncer/storagepool/intended_state.go:151
2022-06-22T18:50:30.091662026Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool.ReconcileAllStoragePools
2022-06-22T18:50:30.091665803Z  /build/pkg/syncer/storagepool/listener.go:245
2022-06-22T18:50:30.091669229Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool.scheduleReconcileAllStoragePools.func1
2022-06-22T18:50:30.091672643Z  /build/pkg/syncer/storagepool/listener.go:199
2022-06-22T18:50:30.093227447Z 2022-06-22T18:50:30.093Z DEBUG   vsphere/virtualcenter.go:158    Setting vCenter soap client timeout to 5m0s     {"TraceId": "e00c930d-ff1b-413b-a0a2-10a2b8205fa5"}
2022-06-22T18:50:30.160113044Z 2022-06-22T18:50:30.159Z INFO    vsphere/virtualcenter.go:183    New session ID for 'VSPHERE.LOCAL\workload_storage_management-079c1f4f-2304-42c5-8d03-52dd8bd3f43a' = 520cd35f-37a1-72a9-0a32-8923c5966ff7      {"TraceId": "e00c930d-ff1b-413b-a0a2-10a2b8205fa5"}
2022-06-22T18:50:30.241619000Z 2022-06-22T18:50:30.241Z INFO
```

```
2022-06-22T18:50:42.574328139Z 2022-06-22T18:50:42.573Z WARN    vsphere/virtualcenter.go:285    Creating a new client session as the existing one isn't valid or not authenticated
2022-06-22T18:50:42.574364609Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*VirtualCenter).connect
2022-06-22T18:50:42.574413286Z  /build/pkg/common/cns-lib/vsphere/virtualcenter.go:285
2022-06-22T18:50:42.574418451Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*VirtualCenter).Connect
2022-06-22T18:50:42.574422015Z  /build/pkg/common/cns-lib/vsphere/virtualcenter.go:237
2022-06-22T18:50:42.574426042Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool.initListener.func1
2022-06-22T18:50:42.574430319Z  /build/pkg/syncer/storagepool/listener.go:164
```
3. Created a sample instances and the the pods were in running state. PVCs were bound.