### PR TITLE
Add lock to protect FSS values in K8Sorchestrator instance 

### DIFF
--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -28,7 +28,9 @@ import (
 
 // FakeK8SOrchestrator is used to mock common K8S Orchestrator instance to store FSS values
 type FakeK8SOrchestrator struct {
-	featureStates map[string]string
+	// RWMutex to synchronize access to 'featureStates' field from multiple callers
+	featureStatesLock *sync.RWMutex
+	featureStates     map[string]string
 }
 
 // volumeMigration holds mocked migrated volume information

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -44,6 +44,7 @@ var mapVolumePathToID map[string]map[string]string
 func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCommonInterface, error) {
 	if orchestratorType == common.Kubernetes {
 		fakeCO := &FakeK8SOrchestrator{
+			featureStatesLock: &sync.RWMutex{},
 			featureStates: map[string]string{
 				"volume-extend":                     "true",
 				"volume-health":                     "true",
@@ -65,13 +66,16 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 func (c *FakeK8SOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) bool {
 	var featureState bool
 	var err error
+	c.featureStatesLock.RLock()
 	if flag, ok := c.featureStates[featureName]; ok {
+		c.featureStatesLock.RUnlock()
 		featureState, err = strconv.ParseBool(flag)
 		if err != nil {
 			return false
 		}
 		return featureState
 	}
+	c.featureStatesLock.RUnlock()
 	return false
 }
 

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go
@@ -51,6 +51,7 @@ func TestIsFSSEnabledInGcWithSync(t *testing.T) {
 		configMapName:      cnsconfig.DefaultSupervisorFSSConfigMapName,
 		configMapNamespace: cnsconfig.DefaultCSINamespace,
 		featureStates:      svFSS,
+		featureStatesLock:  &sync.RWMutex{},
 	}
 	internalFSS := map[string]string{
 		"volume-extend": "true",
@@ -60,6 +61,7 @@ func TestIsFSSEnabledInGcWithSync(t *testing.T) {
 		configMapName:      cnsconfig.DefaultInternalFSSConfigMapName,
 		configMapNamespace: cnsconfig.DefaultCSINamespace,
 		featureStates:      internalFSS,
+		featureStatesLock:  &sync.RWMutex{},
 	}
 	k8sOrchestrator := K8sOrchestrator{
 		supervisorFSS: svFSSConfigMapInfo,
@@ -88,6 +90,7 @@ func TestIsFSSEnabledInGcWithoutSync(t *testing.T) {
 		configMapName:      cnsconfig.DefaultSupervisorFSSConfigMapName,
 		configMapNamespace: cnsconfig.DefaultCSINamespace,
 		featureStates:      svFSS,
+		featureStatesLock:  &sync.RWMutex{},
 	}
 	internalFSS := map[string]string{
 		"volume-extend": "false",
@@ -97,6 +100,7 @@ func TestIsFSSEnabledInGcWithoutSync(t *testing.T) {
 		configMapName:      cnsconfig.DefaultInternalFSSConfigMapName,
 		configMapNamespace: cnsconfig.DefaultCSINamespace,
 		featureStates:      internalFSS,
+		featureStatesLock:  &sync.RWMutex{},
 	}
 	k8sOrchestrator := K8sOrchestrator{
 		supervisorFSS: svFSSConfigMapInfo,
@@ -125,6 +129,7 @@ func TestIsFSSEnabledInGcWrongValues(t *testing.T) {
 		configMapName:      cnsconfig.DefaultSupervisorFSSConfigMapName,
 		configMapNamespace: cnsconfig.DefaultCSINamespace,
 		featureStates:      svFSS,
+		featureStatesLock:  &sync.RWMutex{},
 	}
 	internalFSS := map[string]string{
 		"volume-extend": "enabled",
@@ -133,6 +138,7 @@ func TestIsFSSEnabledInGcWrongValues(t *testing.T) {
 		configMapName:      cnsconfig.DefaultInternalFSSConfigMapName,
 		configMapNamespace: cnsconfig.DefaultCSINamespace,
 		featureStates:      internalFSS,
+		featureStatesLock:  &sync.RWMutex{},
 	}
 	k8sOrchestrator := K8sOrchestrator{
 		supervisorFSS: svFSSConfigMapInfo,
@@ -162,6 +168,7 @@ func TestIsFSSEnabledInSV(t *testing.T) {
 		configMapName:      cnsconfig.DefaultSupervisorFSSConfigMapName,
 		configMapNamespace: cnsconfig.DefaultCSINamespace,
 		featureStates:      svFSS,
+		featureStatesLock:  &sync.RWMutex{},
 	}
 	k8sOrchestrator := K8sOrchestrator{
 		supervisorFSS: svFSSConfigMapInfo,
@@ -198,6 +205,7 @@ func TestIsFSSEnabledInVanilla(t *testing.T) {
 		configMapName:      cnsconfig.DefaultInternalFSSConfigMapName,
 		configMapNamespace: cnsconfig.DefaultCSINamespace,
 		featureStates:      internalFSS,
+		featureStatesLock:  &sync.RWMutex{},
 	}
 	k8sOrchestrator := K8sOrchestrator{
 		clusterFlavor: cnstypes.CnsClusterFlavorVanilla,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Singleton instance of k8sOrchestratorInstance created is used and updated at multiple places by different callers, however most of the fields, except FSS values, are not updated once initialized.
However, FSS values maintained in internalFSS and supervisorFSS fields are updated and read frequently and hence the access needs to be synchronized.
Thus, added read-write mutex lock that synchronizes access to these fields.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested basic volume provisioning and pod creation on vanilla.
Need to test on WCP and Guest cluster yet and will execute pipeline run as well

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add lock to synchronize access to FSS values in K8Sorchestrator instance 
```
