### PR TITLE
Upgrade CSI Provisioner Attacher Resizer & Snapshotter sidecars

### DIFF
--- a/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
+++ b/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
@@ -55,7 +55,7 @@ spec:
     spec:
       containers:
         - name: snapshot-validation
-          image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.0.1 # change the image if you wish to use your own custom validation server image
+          image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.1.0 # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/run/secrets/tls/tls.crt', '--tls-private-key-file=/run/secrets/tls/tls.key']
           ports:

--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -59,7 +59,7 @@ else
         exit 1
 fi
 
-qualified_version="v6.0.1"
+qualified_version="v6.1.0"
 volumesnapshotclasses_crd="volumesnapshotclasses.snapshot.storage.k8s.io"
 volumesnapshotcontents_crd="volumesnapshotcontents.snapshot.storage.k8s.io"
 volumesnapshots_crd="volumesnapshots.snapshot.storage.k8s.io"
@@ -161,9 +161,6 @@ deploy_snapshot_controller(){
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/"${qualified_version}"/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml 2>/dev/null || true
 	echo -e "✅ Created  RBACs for snapshot-controller"
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/"${qualified_version}"/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml 2>/dev/null || true
-	# The released yaml for v6.0.1 does not have v6.0.1 image for snapshot-controller, explicitly updating it.
-	snapshot_controller_image="gcr.io/k8s-staging-sig-storage/snapshot-controller:"${qualified_version}
-	kubectl -n kube-system set image deployment/snapshot-controller snapshot-controller=$snapshot_controller_image
 	kubectl patch deployment -n kube-system snapshot-controller --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/control-plane": ""}, "tolerations": [{"key":"node-role.kubernetes.io/master","operator":"Exists", "effect":"NoSchedule"},{"key":"node-role.kubernetes.io/control-plane","operator":"Exists", "effect":"NoSchedule"}]}}}}'
 	kubectl patch deployment -n kube-system snapshot-controller --type=json \
 	-p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-qps=100"},{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-burst=100"}]'

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -374,7 +374,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0
           args:
             - "--v=4"
             - "--kube-api-qps=100"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -355,7 +355,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -236,7 +236,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v4.0.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -251,7 +251,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR updates csi-provisioner to 3.3.0, csi-attacher to 4.0, csi-resizer to 1.6.0 & csi-snapshotter to 6.1.0
For more details, refer https://github.com/kubernetes-csi/external-attacher/blob/release-4.0/CHANGELOG/CHANGELOG-4.0.md & https://github.com/kubernetes-csi/external-resizer/blob/release-1.6/CHANGELOG/CHANGELOG-1.6.md, https://github.com/kubernetes-csi/external-provisioner/blob/v3.3.0/CHANGELOG/CHANGELOG-3.3.md & https://github.com/kubernetes-csi/external-snapshotter/blob/v6.1.0/CHANGELOG/CHANGELOG-6.1.md

Making additional changes in snapshot-components deploy script as the https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v6.1.0/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml file now contains the correct snapshotter image.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
e2e Pipeline results: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1999#issuecomment-1256847412

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Upgrade csi-provisioner to 3.3.0, csi-attacher to 4.0 & csi-resizer to 1.6.0
```
