### PR TITLE
CreateSnapshot and DeleteSnapshot changes to support multi-vCenter CSI topology

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -1036,12 +1036,12 @@ func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int
 //
 // The returned string is a combination of CNS VolumeID and CNS SnapshotID concatenated by the "+" sign.
 // The returned *time.Time denotes the creation time of snapshot from the storage system, i.e., CNS.
-func CreateSnapshotUtil(ctx context.Context, manager *Manager, volumeID string, snapshotName string) (string,
-	*time.Time, error) {
+func CreateSnapshotUtil(ctx context.Context, volumeManager cnsvolume.Manager, volumeID string,
+	snapshotName string) (string, *time.Time, error) {
 	log := logger.GetLogger(ctx)
 
 	log.Debugf("vSphere CSI driver is creating snapshot with description, %q, on volume: %q", snapshotName, volumeID)
-	cnsSnapshotInfo, err := manager.VolumeManager.CreateSnapshot(ctx, volumeID, snapshotName)
+	cnsSnapshotInfo, err := volumeManager.CreateSnapshot(ctx, volumeID, snapshotName)
 	if err != nil {
 		log.Errorf("failed to create snapshot on volume %q with description %q with error %+v",
 			volumeID, snapshotName, err)
@@ -1056,7 +1056,7 @@ func CreateSnapshotUtil(ctx context.Context, manager *Manager, volumeID string, 
 }
 
 // DeleteSnapshotUtil is the helper function to delete CNS snapshot for given snapshotId
-func DeleteSnapshotUtil(ctx context.Context, manager *Manager, csiSnapshotID string) error {
+func DeleteSnapshotUtil(ctx context.Context, volumeManager cnsvolume.Manager, csiSnapshotID string) error {
 	log := logger.GetLogger(ctx)
 
 	cnsVolumeID, cnsSnapshotID, err := ParseCSISnapshotID(csiSnapshotID)
@@ -1065,7 +1065,7 @@ func DeleteSnapshotUtil(ctx context.Context, manager *Manager, csiSnapshotID str
 	}
 
 	log.Debugf("vSphere CSI driver is deleting snapshot %q on volume: %q", cnsSnapshotID, cnsVolumeID)
-	err = manager.VolumeManager.DeleteSnapshot(ctx, cnsVolumeID, cnsSnapshotID)
+	err = volumeManager.DeleteSnapshot(ctx, cnsVolumeID, cnsSnapshotID)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to delete snapshot %q on volume %q with error %+v",
 			cnsSnapshotID, cnsVolumeID, err)

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1482,7 +1482,8 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 		// sign. That is, a string of "<UUID>+<UUID>". Because, all other CNS snapshot APIs still require both
 		// VolumeID and SnapshotID as the input, while corresponding snapshot APIs in upstream CSI require SnapshotID.
 		// So, we need to bridge the gap in vSphere CSI driver and return a combined SnapshotID to CSI Snapshotter.
-		snapshotID, snapshotCreateTimePtr, err := common.CreateSnapshotUtil(ctx, c.manager, volumeID, req.Name)
+		snapshotID, snapshotCreateTimePtr, err := common.CreateSnapshotUtil(ctx, c.manager.VolumeManager,
+			volumeID, req.Name)
 		if err != nil {
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to create snapshot on volume %q: %v", volumeID, err)
@@ -1546,7 +1547,7 @@ func (c *controller) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshot
 	}
 	deleteSnapshotInternal := func() (*csi.DeleteSnapshotResponse, error) {
 		csiSnapshotID := req.GetSnapshotId()
-		err := common.DeleteSnapshotUtil(ctx, c.manager, csiSnapshotID)
+		err := common.DeleteSnapshotUtil(ctx, c.manager.VolumeManager, csiSnapshotID)
 		if err != nil {
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"Failed to delete WCP snapshot %q. Error: %+v",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CreateSnapshot and DeleteSnapshot changes to support multi-vCenter CSI topology

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran Vanilla csi-block-pre-check-in test suite. 
Manually verified that snapshot creation and deletion is working fine when multi-vcenter-csi-topology FSS is disabled.

```
# kubectl get volumesnapshotclass
NAME                              DRIVER                   DELETIONPOLICY   AGE
example-raw-block-snapshotclass   csi.vsphere.vmware.com   Delete           105s

# kubectl get volumesnapshot
NAME                         READYTOUSE   SOURCEPVC               SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                     SNAPSHOTCONTENT                                    CREATIONTIME   AGE
example-raw-block-snapshot   true         example-raw-block-pvc                           5Gi           example-raw-block-snapshotclass   snapcontent-f99f062d-d6c2-49e9-8626-8e3795da8853   93s            103s

# kubectl get volumesnapshotcontent
NAME                                               READYTOUSE   RESTORESIZE   DELETIONPOLICY   DRIVER                   VOLUMESNAPSHOTCLASS               VOLUMESNAPSHOT               VOLUMESNAPSHOTNAMESPACE   AGE
snapcontent-f99f062d-d6c2-49e9-8626-8e3795da8853   true         5368709120    Delete           csi.vsphere.vmware.com   example-raw-block-snapshotclass   example-raw-block-snapshot   default                   4m20s

# kubectl delete -f example-raw-block-snapshot.yaml
volumesnapshot.snapshot.storage.k8s.io "example-raw-block-snapshot" deleted

# kubectl get volumesnapshotcontent
No resources found

# kubectl get volumesnapshot
No resources found in default namespace.
```

**Special notes for your reviewer**:

**Release note**:
```release-note
CreateSnapshot and DeleteSnapshot changes to support multi-vCenter CSI topology
```
