### PR TITLE
fss(disabled): use govmomi listview to wait for CNS tasks

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -163,6 +163,7 @@ data:
   "max-pvscsi-targets-per-vm": "true"
   "multi-vcenter-csi-topology": "false"
   "csi-internal-generated-cluster-id": "false"
+  "listview-tasks": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -1,0 +1,321 @@
+package volume
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25/types"
+
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
+)
+
+const (
+	// in case of vc connection failure, we wait for a minute
+	// to not overwhelm the vc with continuous requests
+	waitForUpdatesRetry = 1 * time.Minute
+	// `info` is a defined property in a Task object
+	// we want to monitor the TaskInfo that includes the status of a task
+	infoPropertyName = "info"
+)
+
+// ListViewImpl is the struct used to manage a single listView instance.
+type ListViewImpl struct {
+	// taskMap provides methods to store, retrieve, and delete tasks stored in the in-memory map
+	// this map holds a mapping between the task and the channel used to return the response to the caller
+	taskMap InMemoryMapIf
+	// virtualCenter: holds a reference to the global VC object
+	virtualCenter *cnsvsphere.VirtualCenter
+	// govmomiClient: separate client created with http.Client.Timeout set to 0
+	govmomiClient *govmomi.Client
+	// listView: holds the managed object used to monitor multiple concurrent VC tasks
+	listView *view.ListView
+	// context.Context: new context for the life of the listview object.
+	// it's separate from the context set by CSI ops
+	// to the channel created by the caller to receive the task result
+	ctx context.Context
+	// shouldStopListening: in case of regular CSI operation, even after receiving a batch of updates,
+	// we want to continue listening for subsequent updates.
+	// in case of unit tests, we need to stop listening for the test to complete execution
+	shouldStopListening bool
+}
+
+// TaskDetails is used to hold state for a task
+type TaskDetails struct {
+	Reference types.ManagedObjectReference
+	// MarkedForRemoval helps in retrying the removal of tasks in case of failures
+	MarkedForRemoval bool
+	// channel to return results. the caller (CSI op) is waiting on this channel
+	ResultCh chan TaskResult
+}
+
+type TaskResult struct {
+	TaskInfo *types.TaskInfo
+	Err      error
+}
+
+// NewListViewImpl creates a new listView object and starts a goroutine to listen to property collector task updates
+func NewListViewImpl(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter,
+	client *govmomi.Client) (*ListViewImpl, error) {
+	log := logger.GetLogger(ctx)
+	t := &ListViewImpl{
+		taskMap:       NewTaskMap(),
+		virtualCenter: virtualCenter,
+		ctx:           ctx,
+		govmomiClient: client,
+	}
+	err := t.createListView(ctx, nil)
+	if err != nil {
+		return nil, logger.LogNewErrorf(log, "failed to create a ListView. error: %+v", err)
+	}
+	go t.listenToTaskUpdates()
+	return t, nil
+}
+
+func (l *ListViewImpl) createListView(ctx context.Context, tasks []types.ManagedObjectReference) error {
+	log := logger.GetLogger(ctx)
+	var err error
+	// doing an assignment to t.listView at line 91 in case of failure
+	// leads to NPE while accessing listView elsewhere
+	listView, err := view.NewManager(l.govmomiClient.Client).CreateListView(ctx, tasks)
+	if err != nil {
+		return err
+	}
+	l.listView = listView
+	log.Infof("created listView object %+v for virtualCenter: %+v", l.listView.Reference(), l.virtualCenter)
+	return nil
+}
+
+// SetVirtualCenter is a setter method for vc. use case: ReloadConfiguration
+func (l *ListViewImpl) SetVirtualCenter(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter) error {
+	log := logger.GetLogger(ctx)
+	l.virtualCenter = virtualCenter
+	client, err := virtualCenter.NewClient(ctx)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to create a govmomiClient for listView. error: %+v", err)
+	}
+	client.Timeout = noTimeout
+	l.govmomiClient = client
+	return nil
+}
+
+func getListViewWaitFilter(listView *view.ListView) *property.WaitFilter {
+	ts := types.TraversalSpec{
+		Type: "ListView",
+		Path: "view",
+		Skip: types.NewBool(false),
+	}
+	filter := new(property.WaitFilter)
+
+	filter.Add(listView.Reference(), "Task", []string{infoPropertyName}, &ts)
+	reportMissingObjectsInResults := true
+	filter.Spec.ReportMissingObjectsInResults = &reportMissingObjectsInResults
+	return filter
+}
+
+// AddTask adds task to listView and the internal map
+func (l *ListViewImpl) AddTask(ctx context.Context, taskMoRef types.ManagedObjectReference, ch chan TaskResult) error {
+	log := logger.GetLogger(ctx)
+	log.Infof("AddTask called for %+v", taskMoRef)
+	err := l.listView.Add(l.ctx, []types.ManagedObjectReference{taskMoRef})
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to add task to ListView. error: %+v", err)
+	}
+	log.Infof("task %+v added to listView", taskMoRef)
+
+	l.taskMap.Upsert(taskMoRef, TaskDetails{
+		Reference:        taskMoRef,
+		MarkedForRemoval: false,
+		ResultCh:         ch,
+	})
+	log.Debugf("task %+v added to map", taskMoRef)
+	return nil
+}
+
+// RemoveTask removes task from listview and the internal map
+func (l *ListViewImpl) RemoveTask(ctx context.Context, taskMoRef types.ManagedObjectReference) error {
+	log := logger.GetLogger(ctx)
+	if l.listView == nil {
+		return logger.LogNewErrorf(log, "failed to remove task from listView: listView not initialized")
+	}
+	err := l.listView.Remove(l.ctx, []types.ManagedObjectReference{taskMoRef})
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to remove task %v from ListView. error: %+v", taskMoRef, err)
+	}
+	log.Infof("task %+v removed from listView", taskMoRef)
+	l.taskMap.Delete(taskMoRef)
+	log.Debugf("task %+v removed from map", taskMoRef)
+	return nil
+}
+
+func (l *ListViewImpl) isClientValid() error {
+	log := logger.GetLogger(l.ctx)
+	// If session hasn't expired, nothing to do.
+	sessionMgr := session.NewManager(l.govmomiClient.Client)
+	// SessionMgr.UserSession(ctx) retrieves and returns the SessionManager's
+	// CurrentSession field. Nil is returned if the session is not
+	// authenticated or timed out.
+	if userSession, err := sessionMgr.UserSession(l.ctx); err != nil {
+		log.Errorf("failed to obtain user session with err: %v", err)
+		return err
+	} else if userSession != nil {
+		return nil
+	}
+	// If session has expired, create a new instance.
+	client, err := l.virtualCenter.NewClient(l.ctx)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to create a govmomi client for listView. error: %+v", err)
+	}
+	client.Timeout = noTimeout
+	l.govmomiClient = client
+	return nil
+}
+
+// listenToTaskUpdates is a long-running goroutine
+// that uses a property collector to listen for task updates
+// CSI ops add CNS tasks to listview and wait for a response from CNS
+// when update(s) are received by the property collector,
+// it spawns a new goroutine to process each task update and return the result to the caller
+func (l *ListViewImpl) listenToTaskUpdates() {
+	log := logger.GetLogger(l.ctx)
+	filter := getListViewWaitFilter(l.listView)
+	// we need to recreate the listView and the wait filter after any error from vc
+	// for the first iteration we already have the listView and filter initialized
+	recreateView := false
+	for {
+		// calling Connect at the beginning to ensure the current session is neither nil nor NotAuthenticated
+		if err := l.isClientValid(); err != nil {
+			log.Errorf("failed to connect to vCenter. err: %v", err)
+			time.Sleep(waitForUpdatesRetry)
+			continue
+		} else {
+			log.Infof("connection to vc successful")
+		}
+
+		if recreateView {
+			log.Info("re-creating the listView object")
+			err := l.createListView(l.ctx, nil)
+			if err != nil {
+				log.Errorf("failed to create a ListView. error: %+v", err)
+				continue
+			}
+
+			filter = getListViewWaitFilter(l.listView)
+			recreateView = false
+		}
+
+		log.Info("Starting listening for task updates...")
+		pc := property.DefaultCollector(l.govmomiClient.Client)
+		err := property.WaitForUpdates(l.ctx, pc, filter, func(updates []types.ObjectUpdate) bool {
+			log.Debugf("Got %d property collector update(s)", len(updates))
+			for _, update := range updates {
+				for _, prop := range update.ChangeSet {
+					log.Debugf("Got update for object %v properties %v", update.Obj, prop)
+					// we don't need a lock at this line as we aren't accessing any map item
+					go l.processTaskUpdate(prop)
+				}
+			}
+
+			// this return value is used by the WaitForUpdates method.
+			// we only want this true while running the unit tests so the test can finish
+			return l.shouldStopListening
+		})
+		// if property collector returns any errors,
+		// we want to immediately return a fault for all the pending tasks in the map
+		// note: this is not a task error but an error from the vc
+		if err != nil {
+			log.Errorf("WaitForUpdates returned err: %v for vc: %+v", err, l.virtualCenter)
+			recreateView = true
+			l.reportErrorOnAllPendingTasks(err)
+		}
+		// use case: unit tests: this will help us stop listening
+		// and finish the unit test
+		if l.shouldStopListening {
+			return
+		}
+	}
+}
+
+// reportErrorOnAllPendingTasks returns failure to all pending tasks in the map in case of vc failure
+func (l *ListViewImpl) reportErrorOnAllPendingTasks(err error) {
+	for _, taskDetails := range l.taskMap.GetAll() {
+		result := TaskResult{
+			TaskInfo: nil,
+			Err:      err,
+		}
+		taskDetails.ResultCh <- result
+	}
+}
+
+// processTaskUpdate is processes each task update in a separate goroutine
+func (l *ListViewImpl) processTaskUpdate(prop types.PropertyChange) {
+	log := logger.GetLogger(l.ctx)
+	log.Infof("processTaskUpdate for property change update: %+v", prop)
+	taskInfo, ok := prop.Val.(types.TaskInfo)
+	if !ok {
+		log.Errorf("failed to cast taskInfo for property change update: %+v", prop)
+		return
+	}
+	if taskInfo.State == types.TaskInfoStateQueued || taskInfo.State == types.TaskInfoStateRunning {
+		return
+	}
+	result := TaskResult{}
+	taskDetails, ok := l.taskMap.Get(taskInfo.Task)
+	if !ok {
+		log.Errorf("failed to retrieve receiver channel for task %+v", taskInfo.Task)
+		return
+	} else if taskInfo.State == types.TaskInfoStateError {
+		result.TaskInfo = nil
+		result.Err = errors.New(taskInfo.Error.LocalizedMessage)
+	} else {
+		result.TaskInfo = &taskInfo
+		result.Err = nil
+	}
+
+	taskDetails.ResultCh <- result
+}
+
+// RemoveTasksMarkedForDeletion goes over the list of tasks in the map
+// and removes tasks that have been marked for deletion
+func RemoveTasksMarkedForDeletion(l *ListViewImpl) {
+	ctx := logger.NewContextWithLogger(context.Background())
+	log := logger.GetLogger(ctx)
+	if l.listView == nil {
+		log.Errorf("ListView is empty. Will attempt to remove invalid tasks in next attempt. ")
+		return
+	}
+	log.Debugf("pending tasks count before purging: %v", l.taskMap.Count())
+	var tasksToDelete []types.ManagedObjectReference
+	for _, taskDetails := range l.taskMap.GetAll() {
+		if taskDetails.MarkedForRemoval {
+			err := l.listView.Remove(l.ctx, []types.ManagedObjectReference{taskDetails.Reference})
+			if err != nil {
+				log.Errorf("failed to remove task from ListView. error: %+v", err)
+				continue
+			}
+			tasksToDelete = append(tasksToDelete, taskDetails.Reference)
+		}
+	}
+	for _, task := range tasksToDelete {
+		l.taskMap.Delete(task)
+	}
+	log.Debugf("pending tasks count after purging: %v", l.taskMap.Count())
+}
+
+// MarkTaskForDeletion marks a given task MoRef for deletion by setting a boolean flag in the TaskDetails object
+func (l *ListViewImpl) MarkTaskForDeletion(ctx context.Context, taskMoRef types.ManagedObjectReference) error {
+	log := logger.GetLogger(ctx)
+	taskDetails, ok := l.taskMap.Get(taskMoRef)
+	if !ok {
+		return logger.LogNewErrorf(log, "failed to retrieve taskDetails for %+v", taskMoRef)
+	}
+	taskDetails.MarkedForRemoval = true
+	l.taskMap.Upsert(taskMoRef, taskDetails)
+	log.Infof("%v marked for deletion", taskMoRef)
+	return nil
+}

--- a/pkg/common/cns-lib/volume/listview_if.go
+++ b/pkg/common/cns-lib/volume/listview_if.go
@@ -1,0 +1,24 @@
+package volume
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25/types"
+
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
+)
+
+// ListViewIf provides methods to start and modify a listView object to monitor CNS tasks.
+// NewListViewImpl satisfies ListViewIf and should be initialized to use the interface methods
+type ListViewIf interface {
+	// AddTask adds task to listView and the internal map
+	AddTask(ctx context.Context, taskMoRef types.ManagedObjectReference, ch chan TaskResult) error
+	// RemoveTask removes task from listview and the internal map
+	RemoveTask(ctx context.Context, taskMoRef types.ManagedObjectReference) error
+	// SetVirtualCenter is a setter method for the reference to the global vcenter object.
+	// use case: ReloadConfiguration
+	SetVirtualCenter(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter) error
+	// MarkTaskForDeletion marks a given task MoRef for deletion by a cleanup goroutine
+	// use case: failure to remove task due to a vc issue
+	MarkTaskForDeletion(ctx context.Context, taskMoRef types.ManagedObjectReference) error
+}

--- a/pkg/common/cns-lib/volume/listview_test.go
+++ b/pkg/common/cns-lib/volume/listview_test.go
@@ -1,0 +1,155 @@
+package volume
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/cns"
+	cnssim "github.com/vmware/govmomi/cns/simulator"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
+)
+
+func TestAddRemoveListView(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+
+	model := simulator.VPX()
+	defer model.Remove()
+	if err := model.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	model.Service.RegisterSDK(cnssim.New())
+
+	virtualCenter, err := getVirtualCenterForTest(ctx, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listViewImpl, err := NewListViewImpl(ctx, virtualCenter, virtualCenter.Client)
+	assert.NoError(t, err)
+	listViewImpl.shouldStopListening = true
+	createSpecList := getCreateSpecList()
+	ch := make(chan TaskResult)
+	assert.NotNil(t, ch)
+
+	createTask, err := virtualCenter.CnsClient.CreateVolume(ctx, createSpecList)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("createTask created: %+v", createTask)
+	err = listViewImpl.AddTask(ctx, createTask.Reference(), ch)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, listViewImpl.taskMap.Count())
+	result := <-ch
+	if result.Err != nil {
+		t.Errorf("result.Err: %v", result.Err)
+		return
+	}
+	t.Logf("result: %+v", result.TaskInfo)
+	assert.Equal(t, types.TaskInfoStateSuccess, result.TaskInfo.State)
+	err = listViewImpl.RemoveTask(ctx, createTask.Reference())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, listViewImpl.taskMap.Count())
+}
+
+func TestMarkForDeletion(t *testing.T) {
+	ctx := logger.NewContextWithLogger(context.Background())
+
+	model := simulator.VPX()
+	defer model.Remove()
+	if err := model.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	model.Service.RegisterSDK(cnssim.New())
+
+	virtualCenter, err := getVirtualCenterForTest(ctx, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listViewImpl, err := NewListViewImpl(ctx, virtualCenter, virtualCenter.Client)
+	assert.NoError(t, err)
+	listViewImpl.shouldStopListening = true
+	createSpecList := getCreateSpecList()
+	ch := make(chan TaskResult)
+	assert.NotNil(t, ch)
+
+	createTask, err := virtualCenter.CnsClient.CreateVolume(ctx, createSpecList)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("createTask created: %+v", createTask)
+	err = listViewImpl.AddTask(ctx, createTask.Reference(), ch)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, listViewImpl.taskMap.Count())
+
+	result := <-ch
+	err = result.Err
+	taskInfo := result.TaskInfo
+	assert.NoError(t, err)
+	assert.NotNil(t, taskInfo)
+
+	t.Logf("marking task for deletion")
+	err = listViewImpl.MarkTaskForDeletion(ctx, createTask.Reference())
+	assert.NoError(t, err)
+
+	RemoveTasksMarkedForDeletion(listViewImpl)
+	assert.Equal(t, 0, listViewImpl.taskMap.Count())
+}
+
+func getVirtualCenterForTest(ctx context.Context, s *simulator.Server) (*vsphere.VirtualCenter, error) {
+	newClient, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		return nil, err
+	}
+
+	cnsClient, err := cns.NewClient(ctx, newClient.Client)
+	if err != nil {
+		return nil, err
+	}
+
+	virtualCenter := &vsphere.VirtualCenter{
+		Client:    newClient,
+		CnsClient: cnsClient,
+	}
+	return virtualCenter, nil
+}
+
+func getCreateSpecList() []cnstypes.CnsVolumeCreateSpec {
+	// Get a simulator DS
+	datastore := simulator.Map.Any("Datastore").(*simulator.Datastore)
+	var capacityInMb int64 = 1024
+
+	return []cnstypes.CnsVolumeCreateSpec{
+		{
+			Name:       "test",
+			VolumeType: "TestVolumeType",
+			Datastores: []types.ManagedObjectReference{
+				datastore.Self,
+			},
+			BackingObjectDetails: &cnstypes.CnsBackingObjectDetails{
+				CapacityInMb: capacityInMb,
+			},
+			Profile: []types.BaseVirtualMachineProfileSpec{
+				&types.VirtualMachineDefinedProfileSpec{
+					ProfileId: uuid.New().String(),
+				},
+			},
+		},
+	}
+}

--- a/pkg/common/cns-lib/volume/manager_test.go
+++ b/pkg/common/cns-lib/volume/manager_test.go
@@ -1,0 +1,52 @@
+package volume
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	vim25types "github.com/vmware/govmomi/vim25/types"
+)
+
+const createVolumeTaskTimeout = 3 * time.Second
+
+func TestWaitForResultOrTimeoutFail(t *testing.T) {
+	// slow task times out and fails
+	ctx, cancelFunc := context.WithTimeout(context.TODO(), createVolumeTaskTimeout)
+	defer cancelFunc()
+	ch := make(chan TaskResult)
+	go performSlowTask(ch, 5*time.Second)
+	taskMoRef := vim25types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "task-42",
+	}
+	taskInfo, err := waitForResultOrTimeout(ctx, taskMoRef, ch)
+	assert.Error(t, err)
+	var expectedTaskInfo *vim25types.TaskInfo
+	assert.Equal(t, expectedTaskInfo, taskInfo)
+}
+
+func TestWaitForResultOrTimeoutPass(t *testing.T) {
+	// task within timeout succeeds
+	ctx, cancelFunc := context.WithTimeout(context.TODO(), createVolumeTaskTimeout)
+	defer cancelFunc()
+	ch := make(chan TaskResult)
+	go performSlowTask(ch, 1*time.Second)
+	taskMoRef := vim25types.ManagedObjectReference{
+		Type:  "Task",
+		Value: "task-42",
+	}
+	taskInfo, err := waitForResultOrTimeout(ctx, taskMoRef, ch)
+	assert.NoError(t, err)
+	expectedTaskInfo := &vim25types.TaskInfo{State: vim25types.TaskInfoStateSuccess}
+	assert.Equal(t, expectedTaskInfo, taskInfo)
+}
+
+func performSlowTask(ch chan TaskResult, delay time.Duration) {
+	time.Sleep(delay)
+	ch <- TaskResult{
+		TaskInfo: &vim25types.TaskInfo{State: vim25types.TaskInfoStateSuccess},
+		Err:      nil,
+	}
+}

--- a/pkg/common/cns-lib/volume/taskmap.go
+++ b/pkg/common/cns-lib/volume/taskmap.go
@@ -1,0 +1,79 @@
+package volume
+
+import (
+	"sync"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// InMemoryMapIf is used to not provide direct access to internal mutex or map to methods in the same pkg
+type InMemoryMapIf interface {
+	// Upsert : if task exists in the map, the taskDetails will be overwritten.
+	// if the task doesn't exist, the taskDetails will be stored
+	Upsert(types.ManagedObjectReference, TaskDetails)
+	// Delete task from map
+	Delete(types.ManagedObjectReference)
+	// Get retrieves a single item from a map
+	Get(types.ManagedObjectReference) (TaskDetails, bool)
+	// GetAll retrieves all map items
+	GetAll() []TaskDetails
+	// Count returns the count of all items present in the map
+	Count() int
+}
+
+// TaskMap binds together the task details map and a mutex to guard it
+type TaskMap struct {
+	// sync.RWMutex: a mutex is required for concurrent access to a go map
+	// reference - see the section on Concurrency at https://go.dev/blog/maps
+	// important note - sync.RWMutex can be held by an arbitrary number of readers or a single writer.
+	// an example of how sync.RWMutex works - https://gist.github.com/adikul30/31fad45c2b77bf70cd7e0a352b6d98fb
+	mu sync.RWMutex
+	// taskMap: is an in-memory map to associate task details
+	// taskMap             map[types.ManagedObjectReference]*TaskDetails
+	m map[types.ManagedObjectReference]TaskDetails
+}
+
+// NewTaskMap returns a new instance of TaskMap
+func NewTaskMap() InMemoryMapIf {
+	return &TaskMap{
+		m: make(map[types.ManagedObjectReference]TaskDetails),
+	}
+}
+
+// Upsert adds/updates items and requires an exclusive write lock
+func (t *TaskMap) Upsert(task types.ManagedObjectReference, taskDetails TaskDetails) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.m[task] = taskDetails
+}
+
+// Delete deletes items from the map and requires an exclusive write lock
+func (t *TaskMap) Delete(task types.ManagedObjectReference) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.m, task)
+}
+
+// Get retrieves a single item from the map and requires a read lock
+func (t *TaskMap) Get(task types.ManagedObjectReference) (TaskDetails, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	taskDetails, ok := t.m[task]
+	return taskDetails, ok
+}
+
+// GetAll retrieves all tasks from the map and requires a read lock
+func (t *TaskMap) GetAll() []TaskDetails {
+	var allTasks []TaskDetails
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	for _, details := range t.m {
+		allTasks = append(allTasks, details)
+	}
+	return allTasks
+}
+
+// Count returns the number of tasks present in the map
+func (t *TaskMap) Count() int {
+	return len(t.m)
+}

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -136,8 +136,8 @@ type VirtualCenterConfig struct {
 // clientMutex is used for exclusive connection creation.
 var clientMutex sync.Mutex
 
-// newClient creates a new govmomi Client instance.
-func (vc *VirtualCenter) newClient(ctx context.Context) (*govmomi.Client, error) {
+// NewClient creates a new govmomi Client instance.
+func (vc *VirtualCenter) NewClient(ctx context.Context) (*govmomi.Client, error) {
 	log := logger.GetLogger(ctx)
 	if vc.Config.Scheme == "" {
 		vc.Config.Scheme = DefaultScheme
@@ -273,13 +273,15 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 	// If client was never initialized, initialize one.
 	var err error
 	if vc.Client == nil {
-		if vc.Client, err = vc.newClient(ctx); err != nil {
+		log.Infof("VirtualCenter.connect() creating new client")
+		if vc.Client, err = vc.NewClient(ctx); err != nil {
 			log.Errorf("failed to create govmomi client with err: %v", err)
 			if !vc.Config.Insecure {
 				log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)
 			}
 			return err
 		}
+		log.Infof("VirtualCenter.connect() successfully created new client")
 		return nil
 	}
 	if !requestNewSession {
@@ -297,7 +299,7 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 	}
 	// If session has expired, create a new instance.
 	log.Warnf("Creating a new client session as the existing one isn't valid or not authenticated")
-	if vc.Client, err = vc.newClient(ctx); err != nil {
+	if vc.Client, err = vc.NewClient(ctx); err != nil {
 		log.Errorf("failed to create govmomi client with err: %v", err)
 		if !vc.Config.Insecure {
 			log.Errorf("failed to connect to vCenter using CA file: %q", vc.Config.CAFile)

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware/govmomi/cns/types"
 	"github.com/vmware/govmomi/simulator"
 	vim25types "github.com/vmware/govmomi/vim25/types"
+
 	cnsvolumes "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
@@ -144,7 +145,11 @@ func TestQuerySnapshotsUtil(t *testing.T) {
 	// Create context
 	commonUtilsTestInstance := getCommonUtilsTest(t)
 
-	volumeManager := cnsvolumes.GetManager(ctx, commonUtilsTestInstance.vcenter, nil, false, false, false)
+	volumeManager, err := cnsvolumes.GetManager(ctx, commonUtilsTestInstance.vcenter, nil, false, false, false, false)
+	if err != nil {
+		t.Fatalf("failed to create an instance of volume manager. err=%v", err)
+	}
+
 	queryFilter := types.CnsSnapshotQueryFilter{
 		SnapshotQuerySpecs: nil,
 		Cursor: &types.CnsCursor{

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -385,4 +385,6 @@ const (
 	// CSIInternalGeneratedClusterID enables support to generate unique cluster
 	// ID internally if user doesn't provide it in vSphere config secret.
 	CSIInternalGeneratedClusterID = "csi-internal-generated-cluster-id"
+	// ListViewPerf uses govmomi ListView to wait for CNS tasks
+	ListViewPerf = "listview-tasks"
 )

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -121,6 +121,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		common.MultiVCenterCSITopology)
 	csiMigrationEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration)
 	isAuthCheckFSSEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIAuthCheck)
+	tasksListViewEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ListViewPerf)
 
 	vcManager := cnsvsphere.GetVirtualCenterManager(ctx)
 	if !multivCenterCSITopologyEnabled {
@@ -135,10 +136,16 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			log.Errorf("failed to register VC %q with virtualCenterManager. err=%v", vcenterconfig.Host, err)
 			return err
 		}
+
+		volumeManager, err := cnsvolume.GetManager(ctx, vcenter, operationStore, true, false, false, tasksListViewEnabled)
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
+		}
+
 		c.manager = &common.Manager{
 			VcenterConfig:  vcenterconfig,
 			CnsConfig:      config,
-			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, operationStore, true, false, false),
+			VolumeManager:  volumeManager,
 			VcenterManager: vcManager,
 		}
 		vc, err := common.GetVCenter(ctx, c.manager)
@@ -222,8 +229,12 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 					"err=%v", vcenterconfig.Host, err)
 			}
 			c.managers.VcenterConfigs[vcenterconfig.Host] = vcenterconfig
-			c.managers.VolumeManagers[vcenterconfig.Host] = cnsvolume.GetManager(ctx, vcenter, operationStore,
-				true, true, multivCenterTopologyDeployment)
+			volumeManager, err := cnsvolume.GetManager(ctx, vcenter, operationStore,
+				true, true, multivCenterTopologyDeployment, tasksListViewEnabled)
+			if err != nil {
+				return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
+			}
+			c.managers.VolumeManagers[vcenterconfig.Host] = volumeManager
 		}
 		vCenters, err := common.GetVCenters(ctx, c.managers)
 		if err != nil {
@@ -286,6 +297,9 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		return err
 	}
 
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ListViewPerf) {
+		go cnsvolume.ClearInvalidTasksFromListView(multivCenterCSITopologyEnabled)
+	}
 	cfgPath := common.GetConfigPath(ctx)
 
 	watcher, err := fsnotify.NewWatcher()
@@ -385,6 +399,8 @@ func (c *controller) ReloadConfiguration() error {
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to read config. Error: %+v", err)
 	}
+	tasksListViewEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.ListViewPerf)
 	if multivCenterCSITopologyEnabled {
 		var multivCenterTopologyDeployment bool
 		if len(c.managers.VcenterConfigs) > 1 {
@@ -435,10 +451,17 @@ func (c *controller) ReloadConfiguration() error {
 				}
 				c.managers.VcenterConfigs[newVCConfig.Host] = newVCConfig
 				if c.managers.VolumeManagers[newVCConfig.Host] != nil {
-					c.managers.VolumeManagers[newVCConfig.Host].ResetManager(ctx, vcenter)
+					err = c.managers.VolumeManagers[newVCConfig.Host].ResetManager(ctx, vcenter)
+					if err != nil {
+						return logger.LogNewErrorf(log, "failed to reset volume manager. err=%v", err)
+					}
 				} else {
-					c.managers.VolumeManagers[newVCConfig.Host] = cnsvolume.GetManager(ctx, vcenter, operationStore,
-						true, true, multivCenterTopologyDeployment)
+					volumeManager, err := cnsvolume.GetManager(ctx, vcenter, operationStore,
+						true, true, multivCenterTopologyDeployment, tasksListViewEnabled)
+					if err != nil {
+						return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
+					}
+					c.managers.VolumeManagers[newVCConfig.Host] = volumeManager
 				}
 				if c.authMgrs[newVCConfig.Host] != nil {
 					c.authMgrs[newVCConfig.Host].ResetvCenterInstance(ctx, vcenter)
@@ -535,10 +558,18 @@ func (c *controller) ReloadConfiguration() error {
 				return err
 			}
 
-			c.manager.VolumeManager.ResetManager(ctx, vcenter)
+			err = c.manager.VolumeManager.ResetManager(ctx, vcenter)
+			if err != nil {
+				return logger.LogNewErrorf(log, "failed to reset volume manager. err=%v", err)
+			}
 			c.manager.VcenterConfig = newVCConfig
-			c.manager.VolumeManager = cnsvolume.GetManager(ctx, vcenter, operationStore, true,
-				false, false)
+			volumeManager, err := cnsvolume.GetManager(ctx, vcenter, operationStore, true,
+				false, false, tasksListViewEnabled)
+			if err != nil {
+				return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
+			}
+
+			c.manager.VolumeManager = volumeManager
 			// Re-Initialize Node Manager to cache latest vCenter config.
 			useNodeUuid := false
 			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -47,6 +47,7 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
@@ -329,10 +330,15 @@ func getControllerTest(t *testing.T) *controllerTest {
 			t.Fatal(err)
 		}
 
+		volumeManager, err := cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true, false, false, false)
+		if err != nil {
+			t.Fatalf("failed to create an instance of volume manager. err=%v", err)
+		}
+
 		manager := &common.Manager{
 			VcenterConfig:  vcenterconfig,
 			CnsConfig:      config,
-			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true, false, false),
+			VolumeManager:  volumeManager,
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 
@@ -2135,7 +2141,7 @@ func TestDeleteBlockVolumeSnapshotWithManagedObjectNotFound(t *testing.T) {
 		taskID, "", "", cnsvolumeoperationrequest.TaskInvocationStatusInProgress, "")
 	_ = ct.operationStore.StoreRequestDetails(ctx, operationInstance)
 
-	//logger.SetLoggerLevel(logger.DevelopmentLogLevel) // enable debug level log
+	// logger.SetLoggerLevel(logger.DevelopmentLogLevel) // enable debug level log
 
 	// Delete the snapshot
 	reqDeleteSnapshot := &csi.DeleteSnapshotRequest{

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
+
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
@@ -177,10 +178,15 @@ func getControllerTest(t *testing.T) *controllerTest {
 			t.Fatalf("Failed to create co agnostic interface. err=%v", err)
 		}
 
+		volumeManager, err := cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true, false, false, false)
+		if err != nil {
+			t.Fatalf("failed to create an instance of volume manager. err=%v", err)
+		}
+
 		manager := &common.Manager{
 			VcenterConfig:  vcenterconfig,
 			CnsConfig:      config,
-			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true, false, false),
+			VolumeManager:  volumeManager,
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -76,7 +76,11 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 		if err != nil {
 			return err
 		}
-		volumeManager = volumes.GetManager(ctx, vCenter, nil, false, false, false)
+		volumeManager, err = volumes.GetManager(ctx, vCenter, nil,
+			false, false, false, commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ListViewPerf))
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
+		}
 	}
 
 	// Get a config to talk to the apiserver

--- a/pkg/syncer/storagepool/diskDecommissionController.go
+++ b/pkg/syncer/storagepool/diskDecommissionController.go
@@ -100,7 +100,10 @@ func (w *DiskDecommController) detachVolumes(ctx context.Context, storagePoolNam
 		VirtualCenterHost: vc.Config.Host,
 	}
 
-	volManager := volume.GetManager(ctx, &vc, nil, false, false, false)
+	volManager, err := volume.GetManager(ctx, &vc, nil, false, false, false, false)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
+	}
 
 	volumes, _, err := k8scloudoperator.GetVolumesOnStoragePool(ctx, k8sClient, storagePoolName)
 	if err != nil {

--- a/pkg/syncer/storagepool/migrationController.go
+++ b/pkg/syncer/storagepool/migrationController.go
@@ -80,7 +80,11 @@ func (m *migrationController) relocateCNSVolume(ctx context.Context, volumeID st
 			datastoreURL)
 	}
 
-	volManager := volume.GetManager(ctx, m.vc, nil, false, false, false)
+	volManager, err := volume.GetManager(ctx, m.vc, nil, false, false, false, false)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to create an instance of volume manager. err=%v", err)
+	}
+
 	relocateSpec := cnstypes.NewCnsBlockVolumeRelocateSpec(volumeID, dsInfo.Reference())
 
 	task, err := volManager.RelocateVolume(ctx, relocateSpec)

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -192,14 +192,20 @@ func TestSyncerWorkflows(t *testing.T) {
 		}
 	}()
 
-	volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false)
+	volumeManager, err = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false, false)
+	if err != nil {
+		t.Fatalf("failed to create an instance of volume manager. err=%v", err)
+	}
 
 	// Initialize metadata syncer object.
 	metadataSyncer = &metadataSyncInformer{}
 	configInfo := &cnsconfig.ConfigurationInfo{}
 	configInfo.Cfg = csiConfig
 	metadataSyncer.configInfo = configInfo
-	metadataSyncer.volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false)
+	metadataSyncer.volumeManager, err = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false, false)
+	if err != nil {
+		t.Fatalf("failed to create an instance of volume manager. err=%v", err)
+	}
 	metadataSyncer.host = virtualCenter.Config.Host
 
 	// Create the kubernetes client from config or env.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support CSI operations under high concurrency without crossing the vpxd request limits. 

This is solved by using [govmomi ListView](https://pkg.go.dev/github.com/vmware/govmomi/view#ListView) to monitor multiple concurrent tasks instead of creating a separate Wait() request for every task. 

This fss will also work alongside the multi-vcenter fss change such that either of them can be set independently. 

**Testing done**:

Manual test done so far. Will wait for at least an initial code review before starting the e2e pipelines. 
```
root@k8s-control-28-1665698284:~# k get configmap internal-feature-states.csi.vsphere.vmware.com -n vmware-system-csi -o yaml | grep improved-csi-tasks-listview
  improved-csi-tasks-listview: "true"

root@k8s-control-28-1665698284:~# k get pvc
No resources found in default namespace.

root@k8s-control-28-1665698284:~# k create -f pvc.yaml
persistentvolumeclaim/example-pvc-0 created

root@k8s-control-28-1665698284:~# k get pvc
NAME            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
example-pvc-0   Bound    pvc-0b285d32-eede-43b3-b6c7-83abe0e0f0e0   5Gi        RWO            example-vanilla-rwo-filesystem-sc   3s

root@k8s-control-28-1665698284:~# k create -f pod.yaml
pod/example-pod-0 created

root@k8s-control-28-1665698284:~# k get po
NAME            READY   STATUS    RESTARTS   AGE
example-pod-0   1/1     Running   0          15s

// expand volume
root@k8s-control-28-1665698284:~# k edit pvc
persistentvolumeclaim/example-pvc-0 edited

root@k8s-control-28-1665698284:~# k get pvc
NAME            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
example-pvc-0   Bound    pvc-0b285d32-eede-43b3-b6c7-83abe0e0f0e0   10Gi       RWO            example-vanilla-rwo-filesystem-sc   11m

```

### Tests with FSS disabled

- [x] Vanilla (
Build 1610 (Nov 28, 2022, 12:58:45 AM)
adkulkarni
PR 1949
------------------------------ Ran 1 of 692 Specs in 338.197 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 691 Skipped PASS Ginkgo ran 1 suite in 6m52.771186905s Test Suite Passed -- ------------------------------ Ran 12 of 692 Specs in 4660.498 seconds SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 680 Skipped PASS Ginkgo ran 1 suite in 1h18m3.227634219s Test Suite Passed -- Ran 40 of 692 Specs in 744.943 seconds FAIL! -- 38 Passed | 2 Failed | 0 Pending | 652 Skipped Ginkgo ran 1 suite in 12m48.413105318s Test Suite Failed 

Build 1611 (Nov 28, 2022, 8:15:54 AM)
adkulkarni
PR 1949
Ran 2 of 692 Specs in 1014.672 seconds FAIL! -- 1 Passed | 1 Failed | 0 Pending | 690 Skipped --- FAIL: TestE2E (1014.70s) FAIL Ginkgo ran 1 suite in 18m9.100988021s Test Suite Failed 

Build 1612 (Nov 28, 2022, 8:41:42 AM)
adkulkarni
PR 1949
------------------------------ Ran 1 of 692 Specs in 110.953 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 691 Skipped PASS Ginkgo ran 1 suite in 3m14.448142546s Test Suite Passed )

### Tests with FSS enabled

- [x] Vanilla (
Build 1604 (Nov 23, 2022, 7:52:38 PM)

adkulkarni 
 PR 1949
------------------------------ Ran 1 of 692 Specs in 334.628 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 691 Skipped PASS Ginkgo ran 1 suite in 6m54.226568642s Test Suite Passed -- ------------------------------ Ran 12 of 692 Specs in 4697.082 seconds SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 680 Skipped PASS Ginkgo ran 1 suite in 1h18m34.582478967s Test Suite Passed -- Ran 40 of 692 Specs in 1456.466 seconds FAIL! -- 39 Passed | 1 Failed | 0 Pending | 652 Skipped Ginkgo ran 1 suite in 24m32.284177014s Test Suite Failed



Build 1605 (Nov 24, 2022, 1:43:03 AM)
adkulkarni 
 PR 1949
------------------------------ Ran 1 of 692 Specs in 135.225 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 691 Skipped PASS Ginkgo ran 1 suite in 3m35.626593191s Test Suite Passed)

**Special notes for your reviewer**:
Example of how `sync.RWMutex` works -> https://go.dev/play/p/Gm22qn-lpq-

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add FSS for using govmomi ListView to wait for CNS tasks
```
