### PR TITLE
Multi-VC: Node topology discovery

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -616,6 +616,24 @@ func GetVirtualCenterInstanceForVCenterConfig(ctx context.Context,
 	return vCenterInstances[vcconfig.Host], nil
 }
 
+// GetVirtualCenterInstanceForVCenterHost returns the vcenter object for given vCenter host.
+func GetVirtualCenterInstanceForVCenterHost(ctx context.Context, vcHost string) (*VirtualCenter, error) {
+	log := logger.GetLogger(ctx)
+	vCenterInstancesLock.RLock()
+	defer vCenterInstancesLock.RUnlock()
+
+	vc, found := vCenterInstances[vcHost]
+	if !found || vc == nil {
+		return nil, logger.LogNewErrorf(log, "failed to get VirtualCenter instance for host %q.", vcHost)
+	}
+	err := vc.Connect(ctx)
+	if err != nil {
+		return nil, logger.LogNewErrorf(log, "failed to connect to VirtualCenter host: %q. Error: %v",
+			vcHost, err)
+	}
+	return vc, nil
+}
+
 // GetAllVirtualMachines gets the VM Managed Objects with the given properties from the
 // VM object.
 func (vc *VirtualCenter) GetAllVirtualMachines(ctx context.Context,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR supports discovering node topology in a K8s cluster spanning across multiple VCs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Example syncer logs for multi-VC node discovery:
```
2022-10-20T05:45:47.524Z	INFO	syncer/metadatasyncer.go:650	topoCRAdded: CSINodeTopology instance "k8s-node-877-1664569511" not yet ready. Status: ""	{"TraceId": "16e05028-0cd6-4e17-a411-ed0cc838d3de"}
2022-10-20T05:45:47.533Z	DEBUG	node/manager.go:241	VM VirtualMachine:vm-52 [VirtualCenterHost: 10.78.234.75, UUID: 42351f78-56fb-94ab-050f-53a69f929750, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.234.75]] was successfully renewed with nodeUUID "42351f78-56fb-94ab-050f-53a69f929750"
2022-10-20T05:45:47.533Z	INFO	csinodetopology/csinodetopology_controller.go:312	Detected a topology aware cluster
2022-10-20T05:45:47.748Z	DEBUG	vsphere/virtualmachine.go:234	Host owning node vm: VirtualMachine:vm-52 [VirtualCenterHost: 10.78.234.75, UUID: 42351f78-56fb-94ab-050f-53a69f929750, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.234.75]] is 10.78.224.211
2022-10-20T05:45:47.756Z	DEBUG	vsphere/virtualmachine.go:266	Ancestors of node vm: VirtualMachine:vm-52 [VirtualCenterHost: 10.78.234.75, UUID: 42351f78-56fb-94ab-050f-53a69f929750, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.234.75]] are : [[{ExtensibleManagedObject:{Self:Folder:group-d1 Value:[] AvailableField:[]} Parent:<nil> CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:Datacenters DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Datacenter:datacenter-3 Value:[] AvailableField:[]} Parent:Folder:group-d1 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:VSAN-DC DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:Folder:group-h5 Value:[] AvailableField:[]} Parent:Datacenter:datacenter-3 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:host DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:ClusterComputeResource:domain-c8 Value:[] AvailableField:[]} Parent:Folder:group-h5 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:cluster1 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]} {ExtensibleManagedObject:{Self:HostSystem:host-32 Value:[] AvailableField:[]} Parent:ClusterComputeResource:domain-c8 CustomValue:[] OverallStatus: ConfigStatus: ConfigIssue:[] EffectiveRole:[] Permission:[] Name:10.78.224.211 DisabledMethod:[] RecentTask:[] DeclaredAlarmState:[] TriggeredAlarmState:[] AlarmActionsEnabled:<nil> Tag:[]}]]
2022-10-20T05:45:47.951Z	DEBUG	vsphere/virtualmachine.go:419	Found tag: "zone-2" for object ClusterComputeResource:domain-c8
2022-10-20T05:45:47.971Z	DEBUG	vsphere/virtualmachine.go:427	Found category "" for object ClusterComputeResource:domain-c8 with tag: "zone-2" 
2022-10-20T05:45:47.971Z	INFO	vsphere/virtualmachine.go:431	Found category: zone for object ClusterComputeResource:domain-c8 with tag: zone-2
2022-10-20T05:45:48.067Z	DEBUG	vsphere/virtualmachine.go:419	Found tag: "region-2" for object Folder:group-d1
2022-10-20T05:45:48.095Z	DEBUG	vsphere/virtualmachine.go:427	Found category "" for object Folder:group-d1 with tag: "region-2" 
2022-10-20T05:45:48.095Z	INFO	vsphere/virtualmachine.go:431	Found category: region for object Folder:group-d1 with tag: region-2
2022-10-20T05:45:48.095Z	INFO	vsphere/virtualmachine.go:443	Tags related to all topology categories found. Skipping tag check on following entities: []
2022-10-20T05:45:48.095Z	INFO	csinodetopology/csinodetopology_controller.go:526	NodeVM "VirtualMachine:vm-52" belongs to topology: map[region:region-2 zone:zone-2]
2022-10-20T05:45:48.152Z	DEBUG	node/manager.go:234	Renewing virtual machine VirtualMachine:vm-52 [VirtualCenterHost: 10.78.234.75, UUID: 42351f78-56fb-94ab-050f-53a69f929750, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.234.75]] with nodeUUID "42351f78-56fb-94ab-050f-53a69f929750"	{"TraceId": "397cad4a-fa89-45ad-9b6a-9e2bd8d39dd6"}
2022-10-20T05:45:48.152Z	INFO	csinodetopology/csinodetopology_controller.go:342	Successfully updated topology labels for nodeVM "k8s-node-877-1664569511"
2022-10-20T05:45:48.153Z	DEBUG	csinodetopology/csinodetopology_controller.go:176	Ignoring CSINodeTopology reconciliation on update event
2022-10-20T05:45:48.162Z	DEBUG	node/manager.go:241	VM VirtualMachine:vm-52 [VirtualCenterHost: 10.78.234.75, UUID: 42351f78-56fb-94ab-050f-53a69f929750, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.234.75]] was successfully renewed with nodeUUID "42351f78-56fb-94ab-050f-53a69f929750"	{"TraceId": "397cad4a-fa89-45ad-9b6a-9e2bd8d39dd6"}
2022-10-20T05:45:48.162Z	INFO	syncer/metadatasyncer.go:624	Topology labels [{Key:topology.csi.vmware.com/region Value:region-2} {Key:topology.csi.vmware.com/zone Value:zone-2}] belong to "10.78.234.75" VC	{"TraceId": "397cad4a-fa89-45ad-9b6a-9e2bd8d39dd6"}
2022-10-20T05:45:48.327Z	INFO	node/nodes.go:162	csiNodeUpdate: Observed node UUID change from "" to "42351f78-56fb-94ab-050f-53a69f929750" for the node: "k8s-node-877-1664569511"	{"TraceId": "45b03c99-fc58-4095-be6f-44e6623ee88c"}
2022-10-20T05:45:48.327Z	INFO	node/manager.go:124	Discovering node vm using uuid: "42351f78-56fb-94ab-050f-53a69f929750"	{"TraceId": "45b03c99-fc58-4095-be6f-44e6623ee88c"}
```

Nodes showing correct labels:
```
NAME                         STATUS   ROLES           AGE   VERSION   LABELS
k8s-control-160-1664567688   Ready    control-plane   19d   v1.24.4   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=k8s-control-160-1664567688,kubernetes.io/os=linux,node-role.kubernetes.io/control-plane=,node.kubernetes.io/exclude-from-external-load-balancers=,node.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,topology.csi.vmware.com/region=region-1,topology.csi.vmware.com/zone=zone-1
k8s-control-467-1664567731   Ready    control-plane   19d   v1.24.4   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=k8s-control-467-1664567731,kubernetes.io/os=linux,node-role.kubernetes.io/control-plane=,node.kubernetes.io/exclude-from-external-load-balancers=,node.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,topology.csi.vmware.com/region=region-1,topology.csi.vmware.com/zone=zone-1
k8s-control-922-1664567710   Ready    control-plane   19d   v1.24.4   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=k8s-control-922-1664567710,kubernetes.io/os=linux,node-role.kubernetes.io/control-plane=,node.kubernetes.io/exclude-from-external-load-balancers=,node.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,topology.csi.vmware.com/region=region-1,topology.csi.vmware.com/zone=zone-1
k8s-node-277-1664569574      Ready    <none>          19d   v1.24.4   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=k8s-node-277-1664569574,kubernetes.io/os=linux,node.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,topology.csi.vmware.com/region=region-2,topology.csi.vmware.com/zone=zone-2
k8s-node-439-1664569640      Ready    <none>          19d   v1.24.4   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=k8s-node-439-1664569640,kubernetes.io/os=linux,node.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,topology.csi.vmware.com/region=region-2,topology.csi.vmware.com/zone=zone-2
k8s-node-451-1664567756      Ready    <none>          19d   v1.24.4   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=k8s-node-451-1664567756,kubernetes.io/os=linux,node.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,topology.csi.vmware.com/region=region-1,topology.csi.vmware.com/zone=zone-1
k8s-node-738-1664567775      Ready    <none>          19d   v1.24.4   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=k8s-node-738-1664567775,kubernetes.io/os=linux,node.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,topology.csi.vmware.com/region=region-1,topology.csi.vmware.com/zone=zone-1
k8s-node-759-1664567797      Ready    <none>          19d   v1.24.4   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=k8s-node-759-1664567797,kubernetes.io/os=linux,node.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,topology.csi.vmware.com/region=region-1,topology.csi.vmware.com/zone=zone-1
k8s-node-877-1664569511      Ready    <none>          19d   v1.24.4   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=k8s-node-877-1664569511,kubernetes.io/os=linux,node.kubernetes.io/instance-type=vsphere-vm.cpu-4.mem-4gb.os-ubuntu,topology.csi.vmware.com/region=region-2,topology.csi.vmware.com/zone=zone-2
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Multi-VC: Node topology discovery
```
