### PR TITLE
Create file volume return non-storage fault when vSAN file service is disabled

### DIFF
--- a/pkg/common/fault/constants.go
+++ b/pkg/common/fault/constants.go
@@ -46,6 +46,10 @@ const (
 	// before the volume is provisioned in supervisor cluster.
 	CSIPvNotFoundInPvcSpecFault = "csi.fault.nonstorage.PvNotFoundInPvcSpec"
 
+	// CSIVSanFileServiceDisabledFault is the fault type when trying to create a RWX volume on a cluster which vsan file
+	// service is disabled.
+	CSIVSanFileServiceDisabledFault = "csi.fault.nonstorage.VSanFileServiceDisabled"
+
 	// CSITaskResultEmptyFault is the fault type when taskResult is empty.
 	CSITaskResultEmptyFault = "csi.fault.TaskResultEmpty"
 

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1035,8 +1035,9 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 		}
 
 		if len(filteredDatastores) == 0 {
-			return nil, csifault.CSIInternalFault, logger.LogNewErrorCode(log, codes.Internal,
-				"no datastores found to create file volume")
+			// when len(filteredDatastore)==0, it means vsan file service is not enabled on any vsan cluster
+			return nil, csifault.CSIVSanFileServiceDisabledFault, logger.LogNewErrorCode(log, codes.FailedPrecondition,
+				"no datastores found to create file volume, vsan file service may be disabled")
 		}
 
 		volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
@@ -1046,7 +1047,6 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to create volume. Error: %+v", err)
 		}
-
 	}
 
 	attributes := make(map[string]string)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currenly, create file volume on a VC which vsan file service is disabled will fail with fault "csifault.CSIInternalFault". This will cause the create volume success rate drop incorrectly.  With this change, creating file volume on a VC which vsan file service is disabled will return non-storage fault.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Test for WCP Supervisor cluster
1. disable vsan file service on VC
2. create a file volume in WCP Supervisor cluster, volume create operation will fail
3. see the following metrics reported with non-storage fault
```
root@422e14f0ef0c3c1b18349898322ea9bb [ ~ ]# curl  172.24.20.140:2112/metrics 

...
# HELP vsphere_csi_volume_ops_histogram Histogram vector for CSI volume operations.
# TYPE vsphere_csi_volume_ops_histogram histogram
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="2"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="5"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="10"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="15"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="20"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="25"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="30"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="60"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="120"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="180"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="+Inf"} 6
vsphere_csi_volume_ops_histogram_sum{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file"} 0.968649393
vsphere_csi_volume_ops_histogram_count{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file"} 6

```
4. see the following from vsphere-csi-controller log

```
{"level":"error","time":"2022-11-10T22:38:28.355029784Z","caller":"wcp/controller.go:827","msg":"fileshare volume creation is not supported since vSAN file service is disabled.","TraceId":"e59382cb-36ab-49f3-86d3-f56cf3345e44","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).CreateVolume.func1\n\t/build/pkg/csi/service/wcp/controller.go:827\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).CreateVolume\n\t/build/pkg/csi/service/wcp/controller.go:840\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler\n\t/go/pkg/mod/github.com/container-storage-interface/spec@v1.6.0/lib/go/csi/csi.pb.go:5671\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1283\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1620\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.2\n\t/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:922"}
{"level":"error","time":"2022-11-10T22:38:28.355731015Z","caller":"wcp/controller.go:844","msg":"Operation failed, reporting failure status to Prometheus. Operation Type: \"create-volume\", Volume Type: \"file\", Fault Type: \"csi.fault.nonstorage.VSanFileServiceDisabled\"","TraceId":"e59382cb-36ab-49f3-86d3-f56cf3345e44","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp.(*controller).CreateVolume\n\t/build/pkg/csi/service/wcp/controller.go:844\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler\n\t/go/pkg/mod/github.com/container-storage-interface/spec@v1.6.0/lib/go/csi/csi.pb.go:5671\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1283\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1620\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.2\n\t/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:922"}

```

Test for Vanilla Cluster
1. disable vsan file service on VC
2. create a file volume in WCP Supervisor cluster, volume create operation will fail
3. see the following metrics reported with non-storage fault
```
root@k8s-control-724-1664566639:~# curl 10.100.236.155:2112/metrics 
...
# HELP vsphere_csi_volume_ops_histogram Histogram vector for CSI volume operations.
# TYPE vsphere_csi_volume_ops_histogram histogram
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="2"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="5"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="10"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="15"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="20"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="25"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="30"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="60"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="120"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="180"} 6
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file",le="+Inf"} 6
vsphere_csi_volume_ops_histogram_sum{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file"} 0.556839197
vsphere_csi_volume_ops_histogram_count{faulttype="csi.fault.nonstorage.VSanFileServiceDisabled",optype="create-volume",status="fail",voltype="file"} 6
root@k8s-control-724-1664566639:~# 
```
4. see the following from vsphere-csi-controller log
```
2022-11-10T23:03:50.270Z        INFO    vanilla/controller.go:1073      CreateVolume: called with args {Name:pvc-70b17683-930b-4e2f-8501-42ec3e670117 CapacityRange:required_bytes:524288000  VolumeCapabilities:[mount:<fs_type:"nfs4" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[storagepolicyname:vSAN Default Storage Policy] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}      {"TraceId": "98b4b637-f1c1-4205-841c-23b5ddd19364"}
2022-11-10T23:03:50.271Z        DEBUG   vsphere/utils.go:521    Checking if vCenter version is of vsan 67u3 release     {"TraceId": "98b4b637-f1c1-4205-841c-23b5ddd19364"}
2022-11-10T23:03:50.271Z        DEBUG   vsphere/utils.go:527    vCenter version is :"8.0.0.1"   {"TraceId": "98b4b637-f1c1-4205-841c-23b5ddd19364"}
2022-11-10T23:03:50.344Z        DEBUG   vsphere/vsan.go:103     cluster: ClusterComputeResource:domain-c8 @ /VSAN-DC/host/cluster1 has vSAN file services enabled: false        {"TraceId": "98b4b637-f1c1-4205-841c-23b5ddd19364"}
2022-11-10T23:03:50.344Z        ERROR   vanilla/controller.go:1109      fileshare volume creation is not supported since vSAN file service is disabled. {"TraceId": "98b4b637-f1c1-4205-841c-23b5ddd19364"}
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).CreateVolume.func1
        /build/pkg/csi/service/vanilla/controller.go:1109
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).CreateVolume
        /build/pkg/csi/service/vanilla/controller.go:1117
github.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler
        /go/pkg/mod/github.com/container-storage-interface/spec@v1.6.0/lib/go/csi/csi.pb.go:5671
google.golang.org/grpc.(*Server).processUnaryRPC
        /go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1283
google.golang.org/grpc.(*Server).handleStream
        /go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1620
google.golang.org/grpc.(*Server).serveStreams.func1.2
        /go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:922
2022-11-10T23:03:50.344Z        DEBUG   vanilla/controller.go:1118      createVolumeInternal: returns fault "csi.fault.nonstorage.VSanFileServiceDisabled"      {"TraceId": "98b4b637-f1c1-4205-841c-23b5ddd19364"}
2022-11-10T23:03:50.344Z        ERROR   vanilla/controller.go:1120      Operation failed, reporting failure status to Prometheus. Operation Type: "create-volume", Volume Type: "file", Fault Type: "csi.fault.nonstorage.VSanFileServiceDisabled"      {"TraceId": "98b4b637-f1c1-4205-841c-23b5ddd19364"}
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).CreateVolume
        /build/pkg/csi/service/vanilla/controller.go:1120
github.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler
        /go/pkg/mod/github.com/container-storage-interface/spec@v1.6.0/lib/go/csi/csi.pb.go:5671

```

**Special notes for your reviewer**:

**Release note**:
Create file volume return non-storage fault when vSAN file service is disabled
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
6. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
