### PR TITLE
 Preferential testcase code fix

### DIFF
--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -161,7 +161,6 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 
 		//set preferred datatsore time interval
 		setPreferredDatastoreTimeInterval(client, ctx, csiNamespace, namespace, csiReplicas)
-
 	})
 
 	ginkgo.AfterEach(func() {
@@ -1790,8 +1789,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		preferredDatastoreChosen = 1
 		preferredDatastorePaths = nil
 		scParameters := make(map[string]string)
-		thickDSPolicy := GetAndExpectStringEnvVar(envStoragePolicyNameWithThickProvision)
-		scParameters[scParamStoragePolicyName] = thickDSPolicy
+		scParameters[scParamStoragePolicyName] = "Management Storage Policy - Regular"
 
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-2(cluster-2)")


### PR DESCRIPTION
**What this PR does / why we need it**:
Preferential testcase code fix

**Testing done**:
Yes

**Special notes for your reviewer**:

Make Check

sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/preferential-fix/vsphere-csi-driver /Users/sipriya/preferential-fix /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (name|types_sizes|deps|exports_file|files|compiled_files|imports) took 11.146324601s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 138.853052ms 
INFO [linters context/goanalysis] analyzers took 58.241964451s with top 10 stages: buildir: 19.368413011s, S1038: 3.628198651s, misspell: 2.299905056s, S1039: 1.442913081s, printf: 1.42090113s, unused: 1.066673551s, SA1004: 1.03520445s, ctrlflow: 1.027342691s, S1024: 1.009812648s, SA4030: 952.634308ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude-rules: 1/24, filename_unadjuster: 113/113, skip_files: 113/113, exclude: 24/24, path_prettifier: 113/113, skip_dirs: 113/113, autogenerated_exclude: 24/113, cgo: 113/113, identifier_marker: 24/24, nolint: 0/1 
INFO [runner] processing took 16.033084ms with stages: nolint: 12.334008ms, autogenerated_exclude: 2.865267ms, path_prettifier: 355.61µs, identifier_marker: 292.122µs, skip_dirs: 104.515µs, exclude-rules: 61.643µs, cgo: 9.535µs, filename_unadjuster: 6.376µs, max_same_issues: 1.156µs, uniq_by_line: 441ns, max_from_linter: 393ns, skip_files: 359ns, diff: 275ns, source_code: 253ns, exclude: 220ns, sort_results: 211ns, severity-rules: 200ns, max_per_file_from_linter: 197ns, path_shortener: 193ns, path_prefixer: 110ns 
INFO [runner] linters took 10.191201034s with stages: goanalysis_metalinter: 10.17506758s 
INFO File cache stats: 292 entries of total size 5.3MiB 
INFO Memory: 215 samples, avg is 349.2MB, max is 1636.2MB 
INFO Execution took 21.488287278s                 
sipriya@sipriya-a01 vsphere-csi-driver % 
