### PR TITLE
Return success for DetachVolume when nodeName in PodSpec is not same as nodeName in DetachVolume request

### DIFF
--- a/pkg/common/fault/constants.go
+++ b/pkg/common/fault/constants.go
@@ -23,7 +23,8 @@ const (
 	CSIVmUuidNotFoundFault = "csi.fault.nonstorage.VmUuidNotFound"
 	// CSIVmNotFoundFault is the fault type when VM object is not found in the VC
 	CSIVmNotFoundFault = "csi.fault.nonstorage.VmNotFound"
-
+	// CSIDiskNotDetachedFault is the fault type when disk is still attached to the vm
+	CSIDiskNotDetachedFault = "csi.fault.nonstorage.DiskNotDetached"
 	// CSIDatacenterNotFoundFault is the fault type when Datacenter are not found in the VC
 	CSIDatacenterNotFoundFault = "csi.fault.DatacenterNotFound"
 	// CSIVCenterNotFoundFault is the fault type when VC instance is not found

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -263,10 +263,14 @@ func Newk8sOrchestrator(ctx context.Context, controllerClusterFlavor cnstypes.Cn
 				initVolumeHandleToPvcMap(ctx, controllerClusterFlavor)
 			}
 
-			if k8sOrchestratorInstance.IsFSSEnabled(ctx, common.ListVolumes) {
+			if controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+				// Initialize the map for volumeName to nodes, as it is needed for WCP detach volume handling
 				initVolumeNameToNodesMap(ctx, controllerClusterFlavor)
-				if controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload {
-					initNodeIDToNameMap(ctx)
+				initNodeIDToNameMap(ctx)
+			} else {
+				// Initialize the map for volumeName to nodes, for non-WCP flavors and when ListVolume FSS is on
+				if k8sOrchestratorInstance.IsFSSEnabled(ctx, common.ListVolumes) {
+					initVolumeNameToNodesMap(ctx, controllerClusterFlavor)
 				}
 			}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making changes to DetachVolume call in WCP to return success for DetachVolume when nodeName in PodSpec is not same as nodeName in DetachVolume request. We need to return DetachVolume as a success because for the same volumeId and vmUUID there is a VA with status = Attached. This was observed in one of the WCP setups, assuming this was a Pod scheduling on different node use case, CSI needs to return Success.
Without this change, CSI will keep retrying with the isDiskAttached status. Since  diskUUID and vmUUID is same the isDiskAttached will return true and hence DetachVolume  retry loop kicks in. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
kubectl describe pv pvc-56423938-a7fc-4c67-9c08-73f58cabe9d6
Name:            pvc-56423938-a7fc-4c67-9c08-73f58cabe9d6
Labels:          <none>
Annotations:     pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:      [kubernetes.io/pv-protection external-attacher/csi-vsphere-vmware-com]
StorageClass:    vsan-default-storage-policy
Status:          Bound
Claim:           testing/example-vanilla-rwo-pvc
Reclaim Policy:  Delete
Access Modes:    RWO
VolumeMode:      Filesystem
Capacity:        5Mi
Node Affinity:   <none>
Message:         
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      f3ebbd9c-9e3a-4024-9b2e-2e6d1f6a534b
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1658347735769-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
root@420463b02743709f4e9e32a852639558 [ ~ ]# kubectl get volumeattachments | grep 56423938-a7fc-4c67-9c08-73f58cabe9d6
csi-4f8be08acf717243c345b47b76283357aff65970ae0dd3b3dd125393c92f9be4   csi.vsphere.vmware.com   pvc-56423938-a7fc-4c67-9c08-73f58cabe9d6   sc2-10-185-1-11.eng.vmware.com    true       60s
root@420463b02743709f4e9e32a852639558 [ ~ ]# kubectl get pvc -n testing
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                  AGE
example-vanilla-rwo-pvc   Bound    pvc-56423938-a7fc-4c67-9c08-73f58cabe9d6   5Mi        RWO            vsan-default-storage-policy   4m27s
root@420463b02743709f4e9e32a852639558 [ ~ ]# kubectl get pods -n testing
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   1/1     Running   0          66s
root@420463b02743709f4e9e32a852639558 [ ~ ]# kubectl delete -f pod.yaml -n testing
pod "example-vanilla-block-pod" deleted

```



Logs:
```
{"level":"info","time":"2022-07-20T20:14:15.050678538Z","caller":"wcp/controller.go:1004","msg":"ControllerUnpublishVolume: called with args {VolumeId:f3ebbd9c-9e3a-4024-9b2e-2e6d1f6a534b NodeId:sc2-10-185-1-11.eng.vmware.com Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"c172a191-385d-41f6-b06c-f3f2cfe7d3ac"}
{"level":"error","time":"2022-07-20T20:14:15.070303874Z","caller":"vsphere/datacenter.go:104","msg":"Couldn't find VM given uuid 50048e23-5f85-4807-b1e4-1bb46d6ee548","TraceId":"c172a191-385d-41f6-b06c-f3f2cfe7d3ac","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*Datacenter).GetVirtualMachineByUUID\n\t/build/pkg/common/cns-lib/vsphere/datacenter.go:104\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.getVMByInstanceUUIDInDatacenter\n\t/build/pkg/csi/service/wcp/controller_helper.go:347\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).ControllerUnpublishVolume.func1\n\t/build/pkg/csi/service/wcp/controller.go:1058\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).ControllerUnpublishVolume\n\t/build/pkg/csi/service/wcp/controller.go:1121\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_ControllerUnpublishVolume_Handler\n\t/go/pkg/mod/github.com/container-storage-interface/spec@v1.5.0/lib/go/csi/csi.pb.go:5723\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:1297\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:1626\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.2\n\t/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:941"}
{"level":"error","time":"2022-07-20T20:14:15.07077893Z","caller":"wcp/controller_helper.go:349","msg":"failed to find the VM from the VM Instance UUID: 50048e23-5f85-4807-b1e4-1bb46d6ee548 in datacenter: Datacenter [Datacenter: Datacenter:datacenter-4, VirtualCenterHost: sc2-10-185-9-250.eng.vmware.com] with err: virtual machine wasn't found","TraceId":"c172a191-385d-41f6-b06c-f3f2cfe7d3ac","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.getVMByInstanceUUIDInDatacenter\n\t/build/pkg/csi/service/wcp/controller_helper.go:349\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).ControllerUnpublishVolume.func1\n\t/build/pkg/csi/service/wcp/controller.go:1058\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).ControllerUnpublishVolume\n\t/build/pkg/csi/service/wcp/controller.go:1121\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_ControllerUnpublishVolume_Handler\n\t/go/pkg/mod/github.com/container-storage-interface/spec@v1.5.0/lib/go/csi/csi.pb.go:5723\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:1297\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:1626\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.2\n\t/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:941"}
{"level":"info","time":"2022-07-20T20:14:15.071626279Z","caller":"wcp/controller.go:1061","msg":"virtual machine not found for vmUUID \"50048e23-5f85-4807-b1e4-1bb46d6ee548\". Thus, assuming the volume is detached.","TraceId":"c172a191-385d-41f6-b06c-f3f2cfe7d3ac"}
{"level":"info","time":"2022-07-20T20:14:15.072275109Z","caller":"wcp/controller.go:1131","msg":"Volume \"f3ebbd9c-9e3a-4024-9b2e-2e6d1f6a534b\" detached successfully.","TraceId":"c172a191-385d-41f6-b06c-f3f2cfe7d3ac"}
{"level":"info","time":"2022-07-20T20:14:15.10589782Z","caller":"wcp/controller.go:1004","msg":"ControllerUnpublishVolume: called with args {VolumeId:f3ebbd9c-9e3a-4024-9b2e-2e6d1f6a534b NodeId:sc2-10-185-1-11.eng.vmware.com Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"aa1d6d04-6610-46bf-ae0a-9a8d7a240e69"}
{"level":"error","time":"2022-07-20T20:14:15.113444747Z","caller":"k8sorchestrator/k8sorchestrator.go:1360","msg":"failed to get the volumeattachment \"csi-4f8be08acf717243c345b47b76283357aff65970ae0dd3b3dd125393c92f9be4\" from API server Err: volumeattachments.storage.k8s.io \"csi-4f8be08acf717243c345b47b76283357aff65970ae0dd3b3dd125393c92f9be4\" not found","TraceId":"aa1d6d04-6610-46bf-ae0a-9a8d7a240e69","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator.(*K8sOrchestrator).GetVolumeAttachment\n\t/build/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:1360\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).ControllerUnpublishVolume.func1\n\t/build/pkg/csi/service/wcp/controller.go:1020\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).ControllerUnpublishVolume\n\t/build/pkg/csi/service/wcp/controller.go:1121\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_ControllerUnpublishVolume_Handler\n\t/go/pkg/mod/github.com/container-storage-interface/spec@v1.5.0/lib/go/csi/csi.pb.go:5723\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:1297\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:1626\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.2\n\t/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:941"}
{"level":"info","time":"2022-07-20T20:14:15.114663081Z","caller":"wcp/controller.go:1023","msg":"VolumeAttachments object not found for volume \"f3ebbd9c-9e3a-4024-9b2e-2e6d1f6a534b\" & node \"sc2-10-185-1-11.eng.vmware.com\". Thus, assuming the volume is detached.","TraceId":"aa1d6d04-6610-46bf-ae0a-9a8d7a240e69"}
{"level":"info","time":"2022-07-20T20:14:15.114703017Z","caller":"wcp/controller.go:1131","msg":"Volume \"f3ebbd9c-9e3a-4024-9b2e-2e6d1f6a534b\" detached successfully.","TraceId":"aa1d6d04-6610-46bf-ae0a-9a8d7a240e69"}
```


https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1822#issuecomment-1165103181

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Return success for DetachVolume when identical VA is found for other node with same vmUUID and  volumeId
```
