### PR TITLE
set priorityclass for CSI controller and increased timeout for liveness probe

### DIFF
--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -187,6 +187,7 @@ spec:
           effect: "NoSchedule"
           value: "master"
       hostNetwork: true
+      priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
           image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.1.0_vmware.2
@@ -283,7 +284,7 @@ spec:
               path: /healthz
               port: healthz
             initialDelaySeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 10
             periodSeconds: 5
             failureThreshold: 3
           env:

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -214,6 +214,7 @@ spec:
           effect: "NoSchedule"
           value: "master"
       hostNetwork: true
+      priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
           image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.1.0_vmware.2
@@ -310,7 +311,7 @@ spec:
               path: /healthz
               port: healthz
             initialDelaySeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 10
             periodSeconds: 5
             failureThreshold: 3
           env:

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -214,6 +214,7 @@ spec:
           effect: "NoSchedule"
           value: "master"
       hostNetwork: true
+      priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
           image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.1.0_vmware.2
@@ -310,7 +311,7 @@ spec:
               path: /healthz
               port: healthz
             initialDelaySeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 10
             periodSeconds: 5
             failureThreshold: 3
           env:


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- set priorityclass for CSI controller 
At present csi pods doesn't have a priority set and are at risk of being evicted if there are no enough resource to schedule a high-priority pod. This PR is setting the highest priorityClass `system-node-critical` to CSI controller Pods.

- increase the timeout for the liveness probe
3 seconds timeout is causing a lot of restarts when the cluster is deployed on the ESXi hosts having a lot of other workloads running. When control VMs were deployed on the host having near max available memory was used up, we observed CSI pods were restarting due to liveness probe time out.

The error we observed was 
> Liveness probe failed: Get "http://172.26.0.4:9808/healthz": context deadline exceeded (Client.Timeout exceeded while awaiting headers)



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Before this change, CSI pod restarted 54 times in 31 minutes

```
NAME                                      READY   STATUS    RESTARTS         AGE
vsphere-csi-controller-7dc8cd466c-brwxb   6/6     Running   8 (31m ago)      49m
vsphere-csi-controller-7dc8cd466c-hg9b7   6/6     Running   17 (101s ago)    67m
vsphere-csi-controller-7dc8cd466c-lqtbm   6/6     Running   29 (2m25s ago)   49m
```

After this change, CSI Pods never restarted in about 40 minutes.

```
NAME                                     READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-cc876f5c9-5ngns   6/6     Running   0          40m
vsphere-csi-controller-cc876f5c9-n7qk7   6/6     Running   0          38m
vsphere-csi-controller-cc876f5c9-tkh8t   6/6     Running   0          39m
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
set priorityclass for CSI controller and increased timeout for liveness probe
```
