### PR TITLE
Enable improved idempotency feature by default for Vanilla deployments

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -153,7 +153,6 @@ data:
   "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"
   "async-query-volume": "true"
-  "improved-csi-idempotency": "true"
   "block-volume-snapshot": "true"
   "csi-windows-support": "false"
   "use-csinode-id": "true"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR enables improved idempotency feature by default for Vanilla. FSS is no more required for this feature. Cleaning up all code which is no more required.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running block csi pre-check-in tests

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enable improved idempotency feature by default for Vanilla deployments.
```
