### PR TITLE
[Block volumes] Skip shared datastore computations if CNS task for CreateVolume is persisted in the idempotency CR

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -119,6 +119,13 @@ type Manager interface {
 	// QuerySnapshots retrieves the list of snapshots based on the query filter.
 	QuerySnapshots(ctx context.Context, snapshotQueryFilter cnstypes.CnsSnapshotQueryFilter) (
 		*cnstypes.CnsSnapshotQueryResult, error)
+	// MonitorCreateVolumeTask monitors the CNS task which is created for volume creation
+	// as part of volume idempotency feature
+	MonitorCreateVolumeTask(ctx context.Context,
+		volumeOperationDetails **cnsvolumeoperationrequest.VolumeOperationRequestDetails,
+		task *object.Task, volNameFromInputSpec string, clusterID string) (*CnsVolumeInfo, string, error)
+	// GetOperationStore returns the VolumeOperationRequest interface
+	GetOperationStore() cnsvolumeoperationrequest.VolumeOperationRequest
 }
 
 // CnsVolumeInfo hold information related to volume created by CNS.
@@ -268,6 +275,119 @@ func (m *defaultManager) ResetManager(ctx context.Context, vcenter *cnsvsphere.V
 	log.Infof("Done resetting volume.defaultManager")
 }
 
+// GetOperationStore returns the VolumeOperationRequest interface
+func (m *defaultManager) GetOperationStore() cnsvolumeoperationrequest.VolumeOperationRequest {
+	return m.operationStore
+}
+
+// MonitorCreateVolumeTask monitors the CNS task which is created for volume creation
+// as part of volume idempotency feature
+func (m *defaultManager) MonitorCreateVolumeTask(ctx context.Context,
+	volumeOperationDetails **cnsvolumeoperationrequest.VolumeOperationRequestDetails, task *object.Task,
+	volNameFromInputSpec string, clusterID string) (*CnsVolumeInfo, string, error) {
+	var faultType string
+	log := logger.GetLogger(ctx)
+
+	taskInfo, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		if cnsvsphere.IsManagedObjectNotFound(err, task.Reference()) {
+			log.Debugf("CreateVolume task %s not found in vCenter %s. Querying CNS "+
+				"to determine if the volume %s was successfully created.",
+				m.virtualCenter.Config.Host, task.Reference().Value, volNameFromInputSpec)
+			queryFilter := cnstypes.CnsQueryFilter{
+				Names:               []string{volNameFromInputSpec},
+				ContainerClusterIds: []string{clusterID},
+			}
+			queryResult, queryAllVolumeErr := m.QueryAllVolume(ctx, queryFilter, cnstypes.CnsQuerySelection{})
+			if queryAllVolumeErr != nil {
+				log.Errorf("failed to query CNS for volume %s with error: %v. Cannot "+
+					"determine if CreateVolume task %s was successful.", volNameFromInputSpec,
+					queryAllVolumeErr, task.Reference().Value)
+				return nil, ExtractFaultTypeFromErr(ctx, err), err
+			}
+			if len(queryResult.Volumes) > 0 {
+				if len(queryResult.Volumes) != 1 {
+					log.Infof("CNS Query returned multiple entries for volume %s: %v. Returning volume ID "+
+						"of first entry: %s", volNameFromInputSpec, spew.Sdump(queryResult.Volumes),
+						queryResult.Volumes[0].VolumeId.Id)
+				}
+				volumeID := queryResult.Volumes[0].VolumeId.Id
+				*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, volumeID, "", 0,
+					(*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
+					(*volumeOperationDetails).OperationDetails.TaskID, taskInvocationStatusSuccess, "")
+				log.Debugf("Found volume %s with id %s", volNameFromInputSpec, volumeID)
+				return &CnsVolumeInfo{
+					DatastoreURL: "",
+					VolumeID: cnstypes.CnsVolumeId{
+						Id: volumeID,
+					},
+				}, "", nil
+			}
+			log.Errorf("volume with name %s not present in CNS. Marking task %s as failed.",
+				volNameFromInputSpec, task.Reference().Value)
+			*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
+				(*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
+				(*volumeOperationDetails).OperationDetails.TaskID, taskInvocationStatusError, err.Error())
+
+			return nil, ExtractFaultTypeFromErr(ctx, err), err
+		}
+		// WaitForResult can fail for many reasons, including:
+		// - CNS restarted and marked "InProgress" tasks as "Failed".
+		// - Any failures from CNS.
+		// - Any failures at lower layers like FCD and SPS.
+		// In all cases, mark task as failed and retry.
+		log.Errorf("failed to get CreateVolume taskInfo from CNS with error: %v", err)
+		*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
+			(*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
+			(*volumeOperationDetails).OperationDetails.TaskID, taskInvocationStatusError, err.Error())
+
+		return nil, ExtractFaultTypeFromErr(ctx, err), err
+	}
+
+	log.Infof("CreateVolume: VolumeName: %q, opId: %q", volNameFromInputSpec, taskInfo.ActivationId)
+	taskResult, err := getTaskResultFromTaskInfo(ctx, taskInfo)
+	if taskResult == nil {
+		return nil, csifault.CSITaskResultEmptyFault,
+			logger.LogNewErrorf(log, "taskResult is empty for CreateVolume task: %q, opID: %q",
+				taskInfo.Task.Value, taskInfo.ActivationId)
+	}
+	if err != nil {
+		log.Errorf("failed to get task result for task %s and volume name %s with error: %v",
+			task.Reference().Value, volNameFromInputSpec, err)
+		faultType = ExtractFaultTypeFromErr(ctx, err)
+		return nil, faultType, err
+	}
+	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
+	if volumeOperationRes.Fault != nil {
+		// Validate if the volume is already registered.
+		faultType = ExtractFaultTypeFromVolumeResponseResult(ctx, volumeOperationRes)
+		resp, err := validateCreateVolumeResponseFault(ctx, volNameFromInputSpec, volumeOperationRes)
+		if err != nil {
+			*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
+				(*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
+				taskInfo.ActivationId, taskInvocationStatusError, err.Error())
+		} else {
+			*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, resp.VolumeID.Id, "", 0,
+				(*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
+				taskInfo.ActivationId, taskInvocationStatusSuccess, "")
+		}
+		return resp, faultType, err
+	}
+	// Extract the CnsVolumeInfo from the taskResult.
+	resp, faultType, err := getCnsVolumeInfoFromTaskResult(ctx, m.virtualCenter, volNameFromInputSpec,
+		volumeOperationRes.VolumeId, taskResult)
+	if err != nil {
+		*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
+			(*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
+			taskInfo.ActivationId, taskInvocationStatusError, err.Error())
+	} else {
+		*volumeOperationDetails = createRequestDetails(volNameFromInputSpec, resp.VolumeID.Id, "", 0,
+			(*volumeOperationDetails).OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
+			taskInfo.ActivationId, taskInvocationStatusSuccess, "")
+	}
+	return resp, faultType, err
+}
+
 // createVolumeWithImprovedIdempotency leverages the VolumeOperationRequest
 // interface to persist CNS task information. It uses this persisted information
 // to handle idempotency of CreateVolume callbacks to CNS for the same volume.
@@ -283,6 +403,8 @@ func (m *defaultManager) createVolumeWithImprovedIdempotency(ctx context.Context
 		// Local instance of CreateVolume details that needs to
 		// be persisted.
 		volumeOperationDetails *cnsvolumeoperationrequest.VolumeOperationRequestDetails
+		// Information related to volume created by CNS
+		resp *CnsVolumeInfo
 	)
 
 	if m.operationStore == nil {
@@ -369,105 +491,9 @@ func (m *defaultManager) createVolumeWithImprovedIdempotency(ctx context.Context
 		}
 	}
 
-	taskInfo, err := task.WaitForResult(ctx, nil)
-	if err != nil {
-		if cnsvsphere.IsManagedObjectNotFound(err, task.Reference()) {
-			log.Debugf("CreateVolume task %s not found in vCenter. Querying CNS "+
-				"to determine if the volume %s was successfully created.",
-				task.Reference().Value, volNameFromInputSpec)
-			queryFilter := cnstypes.CnsQueryFilter{
-				Names:               []string{volNameFromInputSpec},
-				ContainerClusterIds: []string{spec.Metadata.ContainerClusterArray[0].ClusterId},
-			}
-			queryResult, queryAllVolumeErr := m.QueryAllVolume(ctx, queryFilter, cnstypes.CnsQuerySelection{})
-			if queryAllVolumeErr != nil {
-				log.Debugf("failed to query CNS for volume %s with error: %v. Cannot "+
-					"determine if CreateVolume task %s was successful.", volNameFromInputSpec,
-					queryAllVolumeErr, task.Reference().Value)
-				return nil, ExtractFaultTypeFromErr(ctx, err), err
-			}
-			if len(queryResult.Volumes) > 0 {
-				if len(queryResult.Volumes) != 1 {
-					log.Infof("CNS Query returned multiple entries for volume %s: %v. Returning volume ID "+
-						"of first entry: %s", volNameFromInputSpec, spew.Sdump(queryResult.Volumes),
-						queryResult.Volumes[0].VolumeId.Id)
-				}
-				volumeID := queryResult.Volumes[0].VolumeId.Id
-				volumeOperationDetails = createRequestDetails(volNameFromInputSpec, volumeID, "", 0,
-					volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
-					volumeOperationDetails.OperationDetails.TaskID, taskInvocationStatusSuccess, "")
-				log.Debugf("Found volume %s with id %s", volNameFromInputSpec, volumeID)
-				return &CnsVolumeInfo{
-					DatastoreURL: "",
-					VolumeID: cnstypes.CnsVolumeId{
-						Id: volumeID,
-					},
-				}, "", nil
-			}
-			log.Errorf("volume with name %s not present in CNS. Marking task %s as failed.",
-				volNameFromInputSpec, task.Reference().Value)
-			volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
-				volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
-				volumeOperationDetails.OperationDetails.TaskID, taskInvocationStatusError, err.Error())
-
-			return nil, ExtractFaultTypeFromErr(ctx, err), err
-		}
-		// WaitForResult can fail for many reasons, including:
-		// - CNS restarted and marked "InProgress" tasks as "Failed".
-		// - Any failures from CNS.
-		// - Any failures at lower layers like FCD and SPS.
-		// In all cases, mark task as failed and retry.
-		log.Errorf("failed to get CreateVolume taskInfo from CNS with error: %v", err)
-		volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
-			volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
-			volumeOperationDetails.OperationDetails.TaskID, taskInvocationStatusError, err.Error())
-
-		return nil, ExtractFaultTypeFromErr(ctx, err), err
-	}
-
-	log.Infof("CreateVolume: VolumeName: %q, opId: %q", volNameFromInputSpec, taskInfo.ActivationId)
-	taskResult, err := getTaskResultFromTaskInfo(ctx, taskInfo)
-	if taskResult == nil {
-		return nil, csifault.CSITaskResultEmptyFault,
-			logger.LogNewErrorf(log, "taskResult is empty for CreateVolume task: %q, opID: %q",
-				taskInfo.Task.Value, taskInfo.ActivationId)
-	}
-	if err != nil {
-		log.Errorf("failed to get task result for task %s and volume name %s with error: %v",
-			task.Reference().Value, volNameFromInputSpec, err)
-		faultType = ExtractFaultTypeFromErr(ctx, err)
-		return nil, faultType, err
-	}
-	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
-	if volumeOperationRes.Fault != nil {
-		// Validate if the volume is already registered.
-		faultType = ExtractFaultTypeFromVolumeResponseResult(ctx, volumeOperationRes)
-		resp, err := validateCreateVolumeResponseFault(ctx, volNameFromInputSpec, volumeOperationRes)
-		if err != nil {
-			volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
-				volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
-				taskInfo.ActivationId, taskInvocationStatusError, err.Error())
-		} else {
-			volumeOperationDetails = createRequestDetails(volNameFromInputSpec, resp.VolumeID.Id, "", 0,
-				volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
-				taskInfo.ActivationId, taskInvocationStatusSuccess, "")
-		}
-		return resp, faultType, err
-	}
-	// Extract the CnsVolumeInfo from the taskResult.
-	resp, faultType, err := getCnsVolumeInfoFromTaskResult(ctx, m.virtualCenter, volNameFromInputSpec,
-		volumeOperationRes.VolumeId, taskResult)
-	if err != nil {
-		volumeOperationDetails = createRequestDetails(volNameFromInputSpec, "", "", 0,
-			volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
-			taskInfo.ActivationId, taskInvocationStatusError, err.Error())
-	} else {
-		volumeOperationDetails = createRequestDetails(volNameFromInputSpec, resp.VolumeID.Id, "", 0,
-			volumeOperationDetails.OperationDetails.TaskInvocationTimestamp, task.Reference().Value,
-			taskInfo.ActivationId, taskInvocationStatusSuccess, "")
-	}
+	resp, faultType, err = m.MonitorCreateVolumeTask(ctx, &volumeOperationDetails, task,
+		volNameFromInputSpec, spec.Metadata.ContainerClusterArray[0].ClusterId)
 	return resp, faultType, err
-
 }
 
 // createVolume invokes CNS CreateVolume. It stores task information in an


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We are finding shared datastores etc. even when the vCenter task for CreateVolume is already registered with improved idempotency. This PR is optimising this code to make sure that heavy computations of finding shared datastore etc. are skipped if task for CreateVolume is already created.
This PR is optimising code for Block Volume creation, we can add changes for File volume creation as part of a separate PR.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
csi-block-vanilla-pre-check-in tests are successful. 

Manual testing logs:
```
# kubectl get pvc
NAME                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
example-raw-block-pvc2   Bound    pvc-1ecc676a-094c-41ad-8491-ac632ec22dd4   1Gi        RWO            example-raw-block-sc   8m52s

# kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM                            STORAGECLASS              REASON   AGE
pvc-1ecc676a-094c-41ad-8491-ac632ec22dd4   1Gi        RWO            Delete           Bound       default/example-raw-block-pvc2   example-raw-block-sc               8m36s

# kubectl get pods
NAME                    READY   STATUS    RESTARTS   AGE
example-raw-block-pod   1/1     Running   0          20s
```

Controller log messages:
```
<snip>
2022-10-27T11:51:19.944Z        INFO    vanilla/controller.go:983       CreateVolume: called with args {Name:pvc-1ecc676a-094c-41ad-8491-ac632ec22dd4 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[block:<> access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}      {"TraceId": "f81c6aeb-bc43-40d6-acd2-7eecd0a15db2"}
2022-10-27T11:51:19.944Z        DEBUG   vanilla/controller.go:602       Checking if vCenter task for volume pvc-1ecc676a-094c-41ad-8491-ac632ec22dd4 is already registered.     {"TraceId": "f81c6aeb-bc43-40d6-acd2-7eecd0a15db2"}
2022-10-27T11:51:19.944Z        DEBUG   cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:141      Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-1ecc676a-094c-41ad-8491-ac632ec22dd4 {"TraceId": "f81c6aeb-bc43-40d6-acd2-7eecd0a15db2"}
2022-10-27T11:51:19.975Z        DEBUG   vanilla/controller.go:624       CreateVolume task details for volume pvc-1ecc676a-094c-41ad-8491-ac632ec22dd4 are not found, cnsvolumeoperationrequests.cns.vmware.com "pvc-1ecc676a-094c-41ad-8491-ac632ec22dd4" not found     {"TraceId": "f81c6aeb-bc43-40d6-acd2-7eecd0a15db2"}
...
2022-10-27T11:51:43.036Z        INFO    volume/util.go:329      Volume created successfully. VolumeName: "pvc-1ecc676a-094c-41ad-8491-ac632ec22dd4", volumeID: "34697dbe-7dfb-4dd0-8ef8-bfb628d172f6"   {"TraceId": "f81c6aeb-bc43-40d6-acd2-7eecd0a15db2"}
</snip>

```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Optimise CreateVolume code to skip shared datastore computations if CNS task for CreateVolume is already created.
```
