### PR TITLE
[Cherry-pick 2.6 #1906] Prevent reconciliation if CSINodeTopology instance is already at Success state

### DIFF
--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -245,6 +245,12 @@ func (r *ReconcileCSINodeTopology) reconcileForVanilla(ctx context.Context, requ
 		// Error reading the object - return with err.
 		return reconcile.Result{}, err
 	}
+	// If the CR status is already at Success, do not reconcile further.
+	if instance.Status.Status == csinodetopologyv1alpha1.CSINodeTopologySuccess {
+		log.Infof("CSINodeTopology instance with name %q is already at %q state. No need to "+
+			"reconcile further.", instance.Name, instance.Status.Status)
+		return reconcile.Result{}, err
+	}
 
 	// Initialize backOffDuration for the instance, if required.
 	backOffDurationMapMutex.Lock()


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR cherry-picks https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1906 from master to release-2.6. This fix is required to make sure fallback mechanism in preferential topology deployment feature works E2E.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
NA

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
[Cherry-pick #1906] Prevent reconciliation if CSINodeTopology instance is already at Success state
```
