### PR TITLE
fix for nil user session

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -179,9 +179,13 @@ func (vc *VirtualCenter) newClient(ctx context.Context) (*govmomi.Client, error)
 	}
 
 	s, err := client.SessionManager.UserSession(ctx)
-	if err == nil {
-		log.Infof("New session ID for '%s' = %s", s.UserName, s.Key)
+	// If session is NotAuthenticated, SessionManager.UserSession returns
+	// nil session with nil error
+	if s == nil || err != nil {
+		log.Errorf("failed to get UserSession. Session may be NotAuthenticated. err: %v", err)
+		return nil, err
 	}
+	log.Infof("New session ID for '%s' = %s", s.UserName, s.Key)
 
 	if vc.Config.RoundTripperCount == 0 {
 		vc.Config.RoundTripperCount = DefaultRoundTripperCount

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -77,7 +77,7 @@ var onceForAuthorizationService sync.Once
 var authManagerInstance *AuthManager
 
 // GetAuthorizationService returns the singleton AuthorizationService.
-func GetAuthorizationService(ctx context.Context, vc *cnsvsphere.VirtualCenter) (AuthorizationService, error) {
+func GetAuthorizationService(ctx context.Context, vc *cnsvsphere.VirtualCenter) (*AuthManager, error) {
 	log := logger.GetLogger(ctx)
 	onceForAuthorizationService.Do(func() {
 		log.Info("Initializing authorization service...")

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -184,8 +184,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			return err
 		}
 		c.authMgr = authMgr
-		go common.ComputeDatastoreMapForBlockVolumes(authMgr.(*common.AuthManager),
-			config.Global.CSIAuthCheckIntervalInMin)
+		go common.ComputeDatastoreMapForBlockVolumes(authMgr, config.Global.CSIAuthCheckIntervalInMin)
 		isvSANFileServicesSupported, err := c.manager.VcenterManager.IsvSANFileServicesSupported(ctx,
 			c.manager.VcenterConfig.Host)
 		if err != nil {
@@ -193,8 +192,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			return err
 		}
 		if isvSANFileServicesSupported {
-			go common.ComputeFSEnabledClustersToDsMap(authMgr.(*common.AuthManager),
-				config.Global.CSIAuthCheckIntervalInMin)
+			go common.ComputeFSEnabledClustersToDsMap(authMgr, config.Global.CSIAuthCheckIntervalInMin)
 		}
 	}
 

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -177,7 +177,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		}
 		c.authMgr = authMgr
 		// TODO: Invoke similar method for block volumes.
-		go common.ComputeFSEnabledClustersToDsMap(authMgr.(*common.AuthManager), config.Global.CSIAuthCheckIntervalInMin)
+		go common.ComputeFSEnabledClustersToDsMap(authMgr, config.Global.CSIAuthCheckIntervalInMin)
 	}
 	// Create dynamic informer for AvailabilityZone instance if FSS is enabled
 	// and CR is present in environment.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
## fix unauthenticated session

Refer to this govmomi code for retrieving the current session using `func (sm *Manager) UserSession(`
https://github.com/vmware/govmomi/blob/v0.29.0/session/manager.go#L182-L193

when user session is not authenticated govmomi returns nil session with nil error.
if we do not check if the session is nil or the error is not nil, it results in the driver's continued attempt to use an unauthenticated session. This needs to be prevented and checked in the CSI driver.

I have discussed this issue with @lipingxue for another customer SR.
 

**Testing done**:
In Progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
 fix for nil user session
```
