### PR TITLE
Improve the code by removing the for loop in processQueryResultsListVolumes

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1575,23 +1575,22 @@ func (c *controller) processQueryResultsListVolumes(ctx context.Context, startin
 		} else {
 			volumeType = prometheus.PrometheusBlockVolumeType
 			blockVolID := queryResult.Volumes[i].VolumeId.Id
-			for volID, nodeVMUUID := range volumeIDToNodeUUIDMap {
-				if blockVolID == volID {
-					//Populate csi.Volume info for the given volume
-					blockVolumeInfo := &csi.Volume{
-						VolumeId: blockVolID,
-					}
-					// Getting published nodes
-					volStatus := &csi.ListVolumesResponse_VolumeStatus{
-						PublishedNodeIds: []string{nodeVMUUID},
-					}
-					entry := &csi.ListVolumesResponse_Entry{
-						Volume: blockVolumeInfo,
-						Status: volStatus,
-					}
-					// Populate List Volumes Entry Response
-					entries = append(entries, entry)
+			nodeVMUUID, found := volumeIDToNodeUUIDMap[blockVolID]
+			if found {
+				//Populate csi.Volume info for the given volume
+				blockVolumeInfo := &csi.Volume{
+					VolumeId: blockVolID,
 				}
+				// Getting published nodes
+				volStatus := &csi.ListVolumesResponse_VolumeStatus{
+					PublishedNodeIds: []string{nodeVMUUID},
+				}
+				entry := &csi.ListVolumesResponse_Entry{
+					Volume: blockVolumeInfo,
+					Status: volStatus,
+				}
+				// Populate List Volumes Entry Response
+				entries = append(entries, entry)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Internal bugzilla PR: 3023524
This is an improvement on the code, to remove the for loop, and use the indexing feature of a map to find the key and value. 

**Testing done**:
In progress

> make check output

```
INFO [config_reader] Config search paths: [./ /Users/mutgia/go/src/vsphere-csi-driver /Users/mutgia/go/src /Users/mutgia/go /Users/mutgia /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (types_sizes|deps|files|name|compiled_files|exports_file|imports) took 4.313207956s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 176.54569ms 
INFO [linters context/goanalysis] analyzers took 6m52.519332797s with top 10 stages: buildir: 4m45.087236618s, nilness: 29.825791537s, printf: 11.348689705s, ctrlflow: 10.869749248s, fact_deprecated: 10.631836138s, typedness: 9.621445796s, fact_purity: 8.549794179s, SA5012: 8.109116457s, inspect: 3.277418742s, S1038: 2.959988855s 
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649. 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_dirs: 113/113, identifier_marker: 24/24, exclude: 24/24, path_prettifier: 113/113, skip_files: 113/113, autogenerated_exclude: 24/113, cgo: 113/113, filename_unadjuster: 113/113, exclude-rules: 1/24, nolint: 0/1 
INFO [runner] processing took 21.89327ms with stages: nolint: 17.263813ms, autogenerated_exclude: 2.527106ms, path_prettifier: 1.374384ms, identifier_marker: 419.632µs, skip_dirs: 185.125µs, exclude-rules: 101.245µs, cgo: 10.068µs, filename_unadjuster: 6.452µs, max_same_issues: 1.344µs, uniq_by_line: 801ns, skip_files: 445ns, max_from_linter: 437ns, exclude: 372ns, diff: 372ns, source_code: 338ns, path_shortener: 307ns, max_per_file_from_linter: 291ns, severity-rules: 285ns, sort_results: 272ns, path_prefixer: 181ns 
INFO [runner] linters took 49.457193809s with stages: goanalysis_metalinter: 49.435174008s, structcheck: 11.1µs 
INFO File cache stats: 277 entries of total size 4.8MiB 
INFO Memory: 481 samples, avg is 1908.7MB, max is 2886.9MB 
INFO Execution took 53.964313597s  
```
Pushed the image with the code changes to a Vanilla testbed and replaced the deployment image.

> root@k8s-control-962-1661463388:~# knc get all

```
NAME                                          READY   STATUS    RESTARTS       AGE
pod/vsphere-csi-controller-76ddbfc97c-8bmjw   7/7     Running   0              2m43s
pod/vsphere-csi-controller-76ddbfc97c-lj2p5   7/7     Running   0              3m27s
pod/vsphere-csi-controller-76ddbfc97c-vvw5n   7/7     Running   0              119s
pod/vsphere-csi-node-82p5t                    3/3     Running   2 (113m ago)   113m
pod/vsphere-csi-node-bjn9f                    3/3     Running   2 (113m ago)   113m
pod/vsphere-csi-node-g5ckm                    3/3     Running   1 (113m ago)   113m
pod/vsphere-csi-node-jrnzw                    3/3     Running   2 (113m ago)   113m
pod/vsphere-csi-node-s2p2g                    3/3     Running   2 (113m ago)   113m
pod/vsphere-csi-node-wjp7k                    3/3     Running   2 (113m ago)   113m
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
