### PR TITLE
Fix issue in getting vCenter with MultiVCenterCSITopology FSS enabled in single VC config

### DIFF
--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -155,7 +155,7 @@ func getBlockVolumeToHostMap(ctx context.Context, c *controller,
 	volumeIDNodeUUIDMap := make(map[string]string)
 	// Get VirtualCenter object(s)
 	// For multi-VC configuration, create map for volumes in all vCenters
-	if multivCenterCSITopologyEnabled && len(c.managers.VcenterConfigs) > 1 {
+	if multivCenterCSITopologyEnabled {
 		vCenters, err = common.GetVCenters(ctx, c.managers)
 		if err != nil {
 			log.Errorf("GetVcenters error %v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This changes fixes issue faced in `ListVolumes()` while fetching vCenter in `getBlockVolumeToHostMap()` for the case of `multi-vcenter-csi-topology` FSS enabled in single VCenter configuration


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested Listvolume with `multi-vcenter-csi-topology` FSS enabled in single VCenter configuration

```
# kubectl get cm -n vmware-system-csi internal-feature-states.csi.vsphere.vmware.com -o yaml
apiVersion: v1
data:
  async-query-volume: "true"
  block-volume-snapshot: "true"
  cnsmgr-suspend-create-volume: "true"
  csi-auth-check: "true"
  csi-internal-generated-cluster-id: "false"
  csi-migration: "true"
  csi-windows-support: "false"
  improved-csi-idempotency: "true"
  list-volumes: "true"
  max-pvscsi-targets-per-vm: "true"
  multi-vcenter-csi-topology: "true"
  online-volume-extend: "true"
  pv-to-backingdiskobjectid-mapping: "false"
  topology-preferential-datastores: "true"
  trigger-csi-fullsync: "false"
  use-csinode-id: "true"
kind: ConfigMap
metadata:
...
#
```

CSI controller logs:
```
2022-11-02T12:28:00.241Z        DEBUG   vanilla/controller.go:1735      ListVolumes served 1 results, token for next set:       {"TraceId": "85258c6f-de5a-46a3-addb-5d3602338c5d"}
2022-11-02T12:28:00.242Z        DEBUG   vanilla/controller.go:1739      List volume response: entries:<volume:<volume_id:"b3cafa31-0d0c-4681-bea7-16e333eb35d1" > status:<published_node_ids:"42056dbd-d42a-6d72-f801-3e6f8dc40748" > >         {"TraceId": "85258c6f-de5a-46a3-addb-5d3602338c5d"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix issue in getting vCenter with MultiVCenterCSITopology FSS enabled in single VC config
```
