### PR TITLE
Fixing list-volumes to use supervisorID instead of clusterID in cnsQueryFilter

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1273,7 +1273,7 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 		if startingIdx == 0 || startingIdx != expectedStartingIndex {
 			queryFilter := cnstypes.CnsQueryFilter{
 				ContainerClusterIds: []string{
-					c.manager.CnsConfig.Global.ClusterID,
+					c.manager.CnsConfig.Global.SupervisorID,
 				},
 			}
 			querySelection := cnstypes.CnsQuerySelection{


### PR DESCRIPTION
This PR fixes list-volumes to use supervisorID instead of clusterID in the cnsQueryFilter while fetching all the volumes from CNS. This is required post-8.0 after TKGSHA was enabled.

Manual testing with 2 volumes on 2 nodes.
```
2022-09-12T16:14:04.001Z	DEBUG	wcp/controller.go:1321	ListVolumes: cnsVolumeIDs [4e348872-c682-489d-823f-80d40a7b931b 3d325eb2-83f5-465b-88ed-6976ce1569a4], startingIdx 0, queryLimit 2	{"TraceId": "e9514279-e9be-4f1b-86af-29d943f42ab1"}
2022-09-12T16:14:04.051Z	DEBUG	wcp/controller.go:1342	ListVolumes: Response entries entries:<volume:<volume_id:"3d325eb2-83f5-465b-88ed-6976ce1569a4" > status:<published_node_ids:"sc2-10-186-1-175.eng.vmware.com" > > entries:<volume:<volume_id:"4e348872-c682-489d-823f-80d40a7b931b" > status:<published_node_ids:"sc2-10-186-5-209.eng.vmware.com" > > 	{"TraceId": "e9514279-e9be-4f1b-86af-29d943f42ab1"}
```

Output of make check
```
msmruthi@msmruthi-a01 vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2022.1.2
go: downloading honnef.co/go/tools v0.3.2
go: downloading golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
go: downloading github.com/onsi/gomega v1.18.1
go: downloading k8s.io/kubectl v0.24.2
go: downloading k8s.io/pod-security-admission v0.24.2
go: downloading k8s.io/kubelet v0.24.2
go: downloading github.com/aws/aws-sdk-go v1.38.49
go: downloading github.com/google/cadvisor v0.44.1
go: downloading github.com/opencontainers/runc v1.1.1
go: downloading k8s.io/cri-api v0.24.2
go: downloading github.com/docker/distribution v2.8.1+incompatible
go: downloading go.opentelemetry.io/otel/trace v0.20.0
go: downloading go.opentelemetry.io/otel v0.20.0
go: downloading k8s.io/cli-runtime v0.24.2
go: downloading github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
go: downloading k8s.io/csi-translation-lib v0.24.2
go: downloading go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0
go: downloading go.opentelemetry.io/otel/exporters/otlp v0.20.0
go: downloading sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30
go: downloading go.opentelemetry.io/otel/sdk v0.20.0
go: downloading go.opentelemetry.io/contrib v0.20.0
go: downloading sigs.k8s.io/kustomize/kyaml v0.13.6
go: downloading sigs.k8s.io/kustomize/api v0.11.4
go: downloading k8s.io/kube-scheduler v0.24.2
go: downloading github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
go: downloading github.com/golang/mock v1.6.0
go: downloading go.etcd.io/etcd/api/v3 v3.5.1
go: downloading go.etcd.io/etcd/client/v3 v3.5.1
go: downloading go.opentelemetry.io/otel/sdk/export/metric v0.20.0
go: downloading go.opentelemetry.io/proto/otlp v0.7.0
go: downloading go.opentelemetry.io/otel/metric v0.20.0
go: downloading go.opentelemetry.io/otel/sdk/metric v0.20.0
go: downloading github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
go: downloading github.com/felixge/httpsnoop v1.0.1
go: downloading github.com/NYTimes/gziphandler v1.1.1
go: downloading go.etcd.io/etcd/client/pkg/v3 v3.5.1
go: downloading github.com/grpc-ecosystem/grpc-gateway v1.16.0
go: downloading github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
go: downloading github.com/coreos/go-semver v0.3.0
go: downloading github.com/google/btree v1.0.1
go: downloading github.com/coreos/go-systemd/v22 v22.3.2
+ GOOS=linux
+ /Users/msmruthi/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/cnsctl sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ov sigs.k8s.io/vsphere-csi-driver/v2/cnsctl/cmd/ova sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e

hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.46.2'
golangci/golangci-lint info found version: 1.46.2 for v1.46.2/darwin/amd64
golangci/golangci-lint info installed /Users/msmruthi/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/msmruthi/k8s/vsphere-csi-driver /Users/msmruthi/k8s /Users/msmruthi /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (exports_file|files|name|types_sizes|compiled_files|deps|imports) took 2.711363661s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 135.897401ms 


INFO [linters context/goanalysis] analyzers took 6m51.604558192s with top 10 stages: buildir: 4m48.309412289s, nilness: 28.344187541s, ctrlflow: 10.974287839s, fact_deprecated: 10.806529324s, printf: 10.715217108s, typedness: 8.129103404s, fact_purity: 7.950742178s, SA5012: 6.942882259s, inspect: 4.92966172s, S1038: 2.340836622s 
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649. 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_dirs: 113/113, autogenerated_exclude: 24/113, identifier_marker: 24/24, exclude: 24/24, exclude-rules: 1/24, cgo: 113/113, filename_unadjuster: 113/113, skip_files: 113/113, path_prettifier: 113/113, nolint: 0/1 
INFO [runner] processing took 16.156511ms with stages: nolint: 11.994048ms, autogenerated_exclude: 2.85004ms, path_prettifier: 539.944µs, identifier_marker: 479.319µs, skip_dirs: 169.182µs, exclude-rules: 102.954µs, cgo: 10.551µs, filename_unadjuster: 6.073µs, max_same_issues: 1.139µs, uniq_by_line: 542ns, skip_files: 380ns, max_from_linter: 351ns, diff: 329ns, severity-rules: 285ns, path_shortener: 282ns, sort_results: 271ns, exclude: 263ns, source_code: 247ns, max_per_file_from_linter: 208ns, path_prefixer: 103ns 
INFO [runner] linters took 58.153447964s with stages: goanalysis_metalinter: 58.137174775s, structcheck: 11.693µs 
INFO File cache stats: 287 entries of total size 4.9MiB 
INFO Memory: 491 samples, avg is 1850.0MB, max is 2702.7MB 
INFO Execution took 1m1.011427516s                
msmruthi@msmruthi-a01 vsphere-csi-driver % 
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
