### PR TITLE
[cherry pick 1971 to release 2.5] fix node discovery when nodes are not upgraded (#1971)

### DIFF
--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"sync"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 
 	clientset "k8s.io/client-go/kubernetes"
@@ -47,6 +49,8 @@ type Manager interface {
 	// scans all virtual centers registered on the VirtualCenterManager for a
 	// virtual machine with the given UUID.
 	DiscoverNode(ctx context.Context, nodeUUID string) error
+	// GetK8sNode returns Kubernetes Node object for the given node name
+	GetK8sNode(ctx context.Context, nodename string) (*v1.Node, error)
 	// GetNode refreshes and returns the VirtualMachine for a registered node
 	// given its UUID. If datacenter is present, GetNode will search within this
 	// datacenter given its UUID. If not, it will search in all registered
@@ -116,14 +120,15 @@ func (m *defaultManager) SetUseNodeUuid(useNodeUuid bool) {
 // RegisterNode registers a node with node manager using its UUID, name.
 func (m *defaultManager) RegisterNode(ctx context.Context, nodeUUID string, nodeName string) error {
 	log := logger.GetLogger(ctx)
-	m.nodeNameToUUID.Store(nodeName, nodeUUID)
-	log.Infof("Successfully registered node: %q with nodeUUID %q", nodeName, nodeUUID)
+	log.Infof("Discovering node vm using uuid: %q", nodeUUID)
 	err := m.DiscoverNode(ctx, nodeUUID)
 	if err != nil {
 		log.Errorf("failed to discover VM with uuid: %q for node: %q", nodeUUID, nodeName)
 		return err
 	}
 	log.Infof("Successfully discovered node: %q with nodeUUID %q", nodeName, nodeUUID)
+	m.nodeNameToUUID.Store(nodeName, nodeUUID)
+	log.Infof("Successfully registered node: %q with nodeUUID %q", nodeName, nodeUUID)
 	return nil
 }
 
@@ -182,6 +187,16 @@ func (m *defaultManager) GetNodeNameByUUID(ctx context.Context, nodeUUID string)
 		return "", logger.LogNewErrorf(log, "failed to find node name for node with UUID: %q", nodeUUID)
 	}
 	return nodeName, nil
+}
+
+// GetK8sNode returns Kubernetes Node object for the given node name
+func (m *defaultManager) GetK8sNode(ctx context.Context, nodename string) (*v1.Node, error) {
+	log := logger.GetLogger(ctx)
+	node, err := m.k8sClient.CoreV1().Nodes().Get(ctx, nodename, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("failed to obtain node for nodename:%q", nodename)
+	}
+	return node, err
 }
 
 // GetNode refreshes and returns the VirtualMachine for a registered node

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1077,11 +1077,18 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 						"failed to set keepAfterDeleteVm control flag for VolumeID %q", req.VolumeId)
 				}
 			}
-			var node *cnsvsphere.VirtualMachine
+			var nodevm *cnsvsphere.VirtualMachine
 			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
-				node, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
+				// if node is not yet updated to run the release of the driver publishing Node VM UUID as Node ID
+				// look up Node by name
+				nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+				if err == node.ErrNodeNotFound {
+					log.Infof("Performing node VM lookup using node VM UUID: %q", req.NodeId)
+					nodevm, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
+				}
+
 			} else {
-				node, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+				nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
 			}
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
@@ -1089,7 +1096,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 			}
 			log.Debugf("Found VirtualMachine for node:%q.", req.NodeId)
 			// faultType is returned from manager.AttachVolume.
-			diskUUID, faultType, err := common.AttachVolumeUtil(ctx, c.manager, node, req.VolumeId, false)
+			diskUUID, faultType, err := common.AttachVolumeUtil(ctx, c.manager, nodevm, req.VolumeId, false)
 			if err != nil {
 				return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to attach disk: %+q with node: %q err %+v", req.VolumeId, req.NodeId, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Please see https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1971 for more details.
This is required for TKGi platform to allow upgrading CSI driver to version which makes use of 1use-csinode-id` feature.



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix node discovery when nodes are not upgraded
```
