### PR TITLE
Cherry-pick Enable Suspend Volume Provisioning on datastore FSS (#1945)

### DIFF
--- a/manifests/guestcluster/1.20/pvcsi.yaml
+++ b/manifests/guestcluster/1.20/pvcsi.yaml
@@ -437,7 +437,7 @@ data:
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"
-  "cnsmgr-suspend-create-volume": "false"
+  "cnsmgr-suspend-create-volume": "true"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.21/pvcsi.yaml
+++ b/manifests/guestcluster/1.21/pvcsi.yaml
@@ -465,7 +465,7 @@ data:
   "file-volume": "true"
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"
-  "cnsmgr-suspend-create-volume": "false"
+  "cnsmgr-suspend-create-volume": "true"
   "tkgs-ha": "true"
 kind: ConfigMap
 metadata:

--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -466,7 +466,7 @@ data:
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"
   "tkgs-ha": "true"
-  "cnsmgr-suspend-create-volume": "false"
+  "cnsmgr-suspend-create-volume": "true"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.23/pvcsi.yaml
+++ b/manifests/guestcluster/1.23/pvcsi.yaml
@@ -475,7 +475,7 @@ data:
   "csi-sv-feature-states-replication": "false"
   "block-volume-snapshot": "false"
   "tkgs-ha": "true"
-  "cnsmgr-suspend-create-volume": "false"
+  "cnsmgr-suspend-create-volume": "true"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -394,7 +394,7 @@ data:
   "block-volume-snapshot": "false"
   "sibling-replica-bound-pvc-check": "true"
   "list-volumes": "false"
-  "cnsmgr-suspend-create-volume": "false"
+  "cnsmgr-suspend-create-volume": "true"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -394,7 +394,7 @@ data:
   "improved-csi-idempotency": "true"
   "block-volume-snapshot": "false"
   "sibling-replica-bound-pvc-check": "true"
-  "cnsmgr-suspend-create-volume": "false"
+  "cnsmgr-suspend-create-volume": "true"
   "tkgs-ha": "true"
   "list-volumes": "false"
 kind: ConfigMap

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -414,7 +414,7 @@ data:
   "sibling-replica-bound-pvc-check": "true"
   "tkgs-ha": "true"
   "list-volumes": "false"
-  "cnsmgr-suspend-create-volume": "false"
+  "cnsmgr-suspend-create-volume": "true"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -414,7 +414,7 @@ data:
   "sibling-replica-bound-pvc-check": "true"
   "tkgs-ha": "true"
   "list-volumes": "false"
-  "cnsmgr-suspend-create-volume": "false"
+  "cnsmgr-suspend-create-volume": "true"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -154,7 +154,7 @@ data:
   "use-csinode-id": "true"
   "list-volumes": "false"
   "pv-to-backingdiskobjectid-mapping": "false"
-  "cnsmgr-suspend-create-volume": "false"
+  "cnsmgr-suspend-create-volume": "true"
   "topology-preferential-datastores": "true"
   "max-pvscsi-targets-per-vm": "false"
 kind: ConfigMap


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This MR is cherry-picking commit for https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1945 in release-2.6 branch.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Cherry-pick Enable Suspend Volume Provisioning on datastore FSS (#1945)
```
