### PR TITLE
Explicitly set the min TLS version to 1.2

### DIFF
--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -21,6 +21,7 @@ const (
 	ValidationWebhookPath            = "/validate"
 	DefaultWebhookPort               = 9883
 	DefaultWebhookMetricsBindAddress = "0"
+	WebhookTlsMinVersion = "1.2"
 )
 
 func getWebhookPort() int {
@@ -63,6 +64,7 @@ func startCNSCSIWebhookManager(ctx context.Context) {
 
 	log.Infof("registering validating webhook with the endpoint %v", ValidationWebhookPath)
 	// we should not allow TLS < 1.2
+	mgr.GetWebhookServer().TLSMinVersion = WebhookTlsMinVersion
 	mgr.GetWebhookServer().Register(ValidationWebhookPath, &webhook.Admission{Handler: &CSISupervisorWebhook{
 		Client:       mgr.GetClient(),
 		clientConfig: mgr.GetConfig(),

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -21,7 +21,7 @@ const (
 	ValidationWebhookPath            = "/validate"
 	DefaultWebhookPort               = 9883
 	DefaultWebhookMetricsBindAddress = "0"
-	WebhookTlsMinVersion = "1.2"
+	WebhookTlsMinVersion             = "1.2"
 )
 
 func getWebhookPort() int {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Explicitly set the min TLS version to 1.2

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Internal bug 3004875.

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Explicitly set the min TLS version for webhook to 1.2
```
