### PR TITLE
ExpandVolume changes to support multi-VC CSI topology

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -86,6 +86,25 @@ func GetVCenters(ctx context.Context, managers *Managers) ([]*cnsvsphere.Virtual
 	return vcenters, nil
 }
 
+// GetVCenterFromVCHost returns VirtualCenter object from specified VC host.
+// Before returning VirtualCenter objects, vcenter connection is established if
+// session doesn't exist.
+func GetVCenterFromVCHost(ctx context.Context, vCenterManager cnsvsphere.VirtualCenterManager,
+	vCenterHost string) (*cnsvsphere.VirtualCenter, error) {
+	log := logger.GetLogger(ctx)
+	vcenter, err := vCenterManager.GetVirtualCenter(ctx, vCenterHost)
+	if err != nil {
+		return nil, logger.LogNewErrorf(log,
+			"failed to get VirtualCenter instance for VChost: %q. err=%v", vCenterHost, err)
+	}
+	err = vcenter.Connect(ctx)
+	if err != nil {
+		return nil, logger.LogNewErrorf(log,
+			"failed to connect to VirtualCenter host: %q. err=%v", vCenterHost, err)
+	}
+	return vcenter, nil
+}
+
 // GetUUIDFromProviderID Returns VM UUID from Node's providerID.
 func GetUUIDFromProviderID(providerID string) string {
 	return strings.TrimPrefix(providerID, ProviderPrefix)

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -645,7 +645,8 @@ func DeleteVolumeUtil(ctx context.Context, volManager cnsvolume.Manager, volumeI
 
 // ExpandVolumeUtil is the helper function to extend CNS volume for given
 // volumeId.
-func ExpandVolumeUtil(ctx context.Context, manager *Manager, volumeID string, capacityInMb int64,
+func ExpandVolumeUtil(ctx context.Context, vCenterManager vsphere.VirtualCenterManager,
+	vCenterHost string, volumeManager cnsvolume.Manager, volumeID string, capacityInMb int64,
 	useAsyncQueryVolume bool) (string, error) {
 	var err error
 	log := logger.GetLogger(ctx)
@@ -654,7 +655,7 @@ func ExpandVolumeUtil(ctx context.Context, manager *Manager, volumeID string, ca
 	var isvSphere8AndAbove, expansionRequired bool
 
 	// Checking if vsphere version is 8 and above.
-	vc, err := GetVCenter(ctx, manager)
+	vc, err := GetVCenterFromVCHost(ctx, vCenterManager, vCenterHost)
 	if err != nil {
 		log.Errorf("failed to get vcenter. err=%v", err)
 		return csifault.CSIInternalFault, err
@@ -668,7 +669,8 @@ func ExpandVolumeUtil(ctx context.Context, manager *Manager, volumeID string, ca
 
 	if !isvSphere8AndAbove {
 		// Query Volume to check Volume Size for vSphere version below 8.0
-		expansionRequired, err = isExpansionRequired(ctx, volumeID, capacityInMb, manager, useAsyncQueryVolume)
+		expansionRequired, err = isExpansionRequired(ctx, volumeID, capacityInMb,
+			volumeManager, useAsyncQueryVolume)
 		if err != nil {
 			return csifault.CSIInternalFault, err
 		}
@@ -677,7 +679,7 @@ func ExpandVolumeUtil(ctx context.Context, manager *Manager, volumeID string, ca
 		expansionRequired = true
 	}
 	if expansionRequired {
-		faultType, err = manager.VolumeManager.ExpandVolume(ctx, volumeID, capacityInMb)
+		faultType, err = volumeManager.ExpandVolume(ctx, volumeID, capacityInMb)
 		if err != nil {
 			log.Errorf("failed to expand volume %q with error %+v", volumeID, err)
 			return faultType, err
@@ -994,7 +996,7 @@ func getDatastoreInfoObj(ctx context.Context, vc *vsphere.VirtualCenter,
 // isExpansionRequired verifies if the requested size to expand a volume is
 // greater than the current size.
 func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int64,
-	manager *Manager, useAsyncQueryVolume bool) (bool, error) {
+	volumeManager cnsvolume.Manager, useAsyncQueryVolume bool) (bool, error) {
 	log := logger.GetLogger(ctx)
 	volumeIds := []cnstypes.CnsVolumeId{{Id: volumeID}}
 	queryFilter := cnstypes.CnsQueryFilter{
@@ -1007,7 +1009,7 @@ func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int
 		},
 	}
 	// Query only the backing object details.
-	queryResult, err := manager.VolumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
+	queryResult, err := volumeManager.QueryAllVolume(ctx, queryFilter, querySelection)
 	if err != nil {
 		log.Errorf("queryVolume failed for volumeID: %q with err=%v", volumeID, err)
 		return false, err

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1678,7 +1678,8 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 		volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
 		var faultType string
-		faultType, err = common.ExpandVolumeUtil(ctx, c.manager, volumeID, volSizeMB,
+		faultType, err = common.ExpandVolumeUtil(ctx, c.manager.VcenterManager,
+			c.manager.VcenterConfig.Host, c.manager.VolumeManager, volumeID, volSizeMB,
 			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.AsyncQueryVolume))
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
ExpandVolume operation changes to support multi-VC CSI topology

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manually verified volume expansion works fine when multi-vcenter-csi-topology FSS is disabled

```
# kubectl get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
example-raw-block-pvc-2   Bound    pvc-37318e0a-dd24-44fd-b4e1-275e37eecab6   1Gi        RWO            example-raw-block-sc   9s

# kubectl edit pvc
persistentvolumeclaim/example-raw-block-pvc-2 edited

# kubectl get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
example-raw-block-pvc-2   Bound    pvc-37318e0a-dd24-44fd-b4e1-275e37eecab6   2Gi        RWO            example-raw-block-sc   38s

# kubectl logs -n vmware-system-csi vsphere-csi-controller-95757d965-dlhl5 -c vsphere-csi-controller
...
2022-10-19T06:42:19.794Z        INFO    volume/manager.go:1398  ExpandVolume: Volume expanded successfully to size 2048. volumeID: "43536887-41e9-4ef3-bc7c-055b541044f9", opId: "86c6f873"      {"TraceId": "20a3ff99-d796-49d2-8d7f-07b121f153d0"}
...
2022-10-19T06:42:19.813Z        INFO    common/vsphereutil.go:687       Successfully expanded volume for volumeID "43536887-41e9-4ef3-bc7c-055b541044f9" to new size 2048 Mb.    {"TraceId": "20a3ff99-d796-49d2-8d7f-07b121f153d0"}
2022-10-19T06:42:19.813Z        INFO    vanilla/controller.go:1525      Volume "43536887-41e9-4ef3-bc7c-055b541044f9" expanded successfully.    {"TraceId": "20a3ff99-d796-49d2-8d7f-07b121f153d0"}

```
**Special notes for your reviewer**:

**Release note**:
```release-note
ExpandVolume operation changes to support multi-VC CSI topology
```
