### PR TITLE
ControllerPublishVolume and ControllerUnpublishVolume changes for multi-vc CSI topology

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -343,6 +343,10 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 		log.Error(ErrMissingTopologyCategoriesForMultiVCenterSetup)
 		return ErrMissingTopologyCategoriesForMultiVCenterSetup
 	}
+	var setCfgGlobalvCenter bool
+	if len(cfg.VirtualCenter) == 1 {
+		setCfgGlobalvCenter = true
+	}
 	for vcServer, vcConfig := range cfg.VirtualCenter {
 		log.Debugf("Initializing vc server %s", vcServer)
 		if vcServer == "" {
@@ -375,6 +379,9 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 		insecure := vcConfig.InsecureFlag
 		if !insecure {
 			vcConfig.InsecureFlag = cfg.Global.InsecureFlag
+		}
+		if setCfgGlobalvCenter && cfg.Global.VCenterIP == "" {
+			cfg.Global.VCenterIP = vcServer
 		}
 		// Print out the config. WARNING: This will print the password used in plain text.
 		log.Debugf("vc server %s config: %+v", vcServer, vcConfig)

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -596,12 +596,12 @@ func getHostVsanUUID(ctx context.Context, hostMoID string, vc *vsphere.VirtualCe
 }
 
 // AttachVolumeUtil is the helper function to attach CNS volume to specified vm.
-func AttachVolumeUtil(ctx context.Context, manager *Manager,
+func AttachVolumeUtil(ctx context.Context, volumeManager cnsvolume.Manager,
 	vm *vsphere.VirtualMachine,
 	volumeID string, checkNVMeController bool) (string, string, error) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("vSphere CSI driver is attaching volume: %q to vm: %q", volumeID, vm.String())
-	diskUUID, faultType, err := manager.VolumeManager.AttachVolume(ctx, vm, volumeID, checkNVMeController)
+	diskUUID, faultType, err := volumeManager.AttachVolume(ctx, vm, volumeID, checkNVMeController)
 	if err != nil {
 		log.Errorf("failed to attach disk %q with VM: %q. err: %+v faultType %q", volumeID, vm.String(), err, faultType)
 		return "", faultType, err
@@ -612,12 +612,12 @@ func AttachVolumeUtil(ctx context.Context, manager *Manager,
 
 // DetachVolumeUtil is the helper function to detach CNS volume from specified
 // vm.
-func DetachVolumeUtil(ctx context.Context, manager *Manager,
+func DetachVolumeUtil(ctx context.Context, volumeManager cnsvolume.Manager,
 	vm *vsphere.VirtualMachine,
 	volumeID string) (string, error) {
 	log := logger.GetLogger(ctx)
 	log.Debugf("vSphere CSI driver is detaching volume: %s from node vm: %s", volumeID, vm.InventoryPath)
-	faultType, err := manager.VolumeManager.DetachVolume(ctx, vm, volumeID)
+	faultType, err := volumeManager.DetachVolume(ctx, vm, volumeID)
 	if err != nil {
 		log.Errorf("failed to detach disk %s with err %+v", volumeID, err)
 		return faultType, err

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1008,7 +1008,8 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 
 		// Attach the volume to the node.
 		// faultType is returned from manager.AttachVolume.
-		diskUUID, faultType, err := common.AttachVolumeUtil(ctx, c.manager, podVM, req.VolumeId, true)
+		diskUUID, faultType, err := common.AttachVolumeUtil(ctx, c.manager.VolumeManager, podVM,
+			req.VolumeId, true)
 		if err != nil {
 			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.FakeAttach) {
 				log.Infof("Volume attachment failed. Checking if it can be fake attached")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
ControllerPublishVolume and ControllerUnpublishVolume changes for multi-vc CSI topology


**Testing done**:

- Manually verified there is no regression in attach/detach when `multi-vcenter-csi-topology` is disabled.
- Also verified attach/detach works fine with `multi-vcenter-csi-topology` is enabled and vSphere config secret has one vCenter.

Further end-to-end testing can be done only after Volume Creation feature is added for multi-vcenter-csi-topology.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
ControllerPublishVolume and ControllerUnpublishVolume changes for multi-vc CSI topology
```
