### PR TITLE
Collecting csi pod logs before restart of daemonset

### DIFF
--- a/tests/e2e/file_volume_statefulsets.go
+++ b/tests/e2e/file_volume_statefulsets.go
@@ -574,6 +574,9 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		num_csi_pods := len(list_of_pods)
 
+		// Collecting csi pod logs before restrating CSI daemonset
+		collectPodLogs(ctx, client, csiSystemNamespace)
+
 		// Restart CSI daemonset
 		ginkgo.By("Restart Daemonset")
 		cmd := []string{"rollout", "restart", "daemonset/vsphere-csi-node", "--namespace=" + csiSystemNamespace}


### PR DESCRIPTION
**What this PR does / why we need it**:
Collecting csi pod logs before restart of daemonset

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Collecting csi pod logs before restart of daemonset

**Testing done**:
Yes
https://gist.github.com/sipriyaa/8d892d382a112d2730decdd3a655c72d

**Special notes for your reviewer**:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.46.2'
golangci/golangci-lint info found version: 1.46.2 for v1.46.2/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/node-restart-code-fix/vsphere-csi-driver /Users/sipriya/node-restart-code-fix /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (files|imports|compiled_files|exports_file|types_sizes|deps|name) took 12.085224274s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 119.263879ms 
INFO [linters context/goanalysis] analyzers took 48.431287613s with top 10 stages: buildir: 14.389401053s, S1038: 2.542324476s, misspell: 1.946401995s, lll: 1.102619547s, ctrlflow: 973.731709ms, isgenerated: 907.552395ms, printf: 835.422366ms, fact_deprecated: 829.001218ms, unused: 742.876958ms, directives: 717.720773ms 
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649. 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 24/113, identifier_marker: 24/24, exclude: 24/24, exclude-rules: 1/24, cgo: 113/113, skip_dirs: 113/113, path_prettifier: 113/113, skip_files: 113/113, nolint: 0/1, filename_unadjuster: 113/113 
INFO [runner] processing took 14.606578ms with stages: nolint: 12.074018ms, autogenerated_exclude: 1.665866ms, path_prettifier: 363.696µs, identifier_marker: 299.348µs, skip_dirs: 118.597µs, exclude-rules: 65.808µs, cgo: 9.475µs, filename_unadjuster: 5.996µs, max_same_issues: 1.001µs, uniq_by_line: 477ns, skip_files: 319ns, max_from_linter: 284ns, diff: 255ns, source_code: 245ns, exclude: 223ns, severity-rules: 212ns, path_shortener: 202ns, max_per_file_from_linter: 192ns, sort_results: 189ns, path_prefixer: 175ns 
INFO [runner] linters took 9.706952835s with stages: goanalysis_metalinter: 9.692242113s, structcheck: 12.896µs 
INFO File cache stats: 285 entries of total size 4.7MiB 
INFO Memory: 220 samples, avg is 304.3MB, max is 1817.1MB 
INFO Execution took 21.925307758s         
