### PR TITLE
supervisor: upgrade provisioner, attacher, and resizer sidecars

### DIFF
--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -271,7 +271,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.5.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.6.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -213,7 +213,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.2.1_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.3.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -248,7 +248,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.5.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.0.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -213,7 +213,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.2.1_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.3.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -272,7 +272,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.5.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.6.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -248,7 +248,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.5.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.0.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -275,7 +275,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.5.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.6.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -251,7 +251,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.5.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.0.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -216,7 +216,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.2.1_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.3.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -213,7 +213,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.2.1_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.3.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -272,7 +272,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.5.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.6.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -248,7 +248,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v3.5.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.0.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The upgraded versions will help address a few OSS vulnerabilities. 

**Testing done**:
Manually replaced the 3 sidecars on the testbed and then ran the e2e pipeline. 
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2071#issuecomment-1301843466 and https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2071#issuecomment-1302364702

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
supervisor: upgrade provisioner to v3.3.0, attacher to v4.0.0, and resizer to v1.6.0
```
