### PR TITLE
TKGs HA PART3

### DIFF
--- a/tests/e2e/tkgs_ha.go
+++ b/tests/e2e/tkgs_ha.go
@@ -19,21 +19,18 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"math/rand"
-	"os/exec"
 	"strings"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	cnstypes "github.com/vmware/govmomi/cns/types"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	fdep "k8s.io/kubernetes/test/e2e/framework/deployment"
 	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
@@ -55,16 +52,11 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests",
 			zonalWffcPolicy      string
 		)
 		ginkgo.BeforeEach(func() {
-			//var cancel context.CancelFunc
-			//ctx, cancel := context.WithCancel(context.Background())
-			//defer cancel()
 			client = f.ClientSet
 			namespace = getNamespaceToRunTests(f)
 			bootstrap()
 			scParameters = make(map[string]string)
 			topologyHaMap := GetAndExpectStringEnvVar(topologyHaMap)
-			//topologyHAMap, categories := createAllowedTopolgies(topologyHaMap, tkgshaTopologyLevels)
-			//allowedTopologyHAMap = createAllowedTopologiesMap(topologyHAMap)
 			_, categories = createTopologyMapLevel5(topologyHaMap, tkgshaTopologyLevels)
 			allowedTopologies := createAllowedTopolgies(topologyHaMap, tkgshaTopologyLevels)
 			allowedTopologyHAMap = createAllowedTopologiesMap(allowedTopologies)
@@ -87,7 +79,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests",
 
 			if guestCluster {
 				svcClient, svNamespace := getSvcClientAndNamespace()
-				setResourceQuota(svcClient, svNamespace, rqLimit)
+				setResourceQuota(svcClient, svNamespace, rqLimitScaleTest)
 			}
 
 		})
@@ -724,416 +716,393 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests",
 
 		})
 
-	})
+		/*
+			Stateful set - storage class with Zonal storage and
+			Immediate and with parallel pod management policy with nodeAffinity
+			1. Create a zonal storage policy, on the datastore that is shared only to specific cluster
+			2. Use the Zonal storage class and Immediate binding mode and create statefulset
+				with parallel pod management policy with replica 3
+			3. wait for all the gc-PVC to bound - Make sure corresponding SVC-PVC will
+				have "csi.vsphere.volume-accessible-topology" annotation
+				csi.vsphere.requested.cluster-topology=
+				[{"topology.kubernetes.io/zone":"zone1"},{"topology.kubernetes.io/zone":"zone2"},
+				{"topology.kubernetes.io/zone":"zone2"}]
+			4. storageClassName: should point to gcStorageclass
+			5. Wait for the PODs to reach running state - make sure Pod scheduled on appropriate nodes
+				preset in the availability zone
+			6. Describe SVC-PV , and GC-PV  and verify node affinity, make sure appropriate node affinity gets added
+			7. Scale up the statefulset replica to 5 , and validate the node affinity on
+			   the newly create PV's and annotations on PVC's
+			8. Validate the CNS metadata
+			9. Scale down the sts to 0
+			10.Delete PVC,POD,SC
+		*/
+		ginkgo.It("Stateful set - storage class with Zonal storage and Immediate and"+
+			" with parallel pod management policy with nodeAffinity", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ginkgo.By("CNS_TEST: Running for GC setup")
+			nodeList, _ := fnodes.GetReadySchedulableNodes(client)
 
-// verifyVolumeProvisioningWithServiceDown brings the service down and creates the statefulset and then brings up
-// the service and validates the volumes are bound and required annotations and node affinity are present
-func verifyVolumeProvisioningWithServiceDown(serviceName string, namespace string, client clientset.Interface,
-	storagePolicyName string, allowedTopologyHAMap map[string][]string, categories []string, isServiceStopped bool,
-	f *framework.Framework) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ginkgo.By("CNS_TEST: Running for GC setup")
-	nodeList, err := fnodes.GetReadySchedulableNodes(client)
-	framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
-	if !(len(nodeList.Items) > 0) {
-		framework.Failf("Unable to find ready and schedulable Node")
-	}
-
-	ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
-	vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
-	err = invokeVCenterServiceControl(stopOperation, serviceName, vcAddress)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	isServiceStopped = true
-	err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcStoppedMessage)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	defer func() {
-		if isServiceStopped {
-			ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", serviceName))
-			err = invokeVCenterServiceControl(startOperation, serviceName, vcAddress)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			bootstrap()
-			isServiceStopped = false
-		}
-	}()
-
-	ginkgo.By("Create statefulset with default pod management policy with replica 3")
-	createResourceQuota(client, namespace, rqLimit, storagePolicyName)
-	storageclass, err := client.StorageV1().StorageClasses().Get(ctx, storagePolicyName, metav1.GetOptions{})
-	if !apierrors.IsNotFound(err) {
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}
-
-	// Creating StatefulSet service
-	ginkgo.By("Creating service")
-	service := CreateService(namespace, client)
-	defer func() {
-		deleteService(namespace, client, service)
-	}()
-
-	statefulset := GetStatefulSetFromManifest(namespace)
-	ginkgo.By("Creating statefulset")
-	statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-		Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
-	*statefulset.Spec.Replicas = 3
-	_, err = client.AppsV1().StatefulSets(namespace).Create(ctx, statefulset, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
-	replicas := *(statefulset.Spec.Replicas)
-
-	defer func() {
-		scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
-		pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		for _, claim := range pvcs.Items {
-			pv := getPvFromClaim(client, namespace, claim.Name)
-			err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			ginkgo.By("Verify it's PV and corresponding volumes are deleted from CNS")
-			err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
-				pollTimeout)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			volumeHandle := pv.Spec.CSI.VolumeHandle
-			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-				fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
-					"kubernetes", volumeHandle))
-		}
-	}()
-
-	ginkgo.By(fmt.Sprintf("PVC and POD creations should be in pending state since %s is down", serviceName))
-	pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	for _, pvc := range pvcs.Items {
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
-			pvc.Namespace, pvc.Name, framework.Poll, time.Minute)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
-	}
-
-	pods := fss.GetPodList(client, statefulset)
-	for _, pod := range pods.Items {
-		if pod.Status.Phase != v1.PodPending {
-			framework.Failf("Expected pod to be in: %s state but is in: %s state", v1.PodPending,
-				pod.Status.Phase)
-		}
-	}
-
-	ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", serviceName))
-	err = invokeVCenterServiceControl(startOperation, serviceName, vcAddress)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	isServiceStopped = false
-	err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	bootstrap()
-
-	verifyVolumeMetadataOnStatefulsets(client, ctx, namespace, statefulset, replicas,
-		allowedTopologyHAMap, categories, storagePolicyName, nodeList, f)
-
-}
-
-// verifyOnlineVolumeExpansionOnGc is a util method which helps in verifying online volume expansion on gc
-func verifyOnlineVolumeExpansionOnGc(client clientset.Interface, namespace string, svcPVCName string,
-	volHandle string, pvclaim *v1.PersistentVolumeClaim, pod *v1.Pod, f *framework.Framework) {
-	rand.Seed(time.Now().Unix())
-	testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
-	ginkgo.By(fmt.Sprintf("Creating a 512mb test data file %v", testdataFile))
-	op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),
-		"bs=64k", "count=8000").Output()
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	defer func() {
-		op, err = exec.Command("rm", "-f", testdataFile).Output()
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}()
-
-	_ = framework.RunKubectlOrDie(namespace, "cp", testdataFile,
-		fmt.Sprintf("%v/%v:/mnt/volume1/testdata", namespace, pod.Name))
-
-	onlineVolumeResizeCheck(f, client, namespace, svcPVCName, volHandle, pvclaim, pod)
-
-	ginkgo.By("Checking data consistency after PVC resize")
-	_ = framework.RunKubectlOrDie(namespace, "cp",
-		fmt.Sprintf("%v/%v:/mnt/volume1/testdata", namespace, pod.Name), testdataFile+"_pod")
-	defer func() {
-		op, err = exec.Command("rm", "-f", testdataFile+"_pod").Output()
-		fmt.Println("rm: ", op)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}()
-	ginkgo.By("Running diff...")
-	op, err = exec.Command("diff", testdataFile, testdataFile+"_pod").Output()
-	fmt.Println("diff: ", op)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(len(op)).To(gomega.BeZero())
-
-	ginkgo.By("File system resize finished successfully in GC")
-	ginkgo.By("Checking for PVC resize completion on SVC PVC")
-	_, err = waitForFSResizeInSvc(svcPVCName)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-}
-
-// verifyOfflineVolumeExpansionOnGc is a util method which helps in verifying offline volume expansion on gc
-func verifyOfflineVolumeExpansionOnGc(client clientset.Interface, pvclaim *v1.PersistentVolumeClaim, svcPVCName string,
-	namespace string, volHandle string, pod *v1.Pod, pv *v1.PersistentVolume, f *framework.Framework) {
-	cmd := []string{"exec", "", "--namespace=" + namespace, "--", "/bin/sh", "-c", "df -Tkm | grep /mnt/volume1"}
-	ginkgo.By("Verify the volume is accessible and filesystem type is as expected")
-	cmd[1] = pod.Name
-	lastOutput := framework.RunKubectlOrDie(namespace, cmd...)
-	gomega.Expect(strings.Contains(lastOutput, ext4FSType)).NotTo(gomega.BeFalse())
-
-	ginkgo.By("Check filesystem size for mount point /mnt/volume1 before expansion")
-	originalFsSize, err := getFSSizeMb(f, pod)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	rand.Seed(time.Now().Unix())
-	testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
-	ginkgo.By(fmt.Sprintf("Creating a 512mb test data file %v", testdataFile))
-	op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),
-		"bs=64k", "count=8000").Output()
-	fmt.Println(op)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	defer func() {
-		op, err = exec.Command("rm", "-f", testdataFile).Output()
-		fmt.Println(op)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}()
-
-	_ = framework.RunKubectlOrDie(namespace, "cp", testdataFile,
-		fmt.Sprintf("%v/%v:/mnt/volume1/testdata", namespace, pod.Name))
-
-	// Delete POD.
-	ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s before expansion", pod.Name, namespace))
-	err = fpod.DeletePodWithWait(client, pod)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	ginkgo.By("Verify volume is detached from the node before expansion")
-	isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
-		pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
-		fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, pod.Spec.NodeName))
-
-	// Modify PVC spec to trigger volume expansion. We expand the PVC while
-	// no pod is using it to ensure offline expansion.
-	ginkgo.By("Expanding current pvc")
-	currentPvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
-	newSize := currentPvcSize.DeepCopy()
-	newSize.Add(resource.MustParse(diskSize))
-	framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
-	pvclaim, err = expandPVCSize(pvclaim, newSize, client)
-	framework.ExpectNoError(err, "While updating pvc for more size")
-	gomega.Expect(pvclaim).NotTo(gomega.BeNil())
-
-	pvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
-	if pvcSize.Cmp(newSize) != 0 {
-		framework.Failf("error updating pvc size %q", pvclaim.Name)
-	}
-	ginkgo.By("Checking for PVC request size change on SVC PVC")
-	b, err := verifyPvcRequestedSizeUpdateInSupervisorWithWait(svcPVCName, newSize)
-	gomega.Expect(b).To(gomega.BeTrue())
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	ginkgo.By("Waiting for controller volume resize to finish")
-	err = waitForPvResizeForGivenPvc(pvclaim, client, totalResizeWaitPeriod)
-	framework.ExpectNoError(err, "While waiting for pvc resize to finish")
-
-	ginkgo.By("Checking for resize on SVC PV")
-	verifyPVSizeinSupervisor(svcPVCName, newSize)
-
-	ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
-	err = waitForSvcPvcToReachFileSystemResizePendingCondition(svcPVCName, pollTimeout)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	ginkgo.By("Checking for conditions on pvc")
-	pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
-	queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volHandle)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	if len(queryResult.Volumes) == 0 {
-		err = fmt.Errorf("QueryCNSVolumeWithResult returned no volume")
-	}
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	ginkgo.By("Verifying disk size requested in volume expansion is honored")
-	newSizeInMb := convertGiStrToMibInt64(newSize)
-	if queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).CapacityInMb != newSizeInMb {
-		err = fmt.Errorf("got wrong disk size after volume expansion")
-	}
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	// Create a new Pod to use this PVC, and verify volume has been attached.
-	ginkgo.By("Creating a new pod to attach PV again to the node")
-	pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	defer func() {
-		ginkgo.By("Delete pod")
-		err = fpod.DeletePodWithWait(client, pod)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}()
-
-	ginkgo.By(fmt.Sprintf("Verify volume after expansion: %s is attached to the node: %s",
-		pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
-	vmUUID, err := getVMUUIDFromNodeName(pod.Spec.NodeName)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
-
-	ginkgo.By("Verify after expansion the filesystem type is as expected")
-	cmd[1] = pod.Name
-	lastOutput = framework.RunKubectlOrDie(namespace, cmd...)
-	gomega.Expect(strings.Contains(lastOutput, ext4FSType)).NotTo(gomega.BeFalse())
-
-	ginkgo.By("Waiting for file system resize to finish")
-	pvclaim, err = waitForFSResize(pvclaim, client)
-	framework.ExpectNoError(err, "while waiting for fs resize to finish")
-
-	pvcConditions := pvclaim.Status.Conditions
-	expectEqual(len(pvcConditions), 0, "pvc should not have conditions")
-
-	ginkgo.By("Verify filesystem size for mount point /mnt/volume1 after expansion")
-	fsSize, err := getFSSizeMb(f, pod)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	// Filesystem size may be smaller than the size of the block volume.
-	// Here since filesystem was already formatted on the original volume,
-	// we can compare the new filesystem size with the original filesystem size.
-	if fsSize < originalFsSize {
-		framework.Failf("error updating filesystem size for %q. Resulting filesystem size is %d", pvclaim.Name, fsSize)
-	}
-
-	ginkgo.By("Checking data consistency after PVC resize")
-	_ = framework.RunKubectlOrDie(namespace, "cp",
-		fmt.Sprintf("%v/%v:/mnt/volume1/testdata", namespace, pod.Name), testdataFile+"_pod")
-	defer func() {
-		op, err = exec.Command("rm", "-f", testdataFile+"_pod").Output()
-		fmt.Println("rm: ", op)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}()
-	ginkgo.By("Running diff...")
-	op, err = exec.Command("diff", testdataFile, testdataFile+"_pod").Output()
-	fmt.Println("diff: ", op)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(len(op)).To(gomega.BeZero())
-
-	ginkgo.By("File system resize finished successfully in GC")
-	ginkgo.By("Checking for PVC resize completion on SVC PVC")
-	_, err = waitForFSResizeInSvc(svcPVCName)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-}
-
-// verifyVolumeMetadataOnStatefulsets verifies sts pod replicas and tkg annotations and
-// node affinities on svc pvc and verify cns volume meetadata
-func verifyVolumeMetadataOnStatefulsets(client clientset.Interface, ctx context.Context, namespace string,
-	statefulset *appsv1.StatefulSet, replicas int32, allowedTopologyHAMap map[string][]string,
-	categories []string, storagePolicyName string, nodeList *v1.NodeList, f *framework.Framework) {
-	// Waiting for pods status to be Ready
-	fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
-	gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
-	ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
-	gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
-		fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
-	gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
-		"Number of Pods in the statefulset should match with number of replicas")
-
-	ginkgo.By("Verify GV PV and SV PV has has required PV node affinity details")
-	ginkgo.By("Verify SV PVC has TKG HA annotations set")
-	// Get the list of Volumes attached to Pods before scale down
-	for _, sspod := range ssPodsBeforeScaleDown.Items {
-		pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		for _, volumespec := range sspod.Spec.Volumes {
-			if volumespec.PersistentVolumeClaim != nil {
-				pvcName := volumespec.PersistentVolumeClaim.ClaimName
-				pv := getPvFromClaim(client, statefulset.Namespace, pvcName)
-				pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
-					pvcName, metav1.GetOptions{})
-				gomega.Expect(pvclaim).NotTo(gomega.BeNil())
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				volHandle := getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
-				gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
-				svcPVCName := pv.Spec.CSI.VolumeHandle
-
-				svcPVC := getPVCFromSupervisorCluster(svcPVCName)
-				gomega.Expect(*svcPVC.Spec.StorageClassName == storagePolicyName).To(
-					gomega.BeTrue(), "SV Pvc storageclass does not match with SV storageclass")
-				framework.Logf("GC PVC's storageclass matches SVC PVC's storageclass")
-
-				verifyAnnotationsAndNodeAffinity(allowedTopologyHAMap, categories, pod,
-					nodeList, svcPVC, pv, svcPVCName)
-
-				// Verify the attached volume match the one in CNS cache
-				err = waitAndVerifyCnsVolumeMetadata4GCVol(volHandle, svcPVCName, pvclaim,
-					pv, pod)
+			ginkgo.By("Create statefulset with parallel pod management policy with replica 3")
+			createResourceQuota(client, namespace, rqLimit, zonalPolicy)
+			scParameters[svStorageClassName] = zonalWffcPolicy
+			storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+			if !apierrors.IsNotFound(err) {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
-		}
-	}
 
-	replicas = 5
-	framework.Logf(fmt.Sprintf("Scaling up statefulset: %v to number of Replica: %v",
-		statefulset.Name, replicas))
-	_, scaleupErr := fss.Scale(client, statefulset, replicas)
-	gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
+			// Creating StatefulSet service
+			ginkgo.By("Creating service")
+			service := CreateService(namespace, client)
+			defer func() {
+				deleteService(namespace, client, service)
+			}()
 
-	fss.WaitForStatusReplicas(client, statefulset, replicas)
-	fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
-	ssPodsAfterScaleUp := fss.GetPodList(client, statefulset)
-	gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
-		fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
-	gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
-		"Number of Pods in the statefulset %s, %v, should match with number of replicas %v",
-		statefulset.Name, ssPodsAfterScaleUp.Size(), replicas,
-	)
+			statefulset := GetStatefulSetFromManifest(namespace)
+			ginkgo.By("Creating statefulset with node affinity")
+			allowedTopologies := getTopologySelector(allowedTopologyHAMap, categories,
+				tkgshaTopologyLevels)
+			framework.Logf("allowedTopo: %v", allowedTopologies)
+			statefulset.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+			statefulset.Spec.Template.Spec.Affinity = new(v1.Affinity)
+			statefulset.Spec.Template.Spec.Affinity.NodeAffinity = new(v1.NodeAffinity)
+			statefulset.Spec.Template.Spec.Affinity.NodeAffinity.
+				RequiredDuringSchedulingIgnoredDuringExecution = new(v1.NodeSelector)
+			statefulset.Spec.Template.Spec.Affinity.NodeAffinity.
+				RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = getNodeSelectorTerms(allowedTopologies)
+			*statefulset.Spec.Replicas = 3
 
-	// Get the list of Volumes attached to Pods before scale down
-	for _, sspod := range ssPodsBeforeScaleDown.Items {
-		pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		for _, volumespec := range sspod.Spec.Volumes {
-			if volumespec.PersistentVolumeClaim != nil {
-				pvcName := volumespec.PersistentVolumeClaim.ClaimName
-				pv := getPvFromClaim(client, statefulset.Namespace, pvcName)
-				pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
-					pvcName, metav1.GetOptions{})
-				gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+			CreateStatefulSet(namespace, statefulset, client)
+			replicas := *(statefulset.Spec.Replicas)
+
+			defer func() {
+				scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
+				pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				for _, claim := range pvcs.Items {
+					pv := getPvFromClaim(client, namespace, claim.Name)
+					err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					ginkgo.By("Verify it's PV and corresponding volumes are deleted from CNS")
+					err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+						pollTimeout)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					volumeHandle := pv.Spec.CSI.VolumeHandle
+					err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+						fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+							"kubernetes", volumeHandle))
+				}
+			}()
 
-				volHandle := getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
-				gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
-				svcPVCName := pv.Spec.CSI.VolumeHandle
-				svcPVC := getPVCFromSupervisorCluster(svcPVCName)
+			ginkgo.By("Verify annotations on SVC PV and required node affinity details on SVC PV and GC PV")
+			ginkgo.By("Verify pod gets scheduled on appropriate nodes preset in the availability zone")
+			verifyVolumeMetadataOnStatefulsets(client, ctx, namespace, statefulset, replicas,
+				allowedTopologyHAMap, categories, zonalPolicy, nodeList, f)
 
-				verifyAnnotationsAndNodeAffinity(allowedTopologyHAMap, categories, pod,
-					nodeList, svcPVC, pv, svcPVCName)
+		})
 
-				framework.Logf(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
-					pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
-				var vmUUID string
+		/*
+			Provision volume with zonal storage when no resource quota available
+			1. Create a zonal storage policy.
+			2. Delete the resource quota assigned to zonal storage class.
+			3. Use the Zonal storage class and WaitForFirstConsumer binding mode and create statefulset
+				with parallel pod management policy with replica 3.
+			4. Statefulset pods and pvc should be in pending state.
+			5. Increase the resource quota of the zonal SC.
+			6. Wait for some time and make sure all the PVC
+			   and POD's of sts are bound and in running state
+			7. wait for all the gc-PVC to bound - Make sure corresponding SVC-PVC
+			   will have "csi.vsphere.volume-accessible-topology" annotation
+				csi.vsphere.guestcluster-topology=
+				[{"topology.kubernetes.io/zone":"zone1"},{"topology.kubernetes.io/zone":"zone2"},
+				{"topology.kubernetes.io/zone":"zone2"}]
+			8. storageClassName: should point to gcStorageclass.
+			9. Wait for the PODs to reach running state - make sure Pod scheduled on appropriate nodes
+				preset in the availability zone.
+			10. Describe SVC-PV , and GC-PV  and verify node affinity, make sure appropriate node affinity gets added.
+			11. Scale up the statefulset replica to 5 , and validate the node affinity
+			   on the newly create PV's and annotations on PVC's.
+			12. Validate the CNS metadata.
+			13. Scale down the sts to 0.
+			14.Delete PVC,POD,SC.
+		*/
+		ginkgo.It("Provision volume with zonal storage when no resource quota available",
+			func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
-				vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName,
-					crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
+				ginkgo.By("CNS_TEST: Running for GC setup")
+				nodeList, _ := fnodes.GetReadySchedulableNodes(client)
 
-				isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
+				scParameters[svStorageClassName] = zonalPolicy
+				storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+				if !apierrors.IsNotFound(err) {
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+
+				// Creating StatefulSet service
+				ginkgo.By("Creating service")
+				service := CreateService(namespace, client)
+				defer func() {
+					deleteService(namespace, client, service)
+				}()
+
+				ginkgo.By("Decrease SVC storage policy resource quota")
+				svcClient, svNamespace := getSvcClientAndNamespace()
+				quotaName := svcNamespace + "-storagequota"
+				framework.Logf("quotaName: %s", quotaName)
+				resourceQuota := newTestResourceQuota(quotaName, "10Mi", zonalPolicy)
+				resourceQuota, err = svcClient.CoreV1().ResourceQuotas(svNamespace).Update(
+					ctx, resourceQuota, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached to the node")
-				framework.Logf("After scale up, verify the attached volumes match those in CNS Cache")
-				err = waitAndVerifyCnsVolumeMetadata4GCVol(volHandle, svcPVCName, pvclaim,
-					pv, pod)
+				ginkgo.By(fmt.Sprintf("Create Resource quota: %+v", resourceQuota))
+				framework.Logf("Sleeping for 15 seconds to claim resource quota fully")
+				time.Sleep(time.Duration(15) * time.Second)
+
+				ginkgo.By("Create statefulset with parallel pod management policy with replica 1")
+				statefulset := GetStatefulSetFromManifest(namespace)
+				ginkgo.By("Creating statefulset")
+				statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+					Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+				*statefulset.Spec.Replicas = 1
+				replicas := *(statefulset.Spec.Replicas)
+
+				_, err = client.AppsV1().StatefulSets(namespace).Create(ctx, statefulset, metav1.CreateOptions{})
+				framework.Logf("Error from creating statefulset when no resource quota available is: %v", err)
+				//gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				defer func() {
+					scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
+					pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					for _, claim := range pvcs.Items {
+						pv := getPvFromClaim(client, namespace, claim.Name)
+						err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						ginkgo.By("Verify it's PV and corresponding volumes are deleted from CNS")
+						err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+							pollTimeout)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						volumeHandle := pv.Spec.CSI.VolumeHandle
+						err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+							fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+								"kubernetes", volumeHandle))
+					}
+				}()
+
+				ginkgo.By("PVC and POD creations should be in pending state" +
+					" since there is no resourcequota")
+				pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				for _, pvc := range pvcs.Items {
+					err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
+						pvc.Namespace, pvc.Name, framework.Poll, time.Minute)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+						fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+				}
+
+				pods := fss.GetPodList(client, statefulset)
+				for _, pod := range pods.Items {
+					if pod.Status.Phase != v1.PodPending {
+						framework.Failf("Expected pod to be in: %s state but is in: %s state", v1.PodPending,
+							pod.Status.Phase)
+					}
+				}
+
+				ginkgo.By("Increase SVC storagepolicy resource quota")
+				framework.Logf("quotaName: %s", quotaName)
+				resourceQuota = newTestResourceQuota(quotaName, rqLimit, zonalPolicy)
+				resourceQuota, err = svcClient.CoreV1().ResourceQuotas(svNamespace).Update(
+					ctx, resourceQuota, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				ginkgo.By(fmt.Sprintf("ResourceQuota details: %+v", resourceQuota))
+				framework.Logf("Sleeping for 15 seconds to claim resource quota fully")
+				time.Sleep(time.Duration(15) * time.Second)
+
+				ginkgo.By("Verify annotations on SVC PV and required node affinity details on SVC PV and GC PV")
+				ginkgo.By("Verify pod gets scheduled on appropriate nodes preset in the availability zone")
+				verifyVolumeMetadataOnStatefulsets(client, ctx, namespace, statefulset, replicas,
+					allowedTopologyHAMap, categories, zonalPolicy, nodeList, f)
+
+			})
+
+		/*
+			Create PVC using zonal storage and deploy deployment POD
+			1. Create a zonal storage policy
+			2. Use the Zonal storage class and Immediate binding mode and gc-PVC
+			3. wait for all the gc-PVC to bound
+			4. Create Deployment POD using the above gc-PVC
+			5. Wait  deployment to reach running state
+			6. Describe gc-PV and verify node affinity
+			7. Verify that POD's should come up on the nodes of appropriate Availability zone
+			8. Delete deployment,POD,SC
+		*/
+		ginkgo.It("Create PVC using zonal storage and deploy deployment POD",
+			func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				ginkgo.By("CNS_TEST: Running for GC setup")
+				nodeList, _ := fnodes.GetReadySchedulableNodes(client)
+
+				createResourceQuota(client, namespace, rqLimit, zonalPolicy)
+				scParameters[svStorageClassName] = zonalWffcPolicy
+				storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+				if !apierrors.IsNotFound(err) {
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+
+				ginkgo.By("Creating PVC")
+
+				pvclaim, err := createPVC(client, namespace, nil, "", storageclass, "")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				pvclaims = append(pvclaims, pvclaim)
+
+				ginkgo.By("Expect the pvc to provision volume successfully")
+				_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				labelsMap := make(map[string]string)
+				labelsMap["app"] = "test"
+
+				ginkgo.By("Creating deployment with PVC created earlier")
+				deployment, err := createDeployment(
+					ctx, client, 1, labelsMap, nil, namespace, pvclaims, "", false, busyBoxImageOnGcr)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				deployment, err = client.AppsV1().Deployments(namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				pods, err := fdep.GetPodsForDeployment(client, deployment)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				pod := pods.Items[0]
+				err = fpod.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				defer func() {
+					scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
+					pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					for _, claim := range pvcs.Items {
+						pv := getPvFromClaim(client, namespace, claim.Name)
+						err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						ginkgo.By("Verify it's PV and corresponding volumes are deleted from CNS")
+						err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+							pollTimeout)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						volumeHandle := pv.Spec.CSI.VolumeHandle
+						err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+							fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+								"kubernetes", volumeHandle))
+					}
+				}()
+
+				ginkgo.By("Verify annotations on SVC PV and required node affinity details on SVC PV and GC PV")
+				ginkgo.By("Verify pod gets scheduled on appropriate nodes preset in the availability zone")
+				verifyVolumeMetadataOnDeployments(ctx, client, deployment, namespace, allowedTopologyHAMap,
+					categories, nodeList, zonalPolicy)
+
+			})
+
+		/*
+			Re-start GC-CSI during sts creation
+			1. Create a zonal storage policy, on the datastore that is shared only to specific cluster
+			2. Use the Zonal storage class and Immediate binding mode and create statefulset
+				with parallel pod management policy with replica 3
+			3. Restart gc-csi and SVC CSI
+			4. wait for all the gc-PVC to bound - Make sure corresponding SVC-PVC will
+			    have "csi.vsphere.volume-accessible-topology" annotation
+				csi.vsphere.requested.cluster-topology=
+				[{"topology.kubernetes.io/zone":"zone1"},{"topology.kubernetes.io/zone":"zone2"},
+				{"topology.kubernetes.io/zone":"zone2"}]
+			5. storageClassName: should point to gcStorageclass
+			6. Wait for the PODs to reach running state - make sure Pod scheduled on appropriate nodes
+				preset in the availability zone
+			7. Describe SVC-PV , and GC-PV  and verify node affinity, make sure appropriate node affinity gets added
+			8. scale up the sts to 5, and validate the node affinity on the newly create PV's and annotations on PVC's
+			9. Validate the CNS metadata
+			10. Scale down the sts to 0
+			11.Delete PVC,POD,SC
+		*/
+		ginkgo.It("Re-start GC-CSI during sts creation", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ginkgo.By("CNS_TEST: Running for GC setup")
+			nodeList, _ := fnodes.GetReadySchedulableNodes(client)
+
+			ginkgo.By("Create statefulset with parallel pod management policy with replica 3")
+			createResourceQuota(client, namespace, rqLimit, zonalPolicy)
+			scParameters[svStorageClassName] = zonalWffcPolicy
+			storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+			if !apierrors.IsNotFound(err) {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
-		}
-	}
 
-}
+			svClient, _ := getSvcClientAndNamespace()
+			csiNamespace := GetAndExpectStringEnvVar(envCSINamespace)
+			csiDeployment, err := client.AppsV1().Deployments(csiNamespace).Get(
+				ctx, vSphereCSIControllerPodNamePrefix, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			csiReplicas := *csiDeployment.Spec.Replicas
+			svcCsiDeployment, err := svClient.AppsV1().Deployments(csiNamespace).Get(
+				ctx, vSphereCSIControllerPodNamePrefix, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			svcCsiReplicas := *svcCsiDeployment.Spec.Replicas
+
+			// Creating StatefulSet service
+			ginkgo.By("Creating service")
+			service := CreateService(namespace, client)
+			defer func() {
+				deleteService(namespace, client, service)
+			}()
+
+			statefulset := GetStatefulSetFromManifest(namespace)
+			ginkgo.By("Creating statefulset")
+			statefulset.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+			*statefulset.Spec.Replicas = 3
+
+			CreateStatefulSet(namespace, statefulset, client)
+			replicas := *(statefulset.Spec.Replicas)
+
+			ginkgo.By("Restarting GC CSI and SVC CSI")
+			_ = updateDeploymentReplica(client, 0, vSphereCSIControllerPodNamePrefix, csiNamespace)
+			_ = updateDeploymentReplica(svClient, 0, vSphereCSIControllerPodNamePrefix, csiNamespace)
+
+			_ = updateDeploymentReplica(svClient, svcCsiReplicas, vSphereCSIControllerPodNamePrefix, csiNamespace)
+			_ = updateDeploymentReplica(client, csiReplicas, vSphereCSIControllerPodNamePrefix, csiNamespace)
+
+			defer func() {
+				scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
+				pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				for _, claim := range pvcs.Items {
+					pv := getPvFromClaim(client, namespace, claim.Name)
+					err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					ginkgo.By("Verify it's PV and corresponding volumes are deleted from CNS")
+					err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+						pollTimeout)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					volumeHandle := pv.Spec.CSI.VolumeHandle
+					err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+						fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+							"kubernetes", volumeHandle))
+				}
+			}()
+
+			ginkgo.By("Verify annotations on SVC PV and required node affinity details on SVC PV and GC PV")
+			ginkgo.By("Verify pod gets scheduled on appropriate nodes preset in the availability zone")
+			verifyVolumeMetadataOnStatefulsets(client, ctx, namespace, statefulset, replicas,
+				allowedTopologyHAMap, categories, zonalPolicy, nodeList, f)
+
+		})
+
+	})

--- a/tests/e2e/tkgs_ha_utils.go
+++ b/tests/e2e/tkgs_ha_utils.go
@@ -17,12 +17,27 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"fmt"
+	"math/rand"
+	"os/exec"
 	"strings"
+	"time"
 
+	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
 )
 
 // checkAnnotationOnSvcPvc checks tkg HA specific annotations on SVC PVC
@@ -108,4 +123,458 @@ func verifyAnnotationsAndNodeAffinity(allowedTopologyHAMap map[string][]string,
 
 	_, err = verifyPodLocationLevel5(pod, nodeList, allowedTopologyHAMap)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+// verifyVolumeProvisioningWithServiceDown brings the service down and creates the statefulset and then brings up
+// the service and validates the volumes are bound and required annotations and node affinity are present
+func verifyVolumeProvisioningWithServiceDown(serviceName string, namespace string, client clientset.Interface,
+	storagePolicyName string, allowedTopologyHAMap map[string][]string, categories []string, isServiceStopped bool,
+	f *framework.Framework) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ginkgo.By("CNS_TEST: Running for GC setup")
+	nodeList, err := fnodes.GetReadySchedulableNodes(client)
+	framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+	if !(len(nodeList.Items) > 0) {
+		framework.Failf("Unable to find ready and schedulable Node")
+	}
+
+	ginkgo.By(fmt.Sprintf("Stopping %v on the vCenter host", serviceName))
+	vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
+	err = invokeVCenterServiceControl(stopOperation, serviceName, vcAddress)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	isServiceStopped = true
+	err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcStoppedMessage)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer func() {
+		if isServiceStopped {
+			ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", serviceName))
+			err = invokeVCenterServiceControl(startOperation, serviceName, vcAddress)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			bootstrap()
+			isServiceStopped = false
+		}
+	}()
+
+	ginkgo.By("Create statefulset with default pod management policy with replica 3")
+	createResourceQuota(client, namespace, rqLimit, storagePolicyName)
+	storageclass, err := client.StorageV1().StorageClasses().Get(ctx, storagePolicyName, metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	// Creating StatefulSet service
+	ginkgo.By("Creating service")
+	service := CreateService(namespace, client)
+	defer func() {
+		deleteService(namespace, client, service)
+	}()
+
+	statefulset := GetStatefulSetFromManifest(namespace)
+	ginkgo.By("Creating statefulset")
+	statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+		Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+	*statefulset.Spec.Replicas = 3
+	_, err = client.AppsV1().StatefulSets(namespace).Create(ctx, statefulset, metav1.CreateOptions{})
+	framework.ExpectNoError(err)
+	replicas := *(statefulset.Spec.Replicas)
+
+	defer func() {
+		scaleDownNDeleteStsDeploymentsInNamespace(ctx, client, namespace)
+		pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, claim := range pvcs.Items {
+			pv := getPvFromClaim(client, namespace, claim.Name)
+			err := fpv.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Verify it's PV and corresponding volumes are deleted from CNS")
+			err = fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll,
+				pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			volumeHandle := pv.Spec.CSI.VolumeHandle
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+					"kubernetes", volumeHandle))
+		}
+	}()
+
+	ginkgo.By(fmt.Sprintf("PVC and POD creations should be in pending state since %s is down", serviceName))
+	pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	for _, pvc := range pvcs.Items {
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
+			pvc.Namespace, pvc.Name, framework.Poll, time.Minute)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+	}
+
+	pods := fss.GetPodList(client, statefulset)
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != v1.PodPending {
+			framework.Failf("Expected pod to be in: %s state but is in: %s state", v1.PodPending,
+				pod.Status.Phase)
+		}
+	}
+
+	ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", serviceName))
+	err = invokeVCenterServiceControl(startOperation, serviceName, vcAddress)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	isServiceStopped = false
+	err = waitVCenterServiceToBeInState(serviceName, vcAddress, svcRunningMessage)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	bootstrap()
+
+	verifyVolumeMetadataOnStatefulsets(client, ctx, namespace, statefulset, replicas,
+		allowedTopologyHAMap, categories, storagePolicyName, nodeList, f)
+
+}
+
+// verifyOnlineVolumeExpansionOnGc is a util method which helps in verifying online volume expansion on gc
+func verifyOnlineVolumeExpansionOnGc(client clientset.Interface, namespace string, svcPVCName string,
+	volHandle string, pvclaim *v1.PersistentVolumeClaim, pod *v1.Pod, f *framework.Framework) {
+	rand.Seed(time.Now().Unix())
+	testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
+	ginkgo.By(fmt.Sprintf("Creating a 512mb test data file %v", testdataFile))
+	op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),
+		"bs=64k", "count=8000").Output()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	defer func() {
+		op, err = exec.Command("rm", "-f", testdataFile).Output()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}()
+
+	_ = framework.RunKubectlOrDie(namespace, "cp", testdataFile,
+		fmt.Sprintf("%v/%v:/mnt/volume1/testdata", namespace, pod.Name))
+
+	onlineVolumeResizeCheck(f, client, namespace, svcPVCName, volHandle, pvclaim, pod)
+
+	ginkgo.By("Checking data consistency after PVC resize")
+	_ = framework.RunKubectlOrDie(namespace, "cp",
+		fmt.Sprintf("%v/%v:/mnt/volume1/testdata", namespace, pod.Name), testdataFile+"_pod")
+	defer func() {
+		op, err = exec.Command("rm", "-f", testdataFile+"_pod").Output()
+		fmt.Println("rm: ", op)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}()
+	ginkgo.By("Running diff...")
+	op, err = exec.Command("diff", testdataFile, testdataFile+"_pod").Output()
+	fmt.Println("diff: ", op)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(len(op)).To(gomega.BeZero())
+
+	ginkgo.By("File system resize finished successfully in GC")
+	ginkgo.By("Checking for PVC resize completion on SVC PVC")
+	_, err = waitForFSResizeInSvc(svcPVCName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+// verifyOfflineVolumeExpansionOnGc is a util method which helps in verifying offline volume expansion on gc
+func verifyOfflineVolumeExpansionOnGc(client clientset.Interface, pvclaim *v1.PersistentVolumeClaim, svcPVCName string,
+	namespace string, volHandle string, pod *v1.Pod, pv *v1.PersistentVolume, f *framework.Framework) {
+	cmd := []string{"exec", "", "--namespace=" + namespace, "--", "/bin/sh", "-c", "df -Tkm | grep /mnt/volume1"}
+	ginkgo.By("Verify the volume is accessible and filesystem type is as expected")
+	cmd[1] = pod.Name
+	lastOutput := framework.RunKubectlOrDie(namespace, cmd...)
+	gomega.Expect(strings.Contains(lastOutput, ext4FSType)).NotTo(gomega.BeFalse())
+
+	ginkgo.By("Check filesystem size for mount point /mnt/volume1 before expansion")
+	originalFsSize, err := getFSSizeMb(f, pod)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	rand.Seed(time.Now().Unix())
+	testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
+	ginkgo.By(fmt.Sprintf("Creating a 512mb test data file %v", testdataFile))
+	op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),
+		"bs=64k", "count=8000").Output()
+	fmt.Println(op)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	defer func() {
+		op, err = exec.Command("rm", "-f", testdataFile).Output()
+		fmt.Println(op)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}()
+
+	_ = framework.RunKubectlOrDie(namespace, "cp", testdataFile,
+		fmt.Sprintf("%v/%v:/mnt/volume1/testdata", namespace, pod.Name))
+
+	// Delete POD.
+	ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s before expansion", pod.Name, namespace))
+	err = fpod.DeletePodWithWait(client, pod)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By("Verify volume is detached from the node before expansion")
+	isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+		pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+		fmt.Sprintf("Volume %q is not detached from the node %q", volHandle, pod.Spec.NodeName))
+
+	// Modify PVC spec to trigger volume expansion. We expand the PVC while
+	// no pod is using it to ensure offline expansion.
+	ginkgo.By("Expanding current pvc")
+	currentPvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
+	newSize := currentPvcSize.DeepCopy()
+	newSize.Add(resource.MustParse(diskSize))
+	framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
+	pvclaim, err = expandPVCSize(pvclaim, newSize, client)
+	framework.ExpectNoError(err, "While updating pvc for more size")
+	gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+
+	pvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
+	if pvcSize.Cmp(newSize) != 0 {
+		framework.Failf("error updating pvc size %q", pvclaim.Name)
+	}
+	ginkgo.By("Checking for PVC request size change on SVC PVC")
+	b, err := verifyPvcRequestedSizeUpdateInSupervisorWithWait(svcPVCName, newSize)
+	gomega.Expect(b).To(gomega.BeTrue())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By("Waiting for controller volume resize to finish")
+	err = waitForPvResizeForGivenPvc(pvclaim, client, totalResizeWaitPeriod)
+	framework.ExpectNoError(err, "While waiting for pvc resize to finish")
+
+	ginkgo.By("Checking for resize on SVC PV")
+	verifyPVSizeinSupervisor(svcPVCName, newSize)
+
+	ginkgo.By("Checking for 'FileSystemResizePending' status condition on SVC PVC")
+	err = waitForSvcPvcToReachFileSystemResizePendingCondition(svcPVCName, pollTimeout)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By("Checking for conditions on pvc")
+	pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
+	queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volHandle)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	if len(queryResult.Volumes) == 0 {
+		err = fmt.Errorf("QueryCNSVolumeWithResult returned no volume")
+	}
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By("Verifying disk size requested in volume expansion is honored")
+	newSizeInMb := convertGiStrToMibInt64(newSize)
+	if queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).CapacityInMb != newSizeInMb {
+		err = fmt.Errorf("got wrong disk size after volume expansion")
+	}
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Create a new Pod to use this PVC, and verify volume has been attached.
+	ginkgo.By("Creating a new pod to attach PV again to the node")
+	pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer func() {
+		ginkgo.By("Delete pod")
+		err = fpod.DeletePodWithWait(client, pod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}()
+
+	ginkgo.By(fmt.Sprintf("Verify volume after expansion: %s is attached to the node: %s",
+		pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+	vmUUID, err := getVMUUIDFromNodeName(pod.Spec.NodeName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+
+	ginkgo.By("Verify after expansion the filesystem type is as expected")
+	cmd[1] = pod.Name
+	lastOutput = framework.RunKubectlOrDie(namespace, cmd...)
+	gomega.Expect(strings.Contains(lastOutput, ext4FSType)).NotTo(gomega.BeFalse())
+
+	ginkgo.By("Waiting for file system resize to finish")
+	pvclaim, err = waitForFSResize(pvclaim, client)
+	framework.ExpectNoError(err, "while waiting for fs resize to finish")
+
+	pvcConditions := pvclaim.Status.Conditions
+	expectEqual(len(pvcConditions), 0, "pvc should not have conditions")
+
+	ginkgo.By("Verify filesystem size for mount point /mnt/volume1 after expansion")
+	fsSize, err := getFSSizeMb(f, pod)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	// Filesystem size may be smaller than the size of the block volume.
+	// Here since filesystem was already formatted on the original volume,
+	// we can compare the new filesystem size with the original filesystem size.
+	if fsSize < originalFsSize {
+		framework.Failf("error updating filesystem size for %q. Resulting filesystem size is %d", pvclaim.Name, fsSize)
+	}
+
+	ginkgo.By("Checking data consistency after PVC resize")
+	_ = framework.RunKubectlOrDie(namespace, "cp",
+		fmt.Sprintf("%v/%v:/mnt/volume1/testdata", namespace, pod.Name), testdataFile+"_pod")
+	defer func() {
+		op, err = exec.Command("rm", "-f", testdataFile+"_pod").Output()
+		fmt.Println("rm: ", op)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}()
+	ginkgo.By("Running diff...")
+	op, err = exec.Command("diff", testdataFile, testdataFile+"_pod").Output()
+	fmt.Println("diff: ", op)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(len(op)).To(gomega.BeZero())
+
+	ginkgo.By("File system resize finished successfully in GC")
+	ginkgo.By("Checking for PVC resize completion on SVC PVC")
+	_, err = waitForFSResizeInSvc(svcPVCName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+}
+
+// verifyVolumeMetadataOnStatefulsets verifies sts pod replicas and tkg annotations and
+// node affinities on svc pvc and verify cns volume meetadata
+func verifyVolumeMetadataOnStatefulsets(client clientset.Interface, ctx context.Context, namespace string,
+	statefulset *appsv1.StatefulSet, replicas int32, allowedTopologyHAMap map[string][]string,
+	categories []string, storagePolicyName string, nodeList *v1.NodeList, f *framework.Framework) {
+	// Waiting for pods status to be Ready
+	fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+	gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+	ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+	gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+		fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+	gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+		"Number of Pods in the statefulset should match with number of replicas")
+
+	ginkgo.By("Verify GV PV and SV PV has has required PV node affinity details")
+	ginkgo.By("Verify SV PVC has TKG HA annotations set")
+	// Get the list of Volumes attached to Pods before scale down
+	for _, sspod := range ssPodsBeforeScaleDown.Items {
+		pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, volumespec := range sspod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				pvcName := volumespec.PersistentVolumeClaim.ClaimName
+				pv := getPvFromClaim(client, statefulset.Namespace, pvcName)
+				pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
+					pvcName, metav1.GetOptions{})
+				gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volHandle := getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+				svcPVCName := pv.Spec.CSI.VolumeHandle
+
+				svcPVC := getPVCFromSupervisorCluster(svcPVCName)
+				gomega.Expect(*svcPVC.Spec.StorageClassName == storagePolicyName).To(
+					gomega.BeTrue(), "SV Pvc storageclass does not match with SV storageclass")
+				framework.Logf("GC PVC's storageclass matches SVC PVC's storageclass")
+
+				verifyAnnotationsAndNodeAffinity(allowedTopologyHAMap, categories, pod,
+					nodeList, svcPVC, pv, svcPVCName)
+
+				// Verify the attached volume match the one in CNS cache
+				err = waitAndVerifyCnsVolumeMetadata4GCVol(volHandle, svcPVCName, pvclaim,
+					pv, pod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+	}
+
+	replicas = 5
+	framework.Logf(fmt.Sprintf("Scaling up statefulset: %v to number of Replica: %v",
+		statefulset.Name, replicas))
+	_, scaleupErr := fss.Scale(client, statefulset, replicas)
+	gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
+
+	fss.WaitForStatusReplicas(client, statefulset, replicas)
+	fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+	ssPodsAfterScaleUp := fss.GetPodList(client, statefulset)
+	gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
+		fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+	gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
+		"Number of Pods in the statefulset %s, %v, should match with number of replicas %v",
+		statefulset.Name, ssPodsAfterScaleUp.Size(), replicas,
+	)
+
+	// Get the list of Volumes attached to Pods before scale down
+	for _, sspod := range ssPodsBeforeScaleDown.Items {
+		pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, volumespec := range sspod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				pvcName := volumespec.PersistentVolumeClaim.ClaimName
+				pv := getPvFromClaim(client, statefulset.Namespace, pvcName)
+				pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
+					pvcName, metav1.GetOptions{})
+				gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				volHandle := getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+				svcPVCName := pv.Spec.CSI.VolumeHandle
+				svcPVC := getPVCFromSupervisorCluster(svcPVCName)
+
+				verifyAnnotationsAndNodeAffinity(allowedTopologyHAMap, categories, pod,
+					nodeList, svcPVC, pv, svcPVCName)
+
+				framework.Logf(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+					pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+				var vmUUID string
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName,
+					crdCNSNodeVMAttachment, crdVersion, crdGroup, true)
+
+				isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached to the node")
+				framework.Logf("After scale up, verify the attached volumes match those in CNS Cache")
+				err = waitAndVerifyCnsVolumeMetadata4GCVol(volHandle, svcPVCName, pvclaim,
+					pv, pod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+	}
+
+}
+
+// verifyVolumeMetadataOnDeployments verifies tkg annotations and
+// node affinities on svc pvc and and verify cns volume metadata
+func verifyVolumeMetadataOnDeployments(ctx context.Context,
+	client clientset.Interface, deployment *appsv1.Deployment, namespace string,
+	allowedTopologyHAMap map[string][]string, categories []string,
+	nodeList *v1.NodeList, storagePolicyName string) {
+
+	pods, err := GetPodsForMultipleDeployment(client, deployment)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	for _, depPod := range pods.Items {
+		pod, err := client.CoreV1().Pods(namespace).Get(ctx, depPod.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, volumespec := range depPod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				pvcName := volumespec.PersistentVolumeClaim.ClaimName
+				pv := getPvFromClaim(client, namespace, pvcName)
+				pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx,
+					pvcName, metav1.GetOptions{})
+				gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				volHandle := getVolumeIDFromSupervisorCluster(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+				svcPVCName := pv.Spec.CSI.VolumeHandle
+
+				svcPVC := getPVCFromSupervisorCluster(svcPVCName)
+				gomega.Expect(*svcPVC.Spec.StorageClassName == storagePolicyName).To(
+					gomega.BeTrue(), "SV Pvc storageclass does not match with SV storageclass")
+				framework.Logf("GC PVC's storageclass matches SVC PVC's storageclass")
+
+				verifyAnnotationsAndNodeAffinity(allowedTopologyHAMap, categories, pod,
+					nodeList, svcPVC, pv, svcPVCName)
+
+				// Verify the attached volume match the one in CNS cache
+				err = waitAndVerifyCnsVolumeMetadata4GCVol(volHandle, svcPVCName, pvclaim,
+					pv, pod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+	}
 }

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -2150,12 +2150,12 @@ func deleteResourceQuota(client clientset.Interface, namespace string) {
 }
 
 // checks if resource quota gets updated or not
-func checkResourceQuota(client clientset.Interface, namespace string, size string) error {
+func checkResourceQuota(client clientset.Interface, namespace string, name string, size string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	waitErr := wait.PollImmediate(poll, pollTimeoutShort, func() (bool, error) {
-		currentResourceQuota, err := client.CoreV1().ResourceQuotas(namespace).Get(ctx, namespace, metav1.GetOptions{})
+		currentResourceQuota, err := client.CoreV1().ResourceQuotas(namespace).Get(ctx, name, metav1.GetOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		framework.Logf("currentResourceQuota %v", currentResourceQuota)
 		if err != nil {
@@ -2186,7 +2186,7 @@ func setResourceQuota(client clientset.Interface, namespace string, size string)
 			ctx, requestStorageQuota, metav1.UpdateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By(fmt.Sprintf("ResourceQuota details: %+v", testResourceQuota))
-		err = checkResourceQuota(client, namespace, size)
+		err = checkResourceQuota(client, namespace, existingResourceQuota.GetName(), size)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Automation deployment and statefulset creation for tkgs ha feature

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/1b4527c75dea2cfac84875ac49ffe8c8
make check output:
```
(base) kai@kai-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.2
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/kai/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.46.2'
golangci/golangci-lint info found version: 1.46.2 for v1.46.2/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/tkg_ha_part3/vsphere-csi-driver /Users/kai/CSI/tkg_ha_part3 /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|exports_file|imports|name|types_sizes|compiled_files|files) took 2.356991811s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 112.940181ms 
INFO [linters context/goanalysis] analyzers took 12.362676105s with top 10 stages: buildir: 1.376730626s, S1038: 1.293391076s, misspell: 638.746958ms, S1039: 379.141708ms, SA4030: 372.7022ms, SA1012: 367.58689ms, S1028: 308.108378ms, SA1004: 299.040434ms, S1024: 282.82712ms, directives: 280.243681ms 
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649. 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 113/113, exclude-rules: 1/24, skip_dirs: 113/113, identifier_marker: 24/24, nolint: 0/1, cgo: 113/113, filename_unadjuster: 113/113, skip_files: 113/113, autogenerated_exclude: 24/113, exclude: 24/24 
INFO [runner] processing took 16.160171ms with stages: nolint: 13.167954ms, autogenerated_exclude: 1.910237ms, path_prettifier: 575.96µs, identifier_marker: 295.08µs, skip_dirs: 128.831µs, exclude-rules: 64.986µs, cgo: 8.061µs, filename_unadjuster: 4.765µs, max_same_issues: 1.232µs, uniq_by_line: 462ns, path_shortener: 395ns, skip_files: 365ns, max_from_linter: 343ns, exclude: 253ns, diff: 250ns, source_code: 250ns, max_per_file_from_linter: 215ns, severity-rules: 207ns, sort_results: 205ns, path_prefixer: 120ns 
INFO [runner] linters took 7.362651607s with stages: goanalysis_metalinter: 7.346395795s, structcheck: 7.866µs 
INFO File cache stats: 96 entries of total size 2.9MiB 
INFO Memory: 100 samples, avg is 238.2MB, max is 796.4MB 
INFO Execution took 9.84684538s
```