### PR TITLE
CSI vanilla controller Init changes for multi vCenter support

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -136,6 +136,11 @@ var (
 	// ErrInvalidNetPermission is returned when the value of Permission in
 	// NetPermissions is not among the ones listed.
 	ErrInvalidNetPermission = errors.New("invalid value for Permissions under NetPermission Config")
+
+	// ErrMissingTopologyCategoriesForMultiVCenterSetup is returned when the TopologyCategories are not specified for
+	// Multi vCenter deployment
+	ErrMissingTopologyCategoriesForMultiVCenterSetup = errors.New("vsphere CSI config requires " +
+		"topology-categories to be specified for multi vCenter deployment")
 )
 
 func getEnvKeyValue(match string, partial bool) (string, string, error) {
@@ -323,6 +328,10 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 	if len(cfg.Global.SupervisorID) > 64 {
 		log.Error(ErrSupervisorIDCharLimit)
 		return ErrSupervisorIDCharLimit
+	}
+	if len(cfg.VirtualCenter) > 1 && strings.TrimSpace(cfg.Labels.TopologyCategories) == "" {
+		log.Error(ErrMissingTopologyCategoriesForMultiVCenterSetup)
+		return ErrMissingTopologyCategoriesForMultiVCenterSetup
 	}
 	for vcServer, vcConfig := range cfg.VirtualCenter {
 		log.Debugf("Initializing vc server %s", vcServer)

--- a/pkg/csi/service/common/types.go
+++ b/pkg/csi/service/common/types.go
@@ -62,6 +62,19 @@ type Manager struct {
 	VcenterManager cnsvsphere.VirtualCenterManager
 }
 
+// Managers type comprises VirtualCenterConfigs, CnsConfig, VolumeManagers and VirtualCenterManager
+// If k8s cluster is deployed on single vCenter server VcenterConfigs and VolumeManagers will hold single entry
+// if k8s cluster is deployed on multi vCenter server, we will have VirtualCenterConfig and VolumeManagers for each
+// participating vCenter server.
+type Managers struct {
+	// map of VC Host to *VirtualCenterConfig
+	VcenterConfigs map[string]*cnsvsphere.VirtualCenterConfig
+	CnsConfig      *config.Config
+	// map of VC Host to Volume Manager
+	VolumeManagers map[string]cnsvolume.Manager
+	VcenterManager cnsvsphere.VirtualCenterManager
+}
+
 // CreateVolumeSpec is the Volume Spec used by CSI driver
 type CreateVolumeSpec struct {
 	Name     string

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -65,14 +65,22 @@ type NodeManagerInterface interface {
 }
 
 type controller struct {
-	manager     *common.Manager
-	nodeMgr     NodeManagerInterface
+	// Deprecated - To be removed after multi vCenter support is added
+	manager  *common.Manager
+	managers *common.Managers
+	nodeMgr  NodeManagerInterface
+	// Deprecated - To be removed after multi vCenter support is added
 	authMgr     common.AuthorizationService
+	authMgrs    map[string]*common.AuthManager
 	topologyMgr commoncotypes.ControllerTopologyService
 }
 
 // volumeMigrationService holds the pointer to VolumeMigration instance.
 var volumeMigrationService migration.VolumeMigrationService
+
+// multivCenterCSITopologyEnabled holds the feature gate status for
+// multi-vcenter-csi-topology feature
+var multivCenterCSITopologyEnabled bool
 
 // variables for list volumes
 var volIDsInK8s = make([]string, 0)
@@ -88,18 +96,6 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Infof("Initializing CNS controller")
 	var err error
-	// Get VirtualCenterManager instance and validate version.
-	vcenterconfig, err := cnsvsphere.GetVirtualCenterConfig(ctx, config)
-	if err != nil {
-		log.Errorf("failed to get VirtualCenterConfig. err=%v", err)
-		return err
-	}
-	vcManager := cnsvsphere.GetVirtualCenterManager(ctx)
-	vcenter, err := vcManager.RegisterVirtualCenter(ctx, vcenterconfig)
-	if err != nil {
-		log.Errorf("failed to register VC with virtualCenterManager. err=%v", err)
-		return err
-	}
 	var operationStore cnsvolumeoperationrequest.VolumeOperationRequest
 	idempotencyHandlingEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 		common.CSIVolumeManagerIdempotency)
@@ -115,53 +111,147 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 			return err
 		}
 	}
-	c.manager = &common.Manager{
-		VcenterConfig:  vcenterconfig,
-		CnsConfig:      config,
-		VolumeManager:  cnsvolume.GetManager(ctx, vcenter, operationStore, idempotencyHandlingEnabled),
-		VcenterManager: vcManager,
-	}
-
-	vc, err := common.GetVCenter(ctx, c.manager)
-	if err != nil {
-		log.Errorf("failed to get vcenter. err=%v", err)
-		return err
-	}
-
+	multivCenterCSITopologyEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.MultiVCenterCSITopology)
 	isAuthCheckFSSEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIAuthCheck)
-	// Check if vSAN FS is enabled for TargetvSANFileShareDatastoreURLs only if
-	// CSIAuthCheck FSS is not enabled.
-	if !isAuthCheckFSSEnabled && len(c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs) > 0 {
-		datacenters, err := vc.ListDatacenters(ctx)
+
+	vcManager := cnsvsphere.GetVirtualCenterManager(ctx)
+	if !multivCenterCSITopologyEnabled {
+		// Get VirtualCenterManager instance and validate version.
+		vcenterconfig, err := cnsvsphere.GetVirtualCenterConfig(ctx, config)
 		if err != nil {
-			return logger.LogNewErrorf(log, "failed to find datacenters from VC: %q, Error: %+v", vc.Config.Host, err)
+			log.Errorf("failed to get VirtualCenterConfig. err=%v", err)
+			return err
 		}
-		// Check if file service is enabled on datastore present in
-		// targetvSANFileShareDatastoreURLs.
-		dsToFileServiceEnabledMap, err := common.IsFileServiceEnabled(ctx,
-			c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs, vc, datacenters)
+		vcenter, err := vcManager.RegisterVirtualCenter(ctx, vcenterconfig)
 		if err != nil {
-			return logger.LogNewErrorf(log, "file service enablement check failed for datastore specified in "+
-				"TargetvSANFileShareDatastoreURLs. err=%v", err)
+			log.Errorf("failed to register VC %q with virtualCenterManager. err=%v", vcenterconfig.Host, err)
+			return err
 		}
-		for _, targetFSDatastore := range c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs {
-			isFSEnabled := dsToFileServiceEnabledMap[targetFSDatastore]
-			if !isFSEnabled {
-				return logger.LogNewErrorf(log, "file service is not enabled on datastore %s specified in "+
-					"TargetvSANFileShareDatastoreURLs", targetFSDatastore)
+		c.manager = &common.Manager{
+			VcenterConfig:  vcenterconfig,
+			CnsConfig:      config,
+			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, operationStore, idempotencyHandlingEnabled),
+			VcenterManager: vcManager,
+		}
+		vc, err := common.GetVCenter(ctx, c.manager)
+		if err != nil {
+			log.Errorf("failed to get vcenter. err=%v", err)
+			return err
+		}
+		// Check vCenter API Version
+		err = common.CheckAPI(ctx, vc.Client.ServiceContent.About.ApiVersion, common.MinSupportedVCenterMajor,
+			common.MinSupportedVCenterMinor, common.MinSupportedVCenterPatch)
+		if err != nil {
+			log.Errorf("checkAPI failed for vcenter API version: %s, err=%v",
+				vc.Client.ServiceContent.About.ApiVersion, err)
+			return err
+		}
+		// Check if vSAN FS is enabled for TargetvSANFileShareDatastoreURLs only if
+		// CSIAuthCheck FSS is not enabled.
+		if !isAuthCheckFSSEnabled && len(c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs) > 0 {
+			datacenters, err := vc.ListDatacenters(ctx)
+			if err != nil {
+				return logger.LogNewErrorf(log, "failed to find datacenters from VC: %q, Error: %+v", vc.Config.Host, err)
+			}
+			// Check if file service is enabled on datastore present in
+			// targetvSANFileShareDatastoreURLs.
+			dsToFileServiceEnabledMap, err := common.IsFileServiceEnabled(ctx,
+				c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs, vc, datacenters)
+			if err != nil {
+				return logger.LogNewErrorf(log, "file service enablement check failed for datastore specified in "+
+					"TargetvSANFileShareDatastoreURLs. err=%v", err)
+			}
+			for _, targetFSDatastore := range c.manager.VcenterConfig.TargetvSANFileShareDatastoreURLs {
+				isFSEnabled := dsToFileServiceEnabledMap[targetFSDatastore]
+				if !isFSEnabled {
+					return logger.LogNewErrorf(log, "file service is not enabled on datastore %s specified in "+
+						"TargetvSANFileShareDatastoreURLs", targetFSDatastore)
+				}
+			}
+		}
+		if isAuthCheckFSSEnabled {
+			log.Info("CSIAuthCheck feature is enabled, loading AuthorizationService")
+			authMgr, err := common.GetAuthorizationService(ctx, vc)
+			if err != nil {
+				log.Errorf("failed to initialize authMgr. err=%v", err)
+				return err
+			}
+			c.authMgr = authMgr
+			go common.ComputeDatastoreMapForBlockVolumes(authMgr.(*common.AuthManager),
+				config.Global.CSIAuthCheckIntervalInMin)
+			isvSANFileServicesSupported, err := c.manager.VcenterManager.IsvSANFileServicesSupported(ctx,
+				c.manager.VcenterConfig.Host)
+			if err != nil {
+				log.Errorf("failed to verify if vSAN file services is supported or not. Error:%+v", err)
+				return err
+			}
+			if isvSANFileServicesSupported {
+				go common.ComputeFSEnabledClustersToDsMap(authMgr.(*common.AuthManager),
+					config.Global.CSIAuthCheckIntervalInMin)
+			}
+		}
+	} else {
+		// Multi vCenter feature enabled
+		c.managers = &common.Managers{
+			CnsConfig:      config,
+			VcenterManager: vcManager,
+		}
+		c.managers.VcenterConfigs = make(map[string]*cnsvsphere.VirtualCenterConfig)
+		c.managers.VolumeManagers = make(map[string]cnsvolume.Manager)
+		// Get VirtualCenterManager instance and validate version.
+		vcenterconfigs, err := cnsvsphere.GetVirtualCenterConfigs(ctx, config)
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to get VirtualCenterConfigs. err=%v", err)
+		}
+		for _, vcenterconfig := range vcenterconfigs {
+			vcenter, err := vcManager.RegisterVirtualCenter(ctx, vcenterconfig)
+			if err != nil {
+				return logger.LogNewErrorf(log, "failed to register VC %q with virtualCenterManager. "+
+					"err=%v", vcenterconfig.Host, err)
+			}
+			c.managers.VcenterConfigs[vcenterconfig.Host] = vcenterconfig
+			c.managers.VolumeManagers[vcenterconfig.Host] = cnsvolume.GetManager(ctx, vcenter,
+				operationStore, idempotencyHandlingEnabled)
+		}
+		vCenters, err := common.GetVCenters(ctx, c.managers)
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to get vcenters. err=%v", err)
+		}
+		// Check vCenter API Version
+		for _, vc := range vCenters {
+			err = common.CheckAPI(ctx, vc.Client.ServiceContent.About.ApiVersion, common.MinSupportedVCenterMajor,
+				common.MinSupportedVCenterMinor, common.MinSupportedVCenterPatch)
+			if err != nil {
+				return logger.LogNewErrorf(log, "checkAPI failed for vcenter API version: %s for vCenter %s, err=%v",
+					vc.Client.ServiceContent.About.ApiVersion, vc.Config.Host, err)
+			}
+		}
+		if isAuthCheckFSSEnabled {
+			log.Info("CSIAuthCheck feature is enabled, loading AuthorizationService")
+			authMgrs, err := common.GetAuthorizationServices(ctx, vCenters)
+			if err != nil {
+				return logger.LogNewErrorf(log, "failed to initialize authMgr. err=%v", err)
+			}
+			c.authMgrs = authMgrs
+			for _, authMgr := range authMgrs {
+				go common.ComputeDatastoreMapForBlockVolumes(authMgr, config.Global.CSIAuthCheckIntervalInMin)
+			}
+			for _, vcconfig := range c.managers.VcenterConfigs {
+				isvSANFileServicesSupported, err := c.managers.VcenterManager.IsvSANFileServicesSupported(ctx,
+					vcconfig.Host)
+				if err != nil {
+					return logger.LogNewErrorf(log, "failed to verify if vSAN file services is supported or not for vCenter: %s. "+
+						"Error:%+v", vcconfig.Host, err)
+				}
+				if isvSANFileServicesSupported {
+					for _, authMgr := range authMgrs {
+						go common.ComputeFSEnabledClustersToDsMap(authMgr, config.Global.CSIAuthCheckIntervalInMin)
+					}
+				}
 			}
 		}
 	}
-
-	// Check vCenter API Version against 6.7.3.
-	err = common.CheckAPI(ctx, vc.Client.ServiceContent.About.ApiVersion, common.MinSupportedVCenterMajor,
-		common.MinSupportedVCenterMinor, common.MinSupportedVCenterPatch)
-	if err != nil {
-		log.Errorf("checkAPI failed for vcenter API version: %s, err=%v",
-			vc.Client.ServiceContent.About.ApiVersion, err)
-		return err
-	}
-
 	useNodeUuid := false
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
 		useNodeUuid = true
@@ -175,28 +265,6 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 
 	go cnsvolume.ClearTaskInfoObjects()
 	cfgPath := common.GetConfigPath(ctx)
-
-	if isAuthCheckFSSEnabled {
-		log.Info("CSIAuthCheck feature is enabled, loading AuthorizationService")
-		authMgr, err := common.GetAuthorizationService(ctx, vc)
-		if err != nil {
-			log.Errorf("failed to initialize authMgr. err=%v", err)
-			return err
-		}
-		c.authMgr = authMgr
-		go common.ComputeDatastoreMapForBlockVolumes(authMgr.(*common.AuthManager),
-			config.Global.CSIAuthCheckIntervalInMin)
-		isvSANFileServicesSupported, err := c.manager.VcenterManager.IsvSANFileServicesSupported(ctx,
-			c.manager.VcenterConfig.Host)
-		if err != nil {
-			log.Errorf("failed to verify if vSAN file services is supported or not. Error:%+v", err)
-			return err
-		}
-		if isvSANFileServicesSupported {
-			go common.ComputeFSEnabledClustersToDsMap(authMgr.(*common.AuthManager),
-				config.Global.CSIAuthCheckIntervalInMin)
-		}
-	}
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -240,13 +308,32 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		return err
 	}
 	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration) {
-		log.Info("CSI Migration Feature is Enabled. Loading Volume Migration Service")
-		volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &c.manager.VolumeManager, config, false)
-		if err != nil {
-			log.Errorf("failed to get migration service. Err: %v", err)
-			return err
+		if !multivCenterCSITopologyEnabled {
+			log.Info("CSI Migration Feature is Enabled. Loading Volume Migration Service")
+			volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &c.manager.VolumeManager, config, false)
+			if err != nil {
+				log.Errorf("failed to get migration service. Err: %v", err)
+				return err
+			}
+		} else {
+			if len(c.managers.VcenterConfigs) == 1 {
+				log.Info("CSI Migration Feature is Enabled. Loading Volume Migration Service")
+				var vcHost string
+				for _, vcconfig := range c.managers.VcenterConfigs {
+					vcHost = vcconfig.Host
+				}
+				volumeManager := c.managers.VolumeManagers[vcHost]
+				volumeMigrationService, err = migration.GetVolumeMigrationService(ctx, &volumeManager, config, false)
+				if err != nil {
+					log.Errorf("failed to get migration service. Err: %v", err)
+					return err
+				}
+			} else {
+				log.Infof("vSphere CSI Migration is not supported on the multi vCenter setup")
+			}
 		}
 	}
+
 	// Create dynamic informer for CSINodeTopology instance if FSS is enabled.
 	// Initialize volume topology service.
 	c.topologyMgr, err = commonco.ContainerOrchestratorUtility.InitTopologyServiceInController(ctx)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CSI vanilla controller Init changes for multi vCenter support


**Testing done**:
Regression tests passed.


Created vSphere Config Secret with multiple vCenter Servers

```
[Global]
cluster-id = "cluster1"
cluster-distribution = "CSI-Vanilla"

[VirtualCenter "10.184.89.220"]
insecure-flag = "true"
user = "Administrator@vsphere.local"
password = "*******"
port = "443"
datacenters = "VSAN-DC"

[VirtualCenter "10.78.234.75"]
insecure-flag = "true"
user = "Administrator@vsphere.local"
password = "*******"
port = "443"
datacenters = "VSAN-DC"

[Labels]
topology-categories = "region, zone"
```

Note:
- 3 Worker Nodes and 3 Control nodes belong to vCenter: 10.184.89.220 and 3 Worker Nodes belong to vCenter: 10.78.234.75
- region-1 tag is assigned to VC root 10.184.89.220 
- region-2 tag is assigned to VC root 10.78.234.75
- zone-1 tag is assigned to cluster1 on vCenter 10.184.89.220 
- zone-2 tag is assigned to cluster1 on vCenter 10.78.234.75


Logs
-----

```
{"level":"info","time":"2022-09-30T23:09:59.111783126Z","caller":"vsphere/datacenter.go:152","msg":"Publishing datacenter Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]","TraceId":"c1a3d138-fc99-431b-b311-1f7c08f49f53"}
{"level":"info","time":"2022-09-30T23:09:59.111909928Z","caller":"vsphere/virtualmachine.go:184","msg":"AsyncGetAllDatacenters with uuid 4209228f-0723-51d9-8458-57c166d6292d sent a dc Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]","TraceId":"c1a3d138-fc99-431b-b311-1f7c08f49f53"}
{"level":"info","time":"2022-09-30T23:09:59.116256387Z","caller":"vsphere/virtualmachine.go:198","msg":"Found VM VirtualMachine:vm-52 [VirtualCenterHost: 10.184.89.220, UUID: 4209228f-0723-51d9-8458-57c166d6292d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]] given uuid 4209228f-0723-51d9-8458-57c166d6292d on DC Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]","TraceId":"c1a3d138-fc99-431b-b311-1f7c08f49f53"}
{"level":"info","time":"2022-09-30T23:09:59.116456704Z","caller":"vsphere/virtualmachine.go:209","msg":"Returning VM VirtualMachine:vm-52 [VirtualCenterHost: 10.184.89.220, UUID: 4209228f-0723-51d9-8458-57c166d6292d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]] for UUID 4209228f-0723-51d9-8458-57c166d6292d","TraceId":"c1a3d138-fc99-431b-b311-1f7c08f49f53"}
{"level":"info","time":"2022-09-30T23:09:59.116519449Z","caller":"node/manager.go:147","msg":"Successfully discovered node with nodeUUID 4209228f-0723-51d9-8458-57c166d6292d in vm VirtualMachine:vm-52 [VirtualCenterHost: 10.184.89.220, UUID: 4209228f-0723-51d9-8458-57c166d6292d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]]","TraceId":"c1a3d138-fc99-431b-b311-1f7c08f49f53"}
{"level":"info","time":"2022-09-30T23:09:59.116552304Z","caller":"node/manager.go:130","msg":"Successfully discovered node: \"k8s-node-738-1664567775\" with nodeUUID \"4209228f-0723-51d9-8458-57c166d6292d\"","TraceId":"c1a3d138-fc99-431b-b311-1f7c08f49f53"}
{"level":"info","time":"2022-09-30T23:09:59.116561586Z","caller":"node/manager.go:132","msg":"Successfully registered node: \"k8s-node-738-1664567775\" with nodeUUID \"4209228f-0723-51d9-8458-57c166d6292d\"","TraceId":"c1a3d138-fc99-431b-b311-1f7c08f49f53"}
{"level":"info","time":"2022-09-30T23:09:59.119749135Z","caller":"node/manager.go:124","msg":"Discovering node vm using uuid: \"42090916-b9db-e922-83ad-ae28be2cc978\"","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416"}
{"level":"info","time":"2022-09-30T23:09:59.11981463Z","caller":"vsphere/virtualmachine.go:147","msg":"Initiating asynchronous datacenter listing with uuid 42090916-b9db-e922-83ad-ae28be2cc978","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416"}
{"level":"info","time":"2022-09-30T23:09:59.129537979Z","caller":"vsphere/datacenter.go:152","msg":"Publishing datacenter Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416"}
{"level":"info","time":"2022-09-30T23:09:59.130170082Z","caller":"vsphere/virtualmachine.go:184","msg":"AsyncGetAllDatacenters with uuid 42090916-b9db-e922-83ad-ae28be2cc978 sent a dc Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416"}
{"level":"info","time":"2022-09-30T23:09:59.135154454Z","caller":"vsphere/virtualmachine.go:198","msg":"Found VM VirtualMachine:vm-51 [VirtualCenterHost: 10.184.89.220, UUID: 42090916-b9db-e922-83ad-ae28be2cc978, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]] given uuid 42090916-b9db-e922-83ad-ae28be2cc978 on DC Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416"}
{"level":"info","time":"2022-09-30T23:09:59.144516047Z","caller":"vsphere/datacenter.go:152","msg":"Publishing datacenter Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.78.234.75]","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416"}
{"level":"info","time":"2022-09-30T23:09:59.144616869Z","caller":"vsphere/virtualmachine.go:184","msg":"AsyncGetAllDatacenters with uuid 42090916-b9db-e922-83ad-ae28be2cc978 sent a dc Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.78.234.75]","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416"}
{"level":"error","time":"2022-09-30T23:09:59.150082149Z","caller":"vsphere/datacenter.go:105","msg":"Couldn't find VM given uuid 42090916-b9db-e922-83ad-ae28be2cc978","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*Datacenter).GetVirtualMachineByUUID\n\t/build/pkg/common/cns-lib/vsphere/datacenter.go:105\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.GetVirtualMachineByUUID.func1\n\t/build/pkg/common/cns-lib/vsphere/virtualmachine.go:185"}
{"level":"warn","time":"2022-09-30T23:09:59.150210815Z","caller":"vsphere/virtualmachine.go:188","msg":"Couldn't find VM given uuid 42090916-b9db-e922-83ad-ae28be2cc978 on DC Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.78.234.75] with err: virtual machine wasn't found, continuing search","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416"}
{"level":"info","time":"2022-09-30T23:09:59.150246173Z","caller":"vsphere/virtualmachine.go:209","msg":"Returning VM VirtualMachine:vm-51 [VirtualCenterHost: 10.184.89.220, UUID: 42090916-b9db-e922-83ad-ae28be2cc978, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]] for UUID 42090916-b9db-e922-83ad-ae28be2cc978","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416"}
{"level":"info","time":"2022-09-30T23:09:59.150264928Z","caller":"node/manager.go:147","msg":"Successfully discovered node with nodeUUID 42090916-b9db-e922-83ad-ae28be2cc978 in vm VirtualMachine:vm-51 [VirtualCenterHost: 10.184.89.220, UUID: 42090916-b9db-e922-83ad-ae28be2cc978, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]]","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416"}
{"level":"info","time":"2022-09-30T23:09:59.150276244Z","caller":"node/manager.go:130","msg":"Successfully discovered node: \"k8s-node-759-1664567797\" with nodeUUID \"42090916-b9db-e922-83ad-ae28be2cc978\"","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416"}
{"level":"info","time":"2022-09-30T23:09:59.150284631Z","caller":"node/manager.go:132","msg":"Successfully registered node: \"k8s-node-759-1664567797\" with nodeUUID \"42090916-b9db-e922-83ad-ae28be2cc978\"","TraceId":"97db60cc-5221-4bda-be32-8f0cffa42416"}
{"level":"info","time":"2022-09-30T23:09:59.155141967Z","caller":"node/manager.go:124","msg":"Discovering node vm using uuid: \"42357525-800d-f9be-a5cc-84ffc7c6836d\"","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc"}
{"level":"info","time":"2022-09-30T23:09:59.155181193Z","caller":"vsphere/virtualmachine.go:147","msg":"Initiating asynchronous datacenter listing with uuid 42357525-800d-f9be-a5cc-84ffc7c6836d","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc"}
{"level":"info","time":"2022-09-30T23:09:59.171815682Z","caller":"vsphere/datacenter.go:152","msg":"Publishing datacenter Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.78.234.75]","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc"}
{"level":"info","time":"2022-09-30T23:09:59.172583144Z","caller":"vsphere/virtualmachine.go:184","msg":"AsyncGetAllDatacenters with uuid 42357525-800d-f9be-a5cc-84ffc7c6836d sent a dc Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.78.234.75]","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc"}
{"level":"info","time":"2022-09-30T23:09:59.178229391Z","caller":"vsphere/virtualmachine.go:198","msg":"Found VM VirtualMachine:vm-53 [VirtualCenterHost: 10.78.234.75, UUID: 42357525-800d-f9be-a5cc-84ffc7c6836d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.78.234.75]] given uuid 42357525-800d-f9be-a5cc-84ffc7c6836d on DC Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.78.234.75]","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc"}
{"level":"info","time":"2022-09-30T23:09:59.182393957Z","caller":"vsphere/datacenter.go:152","msg":"Publishing datacenter Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc"}
{"level":"info","time":"2022-09-30T23:09:59.182984116Z","caller":"vsphere/virtualmachine.go:184","msg":"AsyncGetAllDatacenters with uuid 42357525-800d-f9be-a5cc-84ffc7c6836d sent a dc Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220]","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc"}
{"level":"error","time":"2022-09-30T23:09:59.191391617Z","caller":"vsphere/datacenter.go:105","msg":"Couldn't find VM given uuid 42357525-800d-f9be-a5cc-84ffc7c6836d","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*Datacenter).GetVirtualMachineByUUID\n\t/build/pkg/common/cns-lib/vsphere/datacenter.go:105\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.GetVirtualMachineByUUID.func1\n\t/build/pkg/common/cns-lib/vsphere/virtualmachine.go:185"}
{"level":"warn","time":"2022-09-30T23:09:59.191482881Z","caller":"vsphere/virtualmachine.go:188","msg":"Couldn't find VM given uuid 42357525-800d-f9be-a5cc-84ffc7c6836d on DC Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.184.89.220] with err: virtual machine wasn't found, continuing search","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc"}
{"level":"info","time":"2022-09-30T23:09:59.191511477Z","caller":"vsphere/virtualmachine.go:209","msg":"Returning VM VirtualMachine:vm-53 [VirtualCenterHost: 10.78.234.75, UUID: 42357525-800d-f9be-a5cc-84ffc7c6836d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.78.234.75]] for UUID 42357525-800d-f9be-a5cc-84ffc7c6836d","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc"}
{"level":"info","time":"2022-09-30T23:09:59.191534296Z","caller":"node/manager.go:147","msg":"Successfully discovered node with nodeUUID 42357525-800d-f9be-a5cc-84ffc7c6836d in vm VirtualMachine:vm-53 [VirtualCenterHost: 10.78.234.75, UUID: 42357525-800d-f9be-a5cc-84ffc7c6836d, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.78.234.75]]","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc"}
{"level":"info","time":"2022-09-30T23:09:59.191545717Z","caller":"node/manager.go:130","msg":"Successfully discovered node: \"k8s-node-277-1664569574\" with nodeUUID \"42357525-800d-f9be-a5cc-84ffc7c6836d\"","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc"}
{"level":"info","time":"2022-09-30T23:09:59.191555637Z","caller":"node/manager.go:132","msg":"Successfully registered node: \"k8s-node-277-1664569574\" with nodeUUID \"42357525-800d-f9be-a5cc-84ffc7c6836d\"","TraceId":"dbc95620-1074-4823-9ad8-b72bcc862dfc"}
{"level":"info","time":"2022-09-30T23:09:59.250573007Z","caller":"k8sorchestrator/topology.go:303","msg":"failed to retrieve tags for category \"cns.vmware.topology-preferred-datastores\". Reason: GET https://10.78.234.75:443/rest/com/vmware/cis/tagging/category/id:cns.vmware.topology-preferred-datastores: 404 Not Found","TraceId":"faa543a9-8ad4-4246-913f-f95a169abf21"}
{"level":"info","time":"2022-09-30T23:09:59.463228797Z","caller":"vanilla/controller.go:1746","msg":"ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"bdcd69b4-192f-4f25-aed0-75d942693998"}
{"level":"info","time":"2022-09-30T23:09:59.464696642Z","caller":"vanilla/controller.go:1746","msg":"ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"4fb02dcb-c5bd-4c20-a9de-895059885357"}
{"level":"info","time":"2022-09-30T23:10:01.480754918Z","caller":"vanilla/controller.go:1746","msg":"ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"23e6bfa3-b5b8-4d7e-9fc5-871d6c2a9c84"}
{"level":"info","time":"2022-09-30T23:10:01.881463571Z","caller":"vanilla/controller.go:1746","msg":"ControllerGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"5798f6de-ca82-4084-a1a4-7a0561e441ca"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
CSI vanilla controller Init changes for multi vCenter support
```
