### PR TITLE
Add priority class for vsphere csi driver deployment and daemon set

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -203,6 +203,7 @@ spec:
         app: vsphere-csi-controller
         role: vsphere-csi
     spec:
+      priorityClassName: system-cluster-critical # Guarantees scheduling for critical system pods
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -236,7 +237,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v4.0.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -251,7 +252,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -414,6 +415,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      priorityClassName: system-node-critical
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: vsphere-csi-node
@@ -562,6 +564,7 @@ spec:
         app: vsphere-csi-node-windows
         role: vsphere-csi-windows
     spec:
+      priorityClassName: system-node-critical
       nodeSelector:
         kubernetes.io/os: windows
       serviceAccountName: vsphere-csi-node

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -237,7 +237,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v4.0.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -252,7 +252,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds priority class for vsphere csi driver deployment and daemon set to guarantee scheduling for critical system pods.
Note that marking a pod as critical is not meant to prevent evictions entirely; it only prevents the pod from becoming permanently unavailable

`system-node-critical`: This class has a value of 2000001000. Pods like etcd, kube-apiserver, and Controller manager use this priority class.
- We will use this class for NodeDaemonSet pods as it is run in all the worker node vms

`system-cluster-critical`: This class has a value of 2000000000. Add-on Pods like coredns, calico controller, metrics server, etc use this Priority class
- We will use this class for CSI Driver Deployment pods


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
e2e Pipeline results: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2000#issuecomment-1256899835
Observed 8 failures, not related to this PR. Will re-run the failed tests

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add priority class for vsphere csi driver deployment and daemon set
```
