### PR TITLE
Create topology label to VC map in syncer

### DIFF
--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -37,7 +37,6 @@ import (
 
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator"
 	cnsvolumemetadatav1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1"
-	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	commonconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
@@ -187,18 +186,6 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			csinodetopologyconfig.EmbedCSINodeTopologyFileName)
 		if err != nil {
 			log.Errorf("Failed to create %q CRD. Error: %+v", csinodetopology.CRDSingular, err)
-			return err
-		}
-		// Initialize node manager so that CSINodeTopology controller can
-		// retrieve NodeVM using the NodeID in the spec.
-		useNodeUuid := false
-		if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.UseCSINodeId) {
-			useNodeUuid = true
-		}
-		nodeMgr := &node.Nodes{}
-		err = nodeMgr.Initialize(ctx, useNodeUuid)
-		if err != nil {
-			log.Errorf("failed to initialize nodeManager. Error: %+v", err)
 			return err
 		}
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorGuest {

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -114,6 +114,13 @@ type metadataSyncInformer struct {
 	pvcLister          corelisters.PersistentVolumeClaimLister
 	podLister          corelisters.PodLister
 	coCommonInterface  commonco.COCommonInterface
+	// topologyVCMap maintains a cache of topology tags to the vCenter IP/FQDN which holds the tag.
+	// Example - {region1: {VC1: struct{}{}, VC2: struct{}{}},
+	//            zone1: {VC1: struct{}{}},
+	//            zone2: {VC2: struct{}{}}}
+	// The vCenter IP/FQDN under each tag are maintained as a map of string with nil values to improve
+	// retrieval and deletion performance.
+	topologyVCMap map[string]map[string]struct{}
 }
 
 const (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR caches topology labels to VC mapping in syncer to facilitate identifying the VC given PV node affinity terms during static volume provisioning. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Unit tests added:
```
=== RUN   TestGetVCForTopologySegments
=== RUN   TestGetVCForTopologySegments/Higher-level_topology_label_present_in_more_than_one_VC
{"level":"info","time":"2022-10-27T10:07:09.366538-07:00","caller":"syncer/metadatasyncer.go:793","msg":"Topology segment(s) map[topology.csi.vmware.com/region:region-1 topology.csi.vmware.com/zone:zone-2] belong to VC: \"10.100.100.1\""}
=== RUN   TestGetVCForTopologySegments/Invalid_topology_label_given_as_input
{"level":"error","time":"2022-10-27T10:07:09.367151-07:00","caller":"syncer/metadatasyncer.go:776","msg":"Topology label \"topology.csi.vmware.com/zone:zone-3\" not found in topology to VC mapping.","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer.getVCForTopologySegments\n\t/Users/sbhaskara/github-csi/vsphere-csi-driver/pkg/syncer/metadatasyncer.go:776\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer.TestGetVCForTopologySegments.func1\n\t/Users/sbhaskara/github-csi/vsphere-csi-driver/pkg/syncer/syncer_test.go:993\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1446"}
=== RUN   TestGetVCForTopologySegments/Topology_label_belongs_to_more_than_one_VC
{"level":"error","time":"2022-10-27T10:07:09.367956-07:00","caller":"syncer/metadatasyncer.go:790","msg":"Topology segment(s) map[topology.csi.vmware.com/region:region-1 topology.csi.vmware.com/zone:zone-1] belong to more than one VC: [10.100.100.0 10.100.100.1]","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer.getVCForTopologySegments\n\t/Users/sbhaskara/github-csi/vsphere-csi-driver/pkg/syncer/metadatasyncer.go:790\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer.TestGetVCForTopologySegments.func1\n\t/Users/sbhaskara/github-csi/vsphere-csi-driver/pkg/syncer/syncer_test.go:993\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1446"}
=== RUN   TestGetVCForTopologySegments/Leaf-level_topology_label_present_in_more_than_one_VC
{"level":"info","time":"2022-10-27T10:07:09.368234-07:00","caller":"syncer/metadatasyncer.go:793","msg":"Topology segment(s) map[topology.csi.vmware.com/region:region-2 topology.csi.vmware.com/zone:zone-1] belong to VC: \"10.100.100.1\""}
=== RUN   TestGetVCForTopologySegments/Topology_labels_distinct_across_VCs
{"level":"info","time":"2022-10-27T10:07:09.368288-07:00","caller":"syncer/metadatasyncer.go:793","msg":"Topology segment(s) map[topology.csi.vmware.com/city:city-2 topology.csi.vmware.com/region:region-2 topology.csi.vmware.com/zone:zone-2] belong to VC: \"10.100.100.1\""}
--- PASS: TestGetVCForTopologySegments (0.00s)
    --- PASS: TestGetVCForTopologySegments/Higher-level_topology_label_present_in_more_than_one_VC (0.00s)
    --- PASS: TestGetVCForTopologySegments/Invalid_topology_label_given_as_input (0.00s)
    --- PASS: TestGetVCForTopologySegments/Topology_label_belongs_to_more_than_one_VC (0.00s)
    --- PASS: TestGetVCForTopologySegments/Leaf-level_topology_label_present_in_more_than_one_VC (0.00s)
    --- PASS: TestGetVCForTopologySegments/Topology_labels_distinct_across_VCs (0.00s)
PASS
```


Used sample testing program:
```
vc, err := getVCForTopologySegments(ctx, map[string]string{"key1": "region-2", "key2": "zone-2"})
if err != nil {
	log.Errorf("getVCForTopologySegments returned error: %+v", err)
} else {
	log.Infof("getVCForTopologySegments returned VC %q", vc)
}
```

Received the following log:
```
2022-10-20T05:41:25.462Z	INFO	syncer/metadatasyncer.go:577	getVCForTopologySegments returned VC "10.78.234.75"
```

Confirmed that the informer gets started:
```
2022-10-20T05:41:25.259Z	INFO	syncer/metadatasyncer.go:610	Informer to watch on csinodetopology CR starting..
```

When topology label to VC mapping is updated:
```
2022-10-20T05:41:25.393Z	INFO	syncer/metadatasyncer.go:624	Topology labels [{Key:topology.csi.vmware.com/region Value:region-1} {Key:topology.csi.vmware.com/zone Value:zone-1}] belong to "10.184.89.220" VC	{"TraceId": "bf7a9315-7105-4f5c-ac61-b313aac2e368"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Create topology label to VC map in syncer
```
