### PR TITLE
[Work in Progress] 256-disk support automation - set of util methods and testcases for verifying 255 disks attachment

### DIFF
--- a/tests/e2e/create_256_volumes.go
+++ b/tests/e2e/create_256_volumes.go
@@ -1,0 +1,1154 @@
+/*
+	Copyright 2022 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubectl/pkg/drain"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+// path to 256 disk statefulset spec
+const (
+	manifestPathFor256Disks = "tests/e2e/testing-manifests/statefulset256disk"
+)
+
+var _ = ginkgo.Describe("[csi-vanilla-256-disk-support] Volume-Provisioning-With-256-Disk-Support", func() {
+	f := framework.NewDefaultFramework("e2e-vsphere-aware-provisioning")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		client                  clientset.Interface
+		namespace               string
+		statefulSetReplicaCount int32
+		pvcCount                int
+		csiReplicas             int32
+		csiNamespace            string
+	)
+
+	ginkgo.BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		bootstrap()
+		sc, err := client.StorageV1().StorageClasses().Get(ctx, defaultNginxStorageClassName, metav1.GetOptions{})
+		if err == nil && sc != nil {
+			gomega.Expect(client.StorageV1().StorageClasses().Delete(ctx, sc.Name,
+				*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+		}
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		csiNamespace = GetAndExpectStringEnvVar(envCSINamespace)
+		csiDeployment, err := client.AppsV1().Deployments(csiNamespace).Get(
+			ctx, vSphereCSIControllerPodNamePrefix, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		csiReplicas = *csiDeployment.Spec.Replicas
+
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By(fmt.Sprintf("Deleting all statefulsets in namespace: %v", namespace))
+		fss.DeleteAllStatefulSets(client, namespace)
+		ginkgo.By(fmt.Sprintf("Deleting service nginx in namespace: %v", namespace))
+		err := client.CoreV1().Services(namespace).Delete(ctx, servicename, *metav1.NewDeleteOptions(0))
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	})
+
+	/*
+		TESTCASE-1
+		Consider a testbed of 3 worker nodes and each worker node supports 255 volumes attachment.
+		so - 253 * 3 = 765 volume attachment we need to create and attach it to Pods and verify.
+
+		Steps//
+		1. Create Storage Class with Immediate Binding mode
+		2. Trigger StatefulSet-1 with replica count 63 and with 4 PVC's attached to each replica Pod
+		 using above created SC (i.e 63 Pods with 252 volume attachment)
+		3. Verify all PV's, PVC's are in Bound state and Statefulset Pods are in up and running state.
+		4. Trigger StatefulSet-2 with replica count 63 and with 4 PVC's attached to each replica Pod
+		 using above created SC (i.e 63 Pods with 252 volume attachment)
+		5. Verify all PV's, PVC's are in Bound state and Statefulset Pods are in up and running state.
+		6. Trigger StatefulSet-3 with replica count 63 and with 4 PVC's attached to each replica Pod
+		 using above created SC (i.e 63 Pods with 252 volume attachment)
+		7. Verify all PV's, PVC's are in Bound state and Statefulset Pods are in up and running state.
+		8. Create 9 standalone PVC's.
+		9. Verify all standalone PVC's are in Bound state.
+		10. Create 9 Pods using above created PVC's
+		11. Verify standalone Pods are in up and running state.
+		12. Perform cleanup. Delete StatefulSet Pods, PVC's, PV.
+	*/
+
+	ginkgo.It("Verify volume provisioning when multiple statefulsets are triggered with 63 replicas and "+
+		"each replica pod is attached to 4 pvcs", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		statefulSetReplicaCount = 63
+		pvcCount = 9
+		var podList []*v1.Pod
+
+		ginkgo.By("Create Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "nginx-sc")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Create statefulset-1 with 63 replica pods and each pod is attached to 4 pvcs")
+		statefulset1 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset1.Spec.Replicas = &statefulSetReplicaCount
+		statefulset1.Name = "sts1"
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset1, client,
+			statefulSetReplicaCount)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			DeleteMultipleStsInGivenNameSpace(client, namespace)
+		}()
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset1, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset1, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods := GetListOfPodsInSts(client, statefulset1)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset1.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Create statefulset-2 with 63 replica pods and each pod is attached to 4 pvcs")
+		statefulset2 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset2.Spec.Replicas = &statefulSetReplicaCount
+		statefulset2.Name = "sts2"
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset2, client, statefulSetReplicaCount)
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset2, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset2, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods = GetListOfPodsInSts(client, statefulset2)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset2.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Create statefulset-3 with 63 replica pods and each pod is attached to 4 pvcs")
+		statefulset3 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset3.Spec.Replicas = &statefulSetReplicaCount
+		statefulset3.Name = "sts3"
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset3, client, statefulSetReplicaCount)
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset3, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset3, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods = GetListOfPodsInSts(client, statefulset3)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset3.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Trigger multiple PVCs")
+		pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount)
+		defer func() {
+			ginkgo.By("Deleting PVC's and PV's")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				err = fpv.DeletePersistentVolumeClaim(client, pvclaimsList[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC claim to be in bound phase and create POD for each PVC")
+		for i := 0; i < len(pvclaimsList); i++ {
+			var pvclaims []*v1.PersistentVolumeClaim
+			pvc, err := fpv.WaitForPVClaimBoundPhase(client,
+				[]*v1.PersistentVolumeClaim{pvclaimsList[i]}, framework.ClaimProvisionTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pvc).NotTo(gomega.BeEmpty())
+			pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+
+			ginkgo.By("Creating Pod")
+			pvclaims = append(pvclaims, pvclaimsList[i])
+			pod, err := createPod(client, namespace, nil, pvclaims, false, "")
+			podList = append(podList, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+			isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
+		}
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err = fpod.DeletePodWithWait(client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			ginkgo.By("Verify volume is detached from the node")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+					pv.Spec.CSI.VolumeHandle, podList[i].Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+					fmt.Sprintf("Volume %q is not detached from the node", pv.Spec.CSI.VolumeHandle))
+			}
+		}()
+	})
+
+	/*
+		TESTCASE-2
+		Perform multiple times scaleup/scaledown operation when creating 765 volume attachment
+
+		Steps//
+		1. Create Storage Class with Immediate Binding mode
+		2. Trigger StatefulSet-1 with replica count 40, with each replica Pod is attached to 4 PVC's.
+		3. Verify PVC's are in Bound state and Statefulset Pods are in up and running state.
+		4. Trigger StatefulSet-2 with replica count 35, with each replica Pod is attached to 4 PVC's.
+		5. Verify PVC's are in Bound state and Statefulset Pods are in up and running state.
+		6. Trigger StatefulSet-3 with replica count 50, with each replica Pod is attached to 4 PVC's.
+		7. Verify PVC's are in Bound state and Statefulset Pods are in up and running state.
+		8. Perform scaleup operation on StatefulSet-1. Scale up the replica count of sts-1 from 40 to 52.
+		9. Verify scaleup operation of StatefulSet-1 went successful.
+		10. Perform scaleup operation on StatefulSet-2. Increase the replica count of sts-2 from 35 to 40.
+		11. Verify scaleup operation went successful.
+		12. Perform scaledown operation on StatefulSet-3. Scale down the replica count of sts-3 from 50 to 30.
+		13. Verify scaledown operation went successful.
+		14. Perform scaledown operation on StatefulSet-1. Scale down the replica count of sts-1 from 52 to 42.
+		15. Verify scaledown operation went successful.
+		16. Perform scaleup operation on StatefulSet-2. Scale up the replica count of sts-2 from 40 to 60.
+		17. Verify scaleup operation went successful.
+		18. Perform scaleup operation on StatefulSet-3. Scale up the replica count of sts-3 from 30 to 50.
+		19. Verify scaleup operation went successful.
+		20. Scale up all 3 statefulsets (sts-1,sts-2,sts-3) to replica count 63.
+		21. Verify scaleup operation on all 3 statefulsets are successful.
+		22. Create 9 standalone PVC's.
+		23. Verify standalone PVC's are in Bound state.
+		24. Create 9 Pods using above created PVC's
+		25. Verify standalone Pods are in up and running state.
+		26. Perform cleanup. Delete StatefulSet Pods, PVC's, PV.
+	*/
+
+	ginkgo.It("Perform multiple times scaleup scaledown operation on multiple triggered statefulsets "+
+		"while creating 256 volumes attachment", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		pvcCount = 9
+		var podList []*v1.Pod
+
+		ginkgo.By("Create Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "nginx-sc")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Create statefulset-1 with 40 replica pods and each replica pod is attached to 4 pvcs")
+		statefulSetReplicaCount = 40
+		statefulset1 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset1.Spec.Replicas = &statefulSetReplicaCount
+		statefulset1.Name = "sts1"
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset1, client, statefulSetReplicaCount)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			DeleteMultipleStsInGivenNameSpace(client, namespace)
+		}()
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset1, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset1, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods := GetListOfPodsInSts(client, statefulset1)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset1.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Create statefulset-2 with 35 replica pods and each replica pod is attached to 4 pvcs")
+		statefulSetReplicaCount = 35
+		statefulset2 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset2.Spec.Replicas = &statefulSetReplicaCount
+		statefulset2.Name = "sts2"
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset2, client,
+			statefulSetReplicaCount)
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset2, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset2, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods = GetListOfPodsInSts(client, statefulset2)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset2.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Create statefulset-3 with 50 replica pods and each replica pod is attached to 4 pvcs")
+		statefulSetReplicaCount = 50
+		statefulset3 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset3.Spec.Replicas = &statefulSetReplicaCount
+		statefulset3.Name = "sts3"
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset3, client,
+			statefulSetReplicaCount)
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset3, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset3, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods = GetListOfPodsInSts(client, statefulset3)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset3.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Scaleup statefulset-1 replica pod count to 52")
+		statefulSetReplicaCount = 52
+		scaleUpStatefulSetPod(ctx, client, statefulset1, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Scaleup statefulset-2 replica pod count to 40")
+		statefulSetReplicaCount = 40
+		scaleUpStatefulSetPod(ctx, client, statefulset2, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Scaledown statefulset-3 replica pod count to 30")
+		statefulSetReplicaCount = 30
+		scaleDownStatefulSetPod(ctx, client, statefulset3, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Scaledown statefulset-1 replica pod count to 42")
+		statefulSetReplicaCount = 42
+		scaleDownStatefulSetPod(ctx, client, statefulset1, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Scaleup statefulset-2 replica pod count to 60")
+		statefulSetReplicaCount = 60
+		scaleUpStatefulSetPod(ctx, client, statefulset2, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Scaleup statefulset-3 replica pod count to 50")
+		statefulSetReplicaCount = 50
+		scaleUpStatefulSetPod(ctx, client, statefulset3, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("ScaleUp statefulset-1, statefulset-2, statefulset-3 replica pod count to 63")
+		statefulSetReplicaCount = 63
+		scaleUpStatefulSetPod(ctx, client, statefulset1, namespace, statefulSetReplicaCount, true, true)
+		scaleUpStatefulSetPod(ctx, client, statefulset2, namespace, statefulSetReplicaCount, true, true)
+		scaleUpStatefulSetPod(ctx, client, statefulset3, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Trigger multiple PVCs")
+		pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount)
+		defer func() {
+			ginkgo.By("Deleting PVC's and PV's")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				err = fpv.DeletePersistentVolumeClaim(client, pvclaimsList[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC claim to be in bound phase and create POD for each PVC")
+		for i := 0; i < len(pvclaimsList); i++ {
+			var pvclaims []*v1.PersistentVolumeClaim
+			pvc, err := fpv.WaitForPVClaimBoundPhase(client,
+				[]*v1.PersistentVolumeClaim{pvclaimsList[i]}, framework.ClaimProvisionTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pvc).NotTo(gomega.BeEmpty())
+			pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+
+			ginkgo.By("Creating Pod")
+			pvclaims = append(pvclaims, pvclaimsList[i])
+			pod, err := createPod(client, namespace, nil, pvclaims, false, "")
+			podList = append(podList, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+			isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
+		}
+
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err = fpod.DeletePodWithWait(client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			ginkgo.By("Verify volume is detached from the node")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+					pv.Spec.CSI.VolumeHandle, podList[i].Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+					fmt.Sprintf("Volume %q is not detached from the node", pv.Spec.CSI.VolumeHandle))
+			}
+		}()
+	})
+
+	/*
+		TESTCASE-3
+		Restart node daemonset when multiple times scaleup/scaledown operation is in progress
+
+		Steps//
+		1. Create Storage Class with Immediate Binding mode
+		2. Trigger StatefulSet-1 using parallel pod management policy with replica count 40,
+		with each replica Pod is attached to 4 PVC's.
+		3. Verify PVC's are in Bound state and Statefulset Pods are in up and running state.
+		4. Trigger StatefulSet-2 using default pod management policy with replica count 35,
+		with each replica Pod is attached to 4 PVC's.
+		5. Verify PVC's are in Bound state and Statefulset Pods are in up and running state.
+		6. Trigger StatefulSet-3 using parallel pod management policy with replica count 50,
+		with each replica Pod is attached to 4 PVC's.
+		7. Verify PVC's are in Bound state and Statefulset Pods are in up and running state.
+		8. Perform scaleup operation on StatefulSet-1. Scale up the replica count of sts-1 from 40 to 52.
+		9. Verify scaleup operation of StatefulSet-1 went successful.
+		10. Restart node daemon set.
+		11. Perform scaleup operation on StatefulSet-2. Increase the replica count of sts-2 from 35 to 40.
+		12. Verify scaleup operation went successful.
+		13. Perform scaledown operation on StatefulSet-3. Scale down the replica count of sts-3 from 50 to 30.
+		14. Verify scaledown operation went successful.
+		15. Perform scaledown operation on StatefulSet-1. Scale down the replica count of sts-1 from 52 to 42.
+		16. Verify scaledown operation went successful.
+		17. Perform scaleup operation on StatefulSet-2. Scale up the replica count of sts-2 from 40 to 60.
+		18. Verify scaleup operation went successful.
+		19. Perform scaleup operation on StatefulSet-3. Scale up the replica count of sts-3 from 30 to 50.
+		20. Verify scaleup operation went successful.
+		21. Restart node daemo set.
+		22. Scale up all 3 statefulsets (sts-1,sts-2,sts-3) to replica count 63.
+		23. Verify scaleup operation on all 3 statefulsets are successful.
+		24. Create 9 standalone PVC's.
+		25. Verify standalone PVC's are in Bound state.
+		26. Create 9 Pods using above created PVC's
+		27. Verify standalone Pods are in up and running state.
+		28. Perform cleanup. Delete StatefulSet Pods, PVC's, PV.
+	*/
+
+	ginkgo.It("Trigger multiple statefulsets using different management policy and restart node "+
+		"daemon set when statefulsets scaleup/sclaedown operation is in progress", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		pvcCount = 9
+		var podList []*v1.Pod
+		ignoreLabels := make(map[string]string)
+
+		ginkgo.By("Create Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "nginx-sc")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Create statefulset-1 with 40 replica pods and each replica pod is attached to 4 pvcs")
+		statefulSetReplicaCount = 40
+		statefulset1 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset1.Spec.Replicas = &statefulSetReplicaCount
+		statefulset1.Name = "sts1"
+		statefulset1.Spec.PodManagementPolicy = apps.ParallelPodManagement
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset1, client, statefulSetReplicaCount)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			DeleteMultipleStsInGivenNameSpace(client, namespace)
+		}()
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset1, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset1, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods := GetListOfPodsInSts(client, statefulset1)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset1.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Create statefulset-2 with 35 replica pods and each replica pod is attached to 4 pvcs")
+		statefulSetReplicaCount = 35
+		statefulset2 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset2.Spec.Replicas = &statefulSetReplicaCount
+		statefulset2.Name = "sts2"
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset2, client,
+			statefulSetReplicaCount)
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset2, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset2, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods = GetListOfPodsInSts(client, statefulset2)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset2.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Create statefulset-3 with 50 replica pods and each replica pod is attached to 4 pvcs")
+		statefulSetReplicaCount = 50
+		statefulset3 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset3.Spec.Replicas = &statefulSetReplicaCount
+		statefulset3.Name = "sts3"
+		statefulset3.Spec.PodManagementPolicy = apps.ParallelPodManagement
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset3, client,
+			statefulSetReplicaCount)
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset3, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset3, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods = GetListOfPodsInSts(client, statefulset3)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset3.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Scaleup statefulset-1 replica pod count to 52")
+		statefulSetReplicaCount = 52
+		scaleUpStatefulSetPod(ctx, client, statefulset1, namespace, statefulSetReplicaCount, true, true)
+
+		// Fetch the number of CSI pods running before restart
+		list_of_pods, err := fpod.GetPodsInNamespace(client, csiSystemNamespace, ignoreLabels)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		num_csi_pods := len(list_of_pods)
+
+		// Collecting and dumping csi pod logs before restrating CSI daemonset
+		collectPodLogs(ctx, client, csiSystemNamespace)
+		ginkgo.By("Restart Daemonset")
+		cmd := []string{"rollout", "restart", "daemonset/vsphere-csi-node", "--namespace=" + csiSystemNamespace}
+		framework.RunKubectlOrDie(csiSystemNamespace, cmd...)
+		ginkgo.By("Waiting for daemon set rollout status to finish")
+		statusCheck := []string{"rollout", "status", "daemonset/vsphere-csi-node", "--namespace=" + csiSystemNamespace}
+		framework.RunKubectlOrDie(csiSystemNamespace, statusCheck...)
+		// wait for csi Pods to be in running ready state
+		err = fpod.WaitForPodsRunningReady(client, csiSystemNamespace, int32(num_csi_pods), 0, pollTimeout,
+			ignoreLabels)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scaleup statefulset-2 replica pod count to 40")
+		statefulSetReplicaCount = 40
+		scaleUpStatefulSetPod(ctx, client, statefulset2, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Scaledown statefulset-3 replica pod count to 30")
+		statefulSetReplicaCount = 30
+		scaleDownStatefulSetPod(ctx, client, statefulset3, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Scaledown statefulset-1 replica pod count to 42")
+		statefulSetReplicaCount = 42
+		scaleDownStatefulSetPod(ctx, client, statefulset1, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Scaleup statefulset-2 replica pod count to 60")
+		statefulSetReplicaCount = 60
+		scaleUpStatefulSetPod(ctx, client, statefulset2, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Scaleup statefulset-3 replica pod count to 50")
+		statefulSetReplicaCount = 50
+		scaleUpStatefulSetPod(ctx, client, statefulset3, namespace, statefulSetReplicaCount, true, true)
+
+		// Collecting and dumping csi pod logs before restrating CSI daemonset
+		collectPodLogs(ctx, client, csiSystemNamespace)
+		ginkgo.By("Restart Daemonset")
+		cmd = []string{"rollout", "restart", "daemonset/vsphere-csi-node", "--namespace=" + csiSystemNamespace}
+		framework.RunKubectlOrDie(csiSystemNamespace, cmd...)
+		ginkgo.By("Waiting for daemon set rollout status to finish")
+		statusCheck = []string{"rollout", "status", "daemonset/vsphere-csi-node", "--namespace=" + csiSystemNamespace}
+		framework.RunKubectlOrDie(csiSystemNamespace, statusCheck...)
+		// wait for csi Pods to be in running ready state
+		err = fpod.WaitForPodsRunningReady(client, csiSystemNamespace, int32(num_csi_pods), 0, pollTimeout,
+			ignoreLabels)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("ScaleUp statefulset-1, statefulset-2, statefulset-3 replica pod count to 63")
+		statefulSetReplicaCount = 63
+		scaleUpStatefulSetPod(ctx, client, statefulset1, namespace, statefulSetReplicaCount, true, true)
+		scaleUpStatefulSetPod(ctx, client, statefulset2, namespace, statefulSetReplicaCount, true, true)
+		scaleUpStatefulSetPod(ctx, client, statefulset3, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Trigger multiple PVCs")
+		pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount)
+		defer func() {
+			ginkgo.By("Deleting PVC's and PV's")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				err = fpv.DeletePersistentVolumeClaim(client, pvclaimsList[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC claim to be in bound phase and create POD for each PVC")
+		for i := 0; i < len(pvclaimsList); i++ {
+			var pvclaims []*v1.PersistentVolumeClaim
+			pvc, err := fpv.WaitForPVClaimBoundPhase(client,
+				[]*v1.PersistentVolumeClaim{pvclaimsList[i]}, framework.ClaimProvisionTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pvc).NotTo(gomega.BeEmpty())
+			pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+
+			ginkgo.By("Creating Pod")
+			pvclaims = append(pvclaims, pvclaimsList[i])
+			pod, err := createPod(client, namespace, nil, pvclaims, false, "")
+			podList = append(podList, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+			isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
+		}
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err = fpod.DeletePodWithWait(client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			ginkgo.By("Verify volume is detached from the node")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+					pv.Spec.CSI.VolumeHandle, podList[i].Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+					fmt.Sprintf("Volume %q is not detached from the node", pv.Spec.CSI.VolumeHandle))
+			}
+		}()
+	})
+
+	/*
+		TESTCASE-4
+		Restart csi driver when multiple times scaleup/scaledown operation is in progress
+
+		Steps//
+		1. Create Storage Class with Immediate Binding mode
+		2. Trigger StatefulSet-1 using parallel pod management policy with replica count 40,
+		with each replica Pod is attached to 4 PVC's.
+		3. Verify PVC's are in Bound state and Statefulset Pods are in up and running state.
+		4. Trigger StatefulSet-2 using default pod management policy with replica count 35,
+		with each replica Pod is attached to 4 PVC's.
+		5. Verify PVC's are in Bound state and Statefulset Pods are in up and running state.
+		6. Trigger StatefulSet-3 using parallel pod management policy with replica count 50,
+		with each replica Pod is attached to 4 PVC's.
+		7. Verify PVC's are in Bound state and Statefulset Pods are in up and running state.
+		8. Perform scaleup operation on StatefulSet-1. Scale up the replica count of sts-1 from 40 to 52.
+		9. Verify scaleup operation of StatefulSet-1 went successful.
+		10. Restart csi driver.
+		11. Perform scaleup operation on StatefulSet-2. Increase the replica count of sts-2 from 35 to 40.
+		12. Verify scaleup operation went successful.
+		13. Perform scaledown operation on StatefulSet-3. Scale down the replica count of sts-3 from 50 to 30.
+		14. Verify scaledown operation went successful.
+		15. Perform scaledown operation on StatefulSet-1. Scale down the replica count of sts-1 from 52 to 42.
+		16. Verify scaledown operation went successful.
+		17. Perform scaleup operation on StatefulSet-2. Scale up the replica count of sts-2 from 40 to 60.
+		18. Verify scaleup operation went successful.
+		19. Restart csi driver.
+		20. Perform scaleup operation on StatefulSet-3. Scale up the replica count of sts-3 from 30 to 50.
+		21. Verify scaleup operation went successful.
+		22. Scale up all 3 statefulsets (sts-1,sts-2,sts-3) to replica count 63.
+		23. Verify scaleup operation on all 3 statefulsets are successful.
+		24. Restart csi driver.
+		25. Create 9 standalone PVC's.
+		26. Verify standalone PVC's are in Bound state.
+		27. Create 9 Pods using above created PVC's
+		28. Verify standalone Pods are in up and running state.
+		29. Perform cleanup. Delete StatefulSet Pods, PVC's, PV.
+	*/
+
+	ginkgo.It("Trigger multiple statefulsets using parallel management policy and restart csi "+
+		"driver when statefulsets scaleup/sclaedown operation is in progress", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		pvcCount = 9
+		var podList []*v1.Pod
+
+		ginkgo.By("Create Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "nginx-sc")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Create statefulset-1 with 40 replica pods and each replica pod is attached to 4 pvcs")
+		statefulSetReplicaCount = 40
+		statefulset1 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset1.Spec.Replicas = &statefulSetReplicaCount
+		statefulset1.Name = "sts1"
+		statefulset1.Spec.PodManagementPolicy = apps.ParallelPodManagement
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset1, client, statefulSetReplicaCount)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			DeleteMultipleStsInGivenNameSpace(client, namespace)
+		}()
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset1, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset1, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods := GetListOfPodsInSts(client, statefulset1)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset1.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Create statefulset-2 with 35 replica pods and each replica pod is attached to 4 pvcs")
+		statefulSetReplicaCount = 35
+		statefulset2 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset2.Spec.Replicas = &statefulSetReplicaCount
+		statefulset2.Name = "sts2"
+		statefulset2.Spec.PodManagementPolicy = apps.ParallelPodManagement
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset2, client,
+			statefulSetReplicaCount)
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset2, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset2, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods = GetListOfPodsInSts(client, statefulset2)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset2.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Create statefulset-3 with 50 replica pods and each replica pod is attached to 4 pvcs")
+		statefulSetReplicaCount = 50
+		statefulset3 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset3.Spec.Replicas = &statefulSetReplicaCount
+		statefulset3.Name = "sts3"
+		statefulset3.Spec.PodManagementPolicy = apps.ParallelPodManagement
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset3, client,
+			statefulSetReplicaCount)
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset3, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset3, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods = GetListOfPodsInSts(client, statefulset3)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset3.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Scaleup statefulset-1 replica pod count to 52")
+		statefulSetReplicaCount = 52
+		scaleUpStatefulSetPod(ctx, client, statefulset1, namespace, statefulSetReplicaCount, true, true)
+
+		restartSuccess, err := restartCSIDriver(ctx, client, csiNamespace, csiReplicas)
+		gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scaleup statefulset-2 replica pod count to 40")
+		statefulSetReplicaCount = 40
+		scaleUpStatefulSetPod(ctx, client, statefulset2, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Scaledown statefulset-3 replica pod count to 30")
+		statefulSetReplicaCount = 30
+		scaleDownStatefulSetPod(ctx, client, statefulset3, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Scaledown statefulset-1 replica pod count to 42")
+		statefulSetReplicaCount = 42
+		scaleDownStatefulSetPod(ctx, client, statefulset1, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Scaleup statefulset-2 replica pod count to 60")
+		statefulSetReplicaCount = 60
+		scaleUpStatefulSetPod(ctx, client, statefulset2, namespace, statefulSetReplicaCount, true, true)
+
+		restartSuccess, err = restartCSIDriver(ctx, client, csiNamespace, csiReplicas)
+		gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scaleup statefulset-3 replica pod count to 50")
+		statefulSetReplicaCount = 50
+		scaleUpStatefulSetPod(ctx, client, statefulset3, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("ScaleUp statefulset-1, statefulset-2, statefulset-3 replica pod count to 63")
+		statefulSetReplicaCount = 63
+		scaleUpStatefulSetPod(ctx, client, statefulset1, namespace, statefulSetReplicaCount, true, true)
+		scaleUpStatefulSetPod(ctx, client, statefulset2, namespace, statefulSetReplicaCount, true, true)
+
+		restartSuccess, err = restartCSIDriver(ctx, client, csiNamespace, csiReplicas)
+		gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		scaleUpStatefulSetPod(ctx, client, statefulset3, namespace, statefulSetReplicaCount, true, true)
+
+		ginkgo.By("Trigger multiple PVCs")
+		pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount)
+		defer func() {
+			ginkgo.By("Deleting PVC's and PV's")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				err = fpv.DeletePersistentVolumeClaim(client, pvclaimsList[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC claim to be in bound phase and create POD for each PVC")
+		for i := 0; i < len(pvclaimsList); i++ {
+			var pvclaims []*v1.PersistentVolumeClaim
+			pvc, err := fpv.WaitForPVClaimBoundPhase(client,
+				[]*v1.PersistentVolumeClaim{pvclaimsList[i]}, framework.ClaimProvisionTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pvc).NotTo(gomega.BeEmpty())
+			pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+
+			ginkgo.By("Creating Pod")
+			pvclaims = append(pvclaims, pvclaimsList[i])
+			pod, err := createPod(client, namespace, nil, pvclaims, false, "")
+			podList = append(podList, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+			isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
+		}
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err = fpod.DeletePodWithWait(client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			ginkgo.By("Verify volume is detached from the node")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+					pv.Spec.CSI.VolumeHandle, podList[i].Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+					fmt.Sprintf("Volume %q is not detached from the node", pv.Spec.CSI.VolumeHandle))
+			}
+		}()
+	})
+
+	/*
+		TESTCASE-5
+		Scaleup/Scaledown of worker nodes
+
+		Steps//
+		1. Scaledown worker node to count 1.
+		2. Create Storage Class with Immediate Binding mode.
+		3. Trigger StatefulSet-1 with replica count 63, with each replica Pod is attached to 4 PVCs.
+		4. Verify all PVs, PVCs to reach Bound state and Statefulset Pods to reach running state.
+		5. Trigger StatefulSet-2 with replica count 63 with each replica Pod is attached to 4 PVCs.
+		6. Verify all PVs, PVCs to reach Bound state and Statefulset Pods to reach running state.
+		7. Trigger 6 standalone PVCs.
+		8. Verity PVC should reach Bound state.
+		9. Create 6 Pods using above created PVCs.
+		10. Create StatefulSet-3 with replica count 1.
+		11. PVC should reach Bound state but Pod creation should get stuck in Pending state due to
+		max volume count reached.
+		12. Scaleup worker node count to 1.
+		13. Trigger StatefulSet-4 with replica count 40 with each replica Pod is attached to 4 PVCs.
+		14. Verify all PVs, PVCs to reach Bound state and Statefulset Pods to reach running state.
+		15. Verify StatefulSet-3 Pods status which was stuck in Pending state. It should now reach to
+		running state.
+		16. Scaledown worker node count to 1.
+		17. Verify StatefulSet-1, StatefulSet-2 Pods status.
+		18. Verify StatefulSet-3, StatefulSet-4 Pods status. Pods should get stuck in Pending state and
+		should start eviction.
+		19. Perform cleanup. Delete StatefulSet Pods, PVC's, PV.
+	*/
+
+	ginkgo.It("Perform scaleup scaledown of worker nodes", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		statefulSetReplicaCount = 63
+		pvcCount = 6
+		var podList []*v1.Pod
+		expectedErrMsg := "exceed max volume count"
+		isNodeUncordon := true
+
+		dh := drain.Helper{
+			Ctx:                 ctx,
+			Client:              client,
+			Force:               true,
+			IgnoreAllDaemonSets: true,
+			Out:                 ginkgo.GinkgoWriter,
+			ErrOut:              ginkgo.GinkgoWriter,
+		}
+
+		framework.Logf("Fetch the Node Details")
+		nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		var nodeToCordon *v1.Node
+		for _, node := range nodes.Items {
+			if strings.Contains(node.Name, "master") || strings.Contains(node.Name, "control") {
+				continue
+			} else {
+				nodeToCordon = &node
+				ginkgo.By("Cordoning of node: " + node.Name)
+				err = drain.RunCordonOrUncordon(&dh, &node, true)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				ginkgo.By("Draining of node: " + node.Name)
+				err = drain.RunNodeDrain(&dh, node.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				isNodeUncordon = false
+				break
+			}
+		}
+		defer func() {
+			if !isNodeUncordon {
+				ginkgo.By("Uncordoning of node: " + nodeToCordon.Name)
+				err = drain.RunCordonOrUncordon(&dh, nodeToCordon, false)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Create Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "nginx-sc")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Create statefulset-1 with 63 replica pods and each replica pod is attached to 4 pvcs")
+		statefulset1 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset1.Spec.Replicas = &statefulSetReplicaCount
+		statefulset1.Name = "sts1"
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset1, client,
+			statefulSetReplicaCount)
+		defer func() {
+			framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+			DeleteMultipleStsInGivenNameSpace(client, namespace)
+		}()
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset1, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset1, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods := GetListOfPodsInSts(client, statefulset1)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset1.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Create statefulset-2 with 63 replica pods and each pod is attached to 4 pvcs")
+		statefulset2 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulset2.Spec.Replicas = &statefulSetReplicaCount
+		statefulset2.Name = "sts2"
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset2, client, statefulSetReplicaCount)
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset2, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset2, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods = GetListOfPodsInSts(client, statefulset2)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset2.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Trigger multiple PVCs")
+		pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount)
+		defer func() {
+			ginkgo.By("Deleting PVC's and PV's")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				err = fpv.DeletePersistentVolumeClaim(client, pvclaimsList[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC claim to be in bound phase and create POD for each PVC")
+		for i := 0; i < len(pvclaimsList); i++ {
+			var pvclaims []*v1.PersistentVolumeClaim
+			pvc, err := fpv.WaitForPVClaimBoundPhase(client,
+				[]*v1.PersistentVolumeClaim{pvclaimsList[i]}, framework.ClaimProvisionTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pvc).NotTo(gomega.BeEmpty())
+			pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+
+			ginkgo.By("Creating Pod")
+			pvclaims = append(pvclaims, pvclaimsList[i])
+			pod, err := createPod(client, namespace, nil, pvclaims, false, "")
+			if i == 9 && err != nil {
+				framework.Logf("Pod is stuck in Pending state due to no space left")
+			} else {
+				podList = append(podList, pod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+					pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+				vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+				isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
+			}
+		}
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err = fpod.DeletePodWithWait(client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			ginkgo.By("Verify volume is detached from the node")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
+					pv.Spec.CSI.VolumeHandle, podList[i].Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+					fmt.Sprintf("Volume %q is not detached from the node", pv.Spec.CSI.VolumeHandle))
+			}
+		}()
+
+		ginkgo.By("Create statefulset-3 with 1 replica pod and it is attached to 4 pvcs")
+		statefulset3 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulSetReplicaCount = 1
+		statefulset3.Spec.Replicas = &statefulSetReplicaCount
+		statefulset3.Name = "sts3"
+		framework.Logf(fmt.Sprintf("Creating statefulset %v/%v with %d replicas and selector %+v",
+			statefulset3.Namespace, statefulset3.Name, statefulSetReplicaCount, statefulset3.Spec.Selector))
+		_, err = client.AppsV1().StatefulSets(namespace).Create(ctx, statefulset3, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		sts3Pods := GetListOfPodsInSts(client, statefulset3)
+		for _, pod := range sts3Pods.Items {
+			if pod.Status.Phase == v1.PodPending {
+				framework.Logf("Pod creation is stuck in Pending state due to max volume count reached")
+			}
+			err = waitForEvent(ctx, client, namespace, expectedErrMsg, pod.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+		}
+
+		ginkgo.By("Uncordoning of node: " + nodeToCordon.Name)
+		err = drain.RunCordonOrUncordon(&dh, nodeToCordon, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isNodeUncordon = true
+
+		ginkgo.By("Create statefulset-4 with 40 replica pods and each replica pod is attached to 4 pvcs")
+		statefulset4 := GetStatefulSetFromManifestFor265Disks(namespace)
+		statefulSetReplicaCount = 40
+		statefulset4.Spec.Replicas = &statefulSetReplicaCount
+		statefulset4.Name = "sts4"
+		CreateMultipleStatefulSetsInSameNsFor256DiskSupport(namespace, statefulset4, client, statefulSetReplicaCount)
+
+		// verify that the StatefulSets pods are in ready state
+		fss.WaitForStatusReadyReplicas(client, statefulset4, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset4, mountPath)).NotTo(gomega.HaveOccurred())
+		sts4Pods := GetListOfPodsInSts(client, statefulset4)
+		gomega.Expect(sts4Pods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset4.Name))
+		gomega.Expect(len(sts4Pods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		ginkgo.By("Verify statefulset-3 pods status")
+		statefulSetReplicaCount = 1
+		WaitForStsPodsToBeInRunningReadyState(client, statefulSetReplicaCount, statefulset3)
+		fss.WaitForStatusReadyReplicas(client, statefulset3, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset3, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPods = GetListOfPodsInSts(client, statefulset3)
+		gomega.Expect(ssPods.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset3.Name))
+		gomega.Expect(len(ssPods.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// cordon same node
+		ginkgo.By("Cordoning of node: " + nodeToCordon.Name)
+		err = drain.RunCordonOrUncordon(&dh, nodeToCordon, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Draining of node: " + nodeToCordon.Name)
+		err = drain.RunNodeDrain(&dh, nodeToCordon.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isNodeUncordon = false
+		defer func() {
+			if !isNodeUncordon {
+				ginkgo.By("Uncordoning of node: " + nodeToCordon.Name)
+				err = drain.RunCordonOrUncordon(&dh, nodeToCordon, false)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				isNodeUncordon = true
+			}
+		}()
+
+		// verify Pods running state
+		ginkgo.By("Verify statefulset-1, statefulset-2 Pods status after node cordon")
+		statefulSetReplicaCount = 63
+		fss.WaitForStatusReadyReplicas(client, statefulset1, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset1, mountPath)).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReadyReplicas(client, statefulset2, statefulSetReplicaCount)
+		gomega.Expect(CheckMountForStsPods(client, statefulset2, mountPath)).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify statefulset-3, statefulset-4 Pods status after node cordon")
+		statefulSetReplicaCount = 0
+		fss.WaitForStatusReadyReplicas(client, statefulset3, statefulSetReplicaCount)
+		for _, pod := range sts3Pods.Items {
+			if pod.Status.Phase == v1.PodPending {
+				framework.Logf("Pod creation is stuck in Pending state due to max volume count reached")
+			}
+			err = waitForEvent(ctx, client, namespace, expectedErrMsg, pod.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+		}
+
+		fss.WaitForStatusReadyReplicas(client, statefulset4, statefulSetReplicaCount)
+		for _, pod := range sts4Pods.Items {
+			if pod.Status.Phase == v1.PodPending {
+				framework.Logf("Pod creation is stuck in Pending state due to max volume count reached")
+			}
+			err = waitForEvent(ctx, client, namespace, expectedErrMsg, pod.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+		}
+	})
+})

--- a/tests/e2e/create_256_volumes.go
+++ b/tests/e2e/create_256_volumes.go
@@ -1725,8 +1725,7 @@ var _ = ginkgo.Describe("[csi-vanilla-256-disk-support] Volume-Provisioning-With
 		12. Perform cleanup. Delete StatefulSet Pods, PVC's, PV.
 	*/
 
-	ginkgo.It("Verify volume provisioning when multiple statefulsets are triggered with 63 replicas and "+
-		"each replica pod is attached to 4 pvcs", func() {
+	ginkgo.It("Verify volume provisioning when multiple  replicas", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		statefulSetReplicaCount = 63

--- a/tests/e2e/create_256_volumes.go
+++ b/tests/e2e/create_256_volumes.go
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("[csi-vanilla-256-disk-support] Volume-Provisioning-With
 		csiReplicas = *csiDeployment.Spec.Replicas
 		bindingMode = storagev1.VolumeBindingWaitForFirstConsumer
 
-		setvCenterFlagFor255Disks()
+		//setvCenterFlagFor255Disks()
 
 	})
 

--- a/tests/e2e/create_256_volumes_utils.go
+++ b/tests/e2e/create_256_volumes_utils.go
@@ -43,8 +43,8 @@ import (
 // 256 disk statefulset poll timeouts
 const (
 	StatefulSetPollFor256DiskSupport    = 10 * time.Second
-	StatefulSetTimeoutFor256DiskSupport = 30 * time.Minute
-	StatefulPodTimeoutFor256DiskSupport = 60 * time.Minute
+	StatefulSetTimeoutFor256DiskSupport = 80 * time.Minute
+	StatefulPodTimeoutFor256DiskSupport = 80 * time.Minute
 )
 
 var statefulPodRegex = regexp.MustCompile("(.*)-([0-9]+)$")

--- a/tests/e2e/create_256_volumes_utils.go
+++ b/tests/e2e/create_256_volumes_utils.go
@@ -45,8 +45,8 @@ import (
 // 256 disk statefulset poll timeouts
 const (
 	StatefulSetPollFor256DiskSupport    = 10 * time.Second
-	StatefulSetTimeoutFor256DiskSupport = 120 * time.Minute
-	StatefulPodTimeoutFor256DiskSupport = 180 * time.Minute
+	StatefulSetTimeoutFor256DiskSupport = 150 * time.Minute
+	StatefulPodTimeoutFor256DiskSupport = 220 * time.Minute
 )
 
 var statefulPodRegex = regexp.MustCompile("(.*)-([0-9]+)$")

--- a/tests/e2e/create_256_volumes_utils.go
+++ b/tests/e2e/create_256_volumes_utils.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubectl/pkg/util/podutils"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/manifest"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+)
+
+// 256 disk statefulset poll timeouts
+const (
+	StatefulSetPollFor256DiskSupport    = 10 * time.Second
+	StatefulSetTimeoutFor256DiskSupport = 30 * time.Minute
+	StatefulPodTimeoutFor256DiskSupport = 60 * time.Minute
+)
+
+var statefulPodRegex = regexp.MustCompile("(.*)-([0-9]+)$")
+
+// GetStatefulSetFromManifestFor265Disks fetches statefulset spec for 256 disk volumes
+func GetStatefulSetFromManifestFor265Disks(ns string) *appsv1.StatefulSet {
+	ssManifestFilePath := filepath.Join(manifestPathFor256Disks, "statefulset.yaml")
+	framework.Logf("Parsing statefulset from %v", ssManifestFilePath)
+	ss, err := manifest.StatefulSetFromManifest(ssManifestFilePath, ns)
+	framework.ExpectNoError(err)
+	return ss
+}
+
+// CreateMultipleStatefulSetsInSameNsFor256DiskSupport creates multiple statefulsets in given namespace
+func CreateMultipleStatefulSetsInSameNsFor256DiskSupport(ns string, ss *appsv1.StatefulSet,
+	c clientset.Interface, replicas int32) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	framework.Logf(fmt.Sprintf("Creating statefulset %v/%v with %d replicas and selector %+v",
+		ss.Namespace, ss.Name, replicas, ss.Spec.Selector))
+	_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
+	framework.ExpectNoError(err)
+	WaitForStsPodsToBeInRunningReadyState(c, replicas, ss)
+}
+
+// WaitForStsPodsToBeInRunningReadyState waits for sts pods to be in ready running state
+func WaitForStsPodsToBeInRunningReadyState(c clientset.Interface, numStatefulPods int32, ss *appsv1.StatefulSet) {
+	numPodsRunning := numStatefulPods
+	numPodsReady := numStatefulPods
+	{
+		pollErr := wait.PollImmediate(StatefulSetPollFor256DiskSupport, StatefulSetTimeoutFor256DiskSupport,
+			func() (bool, error) {
+				podList := GetListOfPodsInSts(c, ss)
+				fss.SortStatefulPods(podList)
+				if int32(len(podList.Items)) < numPodsRunning {
+					framework.Logf("Found %d stateful pods, waiting for %d", len(podList.Items), numPodsRunning)
+					return false, nil
+				}
+				if int32(len(podList.Items)) > numPodsRunning {
+					return false, fmt.Errorf("too many pods scheduled, expected %d got %d", numPodsRunning, len(podList.Items))
+				}
+				for _, p := range podList.Items {
+					shouldBeReady := getOrdinalForMultipleStsPodsInGivenNS(&p) < int(numPodsReady)
+					isReady := podutils.IsPodReady(&p)
+					desiredReadiness := shouldBeReady == isReady
+					framework.Logf("Waiting for pod %v to enter %v - Ready=%v, currently %v - Ready=%v",
+						p.Name, v1.PodRunning, shouldBeReady, p.Status.Phase, isReady)
+					if p.Status.Phase != v1.PodRunning || !desiredReadiness {
+						return false, nil
+					}
+				}
+				return true, nil
+			})
+		if pollErr != nil {
+			framework.Failf("Failed waiting for pods to enter running: %v", pollErr)
+		}
+	}
+}
+
+/*
+getOrdinalForMultipleStsPodsInGivenNS  is used to fetch statefulSet Pods unique identity that is ordinal
+*/
+func getOrdinalForMultipleStsPodsInGivenNS(pod *v1.Pod) int {
+	ordinal := -1
+	subMatches := statefulPodRegex.FindStringSubmatch(pod.Name)
+	if len(subMatches) < 3 {
+		return ordinal
+	}
+	if i, err := strconv.ParseInt(subMatches[2], 10, 32); err == nil {
+		ordinal = int(i)
+	}
+	return ordinal
+}
+
+// DeleteMultipleStsInGivenNameSpace deletes all the multiple sts pods created in a given namesspace
+func DeleteMultipleStsInGivenNameSpace(c clientset.Interface, ns string) {
+	ssList, err := c.AppsV1().StatefulSets(ns).List(context.TODO(),
+		metav1.ListOptions{LabelSelector: labels.Everything().String()})
+	framework.ExpectNoError(err)
+	errList := []string{}
+	for i := range ssList.Items {
+		ss := &ssList.Items[i]
+		var err error
+		if ss, err = scaleStatefulSetPods(c, ss, 0, true); err != nil {
+			errList = append(errList, fmt.Sprintf("%v", err))
+		}
+		fss.WaitForStatusReplicas(c, ss, 0)
+		framework.Logf("Deleting statefulset %v", ss.Name)
+		if err := c.AppsV1().StatefulSets(ss.Namespace).Delete(context.TODO(), ss.Name,
+			metav1.DeleteOptions{OrphanDependents: new(bool)}); err != nil {
+			errList = append(errList, fmt.Sprintf("%v", err))
+		}
+	}
+	pvNames := sets.NewString()
+	pvcPollErr := wait.PollImmediate(StatefulSetPollFor256DiskSupport,
+		StatefulPodTimeoutFor256DiskSupport, func() (bool, error) {
+			pvcList, err := c.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(),
+				metav1.ListOptions{LabelSelector: labels.Everything().String()})
+			if err != nil {
+				framework.Logf("WARNING: Failed to list pvcs, retrying %v", err)
+				return false, nil
+			}
+			for _, pvc := range pvcList.Items {
+				pvNames.Insert(pvc.Spec.VolumeName)
+				framework.Logf("Deleting pvc: %v with volume %v", pvc.Name, pvc.Spec.VolumeName)
+				if err := c.CoreV1().PersistentVolumeClaims(ns).Delete(context.TODO(), pvc.Name,
+					metav1.DeleteOptions{}); err != nil {
+					return false, nil
+				}
+			}
+			return true, nil
+		})
+	if pvcPollErr != nil {
+		errList = append(errList, "Timeout waiting for pvc deletion.")
+	}
+	pollErr := wait.PollImmediate(StatefulSetPollFor256DiskSupport,
+		StatefulPodTimeoutFor256DiskSupport, func() (bool, error) {
+			pvList, err := c.CoreV1().PersistentVolumes().List(context.TODO(),
+				metav1.ListOptions{LabelSelector: labels.Everything().String()})
+			if err != nil {
+				framework.Logf("WARNING: Failed to list pvs, retrying %v", err)
+				return false, nil
+			}
+			waitingFor := []string{}
+			for _, pv := range pvList.Items {
+				if pvNames.Has(pv.Name) {
+					waitingFor = append(waitingFor, fmt.Sprintf("%v: %+v", pv.Name, pv.Status))
+				}
+			}
+			if len(waitingFor) == 0 {
+				return true, nil
+			}
+			framework.Logf("Still waiting for pvs of statefulset to disappear:\n%v", strings.Join(waitingFor, "\n"))
+			return false, nil
+		})
+	if pollErr != nil {
+		errList = append(errList, fmt.Sprintf("Timeout waiting for pv provisioner to delete pvs, "+
+			"this might mean the test leaked pvs."))
+	}
+	if len(errList) != 0 {
+		framework.ExpectNoError(fmt.Errorf("%v", strings.Join(errList, "\n")))
+	}
+}
+
+// WaitForStsPodsReadyReplicaStatus waits for sts pods replicas to be in ready state
+func WaitForStsPodsReadyReplicaStatus(c clientset.Interface, ss *appsv1.StatefulSet, expectedReplicas int32) {
+	framework.Logf("Waiting for statefulset status.replicas updated to %d", expectedReplicas)
+	ns, name := ss.Namespace, ss.Name
+	pollErr := wait.PollImmediate(StatefulSetPollFor256DiskSupport, StatefulSetTimeoutFor256DiskSupport,
+		func() (bool, error) {
+			ssGet, err := c.AppsV1().StatefulSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if ssGet.Status.ObservedGeneration < ss.Generation {
+				return false, nil
+			}
+			if ssGet.Status.ReadyReplicas != expectedReplicas {
+				framework.Logf("Waiting for stateful set status.readyReplicas to become %d, "+
+					"currently %d", expectedReplicas, ssGet.Status.ReadyReplicas)
+				return false, nil
+			}
+			return true, nil
+		})
+	if pollErr != nil {
+		framework.Failf("Failed waiting for stateful set status.readyReplicas updated to %d: %v", expectedReplicas, pollErr)
+	}
+}

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -183,6 +183,7 @@ const (
 	vpxdServiceName                           = "vpxd"
 	vpxdReducedTaskTimeoutSecsInt             = 90
 	vSphereCSIControllerPodNamePrefix         = "vsphere-csi-controller"
+	vSphereCSINodePrefix                      = "vsphere-csi-node"
 	vmUUIDLabel                               = "vmware-system-vm-uuid"
 	vsanDefaultStorageClassInSVC              = "vsan-default-storage-policy"
 	vsanDefaultStoragePolicyName              = "vSAN Default Storage Policy"

--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -463,7 +463,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		replicas = 10
 		ginkgo.By("Scale up statefulset replica count from 3 to 10")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -585,7 +585,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		replicas = 10
 		ginkgo.By("Scale up statefulset replica count from 3 to 10")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -601,7 +601,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaledown
 		replicas = 5
 		ginkgo.By("Scale down statefulset replica count from 10 to 5")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -1303,7 +1303,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		sts1Replicas = 10
 		ginkgo.By("Scale up statefulset replica count from 3 to 10")
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
-		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		//verifying volume is provisioned on the preferred datastore
 		ginkgo.By("Verify volume is provisioned on the specified datatsore")
@@ -1434,7 +1434,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 13
 		ginkgo.By("Scale up statefulset replica count from 3 to 13")
-		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the specified datatsore")
@@ -1450,7 +1450,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaledown
 		sts1Replicas = 6
 		ginkgo.By("Scale down statefulset replica count from 13 to 6")
-		scaleDownStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleDownStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, preferredDatastorePaths[1], allowedTopologyRacks[0])
@@ -1476,7 +1476,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 20
 		ginkgo.By("Scale up statefulset replica count from 6 to 20")
-		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the specified datatsore")
@@ -1615,7 +1615,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 7
 		ginkgo.By("Scale up statefulset replica count from 3 to 7")
-		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		//verify volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -1650,7 +1650,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 13
 		ginkgo.By("Scale up statefulset replica count from 7 to 13")
-		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		// verify volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -2068,7 +2068,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 13
 		ginkgo.By("Scale up statefulset replica count from 7 to 13")
-		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")

--- a/tests/e2e/preferential_topology_disruptive.go
+++ b/tests/e2e/preferential_topology_disruptive.go
@@ -361,7 +361,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 
 		ginkgo.By("Scale up statefulset replica and verify the replica count")
 		replicas = 10
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, true)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulset)
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -396,7 +396,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// Scale down statefulSets replica count
 		replicas = 5
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, true)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, true, false)
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulset)
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -423,7 +423,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// Scale up statefulSets replicas count
 		ginkgo.By("Scale up statefulset replica and verify the replica count")
 		replicas = 13
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, true)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, true, false)
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulset)
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -612,7 +612,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// perform statefulset scaleup
 		replicas = 15
 		ginkgo.By("Scale up statefulset replica count from 10 to 15")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -640,7 +640,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// perform statefulset scaleup
 		replicas = 20
 		ginkgo.By("Scale up statefulset replica count from 15 to 20")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -832,7 +832,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// perform statefulset scaleup
 		replicas = 15
 		ginkgo.By("Scale up statefulset replica count from 10 to 15")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -861,7 +861,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// perform statefulset scaleup
 		replicas = 20
 		ginkgo.By("Scale up statefulset replica count from 15 to 20")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -1051,7 +1051,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// perform statefulset scaleup
 		replicas = 15
 		ginkgo.By("Scale up statefulset replica count from 10 to 15")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -1079,7 +1079,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// perform statefulset scaleup
 		replicas = 20
 		ginkgo.By("Scale up statefulset replica count from 15 to 20")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")

--- a/tests/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
+++ b/tests/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
@@ -4,6 +4,7 @@ metadata:
   name: web
 spec:
   serviceName: "nginx"
+  podManagementPolicy: "Parallel"
   replicas: 3
   selector:
     matchLabels:

--- a/tests/e2e/testing-manifests/statefulset256disk/statefulset.yaml
+++ b/tests/e2e/testing-manifests/statefulset256disk/statefulset.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  serviceName: "nginx"
+  replicas: 63
+  selector:
+    matchLabels:
+      app: nginx
+  serviceName: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: gcr.io/google_containers/nginx-slim:0.8
+          ports:
+            - containerPort: 80
+              name: web
+          volumeMounts:
+            - name: www
+              mountPath: /usr/share/nginx/html
+            - name: logs
+              mountPath: /logs
+            - name: logs1
+              mountPath: /logs1
+            - name: logs2
+              mountPath: /logs2 
+  volumeClaimTemplates:
+    - metadata:
+        name: logs
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: nginx-sc
+        resources:
+          requests:
+            storage: 10Mi
+    - metadata:
+        name: www
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: nginx-sc
+        resources:
+          requests:
+            storage: 10Mi
+    - metadata:
+        name: logs1
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: nginx-sc
+        resources:
+          requests:
+            storage: 10Mi
+    - metadata:
+        name: logs2
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: nginx-sc
+        resources:
+          requests:
+            storage: 10Mi     

--- a/tests/e2e/topology_multi_replica.go
+++ b/tests/e2e/topology_multi_replica.go
@@ -323,7 +323,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 2
 			ginkgo.By("Scale down statefulset replica and verify the replica count")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 				ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 				gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 					"Number of Pods in the statefulset should match with number of replicas")
@@ -352,7 +352,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 0
 			ginkgo.By("Scale down statefulset replica count to 0")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 				ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 				gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 					"Number of Pods in the statefulset should match with number of replicas")
@@ -508,7 +508,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 2
 			ginkgo.By("Scale down statefulset replica count")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 				ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 				gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 					"Number of Pods in the statefulset should match with number of replicas")
@@ -534,7 +534,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 0
 			ginkgo.By("Scale down statefulset replica count to 0")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 				ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 				gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 					"Number of Pods in the statefulset should match with number of replicas")
@@ -707,7 +707,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Scale up StaefulSets replicas in parallel")
 			statefulSetReplicaCount = 5
 			for i := 0; i < len(statefulSets); i++ {
-				scaleUpStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleUpStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			}
 
 			/* Verify PV nde affinity and that the pods are running on appropriate nodes
@@ -722,7 +722,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 0
 			ginkgo.By("Scale down statefulset replica count to 0")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			}
 		})
 
@@ -1427,7 +1427,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 2
 			ginkgo.By("Scale down statefulset replica count")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 				if i == 1 {
 					/* Delete newly elected leader CSi-Controller-Pod where CSI-Attacher is running */
 					ginkgo.By("Delete elected leader CSi-Controller-Pod where CSI-Attacher is running")
@@ -1450,7 +1450,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 0
 			ginkgo.By("Scale down statefulset replica count to 0")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			}
 
 			// Verify that the StatefulSet Pods, PVC's are deleted successfully

--- a/tests/e2e/topology_operation_strom_cases.go
+++ b/tests/e2e/topology_operation_strom_cases.go
@@ -233,7 +233,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		// Scale up statefulSets replicas count
 		ginkgo.By("Scale up statefulset replica and verify the replica count")
 		statefulSetReplicaCount = 35
-		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -241,7 +241,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		// Scale down statefulSets replica count
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleDownStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount, true)
+		scaleDownStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulSets[1])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -281,7 +281,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		// Scale down statefulSets replicas count
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleDownStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleDownStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -289,7 +289,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		// Scale up statefulSets replica count
 		statefulSetReplicaCount = 35
 		ginkgo.By("Scale up statefulset replica and verify the replica count")
-		scaleUpStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulSets[1])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -347,7 +347,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -596,7 +596,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -622,7 +622,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 			// Scale up statefulSets replicas count
 			statefulSetReplicaCount = 20
 			ginkgo.By("Scale up statefulset replica and verify the replica count")
-			scaleUpStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleUpStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -640,7 +640,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")

--- a/tests/e2e/topology_site_down_cases.go
+++ b/tests/e2e/topology_site_down_cases.go
@@ -234,7 +234,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Scaleup any one StatefulSets replica")
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -243,7 +243,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -301,7 +301,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -438,7 +438,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Scaleup any one StatefulSets replica")
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -447,7 +447,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -498,7 +498,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -631,7 +631,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Scaleup any one StatefulSets replica")
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -640,7 +640,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -685,7 +685,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -816,7 +816,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Scaleup any one StatefulSets replica")
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -825,7 +825,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -876,7 +876,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -1005,7 +1005,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Scaleup any one StatefulSets replica")
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -1014,7 +1014,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -1065,7 +1065,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -1205,7 +1205,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		// Scale up statefulSets replicas count
 		ginkgo.By("Scaleup any one StatefulSets replica")
 		statefulSetReplicaCount = 10
-		_, scaleupErr := scaleStatefulSetPods(client, statefulSets[1], statefulSetReplicaCount)
+		_, scaleupErr := scaleStatefulSetPods(client, statefulSets[1], statefulSetReplicaCount, false)
 		gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
 
 		// Bring up
@@ -1251,7 +1251,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		// Scale down statefulSets replica count
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
-		scaleDownStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleDownStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -1297,7 +1297,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -4690,11 +4690,20 @@ func updateSts(c clientset.Interface, ns, name string, update func(ss *appsv1.St
 }
 
 // Scale scales ss to count replicas.
-func scaleStatefulSetPods(c clientset.Interface, ss *appsv1.StatefulSet, count int32) (*appsv1.StatefulSet, error) {
+// Scale scales ss to count replicas.
+func scaleStatefulSetPods(c clientset.Interface, ss *appsv1.StatefulSet, count int32,
+	is256Disk bool) (*appsv1.StatefulSet, error) {
 	name := ss.Name
 	ns := ss.Namespace
-	StatefulSetPoll := 10 * time.Second
-	StatefulSetTimeout := 10 * time.Minute
+	var StatefulSetPoll time.Duration
+	var StatefulSetTimeout time.Duration
+	if is256Disk {
+		StatefulSetPoll = 10 * time.Second
+		StatefulSetTimeout = 30 * time.Minute
+	} else {
+		StatefulSetPoll = 10 * time.Second
+		StatefulSetTimeout = 10 * time.Minute
+	}
 	framework.Logf("Scaling statefulset %s to %d", name, count)
 	ss = updateSts(c, ns, name, func(ss *appsv1.StatefulSet) { *(ss.Spec.Replicas) = count })
 
@@ -4726,15 +4735,23 @@ func scaleStatefulSetPods(c clientset.Interface, ss *appsv1.StatefulSet, count i
 scaleDownStatefulSetPod is a utility method which is used to scale down the count of StatefulSet replicas.
 */
 func scaleDownStatefulSetPod(ctx context.Context, client clientset.Interface,
-	statefulset *appsv1.StatefulSet, namespace string, replicas int32, parallelStatefulSetCreation bool) {
+	statefulset *appsv1.StatefulSet, namespace string, replicas int32,
+	parallelStatefulSetCreation bool, is256Disk bool) {
 	ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas))
 	var ssPodsAfterScaleDown *v1.PodList
-	if parallelStatefulSetCreation {
-		_, scaledownErr := scaleStatefulSetPods(client, statefulset, replicas)
+	if parallelStatefulSetCreation && !is256Disk {
+		_, scaledownErr := scaleStatefulSetPods(client, statefulset, replicas, is256Disk)
 		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
 		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulset)
-	} else {
+	}
+	if parallelStatefulSetCreation && is256Disk {
+		_, scaledownErr := scaleStatefulSetPods(client, statefulset, replicas, true)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulset)
+	}
+	if !parallelStatefulSetCreation && !is256Disk {
 		_, scaledownErr := fss.Scale(client, statefulset, replicas)
 		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
 		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
@@ -4779,11 +4796,12 @@ func scaleDownStatefulSetPod(ctx context.Context, client clientset.Interface,
 scaleUpStatefulSetPod is a utility method which is used to scale up the count of StatefulSet replicas.
 */
 func scaleUpStatefulSetPod(ctx context.Context, client clientset.Interface,
-	statefulset *appsv1.StatefulSet, namespace string, replicas int32, parallelStatefulSetCreation bool) {
+	statefulset *appsv1.StatefulSet, namespace string, replicas int32,
+	parallelStatefulSetCreation bool, is256Disk bool) {
 	ginkgo.By(fmt.Sprintf("Scaling up statefulsets to number of Replica: %v", replicas))
 	var ssPodsAfterScaleUp *v1.PodList
-	if parallelStatefulSetCreation {
-		_, scaleupErr := scaleStatefulSetPods(client, statefulset, replicas)
+	if parallelStatefulSetCreation && !is256Disk {
+		_, scaleupErr := scaleStatefulSetPods(client, statefulset, replicas, is256Disk)
 		gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
 		fss.WaitForStatusReplicas(client, statefulset, replicas)
 		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
@@ -4793,7 +4811,20 @@ func scaleUpStatefulSetPod(ctx context.Context, client clientset.Interface,
 			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
 		gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
-	} else {
+	}
+	if parallelStatefulSetCreation && is256Disk {
+		_, scaleupErr := scaleStatefulSetPods(client, statefulset, replicas, is256Disk)
+		gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		WaitForStsPodsReadyReplicaStatus(client, statefulset, replicas)
+
+		ssPodsAfterScaleUp = GetListOfPodsInSts(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+	}
+	if !parallelStatefulSetCreation && !is256Disk {
 		_, scaleupErr := fss.Scale(client, statefulset, replicas)
 		gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
 		fss.WaitForStatusReplicas(client, statefulset, replicas)

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -196,7 +196,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Scale down statefulset to 0 replicas
 		replicas -= 3
 		ginkgo.By("Scale down statefulset replica count to 0")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -271,12 +271,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Scale up statefulset replica count to 5
 		replicas += 5
 		ginkgo.By("Scale up statefulset replica count to 5")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		// Scale down statefulset replica count to 1
 		replicas -= 1
 		ginkgo.By("Scale down statefulset replica count to 1")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		// Verify newly created PV node affinity details  and that the new PODS are running on appropriate nodes
 		ginkgo.By("Verify newly created PV node affinity details  and that the new PODS are running on appropriate nodes")
@@ -286,7 +286,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Scale down statefulset replicas to 0
 		replicas = 0
 		ginkgo.By("Scale down statefulset replica count to 0")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -362,7 +362,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Scale up statefulset replicas to 5
 		replicas += 5
 		ginkgo.By("Scale up statefulset replica count to 5")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		/* Verify newly created PV node affinity and that the news PODS are running
 		on appropriate node as specified in the allowed topologies of SC */
@@ -374,7 +374,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Scale down statefulset replicas to 0
 		replicas = 0
 		ginkgo.By("Scale down statefulset replica count to 0")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -450,12 +450,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Scale up statefulset replicas to 5
 		replicas += 5
 		ginkgo.By("Scale up statefulset replica count to 5")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		// Scale down statefulset replicas to 1
 		replicas -= 1
 		ginkgo.By("Scale down statefulset replica count to 1")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		/* "Verify newly created PV node affinity and that the new PODS are
 		running on appropriate node as specified in the allowed topologies of SC */
@@ -467,7 +467,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Scale down statefulset replicas to 0
 		replicas = 0
 		ginkgo.By("Scale down statefulset replica count to 0")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -552,12 +552,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Scale up statefulset replicas to 5
 		replicas += 5
 		ginkgo.By("Scale up statefulset replica count to 5")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		// Scale down statefulset replicas to 1
 		replicas -= 1
 		ginkgo.By("Scale down statefulset replica count to 1")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		/* Verify newly created PV node affinity and that the new PODS are running on
 		appropriate node as specified in the allowed topologies of SC */
@@ -569,7 +569,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Scale down statefulset replicas to 0
 		replicas = 0
 		ginkgo.By("Scale down statefulset replica count to 0")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -719,7 +719,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Scale down statefulset to 0 replicas
 		replicas -= 3
 		ginkgo.By("Scale down statefulset replica count to 0")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*


### PR DESCRIPTION
**What this PR does / why we need it**:
256 disk automation - Part1
This Part1 consist of set of util methods and consists of testcases which will verify 255 disk attachments


**Testing done**:
Yes
[testlogs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/9919815/testlogs.txt)

Release note:
-->
set of util methods for verifying 255 disks attachment

**Special notes for your reviewer**:

Make Check:

sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll 
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/256disk-automation-part1/vsphere-csi-driver /Users/sipriya/256disk-automation-part1 /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|files|imports|name|types_sizes) took 1.405793098s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 147.244082ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): identifier_marker: 24/24, exclude: 24/24, cgo: 113/113, skip_files: 113/113, filename_unadjuster: 113/113, skip_dirs: 113/113, nolint: 0/1, path_prettifier: 113/113, autogenerated_exclude: 24/113, exclude-rules: 1/24 
INFO [runner] processing took 16.045211ms with stages: nolint: 12.410734ms, autogenerated_exclude: 2.711582ms, path_prettifier: 375.462µs, identifier_marker: 309.348µs, skip_dirs: 152.709µs, exclude-rules: 58.291µs, cgo: 15.686µs, filename_unadjuster: 7.23µs, max_same_issues: 1.202µs, uniq_by_line: 525ns, max_from_linter: 391ns, diff: 307ns, skip_files: 257ns, sort_results: 254ns, max_per_file_from_linter: 242ns, source_code: 234ns, severity-rules: 220ns, exclude: 220ns, path_shortener: 205ns, path_prefixer: 112ns 
INFO [runner] linters took 1.456021038s with stages: goanalysis_metalinter: 1.439885277s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 32 samples, avg is 58.1MB, max is 84.8MB 
INFO Execution took 3.021556797s                  
sipriya@sipriya-a01 vsphere-csi-driver % 
