### PR TITLE
cns-csi.yaml changes for k8s 1.24

### DIFF
--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -204,20 +204,19 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       serviceAccount: vsphere-csi-controller
       nodeSelector:
-        node-role.kubernetes.io/master: ''
+        node-role.kubernetes.io/control-plane: ''
       tolerations:
         - operator: "Exists"
           key: "node-role.kubernetes.io/master"
           effect: "NoSchedule"
-        - operator: "Equal"
-          key: "kubeadmNode"
+        - operator: "Exists"
+          key: "node-role.kubernetes.io/control-plane"
           effect: "NoSchedule"
-          value: "master"
       hostNetwork: true
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.1.0_vmware.2
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.2.1_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -252,7 +251,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.4.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v3.5.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -275,7 +274,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.4.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.5.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -347,7 +346,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.6.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.7.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
           volumeMounts:
@@ -599,10 +598,13 @@ spec:
               topologyKey: kubernetes.io/hostname
       hostNetwork: true
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10
       tolerations:
         - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
         - effect: NoExecute
@@ -611,10 +613,6 @@ spec:
         - effect: NoExecute
           key: node.alpha.kubernetes.io/unreachable
           operator: Exists
-        - effect: NoSchedule
-          key: kubeadmNode
-          operator: Equal
-          value: master
       containers:
         - name: vsphere-webhook
           image: localhost:5000/vmware/syncer:<syncer_ver>

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -139,9 +139,9 @@ kind: ClusterRoleBinding
 metadata:
   name: wcp:administrators:cluster-edit-csirole
 subjects:
-- kind: Group
-  name: sso:Administrators@<sso_domain>
-  apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: sso:Administrators@<sso_domain>
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: vsphere-admin-csi-role
@@ -153,9 +153,9 @@ metadata:
   namespace: vmware-system-csi
   name: vsphere-csi-secret-reader
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -207,9 +207,6 @@ spec:
         node-role.kubernetes.io/control-plane: ''
       tolerations:
         - operator: "Exists"
-          key: "node-role.kubernetes.io/master"
-          effect: "NoSchedule"
-        - operator: "Exists"
           key: "node-role.kubernetes.io/control-plane"
           effect: "NoSchedule"
       hostNetwork: true
@@ -245,7 +242,7 @@ spec:
             - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAME # service name to be used by csi-provisioner to connect to placement engine
               value: vmware-system-psp-operator-k8s-cloud-operator-service
             - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAMESPACE # namespace for service name to be used by csi-provisioner to connect to placement engine
-              value: vmware-system-appplatform-operator-system                
+              value: vmware-system-appplatform-operator-system
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
@@ -299,12 +296,12 @@ spec:
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
           ports:
-           - containerPort: 2112
-             name: prometheus
-             protocol: TCP
-           - name: healthz
-             containerPort: 9808
-             protocol: TCP
+            - containerPort: 2112
+              name: prometheus
+              protocol: TCP
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
@@ -381,9 +378,9 @@ spec:
               value: "50"
           imagePullPolicy: "IfNotPresent"
           ports:
-           - containerPort: 2113
-             name: prometheus
-             protocol: TCP
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -601,9 +598,6 @@ spec:
         node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10
       tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This change creates a new cns-csi.yaml for k8s 1.24 that includes, 

1. Change nodeSelector from `node-role.kubernetes.io/master` to `node-role.kubernetes.io/control-plane`
https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-control-plane
> Starting in v1.20, this taint is deprecated in favor of [node-role.kubernetes.io/control-plane](http://node-role.kubernetes.io/control-plane) and will be removed in v1.25.

2. Change toleration from `node-role.kubernetes.io/master` to `node-role.kubernetes.io/control-plane`
- Add the control-plane toleration to 1.22 and 1.23 while retaining the master toleration. 

Reference to a similar change done for Vanilla -> https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1759

Refer to https://github.com/kubernetes/kubernetes/pull/107533 and https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint

3. Sidecar upgrades

#### csi-provisioner

https://github.com/kubernetes-csi/external-provisioner/releases

Bumped from v3.1.0 (Jan 12, 2022) to v3.2.1 (Jun 28, 2022)

#### csi-attacher

https://github.com/kubernetes-csi/external-attacher/releases

Bumped from v3.4.0 (Dec 21, 2021) to v3.5.0 (Jun 08, 2022)

#### csi-resizer

https://github.com/kubernetes-csi/external-resizer/releases

Bumped from v1.4.0 (Jan 21, 2022) to v1.5.0 (Jun 15, 2022)

#### liveness-probe

https://github.com/kubernetes-csi/livenessprobe/releases

Bumped from v2.6.0 (Feb 01, 2022) to v2.7.0 (May 12, 2022)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

Pre-checkin tests have been run for 1.22 and 1.23. 
For 1.22, please refer to # 27 (12 passed), 29 (1 passed) and 10 (1 passed) for the pre-checkin pipeline jobs. 
For 1.23, please refer to # 595
For 1.24, please refer to # 650, 651, and 652

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
cns-csi.yaml changes for k8s 1.24
```