### PR TITLE
Adding kavyashree-r to reviewers and approvers lists for tests/e2e fo…

### DIFF
--- a/tests/e2e/OWNERS
+++ b/tests/e2e/OWNERS
@@ -3,6 +3,8 @@
 
 reviewers:
 - sashrith
+- kavyashree-r
 
 approvers:
 - sashrith
+- kavyashree-r


### PR DESCRIPTION
What this PR does / why we need it: Adding kavyashree-r to reviewers and approvers lists for tests/e2e folder

Testing done: N/A

Special notes for your reviewer: Created new OWNERS file under tests/e2e 