### PR TITLE
Volume allocation tests PART-2 

### DIFF
--- a/tests/e2e/vcp_to_csi_syncer.go
+++ b/tests/e2e/vcp_to_csi_syncer.go
@@ -1606,7 +1606,12 @@ func getVolHandle4Pv(ctx context.Context, c clientset.Interface, pv *v1.Persiste
 		gomega.Expect(found).To(gomega.BeTrue())
 		return crd.Spec.VolumeID
 	}
-	return pv.Spec.CSI.VolumeHandle
+	volumeID := pv.Spec.CSI.VolumeHandle
+	if guestCluster {
+		volumeID = getVolumeIDFromSupervisorCluster(volumeID)
+		gomega.Expect(volumeID).NotTo(gomega.BeEmpty())
+	}
+	return volumeID
 }
 
 // deletePodAndWaitForVolsToDetach Delete given pod and wait for its volumes to detach


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Offline volume expansion and changes for WCP and GC testcases in volume allocation automation

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/b0d1e8b825cf31f271292f359931c1e6
make-check:
```
(base) kai@kai-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.2
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/kai/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.46.2'
golangci/golangci-lint info found version: 1.46.2 for v1.46.2/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/kai_vol_allocation_part2/vsphere-csi-driver /Users/kai/CSI/kai_vol_allocation_part2 /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (exports_file|name|types_sizes|compiled_files|deps|files|imports) took 2.427033797s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 118.483934ms 
INFO [linters context/goanalysis] analyzers took 10.824696339s with top 10 stages: S1038: 1.167019895s, buildir: 870.509144ms, misspell: 644.917981ms, SA4030: 400.383486ms, SA1012: 365.549778ms, unused: 348.090622ms, S1039: 342.305097ms, SA1004: 284.190914ms, directives: 250.369498ms, S1024: 240.484481ms 
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649. 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): nolint: 0/1, skip_dirs: 113/113, autogenerated_exclude: 24/113, identifier_marker: 24/24, cgo: 113/113, path_prettifier: 113/113, skip_files: 113/113, filename_unadjuster: 113/113, exclude: 24/24, exclude-rules: 1/24 
INFO [runner] processing took 16.609529ms with stages: nolint: 13.678162ms, autogenerated_exclude: 1.755686ms, path_prettifier: 621.319µs, identifier_marker: 326.174µs, skip_dirs: 146.712µs, exclude-rules: 64.209µs, cgo: 8.675µs, filename_unadjuster: 4.367µs, max_same_issues: 1.106µs, skip_files: 618ns, uniq_by_line: 449ns, max_from_linter: 362ns, source_code: 268ns, diff: 263ns, exclude: 218ns, max_per_file_from_linter: 211ns, path_shortener: 206ns, severity-rules: 204ns, sort_results: 201ns, path_prefixer: 119ns 
INFO [runner] linters took 7.985597164s with stages: goanalysis_metalinter: 7.96888299s, structcheck: 8.316µs 
INFO File cache stats: 96 entries of total size 2.9MiB 
INFO Memory: 107 samples, avg is 223.6MB, max is 754.6MB 
INFO Execution took 10.548650583s                 
(base) kai@kai-a01 vsphere-csi-driver % 
```