### PR TITLE
Fix the pagination logic for list volumes

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1716,13 +1716,9 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 		}
 
 		nextToken := ""
-		endIndex := maxEntries + startingToken
-		if endIndex > len(CNSVolumesforListVolume) {
-			endIndex = len(CNSVolumesforListVolume)
-		}
-		log.Debugf("Starting token: %d, End index: %d, Length of Query volume result: %d, Max entries: %d ",
-			startingToken, endIndex, len(CNSVolumesforListVolume), maxEntries)
-		entries, nextToken, volumeType, err = c.processQueryResultsListVolumes(ctx, startingToken, endIndex,
+		log.Debugf("Starting token: %d, Length of Query volume result: %d, Max entries: %d ",
+			startingToken, len(CNSVolumesforListVolume), maxEntries)
+		entries, nextToken, volumeType, err = c.processQueryResultsListVolumes(ctx, startingToken, maxEntries,
 			CNSVolumesforListVolume, allNodeVMs)
 		if err != nil {
 			return nil, csifault.CSIInternalFault, fmt.Errorf("error while processing query results for list "+
@@ -1751,21 +1747,23 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 	return listVolResponse, err
 }
 
-func (c *controller) processQueryResultsListVolumes(ctx context.Context, startingToken int, endIndex int,
+func (c *controller) processQueryResultsListVolumes(ctx context.Context, startingToken int, maxEntries int,
 	cnsVolumes []cnstypes.CnsVolume, allNodeVMs []*cnsvsphere.VirtualMachine) ([]*csi.ListVolumesResponse_Entry,
 	string, string, error) {
 
 	volumeType := ""
 	nextToken := ""
+	volCounter := 0
+	nextTokenCounter := 0
 	log := logger.GetLogger(ctx)
 	var entries []*csi.ListVolumesResponse_Entry
 
-	volumeIDToNodeUUIDMap, err := getBlockVolumeToHostMap(ctx, c, allNodeVMs)
+	volumeIDToNodeUUIDMap, err := getBlockVolumeIDToNodeUUIDMap(ctx, c, allNodeVMs)
 	if err != nil {
 		return entries, nextToken, volumeType, err
 	}
 
-	for i := startingToken; i < endIndex; i++ {
+	for i := startingToken; i < len(cnsVolumes); i++ {
 		if cnsVolumes[i].VolumeType == common.FileVolumeType {
 			// If this is multi-VC configuration, then
 			// skip processing query results for file volumes
@@ -1790,6 +1788,7 @@ func (c *controller) processQueryResultsListVolumes(ctx context.Context, startin
 						log.Errorf("Failed to get node vm object from the node name, err:%v", err)
 						return entries, nextToken, volumeType, err
 					}
+					volCounter += 1
 					nodeVMUUID := nodeVMObj.UUID
 
 					// Populate published node
@@ -1806,11 +1805,16 @@ func (c *controller) processQueryResultsListVolumes(ctx context.Context, startin
 					entries = append(entries, entry)
 				}
 			}
+			if volCounter == maxEntries {
+				nextTokenCounter = i + 1
+				break
+			}
 		} else {
 			volumeType = prometheus.PrometheusBlockVolumeType
 			blockVolID := cnsVolumes[i].VolumeId.Id
 			nodeVMUUID, found := volumeIDToNodeUUIDMap[blockVolID]
 			if found {
+				volCounter += 1
 				//Populate csi.Volume info for the given volume
 				blockVolumeInfo := &csi.Volume{
 					VolumeId: blockVolID,
@@ -1825,18 +1829,22 @@ func (c *controller) processQueryResultsListVolumes(ctx context.Context, startin
 				}
 				// Populate List Volumes Entry Response
 				entries = append(entries, entry)
+				if volCounter == maxEntries {
+					nextTokenCounter = i + 1
+					break
+				}
 			}
 		}
 	}
 
-	// if length of queryAll entries > queryLimit, set nextToken to
-	// start_token + queryLimit
-	if len(cnsVolumes) > endIndex {
-		nextTokenInt := endIndex
-		nextToken = strconv.Itoa(nextTokenInt)
+	// if nextTokenCounter = 0, it means all cns volumes were processed(i = len(cnsVolumes)), and
+	// fewer than 'maxEntries' no. of volumes were found. So nextToken is empty.
+	// If nextTokenCounter is not 0 and there are more volumes to process, then set the nextToken
+	if nextTokenCounter != 0 && len(cnsVolumes) > nextTokenCounter {
+		nextToken = strconv.Itoa(nextTokenCounter)
 	}
-	return entries, nextToken, volumeType, nil
 
+	return entries, nextToken, volumeType, nil
 }
 
 func (c *controller) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (

--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -145,7 +145,7 @@ func convertCnsVolumeType(ctx context.Context, cnsVolumeType string) string {
 	return volumeType
 }
 
-func getBlockVolumeToHostMap(ctx context.Context, c *controller,
+func getBlockVolumeIDToNodeUUIDMap(ctx context.Context, c *controller,
 	allnodeVMs []*vsphere.VirtualMachine) (map[string]string, error) {
 	var vCenters []*vsphere.VirtualCenter
 	var err error


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is a fix for Bug id =3057370. When a statefulset is scaled down, some volumes  are not mounted on the pod, so they do not have a vdisk ID. Even though the volumes may exist on K8s or CNS, they are not served since they are not present in volumeIDNodeUUIDMap. So the way to process the Volumes is to go through the entire list of CNS volumes, break if it reaches the querylimit, and set the nextToken accordingly.

**Testing done**:
Set threshold = 1, query limit = 15

1. Volumes = 15, 3 sts with 5 replicas each
```
2022-11-03T21:57:56.607262749Z 2022-11-03T21:57:56.606Z DEBUG   vanilla/controller.go:1642      ListVolumes: called with args {MaxEntries:0 StartingToken: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.607587295Z 2022-11-03T21:57:56.607Z DEBUG   vanilla/controller.go:1659      Number of Volume IDs of PVs from K8s cluster 15, list of volumes [f0675a53-139a-47f3-af9a-e6355db77b70 85f1d64e-6be4-419a-8b7d-fb14ca6faa4c 832510fe-f50e-4e18-8525-d3e5610bc2db a088d76f-1025-4e7a-b8f0-dcf1aa946524 15cc057b-d8b6-414b-89df-3eb6966563ec d34b17ae-d7e5-44cb-9fb6-023af6994603 3d54b568-bbb8-4c27-a067-42822ba0d8b8 abf609fd-bb92-4da4-84a7-e3183cd8284f 75fd9540-ab7b-4148-a881-c866fd84eab0 5289a035-b3ac-477a-996c-9c9170ed2ecc 9c382a31-b89f-459c-a209-45fc4b420d65 a19e3b1d-19ac-4dc5-9278-a72de3f9d34a 5d4a4c49-36b5-4bfb-87c7-a450dc3cfd35 d3e47d7d-634d-40c5-ab93-d10dfab54536 62e9fed1-1be9-4c88-b832-25ae29c23dbe]   {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}

2022-11-03T21:57:56.644207123Z 2022-11-03T21:57:56.644Z DEBUG   vanilla/controller.go:1723      Starting token: 0, Length of Query volume result: 15, Max entries: 15   {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694299984Z 2022-11-03T21:57:56.693Z DEBUG   vanilla/controller.go:1771      Processing value of i = 0       {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694331687Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 1, maxEntries = 15   {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694335579Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1771      Processing value of i = 1       {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694757036Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 2, maxEntries = 15   {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694779929Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1771      Processing value of i = 2       {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694805233Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 3, maxEntries = 15   {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694811195Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1771      Processing value of i = 3       {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694815400Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 4, maxEntries = 15   {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694819903Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1771      Processing value of i = 4       {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694823943Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 5, maxEntries = 15   {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694828260Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1771      Processing value of i = 5       {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694832413Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 6, maxEntries = 15   {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694836652Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1771      Processing value of i = 6       {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694851999Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 7, maxEntries = 15   {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.694861834Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1771      Processing value of i = 7       {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695068133Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 8, maxEntries = 15   {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695075513Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1771      Processing value of i = 8       {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695078345Z 2022-11-03T21:57:56.694Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 9, maxEntries = 15   {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695081020Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1771      Processing value of i = 9       {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695083925Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 10, maxEntries = 15  {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695090200Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1771      Processing value of i = 10      {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695093272Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 11, maxEntries = 15  {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695414365Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1771      Processing value of i = 11      {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695429628Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 12, maxEntries = 15  {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695513794Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1771      Processing value of i = 12      {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695719963Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 13, maxEntries = 15  {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695729689Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1771      Processing value of i = 13      {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695739261Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 14, maxEntries = 15  {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695756046Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1771      Processing value of i = 14      {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695822505Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 15, maxEntries = 15  {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.695829386Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1841      Volcounter = maxentries, so break       {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.696048292Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1856      Value of nextTokenCounter after processing = 15 {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.696058353Z 2022-11-03T21:57:56.695Z DEBUG   vanilla/controller.go:1736      ListVolumes served 15 results, token for next set:      {"TraceId": "4cb9842d-871f-42d0-a133-393346ed828a"}
2022-11-03T21:57:56.696863925Z 2022-11-03T21:57:56.696Z DEBUG   vanilla/controller.go:1740      List volume response: entries:<volume:<volume_id:"d3e47d7d-634d-40c5-ab93-d10dfab54536" > status:<published_node_ids:"422b5992-743a-8a8b-a94e-dc0db2ce0b7d" > > ..........15 entries
```

2. Scale down to 9 replicas from 15
```
2022-11-03T21:58:56.703340531Z 2022-11-03T21:58:56.702Z DEBUG   vanilla/controller.go:1642      ListVolumes: called with args {MaxEntries:0 StartingToken: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.703344432Z 2022-11-03T21:58:56.703Z DEBUG   vanilla/controller.go:1659      Number of Volume IDs of PVs from K8s cluster 15, list of volumes [d34b17ae-d7e5-44cb-9fb6-023af6994603 f0675a53-139a-47f3-af9a-e6355db77b70 85f1d64e-6be4-419a-8b7d-fb14ca6faa4c 832510fe-f50e-4e18-8525-d3e5610bc2db a088d76f-1025-4e7a-b8f0-dcf1aa946524 15cc057b-d8b6-414b-89df-3eb6966563ec 3d54b568-bbb8-4c27-a067-42822ba0d8b8 abf609fd-bb92-4da4-84a7-e3183cd8284f d3e47d7d-634d-40c5-ab93-d10dfab54536 62e9fed1-1be9-4c88-b832-25ae29c23dbe 75fd9540-ab7b-4148-a881-c866fd84eab0 5289a035-b3ac-477a-996c-9c9170ed2ecc 9c382a31-b89f-459c-a209-45fc4b420d65 a19e3b1d-19ac-4dc5-9278-a72de3f9d34a 5d4a4c49-36b5-4bfb-87c7-a450dc3cfd35]   {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.734992246Z 2022-11-03T21:58:56.734Z DEBUG   vanilla/controller.go:1723      Starting token: 0, Length of Query volume result: 15, Max entries: 15   {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778786306Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 0       {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778818462Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 1       {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778824299Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 2       {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778829309Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 1, maxEntries = 15   {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778833620Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 3       {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778837906Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 4       {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778842047Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 2, maxEntries = 15   {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778846211Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 5       {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778850477Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 3, maxEntries = 15   {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778854663Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 6       {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778858864Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 4, maxEntries = 15   {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778862937Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 7       {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778866942Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 8       {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778869789Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 5, maxEntries = 15   {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778872513Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 9       {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778875241Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 10      {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778877991Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 11      {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778880735Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 6, maxEntries = 15   {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778883426Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 12      {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778901507Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 7, maxEntries = 15   {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778904356Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 13      {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778907060Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 8, maxEntries = 15   {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778909759Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1771      Processing value of i = 14      {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778918091Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 9, maxEntries = 15   {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778921093Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1856      Value of nextTokenCounter after processing = 15 {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.778923841Z 2022-11-03T21:58:56.778Z DEBUG   vanilla/controller.go:1736      ListVolumes served 9 results, token for next set:       {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
2022-11-03T21:58:56.779527502Z 2022-11-03T21:58:56.779Z DEBUG   vanilla/controller.go:1740      List volume response: entries:<volume:<volume_id:"5d4a4c49-36b5-4bfb-87c7-a450dc3cfd35" > status:<published_node_ids:"422b869a-6a2a-3fca-3197-2f434ca57cc4" > > entries:<volume:<volume_id:"62e9fed1-1be9-4c88-b832-25ae29c23dbe" > status:<published_node_ids:"422b869a-6a2a-3fca-3197-2f434ca57cc4" > > entries:<volume:<volume_id:"15cc057b-d8b6-414b-89df-3eb6966563ec" > status:<published_node_ids:"422b27cd-2357-f7d8-3c42-3da716342d59" > > entries:<volume:<volume_id:"f0675a53-139a-47f3-af9a-e6355db77b70" > status:<published_node_ids:"422b5992-743a-8a8b-a94e-dc0db2ce0b7d" > > entries:<volume:<volume_id:"9c382a31-b89f-459c-a209-45fc4b420d65" > status:<published_node_ids:"422b5992-743a-8a8b-a94e-dc0db2ce0b7d" > > entries:<volume:<volume_id:"75fd9540-ab7b-4148-a881-c866fd84eab0" > status:<published_node_ids:"422b869a-6a2a-3fca-3197-2f434ca57cc4" > > entries:<volume:<volume_id:"85f1d64e-6be4-419a-8b7d-fb14ca6faa4c" > status:<published_node_ids:"422b27cd-2357-f7d8-3c42-3da716342d59" > > entries:<volume:<volume_id:"a088d76f-1025-4e7a-b8f0-dcf1aa946524" > status:<published_node_ids:"422b5992-743a-8a8b-a94e-dc0db2ce0b7d" > > entries:<volume:<volume_id:"a19e3b1d-19ac-4dc5-9278-a72de3f9d34a" > status:<published_node_ids:"422b27cd-2357-f7d8-3c42-3da716342d59" > >         {"TraceId": "8fe30c4b-3b1f-4f5f-9d9f-2d55edbed63d"}
```

3. Scale up to 16 replicas from 9 and we can see pagination
```
2022-11-03T22:22:44.130759744Z 2022-11-03T22:22:44.129Z DEBUG   vanilla/controller.go:1642      ListVolumes: called with args {MaxEntries:0 StartingToken: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.130765195Z 2022-11-03T22:22:44.129Z DEBUG   vanilla/controller.go:1659      Number of Volume IDs of PVs from K8s cluster 20, list of volumes [3d54b568-bbb8-4c27-a067-42822ba0d8b8 abf609fd-bb92-4da4-84a7-e3183cd8284f 9c382a31-b89f-459c-a209-45fc4b420d65 a19e3b1d-19ac-4dc5-9278-a72de3f9d34a 5d4a4c49-36b5-4bfb-87c7-a450dc3cfd35 d3e47d7d-634d-40c5-ab93-d10dfab54536 62e9fed1-1be9-4c88-b832-25ae29c23dbe e62fe7a8-ca75-48c8-acac-4e7f6a99dbe7 75fd9540-ab7b-4148-a881-c866fd84eab0 5289a035-b3ac-477a-996c-9c9170ed2ecc e5759581-ff43-483b-939a-9ee278d00ab0 832510fe-f50e-4e18-8525-d3e5610bc2db a088d76f-1025-4e7a-b8f0-dcf1aa946524 15cc057b-d8b6-414b-89df-3eb6966563ec d34b17ae-d7e5-44cb-9fb6-023af6994603 688c1de7-29f3-4f50-a521-991811a1792f f00263a9-d898-48de-8caa-b1cb85204722 f0675a53-139a-47f3-af9a-e6355db77b70 85f1d64e-6be4-419a-8b7d-fb14ca6faa4c bd9230e0-d732-4ff9-9604-e9788760dd53]  {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.166793381Z 2022-11-03T22:22:44.166Z DEBUG   vanilla/controller.go:1723      Starting token: 0, Length of Query volume result: 20, Max entries: 15   {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.216953222Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1771      Processing value of i = 0       {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217027813Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 1, maxEntries = 15   {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217033005Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1771      Processing value of i = 1       {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217036443Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1771      Processing value of i = 2       {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217040542Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1771      Processing value of i = 3       {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217045562Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 2, maxEntries = 15   {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217049986Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1771      Processing value of i = 4       {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217054418Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 3, maxEntries = 15   {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217058676Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1771      Processing value of i = 5       {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217335936Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1771      Processing value of i = 6       {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217346092Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 4, maxEntries = 15   {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217348884Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1771      Processing value of i = 7       {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217351558Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 5, maxEntries = 15   {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217354358Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1771      Processing value of i = 8       {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217357037Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 6, maxEntries = 15   {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217359702Z 2022-11-03T22:22:44.216Z DEBUG   vanilla/controller.go:1771      Processing value of i = 9       {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217362356Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 7, maxEntries = 15   {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217365040Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1771      Processing value of i = 10      {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217367837Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 8, maxEntries = 15   {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217370487Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1771      Processing value of i = 11      {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217373123Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 9, maxEntries = 15   {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217375869Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1771      Processing value of i = 12      {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217378484Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 10, maxEntries = 15  {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217389895Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1771      Processing value of i = 13      {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217392668Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1771      Processing value of i = 14      {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217395301Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 11, maxEntries = 15  {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217397939Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1771      Processing value of i = 15      {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217400551Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 12, maxEntries = 15  {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217403246Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1771      Processing value of i = 16      {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217405993Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 13, maxEntries = 15  {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217408733Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1771      Processing value of i = 17      {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217411628Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 14, maxEntries = 15  {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217414279Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1771      Processing value of i = 18      {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217416938Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 15, maxEntries = 15  {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217419596Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1841      Volcounter = maxentries, so break       {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217422238Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1856      Value of nextTokenCounter after processing = 19 {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217425590Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1736      ListVolumes served 15 results, token for next set: 19   {"TraceId": "69d026aa-4ddb-43ae-b141-e3684473a3cc"}
2022-11-03T22:22:44.217937529Z 2022-11-03T22:22:44.217Z DEBUG   vanilla/controller.go:1740      List volume response: entries:<volume:<volume_id:".....15 entries

2022-11-03T22:22:44.220862656Z 2022-11-03T22:22:44.220Z DEBUG   vanilla/controller.go:1642      ListVolumes: called with args {MaxEntries:0 StartingToken:19 XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}       {"TraceId": "a103f102-cb8a-4f04-aabd-a86b3b82fb92"}
2022-11-03T22:22:44.228450759Z 2022-11-03T22:22:44.228Z DEBUG   vanilla/controller.go:1723      Starting token: 19, Length of Query volume result: 20, Max entries: 15  {"TraceId": "a103f102-cb8a-4f04-aabd-a86b3b82fb92"}
2022-11-03T22:22:44.268550615Z 2022-11-03T22:22:44.268Z DEBUG   vanilla/controller.go:1771      Processing value of i = 19      {"TraceId": "a103f102-cb8a-4f04-aabd-a86b3b82fb92"}
2022-11-03T22:22:44.268586632Z 2022-11-03T22:22:44.268Z DEBUG   vanilla/controller.go:1839      BLOCK volCounter = 1, maxEntries = 15   {"TraceId": "a103f102-cb8a-4f04-aabd-a86b3b82fb92"}
2022-11-03T22:22:44.268592709Z 2022-11-03T22:22:44.268Z DEBUG   vanilla/controller.go:1856      Value of nextTokenCounter after processing = 20 {"TraceId": "a103f102-cb8a-4f04-aabd-a86b3b82fb92"}
2022-11-03T22:22:44.268597461Z 2022-11-03T22:22:44.268Z DEBUG   vanilla/controller.go:1736      ListVolumes served 1 results, token for next set:       {"TraceId": "a103f102-cb8a-4f04-aabd-a86b3b82fb92"}
2022-11-03T22:22:44.268679735Z 2022-11-03T22:22:44.268Z DEBUG   vanilla/controller.go:1740      List volume response: entries:<volume:<volume_id:"85f1d64e-6be4-419a-8b7d-fb14ca6faa4c" > status:<published_node_ids:"422b27cd-2357-f7d8-3c42-3da716342d59" > >         {"TraceId": "a103f102-cb8a-4f04-aabd-a86b3b82fb92"}



```

Release Note:
This fix is not there in the 2.6 branch. 