### PR TITLE
Prevent duplicate cluster IDs in vSphere CSI driver

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -18,8 +18,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods", "configmaps"]
+    resources: ["nodes", "pods"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]
@@ -157,6 +160,7 @@ data:
   "topology-preferential-datastores": "true"
   "max-pvscsi-targets-per-vm": "true"
   "multi-vcenter-csi-topology": "false"
+  "csi-internal-generated-cluster-id": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -45,13 +45,14 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 	if orchestratorType == common.Kubernetes {
 		fakeCO := &FakeK8SOrchestrator{
 			featureStates: map[string]string{
-				"volume-extend":         "true",
-				"volume-health":         "true",
-				"csi-migration":         "true",
-				"file-volume":           "true",
-				"block-volume-snapshot": "true",
-				"tkgs-ha":               "true",
-				"list-volumes":          "true",
+				"volume-extend":                     "true",
+				"volume-health":                     "true",
+				"csi-migration":                     "true",
+				"file-volume":                       "true",
+				"block-volume-snapshot":             "true",
+				"tkgs-ha":                           "true",
+				"list-volumes":                      "true",
+				"csi-internal-generated-cluster-id": "true",
 			},
 		}
 		return fakeCO, nil
@@ -263,4 +264,18 @@ func (c *FakeK8SOrchestrator) GetAllK8sVolumes() []string {
 func (c *FakeK8SOrchestrator) AnnotateVolumeSnapshot(ctx context.Context, volumeSnapshotName string,
 	volumeSnapshotNamespace string, annotations map[string]string) (bool, error) {
 	return true, nil
+}
+
+// GetConfigMap checks if ConfigMap with given name exists in the given namespace.
+// If it exists, this function returns ConfigMap data, otherwise returns error.
+func (c *FakeK8SOrchestrator) GetConfigMap(ctx context.Context, name string,
+	namespace string) (map[string]string, error) {
+	return nil, nil
+}
+
+// CreateConfigMap creates the ConfigMap with given name, namespace, data and immutable
+// parameter values.
+func (c *FakeK8SOrchestrator) CreateConfigMap(ctx context.Context, name string, namespace string,
+	data map[string]string, isImmutable bool) error {
+	return nil
 }

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -69,6 +69,13 @@ type COCommonInterface interface {
 	// AnnotateVolumeSnapshot annotates the volumesnapshot CR in k8s cluster with the snapshot-id and fcd-id
 	AnnotateVolumeSnapshot(ctx context.Context, volumeSnapshotName string,
 		volumeSnapshotNamespace string, annotations map[string]string) (bool, error)
+	// GetConfigMap checks if ConfigMap with given name exists in the given namespace.
+	// If it exists, this function returns ConfigMap data, otherwise returns error.
+	GetConfigMap(ctx context.Context, name string, namespace string) (map[string]string, error)
+	// CreateConfigMap creates the ConfigMap with given name, namespace, data and immutable
+	// parameter values.
+	CreateConfigMap(ctx context.Context, name string, namespace string, data map[string]string,
+		isImmutable bool) error
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -382,4 +382,7 @@ const (
 	MaxPVSCSITargetsPerVM = "max-pvscsi-targets-per-vm"
 	// MultiVCenterCSITopology is the feature gate for enabling multi vCenter topology support for vSphere CSI driver.
 	MultiVCenterCSITopology = "multi-vcenter-csi-topology"
+	// CSIInternalGeneratedClusterID enables support to generate unique cluster
+	// ID internally if user doesn't provide it in vSphere config secret.
+	CSIInternalGeneratedClusterID = "csi-internal-generated-cluster-id"
 )

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -464,3 +464,13 @@ func MergeMaps(first map[string]string, second map[string]string) map[string]str
 	}
 	return merged
 }
+
+// GetCSINamespace returns the namespace in which CSI driver is installed
+func GetCSINamespace() string {
+	CSINamespace := os.Getenv(csitypes.EnvVarNamespace)
+	if CSINamespace == "" {
+		CSINamespace = cnsconfig.DefaultCSINamespace
+	}
+
+	return CSINamespace
+}

--- a/pkg/csi/types/envvars.go
+++ b/pkg/csi/types/envvars.go
@@ -35,6 +35,9 @@ const (
 	// EnvVarEndpoint specifies the CSI endpoint for CSI driver.
 	EnvVarEndpoint = "CSI_ENDPOINT"
 
+	// EnvVarNamespace specifies the namespace in which CSI driver is installed.
+	EnvVarNamespace = "CSI_NAMESPACE"
+
 	// EnvVarMode is the name of the environment variable used to specify
 	// the service mode of the plugin. Valid values are:
 	// * controller

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -555,7 +555,15 @@ func updateTriggerCsiFullSyncInstance(ctx context.Context,
 func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFromNewConfig bool) error {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Info("Reloading Configuration")
-	cfg, err := common.GetConfig(ctx)
+	var cfg *cnsconfig.Config
+	var err error
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorVanilla &&
+		commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIInternalGeneratedClusterID) {
+		cfg, err = getConfig(ctx)
+	} else {
+		cfg, err = common.GetConfig(ctx)
+	}
+
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to read config. Error: %+v", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
At present we are asking the admin to manually specify a unique cluster id in the vSphere CSI Driver. There are cases where admin specified same cluster ID in multiple Kubernetes clusters, and it led to multiple issues.
So, instead of relying on a user to provide unique cluster id, we are generating a globally unique cluster-id in the vSphere CSI driver and persisting it into etcd (in immutable ConfigMap).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

New ConfigMap was created to store cluster ID:
root@k8s-control-302-1662462681:~# k get cm -n vmware-system-csi
NAME                                             DATA   AGE
internal-feature-states.csi.vsphere.vmware.com   15     9d
kube-root-ca.crt                                 1      12d
vsphere-csi-cluster-id                           1      9d

root@k8s-control-302-1662462681:~# k describe cm vsphere-csi-cluster-id -n vmware-system-csi
Name:         vsphere-csi-cluster-id
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>

Data
\====
clusterID:
----
00b0c76a-70de-43f7-8186-e51381c9fce9
BinaryData
\====
Events:  <none>


vSphere Config secret without cluster ID was used:
root@k8s-control-302-1662462681:~# k get secret -n vmware-system-csi
NAME                    TYPE                             DATA   AGE
pvt0repo0cred           kubernetes.io/dockerconfigjson   1      12d
vsphere-config-secret   Opaque                           1      9d

root@k8s-control-302-1662462681:~# echo W0...MiCg== | base64 -d
[Global]
cluster-distribution = "CSI-Vanilla".  <<<< No Cluster ID

[VirtualCenter "X.X.X.X"]
insecure-flag = "true"
...
port = "443"
datacenters = "VSAN-DC"


PVC and pod creation worked fine:
root@k8s-control-302-1662462681:~# k get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
example-vanilla-rwo-pvc   Bound    pvc-d794f99e-77f4-4ffa-83bb-b2dfb4c635a4   1Gi        RWO            example-vanilla-rwo-filesystem-sc   80s

root@k8s-control-302-1662462681:~# k get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                             STORAGECLASS                        REASON   AGE
pvc-d794f99e-77f4-4ffa-83bb-b2dfb4c635a4   1Gi        RWO            Delete           Bound    default/example-vanilla-rwo-pvc   example-vanilla-rwo-filesystem-sc            71s


root@k8s-control-302-1662462681:~# k get pod
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   1/1     Running   0          2m8s


VC snippet with generated cluster ID:
![Screenshot 2022-10-06 at 4 22 21 PM](https://user-images.githubusercontent.com/110086635/194296214-450805a0-452c-4f27-b53b-e3da9d71ee38.png)

Please refer to CSI controller logs for detailed logs for cases where:
1. New ConfigMap is created if cluster ID is "" in vSphere CSI driver
2. When cluster ID is "" in vSphere CSI driver and ConfigMap already exists on system, so it reads cluster ID from existing CM.
[Create new immutable config map.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/9606574/Create.new.immutable.config.map.txt)
[Reuse cluster ID from immutable config map.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/9606576/Reuse.cluster.ID.from.immutable.config.map.txt)
[syncer logs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/9707329/syncer.logs.txt)



**Special notes for your reviewer**:

**Release note**:
```Release note
 Instead of relying on a user to provide unique cluster id, generating a globally unique cluster-id in the vSphere CSI driver.
```
