### PR TITLE
fixed windows node daemonset pod spec

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -585,6 +585,7 @@ spec:
             initialDelaySeconds: 3
         - name: vsphere-csi-node
           image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.4-rc.4
+          args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fixed windows node daemonset pod spec.
windows node daemonset pod spec was missing `args:` for the image driver image.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fixed windows node daemonset pod spec
```
