### PR TITLE
add a connect() after service restart

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -5758,6 +5758,7 @@ func startVCServiceWait4VPs(ctx context.Context, vcAddress string, service strin
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = waitVCenterServiceToBeInState(service, vcAddress, svcRunningMessage)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	connect(ctx, &e2eVSphere)
 	err = e2eVSphere.wait4allVPs2ComeUp(ctx)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	*isSvcStopped = false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: add a connect() after service restart, since existing VC session will no longer be valid

**Testing done**:
https://gist.github.com/sashrith/3587444df1884e7a34ddb4bf13ba3174
