### PR TITLE
initialize volume managers for multi vCenter servers

### DIFF
--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -144,7 +144,7 @@ func TestQuerySnapshotsUtil(t *testing.T) {
 	// Create context
 	commonUtilsTestInstance := getCommonUtilsTest(t)
 
-	volumeManager := cnsvolumes.GetManager(ctx, commonUtilsTestInstance.vcenter, nil, false)
+	volumeManager := cnsvolumes.GetManager(ctx, commonUtilsTestInstance.vcenter, nil, false, false)
 	queryFilter := types.CnsSnapshotQueryFilter{
 		SnapshotQuerySpecs: nil,
 		Cursor: &types.CnsCursor{

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -135,7 +135,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		c.manager = &common.Manager{
 			VcenterConfig:  vcenterconfig,
 			CnsConfig:      config,
-			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, operationStore, true),
+			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, operationStore, true, false),
 			VcenterManager: vcManager,
 		}
 		vc, err := common.GetVCenter(ctx, c.manager)
@@ -215,8 +215,8 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 					"err=%v", vcenterconfig.Host, err)
 			}
 			c.managers.VcenterConfigs[vcenterconfig.Host] = vcenterconfig
-			c.managers.VolumeManagers[vcenterconfig.Host] = cnsvolume.GetManager(ctx, vcenter,
-				operationStore, true)
+			c.managers.VolumeManagers[vcenterconfig.Host] = cnsvolume.GetManager(ctx, vcenter, operationStore,
+				true, true)
 		}
 		vCenters, err := common.GetVCenters(ctx, c.managers)
 		if err != nil {
@@ -423,7 +423,7 @@ func (c *controller) ReloadConfiguration() error {
 
 		c.manager.VolumeManager.ResetManager(ctx, vcenter)
 		c.manager.VcenterConfig = newVCConfig
-		c.manager.VolumeManager = cnsvolume.GetManager(ctx, vcenter, operationStore, true)
+		c.manager.VolumeManager = cnsvolume.GetManager(ctx, vcenter, operationStore, true, false)
 		// Re-Initialize Node Manager to cache latest vCenter config.
 		useNodeUuid := false
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -335,7 +335,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 		manager := &common.Manager{
 			VcenterConfig:  vcenterconfig,
 			CnsConfig:      config,
-			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true),
+			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true, false),
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -147,7 +147,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	c.manager = &common.Manager{
 		VcenterConfig:  vcenterconfig,
 		CnsConfig:      config,
-		VolumeManager:  cnsvolume.GetManager(ctx, vcenter, operationStore, idempotencyHandlingEnabled),
+		VolumeManager:  cnsvolume.GetManager(ctx, vcenter, operationStore, idempotencyHandlingEnabled, false),
 		VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 	}
 
@@ -351,7 +351,7 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 		c.manager.VolumeManager.ResetManager(ctx, vcenter)
 		c.manager.VcenterConfig = newVCConfig
 		c.manager.VolumeManager = cnsvolume.GetManager(ctx, vcenter, operationStore,
-			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency))
+			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency), false)
 		if c.authMgr != nil {
 			c.authMgr.ResetvCenterInstance(ctx, vcenter)
 			log.Debugf("Updated vCenter in auth manager")

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -180,7 +180,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 		manager := &common.Manager{
 			VcenterConfig:  vcenterconfig,
 			CnsConfig:      config,
-			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true),
+			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true, false),
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -77,7 +77,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 		if err != nil {
 			return err
 		}
-		volumeManager = volumes.GetManager(ctx, vCenter, nil, false)
+		volumeManager = volumes.GetManager(ctx, vCenter, nil, false, false)
 	}
 
 	// Get a config to talk to the apiserver

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -222,7 +222,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			return err
 		}
 		metadataSyncer.host = vCenter.Config.Host
-		metadataSyncer.volumeManager = volumes.GetManager(ctx, vCenter, nil, false)
+		metadataSyncer.volumeManager = volumes.GetManager(ctx, vCenter, nil, false, false)
 		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSISVFeatureStateReplication) {
 			svParams, ok := COInitParams.(k8sorchestrator.K8sSupervisorInitParams)
 			if !ok {
@@ -247,7 +247,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				return err
 			}
 			metadataSyncer.host = vCenter.Config.Host
-			metadataSyncer.volumeManager = volumes.GetManager(ctx, vCenter, nil, false)
+			metadataSyncer.volumeManager = volumes.GetManager(ctx, vCenter, nil, false, false)
 		} else {
 			vcconfigs, err := cnsvsphere.GetVirtualCenterConfigs(ctx, configInfo.Cfg)
 			if err != nil {
@@ -259,7 +259,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				if err != nil {
 					return logger.LogNewErrorf(log, "failed to get vCenterInstance for vCenter Host: %q, err: %v", vcconfig.Host, err)
 				}
-				metadataSyncer.volumeManagers[vcconfig.Host] = volumes.GetManager(ctx, vCenter, nil, false)
+				metadataSyncer.volumeManagers[vcconfig.Host] = volumes.GetManager(ctx, vCenter, nil, false, true)
 			}
 		}
 	}
@@ -655,7 +655,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 				vcenter.Config = newVCConfig
 			}
 			metadataSyncer.volumeManager.ResetManager(ctx, vcenter)
-			metadataSyncer.volumeManager = volumes.GetManager(ctx, vcenter, nil, false)
+			metadataSyncer.volumeManager = volumes.GetManager(ctx, vcenter, nil, false, false)
 			if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 				storagepool.ResetVC(ctx, vcenter)
 			}

--- a/pkg/syncer/storagepool/diskDecommissionController.go
+++ b/pkg/syncer/storagepool/diskDecommissionController.go
@@ -100,7 +100,7 @@ func (w *DiskDecommController) detachVolumes(ctx context.Context, storagePoolNam
 		VirtualCenterHost: vc.Config.Host,
 	}
 
-	volManager := volume.GetManager(ctx, &vc, nil, false)
+	volManager := volume.GetManager(ctx, &vc, nil, false, false)
 
 	volumes, _, err := k8scloudoperator.GetVolumesOnStoragePool(ctx, k8sClient, storagePoolName)
 	if err != nil {

--- a/pkg/syncer/storagepool/migrationController.go
+++ b/pkg/syncer/storagepool/migrationController.go
@@ -80,7 +80,7 @@ func (m *migrationController) relocateCNSVolume(ctx context.Context, volumeID st
 			datastoreURL)
 	}
 
-	volManager := volume.GetManager(ctx, m.vc, nil, false)
+	volManager := volume.GetManager(ctx, m.vc, nil, false, false)
 	relocateSpec := cnstypes.NewCnsBlockVolumeRelocateSpec(volumeID, dsInfo.Reference())
 
 	task, err := volManager.RelocateVolume(ctx, relocateSpec)

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -192,14 +192,14 @@ func TestSyncerWorkflows(t *testing.T) {
 		}
 	}()
 
-	volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false)
+	volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false)
 
 	// Initialize metadata syncer object.
 	metadataSyncer = &metadataSyncInformer{}
 	configInfo := &cnsconfig.ConfigurationInfo{}
 	configInfo.Cfg = csiConfig
 	metadataSyncer.configInfo = configInfo
-	metadataSyncer.volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false)
+	metadataSyncer.volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false)
 	metadataSyncer.host = virtualCenter.Config.Host
 
 	// Create the kubernetes client from config or env.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
initialize volume managers for multi-vCenter servers

**Testing done**:
Verified logs and confirmed Volume Manager for multiple vCenters are getting initialized properly.

> 2022-10-26T22:28:54.308Z	INFO	vsphere/virtualcentermanager.go:123	Successfully registered VC 10.78.234.75:443	{"TraceId": "28e52d14-4aed-4ecf-96af-44e9e1e2a92e"}
2022-10-26T22:28:54.308Z	INFO	volume/manager.go:191	Initializing new defaultManager for vCenter: "10.78.234.75"	{"TraceId": "28e52d14-4aed-4ecf-96af-44e9e1e2a92e"}
2022-10-26T22:28:54.308Z	INFO	vsphere/virtualcentermanager.go:123	Successfully registered VC 10.184.89.220:443	{"TraceId": "28e52d14-4aed-4ecf-96af-44e9e1e2a92e"}
2022-10-26T22:28:54.308Z	INFO	volume/manager.go:191	Initializing new defaultManager for vCenter: "10.184.89.220"	{"TraceId": "28e52d14-4aed-4ecf-96af-44e9e1e2a92e"}

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
initialize volume managers for multi vCenter servers
```
