### PR TITLE
Add env variable to accept SHA1 certificates with Go1.18

### DIFF
--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -310,6 +310,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: GODEBUG
+              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp
@@ -353,6 +355,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: GODEBUG
+              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           ports:
            - containerPort: 2113

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -337,6 +337,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: GODEBUG
+              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp
@@ -380,6 +382,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: GODEBUG
+              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           ports:
            - containerPort: 2113

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -337,6 +337,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: GODEBUG
+              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp
@@ -380,6 +382,8 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
+            - name: GODEBUG
+              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           ports:
            - containerPort: 2113


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We switched to using Go1.18 for building CSI driver and syncer images but 1.18 rejects certificates signed using SHA-1 algorithm by default - https://tip.golang.org/doc/go1.18#sha1.  
While vCenter can still support replacement of SSL certs which has SHA1 (Default VC certificate issued by VMCA uses sha256 though).

If we deploy CSI driver on a vCenter with sha1 certificates, it doesn't come up and fails with below error:
```
{"level":"error","time":"2022-07-29T17:27:53.503287695Z","caller":"common/util.go:63","msg":"failed to connect to VirtualCenter host: \"<removed>\". err=Post \"[https://<removed>:443/sdk](https://<removed>sdk)\": x509: certificate signed by unknown authority (possibly because of \"x509: cannot verify signature: insecure algorithm SHA1-RSA (temporarily override with GODEBUG=x509sha1=1)\" while trying to verify candidate authority certificate \"ssolabs-SSOLABS1-CA\")"...}
```

This PR adds an environment variable `GODEBUG=x509sha1=1` to enable sha1 certificates with images built using Go1.18.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested this by editing the vsphere-csi-controller deployment in a vCenter setup having sha1 certificates, and verified the CSI driver started running fine. Earlier it was in a CLBO state.
```
[ ~ ]# kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-7b4f6d4545-5h5wp   6/6     Running   0          8m7s
vsphere-csi-controller-7b4f6d4545-bfxxm   6/6     Running   0          8m31s
vsphere-csi-webhook-699f558454-lvvpg      1/1     Running   0          7d1h
vsphere-csi-webhook-699f558454-plsnb      1/1     Running   0          7d1h
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add env variable to accept SHA1 certificates with Go1.18
```
