### PR TITLE
fall back to look up the node by name

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1244,11 +1244,17 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		}
 		// Block Volume.
 		volumeType = prometheus.PrometheusBlockVolumeType
-		var node *cnsvsphere.VirtualMachine
+		var nodevm *cnsvsphere.VirtualMachine
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
-			node, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
+			// if node is not yet updated to run the release of the driver publishing Node VM UUID as Node ID
+			// look up Node by name
+			nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+			if err == node.ErrNodeNotFound {
+				log.Infof("Performing node VM lookup using node VM UUID: %q", req.NodeId)
+				nodevm, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
+			}
 		} else {
-			node, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+			nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
 		}
 		if err != nil {
 			if err == cnsvsphere.ErrVMNotFound {
@@ -1260,7 +1266,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 					"failed to find VirtualMachine for node:%q. Error: %v", req.NodeId, err)
 			}
 		}
-		faultType, err = common.DetachVolumeUtil(ctx, c.manager, node, req.VolumeId)
+		faultType, err = common.DetachVolumeUtil(ctx, c.manager, nodevm, req.VolumeId)
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to detach disk: %+q from node: %q err %+v", req.VolumeId, req.NodeId, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fall back to look up the node by name during controller unpublish.

This fix is required for platforms like TKGi where control plane nodes are upgraded first and workload nodes are upgraded later. While upgrading workload nodes, during Node drain operation, `ControllerUnpublishVolume` is called with Node name, as workload node is not yet upgraded to publish Node VM UUID as Node ID. When `ControllerUnpublishVolume` is called with Node name, VM lookup can not be done using UUID, so here we are adding fallback to perform one more look up to find VM by name from the in-memory cache.

This change will help TKGi to utilize `use-csinode-id` feature (also known as decouple CSI from CPI) released in [v2.5.0](https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.5.0).



**Testing done**:
Logs

> {"level":"info","time":"2022-09-12T22:23:15.448894412Z","caller":"vanilla/controller.go:1173","msg":"ControllerUnpublishVolume: called with args {VolumeId:00e2181e-6133-444b-a504-6948aadb6587 NodeId:4202ec7e-5ab3-6cf0-dbaa-8ecf117e4ce9 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"db3cbe3d-ab0a-441f-9da1-47fa5168f078"}
{"level":"error","time":"2022-09-12T22:23:15.458989476Z","caller":"node/manager.go:152","msg":"Node not found with nodeName 4202ec7e-5ab3-6cf0-dbaa-8ecf117e4ce9","TraceId":"db3cbe3d-ab0a-441f-9da1-47fa5168f078","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node.(*defaultManager).GetNodeByName\n\t/build/pkg/common/cns-lib/node/manager.go:152\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node.(*Nodes).GetNodeByName\n\t/build/pkg/common/cns-lib/node/nodes.go:181\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).ControllerUnpublishVolume.func1\n\t/build/pkg/csi/service/vanilla/controller.go:1251\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).ControllerUnpublishVolume\n\t/build/pkg/csi/service/vanilla/controller.go:1277\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_ControllerUnpublishVolume_Handler\n\t/go/pkg/mod/github.com/container-storage-interface/spec@v1.5.0/lib/go/csi/csi.pb.go:5723\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:1297\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:1626\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.2\n\t/go/pkg/mod/google.golang.org/grpc@v1.40.0/server.go:941"}
{"level":"info","time":"2022-09-12T22:23:15.459697682Z","caller":"vanilla/controller.go:1253","msg":"Performing node VM lookup using node VM UUID: \"4202ec7e-5ab3-6cf0-dbaa-8ecf117e4ce9\"","TraceId":"db3cbe3d-ab0a-441f-9da1-47fa5168f078"}
{"level":"info","time":"2022-09-12T22:23:16.674390528Z","caller":"volume/manager.go:757","msg":"DetachVolume: volumeID: \"00e2181e-6133-444b-a504-6948aadb6587\", vm: \"VirtualMachine:vm-53 [VirtualCenterHost: 10.168.197.125, UUID: 4202ec7e-5ab3-6cf0-dbaa-8ecf117e4ce9, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.168.197.125]]\", opId: \"08e460cb\"","TraceId":"db3cbe3d-ab0a-441f-9da1-47fa5168f078"}
{"level":"info","time":"2022-09-12T22:23:16.674567967Z","caller":"volume/manager.go:792","msg":"DetachVolume: Volume detached successfully. volumeID: \"00e2181e-6133-444b-a504-6948aadb6587\", vm: \"VirtualMachine:vm-53 [VirtualCenterHost: 10.168.197.125, UUID: 4202ec7e-5ab3-6cf0-dbaa-8ecf117e4ce9, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.168.197.125]]\", opId: \"08e460cb\"","TraceId":"db3cbe3d-ab0a-441f-9da1-47fa5168f078"}
{"level":"info","time":"2022-09-12T22:23:16.674613441Z","caller":"vanilla/controller.go:1274","msg":"ControllerUnpublishVolume successful for volume ID: 00e2181e-6133-444b-a504-6948aadb6587","TraceId":"db3cbe3d-ab0a-441f-9da1-47fa5168f078"}

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fall back to look up the node by name
```
