### PR TITLE
[Cherry-pick 2.6 #1879] mark volume detach as success when Node vm is deleted from vcenter 

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1238,8 +1238,14 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 			node, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
 		}
 		if err != nil {
-			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
-				"failed to find VirtualMachine for node:%q. Error: %v", req.NodeId, err)
+			if err == cnsvsphere.ErrVMNotFound {
+				log.Infof("Virtual Machine for Node ID: %v is not present in the VC Inventory. "+
+					"Marking ControllerUnpublishVolume for Volume: %q as successful.", req.NodeId, req.VolumeId)
+				return &csi.ControllerUnpublishVolumeResponse{}, "", nil
+			} else {
+				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
+					"failed to find VirtualMachine for node:%q. Error: %v", req.NodeId, err)
+			}
 		}
 		faultType, err = common.DetachVolumeUtil(ctx, c.manager, node, req.VolumeId)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Refer to https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1879 and issue https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/359


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
mark volume detach as success when Node vm is deleted from vcenter 
```
