### PR TITLE
Code fixes for Level-5 topology testcases

### DIFF
--- a/tests/e2e/topology_multi_replica.go
+++ b/tests/e2e/topology_multi_replica.go
@@ -1722,25 +1722,11 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			vsphereCfg.Global.Password = newPassword
 			modifiedConf, err := writeConfigToSecretString(vsphereCfg)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			defer func() {
-				ginkgo.By("Reverting the password change")
-				err = invokeVCenterChangePassword(username, newPassword, adminPassword, vcAddress)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			}()
 
 			ginkgo.By("Updating the secret to reflect the new password")
 			secret.Data[vSphereCSIConf] = []byte(modifiedConf)
 			_, err = c.CoreV1().Secrets(csiSystemNamespace).Update(ctx, secret, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			defer func() {
-				ginkgo.By("Reverting the secret change back to reflect the original password")
-				currentSecret, err := c.CoreV1().Secrets(csiSystemNamespace).Get(ctx, configSecret, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				currentSecret.Data[vSphereCSIConf] = []byte(originalConf)
-				_, err = c.CoreV1().Secrets(csiSystemNamespace).Update(ctx, currentSecret, metav1.UpdateOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			}()
 
 			// Collecting csi pod logs before restarting csi driver
 			collectPodLogs(ctx, client, csiSystemNamespace)

--- a/tests/e2e/topology_multi_replica.go
+++ b/tests/e2e/topology_multi_replica.go
@@ -1747,9 +1747,8 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 				}
 			}()
 			framework.Logf("Starting CSI driver")
-			isServiceStopped, err = startCSIPods(ctx, c, csiReplicaCount)
+			_, err = startCSIPods(ctx, c, csiReplicaCount)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(isServiceStopped).To(gomega.BeTrue(), "csi driver start not successful")
 
 			// As we are in the same vCenter session, deletion of PVC should go through
 			ginkgo.By("Deleting PVC")

--- a/tests/e2e/topology_multi_replica.go
+++ b/tests/e2e/topology_multi_replica.go
@@ -682,15 +682,21 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			// Fetch the number of CSI pods running before restart
 			list_of_pods, err := fpod.GetPodsInNamespace(client, csiSystemNamespace, ignoreLabels)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			num_csi_pods := len(list_of_pods)
+
+			// Collecting and dumping csi pod logs before restrating CSI daemonset
+			collectPodLogs(ctx, client, csiSystemNamespace)
 
 			// Restart CSI daemonset
 			ginkgo.By("Restart Daemonset")
 			cmd := []string{"rollout", "restart", "daemonset/vsphere-csi-node", "--namespace=" + csiSystemNamespace}
 			framework.RunKubectlOrDie(csiSystemNamespace, cmd...)
 
-			// Wait for the CSI Pods to be up and Running
-			time.Sleep(pollTimeoutSixMin)
-			num_csi_pods := len(list_of_pods)
+			ginkgo.By("Waiting for daemon set rollout status to finish")
+			statusCheck := []string{"rollout", "status", "daemonset/vsphere-csi-node", "--namespace=" + csiSystemNamespace}
+			framework.RunKubectlOrDie(csiSystemNamespace, statusCheck...)
+
+			// wait for csi Pods to be in running ready state
 			err = fpod.WaitForPodsRunningReady(client, csiSystemNamespace, int32(num_csi_pods), 0, pollTimeout, ignoreLabels)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1721,6 +1727,29 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			secret.Data[vSphereCSIConf] = []byte(modifiedConf)
 			_, err = c.CoreV1().Secrets(csiSystemNamespace).Update(ctx, secret, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Collecting csi pod logs before restarting csi driver
+			collectPodLogs(ctx, client, csiSystemNamespace)
+
+			deployment, err := c.AppsV1().Deployments(csiSystemNamespace).Get(ctx,
+				vSphereCSIControllerPodNamePrefix, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			csiReplicaCount := *deployment.Spec.Replicas
+
+			ginkgo.By("Stopping CSI driver")
+			isServiceStopped, err := stopCSIPods(ctx, c)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer func() {
+				if isServiceStopped {
+					framework.Logf("Starting CSI driver")
+					isServiceStopped, err = startCSIPods(ctx, c, csiReplicaCount)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}()
+			framework.Logf("Starting CSI driver")
+			isServiceStopped, err = startCSIPods(ctx, c, csiReplicaCount)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isServiceStopped).To(gomega.BeTrue(), "csi driver start not successful")
 
 			// As we are in the same vCenter session, deletion of PVC should go through
 			ginkgo.By("Deleting PVC")

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -814,11 +814,10 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Expect PVC claim to fail as volume topology feature for file volumes is not supported
 		ginkgo.By("Expect PVC claim to fail as volume topology feature for file " +
 			"volumes is not supported")
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
-			pvc.Namespace, pvc.Name, framework.Poll, time.Minute/2)
-		gomega.Expect(err).To(gomega.HaveOccurred())
-		framework.Logf("Volume Provisioning Failed %v because Topology feature for file "+
-			"volumes is not supported", err)
+		expectedErrMsg := "volume topology feature for file volumes is not supported."
+		framework.Logf("Expected failure message: %+q", expectedErrMsg)
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvc.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
 	})
 
 	/*


### PR DESCRIPTION
**What this PR does / why we need it**:
Code fixes for Level-5 topology testcases

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Code fixes for Level-5 topology testcases

**Testing done**:
Yes

**Special notes for your reviewer**:

**Release note**:
Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.46.2'
golangci/golangci-lint info found version: 1.46.2 for v1.46.2/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/topology-code-fix/vsphere-csi-driver /Users/sipriya/topology-code-fix /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|types_sizes|files|imports|name) took 11.46663428s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 95.820147ms 
INFO [linters context/goanalysis] analyzers took 50.101854633s with top 10 stages: buildir: 15.496773628s, S1038: 2.816339744s, misspell: 2.628438139s, fact_deprecated: 2.423496305s, printf: 2.007550632s, ctrlflow: 1.750806341s, lll: 1.622391846s, isgenerated: 1.518446363s, unused: 1.049172753s, S1039: 744.07338ms 
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649. 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): cgo: 113/113, filename_unadjuster: 113/113, identifier_marker: 24/24, path_prettifier: 113/113, autogenerated_exclude: 24/113, skip_dirs: 113/113, exclude: 24/24, exclude-rules: 1/24, skip_files: 113/113, nolint: 0/1 
INFO [runner] processing took 15.378475ms with stages: nolint: 12.549701ms, autogenerated_exclude: 1.83235ms, path_prettifier: 397.219µs, identifier_marker: 365.865µs, skip_dirs: 148.311µs, exclude-rules: 67.39µs, cgo: 7.585µs, filename_unadjuster: 5.496µs, max_same_issues: 1.375µs, uniq_by_line: 497ns, exclude: 341ns, skip_files: 333ns, max_from_linter: 330ns, source_code: 289ns, diff: 279ns, sort_results: 262ns, severity-rules: 247ns, path_shortener: 215ns, max_per_file_from_linter: 201ns, path_prefixer: 189ns 
INFO [runner] linters took 10.453446505s with stages: goanalysis_metalinter: 10.43795325s, structcheck: 9.929µs 
INFO File cache stats: 285 entries of total size 4.7MiB 
INFO Memory: 220 samples, avg is 315.6MB, max is 1626.6MB 
INFO Execution took 22.028912587s        
