### PR TITLE
[cherry-pick 2.5] fall back to look up node by name (#1966)

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1208,11 +1208,17 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		}
 		// Block Volume.
 		volumeType = prometheus.PrometheusBlockVolumeType
-		var node *cnsvsphere.VirtualMachine
+		var nodevm *cnsvsphere.VirtualMachine
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
-			node, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
+			// if node is not yet updated to run the release of the driver publishing Node VM UUID as Node ID
+			// look up Node by name
+			nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+			if err == node.ErrNodeNotFound {
+				log.Infof("Performing node VM lookup using node VM UUID: %q", req.NodeId)
+				nodevm, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
+			}
 		} else {
-			node, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+			nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
 		}
 		if err != nil {
 			if err == cnsvsphere.ErrVMNotFound {
@@ -1224,7 +1230,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 					"failed to find VirtualMachine for node:%q. Error: %v", req.NodeId, err)
 			}
 		}
-		faultType, err = common.DetachVolumeUtil(ctx, c.manager, node, req.VolumeId)
+		faultType, err = common.DetachVolumeUtil(ctx, c.manager, nodevm, req.VolumeId)
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to detach disk: %+q from node: %q err %+v", req.VolumeId, req.NodeId, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry-pick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1966 to release-2.5 branch



**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fall back to look up node by name
```
