### PR TITLE
Volume allocation tests for vsan direct

### DIFF
--- a/tests/e2e/docs/supervisor_cluster_setup.md
+++ b/tests/e2e/docs/supervisor_cluster_setup.md
@@ -98,6 +98,10 @@ datacenters should be comma separated if deployed on multi-datacenters
     export SHARED_NFS_DATASTORE_URL="<shared-NFS-datastore-url>"
     #shared VMFS datastore url
     export SHARED_VMFS_DATASTORE_URL="<shared-VMFS-datastore-url>"
+    #For vsan direct tests for spbm policy driven allocation tests, set following variables
+    export USE_VSAN_DIRECT_DATASTORE_IN_WCP="VSAN_DIRECT"
+    export SHARED_VSAND_DATASTORE_URL="<vsan-direct-datastore-url>"
+    export SHARED_VSAND_DATASTORE2_URL="<vsan-direct-datastore2-url>"
 
 ### To run full sync test, need do extra following steps
 

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -78,6 +78,9 @@ const (
 	envSharedNFSDatastoreURL                   = "SHARED_NFS_DATASTORE_URL"
 	envSharedVMFSDatastoreURL                  = "SHARED_VMFS_DATASTORE_URL"
 	envSharedVMFSDatastore2URL                 = "SHARED_VMFS_DATASTORE2_URL"
+	envVsanDirectSetup                         = "USE_VSAN_DIRECT_DATASTORE_IN_WCP"
+	envVsanDDatastoreURL                       = "SHARED_VSAND_DATASTORE_URL"
+	envVsanDDatastore2URL                      = "SHARED_VSAND_DATASTORE2_URL"
 	envStoragePolicyNameForNonSharedDatastores = "STORAGE_POLICY_FOR_NONSHARED_DATASTORES"
 	envStoragePolicyNameForSharedDatastores    = "STORAGE_POLICY_FOR_SHARED_DATASTORES"
 	envStoragePolicyNameForSharedDatastores2   = "STORAGE_POLICY_FOR_SHARED_DATASTORES_2"
@@ -223,10 +226,11 @@ const (
 // The following variables are required to know cluster type to run common e2e
 // tests. These variables will be set once during test suites initialization.
 var (
-	vanillaCluster    bool
-	supervisorCluster bool
-	guestCluster      bool
-	rwxAccessMode     bool
+	vanillaCluster       bool
+	supervisorCluster    bool
+	guestCluster         bool
+	rwxAccessMode        bool
+	wcpVsanDirectCluster bool
 )
 
 // For VCP to CSI migration tests.

--- a/tests/e2e/storage_policy_utils.go
+++ b/tests/e2e/storage_policy_utils.go
@@ -232,3 +232,192 @@ func updateVmfsPolicyAlloctype(
 	framework.Logf("policy content after update", spew.Sdump(policyContent))
 	return nil
 }
+
+// createVsanDStoragePolicy create a vsand storage policy with given volume allocation type and category/tag map
+func createVsanDStoragePolicy(ctx context.Context, pbmClient *pbm.Client, allocationType string,
+	categoryTagMap map[string]string) (*pbmtypes.PbmProfileId, string) {
+	s1 := rand.NewSource(time.Now().UnixNano())
+	r1 := rand.New(s1)
+	profileName := fmt.Sprintf("vsand-policy-%v-%v", time.Now().UnixNano(), strconv.Itoa(r1.Intn(1000)))
+	pbmCreateSpec := pbm.CapabilityProfileCreateSpec{
+		Name:        profileName,
+		Description: "VSAND test policy",
+		Category:    "REQUIREMENT",
+		CapabilityList: []pbm.Capability{
+			{
+				ID:        "vSANDirectVolumeAllocation",
+				Namespace: "vSANDirect",
+				PropertyList: []pbm.Property{
+					{
+						ID:       "vSANDirectVolumeAllocation",
+						Value:    allocationType,
+						DataType: "string",
+					},
+				},
+			},
+			{
+				ID:        "vSANDirectType",
+				Namespace: "vSANDirect",
+				PropertyList: []pbm.Property{
+					{
+						ID:       "vSANDirectType",
+						Value:    "vSANDirect",
+						DataType: "string",
+					},
+				},
+			},
+		},
+	}
+	for k, v := range categoryTagMap {
+
+		pbmCreateSpec.CapabilityList = append(pbmCreateSpec.CapabilityList, pbm.Capability{
+			ID:        k,
+			Namespace: "http://www.vmware.com/storage/tag",
+			PropertyList: []pbm.Property{
+				{
+					ID:       "com.vmware.storage.tag." + k + ".property",
+					Value:    v,
+					DataType: "set",
+				},
+			},
+		})
+	}
+	createSpecVSAND, err := pbm.CreateCapabilityProfileSpec(pbmCreateSpec)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	profileID, err := pbmClient.CreateProfile(ctx, *createSpecVSAND)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	framework.Logf("VSAND profile with id: %v and name: '%v' created", profileID.UniqueId, profileName)
+
+	return profileID, profileName
+}
+
+// createStoragePolicyWithSharedVmfsNVsand create a storage policy with vmfs and vsand rules
+// with given volume allocation type and category/tag map
+func createStoragePolicyWithSharedVmfsNVsand(ctx context.Context, pbmClient *pbm.Client,
+	allocationType string, categoryTagMap map[string]string) (*pbmtypes.PbmProfileId, string) {
+	s1 := rand.NewSource(time.Now().UnixNano())
+	r1 := rand.New(s1)
+	var category, tag string
+	profileName := fmt.Sprintf("storage-policy-%v-%v", time.Now().UnixNano(), strconv.Itoa(r1.Intn(1000)))
+
+	for k, v := range categoryTagMap {
+		category = k
+		tag = v
+	}
+	framework.Logf("category: %v, tag: %v", category, tag)
+
+	pbmCapabilityProfileSpec := pbmtypes.PbmCapabilityProfileCreateSpec{
+		Name:        profileName,
+		Description: "VSAND-VMFS test policy",
+		Category:    "REQUIREMENT",
+		ResourceType: pbmtypes.PbmProfileResourceType{
+			ResourceType: string(pbmtypes.PbmProfileResourceTypeEnumSTORAGE),
+		},
+		Constraints: &pbmtypes.PbmCapabilitySubProfileConstraints{
+			SubProfiles: []pbmtypes.PbmCapabilitySubProfile{
+				{
+					Capability: []pbmtypes.PbmCapabilityInstance{
+						{
+							Id: pbmtypes.PbmCapabilityMetadataUniqueId{
+								Id:        "vSANDirectVolumeAllocation",
+								Namespace: "vSANDirect",
+							},
+							Constraint: []pbmtypes.PbmCapabilityConstraintInstance{
+								{
+									PropertyInstance: []pbmtypes.PbmCapabilityPropertyInstance{
+										{
+											Id:    "vSANDirectVolumeAllocation",
+											Value: allocationType,
+										},
+									},
+								},
+							},
+						},
+						{
+							Id: pbmtypes.PbmCapabilityMetadataUniqueId{
+								Id:        "vSANDirectType",
+								Namespace: "vSANDirect",
+							},
+							Constraint: []pbmtypes.PbmCapabilityConstraintInstance{
+								{
+									PropertyInstance: []pbmtypes.PbmCapabilityPropertyInstance{
+										{
+											Id:    "vSANDirectType",
+											Value: "vSANDirect",
+										},
+									},
+								},
+							},
+						},
+						{
+							Id: pbmtypes.PbmCapabilityMetadataUniqueId{
+								Id:        category,
+								Namespace: "http://www.vmware.com/storage/tag",
+							},
+							Constraint: []pbmtypes.PbmCapabilityConstraintInstance{
+								{
+									PropertyInstance: []pbmtypes.PbmCapabilityPropertyInstance{
+										{
+											Id: "com.vmware.storage.tag." + category + ".property",
+											Value: pbmtypes.PbmCapabilityDiscreteSet{
+												Values: []vim25types.AnyType{tag},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Name: "vsandirect rules",
+				},
+				{
+					Capability: []pbmtypes.PbmCapabilityInstance{
+						{
+							Id: pbmtypes.PbmCapabilityMetadataUniqueId{
+								Id:        "VolumeAllocationType",
+								Namespace: "com.vmware.storage.volumeallocation",
+							},
+							Constraint: []pbmtypes.PbmCapabilityConstraintInstance{
+								{
+									PropertyInstance: []pbmtypes.PbmCapabilityPropertyInstance{
+										{
+											Id:    "VolumeAllocationType",
+											Value: allocationType,
+										},
+									},
+								},
+							},
+						},
+						{
+							Id: pbmtypes.PbmCapabilityMetadataUniqueId{
+								Id:        category,
+								Namespace: "http://www.vmware.com/storage/tag",
+							},
+							Constraint: []pbmtypes.PbmCapabilityConstraintInstance{
+								{
+									PropertyInstance: []pbmtypes.PbmCapabilityPropertyInstance{
+										{
+											Id: "com.vmware.storage.tag." + category + ".property",
+											Value: pbmtypes.PbmCapabilityDiscreteSet{
+												Values: []vim25types.AnyType{tag},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Name: "vmfs rules",
+				},
+			},
+		},
+	}
+	profileID, err := pbmClient.CreateProfile(ctx, pbmCapabilityProfileSpec)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	framework.Logf("VSAND and vmfs profile with id: %v and name: '%v' created", profileID.UniqueId, profileName)
+
+	return profileID, profileName
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Policy driven volume allocation tests and utils for vsan direct

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/a51e5f2aaa3c3b8574f7ac6f7be820c8

**Special notes for your reviewer**: 
make check:
```
base) kai@kaiYMD6R vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
+ go version
go version go1.19.6 darwin/amd64
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2023.1
++ go env GOPATH
+ GOOS=linux
+ /Users/kai/go/bin/staticcheck --version
staticcheck 2023.1 (v0.4.0)
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/kai/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v3/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v3/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/placementengine sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeinfo sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeinfo/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeinfo/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v3/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/kai/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kai/CSI/vsan_direct_thick_thin/vsphere-csi-driver /Users/kai/CSI/vsan_direct_thick_thin /Users/kai/CSI /Users/kai /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|files|types_sizes|exports_file|imports|name) took 6.909409359s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 336.293411ms 
INFO [linters context/goanalysis] analyzers took 12m4.028989863s with top 10 stages: buildir: 8m41.35332752s, nilness: 30.729793732s, printf: 20.366509092s, ctrlflow: 20.257504536s, fact_deprecated: 19.631082465s, typedness: 18.051069329s, fact_purity: 16.181162094s, SA5012: 14.828365463s, S1038: 6.788593223s, inspect: 6.448390279s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude-rules: 1/24, nolint: 0/1, skip_files: 113/113, skip_dirs: 113/113, autogenerated_exclude: 24/113, exclude: 24/24, filename_unadjuster: 113/113, cgo: 113/113, path_prettifier: 113/113, identifier_marker: 24/24 
INFO [runner] processing took 47.277559ms with stages: nolint: 31.025314ms, autogenerated_exclude: 13.158854ms, path_prettifier: 1.42335ms, identifier_marker: 990.386µs, skip_dirs: 467.979µs, exclude-rules: 167.676µs, cgo: 21.418µs, filename_unadjuster: 13.722µs, max_same_issues: 2.415µs, uniq_by_line: 1.566µs, max_from_linter: 931ns, skip_files: 552ns, diff: 501ns, exclude: 490ns, source_code: 458ns, severity-rules: 436ns, path_shortener: 428ns, max_per_file_from_linter: 414ns, sort_results: 403ns, path_prefixer: 266ns 
INFO [runner] linters took 1m11.559731079s with stages: goanalysis_metalinter: 1m11.51222578s 
INFO File cache stats: 301 entries of total size 5.8MiB 
INFO Memory: 690 samples, avg is 2363.9MB, max is 3494.3MB 
INFO Execution took 1m18.83289873s                
(base) kai@kaiYMD6R vsphere-csi-driver % 
```
