### PR TITLE
DeleteVolume changes for multi-VC CSI topology

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -1074,7 +1074,7 @@ func DeleteSnapshotUtil(ctx context.Context, manager *Manager, csiSnapshotID str
 }
 
 // GetCnsVolumeType is the helper function that determines the volume type based on the volume-id
-func GetCnsVolumeType(ctx context.Context, manager *Manager, volumeId string) (string, error) {
+func GetCnsVolumeType(ctx context.Context, volumeManager cnsvolume.Manager, volumeId string) (string, error) {
 	log := logger.GetLogger(ctx)
 	var volumeType string
 	queryFilter := cnstypes.CnsQueryFilter{
@@ -1086,7 +1086,7 @@ func GetCnsVolumeType(ctx context.Context, manager *Manager, volumeId string) (s
 		},
 	}
 	// Select only the volume type.
-	queryResult, err := manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
+	queryResult, err := volumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
 	if err != nil {
 		return "", logger.LogNewErrorCodef(log, codes.Internal,
 			"queryVolume failed for volumeID: %q with err=%+v", volumeId, err)

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -866,7 +866,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 			return nil, csifault.CSIInvalidArgumentFault, err
 		}
 		if cnsVolumeType == common.UnknownVolumeType {
-			cnsVolumeType, err = common.GetCnsVolumeType(ctx, c.manager, req.VolumeId)
+			cnsVolumeType, err = common.GetCnsVolumeType(ctx, c.manager.VolumeManager, req.VolumeId)
 			if err != nil {
 				if err.Error() == common.ErrNotFound.Error() {
 					// The volume couldn't be found during query, assuming the delete operation as success
@@ -1642,7 +1642,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		// Later we may need to define different csi faults.
 		// Check if the volume contains CNS snapshots only for block volumes.
 		if cnsVolumeType == common.UnknownVolumeType {
-			cnsVolumeType, err = common.GetCnsVolumeType(ctx, c.manager, req.VolumeId)
+			cnsVolumeType, err = common.GetCnsVolumeType(ctx, c.manager.VolumeManager, req.VolumeId)
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to determine CNS volume type for volume: %q. Error: %+v", req.VolumeId, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
DeleteVolume operation changes to support multi-VC CSI topology

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manually verified DeleteVolume works fine when `multi-vcenter-csi-topology` is disabled.

```
# kubectl get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             AGE
example-raw-block-pvc   Bound    pvc-8df92ec4-40b4-4ce0-8bb8-0e409a1f4201   1Gi        RWO            example-raw-block-sc-2   77m
#
# kubectl delete pvc example-raw-block-pvc
persistentvolumeclaim "example-raw-block-pvc" deleted
#
# kubectl get pvc
No resources found in default namespace.

```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
DeleteVolume operation changes to support multi-VC CSI topology
```
