### PR TITLE
Avoid duplicate datastores in CNS CreateVolume Spec

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -1011,7 +1011,19 @@ func (volTopology *controllerVolumeTopology) getSharedDatastoresInTopology(ctx c
 		}
 
 		// Update sharedDatastores with the list of datastores received.
-		sharedDatastores = append(sharedDatastores, sharedDatastoresInTopology...)
+		// Duplicates will not be added.
+		for _, ds := range sharedDatastoresInTopology {
+			var found bool
+			for _, sharedDS := range sharedDatastores {
+				if sharedDS.Info.Url == ds.Info.Url {
+					found = true
+					break
+				}
+			}
+			if !found {
+				sharedDatastores = append(sharedDatastores, ds)
+			}
+		}
 	}
 	log.Infof("Obtained shared datastores: %+v", sharedDatastores)
 	return sharedDatastores, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Avoid sending duplicate datastores to CNS CreateVolume Spec.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before change:
```
2022-07-01T23:23:27.323Z	DEBUG	common/vsphereutil.go:260	vSphere CSI driver creating volume pvc-00676df6-29d0-42e5-97d4-43b7082cbb94 with create spec (*types.CnsVolumeCreateSpec)(0xc000247f00)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-00676df6-29d0-42e5-97d4-43b7082cbb94",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=4 cap=4) {
  (types.ManagedObjectReference) Datastore:datastore-47,
  (types.ManagedObjectReference) Datastore:datastore-47,
  (types.ManagedObjectReference) Datastore:datastore-47,
  (types.ManagedObjectReference) Datastore:datastore-47
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=8) "cluster1",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA",
   ClusterDistribution: (string) (len=11) "CSI-Vanilla"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=8) "cluster1",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA",
    ClusterDistribution: (string) (len=11) "CSI-Vanilla"
   }
  }
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc000bb6fc0)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 1024
  },
  BackingDiskId: (string) "",
  BackingDiskUrlPath: (string) "",
  BackingDiskObjectId: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) (len=1 cap=1) {
  (*types.VirtualMachineDefinedProfileSpec)(0xc000bb7000)({
   VirtualMachineProfileSpec: (types.VirtualMachineProfileSpec) {
    DynamicData: (types.DynamicData) {
    }
   },
   ProfileId: (string) (len=36) "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
   ReplicationSpec: (*types.ReplicationSpec)(<nil>),
   ProfileData: (*types.VirtualMachineProfileRawData)(<nil>),
   ProfileParams: ([]types.KeyValue) <nil>
  })
 },
 CreateSpec: (types.BaseCnsBaseCreateSpec) <nil>,
 VolumeSource: (types.BaseCnsVolumeSource) <nil>
})
	{"TraceId": "e353e4df-450c-4f86-a851-455cc51e3aa9"}
2022-07-01T23:23:27.338Z	DEBUG	volume/util.go:198	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator	{"TraceId": "e353e4df-450c-4f86-a851-455cc51e3aa9"}
2022-07-01T23:23:27.338Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:134	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-00676df6-29d0-42e5-97d4-43b7082cbb94	{"TraceId": "e353e4df-450c-4f86-a851-455cc51e3aa9"}
2022-07-01T23:23:27.419Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:168	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc000bb7ac0)({
 Name: (string) (len=40) "pvc-00676df6-29d0-42e5-97d4-43b7082cbb94",
 VolumeID: (string) "",
 SnapshotID: (string) "",
 Capacity: (int64) 0,
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc00080e900)({
  TaskInvocationTimestamp: (v1.Time) 2022-07-01 23:23:27.419026621 +0000 UTC m=+13449.485711995,
  TaskID: (string) (len=9) "task-3556",
  OpID: (string) "",
  TaskStatus: (string) (len=10) "InProgress",
  Error: (string) ""
 })
})
	{"TraceId": "e353e4df-450c-4f86-a851-455cc51e3aa9"}
```

After the change:
```
2022-07-01T23:38:38.917Z	DEBUG	common/vsphereutil.go:260	vSphere CSI driver creating volume pvc-9817f236-fd7f-4f42-b330-fa9c58dc438a with create spec (*types.CnsVolumeCreateSpec)(0xc000a27600)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-9817f236-fd7f-4f42-b330-fa9c58dc438a",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=1 cap=1) {
  (types.ManagedObjectReference) Datastore:datastore-47
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=8) "cluster1",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA",
   ClusterDistribution: (string) (len=11) "CSI-Vanilla"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=8) "cluster1",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA",
    ClusterDistribution: (string) (len=11) "CSI-Vanilla"
   }
  }
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc000c10340)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 1024
  },
  BackingDiskId: (string) "",
  BackingDiskUrlPath: (string) "",
  BackingDiskObjectId: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) (len=1 cap=1) {
  (*types.VirtualMachineDefinedProfileSpec)(0xc000c10380)({
   VirtualMachineProfileSpec: (types.VirtualMachineProfileSpec) {
    DynamicData: (types.DynamicData) {
    }
   },
   ProfileId: (string) (len=36) "aa6d5a82-1c88-45da-85d3-3d74b91a5bad",
   ReplicationSpec: (*types.ReplicationSpec)(<nil>),
   ProfileData: (*types.VirtualMachineProfileRawData)(<nil>),
   ProfileParams: ([]types.KeyValue) <nil>
  })
 },
 CreateSpec: (types.BaseCnsBaseCreateSpec) <nil>,
 VolumeSource: (types.BaseCnsVolumeSource) <nil>
})
	{"TraceId": "6cb28d85-c562-4329-825f-3d792ed6e2ef"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Avoid duplicate datastores in CNS CreateVolume Spec
```
