### PR TITLE
CreateSnapshot and DeleteSnapshot implementation on Supervisor

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -258,3 +258,9 @@ func (c *FakeK8SOrchestrator) GetAllVolumes() []string {
 func (c *FakeK8SOrchestrator) GetAllK8sVolumes() []string {
 	return nil
 }
+
+// AnnotateVolumeSnapshot annotates the volumesnapshot CR in k8s cluster
+func (c *FakeK8SOrchestrator) AnnotateVolumeSnapshot(ctx context.Context, volumeSnapshotName string,
+	volumeSnapshotNamespace string, annotations map[string]string) (bool, error) {
+	return true, nil
+}

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -66,6 +66,9 @@ type COCommonInterface interface {
 	GetAllVolumes() []string
 	// GetAllK8sVolumes returns list of volumes in a bound state, in the K8s cluster
 	GetAllK8sVolumes() []string
+	// AnnotateVolumeSnapshot annotates the volumesnapshot CR in k8s cluster with the snapshot-id and fcd-id
+	AnnotateVolumeSnapshot(ctx context.Context, volumeSnapshotName string,
+		volumeSnapshotNamespace string, annotations map[string]string) (bool, error)
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -27,6 +27,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
+
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
 	v1 "k8s.io/api/core/v1"
@@ -199,6 +201,7 @@ type K8sOrchestrator struct {
 	volumeNameToNodesMap *volumeNameToNodesMap // used when ListVolume FSS is enabled
 	volumeIDToNameMap    *volumeIDToNameMap    // used when ListVolume FSS is enabled
 	k8sClient            clientset.Interface
+	snapshotterClient    snapshotterClientSet.Interface
 }
 
 // K8sGuestInitParams lists the set of parameters required to run the init for
@@ -229,8 +232,9 @@ type K8sVanillaInitParams struct {
 func Newk8sOrchestrator(ctx context.Context, controllerClusterFlavor cnstypes.CnsClusterFlavor,
 	params interface{}) (*K8sOrchestrator, error) {
 	var (
-		coInstanceErr error
-		k8sClient     clientset.Interface
+		coInstanceErr     error
+		k8sClient         clientset.Interface
+		snapshotterClient snapshotterClientSet.Interface
 	)
 	if atomic.LoadUint32(&k8sOrchestratorInstanceInitialized) == 0 {
 		k8sOrchestratorInitMutex.Lock()
@@ -246,9 +250,17 @@ func Newk8sOrchestrator(ctx context.Context, controllerClusterFlavor cnstypes.Cn
 				return nil, coInstanceErr
 			}
 
+			// Create a snapshotter client
+			snapshotterClient, coInstanceErr = k8s.NewSnapshotterClient(ctx)
+			if coInstanceErr != nil {
+				log.Errorf("Creating Snapshotter client failed. Err: %v", coInstanceErr)
+				return nil, coInstanceErr
+			}
+
 			k8sOrchestratorInstance = &K8sOrchestrator{}
 			k8sOrchestratorInstance.clusterFlavor = controllerClusterFlavor
 			k8sOrchestratorInstance.k8sClient = k8sClient
+			k8sOrchestratorInstance.snapshotterClient = snapshotterClient
 			k8sOrchestratorInstance.informerManager = k8s.NewInformer(k8sClient)
 			coInstanceErr = initFSS(ctx, k8sClient, controllerClusterFlavor, params)
 			if coInstanceErr != nil {
@@ -1375,4 +1387,10 @@ func (c *K8sOrchestrator) GetAllVolumes() []string {
 		volumeIDs = append(volumeIDs, volumeID)
 	}
 	return volumeIDs
+}
+
+// AnnotateVolumeSnapshot annotates the volumesnapshot CR in k8s cluster
+func (c *K8sOrchestrator) AnnotateVolumeSnapshot(ctx context.Context, volumeSnapshotName string,
+	volumeSnapshotNamespace string, annotations map[string]string) (bool, error) {
+	return c.updateVolumeSnapshotAnnotations(ctx, volumeSnapshotName, volumeSnapshotNamespace, annotations)
 }

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -293,6 +293,18 @@ const (
 	// PreferredDatastoresCategory points to the vSphere Category
 	// created to tag preferred datastores in a topology-aware environment.
 	PreferredDatastoresCategory = "cns.vmware.topology-preferred-datastores"
+
+	// VolumeSnapshotNameKey represents the volumesnapshot CR name within
+	// the request parameters
+	VolumeSnapshotNameKey = "csi.storage.k8s.io/volumesnapshot/name"
+
+	// VolumeSnapshotNamespaceKey represents the volumesnapshot CR namespace within
+	// the request parameters
+	VolumeSnapshotNamespaceKey = "csi.storage.k8s.io/volumesnapshot/namespace"
+
+	// VolumeSnapshotInfoKey represents the annotation key of the fcd-id + snapshot-id
+	// on the VolumeSnapshot CR
+	VolumeSnapshotInfoKey = "csi.vsphere.volume/snapshot"
 )
 
 // Supported container orchestrators.

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -431,3 +431,16 @@ func GetClusterComputeResourceMoIds(ctx context.Context) ([]string, error) {
 	}
 	return clusterComputeResourceMoIds, nil
 }
+
+// MergeMaps merges two maps to create a new one, the key-value pair from first
+// are replaced with key-value pair of second
+func MergeMaps(first map[string]string, second map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for key, val := range first {
+		merged[key] = val
+	}
+	for key, val := range second {
+		merged[key] = val
+	}
+	return merged
+}

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -179,6 +179,24 @@ func validateWCPControllerExpandVolumeRequest(ctx context.Context, req *csi.Cont
 	return nil
 }
 
+// validateWCPCreateSnapshotRequest is the helper function to
+// validate CreateSnapshotRequest for CSI driver.
+// Function returns error if validation fails otherwise returns nil.
+func validateWCPCreateSnapshotRequest(ctx context.Context, req *csi.CreateSnapshotRequest) error {
+	log := logger.GetLogger(ctx)
+	volumeID := req.GetSourceVolumeId()
+	if len(volumeID) == 0 {
+		return logger.LogNewErrorCode(log, codes.InvalidArgument,
+			"CreateSnapshot Source Volume ID must be provided")
+	}
+
+	if len(req.Name) == 0 {
+		return logger.LogNewErrorCode(log, codes.InvalidArgument,
+			"Snapshot name must be provided")
+	}
+	return nil
+}
+
 // getK8sCloudOperatorClientConnection is a helper function that creates a
 // clientConnection to k8sCloudOperator GRPC service running on syncer container.
 func getK8sCloudOperatorClientConnection(ctx context.Context) (*grpc.ClientConn, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
CreateSnapshot and DeleteSnapshot implementation on supervisor cluster.
Annotation of the VolumeSnapshot CR with fcd-id+snapshot-id

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Added Unit test that creates and deletes the snapshot:
```
--- PASS: TestWCPCreateDeleteSnapshot (0.02s)
```

Verified that the VolumeSnapshot CR is annotated with the snapshot-id
```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  annotations:
    csi.vsphere.volume/snapshot: d84a0fd7-5e2e-4c86-9f17-6fbb6ae3d977+39bda976-85b9-40ef-9db9-8b2697647a73
  creationTimestamp: '2022-07-08T21:00:27Z'
  finalizers:
    - snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection
    - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
    - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
  generation: 1
  name: 48c2f9c7-cd9f-4e25-956a-1f4720d95cfa-0e148e0b-461b-45d4-b8e8-ec0fac0c07e2
  namespace: guest-ns
  resourceVersion: '1511237'
  uid: 63ff52a7-7db4-46b4-b3a4-d2ca3d571f0b
  selfLink: >-
    /apis/snapshot.storage.k8s.io/v1/namespaces/guest-ns/volumesnapshots/48c2f9c7-cd9f-4e25-956a-1f4720d95cfa-0e148e0b-461b-45d4-b8e8-ec0fac0c07e2
status:
  boundVolumeSnapshotContentName: snapcontent-63ff52a7-7db4-46b4-b3a4-d2ca3d571f0b
  creationTime: '2022-07-08T21:00:29Z'
  readyToUse: true
  restoreSize: 1Gi
spec:
  source:
    persistentVolumeClaimName: 48c2f9c7-cd9f-4e25-956a-1f4720d95cfa-a383a9ce-43dd-4fb2-b5d7-8a4b92b12d19
  volumeSnapshotClassName: example-vanilla-block-snapclass
```


**Special notes for your reviewer**:

**Release note**:
```release-note
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>