### PR TITLE
[Cherry-pick to release-2.6]  Connect to Pbm client before invoking pbm methods

### DIFF
--- a/pkg/common/cns-lib/vsphere/pbm.go
+++ b/pkg/common/cns-lib/vsphere/pbm.go
@@ -24,6 +24,7 @@ import (
 	pbmmethods "github.com/vmware/govmomi/pbm/methods"
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 )
 
@@ -100,6 +101,14 @@ func (vc *VirtualCenter) GetStoragePolicyIDByName(ctx context.Context, storagePo
 // with the given datastores.
 func (vc *VirtualCenter) PbmCheckCompatibility(ctx context.Context,
 	datastores []vimtypes.ManagedObjectReference, profileID string) (pbm.PlacementCompatibilityResult, error) {
+
+	log := logger.GetLogger(ctx)
+	err := vc.ConnectPbm(ctx)
+	if err != nil {
+		log.Errorf("Error occurred while connecting to PBM, err: %+v", err)
+		return nil, err
+	}
+
 	hubs := make([]pbmtypes.PbmPlacementHub, 0)
 	for _, ds := range datastores {
 		hubs = append(hubs, pbmtypes.PbmPlacementHub{
@@ -125,6 +134,13 @@ func (vc *VirtualCenter) PbmCheckCompatibility(ctx context.Context,
 
 // PbmRetrieveContent fetches the policy content of all given policies from SPBM.
 func (vc *VirtualCenter) PbmRetrieveContent(ctx context.Context, policyIds []string) ([]SpbmPolicyContent, error) {
+
+	log := logger.GetLogger(ctx)
+	err := vc.ConnectPbm(ctx)
+	if err != nil {
+		log.Errorf("Error occurred while connecting to PBM, err: %+v", err)
+		return nil, err
+	}
 	pbmPolicyIds := make([]pbmtypes.PbmProfileId, 0)
 	for _, policyID := range policyIds {
 		pbmPolicyIds = append(pbmPolicyIds, pbmtypes.PbmProfileId{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
This PR is cherry-picking https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1815 to the release-2.6 branch.

**What this PR does / why we need it**:
This fix is required for the preferential datastore feature.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Connect to Pbm client before invoking pbm methods
```
