### PR TITLE
Improve logs in authmanager.

### DIFF
--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -138,7 +138,7 @@ func (authManager *AuthManager) refreshDatastoreMapForBlockVolumes() {
 		authManager.rwMutex.Lock()
 		defer authManager.rwMutex.Unlock()
 		authManager.datastoreMapForBlockVolumes = newDatastoreMapForBlockVolumes
-		log.Debugf("auth manager: datastoreMapForBlockVolumes is updated to %v", newDatastoreMapForBlockVolumes)
+		log.Infof("auth manager: datastoreMapForBlockVolumes is updated to %v", newDatastoreMapForBlockVolumes)
 	} else {
 		log.Warnf("auth manager: failed to get updated datastoreMapForBlockVolumes, Err: %v", err)
 	}
@@ -155,7 +155,7 @@ func (authManager *AuthManager) refreshFSEnabledClustersToDsMap() {
 		defer authManager.rwMutex.Unlock()
 
 		authManager.fsEnabledClusterToDsMap = newFsEnabledClusterToDsMap
-		log.Debugf("auth manager: newFsEnabledClusterToDsMap is updated to %v", newFsEnabledClusterToDsMap)
+		log.Infof("auth manager: newFsEnabledClusterToDsMap is updated to %v", newFsEnabledClusterToDsMap)
 	} else {
 		log.Warnf("auth manager: failed to get updated datastoreMapForFileVolumes, Err: %v", err)
 	}
@@ -243,7 +243,7 @@ func GenerateFSEnabledClustersToDsMap(ctx context.Context,
 	}
 	// Return empty map if no vSAN datastores are found.
 	if len(vsanDsURLToInfoMap) == 0 {
-		log.Debug("No vSAN datastores found")
+		log.Info("No vSAN datastores found")
 		return clusterToDsInfoListMap, nil
 	}
 
@@ -447,7 +447,7 @@ func getFSEnabledClustersWithPriv(ctx context.Context, vc *cnsvsphere.VirtualCen
 		clusterComputeResource, err := finder.ClusterComputeResourceList(ctx, "*")
 		if err != nil {
 			if _, ok := err.(*find.NotFoundError); ok {
-				log.Debugf("No clusterComputeResource found in dc: %+v. error: %+v", datacenter, err)
+				log.Errorf("No clusterComputeResource found in datacenter: %+v. error: %+v", datacenter, err)
 				continue
 			}
 			log.Errorf("Error occurred while getting clusterComputeResource. error: %+v", err)
@@ -505,7 +505,7 @@ func getFSEnabledClustersWithPriv(ctx context.Context, vc *cnsvsphere.VirtualCen
 			return nil, err
 		}
 		if !(*config.Enabled) {
-			log.Debugf("cluster: %+v is a non-vSAN cluster. Skipping this cluster", cluster)
+			log.Infof("cluster: %+v is a non-vSAN cluster. Skipping this cluster", cluster)
 			continue
 		} else if config.FileServiceConfig == nil {
 			log.Debugf("VsanClusterGetConfig.FileServiceConfig is empty. Skipping this cluster: %+v with config: %+v",

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -565,6 +565,10 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to get shared datastores in kubernetes cluster. Error: %+v", err)
 		}
+		if len(sharedDatastores) == 0 {
+			return nil, csifault.CSIInternalFault, logger.LogNewErrorCode(log, codes.Internal,
+				"No datastore found for volume provisioning.")
+		}
 	}
 
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIAuthCheck) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. we don't have enough log to triage issue that related to authmanager cannot get refreshed datastore list. We have some useful logs only in DEBUG level.   This change is to convert some important log from DEBUG to INFO which will be available by default.
2. This change also add the logic to check whether sharedDatastore is empty or not. If it is empty, CreateVolume request will returned with error instead of sending the CreateVolume request to CNS with empty datastore list.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
I did the the volume create test in a Vanilla setup.

```
root@k8s-control-305-1661450301:~# kubectl create -f pvc.yaml 
root@k8s-control-305-1661450301:~# kubectl get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
example-vanilla-rwo-pvc   Bound    pvc-1f9e3829-9552-434c-bd74-fbfc8fb3188b   500Mi      RWO            example-vanilla-rwo-filesystem-sc   11s

```
With this change, auth manager print the log like the following
```
2022-08-25T20:51:45.301Z        INFO    common/authmanager.go:141       auth manager: datastoreMapForBlockVolumes is updated to map[ds:///vmfs/volumes/4699c380-767c89e8/:Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/4699c380-767c89e8/ ds:///vmfs/volumes/6307a86b-8ee623ea-8e18-0200ae7f735d/:Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/6307a86b-8ee623ea-8e18-0200ae7f735d/ ds:///vmfs/volumes/6307a86c-0de7fae6-57d5-0200ae7f735d/:Datastore: Datastore:datastore-43, datastore URL: ds:///vmfs/volumes/6307a86c-0de7fae6-57d5-0200ae7f735d/ ds:///vmfs/volumes/6307a86d-4abe3718-c889-0200aec2d774/:Datastore: Datastore:datastore-40, datastore URL: ds:///vmfs/volumes/6307a86d-4abe3718-c889-0200aec2d774/ ds:///vmfs/volumes/6307a86e-ba3da46e-9c64-0200aec2d774/:Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/6307a86e-ba3da46e-9c64-0200aec2d774/ ds:///vmfs/volumes/6307a86f-bedcba5e-74d1-0200aee87bd6/:Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/6307a86f-bedcba5e-74d1-0200aee87bd6/ ds:///vmfs/volumes/6307a870-3d4aa154-f87a-0200aee87bd6/:Datastore: Datastore:datastore-38, datastore URL: ds:///vmfs/volumes/6307a870-3d4aa154-f87a-0200aee87bd6/ ds:///vmfs/volumes/6307a871-75eac3be-24ac-0200ae78dfab/:Datastore: Datastore:datastore-44, datastore URL: ds:///vmfs/volumes/6307a871-75eac3be-24ac-0200ae78dfab/ ds:///vmfs/volumes/6307a872-ee0aa79e-5d16-0200ae78dfab/:Datastore: Datastore:datastore-45, datastore URL: ds:///vmfs/volumes/6307a872-ee0aa79e-5d16-0200ae78dfab/ ds:///vmfs/volumes/vsan:52617f10709f6812-23616c41948a878a/:Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:52617f10709f6812-23616c41948a878a/]      {"TraceId": "0de3d4aa-93ac-487d-8731-07f6bae5175b"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Improve logging in auth manager.
```
