### PR TITLE
Container kill code fix for different k8s version

### DIFF
--- a/tests/e2e/topology_multi_replica.go
+++ b/tests/e2e/topology_multi_replica.go
@@ -78,6 +78,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			defaultDatacenter          *object.Datacenter
 			defaultDatastore           *object.Datastore
 			fullSyncWaitTime           int
+			k8sVersion                 string
 		)
 		ginkgo.BeforeEach(func() {
 			var cancel context.CancelFunc
@@ -96,6 +97,11 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			if !(len(nodeList.Items) > 0) {
 				framework.Failf("Unable to find ready and schedulable Node")
 			}
+			// fetching k8s version
+			v, err := client.Discovery().ServerVersion()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			k8sVersion = v.Major + "." + v.Minor
+
 			bindingMode = storagev1.VolumeBindingWaitForFirstConsumer
 			topologyLength = 5
 			isSPSServiceStopped = false
@@ -257,7 +263,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 					is running */
 					ginkgo.By("Kill container CSI-Provisioner on the master node where elected leader " +
 						"CSi-Controller-Pod is running")
-					err = execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIP, container_name)
+					err = execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIP, container_name, k8sVersion)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
 			}
@@ -326,7 +332,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 					is running */
 					ginkgo.By("Kill container CSI-Attacher on the master node where elected leader CSi-Controller-Pod " +
 						"is running")
-					err = execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIP, container_name)
+					err = execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIP, container_name, k8sVersion)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
 			}
@@ -355,7 +361,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 					is running */
 					ginkgo.By("Kill container CSI-Provisioner on the master node where elected leader CSi-Controller-Pod " +
 						"is running")
-					err = execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIP, container_name)
+					err = execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIP, container_name, k8sVersion)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
 			}

--- a/tests/e2e/topology_operation_strom_cases.go
+++ b/tests/e2e/topology_operation_strom_cases.go
@@ -58,6 +58,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		topologyClusterList     []string
 		powerOffHostsList       []string
 		sshClientConfig         *ssh.ClientConfig
+		k8sVersion              string
 	)
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
@@ -76,6 +77,11 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 			gomega.Expect(client.StorageV1().StorageClasses().Delete(ctx, sc.Name,
 				*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
 		}
+		// fetching k8s version
+		v, err := client.Discovery().ServerVersion()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		k8sVersion = v.Major + "." + v.Minor
+
 		bindingMode = storagev1.VolumeBindingWaitForFirstConsumer
 		topologyMap := GetAndExpectStringEnvVar(topologyMap)
 		topologyAffinityDetails, topologyCategories = createTopologyMapLevel5(topologyMap, topologyLength)
@@ -498,7 +504,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 				is running */
 				ginkgo.By("Kill container CSI-Provisioner on the master node where elected leader " +
 					"is running")
-				err = execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIP, containerName)
+				err = execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIP, containerName, k8sVersion)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}
@@ -597,7 +603,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 			if i == 2 {
 				/* Kill csi-attacher container */
 				ginkgo.By("Kill csi-attacher container")
-				err = execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIP, containerName)
+				err = execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIP, containerName, k8sVersion)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}

--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -480,6 +480,11 @@ func getMasterIpOnSite(ctx context.Context, client clientset.Interface, primaryS
 // a specific master node on that site
 func changeLeaderOfContainerToComeUpOnMaster(ctx context.Context, client clientset.Interface,
 	sshClientConfig *ssh.ClientConfig, csiContainerName string, primarySite bool) error {
+	// fetching k8s version
+	v, err := client.Discovery().ServerVersion()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	k8sVersion := v.Major + "." + v.Minor
+
 	// Fetch the IP address of master node on that site
 	masterIpOnSite, err := getMasterIpOnSite(ctx, client, primarySite)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -519,7 +524,7 @@ func changeLeaderOfContainerToComeUpOnMaster(ctx context.Context, client clients
 		wg.Add(len(allMasterIps))
 		for _, masterIp := range allMasterIps {
 			go invokeDockerPauseNKillOnContainerInParallel(sshClientConfig, masterIp,
-				csiContainerName, &wg)
+				csiContainerName, k8sVersion, &wg)
 		}
 		wg.Wait()
 
@@ -535,9 +540,9 @@ func changeLeaderOfContainerToComeUpOnMaster(ctx context.Context, client clients
 // invokeDockerPauseNKillOnContainerInParallel invokes docker pause and kill command on
 // the particular CSI container on the master node in parallel
 func invokeDockerPauseNKillOnContainerInParallel(sshClientConfig *ssh.ClientConfig, k8sMasterIp string,
-	csiContainerName string, wg *sync.WaitGroup) {
+	csiContainerName string, k8sVersion string, wg *sync.WaitGroup) {
 	defer wg.Done()
-	err := execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIp, csiContainerName)
+	err := execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIp, csiContainerName, k8sVersion)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Container kill code fix for different k8s version

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Container kill code fix for different k8s version

**Testing done**:
Yes

https://gist.githubusercontent.com/sipriyaa/b645a3220704f9a4465bf40ba9f17b46/raw/089ce83eff0cc133cb9e8d7dd588eaf6d92085d0/gistfile1.txt

**Special notes for your reviewer**:

Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint 
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.46.2'
golangci/golangci-lint info found version: 1.46.2 for v1.46.2/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/topology-docker-fix/vsphere-csi-driver /Users/sipriya/topology-docker-fix /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (types_sizes|deps|files|name|compiled_files|exports_file|imports) took 1m19.663706028s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 119.521427ms 
INFO [linters context/goanalysis] analyzers took 8m17.988400356s with top 10 stages: buildir: 5m36.295277323s, nilness: 38.256312054s, fact_deprecated: 16.493929029s, ctrlflow: 16.256248176s, printf: 15.722568916s, typedness: 12.0612667s, fact_purity: 11.75744852s, SA5012: 10.144552616s, inspect: 4.754173337s, misspell: 2.316933683s 
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649. 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude: 24/24, cgo: 113/113, filename_unadjuster: 113/113, exclude-rules: 1/24, skip_dirs: 113/113, identifier_marker: 24/24, path_prettifier: 113/113, skip_files: 113/113, autogenerated_exclude: 24/113, nolint: 0/1 
INFO [runner] processing took 14.856195ms with stages: nolint: 11.873061ms, autogenerated_exclude: 2.149876ms, path_prettifier: 346.425µs, identifier_marker: 292.154µs, skip_dirs: 112.077µs, exclude-rules: 64.651µs, cgo: 8.811µs, filename_unadjuster: 5.072µs, max_same_issues: 995ns, skip_files: 657ns, uniq_by_line: 436ns, max_from_linter: 376ns, source_code: 274ns, diff: 243ns, exclude: 209ns, path_shortener: 199ns, sort_results: 192ns, max_per_file_from_linter: 191ns, severity-rules: 185ns, path_prefixer: 111ns 
INFO [runner] linters took 48.364033345s with stages: goanalysis_metalinter: 48.3490697s, structcheck: 8.866µs 
INFO File cache stats: 287 entries of total size 4.9MiB 
INFO Memory: 1211 samples, avg is 811.7MB, max is 3228.8MB 
INFO Execution took 2m8.163481105s

