### PR TITLE
CreateSnapshot and DeleteSnapshot implementation on Guest

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -305,6 +305,15 @@ const (
 	// VolumeSnapshotInfoKey represents the annotation key of the fcd-id + snapshot-id
 	// on the VolumeSnapshot CR
 	VolumeSnapshotInfoKey = "csi.vsphere.volume/snapshot"
+
+	// AttributeSupervisorVolumeSnapshotClass represents name of VolumeSnapshotClass
+	AttributeSupervisorVolumeSnapshotClass = "svvolumesnapshotclass"
+
+	// VolumeSnapshotApiGroup represents the VolumeSnapshot API Group name
+	VolumeSnapshotApiGroup = "snapshot.storage.k8s.io"
+
+	// VolumeSnapshotKind represents the VolumeSnapshot Kind name
+	VolumeSnapshotKind = "VolumeSnapshot"
 )
 
 // Supported container orchestrators.

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -27,11 +27,13 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fsnotify/fsnotify"
+	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	vmoperatortypes "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -65,13 +67,14 @@ var (
 )
 
 type controller struct {
-	supervisorClient          clientset.Interface
-	restClientConfig          *rest.Config
-	vmOperatorClient          client.Client
-	cnsOperatorClient         client.Client
-	vmWatcher                 *cache.ListWatch
-	supervisorNamespace       string
-	tanzukubernetesClusterUID string
+	supervisorClient            clientset.Interface
+	supervisorSnapshotterClient snapshotterClientSet.Interface
+	restClientConfig            *rest.Config
+	vmOperatorClient            client.Client
+	cnsOperatorClient           client.Client
+	vmWatcher                   *cache.ListWatch
+	supervisorNamespace         string
+	tanzukubernetesClusterUID   string
 }
 
 // New creates a CNS controller
@@ -94,6 +97,12 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	c.supervisorClient, err = k8s.NewSupervisorClient(ctx, c.restClientConfig)
 	if err != nil {
 		log.Errorf("failed to create supervisorClient. Error: %+v", err)
+		return err
+	}
+
+	c.supervisorSnapshotterClient, err = k8s.NewSupervisorSnapshotClient(ctx, c.restClientConfig)
+	if err != nil {
+		log.Errorf("failed to create supervisorSnapshotterClient. Error: %+v", err)
 		return err
 	}
 
@@ -196,6 +205,11 @@ func (c *controller) ReloadConfiguration() error {
 			log.Errorf("failed to create supervisorClient. Error: %+v", err)
 			return err
 		}
+		c.supervisorSnapshotterClient, err = k8s.NewSupervisorSnapshotClient(ctx, c.restClientConfig)
+		if err != nil {
+			log.Errorf("failed to create supervisorSnapshotterClient. Error: %+v", err)
+			return err
+		}
 		log.Infof("successfully re-created supervisorClient using updated configuration")
 		c.vmOperatorClient, err = k8s.NewClientForGroup(ctx, c.restClientConfig, vmoperatortypes.GroupName)
 		if err != nil {
@@ -288,7 +302,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 					annotations[common.AnnGuestClusterRequestedTopology] = topologyAnnotation
 				}
 				claim := getPersistentVolumeClaimSpecWithStorageClass(supervisorPVCName, c.supervisorNamespace,
-					diskSize, supervisorStorageClass, getAccessMode(accessMode), annotations)
+					diskSize, supervisorStorageClass, getAccessMode(accessMode), annotations, "")
 				log.Debugf("PVC claim spec is %+v", spew.Sdump(claim))
 				pvc, err = c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Create(
 					ctx, claim, metav1.CreateOptions{})
@@ -1281,16 +1295,176 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 	*csi.CreateSnapshotResponse, error) {
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
+	start := time.Now()
+	volumeType := prometheus.PrometheusBlockVolumeType
 	log.Infof("CreateSnapshot: called with args %+v", *req)
-	return nil, status.Error(codes.Unimplemented, "")
+	isBlockVolumeSnapshotWCPEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.BlockVolumeSnapshot)
+	if !isBlockVolumeSnapshotWCPEnabled {
+		return nil, logger.LogNewErrorCode(log, codes.Unimplemented, "createSnapshot")
+	}
+	createSnapshotInternal := func() (*csi.CreateSnapshotResponse, error) {
+		// Search for supervisor PVC and ensure it exists
+		supervisorPVCName := req.SourceVolumeId
+		log.Infof("Checking if supervisor PVC %s/%s exists..", c.supervisorNamespace, supervisorPVCName)
+		_, err := c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
+			ctx, supervisorPVCName, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				log.Errorf("the supervisor PVC: %s/%s was not found while attempting to take snapshot",
+					c.supervisorNamespace, supervisorPVCName)
+			}
+			return nil, err
+		}
+		// Get supervisor VolumeSnapshotClass.
+		var supervisorVolumeSnapshotClass string
+		for param := range req.Parameters {
+			paramName := strings.ToLower(param)
+			if paramName == common.AttributeSupervisorVolumeSnapshotClass {
+				supervisorVolumeSnapshotClass = req.Parameters[param]
+			}
+		}
+		// Generate the supervisor VolumeSnapshot name
+		// Assuming snapshot prefix is "snapshot-"
+		supervisorVolumeSnapshotName := c.tanzukubernetesClusterUID + "-" + req.Name[9:]
+		log.Infof("Determined VolumeSnapshotClass: %s for the supervisor VolumeSnapshot: %s",
+			supervisorVolumeSnapshotClass, supervisorVolumeSnapshotName)
+		log.Infof("Looking for VolumeSnapshot %s in supervisor namespace: %s ..",
+			supervisorVolumeSnapshotName, c.supervisorNamespace)
+
+		_, err = c.supervisorSnapshotterClient.SnapshotV1().VolumeSnapshots(c.supervisorNamespace).Get(
+			ctx, supervisorVolumeSnapshotName, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				// New createSnapshot request on the guest
+				supVolumeSnapshot := constructVolumeSnapshotWithVolumeSnapshotClass(supervisorVolumeSnapshotName,
+					c.supervisorNamespace, supervisorVolumeSnapshotClass, supervisorPVCName)
+				log.Infof("Supervisosr VolumeSnapshot Spec: %+v", supVolumeSnapshot)
+				_, err = c.supervisorSnapshotterClient.SnapshotV1().VolumeSnapshots(
+					c.supervisorNamespace).Create(ctx, supVolumeSnapshot, metav1.CreateOptions{})
+				if err != nil {
+					msg := fmt.Sprintf("failed to create volumesnapshot with name: %s on namespace: %s "+
+						"in supervisorCluster. Error: %+v", supervisorVolumeSnapshotName, c.supervisorNamespace, err)
+					log.Error(msg)
+					return nil, status.Errorf(codes.Internal, msg)
+				}
+				log.Infof("Successfully created VolumeSnapshot %s/%s on the supervisor cluster",
+					c.supervisorNamespace, supervisorVolumeSnapshotName)
+			} else {
+				msg := fmt.Sprintf("failed to get volumesnapshot with name: %s on "+
+					"namespace: %s in supervisorCluster. Error: %+v",
+					supervisorVolumeSnapshotName, c.supervisorNamespace, err)
+				log.Error(msg)
+				return nil, status.Errorf(codes.Internal, msg)
+			}
+		}
+		// Wait for VolumeSnapshot to be ready to use
+		isReady, vs, err := common.IsVolumeSnapshotReady(ctx, c.supervisorSnapshotterClient,
+			supervisorVolumeSnapshotName, c.supervisorNamespace,
+			time.Duration(getProvisionTimeoutInMin(ctx))*time.Minute)
+		if !isReady {
+			msg := fmt.Sprintf("volumesnapshot: %s on namespace: %s in supervisor cluster was not Ready. "+
+				"Error: %+v", supervisorVolumeSnapshotName, c.supervisorNamespace, err)
+			log.Error(msg)
+			return nil, status.Errorf(codes.Internal, msg)
+		}
+		// Extract the fcd-id + snapshot-id annotation from the supervisor volumesnapshot CR
+		snapshotID := vs.Annotations[common.VolumeSnapshotInfoKey]
+		volumeSnapshotName := req.Parameters[common.VolumeSnapshotNameKey]
+		volumeSnapshotNamespace := req.Parameters[common.VolumeSnapshotNamespaceKey]
+
+		log.Infof("Attempting to annotate Guest volumesnapshot %s/%s with %s",
+			volumeSnapshotNamespace, volumeSnapshotName, snapshotID)
+		annotated, err := commonco.ContainerOrchestratorUtility.AnnotateVolumeSnapshot(ctx, volumeSnapshotName,
+			volumeSnapshotNamespace, map[string]string{common.VolumeSnapshotInfoKey: snapshotID})
+		if err != nil || !annotated {
+			log.Warnf("The snapshot: %s was created successfully, but failed to annotate volumesnapshot %s/%s"+
+				"with annotation %s:%s. Error: %v", snapshotID, volumeSnapshotNamespace,
+				volumeSnapshotName, common.VolumeSnapshotInfoKey, snapshotID, err)
+		}
+		snapshotCreateTimeInProto := timestamppb.New(vs.Status.CreationTime.Time)
+		snapshotSize := vs.Status.RestoreSize.Value()
+		createSnapshotResponse := &csi.CreateSnapshotResponse{
+			Snapshot: &csi.Snapshot{
+				SizeBytes:      snapshotSize,
+				SnapshotId:     supervisorVolumeSnapshotName,
+				SourceVolumeId: req.SourceVolumeId,
+				CreationTime:   snapshotCreateTimeInProto,
+				ReadyToUse:     true,
+			},
+		}
+		return createSnapshotResponse, nil
+	}
+
+	resp, err := createSnapshotInternal()
+	if err != nil {
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateSnapshotOpType,
+			prometheus.PrometheusFailStatus, "NotComputed").Observe(time.Since(start).Seconds())
+	} else {
+		log.Infof("Snapshot for volume %q created successfully.", req.GetSourceVolumeId())
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusCreateSnapshotOpType,
+			prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
+	}
+	return resp, err
 }
 
 func (c *controller) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (
 	*csi.DeleteSnapshotResponse, error) {
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
+	start := time.Now()
+	volumeType := prometheus.PrometheusBlockVolumeType
 	log.Infof("DeleteSnapshot: called with args %+v", *req)
-	return nil, status.Error(codes.Unimplemented, "")
+	isBlockVolumeSnapshotWCPEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
+	if !isBlockVolumeSnapshotWCPEnabled {
+		return nil, logger.LogNewErrorCode(log, codes.Unimplemented, "deleteSnapshot")
+	}
+	deleteSnapshotInternal := func() (*csi.DeleteSnapshotResponse, error) {
+		csiSnapshotID := req.GetSnapshotId()
+		// Retrieve the supervisor volumesnapshot
+		supervisorVolumeSnapshotName := req.SnapshotId
+		supervisorVolumeSnapshot, err := c.supervisorSnapshotterClient.SnapshotV1().
+			VolumeSnapshots(c.supervisorNamespace).Get(ctx, supervisorVolumeSnapshotName, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				log.Infof("The supervisor volumesnapshot %s/%s was not found in the supervisor cluster, "+
+					"assuming successful delete", c.supervisorNamespace, supervisorVolumeSnapshotName)
+			} else {
+				msg := fmt.Sprintf("failed to retrieve the supervisor volumesnapshot %s/%s, Error: %+v",
+					c.supervisorNamespace, supervisorVolumeSnapshotName, err)
+				log.Error(msg)
+				return nil, status.Errorf(codes.Internal, msg)
+			}
+		}
+		log.Infof("Found the supervisor volumesnapshot %s/%s on the supervisor cluster",
+			supervisorVolumeSnapshot.Namespace, supervisorVolumeSnapshot.Name)
+		err = c.supervisorSnapshotterClient.SnapshotV1().VolumeSnapshots(c.supervisorNamespace).Delete(
+			ctx, supervisorVolumeSnapshotName, *metav1.NewDeleteOptions(0))
+		if err != nil {
+			if errors.IsNotFound(err) {
+				log.Infof("The supervisor volumesnapshot %s/%s was not found in the supervisor cluster "+
+					"while deleting it, assuming successful delete",
+					c.supervisorNamespace, supervisorVolumeSnapshotName)
+				return &csi.DeleteSnapshotResponse{}, nil
+			}
+			msg := fmt.Sprintf("failed to delete the supervisor volumesnapshot %s/%s, Error: %+v",
+				c.supervisorNamespace, supervisorVolumeSnapshotName, err)
+			log.Error(msg)
+			return nil, status.Errorf(codes.Internal, msg)
+		}
+		log.Infof("DeleteSnapshot: successfully deleted snapshot %q", csiSnapshotID)
+		return &csi.DeleteSnapshotResponse{}, nil
+	}
+	resp, err := deleteSnapshotInternal()
+	if err != nil {
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteSnapshotOpType,
+			prometheus.PrometheusFailStatus, "NotComputed").Observe(time.Since(start).Seconds())
+	} else {
+		log.Infof("Snapshot %q deleted successfully.", req.SnapshotId)
+		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusDeleteSnapshotOpType,
+			prometheus.PrometheusPassStatus, "").Observe(time.Since(start).Seconds())
+	}
+	return resp, err
 }
 
 func (c *controller) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	snap "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"google.golang.org/grpc/codes"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -192,9 +193,8 @@ func getAccessMode(accessMode csi.VolumeCapability_AccessMode_Mode) v1.Persisten
 
 // getPersistentVolumeClaimSpecWithStorageClass return the PersistentVolumeClaim spec with specified storage class
 func getPersistentVolumeClaimSpecWithStorageClass(pvcName string, namespace string, diskSize string,
-	storageClassName string, pvcAccessMode v1.PersistentVolumeAccessMode,
-	annotations map[string]string) *v1.PersistentVolumeClaim {
-
+	storageClassName string, pvcAccessMode v1.PersistentVolumeAccessMode, annotations map[string]string,
+	volumeSnapshotName string) *v1.PersistentVolumeClaim {
 	claim := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        pvcName,
@@ -213,7 +213,35 @@ func getPersistentVolumeClaimSpecWithStorageClass(pvcName string, namespace stri
 			StorageClassName: &storageClassName,
 		},
 	}
+	snapshotApiGroup := common.VolumeSnapshotApiGroup
+	volumeSnapshotKind := common.VolumeSnapshotKind
+	if volumeSnapshotName != "" {
+		localObjectReference := &v1.TypedLocalObjectReference{
+			APIGroup: &snapshotApiGroup,
+			Kind:     volumeSnapshotKind,
+			Name:     volumeSnapshotName,
+		}
+		claim.Spec.DataSource = localObjectReference
+	}
 	return claim
+}
+
+func constructVolumeSnapshotWithVolumeSnapshotClass(volumeSnapshotName string, namespace string,
+	volumeSnapshotClassName string, pvcName string) *snap.VolumeSnapshot {
+	volumeSnapshot := &snap.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      volumeSnapshotName,
+			Namespace: namespace,
+		},
+		Spec: snap.VolumeSnapshotSpec{
+			Source: snap.VolumeSnapshotSource{
+				PersistentVolumeClaimName: &pvcName,
+			},
+			VolumeSnapshotClassName: &volumeSnapshotClassName,
+		},
+		Status: nil,
+	}
+	return volumeSnapshot
 }
 
 // generateGuestClusterRequestedTopologyJSON translates the topology into a json string to be set on the supervisor

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -157,6 +157,21 @@ func NewSupervisorClient(ctx context.Context, config *restclient.Config) (client
 
 }
 
+// NewSupervisorSnapshotClient creates a new supervisor client for handling snapshot related objects
+func NewSupervisorSnapshotClient(ctx context.Context, config *restclient.Config) (
+	snapshotterClientSet.Interface, error) {
+	log := logger.GetLogger(ctx)
+	log.Info("Connecting to supervisor cluster using the certs/token in Guest Cluster " +
+		"config to retrieve the snapshotter client")
+	client, err := snapshotterClientSet.NewForConfig(config)
+	if err != nil {
+		log.Error("failed to connect to the supervisor cluster with err: %+v", err)
+		return nil, err
+	}
+	return client, nil
+
+}
+
 // NewClientForGroup creates a new controller-runtime client for a new scheme.
 // The input Group is added to this scheme.
 func NewClientForGroup(ctx context.Context, config *restclient.Config, groupName string) (client.Client, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
CreateSnaphot and DeleteSnapshot implementation on Guest cluster

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
===>Guest VolumeSnapshot


apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  annotations:
    csi.vsphere.volume/snapshot: d84a0fd7-5e2e-4c86-9f17-6fbb6ae3d977+39bda976-85b9-40ef-9db9-8b2697647a73
    kubectl.kubernetes.io/last-applied-configuration: >
      {"apiVersion":"snapshot.storage.k8s.io/v1","kind":"VolumeSnapshot","metadata":{"annotations":{},"name":"example-guest-block-snapshot-1","namespace":"testns"},"spec":{"source":{"persistentVolumeClaimName":"example-guest-block-pvc"},"volumeSnapshotClassName":"example-guest-block-snapclass"}}
  creationTimestamp: '2022-07-08T21:00:27Z'
  finalizers:
    - snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection
    - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
  generation: 1
  name: example-guest-block-snapshot-1
  namespace: testns
  resourceVersion: '35210'
  uid: 0e148e0b-461b-45d4-b8e8-ec0fac0c07e2
  selfLink: >-
    /apis/snapshot.storage.k8s.io/v1/namespaces/testns/volumesnapshots/example-guest-block-snapshot-1
status:
  boundVolumeSnapshotContentName: snapcontent-0e148e0b-461b-45d4-b8e8-ec0fac0c07e2
  creationTime: '2022-07-08T21:00:29Z'
  readyToUse: true
  restoreSize: 1Gi
spec:
  source:
    persistentVolumeClaimName: example-guest-block-pvc
  volumeSnapshotClassName: example-guest-block-snapclass


===> Supervisor VolumeSnapshot

apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  annotations:
    csi.vsphere.volume/snapshot: d84a0fd7-5e2e-4c86-9f17-6fbb6ae3d977+39bda976-85b9-40ef-9db9-8b2697647a73
  creationTimestamp: '2022-07-08T21:00:27Z'
  finalizers:
    - snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection
    - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
    - snapshot.storage.kubernetes.io/volumesnapshot-bound-protection
  generation: 1
  name: 48c2f9c7-cd9f-4e25-956a-1f4720d95cfa-0e148e0b-461b-45d4-b8e8-ec0fac0c07e2
  namespace: guest-ns
  resourceVersion: '1511237'
  uid: 63ff52a7-7db4-46b4-b3a4-d2ca3d571f0b
  selfLink: >-
    /apis/snapshot.storage.k8s.io/v1/namespaces/guest-ns/volumesnapshots/48c2f9c7-cd9f-4e25-956a-1f4720d95cfa-0e148e0b-461b-45d4-b8e8-ec0fac0c07e2
status:
  boundVolumeSnapshotContentName: snapcontent-63ff52a7-7db4-46b4-b3a4-d2ca3d571f0b
  creationTime: '2022-07-08T21:00:29Z'
  readyToUse: true
  restoreSize: 1Gi
spec:
  source:
    persistentVolumeClaimName: 48c2f9c7-cd9f-4e25-956a-1f4720d95cfa-a383a9ce-43dd-4fb2-b5d7-8a4b92b12d19
  volumeSnapshotClassName: example-vanilla-block-snapclass


Verified that Deleting a VolumeSnapshot on Guest deletes the Supervisor volumesnapshot and the snapshot from the underlying storage.
```
**Special notes for your reviewer**:

**Release note**:
```release-note
CreateSnaphot and DeleteSnapshot implementation on Guest cluster
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>