### PR TITLE
Change function "ListDataCenters" to add logic to connect to VC 

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -327,8 +327,9 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 func (vc *VirtualCenter) ListDatacenters(ctx context.Context) (
 	[]*Datacenter, error) {
 	log := logger.GetLogger(ctx)
-	if vc.Client == nil {
-		return nil, logger.LogNewError(log, "failed to list datacenters due to VC client is not set")
+	if err := vc.Connect(ctx); err != nil {
+		log.Errorf("failed to connect to vCenter. err: %v", err)
+		return nil, err
 	}
 	finder := find.NewFinder(vc.Client.Client, false)
 	dcList, err := finder.DatacenterList(ctx, "*")


### PR DESCRIPTION
… the current connection may be invalid.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Change function "ListDataCenters" to add logic to connect to VC since the current connection may be invalid.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

_**_TestResult with only "ListDataCenters" fix_**_
Run local testing with the following steps.

1. Reduce external-provisioner timeout to 10s and wait for csi pod rollout. No need of restart of csi pods.
2. Create 3 PVCs using SC. (file-pvc-8, file-pvc-9, file-pvc-10)
3. Wait for PVCs created to be bound.

All PVCs are bound within 5 minutes.
```
root@k8s-control-72-1656446275:~# kubectl get pvc
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
file-pvc      Bound    pvc-fc4cd56e-218f-414c-bb78-c2769c411053   1Gi        RWX            file-sc        16h
file-pvc-1    Bound    pvc-8556ddb5-2366-49f8-9674-3424f01871bb   1Gi        RWX            file-sc        16h
file-pvc-10   Bound    pvc-f8dd69ed-df90-4899-b8d0-c43a37a57885   1Gi        RWX            file-sc        46s
file-pvc-2    Bound    pvc-9c1954ee-e795-435a-b277-dfae0d6ef65e   1Gi        RWX            file-sc        16h
file-pvc-3    Bound    pvc-599aee11-0607-4b32-9aa0-a9d00a9369ea   1Gi        RWX            file-sc        16h
file-pvc-4    Bound    pvc-a06427d9-b6a7-4287-b297-d1767f3c8417   1Gi        RWX            file-sc        16h
file-pvc-5    Bound    pvc-fee1d04c-abbd-4182-b4da-553680083ee4   1Gi        RWX            file-sc        16h
file-pvc-7    Bound    pvc-2ba8a2aa-2b42-4bc5-b950-6adfdbfb9b8b   1Gi        RWX            file-sc        126m
file-pvc-8    Bound    pvc-deda9ba8-bbe3-4d3e-98f2-465e0a50eb82   1Gi        RWX            file-sc        46s
file-pvc-9    Bound    pvc-b6120ecb-911b-4530-803d-7222785d2268   1Gi        RWX            file-sc        46s
```

CSI logs (CSI make a new session and auth manager function call " newFsEnabledClusterToDsMap" succeeded).
```
022-07-05T23:34:54.788Z        DEBUG   common/authmanager.go:151       auth manager: refreshDatastoreMapsForFileVolumes is triggered   {"TraceId": "79c880b1-4b4e-42b4-a7c2-05a0d35cba3a"}


2022-07-05T23:34:54.806Z        WARN    vsphere/virtualcenter.go:285    Creating a new client session as the existing one isn't valid or not authenticated      {"TraceId": "79c880b1-4b4e-42b4-a7c2-05a0d35cba3a"}
sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*VirtualCenter).connect
        /build/pkg/common/cns-lib/vsphere/virtualcenter.go:285
sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*VirtualCenter).Connect
        /build/pkg/common/cns-lib/vsphere/virtualcenter.go:237
sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*VirtualCenter).ListDatacenters
        /build/pkg/common/cns-lib/vsphere/virtualcenter.go:330
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.GenerateFSEnabledClustersToDsMap
        /build/pkg/csi/service/common/authmanager.go:233
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.(*AuthManager).refreshFSEnabledClustersToDsMap
        /build/pkg/csi/service/common/authmanager.go:152
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.ComputeFSEnabledClustersToDsMap
        /build/pkg/csi/service/common/authmanager.go:182


2022-07-05T23:34:54.807Z        DEBUG   vsphere/virtualcenter.go:158    Setting vCenter soap client timeout to 5m0s     {"TraceId": "79c880b1-4b4e-42b4-a7c2-05a0d35cba3a"}

2022-07-05T23:34:54.856Z        INFO    vsphere/virtualcenter.go:183    New session ID for 'VSPHERE.LOCAL\Administrator' = 52994f32-0bb3-e8c8-9749-fa38dea9cb98 {"TraceId": "79c880b1-4b4e-42b4-a7c2-05a0d35cba3a"}

2022-07-05T23:34:55.050Z        DEBUG   common/authmanager.go:158       auth manager: newFsEnabledClusterToDsMap is updated to map[domain-c8:[Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:5218713da6b547ff-406de3cd9e70be7c/]]    {"TraceId": "79c880b1-4b4e-42b4-a7c2-05a0d35cba3a"}


2022-07-05T23:34:55.050Z        DEBUG   common/authmanager.go:158       auth manager: newFsEnabledClusterToDsMap is updated to map[domain-c8:[Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:5218713da6b547ff-406de3cd9e70be7c/]]    {"TraceId": "79c880b1-4b4e-42b4-a7c2-05a0d35cba3a"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
