### PR TITLE
add rbac rules for tkgs-ha feature for k8s supervisor 1.21

### DIFF
--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -75,6 +75,9 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
     verbs: ["list"]
+  - apiGroups: ["topology.tanzu.vmware.com"]
+    resources: ["availabilityzones"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
we need to add get, list and watch capabilities for availabilityzones CR for k8s 1.21 supervisor CSI yaml.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Deployed supervisor k8s 1.21 with tkgs-ha enabled
Observed CSI controller was in a crash loop back off with the following error

> {"level":"error","time":"2022-06-27T22:09:51.004662722Z","caller":"wcp/controller.go:103","msg":"failed to get clusterComputeResourceMoIds. err: failed to get AvailabilityZone lists. err: availabilityzones.topology.tanzu.vmware.com is forbidden: User \"system:serviceaccount:vmware-system-csi:vsphere-csi-controller\" cannot list resource \"availabilityzones\" in API group \"topology.tanzu.vmware.com\" at the cluster scope","TraceId":"b7c19837-8c05-419c-95e1-a3da7afa73d7","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).Init\n\t/build/mts/release/bora-19937721/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/csi/service/wcp/controller.go:103\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service.(*vsphereCSIDriver).BeforeServe\n\t/build/mts/release/bora-19937721/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/csi/service/driver.go:142\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service.(*vsphereCSIDriver).Run\n\t/build/mts/release/bora-19937721/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/csi/service/driver.go:156\nmain.main\n\t/build/mts/release/bora-19937721/cayman_vsphere_csi_driver/vsphere_csi_driver/src/cmd/vsphere-csi/main.go:89\nruntime.main\n\t/build/mts/release/bora-19937721/compcache/cayman_go/ob-19366519/linux64/src/runtime/proc.go:255"}


```
]# kubectl get pods --namespace=vmware-system-csi
NAME                                      READY   STATUS             RESTARTS   AGE
vsphere-csi-controller-76b7954dfd-jq6sb   4/6     CrashLoopBackOff   149        5h33m
vsphere-csi-webhook-59bbbf647f-cjnlq      1/1     Running            0          5h33m
vsphere-csi-webhook-59bbbf647f-nc6rh      1/1     Running            0          5h33m
vsphere-csi-webhook-59bbbf647f-qhcjt      1/1     Running            0          5h33m
```

Patched  cluster role and re-created CSI controller pod

```
# kubectl describe ClusterRole vsphere-csi-controller-role | grep topology
  availabilityzones.topology.tanzu.vmware.com     []                 []              [get list watch]

deleted controller pod and new pod is now up and running.

# kubectl get pods --namespace=vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-76b7954dfd-wr2lt   6/6     Running   0          23s
vsphere-csi-webhook-59bbbf647f-cjnlq      1/1     Running   0          5h49m
vsphere-csi-webhook-59bbbf647f-nc6rh      1/1     Running   0          5h49m
vsphere-csi-webhook-59bbbf647f-qhcjt      1/1     Running   0          5h49m
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add rbac rules for tkgs-ha feature for k8s supervisor 1.21
```
