### PR TITLE
Enable list volumes FSS in vanilla and WCP

### DIFF
--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -426,7 +426,7 @@ data:
   "block-volume-snapshot": "false"
   "sibling-replica-bound-pvc-check": "true"
   "tkgs-ha": "true"
-  "list-volumes": "false"
+  "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -427,7 +427,7 @@ data:
   "block-volume-snapshot": "false"
   "sibling-replica-bound-pvc-check": "true"
   "tkgs-ha": "true"
-  "list-volumes": "false"
+  "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
 kind: ConfigMap
 metadata:

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -430,7 +430,7 @@ data:
   "block-volume-snapshot": "false"
   "sibling-replica-bound-pvc-check": "true"
   "tkgs-ha": "true"
-  "list-volumes": "false"
+  "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
 kind: ConfigMap
 metadata:

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -156,7 +156,7 @@ data:
   "block-volume-snapshot": "true"
   "csi-windows-support": "false"
   "use-csinode-id": "true"
-  "list-volumes": "false"
+  "list-volumes": "true"
   "pv-to-backingdiskobjectid-mapping": "false"
   "cnsmgr-suspend-create-volume": "true"
   "topology-preferential-datastores": "true"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
To enable list volumes FSS in vanilla and WCP deployments

**Testing done**:
1. Deployed a vanilla testbed with changes and FSS is enabled. Logs show that ListVolumes is being called.
All constroller pods are in Running state
```
root@k8s-control-646-1669155576:~# knc describe cm internal-feature-states.csi.vsphere.vmware.com
Name:         internal-feature-states.csi.vsphere.vmware.com
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>

Data
====
csi-internal-generated-cluster-id:
----
false
...
list-volumes: 
----
true. ======================> set to true

```
```
root@k8s-control-646-1669155576:~# knc get all
NAME                                          READY   STATUS    RESTARTS       AGE
pod/vsphere-csi-controller-78df5978dd-gghkx   7/7     Running   4 (97m ago)    103m
pod/vsphere-csi-controller-78df5978dd-hfdh7   7/7     Running   1 (99m ago)    103m
pod/vsphere-csi-controller-78df5978dd-jct9l   7/7     Running   0              103m
pod/vsphere-csi-node-2cq9z                    3/3     Running   3 (102m ago)   103m
pod/vsphere-csi-node-6j82q                    3/3     Running   2 (102m ago)   103m
pod/vsphere-csi-node-hvb95                    3/3     Running   3 (102m ago)   103m
pod/vsphere-csi-node-jtbch                    3/3     Running   2 (102m ago)   103m
pod/vsphere-csi-node-nnjwf                    3/3     Running   0              103m
pod/vsphere-csi-node-tx2mp                    3/3     Running   1 (102m ago)   103m
pod/vsphere-csi-webhook-85dc64486b-4wxcq      1/1     Running   0              99m
```
```
2022-11-22T22:35:14.597714491Z 2022-11-22T22:35:14.597Z DEBUG   config/config.go:466    Setting default queryLimit to 10000     {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.597718089Z 2022-11-22T22:35:14.597Z DEBUG   config/config.go:471    Setting default list volume threshold to 50     {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.597721973Z 2022-11-22T22:35:14.597Z DEBUG   vanilla/controller.go:1711      ListVolumes: called with args {MaxEntries:0 StartingToken: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.597725026Z 2022-11-22T22:35:14.597Z DEBUG   vanilla/controller.go:1728      Number of Volume IDs of PVs from K8s cluster 0, list of volumes []      {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.636800790Z 2022-11-22T22:35:14.636Z DEBUG   node/manager.go:291     Renewing VM VirtualMachine:vm-53 [VirtualCenterHost: 10.193.39.162, UUID: 422ccc56-9ebb-dc45-8cc7-dd9aa8b57dc0, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.193.39.162]] with new connection: nodeUUID 422ccc56-9ebb-dc45-8cc7-dd9aa8b57dc0   {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.647588706Z 2022-11-22T22:35:14.646Z DEBUG   node/manager.go:301     Updated VM VirtualMachine:vm-53 [VirtualCenterHost: 10.193.39.162, UUID: 422ccc56-9ebb-dc45-8cc7-dd9aa8b57dc0, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.193.39.162]] for node with nodeUUID 422ccc56-9ebb-dc45-8cc7-dd9aa8b57dc0      {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.647616118Z 2022-11-22T22:35:14.647Z DEBUG   node/manager.go:288     Renewing VM VirtualMachine:vm-50 [VirtualCenterHost: 10.193.39.162, UUID: 422c1039-2b4b-26c4-741a-3e1a4ac077f2, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.193.39.162]], no new connection needed: nodeUUID 422c1039-2b4b-26c4-741a-3e1a4ac077f2     {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.647620126Z 2022-11-22T22:35:14.647Z DEBUG   node/manager.go:301     Updated VM VirtualMachine:vm-50 [VirtualCenterHost: 10.193.39.162, UUID: 422c1039-2b4b-26c4-741a-3e1a4ac077f2, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.193.39.162]] for node with nodeUUID 422c1039-2b4b-26c4-741a-3e1a4ac077f2      {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.647636240Z 2022-11-22T22:35:14.647Z DEBUG   node/manager.go:288     Renewing VM VirtualMachine:vm-55 [VirtualCenterHost: 10.193.39.162, UUID: 422c6442-8e9d-3213-5877-898d0ebf2955, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.193.39.162]], no new connection needed: nodeUUID 422c6442-8e9d-3213-5877-898d0ebf2955     {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.647639497Z 2022-11-22T22:35:14.647Z DEBUG   node/manager.go:301     Updated VM VirtualMachine:vm-55 [VirtualCenterHost: 10.193.39.162, UUID: 422c6442-8e9d-3213-5877-898d0ebf2955, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.193.39.162]] for node with nodeUUID 422c6442-8e9d-3213-5877-898d0ebf2955      {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.647642287Z 2022-11-22T22:35:14.647Z DEBUG   node/manager.go:288     Renewing VM VirtualMachine:vm-54 [VirtualCenterHost: 10.193.39.162, UUID: 422c24ec-6f19-5936-f67d-eac967425f97, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.193.39.162]], no new connection needed: nodeUUID 422c24ec-6f19-5936-f67d-eac967425f97     {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.647645130Z 2022-11-22T22:35:14.647Z DEBUG   node/manager.go:301     Updated VM VirtualMachine:vm-54 [VirtualCenterHost: 10.193.39.162, UUID: 422c24ec-6f19-5936-f67d-eac967425f97, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.193.39.162]] for node with nodeUUID 422c24ec-6f19-5936-f67d-eac967425f97      {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.647647865Z 2022-11-22T22:35:14.647Z DEBUG   node/manager.go:288     Renewing VM VirtualMachine:vm-51 [VirtualCenterHost: 10.193.39.162, UUID: 422cfb3f-ca57-2777-a6ce-9122175fda11, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.193.39.162]], no new connection needed: nodeUUID 422cfb3f-ca57-2777-a6ce-9122175fda11     {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.647650556Z 2022-11-22T22:35:14.647Z DEBUG   node/manager.go:301     Updated VM VirtualMachine:vm-51 [VirtualCenterHost: 10.193.39.162, UUID: 422cfb3f-ca57-2777-a6ce-9122175fda11, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.193.39.162]] for node with nodeUUID 422cfb3f-ca57-2777-a6ce-9122175fda11      {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.647653226Z 2022-11-22T22:35:14.647Z DEBUG   node/manager.go:288     Renewing VM VirtualMachine:vm-52 [VirtualCenterHost: 10.193.39.162, UUID: 422cba5d-3c48-eb97-f659-c378c846b076, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.193.39.162]], no new connection needed: nodeUUID 422cba5d-3c48-eb97-f659-c378c846b076     {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.647658869Z 2022-11-22T22:35:14.647Z DEBUG   node/manager.go:301     Updated VM VirtualMachine:vm-52 [VirtualCenterHost: 10.193.39.162, UUID: 422cba5d-3c48-eb97-f659-c378c846b076, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.193.39.162]] for node with nodeUUID 422cba5d-3c48-eb97-f659-c378c846b076      {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.647815239Z 2022-11-22T22:35:14.647Z DEBUG   vanilla/controller.go:1788      Starting token: 0, Length of Query volume result: 0, Max entries: 0     {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.698480804Z 2022-11-22T22:35:14.698Z DEBUG   vanilla/controller.go:1801      ListVolumes served 0 results, token for next set:       {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
2022-11-22T22:35:14.698663281Z 2022-11-22T22:35:14.698Z DEBUG   vanilla/controller.go:1805      List volume response:   {"TraceId": "46ab044b-c83f-4021-a2f4-f63df9647d00"}
```

2. WCP testbed:

Controller pods are running fine
```
root@4226843d3803602a985c135455aea4f1 [ ~ ]# knc get pods
NAME                                      READY   STATUS    RESTARTS      AGE
vsphere-csi-controller-59bdfbfc66-2tx28   6/6     Running   1 (72m ago)   82m
vsphere-csi-controller-59bdfbfc66-8xqwj   6/6     Running   2 (72m ago)   82m
vsphere-csi-controller-59bdfbfc66-zh42p   6/6     Running   0             81m
vsphere-csi-webhook-5998684779-7gcqs      1/1     Running   0             80m
vsphere-csi-webhook-5998684779-jt2qz      1/1     Running   0             80m
vsphere-csi-webhook-5998684779-tlccv      1/1     Running   0             80m
```
```
root@4226843d3803602a985c135455aea4f1 [ ~ ]# knc describe cm
Name:         csi-feature-states
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>

Data
====
tkgs-ha:
----
true
...
list-volumes:  
----
true ========================> Enabled
```
Logs: It has sample pods deployed, hence the 3 volume IDs
```
2022-11-22T23:32:07.345671252Z 2022-11-22T23:32:07.344Z DEBUG   wcp/controller.go:1262  ListVolumes called with args {MaxEntries:0 StartingToken: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}, expectedStartingIndex 0 {"TraceId": "22371720-f6d8-4a82-9af1-32e731dbf3f8"}
2022-11-22T23:32:07.448829176Z 2022-11-22T23:32:07.448Z DEBUG   wcp/controller.go:1326  ListVolumes: cnsVolumeIDs [0f374d35-72d9-426b-b2da-7bd9bbb57e58 be1272ec-56eb-42f7-ae25-66d008594b92 bcff02ad-5db9-4967-aa03-1e1d13d09d6e], startingIdx 0, queryLimit 3 {"TraceId": "22371720-f6d8-4a82-9af1-32e731dbf3f8"}
2022-11-22T23:32:07.468033114Z 2022-11-22T23:32:07.448Z DEBUG   k8sorchestrator/k8sorchestrator_helper.go:41    Getting annotations on pvc corresponding to volume: 0f374d35-72d9-426b-b2da-7bd9bbb57e58        {"TraceId": "22371720-f6d8-4a82-9af1-32e731dbf3f8"}
2022-11-22T23:32:07.468073644Z 2022-11-22T23:32:07.448Z DEBUG   k8sorchestrator/k8sorchestrator_helper.go:41    Getting annotations on pvc corresponding to volume: be1272ec-56eb-42f7-ae25-66d008594b92        {"TraceId": "22371720-f6d8-4a82-9af1-32e731dbf3f8"}
2022-11-22T23:32:07.468082721Z 2022-11-22T23:32:07.448Z DEBUG   k8sorchestrator/k8sorchestrator_helper.go:41    Getting annotations on pvc corresponding to volume: bcff02ad-5db9-4967-aa03-1e1d13d09d6e        {"TraceId": "22371720-f6d8-4a82-9af1-32e731dbf3f8"}
2022-11-22T23:32:07.468086950Z 2022-11-22T23:32:07.448Z DEBUG   wcp/controller_helper.go:613    Fake attached volumes []        {"TraceId": "22371720-f6d8-4a82-9af1-32e731dbf3f8"}
2022-11-22T23:32:07.549811327Z 2022-11-22T23:32:07.549Z DEBUG   wcp/controller.go:1347  ListVolumes: Response entries entries:<volume:<volume_id:"be1272ec-56eb-42f7-ae25-66d008594b92" > status:<published_node_ids:"sc2-10-212-19-75.nimbus.eng.vmware.com" > > entries:<volume:<volume_id:"bcff02ad-5db9-4967-aa03-1e1d13d09d6e" > status:<published_node_ids:"sc2-10-212-30-233.nimbus.eng.vmware.com" > > entries:<volume:<volume_id:"0f374d35-72d9-426b-b2da-7bd9bbb57e58" > status:<published_node_ids:"sc2-10-212-29-0.nimbus.eng.vmware.com" > >       {"TraceId": "22371720-f6d8-4a82-9af1-32e731dbf3f8"}

```
**Special notes for your reviewer**:

**Release note**:

```release-note
Enable list volumes FSS in vanilla and WCP
```
