### PR TITLE
Check datastore compatibility before considering preference in topology

### DIFF
--- a/pkg/csi/service/common/commonco/types/types.go
+++ b/pkg/csi/service/common/commonco/types/types.go
@@ -39,6 +39,12 @@ type VanillaTopologyFetchDSParams struct {
 	// TopologyRequirement represents the topology conditions
 	// which need to be satisfied during volume provisioning.
 	TopologyRequirement *csi.TopologyRequirement
+	// Vc is the vcenter instance using which storage policy
+	// compatibility will be calculated.
+	Vc *cnsvsphere.VirtualCenter
+	// StoragePolicyName is the policy name specified in the storage class
+	// to which the volume should be compatible.
+	StoragePolicyName string
 }
 
 // WCPTopologyFetchDSParams represents the params required to call


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: In preferential deployment feature, we should first check the compatibility of datastores to given storage policy (if applicable) before further filtering with preferred datastores. This PR helps retain the existing behavior of volume provisioning while giving customers a better opportunity to fine-tune their datastore preference. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
1. SC with shared policy pointing to vSAN DS. Preferred DS is NFS:
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: block-sc
provisioner: csi.vsphere.vmware.com
allowVolumeExpansion: true  
parameters:
  storagepolicyname: "vSAN Default Storage Policy"
```

Logs:
```
2022-07-01T19:40:56.311Z	INFO	vanilla/controller.go:847	CreateVolume: called with args {Name:pvc-562fdf99-b800-4e34-b66f-b510c395bbb4 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[storagepolicyname:vSAN Default Storage Policy] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site2" > > requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site3" > > requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site4" > > requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site1" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site3" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site4" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site1" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site2" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.331Z	INFO	k8sorchestrator/topology.go:944	Obtained list of nodeVMs [VirtualMachine:vm-51 [VirtualCenterHost: 10.192.194.116, UUID: 42238a6f-2883-74d7-5731-3a045dbd3d61, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.192.194.116]] VirtualMachine:vm-55 [VirtualCenterHost: 10.192.194.116, UUID: 42231890-dbb6-9cfe-5232-0df53fc91eb2, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.192.194.116]]]	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.468Z	INFO	k8sorchestrator/topology.go:977	Datastores compatible with storage policy "vSAN Default Storage Policy" are map[datastore-47:{}]	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.468Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.471Z	INFO	k8sorchestrator/topology.go:944	Obtained list of nodeVMs [VirtualMachine:vm-52 [VirtualCenterHost: 10.192.194.116, UUID: 42237f06-5ee3-f1de-4964-e0a592f52930, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.192.194.116]]]	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.570Z	INFO	k8sorchestrator/topology.go:977	Datastores compatible with storage policy "vSAN Default Storage Policy" are map[datastore-47:{}]	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.570Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.579Z	INFO	k8sorchestrator/topology.go:944	Obtained list of nodeVMs [VirtualMachine:vm-53 [VirtualCenterHost: 10.192.194.116, UUID: 4223c248-58b2-9e93-2361-660773bbfe24, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.192.194.116]] VirtualMachine:vm-54 [VirtualCenterHost: 10.192.194.116, UUID: 42231fa6-cb6c-b91d-4a12-eb2d23936c37, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.192.194.116]]]	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.700Z	INFO	k8sorchestrator/topology.go:977	Datastores compatible with storage policy "vSAN Default Storage Policy" are map[datastore-47:{}]	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.700Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.704Z	INFO	k8sorchestrator/topology.go:944	Obtained list of nodeVMs [VirtualMachine:vm-50 [VirtualCenterHost: 10.192.194.116, UUID: 4223ca70-fb24-461d-425a-d6ef99969e94, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.192.194.116]]]	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.792Z	INFO	k8sorchestrator/topology.go:977	Datastores compatible with storage policy "vSAN Default Storage Policy" are map[datastore-47:{}]	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.792Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:40:56.792Z	INFO	k8sorchestrator/topology.go:1016	Obtained shared datastores: [Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:52486078f979334f-793a08753c602c98/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:52486078f979334f-793a08753c602c98/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:52486078f979334f-793a08753c602c98/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:52486078f979334f-793a08753c602c98/]	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:41:06.755Z	INFO	volume/manager.go:410	CreateVolume: VolumeName: "pvc-562fdf99-b800-4e34-b66f-b510c395bbb4", opId: "59abf021"	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:41:06.760Z	INFO	volume/util.go:322	Volume created successfully. VolumeName: "pvc-562fdf99-b800-4e34-b66f-b510c395bbb4", volumeID: "bfec35df-4b24-4483-b390-cfb1059754e3"	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:41:06.851Z	INFO	common/vsphereutil.go:1148	Nodes that have access to datastore "ds:///vmfs/volumes/vsan:52486078f979334f-793a08753c602c98/" are [VirtualMachine:vm-52 VirtualMachine:vm-53 VirtualMachine:vm-54 VirtualMachine:vm-50 VirtualMachine:vm-51 VirtualMachine:vm-55]	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:41:06.872Z	INFO	k8sorchestrator/topology.go:1238	Topology segments retrieved from nodes accessible to datastore "ds:///vmfs/volumes/vsan:52486078f979334f-793a08753c602c98/" are: [map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-site:site4] map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-site:site1] map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-site:site2] map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-site:site3]]	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:41:06.873Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:41:06.873Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:41:06.873Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:41:06.873Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:41:06.873Z	INFO	k8sorchestrator/topology.go:1289	Accessible topology calculated for datastore "ds:///vmfs/volumes/vsan:52486078f979334f-793a08753c602c98/" is [map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-site:site4] map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-site:site1] map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-site:site2] map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-site:site3]]	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
2022-07-01T19:41:06.873Z	INFO	vanilla/controller.go:882	Volume created successfully. Volume Handle: "bfec35df-4b24-4483-b390-cfb1059754e3", PV Name: "pvc-562fdf99-b800-4e34-b66f-b510c395bbb4"	{"TraceId": "e0c6b348-3bf7-4f47-b9af-186bf7746be9"}
```

PV:
```
Name:              pvc-562fdf99-b800-4e34-b66f-b510c395bbb4
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      block-sc
Status:            Bound
Claim:             default/block-pvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.csi.vmware.com/k8s-region in [region1]
                   topology.csi.vmware.com/k8s-site in [site4]
    Term 1:        topology.csi.vmware.com/k8s-site in [site1]
                   topology.csi.vmware.com/k8s-region in [region1]
    Term 2:        topology.csi.vmware.com/k8s-site in [site2]
                   topology.csi.vmware.com/k8s-region in [region1]
    Term 3:        topology.csi.vmware.com/k8s-region in [region1]
                   topology.csi.vmware.com/k8s-site in [site3]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      bfec35df-4b24-4483-b390-cfb1059754e3
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1656704295961-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>

```

2. SC with shared datastore policy pointing to NFS and vSAN. Preferred DS is NFS:
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: block-sc-shared
provisioner: csi.vsphere.vmware.com
allowVolumeExpansion: true
parameters:
  storagepolicyname: "shared-ds-policy"
```

Logs:
```
2022-07-01T20:35:04.787Z	INFO	vanilla/controller.go:847	CreateVolume: called with args {Name:pvc-ad37c6d2-9c0d-43c5-838c-b273ce2dcf7b CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[storagepolicyname:shared-ds-policy] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site2" > > requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site3" > > requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site4" > > requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site1" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site1" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site2" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site3" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-site" value:"site4" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:04.815Z	INFO	k8sorchestrator/topology.go:944	Obtained list of nodeVMs [VirtualMachine:vm-54 [VirtualCenterHost: 10.192.194.116, UUID: 42231fa6-cb6c-b91d-4a12-eb2d23936c37, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.192.194.116]] VirtualMachine:vm-53 [VirtualCenterHost: 10.192.194.116, UUID: 4223c248-58b2-9e93-2361-660773bbfe24, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.192.194.116]]]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:04.934Z	INFO	k8sorchestrator/topology.go:977	Datastores compatible with storage policy "shared-ds-policy" are map[datastore-36:{} datastore-47:{}]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:04.934Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:04.935Z	INFO	k8sorchestrator/topology.go:1006	Using preferred datastores: [Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/4488af92-e5822c44/]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:04.944Z	INFO	k8sorchestrator/topology.go:944	Obtained list of nodeVMs [VirtualMachine:vm-50 [VirtualCenterHost: 10.192.194.116, UUID: 4223ca70-fb24-461d-425a-d6ef99969e94, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.192.194.116]]]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.024Z	INFO	k8sorchestrator/topology.go:977	Datastores compatible with storage policy "shared-ds-policy" are map[datastore-36:{} datastore-47:{}]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.024Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.024Z	INFO	k8sorchestrator/topology.go:1006	Using preferred datastores: [Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/4488af92-e5822c44/]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.035Z	INFO	k8sorchestrator/topology.go:944	Obtained list of nodeVMs [VirtualMachine:vm-51 [VirtualCenterHost: 10.192.194.116, UUID: 42238a6f-2883-74d7-5731-3a045dbd3d61, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.192.194.116]] VirtualMachine:vm-55 [VirtualCenterHost: 10.192.194.116, UUID: 42231890-dbb6-9cfe-5232-0df53fc91eb2, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.192.194.116]]]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.125Z	INFO	k8sorchestrator/topology.go:977	Datastores compatible with storage policy "shared-ds-policy" are map[datastore-36:{} datastore-47:{}]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.125Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.125Z	INFO	k8sorchestrator/topology.go:1006	Using preferred datastores: [Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/4488af92-e5822c44/]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.131Z	INFO	k8sorchestrator/topology.go:944	Obtained list of nodeVMs [VirtualMachine:vm-52 [VirtualCenterHost: 10.192.194.116, UUID: 42237f06-5ee3-f1de-4964-e0a592f52930, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.192.194.116]]]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.131Z	DEBUG	vsphere/virtualmachine.go:364	Getting accessible datastores for node VirtualMachine:vm-52	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.212Z	INFO	k8sorchestrator/topology.go:977	Datastores compatible with storage policy "shared-ds-policy" are map[datastore-36:{} datastore-47:{}]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.212Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.212Z	INFO	k8sorchestrator/topology.go:1006	Using preferred datastores: [Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/4488af92-e5822c44/]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:05.212Z	INFO	k8sorchestrator/topology.go:1016	Obtained shared datastores: [Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/4488af92-e5822c44/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/4488af92-e5822c44/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/4488af92-e5822c44/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/4488af92-e5822c44/]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:06.970Z	INFO	volume/manager.go:410	CreateVolume: VolumeName: "pvc-ad37c6d2-9c0d-43c5-838c-b273ce2dcf7b", opId: "59abffef"	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:06.975Z	INFO	volume/util.go:322	Volume created successfully. VolumeName: "pvc-ad37c6d2-9c0d-43c5-838c-b273ce2dcf7b", volumeID: "3f2f1959-3c8c-4dd6-bfc5-bcc4d5596cb7"	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:07.074Z	INFO	common/vsphereutil.go:1148	Nodes that have access to datastore "ds:///vmfs/volumes/4488af92-e5822c44/" are [VirtualMachine:vm-52 VirtualMachine:vm-53 VirtualMachine:vm-54 VirtualMachine:vm-50 VirtualMachine:vm-51 VirtualMachine:vm-55]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:07.105Z	INFO	k8sorchestrator/topology.go:1238	Topology segments retrieved from nodes accessible to datastore "ds:///vmfs/volumes/4488af92-e5822c44/" are: [map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-site:site4] map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-site:site1] map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-site:site2] map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-site:site3]]	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:07.105Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:07.105Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:07.105Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:07.105Z	INFO	k8sorchestrator/topology.go:1035	Found preferred datastores [ds:///vmfs/volumes/4488af92-e5822c44/] for topology domain "region1"	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
2022-07-01T20:35:07.105Z	INFO	vanilla/controller.go:882	Volume created successfully. Volume Handle: "3f2f1959-3c8c-4dd6-bfc5-bcc4d5596cb7", PV Name: "pvc-ad37c6d2-9c0d-43c5-838c-b273ce2dcf7b"	{"TraceId": "e207d61a-fa3f-4ef2-9f2d-3163d6fd7ade"}
```

PV:
```
Name:              pvc-ad37c6d2-9c0d-43c5-838c-b273ce2dcf7b
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      block-sc-shared
Status:            Bound
Claim:             default/block-pvc-shared
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.csi.vmware.com/k8s-region in [region1]
                   topology.csi.vmware.com/k8s-site in [site1]
    Term 1:        topology.csi.vmware.com/k8s-region in [region1]
                   topology.csi.vmware.com/k8s-site in [site2]
    Term 2:        topology.csi.vmware.com/k8s-region in [region1]
                   topology.csi.vmware.com/k8s-site in [site3]
    Term 3:        topology.csi.vmware.com/k8s-site in [site4]
                   topology.csi.vmware.com/k8s-region in [region1]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      3f2f1959-3c8c-4dd6-bfc5-bcc4d5596cb7
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1656704295961-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Check datastore compatibility before considering preference in topology
```
