### PR TITLE
Fix bug in fetching VC instance in preferential deployment feature

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -273,15 +273,18 @@ func (c *K8sOrchestrator) InitTopologyServiceInController(ctx context.Context) (
 // with latest information on the preferential datastores for each topology domain.
 func refreshPreferentialDatastores(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
+	// Get VC instance.
 	cnsCfg, err := common.GetConfig(ctx)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to fetch CNS config. Error: %+v", err)
 	}
-	// Get VC instance.
-	vc, err := cnsvsphere.GetVirtualCenterInstance(ctx, &cnsconfig.ConfigurationInfo{Cfg: cnsCfg},
-		false)
+	vcenterconfig, err := cnsvsphere.GetVirtualCenterConfig(ctx, cnsCfg)
 	if err != nil {
-		return logger.LogNewErrorf(log, "failed to get virtual center instance with error: %v", err)
+		return logger.LogNewErrorf(log, "failed to get VirtualCenterConfig from CNS config. Error: %+v", err)
+	}
+	vc, err := cnsvsphere.GetVirtualCenterManager(ctx).GetVirtualCenter(ctx, vcenterconfig.Host)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to get vCenter instance. Error: %+v", err)
 	}
 	// Get tag manager instance.
 	tagMgr, err := cnsvsphere.GetTagManager(ctx, vc)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Instead of calling `cnsvsphere.GetVirtualCenterInstance`, use `cnsvsphere.GetVirtualCenterManager(ctx).GetVirtualCenter(ctx, vcenterconfig.Host)` to fetch a VC instance in go routine for preferential deployment feature.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before the fix:
```
2022-07-11T21:54:17.099Z	INFO	k8sorchestrator/topology.go:218	Refreshing preferred datastores information...	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.101Z	DEBUG	config/config.go:466	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.114Z	DEBUG	config/config.go:325	Initializing vc server 10.168.186.239	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.114Z	INFO	config/config.go:364	No Net Permissions given in Config. Using default permissions.	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.114Z	DEBUG	config/config.go:434	Setting default queryLimit to 10000	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.114Z	DEBUG	config/config.go:439	Setting default list volume threshold to 50	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.114Z	INFO	vsphere/virtualcenter.go:529	Initializing new vCenterInstance.	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.114Z	INFO	vsphere/utils.go:189	Defaulting timeout for vCenter Client to 5 minutes	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.114Z	DEBUG	vsphere/utils.go:217	Setting the queryLimit = 10000, ListVolumeThreshold = 50	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.114Z	INFO	vsphere/pbm.go:77	PbmClient wasn't connected, ignoring	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.132Z	INFO	vsphere/cns.go:59	CnsClient wasn't connected, ignoring	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.133Z	INFO	vsphere/virtualcentermanager.go:144	Successfully unregistered VC 10.168.186.239	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.133Z	INFO	vsphere/virtualcentermanager.go:122	Successfully registered VC "10.168.186.239"	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.192Z	DEBUG	vsphere/virtualcenter.go:158	Setting vCenter soap client timeout to 5m0s	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.248Z	INFO	vsphere/virtualcenter.go:188	New session ID for 'VSPHERE.LOCAL\Administrator' = 5218c283-a320-9a7e-852f-19c58a45f99f	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.248Z	INFO	vsphere/virtualcenter.go:563	vCenterInstance initialized	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.620Z	INFO	k8sorchestrator/topology.go:331	Datastore "sharedVmfs-all-sites" with URL "ds:///vmfs/volumes/62cc754b-861a1cdc-548d-02010789d3ee/" is preferred in "site-2"	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
2022-07-11T21:54:17.622Z	INFO	k8sorchestrator/topology.go:331	Datastore "nfs-site-2" with URL "ds:///vmfs/volumes/56d89928-569b8fc0/" is preferred in "site-2"	{"TraceId": "e036a83f-f627-4f96-8949-0f3025136fd5"}
```

After the fix:
```
root@k8s-control1:~# kc logs -f vsphere-csi-controller-644ccfdbbf-pfflh  -c vsphere-csi-controller | grep "aef3623e-28eb-45ae-9e7e-504d05218f51"
2022-07-11T23:01:02.870Z	INFO	k8sorchestrator/topology.go:218	Refreshing preferred datastores information...	{"TraceId": "aef3623e-28eb-45ae-9e7e-504d05218f51"}
2022-07-11T23:01:02.870Z	DEBUG	config/config.go:466	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "aef3623e-28eb-45ae-9e7e-504d05218f51"}
2022-07-11T23:01:02.870Z	DEBUG	config/config.go:325	Initializing vc server 10.168.186.239	{"TraceId": "aef3623e-28eb-45ae-9e7e-504d05218f51"}
2022-07-11T23:01:02.870Z	INFO	config/config.go:364	No Net Permissions given in Config. Using default permissions.	{"TraceId": "aef3623e-28eb-45ae-9e7e-504d05218f51"}
2022-07-11T23:01:02.870Z	DEBUG	config/config.go:434	Setting default queryLimit to 10000	{"TraceId": "aef3623e-28eb-45ae-9e7e-504d05218f51"}
2022-07-11T23:01:02.870Z	DEBUG	config/config.go:439	Setting default list volume threshold to 50	{"TraceId": "aef3623e-28eb-45ae-9e7e-504d05218f51"}
2022-07-11T23:01:02.870Z	INFO	vsphere/utils.go:189	Defaulting timeout for vCenter Client to 5 minutes	{"TraceId": "aef3623e-28eb-45ae-9e7e-504d05218f51"}
2022-07-11T23:01:02.870Z	DEBUG	vsphere/utils.go:217	Setting the queryLimit = 10000, ListVolumeThreshold = 50	{"TraceId": "aef3623e-28eb-45ae-9e7e-504d05218f51"}
2022-07-11T23:01:03.402Z	INFO	k8sorchestrator/topology.go:334	Datastore "sharedVmfs-all-sites" with URL "ds:///vmfs/volumes/62cc754b-861a1cdc-548d-02010789d3ee/" is preferred in "site-2"	{"TraceId": "aef3623e-28eb-45ae-9e7e-504d05218f51"}
2022-07-11T23:01:03.405Z	INFO	k8sorchestrator/topology.go:334	Datastore "nfs-site-2" with URL "ds:///vmfs/volumes/56d89928-569b8fc0/" is preferred in "site-2"	{"TraceId": "aef3623e-28eb-45ae-9e7e-504d05218f51"}
```

I did not notice the auth service errors.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix bug in fetching VC instance in preferential deployment feature
```
