### PR TITLE
adding node-role.kubernetes.io/master tolerations to 1.24 yaml

### DIFF
--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -209,6 +209,9 @@ spec:
         - operator: "Exists"
           key: "node-role.kubernetes.io/control-plane"
           effect: "NoSchedule"
+        - operator: "Exists"
+          key: "node-role.kubernetes.io/master"
+          effect: "NoSchedule"
       hostNetwork: true
       priorityClassName: system-node-critical
       containers:
@@ -603,6 +606,9 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
         - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
         - effect: NoExecute


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
adding node-role.kubernetes.io/master tolerations to 1.24 YAML to support the upgrade of supervisor from k8s 1.24 to k8s 1.25.

For the Supervisor upgrade from k8s 1.24 to 1.25, the upgrade script is adding taint `node-role.kubernetes.io/master` on the New k8s 1.25 control plane node so older driver release can run on the new control plane node.  In the upgrade process, After the new CP node is added, and the older driver is up and running, we move on to create a new control plane node. We are removing `node-role.kubernetes.io/master` taint after the upgrade.

For the green field deployment (fresh new install) since the same script is used which taints the new control plane node with `node-role.kubernetes.io/master`, we need 1.24 deployment to tolerate   `node-role.kubernetes.io/master` taint.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
adding node-role.kubernetes.io/master tolerations to 1.24 yaml
```
