### PR TITLE
add VCenterServer to OperationDetails for improved idempotency

### DIFF
--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -144,7 +144,7 @@ func TestQuerySnapshotsUtil(t *testing.T) {
 	// Create context
 	commonUtilsTestInstance := getCommonUtilsTest(t)
 
-	volumeManager := cnsvolumes.GetManager(ctx, commonUtilsTestInstance.vcenter, nil, false, false)
+	volumeManager := cnsvolumes.GetManager(ctx, commonUtilsTestInstance.vcenter, nil, false, false, false)
 	queryFilter := types.CnsSnapshotQueryFilter{
 		SnapshotQuerySpecs: nil,
 		Cursor: &types.CnsCursor{

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -335,7 +335,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 		manager := &common.Manager{
 			VcenterConfig:  vcenterconfig,
 			CnsConfig:      config,
-			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true, false),
+			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true, false, false),
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 
@@ -2135,7 +2135,7 @@ func TestDeleteBlockVolumeSnapshotWithManagedObjectNotFound(t *testing.T) {
 	instanceName := "deletesnapshot-" + volID + "-" + snapshotID
 	operationInstance := cnsvolumeoperationrequest.CreateVolumeOperationRequestDetails(
 		instanceName, "", "", 0, metav1.Now(),
-		taskID, "", cnsvolumeoperationrequest.TaskInvocationStatusInProgress, "")
+		taskID, "", "", cnsvolumeoperationrequest.TaskInvocationStatusInProgress, "")
 	_ = ct.operationStore.StoreRequestDetails(ctx, operationInstance)
 
 	//logger.SetLoggerLevel(logger.DevelopmentLogLevel) // enable debug level log
@@ -2266,7 +2266,7 @@ func TestCreateSnapshotWithManagedObjectNotFound(t *testing.T) {
 	instanceName := snapshotName + "-" + volID
 	operationInstance := cnsvolumeoperationrequest.CreateVolumeOperationRequestDetails(
 		instanceName, volID, "", 0, metav1.Now(),
-		taskID, "", cnsvolumeoperationrequest.TaskInvocationStatusInProgress, "")
+		taskID, "", "", cnsvolumeoperationrequest.TaskInvocationStatusInProgress, "")
 	_ = ct.operationStore.StoreRequestDetails(ctx, operationInstance)
 	// Attempt to create snapshot again, but the task-id is non-existent.
 	// Since the snapshot already exists, no error is expected.

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -147,7 +147,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	c.manager = &common.Manager{
 		VcenterConfig:  vcenterconfig,
 		CnsConfig:      config,
-		VolumeManager:  cnsvolume.GetManager(ctx, vcenter, operationStore, idempotencyHandlingEnabled, false),
+		VolumeManager:  cnsvolume.GetManager(ctx, vcenter, operationStore, idempotencyHandlingEnabled, false, false),
 		VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 	}
 
@@ -351,7 +351,7 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 		c.manager.VolumeManager.ResetManager(ctx, vcenter)
 		c.manager.VcenterConfig = newVCConfig
 		c.manager.VolumeManager = cnsvolume.GetManager(ctx, vcenter, operationStore,
-			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency), false)
+			commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIVolumeManagerIdempotency), false, false)
 		if c.authMgr != nil {
 			c.authMgr.ResetvCenterInstance(ctx, vcenter)
 			log.Debugf("Updated vCenter in auth manager")

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -180,7 +180,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 		manager := &common.Manager{
 			VcenterConfig:  vcenterconfig,
 			CnsConfig:      config,
-			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true, false),
+			VolumeManager:  cnsvolume.GetManager(ctx, vcenter, fakeOpStore, true, false, false),
 			VcenterManager: cnsvsphere.GetVirtualCenterManager(ctx),
 		}
 

--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
@@ -156,7 +156,8 @@ func (or *operationRequestStore) GetRequestDetails(
 
 	return CreateVolumeOperationRequestDetails(instance.Spec.Name, instance.Status.VolumeID, instance.Status.SnapshotID,
 			instance.Status.Capacity, operationDetailsToReturn.TaskInvocationTimestamp, operationDetailsToReturn.TaskID,
-			operationDetailsToReturn.OpID, operationDetailsToReturn.TaskStatus, operationDetailsToReturn.Error),
+			operationDetailsToReturn.VCenterServer, operationDetailsToReturn.OpID, operationDetailsToReturn.TaskStatus,
+			operationDetailsToReturn.Error),
 		nil
 }
 

--- a/pkg/internalapis/cnsvolumeoperationrequest/config/cns.vmware.com_cnsvolumeoperationrequests.yaml
+++ b/pkg/internalapis/cnsvolumeoperationrequest/config/cns.vmware.com_cnsvolumeoperationrequests.yaml
@@ -78,6 +78,9 @@ spec:
                     description: TaskID stores the task for an operation that was
                       invoked on CNS for a volume.
                     type: string
+                  vCenterServer:
+                    description: vCenter server on which task is created
+                    type: string
                   taskInvocationTimestamp:
                     description: TaskInvocationTimestamp represents the time at which
                       the task was invoked. This timestamp is derived from the cluster
@@ -112,6 +115,9 @@ spec:
                     taskId:
                       description: TaskID stores the task for an operation that was
                         invoked on CNS for a volume.
+                      type: string
+                    vCenterServer:
+                      description: vCenter server on which task is created
                       type: string
                     taskInvocationTimestamp:
                       description: TaskInvocationTimestamp represents the time at

--- a/pkg/internalapis/cnsvolumeoperationrequest/util.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/util.go
@@ -50,6 +50,7 @@ type VolumeOperationRequestDetails struct {
 type OperationDetails struct {
 	TaskInvocationTimestamp metav1.Time
 	TaskID                  string
+	VCenterServer           string
 	OpID                    string
 	TaskStatus              string
 	Error                   string
@@ -58,7 +59,8 @@ type OperationDetails struct {
 // CreateVolumeOperationRequestDetails returns an object of type
 // VolumeOperationRequestDetails from the input parameters.
 func CreateVolumeOperationRequestDetails(name, volumeID, snapshotID string, capacity int64,
-	taskInvocationTimestamp metav1.Time, taskID, opID, taskStatus, error string) *VolumeOperationRequestDetails {
+	taskInvocationTimestamp metav1.Time, taskID, vCenterServer, opID,
+	taskStatus, error string) *VolumeOperationRequestDetails {
 	return &VolumeOperationRequestDetails{
 		Name:       name,
 		VolumeID:   volumeID,
@@ -67,6 +69,7 @@ func CreateVolumeOperationRequestDetails(name, volumeID, snapshotID string, capa
 		OperationDetails: &OperationDetails{
 			TaskInvocationTimestamp: taskInvocationTimestamp,
 			TaskID:                  taskID,
+			VCenterServer:           vCenterServer,
 			OpID:                    opID,
 			TaskStatus:              taskStatus,
 			Error:                   error,

--- a/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1/cnsvolumeoperationrequest_types.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1/cnsvolumeoperationrequest_types.go
@@ -57,6 +57,8 @@ type OperationDetails struct {
 	TaskInvocationTimestamp metav1.Time `json:"taskInvocationTimestamp"`
 	// TaskID stores the task for an operation that was invoked on CNS for a volume.
 	TaskID string `json:"taskId"`
+	// vCenter server on which the task is created
+	VCenterServer string `json:"vCenterServer,omitempty"`
 	// OpID stores the OpID for a task that was invoked on CNS for a volume.
 	OpID string `json:"opId,omitempty"`
 	// TaskStatus describes the current status of the task invoked on CNS.

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -76,7 +76,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 		if err != nil {
 			return err
 		}
-		volumeManager = volumes.GetManager(ctx, vCenter, nil, false, false)
+		volumeManager = volumes.GetManager(ctx, vCenter, nil, false, false, false)
 	}
 
 	// Get a config to talk to the apiserver

--- a/pkg/syncer/storagepool/diskDecommissionController.go
+++ b/pkg/syncer/storagepool/diskDecommissionController.go
@@ -100,7 +100,7 @@ func (w *DiskDecommController) detachVolumes(ctx context.Context, storagePoolNam
 		VirtualCenterHost: vc.Config.Host,
 	}
 
-	volManager := volume.GetManager(ctx, &vc, nil, false, false)
+	volManager := volume.GetManager(ctx, &vc, nil, false, false, false)
 
 	volumes, _, err := k8scloudoperator.GetVolumesOnStoragePool(ctx, k8sClient, storagePoolName)
 	if err != nil {

--- a/pkg/syncer/storagepool/migrationController.go
+++ b/pkg/syncer/storagepool/migrationController.go
@@ -80,7 +80,7 @@ func (m *migrationController) relocateCNSVolume(ctx context.Context, volumeID st
 			datastoreURL)
 	}
 
-	volManager := volume.GetManager(ctx, m.vc, nil, false, false)
+	volManager := volume.GetManager(ctx, m.vc, nil, false, false, false)
 	relocateSpec := cnstypes.NewCnsBlockVolumeRelocateSpec(volumeID, dsInfo.Reference())
 
 	task, err := volManager.RelocateVolume(ctx, relocateSpec)

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -192,14 +192,14 @@ func TestSyncerWorkflows(t *testing.T) {
 		}
 	}()
 
-	volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false)
+	volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false)
 
 	// Initialize metadata syncer object.
 	metadataSyncer = &metadataSyncInformer{}
 	configInfo := &cnsconfig.ConfigurationInfo{}
 	configInfo.Cfg = csiConfig
 	metadataSyncer.configInfo = configInfo
-	metadataSyncer.volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false)
+	metadataSyncer.volumeManager = cnsvolumes.GetManager(ctx, virtualCenter, nil, false, false, false)
 	metadataSyncer.host = virtualCenter.Config.Host
 
 	// Create the kubernetes client from config or env.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding a new field `VCenterServer` to the `OperationDetails` for improved idempotency.

In the CreateVolume Call on multi vCenter deployment, we need to use the vCenterserver stored in the CR to re-construct the task object to monitor the progress of the task.


**Testing done**:
Verified CRD is created with the new field - `vCenterServer` to `firstOperationDetails` and `latestOperationDetails`

```json
~# kubectl get crd cnsvolumeoperationrequests.cns.vmware.com -o json
{
    "apiVersion": "apiextensions.k8s.io/v1",
    "kind": "CustomResourceDefinition",
    "metadata": {
        "annotations": {
            "controller-gen.kubebuilder.io/version": "v0.6.2"
        },
        "creationTimestamp": "2022-10-31T22:57:41Z",
        "generation": 2,
        "name": "cnsvolumeoperationrequests.cns.vmware.com",
        "resourceVersion": "10063533",
        "uid": "f7523106-bcee-46ab-af8e-1b26faacb878"
    },
    "spec": {
        "conversion": {
            "strategy": "None"
        },
        "group": "cns.vmware.com",
        "names": {
            "kind": "CnsVolumeOperationRequest",
            "listKind": "CnsVolumeOperationRequestList",
            "plural": "cnsvolumeoperationrequests",
            "singular": "cnsvolumeoperationrequest"
        },
        "scope": "Namespaced",
        "versions": [
            {
                "name": "v1alpha1",
                "schema": {
                    "openAPIV3Schema": {
                        "description": "CnsVolumeOperationRequest is the Schema for the cnsvolumeoperationrequests API",
                        "properties": {
                            "apiVersion": {
                                "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
                                "type": "string"
                            },
                            "kind": {
                                "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
                                "type": "string"
                            },
                            "metadata": {
                                "type": "object"
                            },
                            "spec": {
                                "description": "CnsVolumeOperationRequestSpec defines the desired state of CnsVolumeOperationRequest",
                                "properties": {
                                    "name": {
                                        "description": "Name represents the name of the instance. There is no strict naming convention for instances; it is dependent on the caller.",
                                        "type": "string"
                                    }
                                },
                                "required": [
                                    "name"
                                ],
                                "type": "object"
                            },
                            "status": {
                                "description": "CnsVolumeOperationRequestStatus defines the observed state of CnsVolumeOperationRequest",
                                "properties": {
                                    "capacity": {
                                        "description": "Populated with the latest capacity on every successful ExtendVolume call for a volume.",
                                        "format": "int64",
                                        "type": "integer"
                                    },
                                    "errorCount": {
                                        "description": "ErrorCount is the number of times this operation failed for this volume. Incremented by clients when new OperationDetails are added with error set.",
                                        "type": "integer"
                                    },
                                    "firstOperationDetails": {
                                        "description": "FirstOperationDetails stores the details of the first operation performed on the volume. For debugging purposes, clients should ensure that this information is never overwritten. More recent operation details should be stored in the LatestOperationDetails field.",
                                        "properties": {
                                            "error": {
                                                "description": "Error represents the error returned if the task fails on CNS. Defaults to empty string.",
                                                "type": "string"
                                            },
                                            "opId": {
                                                "description": "OpID stores the OpID for a task that was invoked on CNS for a volume.",
                                                "type": "string"
                                            },
                                            "taskId": {
                                                "description": "TaskID stores the task for an operation that was invoked on CNS for a volume.",
                                                "type": "string"
                                            },
                                            "taskInvocationTimestamp": {
                                                "description": "TaskInvocationTimestamp represents the time at which the task was invoked. This timestamp is derived from the cluster and may not correspond to the task invocation timestamp on CNS.",
                                                "format": "date-time",
                                                "type": "string"
                                            },
                                            "taskStatus": {
                                                "description": "TaskStatus describes the current status of the task invoked on CNS. Valid strings are \"In Progress\", \"Successful\" and \"Failed\".",
                                                "type": "string"
                                            },
                                            "vCenterServer": {
                                                "description": "vCenter server on which task is created",
                                                "type": "string"
                                            }
                                        },
                                        "required": [
                                            "taskId",
                                            "taskInvocationTimestamp"
                                        ],
                                        "type": "object"
                                    },
                                    "latestOperationDetails": {
                                        "description": "LatestOperationDetails stores the details of the latest operations performed on the volume. Should have a maximum of 10 entries.",
                                        "items": {
                                            "description": "OperationDetails stores the details of the operation performed on a volume.",
                                            "properties": {
                                                "error": {
                                                    "description": "Error represents the error returned if the task fails on CNS. Defaults to empty string.",
                                                    "type": "string"
                                                },
                                                "opId": {
                                                    "description": "OpID stores the OpID for a task that was invoked on CNS for a volume.",
                                                    "type": "string"
                                                },
                                                "taskId": {
                                                    "description": "TaskID stores the task for an operation that was invoked on CNS for a volume.",
                                                    "type": "string"
                                                },
                                                "taskInvocationTimestamp": {
                                                    "description": "TaskInvocationTimestamp represents the time at which the task was invoked. This timestamp is derived from the cluster and may not correspond to the task invocation timestamp on CNS.",
                                                    "format": "date-time",
                                                    "type": "string"
                                                },
                                                "taskStatus": {
                                                    "description": "TaskStatus describes the current status of the task invoked on CNS. Valid strings are \"In Progress\", \"Successful\" and \"Failed\".",
                                                    "type": "string"
                                                },
                                                "vCenterServer": {
                                                    "description": "vCenter server on which task is created",
                                                    "type": "string"
                                                }
                                            },
                                            "required": [
                                                "taskId",
                                                "taskInvocationTimestamp"
                                            ],
                                            "type": "object"
                                        },
                                        "type": "array"
                                    },
                                    "snapshotID": {
                                        "description": "SnapshotID is the unique ID of the backend snapshot. Populated during successful CreateSnapshot calls.",
                                        "type": "string"
                                    },
                                    "volumeID": {
                                        "description": "VolumeID is the unique ID of the backend volume. Populated during successful CreateVolume calls.",
                                        "type": "string"
                                    }
                                },
                                "type": "object"
                            }
                        },
                        "type": "object"
                    }
                },
                "served": true,
                "storage": true
            }
        ]
    },
    "status": {
        "acceptedNames": {
            "kind": "CnsVolumeOperationRequest",
            "listKind": "CnsVolumeOperationRequestList",
            "plural": "cnsvolumeoperationrequests",
            "singular": "cnsvolumeoperationrequest"
        },
        "conditions": [
            {
                "lastTransitionTime": "2022-10-31T22:57:41Z",
                "message": "no conflicts found",
                "reason": "NoConflicts",
                "status": "True",
                "type": "NamesAccepted"
            },
            {
                "lastTransitionTime": "2022-10-31T22:57:41Z",
                "message": "the initial names have been accepted",
                "reason": "InitialNamesAccepted",
                "status": "True",
                "type": "Established"
            }
        ],
        "storedVersions": [
            "v1alpha1"
        ]
    }
}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add VCenterServer to OperationDetails for improved idempotency
```
