### PR TITLE
Add validation to check compatible datastore accessible from all vms

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -568,7 +568,7 @@ func IsVolumeCreationSuspended(ctx context.Context, datastoreInfo *DatastoreInfo
 }
 
 // FilterSuspendedDatastores filters out datastores which cns.vmware.com/datastoreSuspended customValue
-func FilterSuspendedDatastores(ctx context.Context, datastoreInfoList []*DatastoreInfo) []*DatastoreInfo {
+func FilterSuspendedDatastores(ctx context.Context, datastoreInfoList []*DatastoreInfo) ([]*DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
 
 	var filteredList []*DatastoreInfo
@@ -578,6 +578,10 @@ func FilterSuspendedDatastores(ctx context.Context, datastoreInfoList []*Datasto
 		}
 	}
 
+	if len(filteredList) == 0 {
+		return filteredList, logger.LogNewErrorf(log, "No datastores are available after filtering suspended datastores")
+	}
+
 	log.Infof("Updated filtered list of datastores %+v", filteredList)
-	return filteredList
+	return filteredList, nil
 }

--- a/pkg/common/cns-lib/vsphere/utils_test.go
+++ b/pkg/common/cns-lib/vsphere/utils_test.go
@@ -32,7 +32,8 @@ func TestFilterSuspendedDatastoresWhenDatastoreIsSuspended(t *testing.T) {
 		},
 	}
 
-	outputDsInfo := FilterSuspendedDatastores(context.TODO(), dsInfo)
+	outputDsInfo, err := FilterSuspendedDatastores(context.TODO(), dsInfo)
+	assert.NotNil(t, err)
 	assert.Equal(t, 0, len(outputDsInfo))
 }
 func TestFilterSuspendedDatastoresWhenDatastoreIsNotSuspended(t *testing.T) {
@@ -55,6 +56,8 @@ func TestFilterSuspendedDatastoresWhenDatastoreIsNotSuspended(t *testing.T) {
 		},
 	}
 
-	outputDsInfo := FilterSuspendedDatastores(context.TODO(), dsInfo)
+	outputDsInfo, err := FilterSuspendedDatastores(context.TODO(), dsInfo)
+	assert.Nil(t, err)
 	assert.Equal(t, 1, len(outputDsInfo))
+
 }

--- a/pkg/common/fault/constants.go
+++ b/pkg/common/fault/constants.go
@@ -57,4 +57,6 @@ const (
 	CSIInvalidArgumentFault = "csi.fault.InvalidArgument"
 	// CSIUnimplementedFault is the fault type returned when the function is unimplemented.
 	CSIUnimplementedFault = "csi.fault.Unimplemented"
+	// CSIInvalidStoragePolicyConfigurationFault is the fault type returned when the user provides invalid storage policy.
+	CSIInvalidStoragePolicyConfigurationFault = "csi.fault.InvalidStoragePolicyConfiguration"
 )

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -993,6 +993,7 @@ func GetNodeVMsWithAccessToDatastore(ctx context.Context, vc *vsphere.VirtualCen
 	return accessibleNodes, nil
 }
 
+// isDataStoreCompatible validates if datastore is accesible from all nodes.
 func isDataStoreCompatible(ctx context.Context, manager *Manager, spec *CreateVolumeSpec,
 	datastores []vim25types.ManagedObjectReference, datastoreObj *vsphere.Datastore) (string, error) {
 	log := logger.GetLogger(ctx)
@@ -1030,8 +1031,8 @@ func isDataStoreCompatible(ctx context.Context, manager *Manager, spec *CreateVo
 		}
 		if !compatibleDsAccessible {
 			return csifault.CSIInvalidStoragePolicyConfigurationFault, logger.LogNewErrorCodef(log, codes.Internal,
-				"none of compatible datastores for given storage policy is in the "+
-					"list of shared datastore accessible to all nodes")
+				"none of compatible datastores for given storage policy ID %q is in the "+
+					"list of shared datastore accessible to all nodes", spec.StoragePolicyID)
 		}
 		if datastoreObj != nil {
 			if _, exists := compatibleDsMoids[datastoreObj.Reference().Value]; !exists {

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -1030,8 +1030,10 @@ func isDataStoreCompatible(ctx context.Context, manager *Manager, spec *CreateVo
 			}
 		}
 		if !compatibleDsAccessible {
+			log.Errorf("no compatible datastore for storage policy ID %q is in list of shared datastores %+v",
+				spec.StoragePolicyID, datastores)
 			return csifault.CSIInvalidStoragePolicyConfigurationFault, logger.LogNewErrorCodef(log, codes.Internal,
-				"none of compatible datastores for given storage policy ID %q is in the "+
+				"none of compatible datastores for given storage policy ID %q, is in the "+
 					"list of shared datastore accessible to all nodes", spec.StoragePolicyID)
 		}
 		if datastoreObj != nil {

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -404,7 +404,7 @@ func TestCreateVolumeWithStoragePolicy(t *testing.T) {
 			},
 		},
 	}
-
+	params["checkCompatibleDatastores"] = "false"
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-" + uuid.New().String(),
 		CapacityRange: &csi.CapacityRange{

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -69,6 +69,7 @@ var (
 		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 	}
+	checkCompatibleDataStores = true
 )
 
 var getCandidateDatastores = cnsvsphere.GetCandidateDatastoresInCluster
@@ -369,7 +370,6 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolumeRequest) (
 	*csi.CreateVolumeResponse, string, error) {
 	log := logger.GetLogger(ctx)
-
 	var (
 		storagePolicyID      string
 		affineToHost         string
@@ -385,7 +385,6 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		zoneLabelPresent     bool
 		err                  error
 	)
-
 	// Support case insensitive parameters.
 	for paramName := range req.Parameters {
 		param := strings.ToLower(paramName)
@@ -573,7 +572,8 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	}
 
 	volumeInfo, faultType, err := common.CreateBlockVolumeUtil(ctx, cnstypes.CnsClusterFlavorWorkload,
-		c.manager, &createVolumeSpec, candidateDatastores, filterSuspendedDatastores, isTKGSHAEnabled)
+		c.manager, &createVolumeSpec, candidateDatastores, filterSuspendedDatastores,
+		isTKGSHAEnabled, checkCompatibleDataStores)
 	if err != nil {
 		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to create volume. Error: %+v", err)
@@ -704,7 +704,6 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 	if req.GetAccessibilityRequirements() != nil {
 		log.Info("Ignoring TopologyRequirement for file volume")
 	}
-
 	// Volume Size - Default is 10 GiB.
 	volSizeBytes := int64(common.DefaultGbDiskSize * common.GbInBytes)
 	if req.GetCapacityRange() != nil && req.GetCapacityRange().RequiredBytes != 0 {
@@ -755,7 +754,8 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 	isTKGSHAEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
 	volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorWorkload,
-		c.manager, &createVolumeSpec, filteredDatastores, filterSuspendedDatastores, isTKGSHAEnabled)
+		c.manager, &createVolumeSpec, filteredDatastores,
+		filterSuspendedDatastores, isTKGSHAEnabled, checkCompatibleDataStores)
 	if err != nil {
 		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to create volume. Error: %+v", err)
@@ -782,6 +782,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	start := time.Now()
 	ctx = logger.NewContextWithLogger(ctx)
 	log := logger.GetLogger(ctx)
+	if chkDataStoreCompatibility := req.Parameters["checkCompatibleDatastores"]; chkDataStoreCompatibility == "false" {
+		checkCompatibleDataStores = false
+		delete(req.Parameters, "checkCompatibleDatastores")
+	}
 	volumeType := prometheus.PrometheusUnknownVolumeType
 	createVolumeInternal := func() (
 		*csi.CreateVolumeResponse, string, error) {

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -309,6 +309,7 @@ func TestWCPCreateVolumeWithStoragePolicy(t *testing.T) {
 			},
 		},
 	}
+	params["checkCompatibleDatastores"] = "false"
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-" + uuid.New().String(),
 		CapacityRange: &csi.CapacityRange{
@@ -421,6 +422,7 @@ func TestWCPCreateVolumeWithZonalLabelPresentButNoStorageTopoType(t *testing.T) 
 			},
 		},
 	}
+	params["checkCompatibleDatastores"] = "false"
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-" + uuid.New().String(),
 		CapacityRange: &csi.CapacityRange{
@@ -517,6 +519,7 @@ func TestWCPCreateDeleteSnapshot(t *testing.T) {
 			},
 		},
 	}
+	params["checkCompatibleDatastores"] = "false"
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-" + uuid.New().String(),
 		CapacityRange: &csi.CapacityRange{
@@ -634,7 +637,7 @@ func TestListSnapshots(t *testing.T) {
 			},
 		},
 	}
-
+	params["checkCompatibleDatastores"] = "false"
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-" + uuid.New().String(),
 		CapacityRange: &csi.CapacityRange{
@@ -755,7 +758,7 @@ func TestListSnapshotsOnSpecificVolume(t *testing.T) {
 			},
 		},
 	}
-
+	params["checkCompatibleDatastores"] = "false"
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-" + uuid.New().String(),
 		CapacityRange: &csi.CapacityRange{
@@ -877,7 +880,7 @@ func TestListSnapshotsWithToken(t *testing.T) {
 			},
 		},
 	}
-
+	params["checkCompatibleDatastores"] = "false"
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-" + uuid.New().String(),
 		CapacityRange: &csi.CapacityRange{
@@ -1008,7 +1011,7 @@ func TestListSnapshotsOnSpecificVolumeAndSnapshot(t *testing.T) {
 			},
 		},
 	}
-
+	params["checkCompatibleDatastores"] = "false"
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-" + uuid.New().String(),
 		CapacityRange: &csi.CapacityRange{
@@ -1127,7 +1130,7 @@ func TestCreateVolumeFromSnapshot(t *testing.T) {
 			},
 		},
 	}
-
+	params["checkCompatibleDatastores"] = "false"
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-" + uuid.New().String(),
 		CapacityRange: &csi.CapacityRange{
@@ -1333,7 +1336,7 @@ func TestWCPDeleteVolumeWithSnapshots(t *testing.T) {
 			},
 		},
 	}
-
+	params["checkCompatibleDatastores"] = "false"
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-" + uuid.New().String(),
 		CapacityRange: &csi.CapacityRange{
@@ -1439,7 +1442,7 @@ func TestWCPExpandVolumeWithSnapshots(t *testing.T) {
 			},
 		},
 	}
-
+	params["checkCompatibleDatastores"] = "false"
 	reqCreate := &csi.CreateVolumeRequest{
 		Name: testVolumeName + "-" + uuid.New().String(),
 		CapacityRange: &csi.CapacityRange{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 will add validation to check if compatible datastores are accessible from all vm nodes.
 will add validation to check if there is at least one non suspended datastore available, if not return error.
**Testing done**:
Manually Tested
Running E2E pipeline

**Special notes for your reviewer**:
logs for manual testing: [logs-non-compatible-ds.TXT](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/9725493/logs-non-compatible-ds.TXT)

logs for manual testing scenario datastores are accessible from all vm nodes  :  
[log-datastores-accesible.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/9938127/log-datastores-accesible.txt)

logs for manual testing scenario datastores are suspended :  
[log-suspended-datastore.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/9938139/log-suspended-datastore.txt)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
adding validation while creating volumes to check if compatible datastores are accessible from all vm nodes.
adding validation while create volume to check at least one non suspended datastore is available.
```
