### PR TITLE
[WIP] Fix using environment variable to configure vCenter port

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -183,7 +183,7 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 	if v := os.Getenv("VSPHERE_VCENTER"); v != "" {
 		cfg.Global.VCenterIP = v
 	}
-	if v := os.Getenv("VSPHERE_VCENTER_PORT"); v != "" {
+	if v := os.Getenv("VSPHERE_PORT"); v != "" {
 		cfg.Global.VCenterPort = v
 	}
 	if v := os.Getenv("VSPHERE_USER"); v != "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This fixes a bug when configuring the plugin via environment variables, setting `VSPHERE_VCENTER_PORT` causes the plugin to treat the set port as a vCenter ID/IP/DNS name and to try to configure it, which fails.

**Which issue this PR fixes** 
fixes #1935 

**Testing done**:
WIP

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
