### PR TITLE
enabled csi-migration feature

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -142,7 +142,7 @@ roleRef:
 ---
 apiVersion: v1
 data:
-  "csi-migration": "false"
+  "csi-migration": "true"
   "csi-auth-check": "true"
   "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is enabling `csi-migration` feature gate in the vSphere CSI Driver.
We have enabled `CSIMigrationvSphere` feature gate in the k8s 1.25 in this PR - https://github.com/kubernetes/kubernetes/pull/103523/ 


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
enabled csi-migration feature
```
