### PR TITLE
Check for cns finalizer using the most recent pvc object

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -720,7 +720,7 @@ func updateSVPVC(ctx context.Context, client client.Client,
 			// The callers of updateSVPVC are only updating the instance finalizers
 			// Hence we add/remove the finalizers on the latest PVC object from API server.
 			if removeCnsPvcFinalizer {
-				for i, finalizer := range pvc.Finalizers {
+				for i, finalizer := range latestPVCObject.Finalizers {
 					if finalizer == cnsoperatortypes.CNSPvcFinalizer {
 						log.Debugf("Removing %q finalizer from PersistentVolumeClaim: %q on namespace: %q",
 							cnsoperatortypes.CNSPvcFinalizer, pvc.Name, pvc.Namespace)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing the issue where `cns.vmware.com/pvc-protection` finalizer is not removed due to resource conflict error. The removeCNSFinalizer method handles the ResourceConflict, but after fetching the recent version of the resource the finalizer list used for verifying is incorrectly checking against older version of the resource.
This results in PVCs(which are created for TKC worker node VM's additional capacity) remaining in Terminating state during TKC deletion & SV Namespace cleanup
 
The PR fixes this issue by using the finalizer list from the most recently fetched PVC object.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before:
```
2022-08-10T21:00:46.286Z	DEBUG	cnsnodevmattachment/cnsnodevmattachment_controller.go:674	Removing "cns.vmware.com/pvc-protection" finalizer from PersistentVolumeClaim: "test-gc-control-plane-t5bvt-rsk9c-containerd" on namespace: "test-gc-e2e-demo-ns"	{"TraceId": "8137a5da-183f-4b52-ad78-67b10cf496b7"}
2022-08-10T21:00:47.407Z	INFO	cnsnodevmattachment/cnsnodevmattachment_controller.go:705	Observed conflict while updating the SV PVC "test-gc-control-plane-t5bvt-rsk9c-containerd" in namespace "test-gc-e2e-demo-ns".Reapplying changes to the latest SV PVC object.	{"TraceId": "8137a5da-183f-4b52-ad78-67b10cf496b7"}
<<<<<<<<<<<<No attempt to remove the finalizer again>>>>>>>>>>
2022-08-10T21:00:47.619Z	DEBUG	cnsnodevmattachment/cnsnodevmattachment_controller.go:645	Removing "cns.vmware.com" finalizer from CnsNodeVmAttachment instance with name: "test-gc-control-plane-cmm6b-test-gc-control-plane-t5bvt-rsk9c-containerd" on namespace: "test-gc-e2e-demo-ns"	{"TraceId": "8137a5da-183f-4b52-ad78-67b10cf496b7"}
2022-08-10T21:00:47.806Z	INFO	cnsnodevmattachment/cnsnodevmattachment_controller.go:911	VM CR is not present with UUID: 4233feb6-a70e-3b54-f2a8-14dee2b6202c in namespace: test-gc-e2e-demo-ns. Removing finalizer on CnsNodeVMAttachment: test-gc-control-plane-cmm6b-test-gc-control-plane-t5bvt-rsk9c-containerd instance.	{"TraceId": "8137a5da-183f-4b52-ad78-67b10cf496b7"}
```

After:
```
2022-08-10T22:55:27.242Z        DEBUG   cnsnodevmattachment/cnsnodevmattachment_controller.go:677       Removing "cns.vmware.com/pvc-protection" finalizer from PersistentVolumeClaim: "test-gc-control-plane-sfrv4-f8tx5-containerd" on namespace: "test-gc-e2e-demo-ns"       {"TraceId": "ee2e8ab1-7403-4b33-b238-5560c2622f3d"}
2022-08-10T22:55:27.294Z        INFO    cnsnodevmattachment/cnsnodevmattachment_controller.go:708       Observed conflict while updating the SV PVC "test-gc-control-plane-sfrv4-f8tx5-containerd" in namespace "test-gc-e2e-demo-ns".Reapplying changes to the latest SV PVC object.   {"TraceId": "ee2e8ab1-7403-4b33-b238-5560c2622f3d"}
2022-08-10T22:55:27.295Z        DEBUG   cnsnodevmattachment/cnsnodevmattachment_controller.go:725       Removing "cns.vmware.com/pvc-protection" finalizer from PersistentVolumeClaim: "test-gc-control-plane-sfrv4-f8tx5-containerd" on namespace: "test-gc-e2e-demo-ns"       {"TraceId": "ee2e8ab1-7403-4b33-b238-5560c2622f3d"}
2022-08-10T22:55:27.641Z        INFO    cnsnodevmattachment/cnsnodevmattachment_controller.go:921       VM CR is not present with UUID: 42331c56-f666-7802-9ca7-c8040ae71b88 in namespace: test-gc-e2e-demo-ns. Removing finalizer on CnsNodeVMAttachment: test-gc-control-plane-qjthz-test-gc-control-plane-sfrv4-f8tx5-containerd instance.   {"TraceId": "ee2e8ab1-7403-4b33-b238-5560c2622f3d"}
```
Running e2e pipelines

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Check for cns finalizer using the most recent pvc object
```
