### PR TITLE
fix node discovery when nodes are not upgraded to v2.5.0

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1117,11 +1117,18 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 						"failed to set keepAfterDeleteVm control flag for VolumeID %q", req.VolumeId)
 				}
 			}
-			var node *cnsvsphere.VirtualMachine
+			var nodevm *cnsvsphere.VirtualMachine
 			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
-				node, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
+				// if node is not yet updated to run the release of the driver publishing Node VM UUID as Node ID
+				// look up Node by name
+				nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+				if err == node.ErrNodeNotFound {
+					log.Infof("Performing node VM lookup using node VM UUID: %q", req.NodeId)
+					nodevm, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
+				}
+
 			} else {
-				node, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+				nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
 			}
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
@@ -1129,7 +1136,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 			}
 			log.Debugf("Found VirtualMachine for node:%q.", req.NodeId)
 			// faultType is returned from manager.AttachVolume.
-			diskUUID, faultType, err := common.AttachVolumeUtil(ctx, c.manager, node, req.VolumeId, false)
+			diskUUID, faultType, err := common.AttachVolumeUtil(ctx, c.manager, nodevm, req.VolumeId, false)
 			if err != nil {
 				return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to attach disk: %+q with node: %q err %+v", req.VolumeId, req.NodeId, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR helps fix node discovery when nodes are not upgraded to use v2.5.0 release of the driver, but CSI controller is upgraded to use v2.5.0

This is happening on TKGi platform during upgrade. After upgrading master node to use v2.5.0 bits, node discovery is failing as worker nodes are not yet upgraded and still have Node name as Node ID in the CSINodes object. For this case, we need to fall back and discover node using the ProviderID set on the Node object.

This PR is needed along with https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1966


**Testing done**:
TKGI team has validated upgrading CSI driver with this change.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix node discovery when nodes are not upgraded to v2.5.0
```
