### PR TITLE
Preferential automation - Part1

### DIFF
--- a/tests/e2e/config.go
+++ b/tests/e2e/config.go
@@ -60,8 +60,8 @@ type e2eTestConfig struct {
 		// CnsRegisterVolumesCleanupIntervalInMin specifies the interval after which
 		// successful CnsRegisterVolumes will be cleaned up.
 		CnsRegisterVolumesCleanupIntervalInMin int `gcfg:"cnsregistervolumes-cleanup-intervalinmin"`
-		// Topology Category Labels
-		TopologyCategories string `gcfg:"topology-categories"`
+		// preferential topology
+		CSIFetchPreferredDatastoresIntervalInMin int `gcfg:"csi-fetch-preferred-datastores-intervalinmin"`
 	}
 	// Multiple sets of Net Permissions applied to all file shares
 	// The string can uniquely represent each Net Permissions config
@@ -69,6 +69,9 @@ type e2eTestConfig struct {
 
 	// Snapshot configurations.
 	Snapshot SnapshotConfig
+
+	// Topology Level-5
+	Labels TopologyLevel5Config
 }
 
 // NetPermissionConfig consists of information used to restrict the
@@ -92,6 +95,11 @@ type SnapshotConfig struct {
 	// GranularMaxSnapshotsPerBlockVolumeInVVOL specifies the maximum number of block volume snapshots
 	// per volume in VVOL datastores.
 	GranularMaxSnapshotsPerBlockVolumeInVVOL int `gcfg:"granular-max-snapshots-per-block-volume-vvol"`
+}
+
+// TopologyLevel5Config contains topology categories
+type TopologyLevel5Config struct {
+	TopologyCategories string `gcfg:"topology-categories"`
 }
 
 // getConfig returns e2eTestConfig struct for e2e tests to help establish vSphere connection.

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -250,6 +250,14 @@ var (
 	lztAllocType  = "Reserve space"
 )
 
+// For Preferential datatsore
+var (
+	preferredDatastoreRefreshTimeInterval = 1
+	preferredDatastoreTimeOutInterval     = 1 * time.Minute
+	preferredDSCat                        = "cns.vmware.topology-preferred-datastores"
+	preferredTagDesc                      = "preferred datastore tag"
+)
+
 // GetAndExpectStringEnvVar parses a string from env variable.
 func GetAndExpectStringEnvVar(varName string) string {
 	varValue := os.Getenv(varName)

--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -1,0 +1,784 @@
+/*
+	Copyright 2020 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/vmware/govmomi/object"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provisioning", func() {
+	f := framework.NewDefaultFramework("preferential-topology-aware-provisioning")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		client                         clientset.Interface
+		namespace                      string
+		bindingMode                    storagev1.VolumeBindingMode
+		allowedTopologies              []v1.TopologySelectorLabelRequirement
+		topologyAffinityDetails        map[string][]string
+		topologyCategories             []string
+		topologyLength                 int
+		leafNode                       int
+		leafNodeTag0                   int
+		leafNodeTag1                   int
+		leafNodeTag2                   int
+		preferredDatastoreChosen       int
+		shareddatastoreListMap         map[string]string
+		nonShareddatastoreListMapRack1 map[string]string
+		nonShareddatastoreListMapRack2 map[string]string
+		nonShareddatastoreListMapRack3 map[string]string
+		allMasterIps                   []string
+		masterIp                       string
+		rack1DatastoreListMap          map[string]string
+		rack2DatastoreListMap          map[string]string
+		rack3DatastoreListMap          map[string]string
+		dataCenters                    []*object.Datacenter
+		clusters                       []string
+		csiReplicas                    int32
+		csiNamespace                   string
+		preferredDatastorePaths        []string
+		allowedTopologyRacks           []string
+		allowedTopologyForRack1        []v1.TopologySelectorLabelRequirement
+		allowedTopologyForRack2        []v1.TopologySelectorLabelRequirement
+		allowedTopologyForRack3        []v1.TopologySelectorLabelRequirement
+		err                            error
+	)
+
+	ginkgo.BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		bootstrap()
+		sc, err := client.StorageV1().StorageClasses().Get(ctx, defaultNginxStorageClassName, metav1.GetOptions{})
+		if err == nil && sc != nil {
+			gomega.Expect(client.StorageV1().StorageClasses().Delete(ctx, sc.Name,
+				*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+		}
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+		bindingMode = storagev1.VolumeBindingWaitForFirstConsumer
+		csiNamespace = GetAndExpectStringEnvVar(envCSINamespace)
+
+		// fetching k8s master ip
+		allMasterIps = getK8sMasterIPs(ctx, client)
+		masterIp = allMasterIps[0]
+
+		// fetching datacenter details
+		dataCenters, err = e2eVSphere.getAllDatacenters(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// fetching cluster details
+		clusters, err = getTopologyLevel5ClusterGroupNames(masterIp, dataCenters)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// creating level-5 allowed topology map
+		topologyLength, leafNode, leafNodeTag0, leafNodeTag1, leafNodeTag2 = 5, 4, 0, 1, 2
+		topologyMap := GetAndExpectStringEnvVar(topologyMap)
+		topologyAffinityDetails, topologyCategories = createTopologyMapLevel5(topologyMap,
+			topologyLength)
+		allowedTopologies = createAllowedTopolgies(topologyMap, topologyLength)
+
+		csiDeployment, err := client.AppsV1().Deployments(csiNamespace).Get(
+			ctx, vSphereCSIControllerPodNamePrefix, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		csiReplicas = *csiDeployment.Spec.Replicas
+
+		// fetching list of datatstores shared between vm's
+		shareddatastoreListMap, err = getListOfSharedDatastoresBetweenVMs(masterIp, dataCenters)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// fetching list of datastores available in different racks
+		rack1DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, clusters[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		rack2DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, clusters[1])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		rack3DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, clusters[2])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// fetching list of datastores which is specific to each rack
+		nonShareddatastoreListMapRack1 = getNonSharedDatastoresInCluster(rack1DatastoreListMap,
+			shareddatastoreListMap)
+		nonShareddatastoreListMapRack2 = getNonSharedDatastoresInCluster(rack2DatastoreListMap,
+			shareddatastoreListMap)
+		nonShareddatastoreListMapRack3 = getNonSharedDatastoresInCluster(rack3DatastoreListMap,
+			shareddatastoreListMap)
+
+		// Get different allowed topologies required for creating Storage Class
+		allowedTopologyForRack1 = getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag0)
+		allowedTopologyForRack2 = getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag1)
+		allowedTopologyForRack3 = getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag2)
+		allowedTopologyRacks = nil
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength)
+		for i := 4; i < len(allowedTopologyForSC); i++ {
+			for j := 0; j < len(allowedTopologyForSC[i].Values); j++ {
+				allowedTopologyRacks = append(allowedTopologyRacks, allowedTopologyForSC[i].Values[j])
+			}
+		}
+
+		//set preferred datatsore time interval
+		setPreferredDatastoreTimeInterval(client, ctx, csiNamespace, namespace, csiReplicas)
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By(fmt.Sprintf("Deleting all statefulsets in namespace: %v", namespace))
+		fss.DeleteAllStatefulSets(client, namespace)
+		ginkgo.By(fmt.Sprintf("Deleting service nginx in namespace: %v", namespace))
+		err := client.CoreV1().Services(namespace).Delete(ctx, servicename, *metav1.NewDeleteOptions(0))
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		framework.Logf("Perform preferred datastore tags cleanup after test completion")
+		err = deleteTagCreatedForPreferredDatastore(masterIp, allowedTopologyRacks)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		framework.Logf("Recreate preferred datastore tags post cleanup")
+		err = createTagForPreferredDatastore(masterIp, allowedTopologyRacks)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+	})
+
+	/*
+		Testcase-1:
+			Tag single datastore and verify it is honored
+
+			Steps
+			1. Assign Tag rack-2, Category "cns.vmware.topology-preferred-datastores" to datastore specific to
+			rack-2. (ex- NFS-2)
+			2. Create Storage Class SC1 with WFC binding mode and allowed topologies set to rack-2.
+			i.e (region-1 > zone-1 > building-1 > level-1 > rack-2)
+			3. Create StatefulSet using default pod management policy with replica 3 using SC1
+			4. Wait for StatefulSet pods to come up.
+			5. Wait for PV, PVC to reach bound and POD to reach running state
+			6. Describe PV and verify node affinity details should contain allowed topology details.
+			7. Verify volume should be provisioned on the selected preferred datastore of rack-2.
+			8. Make sure POD is running on the same node as mentioned in the node affinity details
+			9. Assign Tag rack-1, Category "cns.vmware.topology-preferred-datastores" to datastore specific to
+			rack-1. (ex- NFS-1)
+			10. Create Storage Class SC2 with Immediate binding mode and allowed topologies set to rack-1
+			i.e region-1 > zone-1 > building-1 > level-1 > rack-1.
+			11. Create PVC
+			12. Wait for PVC to reach Bound state.
+			13. Describe PV and verify node affinity details should contain allowed topologies.
+			14. Verify volume should be provisioned on the selected preferred datastore of rack-1.
+			15. Create standlone Pod from PVC created above.
+			16. Wait for Pod to reach running state.
+			17. Make sure Pod is running on the same node as mentioned in the node affinity details.
+			18. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
+			19. Remove datastore preference tags as part of cleanup.
+	*/
+	ginkgo.It("Tag single preferred datastore each in rack-1 and rack-2 and verify it is honored", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datastore for volume provisioning in rack-2(cluster-2))")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[1],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		preferredDatastoreRack2 := preferredDatastorePaths[0]
+		defer func() {
+			ginkgo.By("Remove preferred datastore tag")
+			err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastoreRack2,
+				allowedTopologyRacks[1])
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologyForRack2,
+			"", bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Creating Statefulset
+		ginkgo.By("Creating statefulset with 3 replica")
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
+			nonShareddatastoreListMapRack2, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologyForRack2, false)
+
+		// choose preferred datastore in rack-1
+		ginkgo.By("Tag preferred datatstore for volume provisioning in rack-1(cluster-1))")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[0],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Remove preferred datastore tag")
+			err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[0],
+				allowedTopologyRacks[0])
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating Storage class and standalone PVC")
+		storageclass1, pvclaim, err := createPVCAndStorageClass(client, namespace, nil, nil, "",
+			allowedTopologyForRack1, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass1.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		//Wait for PVC to reach Bound state
+		ginkgo.By("Expect claim to provision volume successfully")
+		pvs1, err := fpv.WaitForPVClaimBoundPhase(client,
+			[]*v1.PersistentVolumeClaim{pvclaim}, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume")
+		pv1 := pvs1[0]
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, pvclaim.Namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv1.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Creating Pod and verifying volume is attached to the node
+		ginkgo.By("Creating a pod")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Verify volume:%s is attached to the node: %s",
+			pv1.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv1.Spec.CSI.VolumeHandle, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+		defer func() {
+			ginkgo.By("Deleting the pod and wait for disk to detach")
+			err := fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify volume is detached from the node")
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv1.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", pv1.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		}()
+
+		// verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, preferredDatastorePaths,
+			nonShareddatastoreListMapRack1)
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
+			"node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
+			allowedTopologyForRack1)
+	})
+
+	/*
+		Testcase-2:
+			Tag multiple datastore specific to rack-3 and verify it is honored
+
+			Steps
+			1. Assign Tag rack-3, Category "cns.vmware.topology-preferred-datastores" to
+			datastore specific to rack-3 (ex- NFS-3)
+			2. Assign Tag rack-3, Category "cns.vmware.topology-preferred-datastores" to datastore
+			shared across all racks (ex- sharedVMFS-12)
+			3. Create SC with WFC binding mode and allowed topologies set to rack-3 in the SC
+			4. Create StatefulSet with replica 3 with the above SC
+			5. Wait for all the StatefulSet to come up
+			6. Wait for PV , PVC to reach Bound and POD to reach running state
+			7. Describe PV and verify node affinity details should contain allowed topology details.
+			8. Verify volume should be provisioned on any of the preferred datastores of rack-3.
+			9. Make sure POD is running on the same node as mentioned in the node affinity details
+			10. Perform Scaleup of StatefulSet. Increase the replica count from 3 to 10.
+			11. Wait for all the StatefulSet to come up
+			12. Wait for PV , PVC to reach bound and POD to reach running state
+			13. Describe PV and verify node affinity details should contain allowed topology details.
+			14. Verify volume should be provisioned on any of the preferred datastores of rack-3.
+			15. Make sure POD is running on the same node as mentioned in the node affinity details
+			16. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
+			17. Remove datastore preference tags as part of cleanup.
+	*/
+	ginkgo.It("Tag multiple preferred datastores in rack-3 and verify it is honored", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datastore for volume provisioning in rack-3(cluster-3))")
+		preferredDatastorePaths, err := tagPreferredDatastore(masterIp, allowedTopologyRacks[2],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		preferredDatastore, err := tagPreferredDatastore(masterIp, allowedTopologyRacks[2],
+			preferredDatastoreChosen, shareddatastoreListMap, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
+		defer func() {
+			ginkgo.By("Remove preferred datatsore tag")
+			for i := 0; i < len(preferredDatastorePaths); i++ {
+				err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[i],
+					allowedTopologyRacks[2])
+			}
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologyForRack3,
+			"", bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Creating statefulset
+		ginkgo.By("Creating statefulset with 3 replica")
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		//verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
+			rack3DatastoreListMap, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologyForRack3, false)
+
+		// perform statefulset scaleup
+		replicas = 10
+		ginkgo.By("Scale up statefulset replica count from 3 to 10")
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+
+		//verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
+			rack3DatastoreListMap, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologyForRack3, false)
+	})
+
+	/*
+		Testcase-3:
+			Tag multiple datastore specific to rack-2 and verify it is honored
+
+			Steps
+			1. Assign Tag rack-2, Category "cns.vmware.topology-preferred-datastores" to datastore specific
+			to rack-2 (ex- NFS-2)
+			2. Assign Tag rack-2, Category "cns.vmware.topology-preferred-datastores" to datastore
+			specific to rack-2 (ex- vSAN-2)
+			3. Assign Tag rack-2, Category "cns.vmware.topology-preferred-datastores" to datastore
+			shared across all racks (ex- NFS-12)
+			4. Create SC with Immediate binding mode and allowed topologies set to rack-2 in the SC
+			5. Create StatefulSet with parallel pod management policy and replica 3 with the above SC
+			6. Wait for all the StatefulSet to come up
+			7. Wait for PV , PVC to reach bound and POD to reach running state
+			8. Describe PV and verify node affinity details should contain allowed topology details.
+			9. Verify volume should be provisioned on any of the preferred datastores of rack-2
+			10. Perform Scaleup of StatefulSet. Increase the replica count from 3 to 10.
+			11. Wait for all the StatefulSet to come up
+			12. Wait for PV , PVC to reach bound and POD to reach running state
+			13. Describe PV and verify node affinity details should contain specified allowed topology details.
+			14. Verify volume should be provisioned on any of the preferred datastores of rack-2
+			15. Make sure POD is running on the same node as mentioned in the node affinity details
+			16. Perform ScaleDown of StatefulSet. Decrease the replica count from 10 to 5.
+			17. Verify scaledown operation went successful.
+			18. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
+			19. Remove datastore preference tags as part of cleanup.
+	*/
+	ginkgo.It("Tag multiple preferred datastores in rack-2 and verify it is honored", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		preferredDatastoreChosen = 2
+		preferredDatastorePaths = nil
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-2(cluster-2))")
+		preferredDatastorePaths, err := tagPreferredDatastore(masterIp, allowedTopologyRacks[1],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		preferredDatastoreChosen = 1
+		preferredDatastore, err := tagPreferredDatastore(masterIp, allowedTopologyRacks[1],
+			preferredDatastoreChosen, shareddatastoreListMap, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
+		defer func() {
+			ginkgo.By("Remove preferred datastore tag")
+			for i := 0; i < len(preferredDatastorePaths); i++ {
+				err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[i],
+					allowedTopologyRacks[1])
+			}
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologyForRack2,
+			"", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Creating statefulset with 3 replicas
+		ginkgo.By("Creating statefulset with 3 replica")
+		statefulset := GetStatefulSetFromManifest(namespace)
+		statefulset.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+		ginkgo.By("Creating statefulset")
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		//verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
+			rack2DatastoreListMap, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologyForRack2, false)
+
+		// perform statefulset scaleup
+		replicas = 10
+		ginkgo.By("Scale up statefulset replica count from 3 to 10")
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+
+		//verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
+			rack2DatastoreListMap, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologyForRack2, false)
+
+		// perform statefulset scaledown
+		replicas = 5
+		ginkgo.By("Scale down statefulset replica count from 10 to 5")
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+	})
+
+	/*
+		Testcase-4:
+			Tag preferred datastore to rack-1 which is accessible across all racks and
+			verify it is honored
+
+			Steps
+			1. Assign Tag rack-1, Category "cns.vmware.topology-preferred-datastores" to datastore
+			accessible across all racks. (ex - sharedVMFS-12)
+			2. Create SC with WFC binding mode and allowed topologies set to all rack levels in the SC
+			3. Create StatefulSet with replica 3 with the above SC
+			4. Wait for all the StatefulSet to come up
+			5. Wait for PV, PVC to reach Bound and POD to reach running state
+			6. Describe PV and verify node affinity details should contain allowed topology details.
+			7. Verify atleast one of the sts volume provisioning should be on the preferred datastore.
+			8. Make sure POD is running on the same node as mentioned in node affinity details
+			9. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
+			10. Remove datastore preference tags as part of cleanup.
+	*/
+	ginkgo.It("Assign preferred tag to shared datastore which is accessible across all racks "+
+		"and verify it is honored", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-1(cluster-1))")
+		preferredDatastorePaths, err := tagPreferredDatastore(masterIp, allowedTopologyRacks[0],
+			preferredDatastoreChosen, shareddatastoreListMap, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Remove preferred datatsore tag")
+			err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[0],
+				allowedTopologyRacks[0])
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies,
+			"", bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Creating statefulset with 3 replicas
+		ginkgo.By("Creating statefulset with 3 replica")
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		//verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
+			shareddatastoreListMap, true, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, false)
+	})
+
+	/*
+		Testcase-5:
+			Multiple tags are assigned to Shared datastore with single allowed topology
+
+			Steps
+			1. Assign Tag rack-1, Category "cns.vmware.topology-preferred-datastores" to datastore
+			accessible across all racks (ex - sharedVMFS-12)
+			2. Assign Tag rack-2, Category "cns.vmware.topology-preferred-datastores" to datastore
+			accessible across all racks (ex - sharedVMFS-12)
+			3. Create SC with WFC binding mode and allowed topologies set to rack-2 in the SC
+			4. Create StatefulSet with replica 3 with the above SC
+			5. Wait for all the StatefulSet to come up
+			6. Wait for PV , PVC to reach Bound and POD to reach running state
+			7. Describe PV and verify node affinity details should contain allowed topology details.
+			8. Verify volume provisioning should be on the preferred datastore.
+			9. Make sure POD is running on the same node as mentioned in node affinity details
+			10. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
+			11. Remove datastore preference tags as part of cleanup.
+	*/
+	ginkgo.It("Assign multiple preferred tags to shared datastore with single allowed topology set", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-2(cluster-2))")
+		preferredDatastorePaths, err := tagPreferredDatastore(masterIp, allowedTopologyRacks[0],
+			preferredDatastoreChosen, shareddatastoreListMap, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = tagSameDatastoreAsPreferenceToDifferentRacks(masterIp, allowedTopologyRacks[1],
+			preferredDatastoreChosen, preferredDatastorePaths)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Remove preferred datatsore tag")
+			for j := 0; j < len(allowedTopologyRacks)-1; j++ {
+				err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[0],
+					allowedTopologyRacks[j])
+			}
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologyForRack2,
+			"", bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		// Creating Statefulset
+		ginkgo.By("Creating statefulset with 3 replica")
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		//verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
+			shareddatastoreListMap, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologyForRack2, false)
+	})
+})

--- a/tests/e2e/preferential_topology_utils.go
+++ b/tests/e2e/preferential_topology_utils.go
@@ -1,0 +1,440 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/vmware/govmomi/object"
+	"golang.org/x/crypto/ssh"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fssh "k8s.io/kubernetes/test/e2e/framework/ssh"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	"k8s.io/utils/strings/slices"
+)
+
+var sshClientConfig *ssh.ClientConfig = &ssh.ClientConfig{
+	User: "root",
+	Auth: []ssh.AuthMethod{
+		ssh.Password(k8sVmPasswd),
+	},
+	HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+}
+
+// govc login cmd
+func govcLoginCmd() string {
+	loginCmd := "export GOVC_INSECURE=1;"
+	loginCmd += fmt.Sprintf("export GOVC_URL='https://%s:%s@%s:%s';",
+		e2eVSphere.Config.Global.User, e2eVSphere.Config.Global.Password,
+		e2eVSphere.Config.Global.VCenterHostname, e2eVSphere.Config.Global.VCenterPort)
+	return loginCmd
+}
+
+/*
+getTopologyLevel5ClusterGroupNames method is used to fetch list of cluster available
+in level-5 testbed
+*/
+func getTopologyLevel5ClusterGroupNames(masterIp string,
+	dataCenter []*object.Datacenter) ([]string, error) {
+	var clusterList, clusList, clusFolderTemp, clusterGroupRes []string
+	var clusterFolderName string
+	for i := 0; i < len(dataCenter); i++ {
+		clusterFolder := govcLoginCmd() + "govc ls " + dataCenter[i].InventoryPath
+		framework.Logf("cmd: %s ", clusterFolder)
+		clusterFolderNameResult, err := sshExec(sshClientConfig, masterIp, clusterFolder)
+		if err != nil && clusterFolderNameResult.Code != 0 {
+			fssh.LogResult(clusterFolderNameResult)
+			return nil, fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				clusterFolder, masterIp, err)
+		}
+		if clusterFolderNameResult.Stdout != "" {
+			clusFolderTemp = strings.Split(clusterFolderNameResult.Stdout, "\n")
+		}
+		for i := 0; i < len(clusFolderTemp)-1; i++ {
+			if strings.Contains(clusFolderTemp[i], "host") {
+				clusterFolderName = clusFolderTemp[i]
+				break
+			}
+		}
+		clusterGroup := govcLoginCmd() + "govc ls " + clusterFolderName
+		framework.Logf("cmd: %s ", clusterGroup)
+		clusterGroupResult, err := sshExec(sshClientConfig, masterIp, clusterGroup)
+		if err != nil && clusterGroupResult.Code != 0 {
+			fssh.LogResult(clusterGroupResult)
+			return nil, fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				clusterGroup, masterIp, err)
+		}
+		if clusterGroupResult.Stdout != "" {
+			clusterGroupRes = strings.Split(clusterGroupResult.Stdout, "\n")
+		}
+		cluster := govcLoginCmd() + "govc ls " + clusterGroupRes[0] + " | sort"
+		framework.Logf("cmd: %s ", cluster)
+		clusterResult, err := sshExec(sshClientConfig, masterIp, cluster)
+		if err != nil && clusterResult.Code != 0 {
+			fssh.LogResult(clusterResult)
+			return nil, fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				cluster, masterIp, err)
+		}
+		if clusterResult.Stdout != "" {
+			clusListTemp := strings.Split(clusterResult.Stdout, "\n")
+			clusList = append(clusList, clusListTemp...)
+		}
+		for i := 0; i < len(clusList)-1; i++ {
+			clusterList = append(clusterList, clusList[i])
+		}
+		clusList = nil
+	}
+	return clusterList, nil
+}
+
+/*
+attachTagToPreferredDatastore method is used to attach the  preferred tag to the
+datastore chosen for volume provisioning
+*/
+func attachTagToPreferredDatastore(masterIp string, datastore string, tagName string) error {
+	attachTagCat := govcLoginCmd() +
+		"govc tags.attach -c " + preferredDSCat + " " + tagName + " " + "'" + datastore + "'"
+	framework.Logf("cmd to attach tag to preferred datastore: %s ", attachTagCat)
+	attachTagCatRes, err := sshExec(sshClientConfig, masterIp, attachTagCat)
+	if err != nil && attachTagCatRes.Code != 0 {
+		fssh.LogResult(attachTagCatRes)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			attachTagCat, masterIp, err)
+	}
+	return nil
+}
+
+/* detachTagCreatedOnPreferredDatastore is used to detach the tag created on preferred datastore */
+func detachTagCreatedOnPreferredDatastore(masterIp string, datastore string, tagName string) error {
+	detachTagCat := govcLoginCmd() +
+		"govc tags.detach -c " + preferredDSCat + " " + tagName + " " + "'" + datastore + "'"
+	framework.Logf("cmd to detach the tag assigned to preferred datastore: %s ", detachTagCat)
+	detachTagCatRes, err := sshExec(sshClientConfig, masterIp, detachTagCat)
+	if err != nil && detachTagCatRes.Code != 0 {
+		fssh.LogResult(detachTagCatRes)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			detachTagCat, masterIp, err)
+	}
+	return nil
+}
+
+/*
+getListOfSharedDatastoresBetweenVMs method is used to fetch the list of datatsores shared between
+node vms or shared across entire k8s cluster
+*/
+func getListOfSharedDatastoresBetweenVMs(masterIp string,
+	dataCenter []*object.Datacenter) (map[string]string, error) {
+	var clusFolderTemp []string
+	var clusterFolderName string
+	shareddatastoreListMap := make(map[string]string)
+	for i := 0; i < len(dataCenter); i++ {
+		clusterFolder := govcLoginCmd() + "govc ls " + dataCenter[i].InventoryPath
+		framework.Logf("cmd: %s ", clusterFolder)
+		clusterFolderNameResult, err := sshExec(sshClientConfig, masterIp, clusterFolder)
+		if err != nil && clusterFolderNameResult.Code != 0 {
+			fssh.LogResult(clusterFolderNameResult)
+			return nil, fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				clusterFolder, masterIp, err)
+		}
+		if clusterFolderNameResult.Stdout != "" {
+			clusFolderTemp = strings.Split(clusterFolderNameResult.Stdout, "\n")
+		}
+		for i := 0; i < len(clusFolderTemp)-1; i++ {
+			if strings.Contains(clusFolderTemp[i], "vm") {
+				clusterFolderName = clusFolderTemp[i]
+				break
+			}
+		}
+	}
+	listOfSharedDatastores := govcLoginCmd() +
+		"govc ls " + clusterFolderName + " | xargs -n1 -I% govc object.collect -s % summary.runtime.host | " +
+		"xargs govc datastore.info -H | grep 'Path\\|URL' | tr -s [:space:]"
+	framework.Logf("cmd for fetching list of shared datastores: %s ", listOfSharedDatastores)
+	result, err := sshExec(sshClientConfig, masterIp, listOfSharedDatastores)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return nil, fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			listOfSharedDatastores, masterIp, err)
+	}
+	sharedDatastoreList := strings.Split(result.Stdout, "\n")
+	for i := 0; i < len(sharedDatastoreList)-1; i = i + 2 {
+		key := strings.ReplaceAll(sharedDatastoreList[i], " Path: ", "")
+		value := strings.ReplaceAll(sharedDatastoreList[i+1], " URL: ", "")
+		shareddatastoreListMap[key] = value
+	}
+	return shareddatastoreListMap, nil
+}
+
+/*
+getListOfDatastoresByClusterName method is used to fetch the list of datastores accessible to
+specific cluster
+*/
+func getListOfDatastoresByClusterName(masterIp string, cluster string) (map[string]string, error) {
+	ClusterdatastoreListMap := make(map[string]string)
+	datastoreListByCluster := govcLoginCmd() +
+		"govc object.collect -s -d ' ' " + cluster + " host | xargs govc datastore.info -H | " +
+		"grep 'Path\\|URL' | tr -s [:space:]"
+	framework.Logf("cmd : %s ", datastoreListByCluster)
+	result, err := sshExec(sshClientConfig, masterIp, datastoreListByCluster)
+	if err != nil && result.Code != 0 {
+		fssh.LogResult(result)
+		return nil, fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			datastoreListByCluster, masterIp, err)
+	}
+	datastoreList := strings.Split(result.Stdout, "\n")
+	for i := 0; i < len(datastoreList)-1; i = i + 2 {
+		key := strings.ReplaceAll(datastoreList[i], " Path: ", "")
+		value := strings.ReplaceAll(datastoreList[i+1], " URL: ", "")
+		ClusterdatastoreListMap[key] = value
+	}
+
+	return ClusterdatastoreListMap, nil
+}
+
+/*
+verifyVolumeProvisioningForStatefulSet is used to check whether the volume is provisioned on the
+chosen preferred datastore or not for statefulsets
+*/
+func verifyVolumeProvisioningForStatefulSet(ctx context.Context,
+	client clientset.Interface, statefulset *appsv1.StatefulSet,
+	namespace string, datastoreNames []string, datastoreListMap map[string]string,
+	multipleAllowedTopology bool, parallelStatefulSetCreation bool) error {
+	counter := 0
+	stsPodCount := 0
+	var dsUrls []string
+	var ssPodsBeforeScaleDown *v1.PodList
+	if parallelStatefulSetCreation {
+		ssPodsBeforeScaleDown = GetListOfPodsInSts(client, statefulset)
+	} else {
+		ssPodsBeforeScaleDown = fss.GetPodList(client, statefulset)
+	}
+	stsPodCount = len(ssPodsBeforeScaleDown.Items)
+	for i := 0; i < len(datastoreNames); i++ {
+		if val, ok := datastoreListMap[datastoreNames[i]]; ok {
+			dsUrls = append(dsUrls, val)
+		}
+	}
+	for _, sspod := range ssPodsBeforeScaleDown.Items {
+		_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, volumespec := range sspod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+				isPreferred := e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle, dsUrls)
+				if isPreferred {
+					framework.Logf("volume %s is created on preferred datastore %v", pv.Spec.CSI.VolumeHandle, dsUrls)
+					counter = counter + 1
+				}
+			}
+		}
+	}
+	if len(datastoreNames) == 1 && counter != stsPodCount && !multipleAllowedTopology {
+		return fmt.Errorf("volume is provisioned on the wrong datastore")
+	} else if len(datastoreNames) == 2 && counter != stsPodCount && !multipleAllowedTopology {
+		return fmt.Errorf("volume is provisioned on the wrong datastore")
+	} else if len(datastoreNames) == 3 && counter != stsPodCount && !multipleAllowedTopology {
+		return fmt.Errorf("volume is provisioned on the wrong datastore")
+	} else if len(datastoreNames) == 4 && counter != stsPodCount && !multipleAllowedTopology {
+		return fmt.Errorf("volume is provisioned on the wrong datastore")
+	} else if counter != stsPodCount && multipleAllowedTopology && counter != 0 {
+		framework.Logf("Few volume is provisioned on some other datastore due to multiple " +
+			"allowed topology set or no topology set in the Storage Class")
+	}
+	return nil
+}
+
+/*
+verifyVolumeProvisioningForStandalonePods is used to check whether the volume is provisioned on the
+chosen preferred datastore or not for standalone pods
+*/
+func verifyVolumeProvisioningForStandalonePods(ctx context.Context,
+	client clientset.Interface, pod *v1.Pod,
+	namespace string, datastoreNames []string, datastoreListMap map[string]string) {
+	var flag bool = false
+	var dsUrls []string
+	for i := 0; i < len(datastoreNames); i++ {
+		if val, ok := datastoreListMap[datastoreNames[i]]; ok {
+			dsUrls = append(dsUrls, val)
+		}
+	}
+	for _, volumespec := range pod.Spec.Volumes {
+		if volumespec.PersistentVolumeClaim != nil {
+			pv := getPvFromClaim(client, pod.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+			isPreferred := e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle, dsUrls)
+			if isPreferred {
+				framework.Logf("volume %s is created on preferred datastore %v", pv.Spec.CSI.VolumeHandle, dsUrls)
+				flag = true
+			}
+		}
+	}
+	if !flag {
+		gomega.Expect(flag).To(gomega.BeTrue(), "Volume is not provisioned on the preferred datastore")
+	}
+}
+
+/*
+tagSameDatastoreAsPreferenceToDifferentRacks method is used to assign same preferred datatsore
+to another racks or clusters available in a testbed
+*/
+func tagSameDatastoreAsPreferenceToDifferentRacks(masterIp string, zoneValue string,
+	itr int, datastoreNames []string) error {
+	i := 0
+	for j := 0; j < len(datastoreNames); j++ {
+		i = i + 1
+		err := attachTagToPreferredDatastore(masterIp, datastoreNames[j], zoneValue)
+		if err != nil {
+			return err
+		}
+		if i == itr {
+			break
+		}
+	}
+	return nil
+}
+
+/*
+tagPreferredDatastore method is used to tag the datastore which is chosen for volume provisioning
+*/
+func tagPreferredDatastore(masterIp string, zoneValue string, itr int,
+	datastoreListMap map[string]string, datastoreNames []string) ([]string, error) {
+	var preferredDatastorePaths []string
+	i := 0
+	if datastoreNames == nil {
+		for dsName := range datastoreListMap {
+			i = i + 1
+			preferredDatastorePaths = append(preferredDatastorePaths, dsName)
+			err := attachTagToPreferredDatastore(masterIp, dsName, zoneValue)
+			if err != nil {
+				return preferredDatastorePaths, err
+			}
+			if i == itr {
+				break
+			}
+		}
+	}
+	if datastoreNames != nil {
+		for dsName := range datastoreListMap {
+			if !slices.Contains(datastoreNames, dsName) {
+				preferredDatastorePaths = append(preferredDatastorePaths, dsName)
+				err := attachTagToPreferredDatastore(masterIp, dsName, zoneValue)
+				if err != nil {
+					return preferredDatastorePaths, err
+				}
+				i = i + 1
+			}
+			if i == itr {
+				break
+			}
+		}
+	}
+	return preferredDatastorePaths, nil
+}
+
+// restartCSIDriver method restarts the csi driver
+func restartCSIDriver(ctx context.Context, client clientset.Interface, namespace string,
+	csiReplicas int32) (bool, error) {
+	isServiceStopped, err := stopCSIPods(ctx, client)
+	if err != nil {
+		return isServiceStopped, err
+	}
+	isServiceStarted, err := startCSIPods(ctx, client, csiReplicas)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	if err != nil {
+		return isServiceStarted, err
+	}
+	return true, nil
+}
+
+/*
+setPreferredDatastoreTimeInterval method is used to set the time interval at which preferred
+datastores are refreshed in the environment
+*/
+func setPreferredDatastoreTimeInterval(client clientset.Interface, ctx context.Context,
+	csiNamespace string, namespace string, csiReplicas int32) {
+	currentSecret, err := client.CoreV1().Secrets(csiNamespace).Get(ctx, configSecret, metav1.GetOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	originalConf := string(currentSecret.Data[vSphereCSIConf])
+	vsphereCfg, err := readConfigFromSecretString(originalConf)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	vsphereCfg.Global.CSIFetchPreferredDatastoresIntervalInMin = preferredDatastoreRefreshTimeInterval
+	modifiedConf, err := writeConfigToSecretString(vsphereCfg)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	ginkgo.By("Updating the secret to reflect new changes")
+	currentSecret.Data[vSphereCSIConf] = []byte(modifiedConf)
+	_, err = client.CoreV1().Secrets(csiNamespace).Update(ctx, currentSecret, metav1.UpdateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	// restart csi driver
+	restartSuccess, err := restartCSIDriver(ctx, client, csiNamespace, csiReplicas)
+	gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+/*
+getNonSharedDatastoresInCluster method is used to fetch the datatsore which is accessible
+only to specific cluster and not shared with any other clusters
+*/
+func getNonSharedDatastoresInCluster(ClusterdatastoreListMap map[string]string,
+	shareddatastoreListMap map[string]string) map[string]string {
+	NonShareddatastoreListMap := make(map[string]string)
+	for ClusterDsName, clusterDsVal := range ClusterdatastoreListMap {
+		if _, ok := shareddatastoreListMap[ClusterDsName]; ok {
+		} else {
+			NonShareddatastoreListMap[ClusterDsName] = clusterDsVal
+		}
+	}
+	return NonShareddatastoreListMap
+}
+
+// deleteTagCreatedForPreferredDatastore method is used to delete the tag created on preferred datastore
+func deleteTagCreatedForPreferredDatastore(masterIp string, tagName []string) error {
+	for i := 0; i < len(tagName); i++ {
+		deleteTagCat := govcLoginCmd() +
+			"govc tags.rm -f -c " + preferredDSCat + " " + tagName[i]
+		framework.Logf("Deleting tag created for preferred datastore: %s ", deleteTagCat)
+		deleteTagCatRes, err := sshExec(sshClientConfig, masterIp, deleteTagCat)
+		if err != nil && deleteTagCatRes.Code != 0 {
+			fssh.LogResult(deleteTagCatRes)
+			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				deleteTagCat, masterIp, err)
+		}
+	}
+	return nil
+}
+
+// createTagForPreferredDatastore method is used to create tag required for choosing preferred datastore
+func createTagForPreferredDatastore(masterIp string, tagName []string) error {
+	for i := 0; i < len(tagName); i++ {
+		createTagCat := govcLoginCmd() +
+			"govc tags.create -d '" + preferredTagDesc + "' -c " + preferredDSCat + " " + tagName[i]
+		framework.Logf("Creating tag for preferred datastore: %s ", createTagCat)
+		createTagCatRes, err := sshExec(sshClientConfig, masterIp, createTagCat)
+		if err != nil && createTagCatRes.Code != 0 {
+			fssh.LogResult(createTagCatRes)
+			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				createTagCat, masterIp, err)
+		}
+	}
+	return nil
+}

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -2780,7 +2780,9 @@ func verifyEntityReferenceInCRDInSupervisor(ctx context.Context, f *framework.Fr
 // trimQuotes takes a quoted string as input and returns the same string unquoted.
 func trimQuotes(str string) string {
 	str = strings.TrimPrefix(str, "\"")
+	str = strings.TrimSuffix(str, " ")
 	str = strings.TrimSuffix(str, "\"")
+
 	return str
 }
 
@@ -2809,9 +2811,16 @@ func readConfigFromSecretString(cfg string) (e2eTestConfig, error) {
 			continue
 		}
 		words := strings.Split(line, " = ")
+		if strings.Contains(words[0], "topology-categories=") {
+			words = strings.Split(line, "=")
+		}
+
 		if len(words) == 1 {
 			// Case Snapshot
 			if strings.Contains(words[0], "Snapshot") {
+				continue
+			}
+			if strings.Contains(words[0], "Labels") {
 				continue
 			}
 			// Case VirtualCenter.
@@ -2851,9 +2860,12 @@ func readConfigFromSecretString(cfg string) (e2eTestConfig, error) {
 			config.Global.CnsRegisterVolumesCleanupIntervalInMin, strconvErr = strconv.Atoi(value)
 			gomega.Expect(strconvErr).NotTo(gomega.HaveOccurred())
 		case "topology-categories":
-			config.Global.TopologyCategories = value
+			config.Labels.TopologyCategories = value
 		case "global-max-snapshots-per-block-volume":
 			config.Snapshot.GlobalMaxSnapshotsPerBlockVolume, strconvErr = strconv.Atoi(value)
+			gomega.Expect(strconvErr).NotTo(gomega.HaveOccurred())
+		case "csi-fetch-preferred-datastores-intervalinmin":
+			config.Global.CSIFetchPreferredDatastoresIntervalInMin, strconvErr = strconv.Atoi(value)
 			gomega.Expect(strconvErr).NotTo(gomega.HaveOccurred())
 		default:
 			return config, fmt.Errorf("unknown key %s in the input string", key)
@@ -2866,11 +2878,16 @@ func readConfigFromSecretString(cfg string) (e2eTestConfig, error) {
 // that into a string.
 func writeConfigToSecretString(cfg e2eTestConfig) (string, error) {
 	result := fmt.Sprintf("[Global]\ninsecure-flag = \"%t\"\ncluster-id = \"%s\"\ncluster-distribution = \"%s\"\n"+
-		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"\n"+
-		"[Snapshot]\nglobal-max-snapshots-per-block-volume = %d",
+		"csi-fetch-preferred-datastores-intervalinmin = %d\n\n"+
+		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"\n\n"+
+		"[Snapshot]\nglobal-max-snapshots-per-block-volume = %d\n\n"+
+		"[Labels]\ntopology-categories = \"%s\"",
 		cfg.Global.InsecureFlag, cfg.Global.ClusterID, cfg.Global.ClusterDistribution,
+		cfg.Global.CSIFetchPreferredDatastoresIntervalInMin,
 		cfg.Global.VCenterHostname, cfg.Global.User, cfg.Global.Password,
-		cfg.Global.Datacenters, cfg.Global.VCenterPort, cfg.Snapshot.GlobalMaxSnapshotsPerBlockVolume)
+		cfg.Global.Datacenters, cfg.Global.VCenterPort,
+		cfg.Snapshot.GlobalMaxSnapshotsPerBlockVolume,
+		cfg.Labels.TopologyCategories)
 	return result, nil
 }
 

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -1137,3 +1137,16 @@ func fetchDsUrl4CnsVol(e2eVSphere vSphere, volHandle string) string {
 	gomega.Expect(queryResult.Volumes).ShouldNot(gomega.BeEmpty())
 	return queryResult.Volumes[0].DatastoreUrl
 }
+
+// verifyPreferredDatastoreMatch verify if any of the given dsUrl matches with the datstore url for the volumeid
+func (vs *vSphere) verifyPreferredDatastoreMatch(volumeID string, dsUrls []string) bool {
+	actualDatastoreUrl := fetchDsUrl4CnsVol(e2eVSphere, volumeID)
+	flag := false
+	for _, dsUrl := range dsUrls {
+		if actualDatastoreUrl == dsUrl {
+			flag = true
+			return flag
+		}
+	}
+	return flag
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Preferential automation - Part1

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
preferential automation - Part1

**Testing done**:
Yes
TC1 - https://gist.githubusercontent.com/sipriyaa/c98d1411f9a50bcc473525aad6a72123/raw/2023f2603ba77b5d22334702e6aaf85140343f8c/gistfile1.txt

TC2 - https://gist.githubusercontent.com/sipriyaa/ec670bf744bf490dd0ae9c23ed8c3e00/raw/46aa5f3d4b4db1f5ea2da5ca03913a6c24a73da7/gistfile1.txt

TC3 - https://gist.githubusercontent.com/sipriyaa/fe282e8df08f123ccaa3387667a5046a/raw/a4f11f05387ad0595a5366ad04881a21bd024fa3/gistfile1.txt

TC4 - https://gist.githubusercontent.com/sipriyaa/77dc8172169eabac17a0dbc374ef0520/raw/661a3984f61d99d2036889b154cd937b10302bdc/gistfile1.txt

TC5 - https://gist.githubusercontent.com/sipriyaa/b878af10abe64a381de56258c6d2f08f/raw/f9cb1cd93add1c21e41f05a5e6df81a0c7997aa8/gistfile1.txt


**Special notes for your reviewer**:
Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.46.2'
golangci/golangci-lint info found version: 1.46.2 for v1.46.2/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/preferential-part1/vsphere-csi-driver /Users/sipriya/preferential-part1 /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (deps|exports_file|name|compiled_files|files|imports|types_sizes) took 13.223014632s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 194.060135ms 
INFO [linters context/goanalysis] analyzers took 7m44.637440641s with top 10 stages: buildir: 5m31.550539473s, nilness: 31.996416849s, fact_deprecated: 12.521351498s, printf: 12.335144913s, ctrlflow: 11.587952209s, typedness: 10.517949348s, fact_purity: 9.423085624s, SA5012: 8.514603275s, inspect: 4.80208124s, S1038: 2.386757706s 
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649. 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 113/113, autogenerated_exclude: 24/113, exclude-rules: 1/24, identifier_marker: 24/24, skip_files: 113/113, skip_dirs: 113/113, nolint: 0/1, cgo: 113/113, filename_unadjuster: 113/113, exclude: 24/24 
INFO [runner] processing took 16.573014ms with stages: nolint: 11.996177ms, autogenerated_exclude: 3.449846ms, path_prettifier: 471.491µs, identifier_marker: 450.338µs, skip_dirs: 102.119µs, exclude-rules: 60.554µs, cgo: 33.87µs, filename_unadjuster: 4.483µs, max_same_issues: 1.09µs, uniq_by_line: 492ns, severity-rules: 383ns, max_from_linter: 357ns, skip_files: 317ns, exclude: 308ns, diff: 245ns, source_code: 235ns, path_shortener: 231ns, sort_results: 190ns, max_per_file_from_linter: 184ns, path_prefixer: 104ns 
INFO [runner] linters took 46.548036028s with stages: goanalysis_metalinter: 46.531325548s, structcheck: 8.065µs 
INFO File cache stats: 289 entries of total size 5.0MiB 
INFO Memory: 543 samples, avg is 1650.8MB, max is 2960.7MB 
INFO Execution took 59.978813537s                 
sipriya@sipriya-a01 vsphere-csi-driver % 
