### PR TITLE
fix GetSystemUUID to return correct VM UUID for Windows Nodes

### DIFF
--- a/pkg/csi/service/osutils/windows_os_utils.go
+++ b/pkg/csi/service/osutils/windows_os_utils.go
@@ -429,10 +429,19 @@ func (osUtils *OsUtils) GetSystemUUID(ctx context.Context) (string, error) {
 		return "", err
 	}
 	log.Infof("Bios serial number: %s", sn)
-	return sn, nil
+	// Here Bios Serial Number has this format - VMware-42 29 92 4b 83 35 d9 77-f3 82 cf 46 56 61 ac 60
+	// We need to convert it to VM UUID - 4229924b-8335-d977-f382-cf465661ac60 which can be used to
+	// look up Node VM in the vCenter inventory
+	uuid, err := osUtils.ConvertUUID(sn)
+	if err != nil {
+		log.Errorf("failed to convert Bios serial number to VM UUID. err: %v", err)
+		return "", err
+	}
+	log.Infof("Node VM UUID: %s", uuid)
+	return uuid, nil
 }
 
-// convertUUID helps convert UUID to vSphere format, for example,
+// ConvertUUID helps convert UUID to vSphere format, for example,
 // Input uuid:    VMware-42 02 e9 7e 3d ad 2a 49-22 86 7f f9 89 c6 64 ef
 // Returned uuid: 4202e97e-3dad-2a49-2286-7ff989c664ef
 func (osUtils *OsUtils) ConvertUUID(uuid string) (string, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is fixing GetSystemUUID to return correct VM UUID for Windows Nodes.
Without this fix, windows Node Daemonsets Pods are crashing with the following error.

```
2022-09-23T13:04:43.254-0700	INFO	osutils/windows_os_utils.go:431	Bios serial number: VMware-42 29 92 4b 83 35 d9 77-f3 82 cf 46 56 61 ac 60  	{"TraceId": "467c3048-c841-4173-8723-4eae01ff88b7"}
2022-09-23T13:04:43.254-0700	INFO	service/node.go:383	NodeGetInfo: MAX_VOLUMES_PER_NODE is set to 0	{"TraceId": "467c3048-c841-4173-8723-4eae01ff88b7"}
2022-09-23T13:04:43.255-0700	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config	{"TraceId": "467c3048-c841-4173-8723-4eae01ff88b7"}
2022-09-23T13:04:43.255-0700	INFO	kubernetes/kubernetes.go:389	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "467c3048-c841-4173-8723-4eae01ff88b7"}
2022-09-23T13:04:43.255-0700	INFO	kubernetes/kubernetes.go:85	k8s client using in-cluster config	{"TraceId": "467c3048-c841-4173-8723-4eae01ff88b7"}
2022-09-23T13:04:43.257-0700	INFO	kubernetes/kubernetes.go:389	Setting client QPS to 100.000000 and Burst to 100.	{"TraceId": "467c3048-c841-4173-8723-4eae01ff88b7"}
2022-09-23T13:04:43.324-0700	INFO	k8sorchestrator/topology.go:661	Topology service initiated successfully	{"TraceId": "467c3048-c841-4173-8723-4eae01ff88b7"}
2022-09-23T13:04:43.353-0700	INFO	k8sorchestrator/topology.go:827	Successfully created a CSINodeTopology instance for NodeName: "tkg-vc-antrea-md-0-windows-containerd-5c7888d6bc-85d9n"	{"TraceId": "467c3048-c841-4173-8723-4eae01ff88b7"}
2022-09-23T13:04:43.353-0700	INFO	k8sorchestrator/topology.go:852	Timeout is set to 1 minute(s)	{"TraceId": "467c3048-c841-4173-8723-4eae01ff88b7"}
2022-09-23T13:04:43.401-0700	ERROR	k8sorchestrator/topology.go:763	failed to retrieve topology information for Node: "tkg-vc-antrea-md-0-windows-containerd-5c7888d6bc-85d9n". Error: "failed to retrieve nodeVM \"VMware-42 29 92 4b 83 35 d9 77-f3 82 cf 46 56 61 ac 60  \" using the node manager. Error: virtual machine wasn't found"	{"TraceId": "467c3048-c841-4173-8723-4eae01ff88b7"}
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator.(*nodeVolumeTopology).GetNodeTopologyLabels
 /build/pkg/csi/service/common/commonco/k8sorchestrator/topology.go:763
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service.(*vsphereCSIDriver).NodeGetInfo
 /build/pkg/csi/service/node.go:432
github.com/container-storage-interface/spec/lib/go/csi._Node_NodeGetInfo_Handler
 /go/pkg/mod/github.com/container-storage-interface/[spec@v1.5.0](mailto:spec@v1.5.0)/lib/go/csi/csi.pb.go:6229
google.golang.org/grpc.(*Server).processUnaryRPC
 /go/pkg/mod/google.golang.org/[grpc@v1.40.0](mailto:grpc@v1.40.0)/server.go:1297
google.golang.org/grpc.(*Server).handleStream
 /go/pkg/mod/google.golang.org/[grpc@v1.40.0](mailto:grpc@v1.40.0)/server.go:1626
google.golang.org/grpc.(*Server).serveStreams.func1.2
 /go/pkg/mod/google.golang.org/[grpc@v1.40.0](mailto:grpc@v1.40.0)/server.go:941
```

```
# kubectl get pods --namespace=vmware-system-csi
NAME                                      READY   STATUS             RESTARTS       AGE
vsphere-csi-controller-78fc759cb6-78vgd   7/7     Running            13 (13h ago)   3d1h
vsphere-csi-controller-78fc759cb6-l99bg   7/7     Running            18 (21h ago)   3d1h
vsphere-csi-controller-78fc759cb6-nl4mg   7/7     Running            24 (21h ago)   3d1h
vsphere-csi-node-dr8mx                    3/3     Running            3 (3d1h ago)   3d1h
vsphere-csi-node-g5n29                    3/3     Running            2 (21h ago)    3d1h
vsphere-csi-node-kzzqb                    3/3     Running            2 (3d1h ago)   3d1h
vsphere-csi-node-windows-7wv2f            2/3     CrashLoopBackOff   6 (90s ago)    5m24s
vsphere-csi-node-windows-q2vz5            2/3     CrashLoopBackOff   7 (85s ago)    12m
vsphere-csi-node-windows-smtrm            2/3     CrashLoopBackOff   8 (20s ago)    12m
```

```
Name:         tkg-vc-antrea-md-0-windows-containerd-5c7888d6bc-85d9n
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-09-23T20:04:41Z
  Generation:          2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"1dad2eee-be89-489f-b547-eb62e7bb271e"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:      csi.exe
    Operation:    Update
    Time:         2022-09-23T20:04:41Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:errorMessage:
        f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2022-09-23T20:04:41Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            tkg-vc-antrea-md-0-windows-containerd-5c7888d6bc-85d9n
    UID:             1dad2eee-be89-489f-b547-eb62e7bb271e
  Resource Version:  1293746
  UID:               4579661b-f69a-4de0-9a04-0922f37b558a
Spec:
  Node ID:   tkg-vc-antrea-md-0-windows-containerd-5c7888d6bc-85d9n
  Nodeuuid:  VMware-42 29 92 4b 83 35 d9 77-f3 82 cf 46 56 61 ac 60  
Status:
  Error Message:  failed to retrieve nodeVM "VMware-42 29 92 4b 83 35 d9 77-f3 82 cf 46 56 61 ac 60  " using the node manager. Error: virtual machine wasn't found
  Status:         Error
Events:
  Type     Reason                   Age    From            Message
  ----     ------                   ----   ----            -------
  Warning  TopologyRetrievalFailed  5m12s  cns.vmware.com  failed to retrieve nodeVM "VMware-42 29 92 4b 83 35 d9 77-f3 82 cf 46 56 61 ac 60  " using the node manager. Error: virtual machine wasn't found
```


**Testing done**:
After the fix, windows Node Daemonsets Pods are no longer crashing and Windows nodes are getting discovered properly.

```
# kubectl get pods --namespace=vmware-system-csi
NAME                                      READY   STATUS    RESTARTS       AGE
vsphere-csi-controller-78fc759cb6-78vgd   7/7     Running   13 (15h ago)   3d2h
vsphere-csi-controller-78fc759cb6-l99bg   7/7     Running   18 (23h ago)   3d2h
vsphere-csi-controller-78fc759cb6-nl4mg   7/7     Running   24 (23h ago)   3d2h
vsphere-csi-node-dr8mx                    3/3     Running   3 (3d2h ago)   3d2h
vsphere-csi-node-g5n29                    3/3     Running   2 (23h ago)    3d2h
vsphere-csi-node-kzzqb                    3/3     Running   2 (3d2h ago)   3d2h
vsphere-csi-node-windows-dxcsq            3/3     Running   0              14m
vsphere-csi-node-windows-mfmtf            3/3     Running   0              14m
vsphere-csi-node-windows-zx76n            3/3     Running   0              12m
```

```
# kubectl describe csinodetopologies tkg-vc-antrea-md-0-windows-containerd-5c7888d6bc-85d9n
Name:         tkg-vc-antrea-md-0-windows-containerd-5c7888d6bc-85d9n
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CSINodeTopology
Metadata:
  Creation Timestamp:  2022-09-23T21:24:23Z
  Generation:          2
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:ownerReferences:
          .:
          k:{"uid":"1dad2eee-be89-489f-b547-eb62e7bb271e"}:
      f:spec:
        .:
        f:nodeID:
        f:nodeuuid:
      f:status:
    Manager:      csi.exe
    Operation:    Update
    Time:         2022-09-23T21:24:23Z
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:status:
    Manager:    vsphere-syncer
    Operation:  Update
    Time:       2022-09-23T21:24:23Z
  Owner References:
    API Version:     v1
    Kind:            Node
    Name:            tkg-vc-antrea-md-0-windows-containerd-5c7888d6bc-85d9n
    UID:             1dad2eee-be89-489f-b547-eb62e7bb271e
  Resource Version:  1313374
  UID:               2abf091d-2752-4ed2-8a40-87a4145f12fb
Spec:
  Node ID:   tkg-vc-antrea-md-0-windows-containerd-5c7888d6bc-85d9n
  Nodeuuid:  4229924b-8335-d977-f382-cf465661ac60
Status:
  Status:  Success
Events:
  Type    Reason                      Age    From            Message
  ----    ------                      ----   ----            -------
  Normal  TopologyRetrievalSucceeded  2m36s  cns.vmware.com  Not a topology aware cluster.
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix GetSystemUUID to return correct VM UUID for Windows Nodes
```
