### PR TITLE
initialize volumemanagers for multiple vCenter servers for syncer

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -74,10 +74,15 @@ type VirtualCenter struct {
 var (
 	// VCenter instance. It is a singleton.
 	vCenterInstance *VirtualCenter
+	// Map of VCenter Hostname and vCenter instances
+	vCenterInstances = make(map[string]*VirtualCenter)
+
 	// Has the vCenter instance been initialized?
 	vCenterInitialized bool
 	// vCenterInstanceLock makes sure only one vCenter instance be initialized.
 	vCenterInstanceLock = &sync.RWMutex{}
+	// vCenterInstancesLock makes sure only one vCenter being initialized for specific host
+	vCenterInstancesLock = &sync.RWMutex{}
 )
 
 func (vc *VirtualCenter) String() string {
@@ -568,6 +573,47 @@ func GetVirtualCenterInstance(ctx context.Context,
 		log.Info("vCenterInstance initialized")
 	}
 	return vCenterInstance, nil
+}
+
+// GetVirtualCenterInstanceForVCenterConfig returns the vcenter object for given vCenter Config
+// Takes in a boolean paramater reloadConfig.
+// If reinitialize is true, the vcenter object is instantiated again and the
+// old object becomes eligible for garbage collection.
+// If reinitialize is false and instance was already initialized, the previous
+// instance is returned.
+func GetVirtualCenterInstanceForVCenterConfig(ctx context.Context,
+	vcconfig *VirtualCenterConfig, reinitialize bool) (*VirtualCenter, error) {
+	log := logger.GetLogger(ctx)
+	vCenterInstancesLock.Lock()
+	defer vCenterInstancesLock.Unlock()
+
+	_, found := vCenterInstances[vcconfig.Host]
+	if !found || reinitialize {
+		log.Infof("Initializing new vCenterInstance for vCenter %q", vcconfig.Host)
+		// Initialize the virtual center manager.
+		virtualcentermanager := GetVirtualCenterManager(ctx)
+		// Unregister the VC from virtual center manager.
+		if err := virtualcentermanager.UnregisterVirtualCenter(ctx, vcconfig.Host); err != nil {
+			return nil, logger.LogNewErrorf(log, "failed to unregister VirtualCenter %q with "+
+				"virtualCenterManager. Err: %+v", vcconfig.Host, err)
+		}
+		// Register with virtual center manager.
+		vcInstance, err := virtualcentermanager.RegisterVirtualCenter(ctx, vcconfig)
+		if err != nil {
+			return nil, logger.LogNewErrorf(log, "failed to register VirtualCenter %q Err: %+v",
+				vcconfig.Host, err)
+		}
+		// Connect to VC.
+		err = vcInstance.Connect(ctx)
+		if err != nil {
+			log.Errorf("failed to connect to VirtualCenter host: %q. Err: %+v",
+				vcconfig.Host, err)
+			return nil, err
+		}
+		vCenterInstances[vcconfig.Host] = vcInstance
+		log.Infof("vCenterInstance for vCenter: %q initialized", vcconfig.Host)
+	}
+	return vCenterInstances[vcconfig.Host], nil
 }
 
 // GetAllVirtualMachines gets the VM Managed Objects with the given properties from the

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -100,8 +100,11 @@ type (
 )
 
 type metadataSyncInformer struct {
-	clusterFlavor      cnstypes.CnsClusterFlavor
-	volumeManager      volumes.Manager
+	clusterFlavor cnstypes.CnsClusterFlavor
+	volumeManager volumes.Manager
+	// map of VC Host to Volume Manager
+	// Use this for Vanilla flavor Multi vCenter Topology feature
+	volumeManagers     map[string]volumes.Manager
 	host               string
 	cnsOperatorClient  client.Client
 	supervisorClient   clientset.Interface


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
initialize volume managers for multiple vCenter servers for syncer.


**Testing done**:
syncer container log with this change

```
{"level":"info","time":"2022-10-05T21:29:40.059686386Z","caller":"logger/logger.go:41","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2022-10-05T21:29:40.063083064Z","caller":"syncer/main.go:76","msg":"Version : v2.1.0-rc.1-1436-gc795b7b9","TraceId":"38f9eb11-5c1f-4e64-834c-7125c362c12a"}
{"level":"info","time":"2022-10-05T21:29:40.064927195Z","caller":"syncer/main.go:93","msg":"Starting container with operation mode: METADATA_SYNC","TraceId":"38f9eb11-5c1f-4e64-834c-7125c362c12a"}
{"level":"info","time":"2022-10-05T21:29:40.066128644Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config","TraceId":"38f9eb11-5c1f-4e64-834c-7125c362c12a"}
{"level":"info","time":"2022-10-05T21:29:40.06722134Z","caller":"kubernetes/kubernetes.go:389","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"38f9eb11-5c1f-4e64-834c-7125c362c12a"}
{"level":"info","time":"2022-10-05T21:29:40.071876316Z","caller":"syncer/main.go:115","msg":"Starting the http server to expose Prometheus metrics..","TraceId":"38f9eb11-5c1f-4e64-834c-7125c362c12a"}
I1005 21:29:40.074468       1 leaderelection.go:248] attempting to acquire leader lease vmware-system-csi/vsphere-syncer...
I1005 21:30:25.067028       1 leaderelection.go:258] successfully acquired lease vmware-system-csi/vsphere-syncer
{"level":"info","time":"2022-10-05T21:30:25.072711642Z","caller":"config/config.go:379","msg":"No Net Permissions given in Config. Using default permissions."}
{"level":"info","time":"2022-10-05T21:30:25.07340568Z","caller":"k8sorchestrator/k8sorchestrator.go:244","msg":"Initializing k8sOrchestratorInstance","TraceId":"16c1bfe1-5aef-4b1b-ba74-6bc9551cad80"}
{"level":"info","time":"2022-10-05T21:30:25.073566815Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config","TraceId":"16c1bfe1-5aef-4b1b-ba74-6bc9551cad80"}
{"level":"info","time":"2022-10-05T21:30:25.073882673Z","caller":"kubernetes/kubernetes.go:389","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"16c1bfe1-5aef-4b1b-ba74-6bc9551cad80"}
{"level":"info","time":"2022-10-05T21:30:25.074253787Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config","TraceId":"16c1bfe1-5aef-4b1b-ba74-6bc9551cad80"}
{"level":"info","time":"2022-10-05T21:30:25.074474224Z","caller":"kubernetes/kubernetes.go:389","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"16c1bfe1-5aef-4b1b-ba74-6bc9551cad80"}
{"level":"info","time":"2022-10-05T21:30:25.119391705Z","caller":"k8sorchestrator/k8sorchestrator.go:371","msg":"New internal feature states values stored successfully: map[async-query-volume:true block-volume-snapshot:true cnsmgr-suspend-create-volume:true csi-auth-check:true csi-migration:true csi-windows-support:false improved-csi-idempotency:true improved-volume-topology:true list-volumes:false max-pvscsi-targets-per-vm:true multi-vcenter-csi-topology:true online-volume-extend:true pv-to-backingdiskobjectid-mapping:false topology-preferential-datastores:true trigger-csi-fullsync:false use-csinode-id:true]","TraceId":"16c1bfe1-5aef-4b1b-ba74-6bc9551cad80"}
{"level":"info","time":"2022-10-05T21:30:25.120241145Z","caller":"k8sorchestrator/k8sorchestrator.go:291","msg":"k8sOrchestratorInstance initialized","TraceId":"16c1bfe1-5aef-4b1b-ba74-6bc9551cad80"}
{"level":"info","time":"2022-10-05T21:30:25.120470312Z","caller":"syncer/metadatasyncer.go:158","msg":"Initializing MetadataSyncer"}
{"level":"info","time":"2022-10-05T21:30:25.120971038Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config"}
{"level":"info","time":"2022-10-05T21:30:25.121773667Z","caller":"manager/init.go:70","msg":"Initializing CNS Operator"}
{"level":"info","time":"2022-10-05T21:30:25.122026349Z","caller":"kubernetes/kubernetes.go:389","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2022-10-05T21:30:25.122525609Z","caller":"vsphere/virtualcenter.go:539","msg":"Initializing new vCenterInstance."}
{"level":"info","time":"2022-10-05T21:30:25.127919082Z","caller":"vsphere/utils.go:189","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2022-10-05T21:30:25.127667439Z","caller":"vsphere/utils.go:264","msg":"Defaulting timeout for vCenter Client to 5 minutes"}
{"level":"info","time":"2022-10-05T21:30:25.128781034Z","caller":"vsphere/virtualcentermanager.go:74","msg":"Initializing defaultVirtualCenterManager..."}
{"level":"info","time":"2022-10-05T21:30:25.128896069Z","caller":"vsphere/virtualcentermanager.go:76","msg":"Successfully initialized defaultVirtualCenterManager"}
{"level":"info","time":"2022-10-05T21:30:25.129020957Z","caller":"vsphere/virtualcenter.go:592","msg":"Initializing new vCenterInstance for vCenter \"10.184.89.220\""}
{"level":"info","time":"2022-10-05T21:30:25.130730928Z","caller":"vsphere/virtualcentermanager.go:123","msg":"Successfully registered VC 10.184.89.220:443"}
{"level":"info","time":"2022-10-05T21:30:25.131979807Z","caller":"vsphere/pbm.go:77","msg":"PbmClient wasn't connected, ignoring"}
{"level":"info","time":"2022-10-05T21:30:25.133642594Z","caller":"vsphere/virtualcenter.go:402","msg":"Client wasn't connected, ignoring"}
{"level":"info","time":"2022-10-05T21:30:25.135228156Z","caller":"vsphere/cns.go:59","msg":"CnsClient wasn't connected, ignoring"}
{"level":"info","time":"2022-10-05T21:30:25.135790108Z","caller":"vsphere/virtualcentermanager.go:145","msg":"Successfully unregistered VC 10.184.89.220"}
{"level":"info","time":"2022-10-05T21:30:25.137629097Z","caller":"k8sorchestrator/k8sorchestrator.go:597","msg":"configMapAdded: Internal feature state values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[async-query-volume:true block-volume-snapshot:true cnsmgr-suspend-create-volume:true csi-auth-check:true csi-migration:true csi-windows-support:false improved-csi-idempotency:true improved-volume-topology:true list-volumes:false max-pvscsi-targets-per-vm:true multi-vcenter-csi-topology:true online-volume-extend:true pv-to-backingdiskobjectid-mapping:false topology-preferential-datastores:true trigger-csi-fullsync:false use-csinode-id:true]","TraceId":"375281f1-ae88-451c-8021-052a5538bb70"}
{"level":"info","time":"2022-10-05T21:30:25.138103192Z","caller":"vsphere/virtualcentermanager.go:123","msg":"Successfully registered VC 10.184.89.220:443"}
{"level":"info","time":"2022-10-05T21:30:25.203918721Z","caller":"vsphere/virtualcenter.go:198","msg":"New session ID for 'VSPHERE.LOCAL\\Administrator' = 52014b2e-accf-b696-fbda-f4387c8460f3"}
{"level":"info","time":"2022-10-05T21:30:25.204213517Z","caller":"vsphere/virtualcenter.go:573","msg":"vCenterInstance initialized"}
{"level":"info","time":"2022-10-05T21:30:25.204863508Z","caller":"volume/manager.go:176","msg":"Initializing new defaultManager..."}
{"level":"info","time":"2022-10-05T21:30:25.2082798Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config"}
{"level":"info","time":"2022-10-05T21:30:25.208497122Z","caller":"kubernetes/kubernetes.go:389","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2022-10-05T21:30:25.254851569Z","caller":"kubernetes/kubernetes.go:480","msg":"\"csinodetopologies.cns.vmware.com\" CRD updated successfully"}
{"level":"info","time":"2022-10-05T21:30:25.255261433Z","caller":"node/manager.go:87","msg":"Initializing node.defaultManager..."}
{"level":"info","time":"2022-10-05T21:30:25.255361359Z","caller":"node/manager.go:91","msg":"node.defaultManager initialized"}
{"level":"info","time":"2022-10-05T21:30:25.255999209Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config"}
{"level":"info","time":"2022-10-05T21:30:25.256543746Z","caller":"kubernetes/kubernetes.go:389","msg":"Setting client QPS to 100.000000 and Burst to 100."}
{"level":"info","time":"2022-10-05T21:30:25.262368488Z","caller":"vsphere/virtualcenter.go:198","msg":"New session ID for 'VSPHERE.LOCAL\\Administrator' = 52fea2b6-a130-36b8-e386-e7faeccd9d76"}
{"level":"info","time":"2022-10-05T21:30:25.262516678Z","caller":"vsphere/virtualcenter.go:615","msg":"vCenterInstance for vCenter: \"10.184.89.220\" initialized"}
{"level":"info","time":"2022-10-05T21:30:25.262606988Z","caller":"volume/manager.go:173","msg":"Retrieving existing defaultManager..."}
{"level":"info","time":"2022-10-05T21:30:25.262956507Z","caller":"vsphere/virtualcenter.go:592","msg":"Initializing new vCenterInstance for vCenter \"10.78.234.75\""}
{"level":"error","time":"2022-10-05T21:30:25.263116249Z","caller":"vsphere/virtualcentermanager.go:93","msg":"Couldn't find VC 10.78.234.75 in registry","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*defaultVirtualCenterManager).GetVirtualCenter\n\t/build/pkg/common/cns-lib/vsphere/virtualcentermanager.go:93\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.(*defaultVirtualCenterManager).UnregisterVirtualCenter\n\t/build/pkg/common/cns-lib/vsphere/virtualcentermanager.go:129\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere.GetVirtualCenterInstanceForVCenterHost\n\t/build/pkg/common/cns-lib/vsphere/virtualcenter.go:597\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer.InitMetadataSyncer\n\t/build/pkg/syncer/metadatasyncer.go:258\nmain.initSyncerComponents.func1\n\t/build/cmd/syncer/main.go:185\ngithub.com/kubernetes-csi/csi-lib-utils/leaderelection.(*leaderElection).Run.func1\n\t/go/pkg/mod/github.com/kubernetes-csi/csi-lib-utils@v0.11.0/leaderelection/leader_election.go:179"}
{"level":"warn","time":"2022-10-05T21:30:25.263281792Z","caller":"vsphere/virtualcentermanager.go:132","msg":"failed to find vCenter: \"10.78.234.75\" Assuming vCenter is already unregistered."}
{"level":"info","time":"2022-10-05T21:30:25.263375184Z","caller":"vsphere/virtualcentermanager.go:123","msg":"Successfully registered VC 10.78.234.75:443"}
{"level":"info","time":"2022-10-05T21:30:25.268269Z","caller":"node/manager.go:124","msg":"Discovering node vm using uuid: \"423574cb-e902-9e37-57ab-add2a1eac272\"","TraceId":"af88f73e-ba6d-4d22-9b26-7b047ca6dea9"}
{"level":"info","time":"2022-10-05T21:30:25.268528903Z","caller":"vsphere/virtualmachine.go:147","msg":"Initiating asynchronous datacenter listing with uuid 423574cb-e902-9e37-57ab-add2a1eac272","TraceId":"af88f73e-ba6d-4d22-9b26-7b047ca6dea9"}
{"level":"info","time":"2022-10-05T21:30:25.336300804Z","caller":"vsphere/virtualcenter.go:198","msg":"New session ID for 'VSPHERE.LOCAL\\Administrator' = 52c642fb-aa06-96a7-465b-4df004f72d8d"}
{"level":"info","time":"2022-10-05T21:30:25.336391152Z","caller":"vsphere/virtualcenter.go:615","msg":"vCenterInstance for vCenter: \"10.78.234.75\" initialized"}

```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
initialize volumemanagers for multiple vCenter servers for syncer
```
