### PR TITLE
[Cherry-pick #1837]: Avoid duplicate datastores in CNS CreateVolume Spec 

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -1011,7 +1011,19 @@ func (volTopology *controllerVolumeTopology) getSharedDatastoresInTopology(ctx c
 		}
 
 		// Update sharedDatastores with the list of datastores received.
-		sharedDatastores = append(sharedDatastores, sharedDatastoresInTopology...)
+		// Duplicates will not be added.
+		for _, ds := range sharedDatastoresInTopology {
+			var found bool
+			for _, sharedDS := range sharedDatastores {
+				if sharedDS.Info.Url == ds.Info.Url {
+					found = true
+					break
+				}
+			}
+			if !found {
+				sharedDatastores = append(sharedDatastores, ds)
+			}
+		}
 	}
 	log.Infof("Obtained shared datastores: %+v", sharedDatastores)
 	return sharedDatastores, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Cherry pick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1837
 to release 2.6

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Not required. Tested in master.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Avoid duplicate datastores in CNS CreateVolume Spec 
```
