### PR TITLE
Report CSI Snapshot capabilities on Supervisor

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1294,6 +1294,11 @@ func (c *controller) ControllerGetCapabilities(ctx context.Context, req *csi.Con
 			csi.ControllerServiceCapability_RPC_LIST_VOLUMES_PUBLISHED_NODES)
 	}
 
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot) {
+		controllerCaps = append(controllerCaps, csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
+			csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS)
+	}
+
 	for _, cap := range controllerCaps {
 		c := &csi.ControllerServiceCapability{
 			Type: &csi.ControllerServiceCapability_Rpc{


### PR DESCRIPTION
**What this PR does / why we need it**:
Reports CSI Snapshot capabilities on Supervisor if BlockVolumeSnapshot FSS is enabled.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
manual testing
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Expose CREATE_DELETE_SNAPSHOT and LIST_SNAPSHOTS capabilities on Supervisor Cluster if BlockVolumeSnapshot FSS is enabled.
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>