### PR TITLE
Initialize CSI migration service correctly for single-VC setup when multi-vc-csi-topology FSS enabled.

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1156,12 +1156,6 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 					"volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", req.VolumeId)
 			}
 			// Migration feature switch is enabled.
-			// If this is multi-VC configuration, fail the operation.
-			if multivCenterCSITopologyEnabled && len(c.managers.VcenterConfigs) > 1 {
-				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
-					"migrated volumes are not supported in multi-VC setup. Cannot use volume with vmdk path: %q", req.VolumeId)
-			}
-
 			volumePath = req.VolumeId
 			// In case if feature state switch is enabled after controller is
 			// deployed, we need to initialize the volumeMigrationService.
@@ -1339,14 +1333,6 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 					// Migration feature switch is disabled.
 					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 						"volume-migration feature switch is disabled. Cannot use volume with vmdk path :%q", req.VolumeId)
-				} else {
-					if multivCenterCSITopologyEnabled && len(c.managers.VcenterConfigs) > 1 {
-						// Migration feature switch is enabled and multi vCenter feature is enabled, and
-						// Kubernetes Cluster is spread on multiple vCenter Servers.
-						return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
-							"volume-migration feature is not supported on the Multi-vCenter deployment. "+
-								"Cannot use volume with vmdk path :%q", req.VolumeId)
-					}
 				}
 				// Migration feature switch is enabled.
 				storagePolicyName := req.VolumeContext[common.AttributeStoragePolicyName]
@@ -1484,14 +1470,6 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 				// Migration feature switch is disabled.
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"volume-migration feature switch is disabled. Cannot use volume with vmdk path: %q", req.VolumeId)
-			} else {
-				if multivCenterCSITopologyEnabled && len(c.managers.VcenterConfigs) > 1 {
-					// Migration feature switch is enabled and multi vCenter feature is enabled, and
-					// Kubernetes Cluster is spread on multiple vCenter Servers.
-					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
-						"volume-migration feature is not supported on the Multi-vCenter deployment. "+
-							"Cannot use volume with vmdk path :%q", req.VolumeId)
-				}
 			}
 			// Migration feature switch is enabled.
 			//
@@ -1943,8 +1921,24 @@ func initVolumeMigrationService(ctx context.Context, c *controller) error {
 	// In case if feature state switch is enabled after controller is deployed,
 	// we need to initialize the volumeMigrationService.
 	var err error
-	volumeMigrationService, err = migration.GetVolumeMigrationService(ctx,
-		&c.manager.VolumeManager, c.manager.CnsConfig, false)
+
+	// If this is multi-VC config, return without initializing service
+	// currently CSI migration is not supported in multi-VC config
+	if multivCenterCSITopologyEnabled {
+		if len(c.managers.VcenterConfigs) > 1 {
+			// Multi-VC case
+			return logger.LogNewErrorf(log,
+				"volume-migration feature is not supported on Multi-vCenter deployment")
+		} else {
+			// Single-VC case
+			volumeManager := c.managers.VolumeManagers[c.managers.CnsConfig.Global.VCenterIP]
+			volumeMigrationService, err = migration.GetVolumeMigrationService(ctx,
+				&volumeManager, c.managers.CnsConfig, false)
+		}
+	} else {
+		volumeMigrationService, err = migration.GetVolumeMigrationService(ctx,
+			&c.manager.VolumeManager, c.manager.CnsConfig, false)
+	}
 	if err != nil {
 		return logger.LogNewErrorCodef(log, codes.Internal,
 			"failed to get migration service. Err: %v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR performs code optimization to handle blocking of CSI migration service in multi-VC config at single place in CSI controller.
It initializes CSI migration service by accessing correct pointers to volume manager and CNS config in case of single-VC setup with `multi-vc-csi-topology `FSS enabled.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Testing in progress, will run CSI migration pipeline to check for any regression

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Initialize CSI migration service correctly for single-VC setup when multi-vc-csi-topology FSS enabled.
```
