### PR TITLE
Add env variable to accept SHA1 certificates with Go1.18+

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -344,6 +344,8 @@ spec:
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
+            - name: GODEBUG
+              value: x509sha1=1
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -464,6 +466,8 @@ spec:
               value: "true"
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: GODEBUG
+              value: x509sha1=1
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We switched to using Go1.18 for building CSI driver and syncer images but 1.18 rejects certificates signed using SHA-1 algorithm by default - https://tip.golang.org/doc/go1.18#sha1.
While vCenter can still support replacement of SSL certs which has SHA1 (Default VC certificate issued by VMCA uses sha256 though).

If we deploy CSI driver on a vCenter with sha1 certificates, it doesn't come up and fails with error.

We have made a similar change for WCP also - #1903 



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add env variable to accept SHA1 certificates with Go1.18+
```
