### PR TITLE
TKGS HA Automation PART-2

### DIFF
--- a/tests/e2e/tkgs_ha.go
+++ b/tests/e2e/tkgs_ha.go
@@ -19,13 +19,18 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	cnstypes "github.com/vmware/govmomi/cns/types"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -154,24 +159,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests",
 				gomega.BeTrue(), "SV storageclass does not match with gc storageclass")
 			framework.Logf("GC PVC's storageclass matches SVC PVC's storageclass")
 
-			ginkgo.By("Verify SV PVC has TKG HA annotations set")
-			err = checkAnnotationOnSvcPvc(svcPVC, allowedTopologyHAMap, categories)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			framework.Logf("SVC PVC: %s has TKG HA annotations set", svcPVC.Name)
-
-			ginkgo.By("Verify GC PV has has required PV node affinity details")
-			_, err = verifyVolumeTopologyForLevel5(pv, allowedTopologyHAMap)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			framework.Logf("GC PV: %s has required Pv node affinity details", pv.Name)
-
-			ginkgo.By("Verify SV PV has has required PV node affinity details")
-			svcPV := getPvFromSupervisorCluster(svcPVCName)
-			_, err = verifyVolumeTopologyForLevel5(svcPV, allowedTopologyHAMap)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			framework.Logf("SVC PV: %s has required PV node affinity details", svcPV.Name)
-
-			ginkgo.By("Create a pod and verify pod gets scheduled on appropriate " +
-				"nodes preset in the availability zone")
+			ginkgo.By("Create a pod and wait for it to come to Running state")
 			pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -188,9 +176,9 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests",
 					fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, pod.Spec.NodeName))
 			}()
 
-			_, err = verifyPodLocationLevel5(pod, nodeList, allowedTopologyHAMap)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
+			ginkgo.By("Verify annotations on SVC PV and required node affinity details on SVC PV and GC PV")
+			ginkgo.By("Verify pod gets scheduled on appropriate nodes preset in the availability zone")
+			verifyAnnotationsAndNodeAffinity(allowedTopologyHAMap, categories, pod, nodeList, svcPVC, pv, svcPVCName)
 		})
 
 		/*
@@ -265,140 +253,8 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests",
 				}
 			}()
 
-			// Waiting for pods status to be Ready
-			fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
-			gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
-			ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
-			gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
-				fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
-			gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
-				"Number of Pods in the statefulset should match with number of replicas")
-
-			ginkgo.By("Verify GC PV and SV PV has has required PV node affinity details")
-			ginkgo.By("Verify SV PVC has TKG HA annotations set")
-			// Get the list of Volumes attached to Pods before scale down
-			for _, sspod := range ssPodsBeforeScaleDown.Items {
-				pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				_, err = verifyPodLocationLevel5(&sspod, nodeList, allowedTopologyHAMap)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				for _, volumespec := range sspod.Spec.Volumes {
-					if volumespec.PersistentVolumeClaim != nil {
-						pvcName := volumespec.PersistentVolumeClaim.ClaimName
-						pv := getPvFromClaim(client, statefulset.Namespace, pvcName)
-						pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
-							pvcName, metav1.GetOptions{})
-						gomega.Expect(pvclaim).NotTo(gomega.BeNil())
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-						volHandle := getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
-						gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
-						svcPVCName := pv.Spec.CSI.VolumeHandle
-						svcPVC := getPVCFromSupervisorCluster(svcPVCName)
-						gomega.Expect(*svcPVC.Spec.StorageClassName == zonalPolicy).To(
-							gomega.BeTrue(), "mismatch in storage class name present in SVC PVC, expected: %s,"+
-								"actual: %s", zonalPolicy, svcPVC.Spec.StorageClassName)
-						framework.Logf("GC PVC's storageclass matches SVC PVC's storageclass")
-
-						err = checkAnnotationOnSvcPvc(svcPVC, allowedTopologyHAMap, categories)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						framework.Logf("SVC PVC: %s has TKG HA annotations set", svcPVC.Name)
-
-						_, err = verifyVolumeTopologyForLevel5(pv, allowedTopologyHAMap)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						framework.Logf("GC PV: %s has required Pv node affinity details", pv.Name)
-
-						svcPV := getPvFromSupervisorCluster(svcPVCName)
-						_, err = verifyVolumeTopologyForLevel5(svcPV, allowedTopologyHAMap)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						framework.Logf("SVC PV: %s has required PV node affinity details", svcPV.Name)
-
-						// Verify the attached volume match the one in CNS cache
-						err = waitAndVerifyCnsVolumeMetadata4GCVol(volHandle, svcPVCName, pvclaim,
-							pv, pod)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					}
-				}
-			}
-
-			replicas = 5
-			framework.Logf(fmt.Sprintf("Scaling up statefulset: %v to number of Replica: %v",
-				statefulset.Name, replicas))
-			_, scaleupErr := fss.Scale(client, statefulset, replicas)
-			gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
-
-			fss.WaitForStatusReplicas(client, statefulset, replicas)
-			fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
-			ssPodsAfterScaleUp := fss.GetPodList(client, statefulset)
-			gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
-				fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
-			gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
-				"Number of Pods in the statefulset %s, %v, should match with number of replicas %v",
-				statefulset.Name, ssPodsAfterScaleUp.Size(), replicas,
-			)
-
-			// Get the list of Volumes attached to Pods before scale down
-			for _, sspod := range ssPodsBeforeScaleDown.Items {
-				pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				for _, volumespec := range sspod.Spec.Volumes {
-					if volumespec.PersistentVolumeClaim != nil {
-						pvcName := volumespec.PersistentVolumeClaim.ClaimName
-						pv := getPvFromClaim(client, statefulset.Namespace, pvcName)
-						pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
-							pvcName, metav1.GetOptions{})
-						gomega.Expect(pvclaim).NotTo(gomega.BeNil())
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-						volHandle := getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
-						gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
-						svcPVCName := pv.Spec.CSI.VolumeHandle
-						svcPVC := getPVCFromSupervisorCluster(svcPVCName)
-
-						err = checkAnnotationOnSvcPvc(svcPVC, allowedTopologyHAMap, categories)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						framework.Logf("SVC PVC: %s has TKG HA annotations set", svcPVC.Name)
-
-						_, err = verifyVolumeTopologyForLevel5(pv, allowedTopologyHAMap)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						framework.Logf("GC PV: %s has required Pv node affinity details", pv.Name)
-
-						svcPV := getPvFromSupervisorCluster(svcPVCName)
-						_, err = verifyVolumeTopologyForLevel5(svcPV, allowedTopologyHAMap)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						framework.Logf("SVC PV: %s has required PV node affinity details", svcPV.Name)
-
-						framework.Logf(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
-							pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
-						var vmUUID string
-						var exists bool
-						ctx, cancel := context.WithCancel(context.Background())
-						defer cancel()
-						if vanillaCluster {
-							vmUUID = getNodeUUID(ctx, client, sspod.Spec.NodeName)
-						} else if supervisorCluster {
-							annotations := sspod.Annotations
-							vmUUID, exists = annotations[vmUUIDLabel]
-							gomega.Expect(exists).To(
-								gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
-							_, err := e2eVSphere.getVMByUUID(ctx, vmUUID)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						} else {
-							vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
-							gomega.Expect(err).NotTo(gomega.HaveOccurred())
-							verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName,
-								crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
-						}
-						isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-						gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached to the node")
-						framework.Logf("After scale up, verify the attached volumes match those in CNS Cache")
-						err = waitAndVerifyCnsVolumeMetadata4GCVol(volHandle, svcPVCName, pvclaim,
-							pv, pod)
-						gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					}
-				}
-			}
+			verifyVolumeMetadataOnStatefulsets(client, ctx, namespace, statefulset, replicas,
+				allowedTopologyHAMap, categories, zonalPolicy, nodeList, f)
 
 		})
 
@@ -488,4 +344,796 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests",
 
 		})
 
+		/*
+			Bring down VSAN during volume provisioning using zonal storage
+			1. Create a zonal storage policy
+			2. Bring down vsan-health
+			3. Use the Zonal storage class and Immediate binding mode and create statefulset
+			   with default pod management policy with replica 3
+			4. PVC and POD creations should be in pending state since vsan is down
+			5. Bring up VSan-health
+			6. wait for all the PVC to bound
+			7. Verify the  annotation csi.vsphere.guest-cluster-topology
+			8. Wait  for all the PODs to reach running state
+			9. Describe gc-PV and svc-pv verify node affinity
+			10. Verify that POD's should come up on the nodes of appropriate  Availability zone
+			11. Scale up the statefulset replica to 5 , and validate the node affinity on the newly create PV's
+			12. Validate the CNS metadata
+			13. Scale down the sts to 0
+			14. Delete PVC,POD,SC
+		*/
+		ginkgo.It("Bring down VSAN during volume provisioning using zonal storage", func() {
+			serviceName := vsanhealthServiceName
+			isServiceStopped := false
+			verifyVolumeProvisioningWithServiceDown(serviceName, namespace, client, zonalPolicy,
+				allowedTopologyHAMap, categories, isServiceStopped, f)
+		})
+
+		/*
+			Bring down sps during volume provisioning using zonal storage
+			1. Create a zonal storage policy
+			2. Bring down sps
+			3. Use the Zonal storage class and Immediate binding mode and create statefulset
+			   with default pod management policy with replica 3
+			4. PVC and POD creations should be in pending state since vsan is down
+			5. Bring up sps
+			6. wait for all the PVC to bound
+			7. Verify the  annotation csi.vsphere.guest-cluster-topology
+			8. Wait  for all the PODs to reach running state
+			9. Describe gc-PV and svc-pv verify node affinity
+			10. Verify that POD's should come up on the nodes of appropriate  Availability zone
+			11. Scale up the statefulset replica to 5 , and validate the node affinity on the newly create PV's
+			12. Validate the CNS metadata
+			13. Scale down the sts to 0
+			14. Delete PVC,POD,SC
+		*/
+		ginkgo.It("Bring down sps during volume provisioning using zonal storage", func() {
+			serviceName := spsServiceName
+			isServiceStopped := false
+			verifyVolumeProvisioningWithServiceDown(serviceName, namespace, client, zonalPolicy,
+				allowedTopologyHAMap, categories, isServiceStopped, f)
+		})
+
+		/*
+			Verify Online Volume expansion using zonal storage
+			1. Create a zonal storage policy, on the datastore that is shared only to specific cluster
+			2. Use the Zonal storage class and Immediate binding mode and create PVC
+			3. wait for the gc-PVC to bound and make sure corresponding SVC-PVC will
+				have annotation "csi.vsphere.volume-accessible-topology:"
+			   [{"topology.kubernetes.io/zone":"zone1"}]
+			"csi.vsphere.volume-requested-topology:"
+			   [{"topology.kubernetes.io/zone":"zone-1"},{"topology.kubernetes.io/zone":"zone-2"},
+			   {"topology.kubernetes.io/zone":"zone-3"}]
+			4. storageClassName: should point to svStorageclass and Create POD using Gc-pvc and
+				make sure Pod scheduled on appropriate nodes preset in the availability zone
+			5. Trigger Online volume expansion on the GC-PVC
+			6. Volume expansion should trigger in SVC-PVC
+			7. Volume expansion should be successful
+			8. Validate the SVC PVC and GC PVC should be of same size
+			9. Validate CNS metadata
+			10.Verify the FS size on the POD
+			11.Clear all PVC,POD and sc
+		*/
+		ginkgo.It("Verify Online Volume expansion using zonal storage", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ginkgo.By("CNS_TEST: Running for GC setup")
+			nodeList, _ := fnodes.GetReadySchedulableNodes(client)
+
+			ginkgo.By("Creating Pvc with Immediate topology storageclass")
+			createResourceQuota(client, namespace, rqLimit, zonalPolicy)
+			scParameters[svStorageClassName] = zonalPolicy
+			storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+			if !apierrors.IsNotFound(err) {
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			pvclaim, err := createPVC(client, namespace, nil, "", storageclass, "")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Wait for GC PVC to come to bound state")
+			persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvclaim},
+				framework.ClaimProvisionTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			pv := persistentvolumes[0]
+			volHandle := getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+			svcPVCName := pv.Spec.CSI.VolumeHandle
+			svcPVC := getPVCFromSupervisorCluster(svcPVCName)
+
+			defer func() {
+				err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				ginkgo.By("Verify PVs, volumes are deleted from CNS")
+				err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, framework.Poll,
+					framework.PodDeleteTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volumeID := pv.Spec.CSI.VolumeHandle
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeID)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+					fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+						"kubernetes", volumeID))
+
+			}()
+
+			ginkgo.By("Verify SV storageclass points to GC storageclass")
+			gomega.Expect(*svcPVC.Spec.StorageClassName == storageclass.Name).To(
+				gomega.BeTrue(), "SV storageclass does not match with gc storageclass")
+			framework.Logf("GC PVC's storageclass matches SVC PVC's storageclass")
+
+			ginkgo.By("Create a pod and wait for it to come to Running state")
+			pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			defer func() {
+				ginkgo.By("Delete pod")
+				err = fpod.DeletePodWithWait(client, pod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				ginkgo.By("Verify volume is detached from the node")
+				isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+					pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+					fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, pod.Spec.NodeName))
+			}()
+
+			ginkgo.By("Verify annotations on SVC PV and required node affinity details on SVC PV and GC PV")
+			ginkgo.By("Verify pod gets scheduled on appropriate nodes preset in the availability zone")
+			verifyAnnotationsAndNodeAffinity(allowedTopologyHAMap, categories, pod, nodeList, svcPVC, pv, svcPVCName)
+
+			verifyOnlineVolumeExpansionOnGc(client, namespace, svcPVCName, volHandle, pvclaim, pod, f)
+
+		})
+
+		/*
+			Verify offline Volume expansion using zonal storage
+			1. Create a zonal storage policy, on the datastore that is shared only to specific cluster
+			2. Use the Zonal storage class and Immediate binding mode and create PVC
+			3. wait for the gc-PVC to bound and make sure corresponding SVC-PVC will have
+				annotation "csi.vsphere.volume-accessible-topology:"
+				[{"topology.kubernetes.io/zone":"zone1"}]
+				"csi.vsphere.volume-requested-topology:"
+				[{"topology.kubernetes.io/zone":"zone-1"},{"topology.kubernetes.io/zone":"zone-2"},
+				{"topology.kubernetes.io/zone":"zone-3"}]
+			4. storageClassName: should point to svStorageclass and Create POD using Gc-pvc and
+				make sure Pod scheduled on appropriate nodes preset in the availability zone
+			5. Trigger offline volume expansion on the GC-PVC
+			6. Volume expansion should trigger in SVC-PVC , and it should reach FilesystemresizePending state
+			7.  Create POD in GC using  GC-PVC
+			8. Volume expansion should be successful
+			9. Validate the SVC PVC and GC PVC should be of same size
+			10. Verify the node affinity on svc-pv and gc-pv and validate CNS metadata
+			11.Verify the FS size on the POD
+			12.Clear all PVC,POD and sc
+		*/
+		ginkgo.It("Verify offline Volume expansion using zonal storage", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ginkgo.By("CNS_TEST: Running for GC setup")
+			nodeList, err := fnodes.GetReadySchedulableNodes(client)
+			framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+
+			ginkgo.By("Creating Pvc with Immediate topology storageclass")
+			createResourceQuota(client, namespace, rqLimit, zonalPolicy)
+			scParameters[svStorageClassName] = zonalPolicy
+			storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+			if !apierrors.IsNotFound(err) {
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			pvclaim, err := createPVC(client, namespace, nil, "", storageclass, "")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Wait for GC PVC to come to bound state")
+			persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvclaim},
+				framework.ClaimProvisionTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			pv := persistentvolumes[0]
+			volHandle := getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+			svcPVCName := pv.Spec.CSI.VolumeHandle
+			svcPVC := getPVCFromSupervisorCluster(svcPVCName)
+
+			defer func() {
+				err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				ginkgo.By("Verify PVs, volumes are deleted from CNS")
+				err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, framework.Poll,
+					framework.PodDeleteTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volumeID := pv.Spec.CSI.VolumeHandle
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeID)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+					fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+						"kubernetes", volumeID))
+
+			}()
+
+			ginkgo.By("Verify SV storageclass points to GC storageclass")
+			gomega.Expect(*svcPVC.Spec.StorageClassName == storageclass.Name).To(
+				gomega.BeTrue(), "SV storageclass does not match with gc storageclass")
+			framework.Logf("GC PVC's storageclass matches SVC PVC's storageclass")
+
+			ginkgo.By("Create a pod and wait for it to come to Running state")
+			pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			defer func() {
+				ginkgo.By("Delete pod")
+				err = fpod.DeletePodWithWait(client, pod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				ginkgo.By("Verify volume is detached from the node")
+				isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+					pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+					fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, pod.Spec.NodeName))
+			}()
+
+			ginkgo.By("Verify annotations on SVC PV and required node affinity details on SVC PV and GC PV")
+			ginkgo.By("Verify pod gets scheduled on appropriate nodes preset in the availability zone")
+			verifyAnnotationsAndNodeAffinity(allowedTopologyHAMap, categories, pod, nodeList, svcPVC, pv, svcPVCName)
+
+			verifyOfflineVolumeExpansionOnGc(client, pvclaim, svcPVCName, namespace, volHandle, pod, pv, f)
+
+		})
+
+		/*
+			Static volume provisioning using zonal storage
+			1. Create a zonal storage policy, on the datastore that is shared only to specific cluster
+			2. Use the Zonal storage class and Immediate binding mode
+			3. Create a FCD in SVC namespace
+			4. Create CNS register volume CRD to statically import PVC on SVC namespace
+			5. Verify the statically created svc-pv and svc-pvc
+			6. In Gc, Create Static gc-pv pointing the volume handle  of svc-pvc  and reclaim policy as retain
+			7. Verify the node affinity of gc1-pv and svc-pv , It should have node affinity of all the zones
+			8. Create POD, verify the status.
+			9. Wait  for the PODs to reach running state - make sure Pod scheduled on
+			   appropriate nodes preset in the availability zone
+			10. Delete pod, gc1-pv and gc1-pvc and svc pvc.
+		*/
+		ginkgo.It("Static volume provisioning using zonal storage", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ginkgo.By("CNS_TEST: Running for GC setup")
+			nodeList, err := fnodes.GetReadySchedulableNodes(client)
+			framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+
+			svClient, svNamespace := getSvcClientAndNamespace()
+			pvcAnnotations := make(map[string]string)
+			annotationVal := "["
+			var topoList []string
+
+			for key, val := range allowedTopologyHAMap {
+				for _, topoVal := range val {
+					str := `{"` + key + `":"` + topoVal + `"}`
+					topoList = append(topoList, str)
+				}
+			}
+			framework.Logf("topoList: %v", topoList)
+			annotationVal += strings.Join(topoList, ",") + "]"
+			pvcAnnotations[tkgHARequestedAnnotationKey] = annotationVal
+			framework.Logf("annotationVal :%s, pvcAnnotations: %v", annotationVal, pvcAnnotations)
+
+			ginkgo.By("Creating Pvc with Immediate topology storageclass")
+			createResourceQuota(client, namespace, rqLimit, zonalPolicy)
+			scParameters[svStorageClassName] = zonalPolicy
+			storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+			if !apierrors.IsNotFound(err) {
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			pvcSpec := getPersistentVolumeClaimSpecWithStorageClass(svNamespace, "", storageclass, nil, "")
+			pvcSpec.Annotations = pvcAnnotations
+			svPvclaim, err := svClient.CoreV1().PersistentVolumeClaims(svNamespace).Create(context.TODO(),
+				pvcSpec, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Wait for SV PVC to come to bound state")
+			svcPv, err := fpv.WaitForPVClaimBoundPhase(svClient, []*v1.PersistentVolumeClaim{svPvclaim},
+				framework.ClaimProvisionTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			volumeID := svPvclaim.Name
+			staticPVLabels := make(map[string]string)
+			staticPVLabels["fcd-id"] = volumeID
+
+			// Get allowed topologies for zonal storage
+			allowedTopologies := getTopologySelector(allowedTopologyHAMap, categories,
+				tkgshaTopologyLevels)
+
+			ginkgo.By("Creating the PV")
+			staticPv := getPersistentVolumeSpecWithStorageClassFCDNodeSelector(volumeID,
+				v1.PersistentVolumeReclaimRetain, storageclass.Name, staticPVLabels,
+				diskSize, allowedTopologies)
+			staticPv, err = client.CoreV1().PersistentVolumes().Create(ctx, staticPv, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Creating the PVC")
+			staticPvc := getPersistentVolumeClaimSpec(namespace, staticPVLabels, staticPv.Name)
+			staticPvc.Spec.StorageClassName = &storageclass.Name
+			staticPvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, staticPvc, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Wait for PV and PVC to Bind.
+			framework.ExpectNoError(fpv.WaitOnPVandPVC(client, framework.NewTimeoutContextWithDefaults(),
+				namespace, staticPv, staticPvc))
+
+			defer func() {
+				err := fpv.DeletePersistentVolumeClaim(client, staticPvc.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = fpv.DeletePersistentVolume(client, staticPv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				ginkgo.By("Verify PVs, volumes are deleted from CNS")
+				err = fpv.WaitForPersistentVolumeDeleted(client, staticPv.Name, framework.Poll,
+					framework.PodDeleteTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeID)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+					fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+						"kubernetes", volumeID))
+				ginkgo.By("Verify volume is deleted in Supervisor Cluster")
+				volumeExists := verifyVolumeExistInSupervisorCluster(svcPv[0].Spec.CSI.VolumeHandle)
+				gomega.Expect(volumeExists).To(gomega.BeFalse())
+
+			}()
+
+			ginkgo.By("Verify SV storageclass points to GC storageclass")
+			gomega.Expect(*svPvclaim.Spec.StorageClassName == storageclass.Name).To(
+				gomega.BeTrue(), "SV storageclass does not match with gc storageclass")
+			framework.Logf("GC PVC's storageclass matches SVC PVC's storageclass")
+
+			ginkgo.By("Verify GV PV has has required PV node affinity details")
+			_, err = verifyVolumeTopologyForLevel5(staticPv, allowedTopologyHAMap)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			framework.Logf("GC PV: %s has required Pv node affinity details", staticPv.Name)
+
+			ginkgo.By("Verify SV PV has has required PV node affinity details")
+			_, err = verifyVolumeTopologyForLevel5(svcPv[0], allowedTopologyHAMap)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			framework.Logf("SVC PV: %s has required PV node affinity details", svcPv[0].Name)
+
+			ginkgo.By("Create a pod and verify pod gets scheduled on appropriate " +
+				"nodes preset in the availability zone")
+			pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{staticPvc}, false, "")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			defer func() {
+				ginkgo.By("Delete pod")
+				err = fpod.DeletePodWithWait(client, pod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				ginkgo.By("Verify volume is detached from the node")
+				isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+					staticPv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+					fmt.Sprintf("Volume %q is not detached from the node %q",
+						staticPv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			}()
+
+			_, err = verifyPodLocationLevel5(pod, nodeList, allowedTopologyHAMap)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		})
+
 	})
+
+// verifyVolumeProvisioningWithServiceDown brings the service down and creates the statefulset and then brings up
+// the service and validates the volumes are bound and required annotations and node affinity are present
+func verifyVolumeProvisioningWithServiceDown(serviceName string, namespace string, client clientset.Interface,
+	storagePolicyName string, allowedTopologyHAMap map[string][]string, categories []string, isServiceStopped bool,
+	f *framework.Framework) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ginkgo.By("CNS_TEST: Running for GC setup")
+	nodeList, err := fnodes.GetReadySchedulableNodes(client)
+	framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+	if !(len(nodeList.Items) > 0) {
+		framework.Failf("Unable to find ready and schedulable Node")
+	}
+
+	ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
+	vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+	err = invokeVCenterServiceControl(stopOperation, serviceName, vcAddress)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	isServiceStopped = true
+	err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcStoppedMessage)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer func() {
+		if isServiceStopped {
+			ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", serviceName))
+			err = invokeVCenterServiceControl(startOperation, serviceName, vcAddress)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			bootstrap()
+			isServiceStopped = false
+		}
+	}()
+
+	ginkgo.By("Create statefulset with default pod management policy with replica 3")
+	createResourceQuota(client, namespace, rqLimit, storagePolicyName)
+	storageclass, err := client.StorageV1().StorageClasses().Get(ctx, storagePolicyName, metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	// Creating StatefulSet service
+	ginkgo.By("Creating service")
+	service := CreateService(namespace, client)
+	defer func() {
+		deleteService(namespace, client, service)
+	}()
+
+	statefulset := GetStatefulSetFromManifest(namespace)
+	ginkgo.By("Creating statefulset")
+	statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+		Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+	*statefulset.Spec.Replicas = 3
+	_, err = client.AppsV1().StatefulSets(namespace).Create(ctx, statefulset, metav1.CreateOptions{})
+	framework.ExpectNoError(err)
+	replicas := *(statefulset.Spec.Replicas)
+
+	defer func() {
+		scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
+		pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, claim := range pvcs.Items {
+			pv := getPvFromClaim(client, namespace, claim.Name)
+			err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Verify it's PV and corresponding volumes are deleted from CNS")
+			err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+				pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			volumeHandle := pv.Spec.CSI.VolumeHandle
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+					"kubernetes", volumeHandle))
+		}
+	}()
+
+	ginkgo.By(fmt.Sprintf("PVC and POD creations should be in pending state since %s is down", serviceName))
+	pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	for _, pvc := range pvcs.Items {
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
+			pvc.Namespace, pvc.Name, framework.Poll, time.Minute)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+	}
+
+	pods := fss.GetPodList(client, statefulset)
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != v1.PodPending {
+			framework.Failf("Expected pod to be in: %s state but is in: %s state", v1.PodPending,
+				pod.Status.Phase)
+		}
+	}
+
+	ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", serviceName))
+	err = invokeVCenterServiceControl(startOperation, serviceName, vcAddress)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	isServiceStopped = false
+	err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	bootstrap()
+
+	verifyVolumeMetadataOnStatefulsets(client, ctx, namespace, statefulset, replicas,
+		allowedTopologyHAMap, categories, storagePolicyName, nodeList, f)
+
+}
+
+// verifyOnlineVolumeExpansionOnGc is a util method which helps in verifying online volume expansion on gc
+func verifyOnlineVolumeExpansionOnGc(client clientset.Interface, namespace string, svcPVCName string,
+	volHandle string, pvclaim *v1.PersistentVolumeClaim, pod *v1.Pod, f *framework.Framework) {
+	rand.Seed(time.Now().Unix())
+	testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
+	ginkgo.By(fmt.Sprintf("Creating a 512mb test data file %v", testdataFile))
+	op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),
+		"bs=64k", "count=8000").Output()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	defer func() {
+		op, err = exec.Command("rm", "-f", testdataFile).Output()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}()
+
+	_ = framework.RunKubectlOrDie(namespace, "cp", testdataFile,
+		fmt.Sprintf("%v/%v:/mnt/volume1/testdata", namespace, pod.Name))
+
+	onlineVolumeResizeCheck(f, client, namespace, svcPVCName, volHandle, pvclaim, pod)
+
+	ginkgo.By("Checking data consistency after PVC resize")
+	_ = framework.RunKubectlOrDie(namespace, "cp",
+		fmt.Sprintf("%v/%v:/mnt/volume1/testdata", namespace, pod.Name), testdataFile+"_pod")
+	defer func() {
+		op, err = exec.Command("rm", "-f", testdataFile+"_pod").Output()
+		fmt.Println("rm: ", op)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}()
+	ginkgo.By("Running diff...")
+	op, err = exec.Command("diff", testdataFile, testdataFile+"_pod").Output()
+	fmt.Println("diff: ", op)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(len(op)).To(gomega.BeZero())
+
+	ginkgo.By("File system resize finished successfully in GC")
+	ginkgo.By("Checking for PVC resize completion on SVC PVC")
+	_, err = waitForFSResizeInSvc(svcPVCName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+// verifyOfflineVolumeExpansionOnGc is a util method which helps in verifying offline volume expansion on gc
+func verifyOfflineVolumeExpansionOnGc(client clientset.Interface, pvclaim *v1.PersistentVolumeClaim, svcPVCName string,
+	namespace string, volHandle string, pod *v1.Pod, pv *v1.PersistentVolume, f *framework.Framework) {
+	cmd := []string{"exec", "", "--namespace=" + namespace, "--", "/bin/sh", "-c", "df -Tkm | grep /mnt/volume1"}
+	ginkgo.By("Verify the volume is accessible and filesystem type is as expected")
+	cmd[1] = pod.Name
+	lastOutput := framework.RunKubectlOrDie(namespace, cmd...)
+	gomega.Expect(strings.Contains(lastOutput, ext4FSType)).NotTo(gomega.BeFalse())
+
+	ginkgo.By("Check filesystem size for mount point /mnt/volume1 before expansion")
+	originalFsSize, err := getFSSizeMb(f, pod)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	rand.Seed(time.Now().Unix())
+	testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
+	ginkgo.By(fmt.Sprintf("Creating a 512mb test data file %v", testdataFile))
+	op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),
+		"bs=64k", "count=8000").Output()
+	fmt.Println(op)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	defer func() {
+		op, err = exec.Command("rm", "-f", testdataFile).Output()
+		fmt.Println(op)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}()
+
+	_ = framework.RunKubectlOrDie(namespace, "cp", testdataFile,
+		fmt.Sprintf("%v/%v:/mnt/volume1/testdata", namespace, pod.Name))
+
+	// Delete POD.
+	ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s before expansion", pod.Name, namespace))
+	err = fpod.DeletePodWithWait(client, pod)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By("Verify volume is detached from the node before expansion")
+	isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+		pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+		fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, pod.Spec.NodeName))
+
+	// Modify PVC spec to trigger volume expansion. We expand the PVC while
+	// no pod is using it to ensure offline expansion.
+	ginkgo.By("Expanding current pvc")
+	currentPvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
+	newSize := currentPvcSize.DeepCopy()
+	newSize.Add(resource.MustParse(diskSize))
+	framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
+	pvclaim, err = expandPVCSize(pvclaim, newSize, client)
+	framework.ExpectNoError(err, "While updating pvc for more size")
+	gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+
+	pvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
+	if pvcSize.Cmp(newSize) != 0 {
+		framework.Failf("error updating pvc size %q", pvclaim.Name)
+	}
+	ginkgo.By("Checking for PVC request size change on SVC PVC")
+	b, err := verifyPvcRequestedSizeUpdateInSupervisorWithWait(svcPVCName, newSize)
+	gomega.Expect(b).To(gomega.BeTrue())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By("Waiting for controller volume resize to finish")
+	err = waitForPvResizeForGivenPvc(pvclaim, client, totalResizeWaitPeriod)
+	framework.ExpectNoError(err, "While waiting for pvc resize to finish")
+
+	ginkgo.By("Checking for resize on SVC PV")
+	verifyPVSizeinSupervisor(svcPVCName, newSize)
+
+	ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
+	err = waitForSvcPvcToReachFileSystemResizePendingCondition(svcPVCName, pollTimeout)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By("Checking for conditions on pvc")
+	pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
+	queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volHandle)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	if len(queryResult.Volumes) == 0 {
+		err = fmt.Errorf("QueryCNSVolumeWithResult returned no volume")
+	}
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By("Verifying disk size requested in volume expansion is honored")
+	newSizeInMb := convertGiStrToMibInt64(newSize)
+	if queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).CapacityInMb != newSizeInMb {
+		err = fmt.Errorf("got wrong disk size after volume expansion")
+	}
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Create a new Pod to use this PVC, and verify volume has been attached.
+	ginkgo.By("Creating a new pod to attach PV again to the node")
+	pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer func() {
+		ginkgo.By("Delete pod")
+		err = fpod.DeletePodWithWait(client, pod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}()
+
+	ginkgo.By(fmt.Sprintf("Verify volume after expansion: %s is attached to the node: %s",
+		pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+	vmUUID, err := getVMUUIDFromNodeName(pod.Spec.NodeName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+
+	ginkgo.By("Verify after expansion the filesystem type is as expected")
+	cmd[1] = pod.Name
+	lastOutput = framework.RunKubectlOrDie(namespace, cmd...)
+	gomega.Expect(strings.Contains(lastOutput, ext4FSType)).NotTo(gomega.BeFalse())
+
+	ginkgo.By("Waiting for file system resize to finish")
+	pvclaim, err = waitForFSResize(pvclaim, client)
+	framework.ExpectNoError(err, "while waiting for fs resize to finish")
+
+	pvcConditions := pvclaim.Status.Conditions
+	expectEqual(len(pvcConditions), 0, "pvc should not have conditions")
+
+	ginkgo.By("Verify filesystem size for mount point /mnt/volume1 after expansion")
+	fsSize, err := getFSSizeMb(f, pod)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	// Filesystem size may be smaller than the size of the block volume.
+	// Here since filesystem was already formatted on the original volume,
+	// we can compare the new filesystem size with the original filesystem size.
+	if fsSize < originalFsSize {
+		framework.Failf("error updating filesystem size for %q. Resulting filesystem size is %d", pvclaim.Name, fsSize)
+	}
+
+	ginkgo.By("Checking data consistency after PVC resize")
+	_ = framework.RunKubectlOrDie(namespace, "cp",
+		fmt.Sprintf("%v/%v:/mnt/volume1/testdata", namespace, pod.Name), testdataFile+"_pod")
+	defer func() {
+		op, err = exec.Command("rm", "-f", testdataFile+"_pod").Output()
+		fmt.Println("rm: ", op)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}()
+	ginkgo.By("Running diff...")
+	op, err = exec.Command("diff", testdataFile, testdataFile+"_pod").Output()
+	fmt.Println("diff: ", op)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(len(op)).To(gomega.BeZero())
+
+	ginkgo.By("File system resize finished successfully in GC")
+	ginkgo.By("Checking for PVC resize completion on SVC PVC")
+	_, err = waitForFSResizeInSvc(svcPVCName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+}
+
+// verifyVolumeMetadataOnStatefulsets verifies sts pod replicas and tkg annotations and
+// node affinities on svc pvc and verify cns volume meetadata
+func verifyVolumeMetadataOnStatefulsets(client clientset.Interface, ctx context.Context, namespace string,
+	statefulset *appsv1.StatefulSet, replicas int32, allowedTopologyHAMap map[string][]string,
+	categories []string, storagePolicyName string, nodeList *v1.NodeList, f *framework.Framework) {
+	// Waiting for pods status to be Ready
+	fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+	gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+	ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+	gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+		fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+	gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+		"Number of Pods in the statefulset should match with number of replicas")
+
+	ginkgo.By("Verify GV PV and SV PV has has required PV node affinity details")
+	ginkgo.By("Verify SV PVC has TKG HA annotations set")
+	// Get the list of Volumes attached to Pods before scale down
+	for _, sspod := range ssPodsBeforeScaleDown.Items {
+		pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, volumespec := range sspod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				pvcName := volumespec.PersistentVolumeClaim.ClaimName
+				pv := getPvFromClaim(client, statefulset.Namespace, pvcName)
+				pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
+					pvcName, metav1.GetOptions{})
+				gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volHandle := getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+				svcPVCName := pv.Spec.CSI.VolumeHandle
+
+				svcPVC := getPVCFromSupervisorCluster(svcPVCName)
+				gomega.Expect(*svcPVC.Spec.StorageClassName == storagePolicyName).To(
+					gomega.BeTrue(), "SV Pvc storageclass does not match with SV storageclass")
+				framework.Logf("GC PVC's storageclass matches SVC PVC's storageclass")
+
+				verifyAnnotationsAndNodeAffinity(allowedTopologyHAMap, categories, pod,
+					nodeList, svcPVC, pv, svcPVCName)
+
+				// Verify the attached volume match the one in CNS cache
+				err = waitAndVerifyCnsVolumeMetadata4GCVol(volHandle, svcPVCName, pvclaim,
+					pv, pod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+	}
+
+	replicas = 5
+	framework.Logf(fmt.Sprintf("Scaling up statefulset: %v to number of Replica: %v",
+		statefulset.Name, replicas))
+	_, scaleupErr := fss.Scale(client, statefulset, replicas)
+	gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
+
+	fss.WaitForStatusReplicas(client, statefulset, replicas)
+	fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+	ssPodsAfterScaleUp := fss.GetPodList(client, statefulset)
+	gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
+		fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+	gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
+		"Number of Pods in the statefulset %s, %v, should match with number of replicas %v",
+		statefulset.Name, ssPodsAfterScaleUp.Size(), replicas,
+	)
+
+	// Get the list of Volumes attached to Pods before scale down
+	for _, sspod := range ssPodsBeforeScaleDown.Items {
+		pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, volumespec := range sspod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				pvcName := volumespec.PersistentVolumeClaim.ClaimName
+				pv := getPvFromClaim(client, statefulset.Namespace, pvcName)
+				pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
+					pvcName, metav1.GetOptions{})
+				gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				volHandle := getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+				svcPVCName := pv.Spec.CSI.VolumeHandle
+				svcPVC := getPVCFromSupervisorCluster(svcPVCName)
+
+				verifyAnnotationsAndNodeAffinity(allowedTopologyHAMap, categories, pod,
+					nodeList, svcPVC, pv, svcPVCName)
+
+				framework.Logf(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+					pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+				var vmUUID string
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName,
+					crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
+
+				isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached to the node")
+				framework.Logf("After scale up, verify the attached volumes match those in CNS Cache")
+				err = waitAndVerifyCnsVolumeMetadata4GCVol(volHandle, svcPVCName, pvclaim,
+					pv, pod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+	}
+
+}

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -4806,6 +4806,13 @@ required for creating Storage Class specific to testcase scenarios.
 func getTopologySelector(topologyAffinityDetails map[string][]string,
 	topologyCategories []string, level int,
 	position ...int) []v1.TopologySelectorLabelRequirement {
+	topologyFeature := os.Getenv(topologyFeature)
+	var key string
+	if topologyFeature == topologyTkgHaName {
+		key = tkgHATopologyKey
+	} else {
+		key = topologykey
+	}
 	allowedTopologyForSC := []v1.TopologySelectorLabelRequirement{}
 	updateLvl := -1
 	var rnges []int
@@ -4821,10 +4828,15 @@ func getTopologySelector(topologyAffinityDetails map[string][]string,
 				values = append(values, topologyAffinityDetails[category][rng])
 			}
 		} else {
-			values = topologyAffinityDetails[category]
+			if topologyFeature == topologyTkgHaName {
+				values = topologyAffinityDetails[key+"/"+category]
+			} else {
+				values = topologyAffinityDetails[category]
+			}
 		}
+
 		topologySelector := v1.TopologySelectorLabelRequirement{
-			Key:    topologykey + "/" + category,
+			Key:    key + "/" + category,
 			Values: values,
 		}
 		allowedTopologyForSC = append(allowedTopologyForSC, topologySelector)


### PR DESCRIPTION
**What this PR does / why we need it**: Automation for 3 volume expansion and static provisioning testcases for tkgs ha 

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/790127cd7d2f97f7db63c46dcdd9c8be
make check output:
```
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.2
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/kai/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.46.2'
golangci/golangci-lint info found version: 1.46.2 for v1.46.2/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/tkgs_ha_part2/vsphere-csi-driver /Users/kai/CSI/tkgs_ha_part2 /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (compiled_files|imports|name|deps|exports_file|files|types_sizes) took 2.394769554s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 110.568697ms 
INFO [linters context/goanalysis] analyzers took 11.125544316s with top 10 stages: S1038: 1.209075802s, buildir: 883.772138ms, misspell: 595.637367ms, S1039: 397.650165ms, SA4030: 358.625599ms, SA1012: 335.05297ms, S1028: 307.41666ms, SA1004: 285.980007ms, unused: 282.009849ms, S1024: 260.890514ms 
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649. 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): cgo: 113/113, filename_unadjuster: 113/113, path_prettifier: 113/113, identifier_marker: 24/24, skip_files: 113/113, skip_dirs: 113/113, autogenerated_exclude: 24/113, exclude: 24/24, exclude-rules: 1/24, nolint: 0/1 
INFO [runner] processing took 14.712999ms with stages: nolint: 11.914708ms, autogenerated_exclude: 1.662465ms, path_prettifier: 608.535µs, identifier_marker: 273.36µs, skip_dirs: 170.43µs, exclude-rules: 62.806µs, cgo: 11.152µs, filename_unadjuster: 5.328µs, max_same_issues: 1.285µs, uniq_by_line: 465ns, max_from_linter: 367ns, skip_files: 324ns, severity-rules: 302ns, exclude: 261ns, diff: 261ns, source_code: 248ns, path_shortener: 220ns, max_per_file_from_linter: 212ns, sort_results: 145ns, path_prefixer: 125ns 
INFO [runner] linters took 7.3643437s with stages: goanalysis_metalinter: 7.349525663s, structcheck: 8.549µs 
INFO File cache stats: 96 entries of total size 2.9MiB 
INFO Memory: 100 samples, avg is 222.7MB, max is 745.8MB 
INFO Execution took 9.884000221s                  
(base) kai@kai-a01 vsphere-csi-driver % 
```