### PR TITLE
fix for nil user session

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -18,6 +18,7 @@ package volume
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -1064,6 +1065,12 @@ func (m *defaultManager) UpdateVolumeMetadata(ctx context.Context, spec *cnstype
 		if err != nil {
 			log.Errorf("failed to get usersession with err: %v", err)
 			return err
+		}
+		// Refer to this issue - https://github.com/vmware/govmomi/issues/2922
+		// Session Manager -> UserSession can return nil user session with nil error
+		// so handling the case for nil session.
+		if s == nil {
+			return errors.New("nil session obtained from session manager")
 		}
 		if s.UserName != spec.Metadata.ContainerCluster.VSphereUser {
 			log.Debugf("Update VSphereUser from %s to %s", spec.Metadata.ContainerCluster.VSphereUser, s.UserName)

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -18,6 +18,7 @@ package volume
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 
@@ -193,6 +194,12 @@ func setupConnection(ctx context.Context, virtualCenter *cnsvsphere.VirtualCente
 	if err != nil {
 		log.Errorf("failed to get usersession with err: %v", err)
 		return err
+	}
+	// Refer to this issue - https://github.com/vmware/govmomi/issues/2922
+	// Session Manager -> UserSession can return nil user session with nil error
+	// so handling the case for nil session.
+	if s == nil {
+		return errors.New("nil session obtained from session manager")
 	}
 	if s.UserName != spec.Metadata.ContainerCluster.VSphereUser {
 		log.Debugf("Update VSphereUser from %s to %s", spec.Metadata.ContainerCluster.VSphereUser, s.UserName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
## fix unauthenticated session

Refer to this govmomi code for retrieving the current session using `func (sm *Manager) UserSession(`
https://github.com/vmware/govmomi/blob/v0.29.0/session/manager.go#L182-L193

Govmomi issue - https://github.com/vmware/govmomi/issues/2922 

when user session is not authenticated govmomi returns nil session with nil error.
if we do not check if the session is nil or the error is not nil, it results in the driver's continued attempt to use an unauthenticated session. This needs to be prevented and checked in the CSI driver.

I have discussed this issue with @lipingxue for customer SR.
 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
 fix for nil user session
```
