### PR TITLE
Update snapshot validation webhook deployment

### DIFF
--- a/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
+++ b/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
@@ -1,6 +1,34 @@
 # Requires k8s 1.20+
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-webhook
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-webhook-runner
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-webhook
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: snapshot-webhook-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: snapshot-validation-service
@@ -21,9 +49,9 @@ webhooks:
   - name: "validation-webhook.snapshot.storage.k8s.io"
     rules:
       - apiGroups:   ["snapshot.storage.k8s.io"]
-        apiVersions: ["v1", "v1beta1"]
+        apiVersions: ["v1"]
         operations:  ["CREATE", "UPDATE"]
-        resources:   ["volumesnapshots", "volumesnapshotcontents"]
+        resources:   ["volumesnapshots", "volumesnapshotcontents", "volumesnapshotclasses"]
         scope:       "*"
     clientConfig:
       service:
@@ -53,6 +81,7 @@ spec:
       labels:
         app: snapshot-validation
     spec:
+      serviceAccountName: snapshot-webhook
       containers:
         - name: snapshot-validation
           image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.1.0 # change the image if you wish to use your own custom validation server image


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the snapshot validation wehbhook yaml according to support snapshot-validation-webhook:v6.1.0

**Which issue this PR fixes** 
fixes # https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/2059

**Testing done**:
Verified that the webook server started
```
I1027 18:29:52.483813       1 certwatcher.go:129] Updated current TLS certificate
I1027 18:29:52.586295       1 webhook.go:196] Starting certificate watcher
Starting webhook server
```

**Special notes for your reviewer**:

**Release note**:
```release-note
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>