### PR TITLE
Preferential automation - Part2

### DIFF
--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -781,4 +781,980 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
 			namespace, allowedTopologyForRack2, false)
 	})
+
+	/*
+		Testcase-6:
+			Multiple tags are assigned to Shared datastore with multiple allowed topology
+
+			Steps
+			1. Assign Tag rack-1, Category "cns.vmware.topology-preferred-datastores" to datastore
+			accessible across all racks (ex - sharedVMFS-12)
+			2. Assign Tag rack-2, Category "cns.vmware.topology-preferred-datastores" to datastore
+			accessible across all racks (ex - sharedVMFS-12)
+			3. Assign Tag rack-3, Category "cns.vmware.topology-preferred-datastores" to datastore
+			accessible across all racks (ex - sharedVMFS-12)
+			4. Create SC with WFC binding mode and allowed topologies set to rack-1/rack-2/rack-3 in the SC
+			5. Create StatefulSet with replica 3 with the above SC
+			6. Wait for all the StatefulSet to come up
+			7. Wait for PV , PVC to reach bound and POD to reach running state
+			8. Describe PV and verify node affinity details should contain allowed topology details.
+			9. Verify volume provisioning should be on the preferred datastore.
+			10. Make sure POD is running on the same node as mentioned in node affinity details
+			11. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
+			12. Remove datastore preference tags as part of cleanup.
+	*/
+	ginkgo.It("Assign multiple tags to preferred shared datastore which is shared across all "+
+		"racks with multiple allowed topologies", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datatsore for volume provisioning")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[0],
+			preferredDatastoreChosen, shareddatastoreListMap, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for i := 1; i < len(allowedTopologyRacks); i++ {
+			err = tagSameDatastoreAsPreferenceToDifferentRacks(masterIp, allowedTopologyRacks[i],
+				preferredDatastoreChosen, preferredDatastorePaths)
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Remove preferred datatsore tag")
+			for j := 0; j < len(allowedTopologyRacks); j++ {
+				err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[0],
+					allowedTopologyRacks[j])
+			}
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies,
+			"", bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating statefulset with 3 replica")
+		statefulset := GetStatefulSetFromManifest(namespace)
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		//verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
+			shareddatastoreListMap, true, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, false)
+	})
+
+	/*
+		Testcase-7:
+			Single tag is assigned to Shared datastore with multiple allowed topology
+
+			Steps
+			1. Assign Tag rack-3, Category "cns.vmware.topology-preferred-datastores" to
+			datastore accessible across all racks (ex - sharedVMFS-12)
+			2. Create SC with WFC binding mode and allowed topologies set to rack-1/rack-2/rack-3 in the SC
+			3. Create StatefulSet with replica 3 with the above SC
+			4. Wait for all the StatefulSet to come up
+			5. Wait for PV , PVC to reach Bound and POD to reach running state
+			6. Describe PV and verify node affinity details.
+			7. Verify atleast one of sts volume provisioning should be on the preferred datastore.
+			8. Make sure POD is running on the same node as mentioned in node affinity details
+			9. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
+			10. Remove datastore preference tags as part of cleanup.
+	*/
+	ginkgo.It("Assign single tag to preferred shared datastore which is shared across all "+
+		"racks with multiple allowed topologies", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datastore for volume provisioning")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[2],
+			preferredDatastoreChosen, shareddatastoreListMap, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Remove the preferred datastore tag")
+			err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[0],
+				allowedTopologyRacks[2])
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies,
+			"", bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating statefulset with 3 replica")
+		statefulset := GetStatefulSetFromManifest(namespace)
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		//verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
+			shareddatastoreListMap, true, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, false)
+	})
+
+	/*
+		Testcase-8:
+			Change datastore preference in rack-1 and verify it is honored
+
+			Steps
+			1. Assign Tag rack-1, Category "cns.vmware.topology-preferred-datastores" to datastore
+			specific to rack-1 (ex - vSAN-1)
+			2. Create SC with  Immediate Binding mode and allowed topologies set to rack-1 in the SC
+			3. Create StatefulSet sts with parallel pod management policy and replica 3 with the above SC
+			4. Wait for all the StatefulSet to come up
+			5. Wait for PV , PVC to reach Bound and POD to reach running state
+			6. Describe PV and verify node affinity details should contain allowed topology details.
+			7. Verify volume should be provisioned on the preferred datastore of rack-1
+			8. Make sure POD is running on the same node as mentioned in the node affinity details
+			9. Remove tag from previously preferred datastore and assign tag rack-1 and category
+			"cns.vmware.topology-preferred-datastores" to new datastore shared across all racks (ex - sharedVMFS-12)
+			10. Wait for the refresh interval time which is set at which preferred datatsore
+			is picked up for volume provisioning.
+			11. Create standlaone PVC and POD.
+			12. Wait for PV , PVC to reach Bound and POD to reach running state
+			13. Describe PV and verify node affinity details should allowed topology details.
+			14. Verify volume should be provisioned on the newly selected preferred datastore of rack-1
+			15. Make sure POD is running on the same node as mentioned in the node affinity details
+			16. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
+			17. Remove datastore preference tags as part of cleanup.
+	*/
+	ginkgo.It("Change datatsore preferences in rack-1 and verify it is honored", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datastore for volume provisioning in rack-1(cluster-1))")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[0],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologyForRack1,
+			"", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating Statefulset with 3 replica")
+		sts1 := GetStatefulSetFromManifest(namespace)
+		sts1.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+		CreateStatefulSet(namespace, sts1, client)
+		sts1Replicas := *(sts1.Spec.Replicas)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, sts1, sts1Replicas)
+		gomega.Expect(CheckMountForStsPods(client, sts1, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := GetListOfPodsInSts(client, sts1)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", sts1.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(sts1Replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		//verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
+			nonShareddatastoreListMapRack1, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
+			namespace, allowedTopologyForRack1, true)
+
+		ginkgo.By("Remove preferred datatsore tag which is chosen for volume provisioning")
+		err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[0], allowedTopologyRacks[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Tag new preferred datastore from rack-1 for volume provisioning")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[0],
+			preferredDatastoreChosen, shareddatastoreListMap, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Remove the datastore preference chosen for volume provisioning")
+			err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[0], allowedTopologyRacks[0])
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating PVC")
+		pvclaim, err := createPVC(client, namespace, nil, "", sc, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaims = append(pvclaims, pvclaim)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		pvs1, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs1).NotTo(gomega.BeEmpty())
+		pv1 := pvs1[0]
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv1.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}()
+
+		ginkgo.By("Creating a pod")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Verify volume:%s is attached to the node: %s",
+			pv1.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv1.Spec.CSI.VolumeHandle, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+		defer func() {
+			ginkgo.By("Deleting the pod and wait for disk to detach")
+			err := fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify volume is detached from the node")
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv1.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", pv1.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		}()
+
+		// verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, preferredDatastorePaths,
+			shareddatastoreListMap)
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
+			"node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
+			allowedTopologyForRack1)
+
+	})
+
+	/*
+		Testcase-9:
+			Change datastore preference in rack-3 and verify it is honored
+
+			Steps
+			1. Assign Tag rack-3, Category "cns.vmware.topology-preferred-datastores" to datastore
+			specific to rack-3 (ex - vSAN-2)
+			2. Create SC with Immediate Binding mode and allowed topologies set to rack-3 in the SC
+			3. Create StatefulSet sts with replica 3 with the above SC
+			4. Wait for all the StatefulSet to come up
+			5. Wait for PV , PVC to reach Bound and POD to reach Running state
+			6. Describe PV and verify node affinity details should contain allowed topology details.
+			7. Verify volume should be provisioned on the selected preferred datastore of rack-3.
+			8. Make sure POD is running on the same node as mentioned in node affinity details
+			9. Remove tags from previously preferred datastore and assign tag rack-3 and category
+			"cns.vmware.topology-preferred-datastores" to new datastore specific to rack-3 (ex - NFS-2)
+			10. Wait for the refresh interval time which is set at which preferred datatsore
+			is picked up for volume provisioning.
+			11. Create standalone PVC and Pod.
+			12. Wait for PVC to reach Bound and Pod to reach running state.
+			13. Describe PV and verify node affinity details should contain the specified allowed topology details.
+			14. Verify volume should be provisioned on the newly selected preferred datastore of rack-3
+			15. Scaleup StatefulSet sts created in step3. Increase the replica count from 3 to 10.
+			16. Wait for all the StatefulSet to come up
+			17. Wait for PV , PVC to reach Bound and POD to reach running state
+			18. Describe PV and verify node affinity details should contain both specified allowed topologies
+			 details.
+			19. Verify volume should be provisioned on the newly selected preferred datastore of rack-3.
+			20. Make sure POD is running on the same node as mentioned in the node affinity details
+			21. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
+			22. Remove datastore preference tags as part of cleanup.
+	*/
+	ginkgo.It("Change datatsore preferences in rack-3 and verify it is honored", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datastore for volume provisioning in rack-3(cluster-3))")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[2],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		preferredDatastore := preferredDatastorePaths
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologyForRack3,
+			"", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating Statefulset with 3 replica")
+		sts1 := GetStatefulSetFromManifest(namespace)
+		sts1.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+		CreateStatefulSet(namespace, sts1, client)
+		sts1Replicas := *(sts1.Spec.Replicas)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, sts1, sts1Replicas)
+		gomega.Expect(fss.CheckMount(client, sts1, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := GetListOfPodsInSts(client, sts1)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", sts1.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(sts1Replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		//verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
+			nonShareddatastoreListMapRack3, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
+			namespace, allowedTopologyForRack3, false)
+
+		ginkgo.By("Remove preferred datatsore tag chosen for volume provisioning")
+		err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[0], allowedTopologyRacks[2])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Tag new preferred datatsore for volume provisioning in rack-3")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[2],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack3, preferredDatastorePaths)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Remove preferred datatsore tag")
+			for i := 0; i < len(preferredDatastorePaths); i++ {
+				err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[i],
+					allowedTopologyRacks[2])
+			}
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating PVC")
+		pvclaim, err := createPVC(client, namespace, nil, "", sc, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaims = append(pvclaims, pvclaim)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		pvs1, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs1).NotTo(gomega.BeEmpty())
+		pv1 := pvs1[0]
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv1.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}()
+
+		ginkgo.By("Creating a pod")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Verify volume:%s is attached to the node: %s",
+			pv1.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv1.Spec.CSI.VolumeHandle, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+		defer func() {
+			ginkgo.By("Deleting the pod and wait for disk to detach")
+			err := fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify volume is detached from the node")
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+				pv1.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", pv1.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		}()
+
+		// verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, preferredDatastorePaths,
+			nonShareddatastoreListMapRack3)
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
+			"node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
+			allowedTopologyForRack3)
+
+		// perform statefulset scaleup
+		sts1Replicas = 10
+		ginkgo.By("Scale up statefulset replica count from 3 to 10")
+		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+
+		//verifying volume is provisioned on the preferred datastore
+		ginkgo.By("Verify volume is provisioned on the specified datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
+			nonShareddatastoreListMapRack3, false, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
+			namespace, allowedTopologyForRack3, true)
+	})
+
+	/*
+		Testcase-10:
+		Change  datastore preference  multiple times and  perform Scaleup/ScaleDown operation on StatefulSet
+
+		Steps
+		1. Assign Tag rack-1, Category "cns.vmware.topology-preferred-datastores" to datastore shared
+		across all racks (ex- NFS-12)
+		2. Create SC with WFC Binding mode and allowed topologies set to rack-1 in the SC
+		3. Create StatefulSet with parallel pod management policy and replica 3 with the above SC
+		4. Wait for all the StatefulSet to come up
+		5. Wait for PV , PVC to reach bound and POD to reach running state
+		6. Describe PV and verify node affinity details should contain specified allowed topologies details.
+		7. Verify volume should be provisioned on the selected preferred datastore of rack-1
+		8. Make sure POD is running on the same node as mentioned in the node affinity details
+		9. Remove tag from preferred datastore and assign tag rack-1  and category
+		"cns.vmware.topology-preferred-datastores" to new datastore specific to rack-1  (ex - vSAN-1).
+		10. Wait for the refresh interval time which is set at which preferred datatsore
+			is picked up for volume provisioning.
+		11. Perform Scaleup operation, Increase the replica count of StatefulSet from 3 to 13.
+		12. Wait for all the StatefulSet to come up
+		13. Wait for PV , PVC to reach Bound and POD to reach running state
+		14. Describe PV and verify node affinity details should contain specified allowed topolgies details.
+		15. Verify volume should be provisioned on the newly selected preferred datastore.
+		16. Perform Scaledown operation. Decrease the replica count from 13 to 6.
+		17. Remove tag from preferred datastore and assign tag rack-1 and  category
+		"cns.vmware.topology-preferred-datastores" to new datastore which is shared specific to rack-1. (ex- NFS-1)
+		18. Wait for the refresh interval time which is set at which preferred datatsore
+			is picked up for volume provisioning.
+		19. Perform Scaleup operation again and increase the replica count from 6 to 20.
+		20. Wait for all the StatefulSet to come up
+		21. Wait for PV , PVC to reach bound and POD to reach running state
+		22. Describe PV and verify node affinity details should contain specified allowed topology details.
+		23. Verify volume should be provisioned on the newly selected preferred datastore of rack-1
+		24. Make sure POD is running on the same node as mentioned in the node affinity details
+		25. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
+		26. Remove datastore preference tags as part of cleanup.
+	*/
+	ginkgo.It("Change datastore preference multiple times and perform scaleup and scaleDown "+
+		"operation on StatefulSet", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datastore for volume provisioning in rack-1(cluster-1))")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[0],
+			preferredDatastoreChosen, shareddatastoreListMap, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologyForRack1,
+			"", bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating Statefulset with 3 replica")
+		sts1 := GetStatefulSetFromManifest(namespace)
+		sts1.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+		CreateStatefulSet(namespace, sts1, client)
+		sts1Replicas := *(sts1.Spec.Replicas)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, sts1, sts1Replicas)
+		gomega.Expect(fss.CheckMount(client, sts1, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := GetListOfPodsInSts(client, sts1)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", sts1.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(sts1Replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// verify volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
+			shareddatastoreListMap, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
+			namespace, allowedTopologyForRack1, false)
+
+		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
+		err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[0], allowedTopologyRacks[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Tag new preferred datatsore for volume provisioning in rack-1(cluster-1)")
+		preferredDatastore, err := tagPreferredDatastore(masterIp, allowedTopologyRacks[0],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		// perform statefulset scaleup
+		sts1Replicas = 13
+		ginkgo.By("Scale up statefulset replica count from 3 to 13")
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+
+		// verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the specified datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
+			rack1DatastoreListMap, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
+			namespace, allowedTopologyForRack1, false)
+
+		// perform statefulset scaledown
+		sts1Replicas = 6
+		ginkgo.By("Scale down statefulset replica count from 13 to 6")
+		scaleDownStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+
+		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
+		err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[1], allowedTopologyRacks[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Tag new datastore chosen for volume provisioning")
+		preferredDatastore, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[0],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, preferredDatastorePaths)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
+		defer func() {
+			ginkgo.By("Remove preferred datastore tags chosen for volume provisioning")
+			for i := 0; i < len(preferredDatastorePaths); i++ {
+				err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[i], allowedTopologyRacks[0])
+			}
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		// perform statefulset scaleup
+		sts1Replicas = 20
+		ginkgo.By("Scale up statefulset replica count from 6 to 20")
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+
+		//verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the specified datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
+			rack1DatastoreListMap, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
+			namespace, allowedTopologyForRack1, false)
+	})
+
+	/*
+		Testcase-11:
+		Tag single datastore but no allowed Topologies are set in the SC
+
+		Steps
+		1. Assign Tag rack-1, Category "cns.vmware.topology-preferred-datastores" to datastore
+		specific to rack-1 (ex - NFS-1)
+		2. Create SC with WFC binding mode with no allowed topologies set in the SC
+		3. Create StatefulSet with replica 3 with the above SC
+		4. Wait for all the StatefulSet to come up.
+		5. Wait for PV , PVC to reach Bound and POD to reach running state
+		6. Pods should get created on any of the racks rack-1/rack-2/rack-3 since no allowed topology
+		is specified.
+		7. Describe PV and verify node affinity details.
+		8. If node affinity has rack-1 allowed topology, then volume should be provisioned on the preferred
+		datastore of rack-1.
+		9. If node affinity has either rack-2/rack-3 allowed topology, then volume should be provisioned
+		on any of the datastores since no preference is given.
+		10. Make sure POD is running on the same node as mentioned in the node affinity details.
+		11. Remove tag from preferred datastore and assign tag rack-2 and
+		category "cns.vmware.topology-preferred-datastores" to new datastore which is shared
+		specific to rack-2 (ex - NFS-2)
+		12. Wait for the refresh interval time which is set at which preferred datatsore
+		is picked up for volume provisioning.
+		13. Perform Scaleup operation, Increase the replica count of StatefulSet from 3 to 7.
+		14. Wait for all the StatefulSet to come up
+		15. Describe PV and verify node affinity details.
+		16. If node affinity has rack-1/rack-3 allowed topology, then volume should be provisioned
+		on any of the datastores since no preference is given.
+		17. If node affinity has rack-2 allowed topology, then volume should be provisioned on the
+		tagged preferred datastore of rack-2.
+		18. Make sure POD is running on the same node as mentioned in the node affinity details
+		18. Remove tag from preferred datastore and assign tag rack-3 and category
+		"cns.vmware.topology-preferred-datastores" to a new datastore which is shared specific
+		to rack-3 (ex - vSAN-3)
+		19. Wait for the refresh interval time which is set at which preferred datatsore
+		is pciked up for volume provisioning.
+		20. Perform Scaleup operation, Increase the replica count of StatefulSet from 7 to 13.
+		21. Wait for all the StatefulSet to come up
+		22. Wait for PV, PVC to reach bound and POD to reach running state
+		23. Describe PV and verify node affinity details.
+		24. If node affinity has rack-1/rack-2 allowed topology, then volume should be provisioned
+		on any of the datastores since no preference is given.
+		25. If node affinity has rack-3 allowed topology, then volume should be provisioned on the
+		tagged preferred datastore of rack-3
+		26. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
+		27. Remove datastore preference tags as part of cleanup.
+	*/
+	ginkgo.It("Tag single datastore from each rack when no allowed topologies are set in the SC", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-1(cluster-1)")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[0],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil,
+			"", bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating Statefulset with 3 replica")
+		sts1 := GetStatefulSetFromManifest(namespace)
+		CreateStatefulSet(namespace, sts1, client)
+		sts1Replicas := *(sts1.Spec.Replicas)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, sts1, sts1Replicas)
+		gomega.Expect(fss.CheckMount(client, sts1, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := GetListOfPodsInSts(client, sts1)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", sts1.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(sts1Replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// verify volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
+			nonShareddatastoreListMapRack1, true, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
+			namespace, allowedTopologies, false)
+
+		ginkgo.By("Remove preferred datatsore tag which was chosen for volume provisioning in rack-1")
+		err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[0], allowedTopologyRacks[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Tag new preferred datatsore for volume provisioning in rack-2(cluster-2)")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[1],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		// perform statefulset scaleup
+		sts1Replicas = 7
+		ginkgo.By("Scale up statefulset replica count from 3 to 7")
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+
+		//verify volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
+			nonShareddatastoreListMapRack2, true, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
+			namespace, allowedTopologies, false)
+
+		ginkgo.By("Remove the datastore preference chosen for volume provisioning")
+		err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[0], allowedTopologyRacks[1])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Tag new preferred datatsore for volume provisioning in rack-3(cluster-3)")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[2],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Remove the datastore preference chosen for volume provisioning")
+			err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[0], allowedTopologyRacks[2])
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		// perform statefulset scaleup
+		sts1Replicas = 13
+		ginkgo.By("Scale up statefulset replica count from 7 to 13")
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+
+		// verify volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
+			nonShareddatastoreListMapRack3, true, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
+			namespace, allowedTopologies, false)
+	})
+
+	/*
+		Testcase-12:
+		Tag multiple datastore and provide specific datastore Url in SC
+
+		Steps
+		1. Assign Tag rack-2, Category "cns.vmware.topology-preferred-datastores" to datastore
+		specific to rack-2(ex- NFS-2)
+		2. Assign Tag rack-2, Category "cns.vmware.topology-preferred-datastores" to datastore
+		specific to rack-2 (ex- vSAN-2)
+		3. Assign Tag rack-2, Category "cns.vmware.topology-preferred-datastores" to datastore shared
+		across all racks (ex- NFS-12)
+		4. Create SC with WFC binding mode with allowed topologies set to rack-2 and
+		provide any specific preferred datastore url in the SC (ex - vSAN datastore url)
+		5. Create StatefulSet with replica 3 with the above SC
+		6. Wait for all the StatefulSet to come up
+		7. Wait for PV , PVC to reach bound and POD to reach running state
+		8. Describe PV and verify node affinity details should contain specified allowed details.
+		9. Verify volume should be provisioned on the preferred datastore mentioned in the storage class.
+		10. Make sure POD is running on the same node as mentioned in node affinity details
+		11. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
+		12. Remove datastore preference tags as part of cleanup.
+	*/
+	ginkgo.It("Tag multiple datastore and provide specific datastore url in SC", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		preferredDatastoreChosen = 2
+		preferredDatastorePaths = nil
+		scParameters := make(map[string]string)
+		DataStoreUrlSpecificToCluster := GetAndExpectStringEnvVar(datastoreUrlSpecificToCluster)
+		scParameters["datastoreurl"] = DataStoreUrlSpecificToCluster
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-2(cluster-2)")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, allowedTopologyRacks[1],
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		preferredDatastoreChosen = 1
+		preferredDatastore, err := tagPreferredDatastore(masterIp, allowedTopologyRacks[1],
+			preferredDatastoreChosen, shareddatastoreListMap, nil)
+		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Remove preferred datastore tag")
+			for i := 0; i < len(preferredDatastorePaths); i++ {
+				err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[i],
+					allowedTopologyRacks[1])
+			}
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Creating StorageClass for Statefulset")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, allowedTopologyForRack2,
+			"", bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating Statefulset with 3 replica")
+		sts1 := GetStatefulSetFromManifest(namespace)
+		CreateStatefulSet(namespace, sts1, client)
+		sts1Replicas := *(sts1.Spec.Replicas)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			fss.DeleteAllStatefulSets(client, namespace)
+		}()
+
+		// Waiting for pods status to be Ready.
+		fss.WaitForStatusReadyReplicas(client, sts1, sts1Replicas)
+		gomega.Expect(fss.CheckMount(client, sts1, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := GetListOfPodsInSts(client, sts1)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", sts1.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(sts1Replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// verify volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
+			rack2DatastoreListMap, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify affinity details
+		ginkgo.By("Verify node and pv topology affinity details")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
+			namespace, allowedTopologyForRack2, false)
+	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Preferential automation - Part2

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Preferential automation - Part2

**Testing done**:
Yes

**Special notes for your reviewer**:
Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll 
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint 
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/preferential-automation-part2/vsphere-csi-driver /Users/sipriya/preferential-automation-part2 /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|files|imports|name|types_sizes) took 1m30.589060458s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 136.960812ms 
INFO [linters context/goanalysis] analyzers took 7m33.870248228s with top 10 stages: buildir: 5m39.748759398s, nilness: 17.210731683s, fact_deprecated: 13.38029946s, ctrlflow: 12.164966661s, printf: 12.119322609s, typedness: 10.063943014s, fact_purity: 9.548630962s, SA5012: 8.819959002s, inspect: 4.660085472s, S1038: 2.326907462s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_dirs: 113/113, autogenerated_exclude: 24/113, exclude-rules: 1/24, path_prettifier: 113/113, skip_files: 113/113, cgo: 113/113, filename_unadjuster: 113/113, identifier_marker: 24/24, exclude: 24/24, nolint: 0/1 
INFO [runner] processing took 19.406629ms with stages: nolint: 14.071527ms, autogenerated_exclude: 4.418751ms, path_prettifier: 394.127µs, identifier_marker: 301.61µs, skip_dirs: 125.429µs, exclude-rules: 67.2µs, cgo: 14.011µs, filename_unadjuster: 7.053µs, max_same_issues: 2.09µs, uniq_by_line: 869ns, skip_files: 699ns, max_from_linter: 681ns, path_shortener: 452ns, source_code: 446ns, diff: 423ns, max_per_file_from_linter: 327ns, exclude: 280ns, sort_results: 276ns, severity-rules: 244ns, path_prefixer: 134ns 
INFO [runner] linters took 46.416616937s with stages: goanalysis_metalinter: 46.396994783s 
INFO File cache stats: 285 entries of total size 5.0MiB 
INFO Memory: 1309 samples, avg is 634.2MB, max is 2658.6MB 
INFO Execution took 2m17.158342338s               
sipriya@sipriya-a01 vsphere-csi-driver % 
