### PR TITLE
post vsan-health/sps svc start wait for all VASA providers to be online

### DIFF
--- a/tests/e2e/connection.go
+++ b/tests/e2e/connection.go
@@ -61,6 +61,7 @@ func connect(ctx context.Context, vs *vSphere) {
 	var err error
 	defer clientLock.Unlock()
 	if vs.Client == nil {
+		framework.Logf("Creating new VC session")
 		vs.Client = newClient(ctx, vs)
 	}
 	manager := session.NewManager(vs.Client.Client)
@@ -69,9 +70,12 @@ func connect(ctx context.Context, vs *vSphere) {
 	if userSession != nil {
 		return
 	}
-	framework.Logf("Creating new client session since the existing session is not valid or not authenticated")
+	framework.Logf("Current session is not valid or not authenticated, trying to logout from it")
 	err = vs.Client.Logout(ctx)
-	framework.Logf("Error from logging out from session is: %v", err)
+	if err != nil {
+		framework.Logf("Ignoring the log out error: %v", err)
+	}
+	framework.Logf("Creating new client session after attempting to logout from existing session")
 	vs.Client = newClient(ctx, vs)
 }
 
@@ -132,4 +136,9 @@ func newVapiRestClient(ctx context.Context, c *govmomi.Client) *vapic.Client {
 //newTagMgr returns tag manager
 func newTagMgr(ctx context.Context, c *govmomi.Client) *tags.Manager {
 	return tags.NewManager(newVapiRestClient(ctx, c))
+}
+
+// newSmsClient creates a new client for sms service APIs.
+func newSmsClient(c *vim25.Client) *soap.Client {
+	return c.Client.NewServiceClient("/sms/sdk", "")
 }

--- a/tests/e2e/csi_cns_telemetry_vc_reboot.go
+++ b/tests/e2e/csi_cns_telemetry_vc_reboot.go
@@ -194,8 +194,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
-		err = checkVcenterServicesRunning(vcAddress, essentialServices)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
 
 		// After reboot.
 		bootstrap()
@@ -298,8 +297,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
-		err = checkVcenterServicesRunning(vcAddress, essentialServices)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
 
 		// After reboot.
 		bootstrap()

--- a/tests/e2e/csi_snapshot_basic.go
+++ b/tests/e2e/csi_snapshot_basic.go
@@ -3808,8 +3808,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ginkgo.By("Done with reboot")
 			essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
-			err = checkVcenterServicesRunning(vcAddress, essentialServices)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
 
 			// After reboot.
 			bootstrap()
@@ -3831,8 +3830,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
 		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
-		err = checkVcenterServicesRunning(vcAddress, essentialServices)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
 
 		// After reboot.
 		bootstrap()
@@ -3882,8 +3880,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		err = waitForHostToBeUp(e2eVSphere.Config.Global.VCenterHostname)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Done with reboot")
-		err = checkVcenterServicesRunning(vcAddress, essentialServices)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
 
 		// After reboot.
 		bootstrap()

--- a/tests/e2e/csi_snapshot_negative.go
+++ b/tests/e2e/csi_snapshot_negative.go
@@ -133,6 +133,9 @@ var _ = ginkgo.Describe("[block-snapshot-negative] Volume Snapshot Fault-Injecti
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				connect(ctx, &e2eVSphere)
+				err = e2eVSphere.wait4allVPs2ComeUp(ctx)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}
 
@@ -401,6 +404,9 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 				err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				isServiceStopped = false
+				connect(ctx, &e2eVSphere)
+				err = e2eVSphere.wait4allVPs2ComeUp(ctx)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
 
@@ -412,6 +418,9 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isServiceStopped = false
 		err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		connect(ctx, &e2eVSphere)
+		err = e2eVSphere.wait4allVPs2ComeUp(ctx)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Sleeping for full sync interval")
@@ -505,6 +514,9 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 					err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					isServiceStopped = false
+					connect(ctx, &e2eVSphere)
+					err = e2eVSphere.wait4allVPs2ComeUp(ctx)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
 			}()
 
@@ -516,6 +528,9 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			isServiceStopped = false
 			err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			connect(ctx, &e2eVSphere)
+			err = e2eVSphere.wait4allVPs2ComeUp(ctx)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Sleeping for full sync interval")
@@ -609,6 +624,9 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 					err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					isServiceStopped = false
+					connect(ctx, &e2eVSphere)
+					err = e2eVSphere.wait4allVPs2ComeUp(ctx)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
 			}()
 
@@ -620,6 +638,9 @@ func snapshotOperationWhileServiceDown(serviceName string, namespace string,
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			isServiceStopped = false
 			err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			connect(ctx, &e2eVSphere)
+			err = e2eVSphere.wait4allVPs2ComeUp(ctx)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Sleeping for full sync interval")
@@ -778,6 +799,9 @@ func snapshotOperationWhileServiceDownNegative(serviceName string, namespace str
 				err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				isServiceStopped = false
+				connect(ctx, &e2eVSphere)
+				err = e2eVSphere.wait4allVPs2ComeUp(ctx)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
 
@@ -789,6 +813,9 @@ func snapshotOperationWhileServiceDownNegative(serviceName string, namespace str
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isServiceStopped = false
 		err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		connect(ctx, &e2eVSphere)
+		err = e2eVSphere.wait4allVPs2ComeUp(ctx)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Sleeping for full sync interval")

--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -68,7 +68,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		err                        error
 		datastoreURL               string
 		storagePolicyName          string
-		isVsanhealthServiceStopped bool
+		isVsanHealthServiceStopped bool
 		isSPSserviceStopped        bool
 		ctx                        context.Context
 		nonSharedDatastoreURL      string
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 			pandoraSyncWaitTime = defaultPandoraSyncWaitTime
 		}
 		deleteFCDRequired = false
-		isVsanhealthServiceStopped = false
+		isVsanHealthServiceStopped = false
 		isSPSserviceStopped = false
 		var datacenters []string
 		datastoreURL = GetAndExpectStringEnvVar(envSharedDatastoreURL)
@@ -146,7 +146,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 			framework.ExpectNoError(e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle))
 		}
 
-		if isVsanhealthServiceStopped {
+		if isVsanHealthServiceStopped {
 			ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
 			err = invokeVCenterServiceControl("start", vsanhealthServiceName, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1176,7 +1176,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
-		isVsanhealthServiceStopped = true
+		isVsanHealthServiceStopped = true
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		err = invokeVCenterServiceControl("stop", vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1203,7 +1203,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again", vsanHealthServiceWaitTime))
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
-		isVsanhealthServiceStopped = false
+		isVsanHealthServiceStopped = false
 
 		ginkgo.By("Wait for some time for the CRD to create PV , PVC")
 		framework.ExpectNoError(waitForCNSRegisterVolumeToGetCreated(ctx,

--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -66,7 +66,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		svNamespace                string
 		defaultDatastore           *object.Datastore
 		restConfig                 *restclient.Config
-		isVsanhealthServiceStopped bool
+		isVsanHealthServiceStopped bool
 		isGCCSIDeploymentPODdown   bool
 	)
 	ginkgo.BeforeEach(func() {
@@ -128,13 +128,8 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		if isVsanhealthServiceStopped {
-			ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
-			err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again",
-				vsanHealthServiceWaitTime))
-			time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
+		if isVsanHealthServiceStopped {
+			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
 		if !pvcDeleted {
 			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
@@ -632,22 +627,17 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 	ginkgo.It("Verify volume expansion eventually succeeds when CNS is unavailable during initial expansion", func() {
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",
 			vsanHealthServiceWaitTime))
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
-		isVsanhealthServiceStopped := true
+		isVsanHealthServiceStopped := true
 		defer func() {
-			if isVsanhealthServiceStopped {
-				ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host (cleanup)"))
-				vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-				err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again",
-					vsanHealthServiceWaitTime))
-				time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
-				isVsanhealthServiceStopped = false
+			if isVsanHealthServiceStopped {
+				startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 			}
 		}()
 
@@ -678,11 +668,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 
 		ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
 		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again", vsanHealthServiceWaitTime))
-		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
-		isVsanhealthServiceStopped = false
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 		ginkgo.By("Waiting for controller volume resize to finish")
 		err = waitForPvResizeForGivenPvc(pvclaim, client, totalResizeWaitPeriod)
@@ -742,22 +728,19 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		"the volume can deleted with pending resize operation", func() {
 		ginkgo.By(fmt.Sprintln("Stopping vsan-health on the vCenter host"))
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to completely shutdown",
 			vsanHealthServiceWaitTime))
 		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
-		isVsanhealthServiceStopped := true
+		isVsanHealthServiceStopped := true
 		defer func() {
-			if isVsanhealthServiceStopped {
+			if isVsanHealthServiceStopped {
 				ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host (cleanup)"))
 				vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-				err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again",
-					vsanHealthServiceWaitTime))
-				time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
-				isVsanhealthServiceStopped = false
+				startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 			}
 		}()
 
@@ -791,11 +774,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 
 		ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
 		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow vsan-health to come up again", vsanHealthServiceWaitTime))
-		time.Sleep(time.Duration(vsanHealthServiceWaitTime) * time.Second)
-		isVsanhealthServiceStopped = false
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 		ginkgo.By("Verify volume is deleted in Supervisor Cluster")
 		volumeExists := verifyVolumeExistInSupervisorCluster(svcPVCName)

--- a/tests/e2e/gc_rwx_service_down.go
+++ b/tests/e2e/gc_rwx_service_down.go
@@ -39,20 +39,20 @@ import (
 var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 	f := framework.NewDefaultFramework("rwx-tkg-service-down")
 	var (
-		client               clientset.Interface
-		namespace            string
-		scParameters         map[string]string
-		storagePolicyName    string
-		volHealthCheck       bool
-		isVsanServiceStopped bool
-		fullSyncWaitTime     int
+		client                     clientset.Interface
+		namespace                  string
+		scParameters               map[string]string
+		storagePolicyName          string
+		volHealthCheck             bool
+		isVsanHealthServiceStopped bool
+		fullSyncWaitTime           int
 	)
 
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
 		// TODO: Read value from command line
 		volHealthCheck = false
-		isVsanServiceStopped = false
+		isVsanHealthServiceStopped = false
 		namespace = getNamespaceToRunTests(f)
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		scParameters = make(map[string]string)
@@ -79,15 +79,13 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
 
-		if isVsanServiceStopped {
+		if isVsanHealthServiceStopped {
 			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-			ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-			err := invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
 	})
 
@@ -134,20 +132,16 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		isVsanServiceStopped = true
+		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcStoppedMessage)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
-			if isVsanServiceStopped {
+			if isVsanHealthServiceStopped {
 				ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-				err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				isVsanServiceStopped = false
+				startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 			}
 		}()
 
@@ -170,11 +164,7 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		gomega.Expect(err).To(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-		err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		isVsanServiceStopped = false
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 		pvArray, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvclaim},
 			framework.ClaimProvisionTimeout)
@@ -218,20 +208,16 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
 		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		isVsanServiceStopped = true
+		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcStoppedMessage)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
-			if isVsanServiceStopped {
+			if isVsanHealthServiceStopped {
 				ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-				err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				isVsanServiceStopped = false
+				startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 			}
 		}()
 
@@ -246,11 +232,7 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		verifyCRDInSupervisorWithWait(ctx, f, pvcNameInSV, crdCNSVolumeMetadatas, crdVersion, crdGroup, false)
 
 		ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-		err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		isVsanServiceStopped = false
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 		err = e2eVSphere.waitForCNSVolumeToBeDeleted(fcdIDInCNS)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -363,20 +345,16 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		isVsanServiceStopped = true
+		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcStoppedMessage)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
-			if isVsanServiceStopped {
+			if isVsanHealthServiceStopped {
 				ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-				err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				isVsanServiceStopped = false
+				startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 			}
 		}()
 
@@ -393,11 +371,7 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-		err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		isVsanServiceStopped = false
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 		ginkgo.By(fmt.Sprintf("Waiting for labels %+v to be updated for pvc %s in namespace %s",
 			labels, pvclaim.Name, pvclaim.Namespace))
@@ -406,20 +380,16 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
-		isVsanServiceStopped = true
+		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcStoppedMessage)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
-			if isVsanServiceStopped {
+			if isVsanHealthServiceStopped {
 				ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-				err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				isVsanServiceStopped = false
+				startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 			}
 		}()
 
@@ -436,11 +406,7 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-		err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		isVsanServiceStopped = false
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 		ginkgo.By(fmt.Sprintf("Waiting for labels %+v to be updated for pv %s", pvLabels, pv.Name))
 		err = e2eVSphere.waitForLabelsToBeUpdated(fcdIDInCNS,
@@ -448,20 +414,16 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
-		isVsanServiceStopped = true
+		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcStoppedMessage)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
-			if isVsanServiceStopped {
+			if isVsanHealthServiceStopped {
 				ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-				err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				isVsanServiceStopped = false
+				startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 			}
 		}()
 
@@ -477,11 +439,7 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-		err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		isVsanServiceStopped = false
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 		ginkgo.By(fmt.Sprintf("Waiting for labels %+v to be deleted for pv %s", pvLabels, pv.Name))
 		err = e2eVSphere.waitForLabelsToBeUpdated(fcdIDInCNS,
@@ -489,20 +447,16 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", vsanhealthServiceName))
-		isVsanServiceStopped = true
+		isVsanHealthServiceStopped = true
 		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcStoppedMessage)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
-			if isVsanServiceStopped {
+			if isVsanHealthServiceStopped {
 				ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-				err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				isVsanServiceStopped = false
+				startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 			}
 		}()
 
@@ -518,11 +472,7 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-		err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		isVsanServiceStopped = false
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 		ginkgo.By(fmt.Sprintf("Waiting for labels %+v to be deleted for pvc %s in namespace %s",
 			labels, pvclaim.Name, pvclaim.Namespace))

--- a/tests/e2e/improved_csi_idempotency.go
+++ b/tests/e2e/improved_csi_idempotency.go
@@ -160,6 +160,9 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				connect(ctx, &e2eVSphere)
+				err = e2eVSphere.wait4allVPs2ComeUp(ctx)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}
 
@@ -581,6 +584,9 @@ func createVolumeWithServiceDown(serviceName string, namespace string, client cl
 				err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				isServiceStopped = false
+				connect(ctx, &e2eVSphere)
+				err = e2eVSphere.wait4allVPs2ComeUp(ctx)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
 
@@ -592,6 +598,9 @@ func createVolumeWithServiceDown(serviceName string, namespace string, client cl
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isServiceStopped = false
 		err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		connect(ctx, &e2eVSphere)
+		err = e2eVSphere.wait4allVPs2ComeUp(ctx)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Sleeping for full sync interval")
@@ -808,6 +817,9 @@ func extendVolumeWithServiceDown(serviceName string, namespace string, client cl
 				err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				isServiceStopped = false
+				connect(ctx, &e2eVSphere)
+				err = e2eVSphere.wait4allVPs2ComeUp(ctx)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
 
@@ -819,6 +831,9 @@ func extendVolumeWithServiceDown(serviceName string, namespace string, client cl
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isServiceStopped = false
 		err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		connect(ctx, &e2eVSphere)
+		err = e2eVSphere.wait4allVPs2ComeUp(ctx)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		time.Sleep(totalResizeWaitPeriod)
 	}

--- a/tests/e2e/vc_reboot_volume_lifecycle.go
+++ b/tests/e2e/vc_reboot_volume_lifecycle.go
@@ -185,8 +185,7 @@ var _ bool = ginkgo.Describe("Verify volume life_cycle operations works fine aft
 		} else {
 			essentialServices = []string{spsServiceName, vsanhealthServiceName, vpxdServiceName, wcpServiceName}
 		}
-		err = checkVcenterServicesRunning(vcAddress, essentialServices)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
 
 		//After reboot
 		bootstrap()

--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -178,10 +178,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		if isVsanHealthServiceStopped {
 			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
-			err := invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
 	})
 
@@ -3551,11 +3548,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 
 		framework.Logf("Starting vsan-health on the vCenter host")
 		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		isVsanHealthServiceStopped = false
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 		framework.Logf("Sleeping full-sync interval for vsan health service " +
 			"to be fully up")
@@ -3886,11 +3879,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 
 		framework.Logf("Starting vsan-health on the vCenter host")
 		vcAddress = e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-		err = invokeVCenterServiceControl(startOperation, vsanhealthServiceName, vcAddress)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = waitVCenterServiceToBeInState(vsanhealthServiceName, vcAddress, svcRunningMessage)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		isVsanHealthServiceStopped = false
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 
 		framework.Logf("Sleeping full-sync interval for vsan health service " +
 			"to be fully up")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:  post vsan-health/sps service start (including reboot) wait for all VASA providers to be online

**Testing done**:
https://gist.github.com/sashrith/403898c1cd16a307941bf43d85790a48 (there are 10 failures, 8 are due to 3008759, for 1 fix is already added now, other one is not related to this PR)

**Special notes for your reviewer**:
Main changes are in the following files,
* connection.go
* util.go
* vsphere.go

Most of the changes in other files are done to use the changes made to the above mentioned files.
Also, I have changed variable names in few files to keep them consistent across all the test files.

