### PR TITLE
cns-csi.yaml changes for k8s 1.24

### DIFF
--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -204,13 +204,10 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       serviceAccount: vsphere-csi-controller
       nodeSelector:
-        node-role.kubernetes.io/control-plane: ''
+        node-role.kubernetes.io/master: ''
       tolerations:
         - operator: "Exists"
           key: "node-role.kubernetes.io/master"
-          effect: "NoSchedule"
-        - operator: "Exists"
-          key: "node-role.kubernetes.io/control-plane"
           effect: "NoSchedule"
       hostNetwork: true
       priorityClassName: system-node-critical
@@ -602,13 +599,10 @@ spec:
               topologyKey: kubernetes.io/hostname
       hostNetwork: true
       nodeSelector:
-        node-role.kubernetes.io/control-plane: ""
+        node-role.kubernetes.io/master: ""
       terminationGracePeriodSeconds: 10
       tolerations:
         - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
         - effect: NoExecute

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -204,13 +204,10 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       serviceAccount: vsphere-csi-controller
       nodeSelector:
-        node-role.kubernetes.io/control-plane: ''
+        node-role.kubernetes.io/master: ''
       tolerations:
         - operator: "Exists"
           key: "node-role.kubernetes.io/master"
-          effect: "NoSchedule"
-        - operator: "Exists"
-          key: "node-role.kubernetes.io/control-plane"
           effect: "NoSchedule"
       hostNetwork: true
       priorityClassName: system-node-critical
@@ -602,13 +599,10 @@ spec:
               topologyKey: kubernetes.io/hostname
       hostNetwork: true
       nodeSelector:
-        node-role.kubernetes.io/control-plane: ""
+        node-role.kubernetes.io/master: ""
       terminationGracePeriodSeconds: 10
       tolerations:
         - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
         - effect: NoExecute

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -204,20 +204,19 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       serviceAccount: vsphere-csi-controller
       nodeSelector:
-        node-role.kubernetes.io/master: ''
+        node-role.kubernetes.io/control-plane: ''
       tolerations:
         - operator: "Exists"
           key: "node-role.kubernetes.io/master"
           effect: "NoSchedule"
-        - operator: "Equal"
-          key: "kubeadmNode"
+        - operator: "Exists"
+          key: "node-role.kubernetes.io/control-plane"
           effect: "NoSchedule"
-          value: "master"
       hostNetwork: true
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.1.0_vmware.2
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.2.1_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -252,7 +251,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.4.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v3.5.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -275,7 +274,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.4.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.5.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -349,7 +348,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.6.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.7.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
           volumeMounts:
@@ -603,10 +602,13 @@ spec:
               topologyKey: kubernetes.io/hostname
       hostNetwork: true
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10
       tolerations:
         - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
         - effect: NoExecute
@@ -615,10 +617,6 @@ spec:
         - effect: NoExecute
           key: node.alpha.kubernetes.io/unreachable
           operator: Exists
-        - effect: NoSchedule
-          key: kubeadmNode
-          operator: Equal
-          value: master
       containers:
         - name: vsphere-webhook
           image: localhost:5000/vmware/syncer:<syncer_ver>

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -139,9 +139,9 @@ kind: ClusterRoleBinding
 metadata:
   name: wcp:administrators:cluster-edit-csirole
 subjects:
-- kind: Group
-  name: sso:Administrators@<sso_domain>
-  apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: sso:Administrators@<sso_domain>
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: vsphere-admin-csi-role
@@ -153,9 +153,9 @@ metadata:
   namespace: vmware-system-csi
   name: vsphere-csi-secret-reader
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -207,9 +207,6 @@ spec:
         node-role.kubernetes.io/control-plane: ''
       tolerations:
         - operator: "Exists"
-          key: "node-role.kubernetes.io/master"
-          effect: "NoSchedule"
-        - operator: "Exists"
           key: "node-role.kubernetes.io/control-plane"
           effect: "NoSchedule"
       hostNetwork: true
@@ -245,7 +242,7 @@ spec:
             - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAME # service name to be used by csi-provisioner to connect to placement engine
               value: vmware-system-psp-operator-k8s-cloud-operator-service
             - name: VSPHERE_CLOUD_OPERATOR_SERVICE_NAMESPACE # namespace for service name to be used by csi-provisioner to connect to placement engine
-              value: vmware-system-appplatform-operator-system                
+              value: vmware-system-appplatform-operator-system
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
@@ -299,12 +296,12 @@ spec:
         - name: vsphere-csi-controller
           image: localhost:5000/vmware/vsphere-csi:<vsphere_csi_ver>
           ports:
-           - containerPort: 2112
-             name: prometheus
-             protocol: TCP
-           - name: healthz
-             containerPort: 9808
-             protocol: TCP
+            - containerPort: 2112
+              name: prometheus
+              protocol: TCP
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
@@ -336,8 +333,6 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
-            - name: GODEBUG
-              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp
@@ -381,13 +376,11 @@ spec:
               value: "50"
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
-            - name: GODEBUG
-              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           ports:
-           - containerPort: 2113
-             name: prometheus
-             protocol: TCP
+            - containerPort: 2113
+              name: prometheus
+              protocol: TCP
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -430,7 +423,7 @@ data:
   "sibling-replica-bound-pvc-check": "true"
   "tkgs-ha": "true"
   "list-volumes": "false"
-  "cnsmgr-suspend-create-volume": "true"
+  "cnsmgr-suspend-create-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states
@@ -605,9 +598,6 @@ spec:
         node-role.kubernetes.io/control-plane: ""
       terminationGracePeriodSeconds: 10
       tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

> Note: #1875 was reverted with #1975 as testing for the 1.24 environment was not correct. 
> This PR is identical to #1875. Testing for 1.22 and 1.23 was done correctly for #1875 and is not being done again here. Test results for 1.24 will be added. 

<br><br>

**What this PR does / why we need it**:

This change creates a new cns-csi.yaml for k8s 1.24 that includes, 

1. Change nodeSelector from `node-role.kubernetes.io/master` to `node-role.kubernetes.io/control-plane`
https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-control-plane
> Starting in v1.20, this taint is deprecated in favor of [node-role.kubernetes.io/control-plane](http://node-role.kubernetes.io/control-plane) and will be removed in v1.25.

2. Change toleration from `node-role.kubernetes.io/master` to `node-role.kubernetes.io/control-plane`

Reference to a similar change done for Vanilla -> https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1759

Refer to https://github.com/kubernetes/kubernetes/pull/107533 and https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint

3. Sidecar upgrades

#### csi-provisioner

https://github.com/kubernetes-csi/external-provisioner/releases

Bumped from v3.1.0 (Jan 12, 2022) to v3.2.1 (Jun 28, 2022)

#### csi-attacher

https://github.com/kubernetes-csi/external-attacher/releases

Bumped from v3.4.0 (Dec 21, 2021) to v3.5.0 (Jun 08, 2022)

#### csi-resizer

https://github.com/kubernetes-csi/external-resizer/releases

Bumped from v1.4.0 (Jan 21, 2022) to v1.5.0 (Jun 15, 2022)

#### liveness-probe

https://github.com/kubernetes-csi/livenessprobe/releases

Bumped from v2.6.0 (Feb 01, 2022) to v2.7.0 (May 12, 2022)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

### Testing for 1.24

Please refer to build 675 for 1.24 e2e tests. Testbeds are having intermittent network issues. I've manually verified the 3 failed tests on the testbed and added the results below. 

```
Ran 14 of 632 Specs in 4417.110 seconds FAIL! -- 11 Passed | 3 Failed | 0 Pending | 618 Skipped --- FAIL: TestE2E (4417.47s) FAIL Ginkgo ran 1 suite in 1h14m34.621434495s Test Suite Failed make: Leaving directory `/home/worker/workspace/csi-wcp-pre-check-in/Results/675/vsphere-csi-driver' 
```

```
root@4234dd94454eea3482547042885bb387 [ ~ ]# k version
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
Client Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.4+vmware.wcp.1", GitCommit:"3be14f808c3bcd6bc14d95c63a6ce2604b0a0831", GitTreeState:"clean", BuildDate:"2022-09-15T07:41:25Z", GoVersion:"go1.18.5", Compiler:"gc", Platform:"linux/amd64"}
Kustomize Version: v4.5.4
Server Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.4+vmware.wcp.1", GitCommit:"3be14f808c3bcd6bc14d95c63a6ce2604b0a0831", GitTreeState:"clean", BuildDate:"2022-09-15T07:35:45Z", GoVersion:"go1.18.5", Compiler:"gc", Platform:"linux/amd64"}
```

Online Volume Expansion

```
root@4234dd94454eea3482547042885bb387 [ ~ ]# vim podpvc.yaml
root@4234dd94454eea3482547042885bb387 [ ~ ]# cat podpvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: aditya-pvc
spec:
  volumeMode: Block
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: wcpglobal-storage-profile
---
apiVersion: v1
kind: Pod
metadata:
  name: aditya-pod
spec:
  containers:
    - name: test-container
      image: gcr.io/google_containers/busybox:1.24
      command: ["/bin/sh", "-c", "while true ; do sleep 2 ; done"]
      volumeDevices:
        - devicePath: /dev/xvda
          name: data
  restartPolicy: Never
  volumes:
    - name: data
      persistentVolumeClaim:
        claimName: aditya-pvc
```

```
root@4234dd94454eea3482547042885bb387 [ ~ ]# k create -f podpvc.yaml -n adi-ns
persistentvolumeclaim/aditya-pvc created
pod/aditya-pod created
root@4234dd94454eea3482547042885bb387 [ ~ ]# k get pvc -A
NAMESPACE                NAME         STATUS        VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
adi-ns                   aditya-pvc   Pending                                                                            wcpglobal-storage-profile   7s
e2e-test-namespace-675   pvc-56cql    Terminating   pvc-f61ac093-de50-4bc5-b5f1-ce13b298a4bc   2Gi        RWO            shared-ds-policy-675        123m
root@4234dd94454eea3482547042885bb387 [ ~ ]# kubectl patch pvc pvc-56cql -p '{"metadata":{"finalizers":null}}' -n e2e-test-namespace-675
persistentvolumeclaim/pvc-56cql patched
root@4234dd94454eea3482547042885bb387 [ ~ ]# k get pvc -A
NAMESPACE   NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
adi-ns      aditya-pvc   Bound    pvc-4a09b786-3703-4b9b-bb57-b47b865cebd0   1Gi        RWO            wcpglobal-storage-profile   35s
root@4234dd94454eea3482547042885bb387 [ ~ ]# k get po -n adi-ns
NAME         READY   STATUS    RESTARTS   AGE
aditya-pod   1/1     Running   0          43s
root@4234dd94454eea3482547042885bb387 [ ~ ]# k edit pvc aditya-pvc -n adi-ns
persistentvolumeclaim/aditya-pvc edited
root@4234dd94454eea3482547042885bb387 [ ~ ]# k get pvc -n adi-ns
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
aditya-pvc   Bound    pvc-4a09b786-3703-4b9b-bb57-b47b865cebd0   5Gi        RWO            wcpglobal-storage-profile   71s
root@4234dd94454eea3482547042885bb387 [ ~ ]# k get po -n adi-ns
NAME         READY   STATUS    RESTARTS   AGE
aditya-pod   1/1     Running   0          76s
```

Accessible health status

```
root@4234dd94454eea3482547042885bb387 [ ~ ]# k describe pvc -n adi-ns aditya-pvc
Name:          aditya-pvc
Namespace:     adi-ns
StorageClass:  wcpglobal-storage-profile
Status:        Bound
Volume:        pvc-4a09b786-3703-4b9b-bb57-b47b865cebd0
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Thu Sep 22 19:04:02 UTC 2022
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      5Gi
Access Modes:  RWO
VolumeMode:    Block
Used By:       aditya-pod
Events:
```



Stateful set with parallel pod management policy

```
root@4234dd94454eea3482547042885bb387 [ ~ ]# vim statefulset.yaml
root@4234dd94454eea3482547042885bb387 [ ~ ]# cat statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: web
spec:
  serviceName: "nginx"
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: k8s.gcr.io/nginx-slim:0.8
        ports:
        - containerPort: 80
          name: web
        volumeMounts:
        - name: www
          mountPath: /usr/share/nginx/html
  podManagementPolicy: Parallel
  volumeClaimTemplates:
  - metadata:
      name: www
      annotations:
        volume.beta.kubernetes.io/storage-class: wcpglobal-storage-profile
    spec:
      accessModes: [ "ReadWriteOnce" ]
      resources:
        requests:
          storage: 1Gi


root@4234dd94454eea3482547042885bb387 [ ~ ]# k create -f statefulset.yaml -n adi-ns
statefulset.apps/web created

root@4234dd94454eea3482547042885bb387 [ ~ ]# k -n adi-ns get sts
NAME   READY   AGE
web    3/3     50s

root@4234dd94454eea3482547042885bb387 [ ~ ]# k -n adi-ns get pods
NAME         READY   STATUS    RESTARTS   AGE
web-0        1/1     Running   0          53s
web-1        1/1     Running   0          53s
web-2        1/1     Running   0          52s


root@4234dd94454eea3482547042885bb387 [ ~ ]# k -n adi-ns scale sts web --replicas=12
statefulset.apps/web scaled

root@4234dd94454eea3482547042885bb387 [ ~ ]# k -n adi-ns get sts
NAME   READY   AGE
web    12/12   2m42s

root@4234dd94454eea3482547042885bb387 [ ~ ]# k -n adi-ns get pods
NAME         READY   STATUS    RESTARTS   AGE
web-0        1/1     Running   0          2m45s
web-1        1/1     Running   0          2m45s
web-10       1/1     Running   0          97s
web-11       1/1     Running   0          96s
web-2        1/1     Running   0          2m44s
web-3        1/1     Running   0          98s
web-4        1/1     Running   0          98s
web-5        1/1     Running   0          97s
web-6        1/1     Running   0          97s
web-7        1/1     Running   0          97s
web-8        1/1     Running   0          97s
web-9        1/1     Running   0          97s


root@4234dd94454eea3482547042885bb387 [ ~ ]# k -n adi-ns scale sts web --replicas=0
statefulset.apps/web scaled

root@4234dd94454eea3482547042885bb387 [ ~ ]# k -n adi-ns get pods
No resources found in adi-ns namespace.
```

### Testing for 1.22 and 1.23

Pre-check-in tests have been run for 1.22 and 1.23. Please refer #1875 for the job comments. 
For 1.22, please refer to # 27 (12 passed), 29 (1 passed) and 10 (1 passed) for the pre-checkin pipeline jobs. 
For 1.23, please refer to # 595

**Special notes for your reviewer**:

Note: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1875 was reverted with https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1975 as testing for the 1.24 environment was not correct.
This PR is identical to https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1875. Testing for 1.22 and 1.23 was done correctly for https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1875 and is not being done again here. Test results for 1.24 will be added.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add cns-csi.yaml for 1.24. Updates sidecar versions for 1.22, 1.23 and 1.24 cns-csi.yaml. 
```
