### PR TITLE
Fix list-volume feature null pointer exception

### DIFF
--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -525,9 +525,12 @@ func (c *controller) GetVolumeToHostMapping(ctx context.Context) (map[string]str
 	for _, info := range vmMoList {
 		vmMoID := info.Reference().Value
 
-		host := info.Runtime.Host
-		vmMoIDToHostMoID[vmMoID] = host.Reference().Value
-
+		if info.Runtime.Host != nil {
+			vmMoIDToHostMoID[vmMoID] = info.Runtime.Host.Reference().Value
+		}
+		if info.Config == nil {
+			continue
+		}
 		devices := info.Config.Hardware.Device
 		vmDevices := object.VirtualDeviceList(devices)
 		for _, device := range vmDevices {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

This PR fixes the null pointer exception seen sometimes when list volumes is enabled.



Testing done:
Manually tested it on a testbed, did not see csi pods crashing.

```
msmruthi@msmruthi-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
Unable to find image 'gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.23.2' locally
0.23.2: Pulling from cluster-api-provider-vsphere/extra/mdlint
4000adbbc3eb: Already exists 
69e2f037cdb3: Pull complete 
3e010093287c: Pull complete 
e9675f44a17f: Pull complete 
fb428da72d0c: Pull complete 
55cf2dd1eb3a: Pull complete 
Digest: sha256:b07f41d2daae397af80250e69575c84e5aa9d9a4b334af890e3dc508a25065e9
Status: Downloaded newer image for gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.23.2
hack/check-shell.sh
Unable to find image 'gcr.io/cluster-api-provider-vsphere/extra/shellcheck:v0.7.1' locally
v0.7.1: Pulling from cluster-api-provider-vsphere/extra/shellcheck
75cb2ebf3b3c: Pull complete 
d8cc84507434: Pull complete 
cd376a308b24: Pull complete 
7852a05dcd82: Pull complete 
Digest: sha256:23b8cfc08f7279f334fc60dcf3d60f9e9889f1bb14e8268cf045e89d3abf64cc
Status: Downloaded newer image for gcr.io/cluster-api-provider-vsphere/extra/shellcheck:v0.7.1
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.1
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/msmruthi/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/provider sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e

hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/msmruthi/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/msmruthi/k8s/vsphere-csi-driver /Users/msmruthi/k8s /Users/msmruthi /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (files|imports|name|deps|exports_file|types_sizes|compiled_files) took 1.907375708s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 115.679326ms 
INFO [linters context/goanalysis] analyzers took 2m59.945126428s with top 10 stages: buildir: 2m12.908960836s, nilness: 6.151401166s, ctrlflow: 3.141128736s, printf: 2.999065901s, fact_deprecated: 2.903638034s, inspect: 2.611475699s, typedness: 2.498864292s, fact_purity: 2.263875691s, misspell: 2.135565936s, SA5012: 2.077632585s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_files: 113/113, skip_dirs: 113/113, exclude: 24/24, nolint: 0/1, path_prettifier: 113/113, cgo: 113/113, autogenerated_exclude: 24/113, exclude-rules: 1/24, filename_unadjuster: 113/113, identifier_marker: 24/24 
INFO [runner] processing took 22.422718ms with stages: nolint: 17.681417ms, path_prettifier: 1.73824ms, autogenerated_exclude: 1.705706ms, identifier_marker: 873.114µs, skip_dirs: 265.458µs, exclude-rules: 125.684µs, cgo: 22.225µs, filename_unadjuster: 6.423µs, max_same_issues: 1.13µs, uniq_by_line: 664ns, source_code: 353ns, max_from_linter: 343ns, diff: 336ns, skip_files: 296ns, exclude: 263ns, sort_results: 256ns, path_shortener: 229ns, severity-rules: 226ns, max_per_file_from_linter: 222ns, path_prefixer: 133ns 
INFO [runner] linters took 29.84399471s with stages: goanalysis_metalinter: 29.813021937s 
INFO File cache stats: 275 entries of total size 4.6MiB 
INFO Memory: 291 samples, avg is 1172.8MB, max is 1628.7MB 
INFO Execution took 31.88313897s                  
msmruthi@msmruthi-a01 vsphere-csi-driver % 
```
