### PR TITLE
Cherrypick release-2.5: fix GetSystemUUID to return correct VM UUID for Windows Nodes (#1996)

### DIFF
--- a/hack/check-golangci-lint.sh
+++ b/hack/check-golangci-lint.sh
@@ -53,8 +53,8 @@ shift $((OPTIND-1))
 
 export GOOS=linux
 if [ ! "${DO_DOCKER-}" ]; then
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.40.1
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.49.0
   "$(go env GOPATH)"/bin/golangci-lint run -v --timeout=1200s
 else
-  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v1.40.1 golangci-lint run -v --timeout=1200s
+  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v1.49.0 golangci-lint run -v --timeout=1200s
 fi

--- a/pkg/csi/service/osutils/windows_os_utils.go
+++ b/pkg/csi/service/osutils/windows_os_utils.go
@@ -429,10 +429,19 @@ func (osUtils *OsUtils) GetSystemUUID(ctx context.Context) (string, error) {
 		return "", err
 	}
 	log.Infof("Bios serial number: %s", sn)
-	return sn, nil
+	// Here Bios Serial Number has this format - VMware-42 29 92 4b 83 35 d9 77-f3 82 cf 46 56 61 ac 60
+	// We need to convert it to VM UUID - 4229924b-8335-d977-f382-cf465661ac60 which can be used to
+	// look up Node VM in the vCenter inventory
+	uuid, err := osUtils.ConvertUUID(sn)
+	if err != nil {
+		log.Errorf("failed to convert Bios serial number to VM UUID. err: %v", err)
+		return "", err
+	}
+	log.Infof("Node VM UUID: %s", uuid)
+	return uuid, nil
 }
 
-// convertUUID helps convert UUID to vSphere format, for example,
+// ConvertUUID helps convert UUID to vSphere format, for example,
 // Input uuid:    VMware-42 02 e9 7e 3d ad 2a 49-22 86 7f f9 89 c6 64 ef
 // Returned uuid: 4202e97e-3dad-2a49-2286-7ff989c664ef
 func (osUtils *OsUtils) ConvertUUID(uuid string) (string, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Cherrypick: fix GetSystemUUID to return correct VM UUID for Windows Nodes (#1996)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: thanks to @divyenpatel 

Before patch
```
2022-09-27T12:27:50.180-0700	INFO	k8sorchestrator/topology.go:444	Successfully patched CSINodeTopology instance: "tkg-vc-antrea-md-0-windows-containerd-5c7888d6bc-pqt4x" with Uuid: "VMware-42 29 05 cc 11 a2 a2 b4-ee 4d c6 88 36 6c 1c 87  "	{"TraceId": "2eeea365-58f4-49c9-bc04-1a61b716a065"}
2022-09-27T12:27:50.180-0700	INFO	k8sorchestrator/topology.go:577	Timeout is set to 1 minute(s)	{"TraceId": "2eeea365-58f4-49c9-bc04-1a61b716a065"}
2022-09-27T12:27:50.188-0700	INFO	service/node.go:461	NodeGetInfo response: node_id:"VMware-42 29 05 cc 11 a2 a2 b4-ee 4d c6 88 36 6c 1c 87  " accessible_topology:<> 	{"TraceId": "2eeea365-58f4-49c9-bc04-1a61b716a065"}
```

After patch
```
2022-09-27T14:18:12.853-0700	INFO	service/node.go:334	NodeGetInfo: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "19dbc971-72d7-42a9-8382-148baef5a9b9"}
2022-09-27T14:18:13.213-0700	INFO	osutils/windows_os_utils.go:431	Bios serial number: VMware-42 29 92 4b 83 35 d9 77-f3 82 cf 46 56 61 ac 60  	{"TraceId": "19dbc971-72d7-42a9-8382-148baef5a9b9"}
2022-09-27T14:18:13.213-0700	INFO	osutils/windows_os_utils.go:440	Node VM UUID: 4229924b-8335-d977-f382-cf465661ac60	{"TraceId": "19dbc971-72d7-42a9-8382-148baef5a9b9"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherrypick release-2.5: fix GetSystemUUID to return correct VM UUID for Windows Nodes (#1996) 
```
