### PR TITLE
Changes for VCP to CSI migration tests since migration is always on in k8s 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
 	github.com/kubernetes-csi/csi-lib-utils v0.11.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/kubernetes-csi/csi-proxy/client v1.0.1
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.1.0
 	github.com/onsi/ginkgo/v2 v2.1.6

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,8 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/tests/e2e/vcp_utils.go
+++ b/tests/e2e/vcp_utils.go
@@ -132,11 +132,16 @@ func getVcpPersistentVolumeSpec(volumePath string, persistentVolumeReclaimPolicy
 }
 
 // getVcpPersistentVolumeClaimSpec function to get vsphere persistent volume spec with given selector labels.
-func getVcpPersistentVolumeClaimSpec(namespace string, size string, storageclass *storagev1.StorageClass,
-	pvclaimlabels map[string]string, accessMode v1.PersistentVolumeAccessMode) *v1.PersistentVolumeClaim {
+func getVcpPersistentVolumeClaimSpec(migrationEnabledByDefault bool, namespace string, size string,
+	storageclass *storagev1.StorageClass, pvclaimlabels map[string]string, accessMode v1.PersistentVolumeAccessMode,
+) *v1.PersistentVolumeClaim {
 	pvc := getPersistentVolumeClaimSpecWithStorageClass(namespace, size, storageclass, pvclaimlabels, accessMode)
 	annotations := make(map[string]string)
-	annotations[pvcAnnotationStorageProvisioner] = vcpProvisionerName
+	if migrationEnabledByDefault {
+		annotations[pvcAnnotationStorageProvisioner] = e2evSphereCSIDriverName
+	} else {
+		annotations[pvcAnnotationStorageProvisioner] = vcpProvisionerName
+	}
 	pvc.Annotations = annotations
 	return pvc
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Changes for VCP to CSI migration tests since migration is always on in k8s 1.25

**Testing done**:
https://gist.github.com/sashrith/a2a81c290e18b7d9296d8ed1b18ad0ea

