### PR TITLE
added a connect() after service restart

### DIFF
--- a/hack/check-format.sh
+++ b/hack/check-format.sh
@@ -29,6 +29,7 @@ on_exit() {
 }
 trap on_exit EXIT
 
+go version
 # Run goformat on all the sources.
 flags="-e -s -w -l"
 [ -z "${PROW_JOB_ID-}" ] || flags="-d ${flags}"

--- a/hack/check-staticcheck.sh
+++ b/hack/check-staticcheck.sh
@@ -23,6 +23,7 @@ set -o xtrace
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
+go version
 go install honnef.co/go/tools/cmd/staticcheck@2022.1.2
 
 # shellcheck disable=SC2046

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -5758,6 +5758,7 @@ func startVCServiceWait4VPs(ctx context.Context, vcAddress string, service strin
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = waitVCenterServiceToBeInState(service, vcAddress, svcRunningMessage)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	connect(ctx, &e2eVSphere)
 	err = e2eVSphere.wait4allVPs2ComeUp(ctx)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	*isSvcStopped = false


### PR DESCRIPTION
What this PR does / why we need it:  connect() after service restart

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

Testing done:    https://gist.github.com/kavyashree-r/6fb97004b2dad282773adf7b2d7a635f
