### PR TITLE
Remove redundant topology related code and enable improved-volume-topology FSS by default

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -148,7 +148,6 @@ data:
   "trigger-csi-fullsync": "false"
   "async-query-volume": "true"
   "improved-csi-idempotency": "true"
-  "improved-volume-topology": "true"
   "block-volume-snapshot": "true"
   "csi-windows-support": "false"
   "use-csinode-id": "true"

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -352,10 +352,6 @@ const (
 	// CSIVolumeManagerIdempotency is the feature flag for idempotency handling
 	// in CSI volume manager.
 	CSIVolumeManagerIdempotency = "improved-csi-idempotency"
-	// ImprovedVolumeTopology is the feature flag used to make the following
-	// improvements to topology feature:
-	// 1. Avoid taking in VC credentials in node daemonset.
-	ImprovedVolumeTopology = "improved-volume-topology"
 	// BlockVolumeSnapshot is the feature to support CSI Snapshots for block
 	// volume on vSphere CSI driver.
 	BlockVolumeSnapshot = "block-volume-snapshot"

--- a/pkg/csi/service/driver.go
+++ b/pkg/csi/service/driver.go
@@ -47,7 +47,6 @@ var (
 	// CO agnostic orchestrator for the controller as well as node containers.
 	COInitParams  interface{}
 	clusterFlavor = defaultClusterFlavor
-	cfgPath       = cnsconfig.DefaultCloudConfigPath
 )
 
 // Driver is a CSI SP and idempotency.Provider.

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -25,9 +25,7 @@ import (
 	"github.com/vmware/govmomi/units"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
-	v1 "k8s.io/api/core/v1"
 
-	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco"
@@ -419,42 +417,16 @@ func (driver *vsphereCSIDriver) NodeGetInfo(
 		}
 		accessibleTopology, err = topologyService.GetNodeTopologyLabels(ctx, &nodeInfo)
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ImprovedVolumeTopology) {
-			// Initialize volume topology service.
-			if err = initVolumeTopologyService(ctx); err != nil {
-				return nil, err
-			}
-			// Fetch topology labels for given node.
-			nodeInfo := commoncotypes.NodeInfo{
-				NodeName: nodeName,
-				NodeID:   nodeID,
-			}
-			accessibleTopology, err = topologyService.GetNodeTopologyLabels(ctx, &nodeInfo)
-		} else {
-			// If ImprovedVolumeTopology is not enabled, use the VC credentials to
-			// fetch node topology information.
-			var cfg *cnsconfig.Config
-			cfgPath = os.Getenv(cnsconfig.EnvVSphereCSIConfig)
-			if cfgPath == "" {
-				cfgPath = cnsconfig.DefaultCloudConfigPath
-			}
-			cfg, err = cnsconfig.GetCnsconfig(ctx, cfgPath)
-			if err != nil {
-				if os.IsNotExist(err) {
-					log.Infof("Config file not provided to node daemonset. Assuming non-topology aware cluster.")
-					nodeInfoResponse = &csi.NodeGetInfoResponse{
-						NodeId:            nodeID,
-						MaxVolumesPerNode: maxVolumesPerNode,
-					}
-					log.Infof("NodeGetInfo response: %v", nodeInfoResponse)
-					return nodeInfoResponse, nil
-				}
-				return nil, logger.LogNewErrorCodef(log, codes.Internal,
-					"failed to read CNS config. Error: %v", err)
-			}
-			// Fetch topology labels using VC TagManager.
-			accessibleTopology, err = driver.fetchTopologyLabelsUsingVCCreds(ctx, nodeID, cfg)
+		// Initialize volume topology service.
+		if err = initVolumeTopologyService(ctx); err != nil {
+			return nil, err
 		}
+		// Fetch topology labels for given node.
+		nodeInfo := commoncotypes.NodeInfo{
+			NodeName: nodeName,
+			NodeID:   nodeID,
+		}
+		accessibleTopology, err = topologyService.GetNodeTopologyLabels(ctx, &nodeInfo)
 	}
 
 	if err != nil {
@@ -490,98 +462,6 @@ func initVolumeTopologyService(ctx context.Context) error {
 			"failed to init topology service. Error: %+v", err)
 	}
 	return nil
-}
-
-// fetchTopologyLabelsUsingVCCreds retrieves topology information of the nodes
-// using VC credentials mounted on the nodes. This approach will be deprecated
-// soon.
-func (driver *vsphereCSIDriver) fetchTopologyLabelsUsingVCCreds(
-	ctx context.Context, nodeID string, cfg *cnsconfig.Config) (
-	map[string]string, error) {
-	log := logger.GetLogger(ctx)
-
-	// If zone or region are empty, return.
-	if cfg.Labels.Zone == "" || cfg.Labels.Region == "" {
-		return nil, nil
-	}
-
-	log.Infof("Config file provided to node daemonset contains zone and region info. " +
-		"Assuming topology aware cluster.")
-	vcenterconfig, err := cnsvsphere.GetVirtualCenterConfig(ctx, cfg)
-	if err != nil {
-		return nil, logger.LogNewErrorCodef(log, codes.Internal,
-			"failed to get VirtualCenterConfig from cns config. err: %v", err)
-	}
-	vcManager := cnsvsphere.GetVirtualCenterManager(ctx)
-	vcenter, err := vcManager.RegisterVirtualCenter(ctx, vcenterconfig)
-	if err != nil {
-		return nil, logger.LogNewErrorCodef(log, codes.Internal,
-			"failed to register vcenter with virtualCenterManager. err: %v", err)
-	}
-	defer func() {
-		if vcManager != nil {
-			err = vcManager.UnregisterAllVirtualCenters(ctx)
-			if err != nil {
-				log.Errorf("UnregisterAllVirtualCenters failed. err: %v", err)
-			}
-		}
-	}()
-
-	// Connect to vCenter.
-	err = vcenter.Connect(ctx)
-	if err != nil {
-		return nil, logger.LogNewErrorCodef(log, codes.Internal,
-			"failed to connect to vcenter host: %s. err: %v", vcenter.Config.Host, err)
-	}
-	// Get VM UUID.
-	uuid, err := driver.osUtils.GetSystemUUID(ctx)
-	if err != nil {
-		return nil, logger.LogNewErrorCodef(log, codes.Internal,
-			"failed to get system uuid for node VM. err: %v", err)
-	}
-	log.Debugf("Successfully retrieved uuid:%s  from the node: %s", uuid, nodeID)
-	nodeVM, err := cnsvsphere.GetVirtualMachineByUUID(ctx, uuid, false)
-	if err != nil || nodeVM == nil {
-		log.Errorf("failed to get nodeVM for uuid: %s. err: %+v", uuid, err)
-		uuid, err = driver.osUtils.ConvertUUID(uuid)
-		if err != nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
-				"convertUUID failed with error: %v", err)
-		}
-		nodeVM, err = cnsvsphere.GetVirtualMachineByUUID(ctx, uuid, false)
-		if err != nil || nodeVM == nil {
-			return nil, logger.LogNewErrorCodef(log, codes.Internal,
-				"failed to get nodeVM for uuid: %s. err: %+v", uuid, err)
-		}
-	}
-	// Get a tag manager instance.
-	tagManager, err := cnsvsphere.GetTagManager(ctx, vcenter)
-	if err != nil {
-		return nil, logger.LogNewErrorCodef(log, codes.Internal,
-			"failed to create tagManager. err: %v", err)
-	}
-	defer func() {
-		err := tagManager.Logout(ctx)
-		if err != nil {
-			log.Errorf("failed to logout tagManager. err: %v", err)
-		}
-	}()
-
-	// Fetch zone and region for given node.
-	zone, region, err := nodeVM.GetZoneRegion(ctx, cfg.Labels.Zone, cfg.Labels.Region, tagManager)
-	if err != nil {
-		return nil, logger.LogNewErrorCodef(log, codes.Internal,
-			"failed to get accessibleTopology for vm: %v, err: %v", nodeVM.Reference(), err)
-	}
-	log.Debugf("zone: [%s], region: [%s], Node VM: [%s]", zone, region, nodeID)
-
-	if zone != "" && region != "" {
-		accessibleTopology := make(map[string]string)
-		accessibleTopology[v1.LabelZoneRegion] = region
-		accessibleTopology[v1.LabelZoneFailureDomain] = zone
-		return accessibleTopology, nil
-	}
-	return nil, nil
 }
 
 func (driver *vsphereCSIDriver) NodeExpandVolume(

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -83,13 +83,6 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		return err
 	}
 
-	if clusterFlavor == cnstypes.CnsClusterFlavorVanilla &&
-		!coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeTopology) {
-		log.Infof("Not initializing the CSINodetopology Controller as %s FSS is disabled in %s",
-			common.ImprovedVolumeTopology, cnstypes.CnsClusterFlavorVanilla)
-		return nil
-	}
-
 	if clusterFlavor == cnstypes.CnsClusterFlavorGuest && !coCommonInterface.IsFSSEnabled(ctx, common.TKGsHA) {
 		log.Infof("Not initializing the CSINodetopology Controller as %s FSS is disabled in %s",
 			common.TKGsHA, cnstypes.CnsClusterFlavorGuest)

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -182,26 +182,24 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			}()
 		}
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-		if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.ImprovedVolumeTopology) {
-			// Create CSINodeTopology CRD.
-			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, csinodetopologyconfig.EmbedCSINodeTopologyFile,
-				csinodetopologyconfig.EmbedCSINodeTopologyFileName)
-			if err != nil {
-				log.Errorf("Failed to create %q CRD. Error: %+v", csinodetopology.CRDSingular, err)
-				return err
-			}
-			// Initialize node manager so that CSINodeTopology controller can
-			// retrieve NodeVM using the NodeID in the spec.
-			useNodeUuid := false
-			if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.UseCSINodeId) {
-				useNodeUuid = true
-			}
-			nodeMgr := &node.Nodes{}
-			err = nodeMgr.Initialize(ctx, useNodeUuid)
-			if err != nil {
-				log.Errorf("failed to initialize nodeManager. Error: %+v", err)
-				return err
-			}
+		// Create CSINodeTopology CRD.
+		err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, csinodetopologyconfig.EmbedCSINodeTopologyFile,
+			csinodetopologyconfig.EmbedCSINodeTopologyFileName)
+		if err != nil {
+			log.Errorf("Failed to create %q CRD. Error: %+v", csinodetopology.CRDSingular, err)
+			return err
+		}
+		// Initialize node manager so that CSINodeTopology controller can
+		// retrieve NodeVM using the NodeID in the spec.
+		useNodeUuid := false
+		if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.UseCSINodeId) {
+			useNodeUuid = true
+		}
+		nodeMgr := &node.Nodes{}
+		err = nodeMgr.Initialize(ctx, useNodeUuid)
+		if err != nil {
+			log.Errorf("failed to initialize nodeManager. Error: %+v", err)
+			return err
 		}
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.TKGsHA) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cleans up redundant code for topology feature, that represents topology implementation with improved-volume-topology FSS disabled. 
improved-volume-topology FSS was set to true, by default, since CSI 2.4 release and has been stable now.
Hence we need to enable improved-volume-topology FSS functionality by default from CSI 2.8 release and remove the old topology implementation (that executes when improved-volume-topology FSS is disabled) as well as the associated FSS option here.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Manually tested volume provisioning and pod deployment on topology testbeds, using latest as well as old topology labels, with the improved-volume-topology FSS enabled by default.

- Logs for CSI vanilla setup with old-style topology labels:

```
Vsphere CSI secret deployed:

[Global]
cluster-id = "XYZ"
cluster-distribution = "CSI-Vanilla"
[VirtualCenter "x.y.z.w"]
insecure-flag = "true"
user = "user1"
password = "XXX"
port = "1234"
datacenters = "DC-1"
[Labels]
region = "region-1"
zone = "zone-1"

PVC provisioned and POD deployment done:

# kubectl get pvc
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
example-raw-block-pvc   Bound    pvc-467c8257-5c7f-44d5-9aa6-8adac5222cd2   1Gi        RWO            example-raw-block-sc   83m

# kubectl get pods
NAME                    READY   STATUS    RESTARTS   AGE
example-raw-block-pod   1/1     Running   0          6m23s

```

- Logs for CSI vanilla setup with new-style topology labels:

```
Vsphere config secret deployed :

[Global]
cluster-id = "XYZ"
cluster-distribution = "CSI-Vanilla"
[VirtualCenter "x.y.z.w"]
insecure-flag = "true"
user = "user1"
password = "XXX"
port = "1234"
datacenters = "DC-1"
[Snapshot]
global-max-snapshots-per-block-volume = X
[Labels]
topology-categories="k8s-region, k8s-zone, k8s-building, k8s-level, k8s-rack"

PVC provisioned and POD deployment done:

# kubectl get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             AGE
example-raw-block-pvc-2   Bound    pvc-38cbe555-fe19-41d4-b71e-39ec26432592   1Gi        RWO            example-raw-block-sc-2   10m

# kubectl get pods
NAME                    READY   STATUS    RESTARTS   AGE
example-raw-block-pod   1/1     Running   0          8m51s
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Remove redundant topology related code and enable improved-volume-topology FSS by default
```
