### PR TITLE
Change vcenter port environment variable name

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcentermanager.go
+++ b/pkg/common/cns-lib/vsphere/virtualcentermanager.go
@@ -119,7 +119,8 @@ func (m *defaultVirtualCenterManager) RegisterVirtualCenter(ctx context.Context,
 	// Note that the Client isn't initialized here.
 	vc := &VirtualCenter{Config: config}
 	m.virtualCenters.Store(config.Host, vc)
-	log.Infof("Successfully registered VC %q", vc.Config.Host)
+	// Adding the port to the message here so errors are more obvious
+	log.Infof("Successfully registered VC %s:%d", vc.Config.Host, vc.Config.Port)
 	return vc, nil
 }
 

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -183,7 +183,7 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 	if v := os.Getenv("VSPHERE_VCENTER"); v != "" {
 		cfg.Global.VCenterIP = v
 	}
-	if v := os.Getenv("VSPHERE_VCENTER_PORT"); v != "" {
+	if v := os.Getenv("VSPHERE_PORT"); v != "" {
 		cfg.Global.VCenterPort = v
 	}
 	if v := os.Getenv("VSPHERE_USER"); v != "" {

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -357,6 +357,9 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 		if !insecure {
 			vcConfig.InsecureFlag = cfg.Global.InsecureFlag
 		}
+		// Print out the config. WARNING: This will print the password used in plain text
+		log.Debugf("vc server %s config: %+v", vcServer, vcConfig)
+		
 	}
 	clusterFlavor, err := GetClusterFlavor(ctx)
 	if err != nil {

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -357,10 +357,10 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 		if !insecure {
 			vcConfig.InsecureFlag = cfg.Global.InsecureFlag
 		}
-		// Print out the config. WARNING: This will print the password used in plain text
+		// Print out the config. WARNING: This will print the password used in plain text.
 		log.Debugf("vc server %s config: %+v", vcServer, vcConfig)
-		
 	}
+
 	clusterFlavor, err := GetClusterFlavor(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This avoids a problem with other environment variables
that start with VSPHERE_VCENTER_ and configure
a specific instance.

Also included is an increase in logging to show the configured port at Info level and a debug level output (potentially problematic since it includes a password) that shows the complete vCenter config.

**Which issue this PR fixes** *
fixes #1935 

**Testing done**:
1. Built modified images and updated deployed config in running cluster:
```yaml
- name: vsphere-csi-controller
          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.6.0
          args:
            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
            - "--fss-namespace=$(CSI_NAMESPACE)"
          imagePullPolicy: "Always"
          env:
...
            # - name: VSPHERE_CSI_CONFIG
            #   value: "/etc/cloud/csi-vsphere.conf"
            - name: VSPHERE_VCENTER
              value: "<vc address>"
            - name: CAFile
              value: "/etc/ssl/certs/0eeb4864.0" 
            - name: VSPHERE_PORT
              value: "443"
            - name: VSPHERE_USER
              value: "svc-csi@vsphere.local"
            - name: VSPHERE_PASSWORD
              value: "<snip>"
            - name: VSPHERE_DATACENTER
              value: "<snip>"
            - name: LOGGER_LEVEL
              value: "DEVELOPMENT" # Options: DEVELOPMENT, PRODUCTION
...
```
2. Monitor startup of container/pod; relevant logs:
```yaml
k logs -n vmware-system-csi -c vsphere-csi-controller vsphere-csi-controller-6dc5b844-jtc4d
2022-08-18T17:26:46.534Z        INFO    logger/logger.go:41     Setting default log level to :"DEVELOPMENT"
2022-08-18T17:26:46.534Z        INFO    vsphere-csi/main.go:52  Version : be578982      {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06"}
2022-08-18T17:26:46.534Z        DEBUG   commonco/utils.go:102   Container orchestrator init params: {InternalFeatureStatesConfigInfo:{Name:internal-feature-states.csi.vsphere.vmware.com Namespace:vmware-system-csi} ServiceMode:controller}      {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06"}
2022-08-18T17:26:46.534Z        INFO    logger/logger.go:41     Setting default log level to :"DEVELOPMENT"
2022-08-18T17:26:46.534Z        INFO    k8sorchestrator/k8sorchestrator.go:244  Initializing k8sOrchestratorInstance
        {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.534Z        INFO    kubernetes/kubernetes.go:85     k8s client using in-cluster config      {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.534Z        INFO    kubernetes/kubernetes.go:389    Setting client QPS to 100.000000 and Burst to 100.    {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.534Z        INFO    kubernetes/kubernetes.go:85     k8s client using in-cluster config      {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.534Z        INFO    kubernetes/kubernetes.go:389    Setting client QPS to 100.000000 and Burst to 100.    {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.546Z        INFO    k8sorchestrator/k8sorchestrator.go:371  New internal feature states values stored successfully: map[async-query-volume:true block-volume-snapshot:true cnsmgr-suspend-create-volume:false csi-auth-check:true csi-migration:false csi-windows-support:false improved-csi-idempotency:true improved-volume-topology:true list-volumes:false max-pvscsi-targets-per-vm:false online-volume-extend:true pv-to-backingdiskobjectid-mapping:false topology-preferential-datastores:true trigger-csi-fullsync:false use-csinode-id:true]      {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.546Z        INFO    k8sorchestrator/k8sorchestrator.go:291  k8sOrchestratorInstance initialized
        {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.548Z        INFO    k8sorchestrator/k8sorchestrator.go:597  configMapAdded: Internal feature state values from "internal-feature-states.csi.vsphere.vmware.com" stored successfully: map[async-query-volume:true block-volume-snapshot:true cnsmgr-suspend-create-volume:false csi-auth-check:true csi-migration:false csi-windows-support:false improved-csi-idempotency:true improved-volume-topology:true list-volumes:false max-pvscsi-targets-per-vm:false online-volume-extend:true pv-to-backingdiskobjectid-mapping:false topology-preferential-datastores:true trigger-csi-fullsync:false use-csinode-id:true]   {"TraceId": "5a7a2a47-ed5e-4505-bad4-cdf7b0cb31b3"}
2022-08-18T17:26:46.580Z        DEBUG   config/config.go:469    GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.580Z        INFO    config/config.go:473    Could not stat /etc/cloud/csi-vsphere.conf (file not found), reading config params from env   {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.580Z        DEBUG   config/config.go:328    Initializing vc server <vc-address>     {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.580Z        DEBUG	config/config.go:360	vc server <vc-address> config: &{User:svc-csi@vsphere.local Password:<snip> VCenterPort:443 InsecureFlag:false Datacenters:Home TargetvSANFileShareDatastoreURLs: TargetvSANFileShareClusters:}	{"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.580Z        INFO    config/config.go:367    No Net Permissions given in Config. Using default permissions.        {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.580Z        DEBUG   config/config.go:437    Setting default queryLimit to 10000     {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.580Z        DEBUG   config/config.go:442    Setting default list volume threshold to 50     {"TraceId": "47876cd6-b4e4-4e0d-bf54-ff5aaf69ee06", "TraceId": "66e9e442-c1a2-4927-9601-ce623ce714e3"}
2022-08-18T17:26:46.580Z        INFO    vanilla/controller.go:89        Initializing CNS controller     {"TraceId": "28074b62-9809-4c10-bb92-361d50fcb19a"}
2022-08-18T17:26:46.580Z        INFO    vsphere/utils.go:189    Defaulting timeout for vCenter Client to 5 minutes
        {"TraceId": "28074b62-9809-4c10-bb92-361d50fcb19a"}
2022-08-18T17:26:46.580Z        DEBUG   vsphere/utils.go:217    Setting the queryLimit = 10000, ListVolumeThreshold = 50      {"TraceId": "28074b62-9809-4c10-bb92-361d50fcb19a"}
2022-08-18T17:26:46.581Z        INFO    vsphere/virtualcentermanager.go:74      Initializing defaultVirtualCenterManager...   {"TraceId": "28074b62-9809-4c10-bb92-361d50fcb19a"}
2022-08-18T17:26:46.581Z        INFO    vsphere/virtualcentermanager.go:76      Successfully initialized defaultVirtualCenterManager  {"TraceId": "28074b62-9809-4c10-bb92-361d50fcb19a"}
2022-08-18T17:26:46.581Z        INFO    vsphere/virtualcentermanager.go:123     Successfully registered VC <vc-address>:<vc-port>"     {"TraceId": "28074b62-9809-4c10-bb92-361d50fcb19a"}
...
```
3. Modify config for a different port:
```yaml
- name: vsphere-csi-controller
          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.6.0
          args:
            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
            - "--fss-namespace=$(CSI_NAMESPACE)"
          imagePullPolicy: "Always"
          env:
...
            # - name: VSPHERE_CSI_CONFIG
            #   value: "/etc/cloud/csi-vsphere.conf"
            - name: VSPHERE_VCENTER
              value: "<vc address>"
            - name: CAFile
              value: "/etc/ssl/certs/0eeb4864.0" 
            **- name: VSPHERE_PORT
              value: "444**"
            - name: VSPHERE_USER
              value: "svc-csi@vsphere.local"
            - name: VSPHERE_PASSWORD
              value: "<snip>"
            - name: VSPHERE_DATACENTER
              value: "<snip>"
            - name: LOGGER_LEVEL
              value: "DEVELOPMENT" # Options: DEVELOPMENT, PRODUCTION
...
```
4. Apply, run, get logs:
```yaml
2022-08-19T14:46:13.606Z	INFO	logger/logger.go:41	Setting default log level to :"DEVELOPMENT"
2022-08-19T14:46:13.606Z	INFO	vsphere-csi/main.go:52	Version : be578982	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a"}
2022-08-19T14:46:13.606Z	DEBUG	commonco/utils.go:102	Container orchestrator init params: {InternalFeatureStatesConfigInfo:{Name:internal-feature-states.csi.vsphere.vmware.com Namespace:vmware-system-csi} ServiceMode:controller}	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a"}
2022-08-19T14:46:13.606Z	INFO	logger/logger.go:41	Setting default log level to :"DEVELOPMENT"
2022-08-19T14:46:13.606Z	INFO	k8sorchestrator/k8sorchestrator.go:244	Initializing k8sOrchestratorInstance	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
2022-08-19T14:46:13.606Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
2022-08-19T14:46:13.607Z	INFO	kubernetes/kubernetes.go:389	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
2022-08-19T14:46:13.607Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
2022-08-19T14:46:13.607Z	INFO	kubernetes/kubernetes.go:389	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
2022-08-19T14:46:13.617Z	INFO	k8sorchestrator/k8sorchestrator.go:371	New internal feature states values stored successfully: map[async-query-volume:true block-volume-snapshot:true cnsmgr-suspend-create-volume:false csi-auth-check:true csi-migration:false csi-windows-support:false improved-csi-idempotency:true improved-volume-topology:true list-volumes:false max-pvscsi-targets-per-vm:false online-volume-extend:true pv-to-backingdiskobjectid-mapping:false topology-preferential-datastores:true trigger-csi-fullsync:false use-csinode-id:true]	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
2022-08-19T14:46:13.617Z	INFO	k8sorchestrator/k8sorchestrator.go:291	k8sOrchestratorInstance initialized	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
2022-08-19T14:46:13.620Z	INFO	k8sorchestrator/k8sorchestrator.go:597	configMapAdded: Internal feature state values from "internal-feature-states.csi.vsphere.vmware.com" stored successfully: map[async-query-volume:true block-volume-snapshot:true cnsmgr-suspend-create-volume:false csi-auth-check:true csi-migration:false csi-windows-support:false improved-csi-idempotency:true improved-volume-topology:true list-volumes:false max-pvscsi-targets-per-vm:false online-volume-extend:true pv-to-backingdiskobjectid-mapping:false topology-preferential-datastores:true trigger-csi-fullsync:false use-csinode-id:true]	{"TraceId": "688dc309-f102-4730-b29e-064bfee6b358"}
2022-08-19T14:46:13.625Z	DEBUG	config/config.go:474	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
2022-08-19T14:46:13.625Z	INFO	config/config.go:478	Could not stat /etc/cloud/csi-vsphere.conf (file not found), reading config params from env	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
2022-08-19T14:46:13.625Z	DEBUG	config/config.go:328	Initializing vc server <vc-server>	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
**2022-08-19T14:46:13.625Z	DEBUG	config/config.go:360	vc server <vc-server> config: &{User:svc-csi@vsphere.local Password:<snip> VCenterPort:444 InsecureFlag:false Datacenters:Home TargetvSANFileShareDatastoreURLs: TargetvSANFileShareClusters:}	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}**
2022-08-19T14:46:13.625Z	INFO	config/config.go:372	No Net Permissions given in Config. Using default permissions.	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
2022-08-19T14:46:13.625Z	DEBUG	config/config.go:442	Setting default queryLimit to 10000	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
2022-08-19T14:46:13.625Z	DEBUG	config/config.go:447	Setting default list volume threshold to 50	{"TraceId": "02175e0f-19a6-4948-9832-c2931c32e83a", "TraceId": "44ba1eb1-055b-4707-8310-f5b1c56b5cfd"}
2022-08-19T14:46:13.625Z	INFO	vanilla/controller.go:89	Initializing CNS controller	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.625Z	INFO	vsphere/utils.go:189	Defaulting timeout for vCenter Client to 5 minutes	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.625Z	DEBUG	vsphere/utils.go:217	Setting the queryLimit = 10000, ListVolumeThreshold = 50	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.625Z	INFO	vsphere/virtualcentermanager.go:74	Initializing defaultVirtualCenterManager...	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.625Z	INFO	vsphere/virtualcentermanager.go:76	Successfully initialized defaultVirtualCenterManager	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
**2022-08-19T14:46:13.625Z	INFO	vsphere/virtualcentermanager.go:123	Successfully registered VC <vc-server>:444	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}**
2022-08-19T14:46:13.626Z	INFO	vanilla/controller.go:107	CSI Volume manager idempotency handling feature flag is enabled.	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.626Z	INFO	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:83	Creating CnsVolumeOperationRequest definition on API server and initializing VolumeOperationRequest instance	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.627Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.627Z	INFO	kubernetes/kubernetes.go:389	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.639Z	INFO	kubernetes/kubernetes.go:480	"cnsvolumeoperationrequests.cns.vmware.com" CRD updated successfully	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.639Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.639Z	INFO	kubernetes/kubernetes.go:389	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.669Z	INFO	volume/manager.go:176	Initializing new defaultManager...	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.669Z	DEBUG	vsphere/virtualcenter.go:159	Setting vCenter soap client timeout to 5m0s	{"TraceId": "23608468-51af-4990-85de-91b373e48113"}
2022-08-19T14:46:13.669Z	INFO	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:311	CnsVolumeOperationRequest clean up interval is set to 1440 minutes	{"TraceId": "c8dee399-5e09-4bb2-920f-a2b06ea974da"}
2022-08-19T14:46:13.669Z	INFO	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:313	Cleaning up stale CnsVolumeOperationRequest instances.	{"TraceId": "c8dee399-5e09-4bb2-920f-a2b06ea974da"}
2022-08-19T14:46:13.673Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config	{"TraceId": "c8dee399-5e09-4bb2-920f-a2b06ea974da"}
2022-08-19T14:46:13.674Z	INFO	kubernetes/kubernetes.go:389	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "c8dee399-5e09-4bb2-920f-a2b06ea974da"}
2022-08-19T14:46:13.677Z	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config	{"TraceId": "c8dee399-5e09-4bb2-920f-a2b06ea974da"}
2022-08-19T14:46:13.677Z	INFO	kubernetes/kubernetes.go:389	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "c8dee399-5e09-4bb2-920f-a2b06ea974da"}
2022-08-19T14:46:13.678Z	ERROR	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:362	failed to list VolumeSnapshotContents with error the server could not find the requested resource (get volumesnapshotcontents.snapshot.storage.k8s.io). Abandoning CnsVolumeOperationRequests clean up ...	{"TraceId": "c8dee399-5e09-4bb2-920f-a2b06ea974da"}
sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest.(*operationRequestStore).cleanupStaleInstances
	/build/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:362
```

**Special notes for your reviewer**:
With apologies, I am not proficient enough at Go to be able to write new tests for this. Testing done is manual.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
6. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
