### PR TITLE
Initial Concourse attempt targeting `release-2.5-fork`

### DIFF
--- a/.ci/build_release
+++ b/.ci/build_release
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+source "$(dirname ${0})/setupenv.src"
+
+
+###############################################################################
+
+docker pull photon:4.0
+docker pull gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest
+cd images/driver-base
+REGISTRY=eu.gcr.io/gardener-project/patches/vsphere-csi-driver make build && REGISTRY=eu.gcr.io/gardener-project/patches/vsphere-csi-driver make push
+cd ../..
+CSI_REGISTRY=eu.gcr.io/gardener-project/patches/vsphere-csi-driver make images && CSI_REGISTRY=eu.gcr.io/gardener-project/patches/vsphere-csi-driver make push

--- a/.ci/get_version
+++ b/.ci/get_version
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ "$(git rev-parse --abbrev-ref HEAD)" =~ "master" ]]; then
+  git log -1 --format=%h
+else
+  git describe --always 2>/dev/null
+fi

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,0 +1,30 @@
+gardener-extension-provider-vsphere-csi-driver:
+  template: 'default'
+  base_definition:
+    repo:
+      branch: 'release-2.5-fork'
+    version:
+      version_interface: 'callback'
+      read_callback: 'get_version'
+  jobs:
+    head-update:
+      steps:
+        build_release: ~
+    pull-request:
+      traits:
+        pull-request: ~
+    release:
+      steps:
+        build_release: ~
+#      traits:
+#        version:
+#          version_interface: 'callback'
+#          preprocess: 'finalize'
+#          read_callback: 'get_version'
+#        slack:
+#          default_channel: 'internal_scp_workspace'
+#          channel_cfgs:
+#            internal_scp_workspace:
+#              channel_name: 'C0170QTBJUW' # gardener-mcm
+#              slack_cfg_name: 'scp_workspace'
+#        component_descriptor: ~

--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+"$(dirname $0)"/../vendor/github.com/gardener/gardener/hack/.ci/set_dependency_version

--- a/.ci/setupenv.src
+++ b/.ci/setupenv.src
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
+
+if [[ -z "${BINARY_PATH}" ]]; then
+  export BINARY_PATH="${SOURCE_PATH}/bin"
+else
+  export BINARY_PATH="$(readlink -f "${BINARY_PATH}")/bin"
+fi
+
+# The `go <cmd>` commands requires to see the target repository to be part of a
+# Go workspace. Thus, if we are not yet in a Go workspace, let's create one
+# temporarily by using symbolic links.
+if [[ "${SOURCE_PATH}" != *"$PATHINWS" || -z "$GOPATH" ]]; then
+  echo "generating local go path..."
+  SOURCE_SYMLINK_PATH="${SOURCE_PATH}/tmp/$PATHINWS"
+  if [[ -d "${SOURCE_PATH}/tmp" ]]; then
+    rm -rf "${SOURCE_PATH}/tmp"
+  fi
+  mkdir -p "$(dirname "${SOURCE_PATH}/tmp/$PATHINWS")"
+  ln -s "${SOURCE_PATH}" "${SOURCE_SYMLINK_PATH}"
+  cd "${SOURCE_SYMLINK_PATH}"
+
+  export GOPATH="${SOURCE_PATH}/tmp"
+  export GOBIN="${SOURCE_PATH}/tmp/bin"
+  export PATH="${GOBIN}:${PATH}"
+else
+  cd "$SOURCE_PATH"
+fi
+


### PR DESCRIPTION
Signed-off-by: Brian Topping <brian.topping@sap.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The vsphere CSI driver fork does not build with CI. This will provide a sterile release environment. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
