### PR TITLE
CSI full sync in a multi VC setup

### DIFF
--- a/pkg/syncer/cnsoperator/controller/triggercsifullsync/triggercsifullsync_controller.go
+++ b/pkg/syncer/cnsoperator/controller/triggercsifullsync/triggercsifullsync_controller.go
@@ -245,7 +245,7 @@ func (r *ReconcileTriggerCsiFullSync) Reconcile(ctx context.Context,
 	if r.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		fullSyncErr = syncer.PvcsiFullSync(ctx, syncer.MetadataSyncer)
 	} else {
-		fullSyncErr = syncer.CsiFullSync(ctx, syncer.MetadataSyncer)
+		fullSyncErr = syncer.CsiFullSync(ctx, syncer.MetadataSyncer, r.configInfo.Cfg.Global.VCenterIP)
 	}
 	err = r.client.Get(ctx, request.NamespacedName, instance)
 	if err != nil {

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -682,11 +682,11 @@ func runTestFullSyncWorkflows(t *testing.T) {
 	// PV does not exist in K8S, but volume exist in CNS cache.
 	// FullSync should delete this volume from CNS cache after two cycles.
 	waitForListerSync()
-	err = CsiFullSync(ctx, metadataSyncer)
+	err = CsiFullSync(ctx, metadataSyncer, csiConfig.Global.VCenterIP)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = CsiFullSync(ctx, metadataSyncer)
+	err = CsiFullSync(ctx, metadataSyncer, csiConfig.Global.VCenterIP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -732,11 +732,11 @@ func runTestFullSyncWorkflows(t *testing.T) {
 		t.Fatal(err)
 	}
 	waitForListerSync()
-	err = CsiFullSync(ctx, metadataSyncer)
+	err = CsiFullSync(ctx, metadataSyncer, csiConfig.Global.VCenterIP)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = CsiFullSync(ctx, metadataSyncer)
+	err = CsiFullSync(ctx, metadataSyncer, csiConfig.Global.VCenterIP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -765,7 +765,7 @@ func runTestFullSyncWorkflows(t *testing.T) {
 		t.Fatal(err)
 	}
 	waitForListerSync()
-	err = CsiFullSync(ctx, metadataSyncer)
+	err = CsiFullSync(ctx, metadataSyncer, csiConfig.Global.VCenterIP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -787,7 +787,7 @@ func runTestFullSyncWorkflows(t *testing.T) {
 		t.Fatal(err)
 	}
 	waitForListerSync()
-	err = CsiFullSync(ctx, metadataSyncer)
+	err = CsiFullSync(ctx, metadataSyncer, csiConfig.Global.VCenterIP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -810,7 +810,7 @@ func runTestFullSyncWorkflows(t *testing.T) {
 		t.Fatal(err)
 	}
 	waitForListerSync()
-	err = CsiFullSync(ctx, metadataSyncer)
+	err = CsiFullSync(ctx, metadataSyncer, csiConfig.Global.VCenterIP)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify CSI full sync to work in a multi VC environment.


**Testing done**:

Removed PV informers in metadatasyncer so that full sync can detect changes and trigger updates.

1. Changed labels on PV. Observed that CNS volume was successfully updated.

```
2022-11-17T09:28:09.894Z	DEBUG	syncer/metadatasyncer.go:500	Starting full sync for Multi VC setup with 1 VCs
2022-11-17T09:28:09.895Z	INFO	syncer/fullsync.go:42	FullSync: start
2022-11-17T09:28:09.895Z	DEBUG	syncer/util.go:30	FullSync: Getting all PVs in Bound, Available or Released state
2022-11-17T09:28:10.145Z	DEBUG	volume/manager.go:1150	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator
2022-11-17T09:28:10.746Z	INFO	volume/manager.go:1173	UpdateVolumeMetadata: volumeID: "1ce89313-b573-4eb1-9214-d11975afa4cf", opId: "400c3562"
2022-11-17T09:28:10.746Z	INFO	volume/manager.go:1190	UpdateVolumeMetadata: Volume metadata updated successfully. volumeID: "1ce89313-b573-4eb1-9214-d11975afa4cf", opId: "400c3562"
```

2. Created a CNS volume by invoking CnsCreateAPI on the VC. Observed that full sync eventually deleted it:
```
2022-11-17T10:09:10.212Z	INFO	syncer/fullsync.go:415	FullSync: fullSyncDeleteVolumes: Calling DeleteVolume for volume d8696995-694d-4c09-82db-c1f4c9ea7d9d with delete disk false
2022-11-17T10:09:11.167Z	INFO	volume/manager.go:943	DeleteVolume: volumeID: "d8696995-694d-4c09-82db-c1f4c9ea7d9d", opId: "400c5732"
2022-11-17T10:09:11.168Z	INFO	volume/manager.go:962	DeleteVolume: Volume deleted successfully. volumeID: "d8696995-694d-4c09-82db-c1f4c9ea7d9d", opId: "400c5732"
```


3. Created a K8s PV and then deleted the CNS volume directly from the VC with CnsDeleteVolume API. Observed that full sync recreated this volume as it was being used by K8s PV.

```
2022-11-17T10:28:10.068Z	DEBUG	syncer/fullsync.go:273	FullSync: cnsDeletionMap at end of cycle: map[]
2022-11-17T10:28:10.068Z	DEBUG	syncer/fullsync.go:274	FullSync: cnsCreationMap at end of cycle: map[1ce89313-b573-4eb1-9214-d11975afa4cf:true]
2022-11-17T10:29:10.082Z	DEBUG	volume/util.go:205	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator
2022-11-17T10:29:17.106Z	INFO	volume/manager.go:570	CreateVolume: VolumeName: "pvc-21d2cfd4-06fe-44ea-937f-436c0908f899", opId: "400c5fd4"
2022-11-17T10:29:17.107Z	INFO	volume/util.go:329	Volume created successfully. VolumeName: "pvc-21d2cfd4-06fe-44ea-937f-436c0908f899", volumeID: "1ce89313-b573-4eb1-9214-d11975afa4cf"
2022-11-17T10:29:17.108Z	DEBUG	volume/util.go:331	CreateVolume volumeId {{} "1ce89313-b573-4eb1-9214-d11975afa4cf"} is placed on datastore ""
2022-11-17T10:29:17.109Z	DEBUG	volume/manager.go:640	internalCreateVolume: returns fault ""
2022-11-17T10:29:17.110Z	DEBUG	syncer/fullsync.go:273	FullSync: cnsDeletionMap at end of cycle: map[]
2022-11-17T10:29:17.111Z	DEBUG	syncer/fullsync.go:274	FullSync: cnsCreationMap at end of cycle: map[]
```

Tested the same on SV cluster as well.



**Special notes for your reviewer**:
1. Creation/Deletion of CNS Volume Info CRs in case they're left out by metadatsyncer will be taken up as a separate task.
2. Testing is not done for a multi VC setup yet as we do not have the required environment.