### PR TITLE
Cherry-pick 1831: Check datastore compatibility before considering preference in topology

### DIFF
--- a/pkg/csi/service/common/commonco/types/types.go
+++ b/pkg/csi/service/common/commonco/types/types.go
@@ -39,6 +39,12 @@ type VanillaTopologyFetchDSParams struct {
 	// TopologyRequirement represents the topology conditions
 	// which need to be satisfied during volume provisioning.
 	TopologyRequirement *csi.TopologyRequirement
+	// Vc is the vcenter instance using which storage policy
+	// compatibility will be calculated.
+	Vc *cnsvsphere.VirtualCenter
+	// StoragePolicyName is the policy name specified in the storage class
+	// to which the volume should be compatible.
+	StoragePolicyName string
 }
 
 // WCPTopologyFetchDSParams represents the params required to call


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Cherry-pick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1831 to release 2.6

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Not required. The original PR tested for regression.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Check datastore compatibility before considering preference in topology
```
