### PR TITLE
Cherry-pick windows support fixes from #1996 and #1998

### DIFF
--- a/hack/check-golangci-lint.sh
+++ b/hack/check-golangci-lint.sh
@@ -53,8 +53,8 @@ shift $((OPTIND-1))
 
 export GOOS=linux
 if [ ! "${DO_DOCKER-}" ]; then
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.40.1
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.49.0
   "$(go env GOPATH)"/bin/golangci-lint run -v --timeout=1200s
 else
-  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v1.40.1 golangci-lint run -v --timeout=1200s
+  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v1.49.0 golangci-lint run -v --timeout=1200s
 fi

--- a/pkg/csi/service/osutils/windows_os_utils.go
+++ b/pkg/csi/service/osutils/windows_os_utils.go
@@ -429,10 +429,19 @@ func (osUtils *OsUtils) GetSystemUUID(ctx context.Context) (string, error) {
 		return "", err
 	}
 	log.Infof("Bios serial number: %s", sn)
-	return sn, nil
+	// Here Bios Serial Number has this format - VMware-42 29 92 4b 83 35 d9 77-f3 82 cf 46 56 61 ac 60
+	// We need to convert it to VM UUID - 4229924b-8335-d977-f382-cf465661ac60 which can be used to
+	// look up Node VM in the vCenter inventory
+	uuid, err := osUtils.ConvertUUID(sn)
+	if err != nil {
+		log.Errorf("failed to convert Bios serial number to VM UUID. err: %v", err)
+		return "", err
+	}
+	log.Infof("Node VM UUID: %s", uuid)
+	return uuid, nil
 }
 
-// convertUUID helps convert UUID to vSphere format, for example,
+// ConvertUUID helps convert UUID to vSphere format, for example,
 // Input uuid:    VMware-42 02 e9 7e 3d ad 2a 49-22 86 7f f9 89 c6 64 ef
 // Returned uuid: 4202e97e-3dad-2a49-2286-7ff989c664ef
 func (osUtils *OsUtils) ConvertUUID(uuid string) (string, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Cherry-pick windows support fixes from #1996 and #1998

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

```
root [ /home/capv ]# k get po -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS        AGE
vsphere-csi-controller-78fc759cb6-hv4wf   7/7     Running   21 (15m ago)    2d20h
vsphere-csi-controller-78fc759cb6-l99bg   7/7     Running   59 (15m ago)    6d23h
vsphere-csi-controller-78fc759cb6-nl4mg   7/7     Running   54 (15m ago)    6d23h
vsphere-csi-node-6v49r                    3/3     Running   1 (2d14h ago)   3d11h
vsphere-csi-node-vpmbj                    3/3     Running   4 (10h ago)     3d11h
vsphere-csi-node-windows-lknt6            3/3     Running   1 (17h ago)     17h
vsphere-csi-node-windows-qcxvh            3/3     Running   1 (17h ago)     17h
vsphere-csi-node-windows-x66xz            3/3     Running   1 (17h ago)     17h
vsphere-csi-node-zfr4t                    3/3     Running   2 (3d4h ago)    3d11h

root [ /home/capv ]# k  -n vmware-system-csi edit ds vsphere-csi-node-windows
daemonset.apps/vsphere-csi-node-windows edited


root [ /home/capv ]# k get po -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS        AGE
vsphere-csi-controller-78fc759cb6-hv4wf   7/7     Running   21 (18m ago)    2d20h
vsphere-csi-controller-78fc759cb6-l99bg   7/7     Running   59 (18m ago)    6d23h
vsphere-csi-controller-78fc759cb6-nl4mg   7/7     Running   54 (18m ago)    6d23h
vsphere-csi-node-6v49r                    3/3     Running   1 (2d14h ago)   3d11h
vsphere-csi-node-vpmbj                    3/3     Running   4 (10h ago)     3d11h
vsphere-csi-node-windows-f2jqv            3/3     Running   0               104s
vsphere-csi-node-windows-jjv6z            3/3     Running   0               82s
vsphere-csi-node-windows-ztlnk            3/3     Running   0               56s
vsphere-csi-node-zfr4t                    3/3     Running   2 (3d4h ago)    3d11h


root [ /home/capv ]# k get sts
NAME                          READY   AGE
statefulset-vspheredisk-win   1/1     3d20h
root [ /home/capv ]# k scale sts statefulset-vspheredisk-win --replicas=4
statefulset.apps/statefulset-vspheredisk-win scaled

root [ /home/capv ]# k get sts
NAME                          READY   AGE
statefulset-vspheredisk-win   4/4     3d20h


root [ /home/capv ]# k get po
NAME                            READY   STATUS    RESTARTS   AGE
statefulset-vspheredisk-win-0   1/1     Running   0          3d19h
statefulset-vspheredisk-win-1   1/1     Running   0          3m25s
statefulset-vspheredisk-win-2   1/1     Running   0          2m46s
statefulset-vspheredisk-win-3   1/1     Running   0          2m


root [ /home/capv ]# k scale sts statefulset-vspheredisk-win --replicas=1
statefulset.apps/statefulset-vspheredisk-win scaled

root [ /home/capv ]# k get sts
NAME                          READY   AGE
statefulset-vspheredisk-win   1/1     3d20h

root [ /home/capv ]# k get po
NAME                            READY   STATUS    RESTARTS   AGE
statefulset-vspheredisk-win-0   1/1     Running   0          3d19h

```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherry-pick windows support fixes from #1996 and #1998
```
