### PR TITLE
CreateVolume changes for multi-VC

### DIFF
--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/vmware/govmomi/vapi/tags"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 
@@ -205,153 +203,15 @@ func (nodes *Nodes) GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsp
 	return nodes.cnsNodeManager.GetNode(ctx, nodeUuid, nil)
 }
 
-// GetAllNodes returns VirtualMachine for all registered.
-// This is called by ControllerExpandVolume to check if volume is attached to
-// a node.
+// GetAllNodes returns VirtualMachine objects for all registered nodes in cluster.
 func (nodes *Nodes) GetAllNodes(ctx context.Context) (
 	[]*cnsvsphere.VirtualMachine, error) {
 	return nodes.cnsNodeManager.GetAllNodes(ctx)
 }
 
-// GetSharedDatastoresInTopology returns shared accessible datastores for
-// specified topologyRequirement along with the map of datastore URL and
-// array of accessibleTopology map for each datastore returned from this
-// function.
-//
-// Here in this function, argument topologyRequirement can be passed in
-// following form:
-// topologyRequirement [requisite:<segments:<key:"failure-domain.beta.kubernetes.io/region" value:"k8s-region-us" >
-//
-//	           segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"k8s-zone-us-east" > >
-//	requisite:<segments:<key:"failure-domain.beta.kubernetes.io/region" value:"k8s-region-us" >
-//	           segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"k8s-zone-us-west" > >
-//	preferred:<segments:<key:"failure-domain.beta.kubernetes.io/region" value:"k8s-region-us" >
-//	           segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"k8s-zone-us-west" > >
-//	preferred:<segments:<key:"failure-domain.beta.kubernetes.io/region" value:"k8s-region-us" >
-//	           segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"k8s-zone-us-east" > > ]
-//
-// Return map datastoreTopologyMap looks like as below
-// map[ ds:///vmfs/volumes/5d119112-7b28fe05-f51d-02000b3a3f4b/:
-//
-//	   [map [ failure-domain.beta.kubernetes.io/region:k8s-region-us
-//	          failure-domain.beta.kubernetes.io/zone:k8s-zone-us-east ]]
-//	ds:///vmfs/volumes/e54abc3f-f6a5bb1f-0000-000000000000/:
-//	   [map [ failure-domain.beta.kubernetes.io/region:k8s-region-us
-//	          failure-domain.beta.kubernetes.io/zone:k8s-zone-us-east ]]
-//	ds:///vmfs/volumes/vsan:524fae1aaca129a5-1ee55a87f26ae626/:
-//	   [map [ failure-domain.beta.kubernetes.io/region:k8s-region-us
-//	          failure-domain.beta.kubernetes.io/zone:k8s-zone-us-west ]
-//	    map [ failure-domain.beta.kubernetes.io/region:k8s-region-us
-//	          failure-domain.beta.kubernetes.io/zone:k8s-zone-us-east ]] ]
-func (nodes *Nodes) GetSharedDatastoresInTopology(
-	ctx context.Context, topologyRequirement *csi.TopologyRequirement,
-	tagManager *tags.Manager, zoneCategoryName string,
-	regionCategoryName string) (
-	[]*cnsvsphere.DatastoreInfo, map[string][]map[string]string, error) {
-	log := logger.GetLogger(ctx)
-	log.Debugf("Get shared datastores with topologyRequirement: %+v, zone: %s, region: %s",
-		topologyRequirement, zoneCategoryName, regionCategoryName)
-	allNodes, err := nodes.cnsNodeManager.GetAllNodes(ctx)
-	if err != nil {
-		log.Errorf("failed to get Nodes from nodeManager with err %+v", err)
-		return nil, nil, err
-	}
-	if len(allNodes) == 0 {
-		errMsg := "empty List of Node VMs returned from nodeManager"
-		log.Errorf(errMsg)
-		return nil, nil, fmt.Errorf(errMsg)
-	}
-	// getNodesInZoneRegion takes zone and region as parameter and returns list
-	// of node VMs which belongs to specified zone and region.
-	getNodesInZoneRegion := func(zoneValue string, regionValue string) (
-		[]*cnsvsphere.VirtualMachine, error) {
-		log.Debugf("Get nodes in zone: %s, region: %s", zoneValue, regionValue)
-		var nodeVMsInZoneAndRegion []*cnsvsphere.VirtualMachine
-		for _, nodeVM := range allNodes {
-			isNodeInZoneRegion, err := nodeVM.IsInZoneRegion(ctx, zoneCategoryName,
-				regionCategoryName, zoneValue, regionValue, tagManager)
-			if err != nil {
-				log.Errorf("Error checking if node VM %v belongs to zone [%s] and region [%s]. err: %+v",
-					nodeVM, zoneValue, regionValue, err)
-				return nil, err
-			}
-			if isNodeInZoneRegion {
-				nodeVMsInZoneAndRegion = append(nodeVMsInZoneAndRegion, nodeVM)
-			}
-		}
-		return nodeVMsInZoneAndRegion, nil
-	}
-
-	// getSharedDatastoresInTopology returns list of shared accessible datastores
-	// for requested topology along with the map of datastore URL and array of
-	// accessibleTopology map for each datastore returned from this function.
-	getSharedDatastoresInTopology := func(topologyArr []*csi.Topology) (
-		[]*cnsvsphere.DatastoreInfo, map[string][]map[string]string, error) {
-		log.Debugf("getSharedDatastoresInTopology: called with topologyArr: %+v", topologyArr)
-		var sharedDatastores []*cnsvsphere.DatastoreInfo
-		datastoreTopologyMap := make(map[string][]map[string]string)
-		for _, topology := range topologyArr {
-			segments := topology.GetSegments()
-			zone := segments[v1.LabelZoneFailureDomain]
-			region := segments[v1.LabelZoneRegion]
-			log.Debugf("Getting list of nodeVMs for zone [%s] and region [%s]", zone, region)
-			nodeVMsInZoneRegion, err := getNodesInZoneRegion(zone, region)
-			if err != nil {
-				log.Errorf("Failed to find nodes in zone [%s] and region [%s]. Error: %+v",
-					zone, region, err)
-				return nil, nil, err
-			}
-			log.Debugf("Obtained list of nodeVMs [%+v] for zone [%s] and region [%s]",
-				nodeVMsInZoneRegion, zone, region)
-			sharedDatastoresInZoneRegion, err :=
-				cnsvsphere.GetSharedDatastoresForVMs(ctx, nodeVMsInZoneRegion)
-			if err != nil {
-				log.Errorf("Failed to get shared datastores for nodes: %+v in zone [%s] and region [%s]. Error: %+v",
-					nodeVMsInZoneRegion, zone, region, err)
-				return nil, nil, err
-			}
-			log.Debugf("Obtained shared datastores : %+v for topology: %+v",
-				sharedDatastores, topology)
-			for _, datastore := range sharedDatastoresInZoneRegion {
-				accessibleTopology := make(map[string]string)
-				if zone != "" {
-					accessibleTopology[v1.LabelZoneFailureDomain] = zone
-				}
-				if region != "" {
-					accessibleTopology[v1.LabelZoneRegion] = region
-				}
-				datastoreTopologyMap[datastore.Info.Url] =
-					append(datastoreTopologyMap[datastore.Info.Url], accessibleTopology)
-			}
-			sharedDatastores = append(sharedDatastores, sharedDatastoresInZoneRegion...)
-		}
-		return sharedDatastores, datastoreTopologyMap, nil
-	}
-
-	var sharedDatastores []*cnsvsphere.DatastoreInfo
-	var datastoreTopologyMap = make(map[string][]map[string]string)
-	if topologyRequirement != nil && topologyRequirement.GetPreferred() != nil {
-		log.Debugf("Using preferred topology")
-		sharedDatastores, datastoreTopologyMap, err =
-			getSharedDatastoresInTopology(topologyRequirement.GetPreferred())
-		if err != nil {
-			log.Errorf("Error finding shared datastores from preferred topology: %+v",
-				topologyRequirement.GetPreferred())
-			return nil, nil, err
-		}
-	}
-	if len(sharedDatastores) == 0 && topologyRequirement != nil &&
-		topologyRequirement.GetRequisite() != nil {
-		log.Debugf("Using requisite topology")
-		sharedDatastores, datastoreTopologyMap, err =
-			getSharedDatastoresInTopology(topologyRequirement.GetRequisite())
-		if err != nil {
-			log.Errorf("Error finding shared datastores from requisite topology: %+v",
-				topologyRequirement.GetRequisite())
-			return nil, nil, err
-		}
-	}
-	return sharedDatastores, datastoreTopologyMap, nil
+// GetAllNodesByVC returns VirtualMachine objects for all registered nodes for a particular VC.
+func (nodes *Nodes) GetAllNodesByVC(ctx context.Context, vcHost string) ([]*cnsvsphere.VirtualMachine, error) {
+	return nodes.cnsNodeManager.GetAllNodesByVC(ctx, vcHost)
 }
 
 // GetSharedDatastoresInK8SCluster returns list of DatastoreInfo objects for

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -554,7 +554,6 @@ func IsvSphereVersion70U3orAbove(ctx context.Context, aboutInfo types.AboutInfo)
 // IsVolumeCreationSuspended checks whether a given Datastore has cns.vmware.com/datastoreSuspended customValue
 func IsVolumeCreationSuspended(ctx context.Context, datastoreInfo *DatastoreInfo) bool {
 	log := logger.GetLogger(ctx)
-
 	for _, customValField := range datastoreInfo.CustomValues {
 		customVal := customValField.(*types.CustomFieldStringValue)
 		if customVal.Value == cnsMgrDatastoreSuspended {
@@ -563,25 +562,22 @@ func IsVolumeCreationSuspended(ctx context.Context, datastoreInfo *DatastoreInfo
 			return true
 		}
 	}
-
 	return false
 }
 
 // FilterSuspendedDatastores filters out datastores which cns.vmware.com/datastoreSuspended customValue
 func FilterSuspendedDatastores(ctx context.Context, datastoreInfoList []*DatastoreInfo) ([]*DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
-
 	var filteredList []*DatastoreInfo
 	for _, ds := range datastoreInfoList {
 		if !IsVolumeCreationSuspended(ctx, ds) {
 			filteredList = append(filteredList, ds)
 		}
 	}
-
 	if len(filteredList) == 0 {
-		return filteredList, logger.LogNewErrorf(log, "No datastores are available after filtering suspended datastores")
+		return filteredList, logger.LogNewErrorf(log,
+			"No datastores are available after filtering suspended datastores")
 	}
-
-	log.Infof("Updated filtered list of datastores %+v", filteredList)
+	log.Infof("Filtered list of datastores after removing suspended ones are: %+v", filteredList)
 	return filteredList, nil
 }

--- a/pkg/common/cns-lib/vsphere/virtualmachine.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine.go
@@ -31,8 +31,12 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-// ErrVMNotFound is returned when a virtual machine isn't found.
-var ErrVMNotFound = errors.New("virtual machine wasn't found")
+var (
+	// ErrVMNotFound is returned when a virtual machine isn't found.
+	ErrVMNotFound = errors.New("virtual machine wasn't found")
+	// ErrNoSharedDatastoresFound is raised when no shared datastores are found among the given NodeVMs.
+	ErrNoSharedDatastoresFound = errors.New("no shared datastores found among given NodeVMs")
+)
 
 // VirtualMachine holds details of a virtual machine instance.
 type VirtualMachine struct {
@@ -384,7 +388,7 @@ func GetSharedDatastoresForVMs(ctx context.Context, nodeVMs []*VirtualMachine) (
 			sharedDatastores = sharedAccessibleDatastores
 		}
 		if len(sharedDatastores) == 0 {
-			return nil, fmt.Errorf("no shared datastores found for nodeVm: %+v", nodeVM)
+			return nil, ErrNoSharedDatastoresFound
 		}
 	}
 	return sharedDatastores, nil

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -283,3 +283,14 @@ func (c *FakeK8SOrchestrator) CreateConfigMap(ctx context.Context, name string, 
 	data map[string]string, isImmutable bool) error {
 	return nil
 }
+
+// GetCSINodeTopologyInstancesList lists CSINodeTopology instances for a given cluster.
+func (c *FakeK8SOrchestrator) GetCSINodeTopologyInstancesList() []interface{} {
+	return nil
+}
+
+// GetCSINodeTopologyInstanceByName fetches the CSINodeTopology instance for a given node name in the cluster.
+func (c *FakeK8SOrchestrator) GetCSINodeTopologyInstanceByName(nodeName string) (
+	item interface{}, exists bool, err error) {
+	return nil, false, nil
+}

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -76,6 +76,10 @@ type COCommonInterface interface {
 	// parameter values.
 	CreateConfigMap(ctx context.Context, name string, namespace string, data map[string]string,
 		isImmutable bool) error
+	// GetCSINodeTopologyInstancesList lists CSINodeTopology instances for a given cluster.
+	GetCSINodeTopologyInstancesList() []interface{}
+	// GetCSINodeTopologyInstanceByName fetches the CSINodeTopology instance for a given node name in the cluster.
+	GetCSINodeTopologyInstanceByName(nodeName string) (item interface{}, exists bool, err error)
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
-
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -104,6 +104,13 @@ var (
 	preferredDatastoresMap = make(map[string][]string)
 	// preferredDatastoresMapInstanceLock guards the preferredDatastoresMap from read-write overlaps.
 	preferredDatastoresMapInstanceLock = &sync.RWMutex{}
+	// isMultiVCSupportEnabled is set to true only when the MultiVCenterCSITopology FSS
+	// is enabled. isMultivCenterCluster is set to true only when the MultiVCenterCSITopology FSS
+	// is enabled and the K8s cluster involves multiple VCs.
+	isMultiVCSupportEnabled, isMultivCenterCluster bool
+	// csiNodeTopologyInformer refers to a shared K8s informer listening on CSINodeTopology instances
+	// in the cluster.
+	csiNodeTopologyInformer *cache.SharedIndexInformer
 )
 
 // nodeVolumeTopology implements the commoncotypes.NodeTopologyService interface. It stores
@@ -139,8 +146,8 @@ type controllerVolumeTopology struct {
 	// isCSINodeIdFeatureEnabled indicates whether the
 	// use-csinode-id feature is enabled or not.
 	isCSINodeIdFeatureEnabled bool
-	// isAcceptPreferredDatatsoresFSSEnabled indicates whether the
-	// accept-preferred-datatsores feature is enabled or not.
+	// isAcceptPreferredDatastoresFSSEnabled indicates whether the
+	// accept-preferred-datastores feature is enabled or not.
 	isTopologyPreferentialDatastoresFSSEnabled bool
 }
 
@@ -180,7 +187,7 @@ func (c *K8sOrchestrator) InitTopologyServiceInController(ctx context.Context) (
 				nodeManager := node.GetManager(ctx)
 
 				// Create and start an informer on CSINodeTopology instances.
-				crInformer, err := startTopologyCRInformer(ctx, config)
+				csiNodeTopologyInformer, err = startTopologyCRInformer(ctx, config)
 				if err != nil {
 					log.Errorf("failed to create an informer for CSINodeTopology instances. Error: %+v", err)
 					return nil, err
@@ -192,10 +199,22 @@ func (c *K8sOrchestrator) InitTopologyServiceInController(ctx context.Context) (
 					return nil, err
 				}
 
+				// Set isMultivCenterCluster if the K8s cluster is a multi-VC cluster.
+				isMultiVCSupportEnabled = c.IsFSSEnabled(ctx, common.MultiVCenterCSITopology)
+				if isMultiVCSupportEnabled {
+					cfg, err := common.GetConfig(ctx)
+					if err != nil {
+						return nil, logger.LogNewErrorf(log, "failed to read config. Error: %+v", err)
+					}
+					if len(cfg.VirtualCenter) > 1 {
+						isMultivCenterCluster = true
+					}
+				}
+
 				controllerVolumeTopologyInstance = &controllerVolumeTopology{
 					k8sConfig:                 config,
 					nodeMgr:                   nodeManager,
-					csiNodeTopologyInformer:   *crInformer,
+					csiNodeTopologyInformer:   *csiNodeTopologyInformer,
 					clusterFlavor:             clusterFlavor,
 					isCSINodeIdFeatureEnabled: c.IsFSSEnabled(ctx, common.UseCSINodeId),
 					isTopologyPreferentialDatastoresFSSEnabled: c.IsFSSEnabled(ctx,
@@ -216,7 +235,11 @@ func (c *K8sOrchestrator) InitTopologyServiceInController(ctx context.Context) (
 						for ; true; <-ticker.C {
 							ctx, log := logger.GetNewContextWithLogger()
 							log.Infof("Refreshing preferred datastores information...")
-							err = refreshPreferentialDatastores(ctx)
+							if isMultiVCSupportEnabled {
+								err = common.RefreshPreferentialDatastores(ctx)
+							} else {
+								err = refreshPreferentialDatastores(ctx)
+							}
 							if err != nil {
 								log.Errorf("failed to refresh preferential datastores in cluster. Error: %v", err)
 								os.Exit(1)
@@ -346,6 +369,21 @@ func refreshPreferentialDatastores(ctx context.Context) error {
 	return nil
 }
 
+// GetCSINodeTopologyInstancesList lists out all the CSINodeTopology
+// instances using the K8s informer cache store.
+func (c *K8sOrchestrator) GetCSINodeTopologyInstancesList() []interface{} {
+	nodeTopologyStore := (*csiNodeTopologyInformer).GetStore()
+	return nodeTopologyStore.List()
+}
+
+// GetCSINodeTopologyInstanceByName fetches the CSINodeTopology instance
+// for a given nodeName using the K8s informer cache store.
+func (c *K8sOrchestrator) GetCSINodeTopologyInstanceByName(nodeName string) (
+	item interface{}, exists bool, err error) {
+	nodeTopologyStore := (*csiNodeTopologyInformer).GetStore()
+	return nodeTopologyStore.GetByKey(nodeName)
+}
+
 // startAvailabilityZoneInformer listens on changes to AvailabilityZone instances and updates the azClusterMap cache.
 func startAvailabilityZoneInformer(ctx context.Context, cfg *restclient.Config) (*cache.SharedIndexInformer, error) {
 	log := logger.GetLogger(ctx)
@@ -457,8 +495,8 @@ func startTopologyCRInformer(ctx context.Context, cfg *restclient.Config) (*cach
 			err)
 		return nil, err
 	}
-	csiNodeTopologyInformer := dynInformer.Informer()
-	csiNodeTopologyInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	topologyInformer := dynInformer.Informer()
+	topologyInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		// Typically when the CSINodeTopology instance is created, the
 		// topology labels are not populated till the reconcile loop runs.
 		// However, this Add function will take care of cases where the node
@@ -480,9 +518,9 @@ func startTopologyCRInformer(ctx context.Context, cfg *restclient.Config) (*cach
 	// Start informer.
 	go func() {
 		log.Infof("Informer to watch on %s CR starting..", csinodetopology.CRDSingular)
-		csiNodeTopologyInformer.Run(make(chan struct{}))
+		topologyInformer.Run(make(chan struct{}))
 	}()
-	return &csiNodeTopologyInformer, nil
+	return &topologyInformer, nil
 }
 
 // topoCRAdded checks if the CSINodeTopology instance Status is set to Success
@@ -503,7 +541,14 @@ func topoCRAdded(obj interface{}) {
 			nodeTopoObj.Name, nodeTopoObj.Status.Status)
 		return
 	}
-	addNodeToDomainNodeMap(ctx, nodeTopoObj)
+	if isMultiVCSupportEnabled {
+		common.AddNodeToDomainNodeMapNew(ctx, nodeTopoObj)
+		if isMultivCenterCluster {
+			common.AddLabelsToTopologyVCMap(ctx, nodeTopoObj)
+		}
+	} else {
+		addNodeToDomainNodeMap(ctx, nodeTopoObj)
+	}
 }
 
 // topoCRUpdated checks if the CSINodeTopology instance Status is set to Success
@@ -550,11 +595,25 @@ func topoCRUpdated(oldObj interface{}, newObj interface{}) {
 		log.Warnf("topoCRUpdated: %q instance with name %q has been updated after the Status was set to "+
 			"Success. Old object - %+v. New object - %+v", csinodetopology.CRDSingular, oldNodeTopoObj.Name,
 			oldNodeTopoObj, newNodeTopoObj)
-		removeNodeFromDomainNodeMap(ctx, oldNodeTopoObj)
+		if isMultiVCSupportEnabled {
+			common.RemoveNodeFromDomainNodeMapNew(ctx, oldNodeTopoObj)
+			if isMultivCenterCluster {
+				common.RemoveLabelsFromTopologyVCMap(ctx, oldNodeTopoObj)
+			}
+		} else {
+			removeNodeFromDomainNodeMap(ctx, oldNodeTopoObj)
+		}
 	}
 	// Add the node name to the domainNodeMap if the Status is set to Success.
 	if newNodeTopoObj.Status.Status == csinodetopologyv1alpha1.CSINodeTopologySuccess {
-		addNodeToDomainNodeMap(ctx, newNodeTopoObj)
+		if isMultiVCSupportEnabled {
+			common.AddNodeToDomainNodeMapNew(ctx, newNodeTopoObj)
+			if isMultivCenterCluster {
+				common.AddLabelsToTopologyVCMap(ctx, newNodeTopoObj)
+			}
+		} else {
+			addNodeToDomainNodeMap(ctx, newNodeTopoObj)
+		}
 	}
 }
 
@@ -571,7 +630,14 @@ func topoCRDeleted(obj interface{}) {
 	}
 	// Delete node name from domainNodeMap if the status of the CR was set to Success.
 	if nodeTopoObj.Status.Status == csinodetopologyv1alpha1.CSINodeTopologySuccess {
-		removeNodeFromDomainNodeMap(ctx, nodeTopoObj)
+		if isMultiVCSupportEnabled {
+			common.RemoveNodeFromDomainNodeMapNew(ctx, nodeTopoObj)
+			if isMultivCenterCluster {
+				common.RemoveLabelsFromTopologyVCMap(ctx, nodeTopoObj)
+			}
+		} else {
+			removeNodeFromDomainNodeMap(ctx, nodeTopoObj)
+		}
 	} else {
 		log.Infof("topoCRDeleted: %q instance with name %q and status %q deleted.", csinodetopology.CRDSingular,
 			nodeTopoObj.Name, nodeTopoObj.Status.Status)
@@ -691,6 +757,8 @@ func (volTopology *nodeVolumeTopology) GetNodeTopologyLabels(ctx context.Context
 				return nil, logger.LogNewErrorCodef(log, codes.Internal, msg)
 			}
 		} else {
+			// If CSINodeTopology instance already exists, check if the NodeUUID
+			// parameter in Spec is populated. If not, patch the instance.
 			if csiNodeTopology.Spec.NodeUUID == "" ||
 				csiNodeTopology.Spec.NodeUUID != nodeInfo.NodeID {
 				if csiNodeTopology.Spec.NodeUUID == "" {
@@ -1244,7 +1312,8 @@ func (volTopology *controllerVolumeTopology) GetTopologyInfoFromNodes(ctx contex
 			continue
 		}
 
-		// Check if the topology segments retrieved from node are already present.
+		// Check if the topology segments retrieved from node are
+		// already present, else add it to topologySegments.
 		var alreadyExists bool
 		for _, topoMap := range topologySegments {
 			if reflect.DeepEqual(topoMap, topoLabels) {
@@ -1299,7 +1368,7 @@ func (volTopology *controllerVolumeTopology) GetTopologyInfoFromNodes(ctx contex
 		}
 	}
 
-	// Check for each calculated topology segment if all nodes in that segment have access to this datastore.
+	// Check for each calculated topology segment to see if all nodes in that segment have access to this datastore.
 	// This check will filter out topology segments in which all nodes do not have access to the chosen datastore.
 	accessibleTopology, err := verifyAllNodesInTopologyAccessibleToDatastore(ctx, params.NodeNames,
 		params.DatastoreURL, topologySegments)

--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -1,0 +1,320 @@
+package placementengine
+
+import (
+	"context"
+	"reflect"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
+	csinodetopologyv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1"
+)
+
+func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
+	[]*cnsvsphere.DatastoreInfo, error) {
+	log := logger.GetLogger(ctx)
+	params := reqParams.(VanillaSharedDatastoresParams)
+	var sharedDatastores []*cnsvsphere.DatastoreInfo
+	nodeMgr := node.GetManager(ctx)
+
+	// Iterate through each set of topology segments and find shared datastores for that segment.
+	for _, segments := range params.TopologySegmentsList {
+		// Fetch nodes compatible with the requested topology segments.
+		matchingNodeVMs, completeTopologySegments, err := getTopologySegmentsWithMatchingNodes(ctx,
+			segments, nodeMgr)
+		if err != nil {
+			return nil, logger.LogNewErrorf(log, "failed to find nodes in topology segment %+v. Error: %+v",
+				segments, err)
+		}
+		if len(matchingNodeVMs) == 0 {
+			log.Warnf("No nodes in the cluster matched the topology requirement provided: %+v",
+				segments)
+			continue
+		}
+		log.Infof("Obtained list of nodeVMs %+v", matchingNodeVMs)
+
+		// Fetch shared datastores for the matching nodeVMs.
+		sharedDatastoresInTopology, err := cnsvsphere.GetSharedDatastoresForVMs(ctx, matchingNodeVMs)
+		if err != nil {
+			if err == cnsvsphere.ErrNoSharedDatastoresFound {
+				log.Errorf("no shared datastores found for topology segment: %+v", segments)
+				continue
+			}
+			return nil, logger.LogNewErrorf(log, "failed to get shared datastores for nodes: %+v "+
+				"in topology segment %+v. Error: %+v", matchingNodeVMs, segments, err)
+		}
+		log.Infof("Obtained list of shared datastores as %+v", sharedDatastoresInTopology)
+
+		// Check storage policy compatibility, if given.
+		// Datastore comparison by moref.
+		if params.StoragePolicyID != "" {
+			var sharedDSMoRef []vimtypes.ManagedObjectReference
+			for _, ds := range sharedDatastoresInTopology {
+				sharedDSMoRef = append(sharedDSMoRef, ds.Reference())
+			}
+			compat, err := params.Vcenter.PbmCheckCompatibility(ctx, sharedDSMoRef, params.StoragePolicyID)
+			if err != nil {
+				return nil, logger.LogNewErrorf(log, "failed to find datastore compatibility "+
+					"with storage policy ID %q. Error: %+v", params.StoragePolicyID, err)
+			}
+			compatibleDsMoids := make(map[string]struct{})
+			for _, ds := range compat.CompatibleDatastores() {
+				compatibleDsMoids[ds.HubId] = struct{}{}
+			}
+			log.Infof("Datastores compatible with storage policy %q are %+v", params.StoragePolicyID,
+				compatibleDsMoids)
+
+			// Filter compatible datastores from shared datastores list.
+			var compatibleDatastores []*cnsvsphere.DatastoreInfo
+			for _, ds := range sharedDatastoresInTopology {
+				if _, exists := compatibleDsMoids[ds.Reference().Value]; exists {
+					compatibleDatastores = append(compatibleDatastores, ds)
+				}
+			}
+			if len(compatibleDatastores) == 0 {
+				log.Errorf("No compatible shared datastores found for storage policy %q",
+					params.StoragePolicyID)
+				continue
+			}
+			sharedDatastoresInTopology = compatibleDatastores
+		}
+		// Further, filter the compatible datastores with preferential datastores, if any.
+		// Datastore comparison by URL.
+		if common.PreferredDatastoresExist {
+			// Fetch all preferred datastore URLs for the matching topology segments.
+			allPreferredDSURLs := make(map[string]struct{})
+			for _, topoSegs := range completeTopologySegments {
+				prefDS := common.GetPreferredDatastoresInSegments(ctx, topoSegs, params.Vcenter.Config.Host)
+				for key, val := range prefDS {
+					allPreferredDSURLs[key] = val
+				}
+			}
+			if len(allPreferredDSURLs) != 0 {
+				// If there are preferred datastores among the compatible
+				// datastores, choose the preferred datastores, otherwise
+				// choose the compatible datastores.
+				var preferredDS []*cnsvsphere.DatastoreInfo
+				for _, dsInfo := range sharedDatastoresInTopology {
+					if _, ok := allPreferredDSURLs[dsInfo.Info.Url]; ok {
+						preferredDS = append(preferredDS, dsInfo)
+					}
+				}
+				if len(preferredDS) != 0 {
+					sharedDatastoresInTopology = preferredDS
+					log.Infof("Using preferred datastores: %+v", preferredDS)
+				}
+			}
+		}
+
+		// Update sharedDatastores with the list of datastores received.
+		// Duplicates will not be added.
+		for _, ds := range sharedDatastoresInTopology {
+			var found bool
+			for _, sharedDS := range sharedDatastores {
+				if sharedDS.Info.Url == ds.Info.Url {
+					found = true
+					break
+				}
+			}
+			if !found {
+				sharedDatastores = append(sharedDatastores, ds)
+			}
+		}
+	}
+	if len(sharedDatastores) != 0 {
+		log.Infof("Shared compatible datastores being considered for volume provisioning are: %+v",
+			sharedDatastores)
+	}
+	return sharedDatastores, nil
+}
+
+func getTopologySegmentsWithMatchingNodes(ctx context.Context, requestedSegments map[string]string,
+	nodeMgr node.Manager) ([]*cnsvsphere.VirtualMachine, []map[string]string, error) {
+	log := logger.GetLogger(ctx)
+
+	var (
+		vcHost                   string
+		matchingNodeVMs          []*cnsvsphere.VirtualMachine
+		completeTopologySegments []map[string]string
+	)
+	// Fetch node topology information from informer cache.
+	for _, val := range commonco.ContainerOrchestratorUtility.GetCSINodeTopologyInstancesList() {
+		var nodeTopologyInstance csinodetopologyv1alpha1.CSINodeTopology
+		// Validate the object received.
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(val.(*unstructured.Unstructured).Object,
+			&nodeTopologyInstance)
+		if err != nil {
+			return nil, nil, logger.LogNewErrorf(log, "failed to convert unstructured object %+v to "+
+				"CSINodeTopology instance. Error: %+v", val, err)
+		}
+
+		// Check CSINodeTopology instance `Status` field for success.
+		if nodeTopologyInstance.Status.Status != csinodetopologyv1alpha1.CSINodeTopologySuccess {
+			return nil, nil, logger.LogNewErrorf(log, "node %q not yet ready. Found CSINodeTopology instance "+
+				"status: %q with error message: %q", nodeTopologyInstance.Name, nodeTopologyInstance.Status.Status,
+				nodeTopologyInstance.Status.ErrorMessage)
+		}
+		// Convert array of labels to map.
+		topoLabelsMap := make(map[string]string)
+		for _, topoLabel := range nodeTopologyInstance.Status.TopologyLabels {
+			topoLabelsMap[topoLabel.Key] = topoLabel.Value
+		}
+		// Check for a match of labels in every segment.
+		isMatch := true
+		for key, value := range requestedSegments {
+			if topoLabelsMap[key] != value {
+				log.Debugf("Node %q with topology %+v did not match the topology requirement - %q: %q ",
+					nodeTopologyInstance.Name, topoLabelsMap, key, value)
+				isMatch = false
+				break
+			}
+		}
+		// If there is a match, fetch the nodeVM object and add it to matchingNodeVMs.
+		if isMatch {
+			nodeVM, err := nodeMgr.GetNode(ctx, nodeTopologyInstance.Spec.NodeUUID, nil)
+			if err != nil {
+				return nil, nil, logger.LogNewErrorf(log,
+					"failed to retrieve NodeVM %q. Error - %+v", nodeTopologyInstance.Spec.NodeID, err)
+			}
+			// Check if each compatible NodeVM belongs to the same VC. If not,
+			// error out as we do not support cross-zonal volume provisioning.
+			if vcHost == "" {
+				vcHost = nodeVM.VirtualCenterHost
+			} else if vcHost != nodeVM.VirtualCenterHost {
+				return nil, nil, logger.LogNewErrorf(log,
+					"found NodeVM %q belonging to different vCenter: %q. Expected vCenter: %q",
+					nodeVM.Name(), nodeVM.VirtualCenterHost, vcHost)
+			}
+			matchingNodeVMs = append(matchingNodeVMs, nodeVM)
+
+			// Store the complete hierarchy of topology requestedSegments for future use.
+			var exists bool
+			for _, segs := range completeTopologySegments {
+				if reflect.DeepEqual(segs, topoLabelsMap) {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				completeTopologySegments = append(completeTopologySegments, topoLabelsMap)
+			}
+		}
+	}
+	return matchingNodeVMs, completeTopologySegments, nil
+}
+
+// GetTopologyInfoFromNodes retrieves the topology information of the given
+// list of node names using the information from CSINodeTopology instances.
+func GetTopologyInfoFromNodes(ctx context.Context, reqParams interface{}) (
+	[]map[string]string, error) {
+	log := logger.GetLogger(ctx)
+	params := reqParams.(VanillaRetrieveTopologyInfoParams)
+	var topologySegments []map[string]string
+
+	// Fetch node topology information from informer cache.
+	for _, nodeName := range params.NodeNames {
+		// Fetch CSINodeTopology instance using node name.
+		item, exists, err := commonco.ContainerOrchestratorUtility.GetCSINodeTopologyInstanceByName(nodeName)
+		if err != nil || !exists {
+			return nil, logger.LogNewErrorf(log, "failed to find a CSINodeTopology instance with name: %q. "+
+				"Error: %+v", nodeName, err)
+		}
+
+		// Validate the object received.
+		var nodeTopologyInstance csinodetopologyv1alpha1.CSINodeTopology
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(item.(*unstructured.Unstructured).Object,
+			&nodeTopologyInstance)
+		if err != nil {
+			return nil, logger.LogNewErrorf(log, "failed to convert unstructured object %+v to "+
+				"CSINodeTopology instance. Error: %+v", item, err)
+		}
+		// Check the status of CSINodeTopology instance.
+		if nodeTopologyInstance.Status.Status != csinodetopologyv1alpha1.CSINodeTopologySuccess {
+			return nil, logger.LogNewErrorf(log, "CSINodeTopology instance with name: %q and Status: %q not "+
+				"ready yet", nodeName, nodeTopologyInstance.Status.Status)
+		}
+
+		// Convert array of labels in instance to map.
+		topoLabels := make(map[string]string)
+		for _, topoLabel := range nodeTopologyInstance.Status.TopologyLabels {
+			topoLabels[topoLabel.Key] = topoLabel.Value
+		}
+		// Check if topology labels received are empty.
+		if len(topoLabels) == 0 {
+			log.Infof("Node %q does not belong to any topology domain. Skipping it for node "+
+				"affinity calculation", nodeName)
+			continue
+		}
+
+		// Check if the topology segments retrieved from node are already present, else add it to topologySegments.
+		var alreadyExists bool
+		for _, topoMap := range topologySegments {
+			if reflect.DeepEqual(topoMap, topoLabels) {
+				alreadyExists = true
+				break
+			}
+		}
+		if !alreadyExists {
+			topologySegments = append(topologySegments, topoLabels)
+		}
+	}
+	log.Infof("Topology segments retrieved from nodes accessible to datastore %q are: %+v",
+		params.DatastoreURL, topologySegments)
+
+	// If the datastore is accessible from only one segment, return with it.
+	if len(topologySegments) == 1 {
+		return topologySegments, nil
+	}
+
+	// If the selected datastore is preferred in a zone which matches the topology requirement
+	// given by customer, set this zone as the node affinity terms.
+	if common.PreferredDatastoresExist {
+		// Get the intersection between topology requirements and accessible topology domains for given datastore URL.
+		var combinedAccessibleTopology []map[string]string
+		for _, reqSegments := range params.RequestedTopologySegments {
+			for _, segments := range topologySegments {
+				isMatchingTopoReq := true
+				for reqCategory, reqTag := range reqSegments {
+					if tag, ok := segments[reqCategory]; ok && tag != reqTag {
+						isMatchingTopoReq = false
+						break
+					}
+				}
+				if isMatchingTopoReq {
+					combinedAccessibleTopology = append(combinedAccessibleTopology, segments)
+				}
+			}
+		}
+		// Finally, filter the accessible topologies with topology domains where datastore is preferred.
+		var preferredAccessibleTopology []map[string]string
+		for _, segments := range combinedAccessibleTopology {
+			PreferredDSURLs := common.GetPreferredDatastoresInSegments(ctx, segments, params.VCHost)
+			if len(PreferredDSURLs) != 0 {
+				if _, ok := PreferredDSURLs[params.DatastoreURL]; ok {
+					preferredAccessibleTopology = append(preferredAccessibleTopology, segments)
+				}
+			}
+		}
+		if len(preferredAccessibleTopology) != 0 {
+			return preferredAccessibleTopology, nil
+		}
+	}
+
+	// Check for each calculated topology segment to see if all nodes in that segment have access to this datastore.
+	// This check will filter out topology segments in which all nodes do not have access to the chosen datastore.
+	accessibleTopology, err := common.VerifyAllNodesInTopologyAccessibleToDatastore(ctx, params.NodeNames,
+		params.DatastoreURL, topologySegments)
+	if err != nil {
+		return nil, logger.LogNewErrorf(log, "failed to verify if all nodes in the topology segments "+
+			"retrieved are accessible to datastore %q. Error: %+v", params.DatastoreURL, err)
+	}
+	log.Infof("Accessible topology calculated for datastore %q is %+v",
+		params.DatastoreURL, accessibleTopology)
+	return accessibleTopology, nil
+}

--- a/pkg/csi/service/common/placementengine/types.go
+++ b/pkg/csi/service/common/placementengine/types.go
@@ -1,0 +1,42 @@
+package placementengine
+
+import cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
+
+// VanillaRetrieveTopologyInfoParams represents the params
+// required to be able to call GetTopologyInfoFromNodes in
+// vanilla cluster.
+type VanillaRetrieveTopologyInfoParams struct {
+	// VCHost is the vCenter IP/FQDN in which volume
+	// provisioning is being attempted.
+	VCHost string
+	// NodeNames is the list of node names which have
+	// access to the selected datastore.
+	NodeNames []string
+	// DatastoreURL is the selected datastore for which the topology
+	// information needs to be retrieved.
+	DatastoreURL string
+	// RequestedTopologySegments represents the topology segments
+	// which need to be satisfied during volume provisioning for a particular VC.
+	RequestedTopologySegments []map[string]string
+	// IsTopologyPreferentialDatastoresFSSEnabled determines the
+	// state of topology-preferential-datastores FSS.
+	IsTopologyPreferentialDatastoresFSSEnabled bool
+}
+
+// VanillaSharedDatastoresParams represents the params
+// required to be able to call GetSharedDatastores function.
+type VanillaSharedDatastoresParams struct {
+	// Vcenter holds the client connection to the VC on
+	// which volume provisioning is being attempted.
+	Vcenter *cnsvsphere.VirtualCenter
+	// TopologySegmentsList is the list of topology segments
+	// which represent the accessibility requirements for the volume provisioning request.
+	TopologySegmentsList []map[string]string
+	// StoragePolicyID represents the unique ID of the storage policy
+	// name given in the Storage Class on the attempted VC.
+	StoragePolicyID string
+	// IsCSINodeIdFeatureEnabled is the FSS state for use-csinode-id.
+	IsCSINodeIdFeatureEnabled bool
+	// IsTopologyPreferentialDatastoresFSSEnabled is the FSS state for topology-preferential-datastores.
+	IsTopologyPreferentialDatastoresFSSEnabled bool
+}

--- a/pkg/csi/service/common/topology.go
+++ b/pkg/csi/service/common/topology.go
@@ -1,0 +1,360 @@
+package common
+
+import (
+	"context"
+	"sync"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
+	csinodetopologyv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1"
+)
+
+var (
+	// domainNodeMap maintains a cache of topology tags to the node names under that tag.
+	// Example - {region1: {Node1: struct{}{}, Node2: struct{}{}},
+	//            zone1: {Node1: struct{}{}},
+	//            zone2: {Node2: struct{}{}}}
+	// The nodes under each tag are maintained as a map of string with nil values to improve
+	// retrieval and deletion performance.
+	// CAUTION: This technique requires that tag values should not be repeated across
+	// categories i.e using `us-east` as a region and as a zone is not allowed.
+	domainNodeMap = make(map[string]map[string]struct{})
+	// domainNodeMapInstanceLock guards the domainNodeMap instance from concurrent writes.
+	domainNodeMapInstanceLock = &sync.RWMutex{}
+	// PreferredDatastoresExist signifies if preferred datastores are present in the cluster.
+	PreferredDatastoresExist bool
+	// preferredDatastoresMap is a map of topology domain to list of
+	// datastore URLs preferred in that domain for each VC.
+	// Ex: {"vc1": {"zone1": [DSURL1, DSURL2], "zone2": [DSURL3]}, "vc2": {"zone3": [DSURL5]} }
+	preferredDatastoresMap = make(map[string]map[string][]string)
+	// preferredDatastoresMapInstanceLock guards the preferredDatastoresMap from read-write overlaps.
+	preferredDatastoresMapInstanceLock = &sync.RWMutex{}
+	// topologyVCMapInstanceLock guards the topologyVCMap instance from concurrent writes.
+	topologyVCMapInstanceLock = &sync.RWMutex{}
+	// topologyVCMap maintains a cache of topology tags to the vCenter IP/FQDN which holds the tag.
+	// Example - {region1: {VC1: struct{}{}, VC2: struct{}{}},
+	//            zone1: {VC1: struct{}{}},
+	//            zone2: {VC2: struct{}{}}}
+	// The vCenter IP/FQDN under each tag are maintained as a map of string with nil values to improve
+	// retrieval and deletion performance.
+	topologyVCMap = make(map[string]map[string]struct{})
+)
+
+// GetAccessibilityRequirementsByVC clubs the accessibility requirements by the VC they belong to.
+func GetAccessibilityRequirementsByVC(ctx context.Context, topoReq *csi.TopologyRequirement) (
+	map[string][]map[string]string, error) {
+	log := logger.GetLogger(ctx)
+	// NOTE: We are only checking for preferred segments as vSphere CSI driver follows strict topology.
+	if topoReq.GetPreferred() == nil {
+		return nil, logger.LogNewErrorf(log, "No preferred segments specified in the "+
+			"accessibility requirements.")
+	}
+	vcTopoSegmentsMap := make(map[string][]map[string]string)
+	for _, topology := range topoReq.GetPreferred() {
+		segments := topology.GetSegments()
+		vcHost, err := getVCForTopologySegments(ctx, segments)
+		if err != nil {
+			return nil, logger.LogNewErrorf(log, "failed to fetch vCenter associated with topology segments %+v",
+				segments)
+		}
+		vcTopoSegmentsMap[vcHost] = append(vcTopoSegmentsMap[vcHost], segments)
+	}
+	return vcTopoSegmentsMap, nil
+}
+
+// getVCForTopologySegments uses the topologyVCMap to retrieve the
+// VC instance for the given topology segments map in a multi-VC environment.
+func getVCForTopologySegments(ctx context.Context, topologySegments map[string]string) (string, error) {
+	log := logger.GetLogger(ctx)
+	// vcCountMap keeps a cumulative count of the occurrences of
+	// VCs across all labels in the given topology segment.
+	vcCountMap := make(map[string]int)
+
+	// Find the VC which contains all the labels given in the topologySegments.
+	// For example, if topologyVCMap looks like
+	// {"region-1": {"vc1": struct{}{}, "vc2": struct{}{} },
+	// "zone-1": {"vc1": struct{}{} },
+	// "zone-2": {"vc2": struct{}{} },}
+	// For a given topologySegment
+	// {"topology.csi.vmware.com/k8s-region": "region-1",
+	// "topology.csi.vmware.com/k8s-zone": "zone-2"}
+	// we will end up with a vcCountMap as follows: {"vc1": 1, "vc2": 2}
+	// We go over the vcCountMap to check which VC has a count equal to
+	// the len(topologySegment), in this case 2 and return that VC.
+	for topologyKey, label := range topologySegments {
+		if vcList, exists := topologyVCMap[label]; exists {
+			for vc := range vcList {
+				vcCountMap[vc] = vcCountMap[vc] + 1
+			}
+		} else {
+			return "", logger.LogNewErrorf(log, "Topology label %q not found in topology to vCenter mapping.",
+				topologyKey+":"+label)
+		}
+	}
+	var commonVCList []string
+	numTopoLabels := len(topologySegments)
+	for vc, count := range vcCountMap {
+		// Add VCs to the commonVCList if they satisfied all the labels in the topology segment.
+		if count == numTopoLabels {
+			commonVCList = append(commonVCList, vc)
+		}
+	}
+	switch {
+	case len(commonVCList) > 1:
+		return "", logger.LogNewErrorf(log, "Topology segment(s) %+v belong to more than one vCenter: %+v",
+			topologySegments, commonVCList)
+	case len(commonVCList) == 1:
+		log.Infof("Topology segment(s) %+v belong to vCenter: %q", topologySegments, commonVCList[0])
+		return commonVCList[0], nil
+	}
+	return "", logger.LogNewErrorf(log, "failed to find the vCenter associated with topology segments %+v",
+		topologySegments)
+}
+
+// RefreshPreferentialDatastores refreshes the preferredDatastoresMap variable
+// with latest information on the preferential datastores for each topology domain.
+func RefreshPreferentialDatastores(ctx context.Context) error {
+	log := logger.GetLogger(ctx)
+	cnsCfg, err := GetConfig(ctx)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to fetch CNS config. Error: %+v", err)
+	}
+	vcenterconfigs, err := cnsvsphere.GetVirtualCenterConfigs(ctx, cnsCfg)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to get VirtualCenterConfig from CNS config. Error: %+v", err)
+	}
+	prefDatastoresMap := make(map[string]map[string][]string)
+	for _, vcConfig := range vcenterconfigs {
+		// Get VC instance.
+		vcMgr := cnsvsphere.GetVirtualCenterManager(ctx)
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to get vCenter manager instance. Error: %+v", err)
+		}
+		vc, err := GetVCenterFromVCHost(ctx, vcMgr, vcConfig.Host)
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to get vCenter instance for host %q. Error: %+v",
+				vcConfig.Host, err)
+		}
+		// Get tag manager instance.
+		tagMgr, err := cnsvsphere.GetTagManager(ctx, vc)
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to create tag manager for vCenter %q. Error: %+v",
+				vcConfig.Host, err)
+		}
+		defer func() {
+			err := tagMgr.Logout(ctx)
+			if err != nil {
+				log.Errorf("failed to logout tagManager for vCenter %q. Error: %v", vcConfig.Host, err)
+			}
+		}()
+		// Get tags for category reserved for preferred datastore tagging.
+		tagIds, err := tagMgr.ListTagsForCategory(ctx, PreferredDatastoresCategory)
+		if err != nil {
+			log.Infof("failed to retrieve tags for category %q in vCenter %q. Reason: %+v",
+				PreferredDatastoresCategory, vcConfig.Host, err)
+			return nil
+		}
+		if len(tagIds) == 0 {
+			log.Infof("No preferred datastores found in vCenter %q.", vcConfig.Host)
+			return nil
+		}
+		// Fetch vSphere entities on which the tags have been applied.
+		prefDatastoresMap[vcConfig.Host] = make(map[string][]string)
+		attachedObjs, err := tagMgr.GetAttachedObjectsOnTags(ctx, tagIds)
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to retrieve objects with tags %v in vCenter %q. Error: %+v",
+				tagIds, vcConfig.Host, err)
+		}
+		for _, attachedObj := range attachedObjs {
+			for _, obj := range attachedObj.ObjectIDs {
+				// Preferred datastore tag should only be applied to datastores.
+				if obj.Reference().Type != "Datastore" {
+					log.Warnf("Preferred datastore tag applied on a non-datastore entity: %+v",
+						obj.Reference())
+					continue
+				}
+				// Fetch Datastore URL.
+				var dsMo mo.Datastore
+				dsObj := object.NewDatastore(vc.Client.Client, obj.Reference())
+				err = dsObj.Properties(ctx, obj.Reference(), []string{"summary"}, &dsMo)
+				if err != nil {
+					return logger.LogNewErrorf(log, "failed to retrieve summary from datastore: %+v in vCenter %q."+
+						" Error: %v", obj.Reference(), vcConfig.Host, err)
+				}
+
+				log.Infof("Datastore %q with URL %q is preferred in %q domain in vCenter %q", dsMo.Summary.Name,
+					dsMo.Summary.Url, attachedObj.Tag.Name, vcConfig.Host)
+				// For each topology domain, store the datastore URLs preferred in that domain.
+				prefDatastoresMap[vcConfig.Host][attachedObj.Tag.Name] = append(
+					prefDatastoresMap[vcConfig.Host][attachedObj.Tag.Name], dsMo.Summary.Url)
+			}
+		}
+	}
+	// Finally, write to cache.
+	if len(prefDatastoresMap) != 0 {
+		preferredDatastoresMapInstanceLock.Lock()
+		defer preferredDatastoresMapInstanceLock.Unlock()
+		preferredDatastoresMap = prefDatastoresMap
+		PreferredDatastoresExist = true
+	}
+	return nil
+}
+
+// GetPreferredDatastoresInSegments fetches preferred datastores in
+// given topology segments as a map for faster retrieval.
+func GetPreferredDatastoresInSegments(ctx context.Context, segments map[string]string,
+	vcHost string) map[string]struct{} {
+	log := logger.GetLogger(ctx)
+	allPreferredDSURLs := make(map[string]struct{})
+
+	preferredDatastoresMapInstanceLock.Lock()
+	defer preferredDatastoresMapInstanceLock.Unlock()
+	if len(preferredDatastoresMap) == 0 || len(preferredDatastoresMap[vcHost]) == 0 {
+		return allPreferredDSURLs
+	}
+	// Arrange applicable preferred datastores as a map.
+	for _, tag := range segments {
+		preferredDS, ok := preferredDatastoresMap[vcHost][tag]
+		if ok {
+			log.Infof("Found preferred datastores %+v for topology domain %q in vCenter %q", preferredDS, tag, vcHost)
+			for _, val := range preferredDS {
+				allPreferredDSURLs[val] = struct{}{}
+			}
+		}
+	}
+	return allPreferredDSURLs
+}
+
+// AddLabelsToTopologyVCMap adds topology label to VC mapping for given CSINodeTopology instance
+// in the topologyVCMap variable.
+func AddLabelsToTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopologyv1alpha1.CSINodeTopology) {
+	log := logger.GetLogger(ctx)
+	// Get node manager instance.
+	nodeManager := node.GetManager(ctx)
+	nodeVM, err := nodeManager.GetNode(ctx, nodeTopoObj.Spec.NodeUUID, nil)
+	if err != nil {
+		log.Errorf("Node %q is not yet registered in the node manager. Error: %+v",
+			nodeTopoObj.Spec.NodeUUID, err)
+		return
+	}
+	log.Infof("Topology labels %+v belong to %q VC", nodeTopoObj.Status.TopologyLabels,
+		nodeVM.VirtualCenterHost)
+	// Update topologyVCMap with topology label and associated VC host.
+	topologyVCMapInstanceLock.Lock()
+	defer topologyVCMapInstanceLock.Unlock()
+	for _, label := range nodeTopoObj.Status.TopologyLabels {
+		if _, exists := topologyVCMap[label.Value]; !exists {
+			topologyVCMap[label.Value] = map[string]struct{}{nodeVM.VirtualCenterHost: {}}
+		} else {
+			topologyVCMap[label.Value][nodeVM.VirtualCenterHost] = struct{}{}
+		}
+	}
+}
+
+// RemoveLabelsFromTopologyVCMap removes the topology label to VC mapping for given CSINodeTopology
+// instance in the topologyVCMap variable.
+func RemoveLabelsFromTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopologyv1alpha1.CSINodeTopology) {
+	log := logger.GetLogger(ctx)
+	// Get node manager instance.
+	nodeManager := node.GetManager(ctx)
+	nodeVM, err := nodeManager.GetNode(ctx, nodeTopoObj.Spec.NodeUUID, nil)
+	if err != nil {
+		log.Errorf("Node %q is not yet registered in the node manager. Error: %+v",
+			nodeTopoObj.Spec.NodeUUID, err)
+		return
+	}
+	log.Infof("Removing VC %q mapping for TopologyLabels %+v.", nodeVM.VirtualCenterHost,
+		nodeTopoObj.Status.TopologyLabels)
+	topologyVCMapInstanceLock.Lock()
+	defer topologyVCMapInstanceLock.Unlock()
+	for _, label := range nodeTopoObj.Status.TopologyLabels {
+		delete(topologyVCMap[label.Value], nodeVM.VirtualCenterHost)
+	}
+}
+
+// AddNodeToDomainNodeMapNew adds the CR instance name in the domainNodeMap wherever appropriate.
+func AddNodeToDomainNodeMapNew(ctx context.Context, nodeTopoObj csinodetopologyv1alpha1.CSINodeTopology) {
+	log := logger.GetLogger(ctx)
+	domainNodeMapInstanceLock.Lock()
+	defer domainNodeMapInstanceLock.Unlock()
+	for _, label := range nodeTopoObj.Status.TopologyLabels {
+		if _, exists := domainNodeMap[label.Value]; !exists {
+			domainNodeMap[label.Value] = map[string]struct{}{nodeTopoObj.Name: {}}
+		} else {
+			domainNodeMap[label.Value][nodeTopoObj.Name] = struct{}{}
+		}
+	}
+	log.Infof("Added %q value to domainNodeMap", nodeTopoObj.Name)
+}
+
+// RemoveNodeFromDomainNodeMapNew removes the CR instance name from the domainNodeMap.
+func RemoveNodeFromDomainNodeMapNew(ctx context.Context, nodeTopoObj csinodetopologyv1alpha1.CSINodeTopology) {
+	log := logger.GetLogger(ctx)
+	domainNodeMapInstanceLock.Lock()
+	defer domainNodeMapInstanceLock.Unlock()
+	for _, label := range nodeTopoObj.Status.TopologyLabels {
+		delete(domainNodeMap[label.Value], nodeTopoObj.Name)
+	}
+	log.Infof("Removed %q value from domainNodeMap", nodeTopoObj.Name)
+}
+
+// VerifyAllNodesInTopologyAccessibleToDatastore verifies whether all the nodes present
+// in a topology segment have access to the given datastore.
+func VerifyAllNodesInTopologyAccessibleToDatastore(ctx context.Context, nodeNames []string,
+	datastoreURL string, topologySegments []map[string]string) ([]map[string]string, error) {
+	log := logger.GetLogger(ctx)
+
+	// Create a map of nodeNames for easy retrieval later on.
+	accessibleNodeNamesMap := make(map[string]struct{})
+	for _, name := range nodeNames {
+		accessibleNodeNamesMap[name] = struct{}{}
+	}
+	// Check if for each topology segment, all the nodes in that segment have access to the chosen datastore.
+	var accessibleTopology []map[string]string
+	for _, segments := range topologySegments {
+		// Create slice of all tag values in the given segments.
+		var tagValues []string
+		for _, tag := range segments {
+			tagValues = append(tagValues, tag)
+		}
+		if len(tagValues) == 0 {
+			continue
+		}
+		// Find the intersection of node names for all the tagValues using the domainNodeMap cached values.
+		var nodesInSegment []string
+		for nodeName := range domainNodeMap[tagValues[0]] {
+			isPresent := true
+			for _, otherTag := range tagValues[1:] {
+				if _, exists := domainNodeMap[otherTag][nodeName]; !exists {
+					isPresent = false
+					break
+				}
+			}
+			if isPresent {
+				// nodeName is present in each of the segments.
+				nodesInSegment = append(nodesInSegment, nodeName)
+			}
+		}
+		log.Debugf("Nodes %+v belong to topology segment %+v", nodesInSegment, segments)
+		// Find if nodesInSegment is a subset of the accessibleNodeNamesMap. If yes, that means all
+		// the nodes in the given list of segments have access to the chosen datastore.
+		isSubset := true
+		for _, segNode := range nodesInSegment {
+			if _, exists := accessibleNodeNamesMap[segNode]; !exists {
+				log.Infof("Node %q in topology segment %+v does not have access to datastore %q", segNode,
+					segments, datastoreURL)
+				isSubset = false
+				break
+			}
+		}
+		if isSubset {
+			accessibleTopology = append(accessibleTopology, segments)
+		}
+	}
+	return accessibleTopology, nil
+}

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
@@ -95,14 +96,26 @@ func GetVCenterFromVCHost(ctx context.Context, vCenterManager cnsvsphere.Virtual
 	vcenter, err := vCenterManager.GetVirtualCenter(ctx, vCenterHost)
 	if err != nil {
 		return nil, logger.LogNewErrorf(log,
-			"failed to get VirtualCenter instance for VChost: %q. err=%v", vCenterHost, err)
+			"failed to get VirtualCenter instance for VC host: %q. Error: %v", vCenterHost, err)
 	}
 	err = vcenter.Connect(ctx)
 	if err != nil {
 		return nil, logger.LogNewErrorf(log,
-			"failed to connect to VirtualCenter host: %q. err=%v", vCenterHost, err)
+			"failed to connect to VirtualCenter host: %q. Error: %v", vCenterHost, err)
 	}
 	return vcenter, nil
+}
+
+// GetVolumeManagerFromVCHost retreives the volume manager associated with
+// vCenterHost under managers. Error out if the vCenterHost does not exist.
+func GetVolumeManagerFromVCHost(ctx context.Context, managers *Managers, vCenterHost string) (
+	cnsvolume.Manager, error) {
+	log := logger.GetLogger(ctx)
+	volumeMgr, exists := managers.VolumeManagers[vCenterHost]
+	if !exists {
+		return nil, logger.LogNewErrorf(log, "failed to find vCenter %q under volume managers.", vCenterHost)
+	}
+	return volumeMgr, nil
 }
 
 // GetUUIDFromProviderID Returns VM UUID from Node's providerID.

--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -220,13 +220,16 @@ func getBlockVolumeIDToNodeUUIDMap(ctx context.Context, c *controller,
 func getVCenterAndVolumeManagerForVolumeID(ctx context.Context, controller *controller, volumeId string,
 	volumeInfoService cnsvolumeinfo.VolumeInfoService) (string, cnsvolume.Manager, error) {
 	log := logger.GetLogger(ctx)
-	var volumeManager cnsvolume.Manager
-	var volumeManagerfound bool
-	var vCenter string
+	var (
+		volumeManager      cnsvolume.Manager
+		volumeManagerfound bool
+		vCenter            string
+		err                error
+	)
 	if multivCenterCSITopologyEnabled {
 		if len(controller.managers.VcenterConfigs) > 1 {
 			// Multi vCenter Deployment
-			vCenter, err := volumeInfoService.GetvCenterForVolumeID(ctx, volumeId)
+			vCenter, err = volumeInfoService.GetvCenterForVolumeID(ctx, volumeId)
 			if err != nil {
 				return "", nil, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to get vCenter for the volumeID: %q with err=%+v", volumeId, err)
@@ -240,7 +243,8 @@ func getVCenterAndVolumeManagerForVolumeID(ctx context.Context, controller *cont
 			vCenterConfig, vCenterFound := controller.managers.VcenterConfigs[controller.managers.CnsConfig.Global.VCenterIP]
 			if !vCenterFound {
 				return "", nil, logger.LogNewErrorCodef(log, codes.Internal,
-					"could not get vCenter config for the vCenter: %q", controller.managers.CnsConfig.Global.VCenterIP)
+					"could not get vCenter config for the vCenter: %q",
+					controller.managers.CnsConfig.Global.VCenterIP)
 			}
 			vCenter = vCenterConfig.Host
 			if volumeManager, volumeManagerfound =

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/simulator/vpx"
-	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -274,10 +273,8 @@ func (f *FakeNodeManager) GetAllNodes(ctx context.Context) ([]*cnsvsphere.Virtua
 	return nil, nil
 }
 
-func (f *FakeNodeManager) GetSharedDatastoresInTopology(ctx context.Context,
-	topologyRequirement *csi.TopologyRequirement, tagManager *tags.Manager,
-	zoneKey string, regionKey string) ([]*cnsvsphere.DatastoreInfo, map[string][]map[string]string, error) {
-	return nil, nil, nil
+func (f *FakeNodeManager) GetAllNodesByVC(ctx context.Context, vcHost string) ([]*cnsvsphere.VirtualMachine, error) {
+	return nil, nil
 }
 
 func (f *FakeAuthManager) GetDatastoreMapForBlockVolumes(ctx context.Context) map[string]*cnsvsphere.DatastoreInfo {

--- a/pkg/internalapis/cnsvolumeinfo/cnsvolumeinfoservice.go
+++ b/pkg/internalapis/cnsvolumeinfo/cnsvolumeinfoservice.go
@@ -112,6 +112,7 @@ func (volumeInfo *volumeInfo) GetvCenterForVolumeID(ctx context.Context, volumeI
 	if err != nil {
 		return "", logger.LogNewErrorf(log, "failed to parse cnsvolumeinfo object: %v, err: %v", info, err)
 	}
+	log.Infof("Volume ID %q is associated with VC %q", volumeID, cnsvolumeinfo.Spec.VCenterServer)
 	return cnsvolumeinfo.Spec.VCenterServer, nil
 }
 

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -361,6 +361,9 @@ func (r *ReconcileCSINodeTopology) reconcileForGuest(ctx context.Context, reques
 		// Error reading the object - return with err.
 		return reconcile.Result{}, err
 	}
+	// TODO: If the CR status is already at Success, do not reconcile further.
+	// This is required only when NodeVM moves from one AZ to another AZ,
+	// otherwise there is no functional impact.
 
 	// Initialize backOffDuration for the instance, if required.
 	var timeout time.Duration

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -603,6 +603,7 @@ func startTopologyCRInformer(ctx context.Context, cfg *restclient.Config) error 
 			csinodetopology.CRDSingular, err)
 	}
 	csiNodeTopologyInformer := dynInformer.Informer()
+	// TODO: Multi-VC: Use a RWLock to guard simultaneous updates to topologyVCMap
 	csiNodeTopologyInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			topoCRAdded(obj)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: CreateVolume changes for multi-VC environment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Regression testing for vanilla - Complete

SC:
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: block-sc
provisioner: csi.vsphere.vmware.com
allowVolumeExpansion: true
parameters:
  storagepolicyname: "vSAN Default Storage Policy"
allowedTopologies:
  - matchLabelExpressions:
      - key: topology.csi.vmware.com/k8s-zone
        values:
          - zone-1
      - key: topology.csi.vmware.com/k8s-region
        values:
          - region-1
```

Logs:
```
2022-11-23T18:16:44.783Z	INFO	vanilla/controller.go:1544	CreateVolume: called with args {Name:pvc-45c0baea-3d98-4a56-af55-acac1f30609f CapacityRange:required_bytes:104857600  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[storagepolicyname:vSAN Default Storage Policy] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-1" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region-1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-1" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.783Z	DEBUG	vanilla/controller.go:1009	Checking if vCenter task for volume pvc-45c0baea-3d98-4a56-af55-acac1f30609f is already registered.	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.783Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:141	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-45c0baea-3d98-4a56-af55-acac1f30609f	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.792Z	DEBUG	vanilla/controller.go:1034	CreateVolume task details for block volume pvc-45c0baea-3d98-4a56-af55-acac1f30609f are not found.	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.792Z	INFO	common/topology.go:112	Topology segment(s) map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-1] belong to vCenter: "sc1-10-78-81-17.eng.vmware.com"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.792Z	DEBUG	vanilla/controller.go:1132	Topology accessibility requirements per VC are map[sc1-10-78-81-17.eng.vmware.com:[map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-1]]]	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.921Z	INFO	vanilla/controller.go:1171	Found ID "aa6d5a82-1c88-45da-85d3-3d74b91a5bad" for storage policy name "vSAN Default Storage Policy"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.923Z	DEBUG	node/manager.go:238	Renewing virtual machine VirtualMachine:vm-51 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 4214c828-0e23-5c44-7ec3-bbc95c034eef, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] with nodeUUID "4214c828-0e23-5c44-7ec3-bbc95c034eef"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.928Z	DEBUG	node/manager.go:245	VM VirtualMachine:vm-51 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 4214c828-0e23-5c44-7ec3-bbc95c034eef, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] was successfully renewed with nodeUUID "4214c828-0e23-5c44-7ec3-bbc95c034eef"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.928Z	DEBUG	node/manager.go:238	Renewing virtual machine VirtualMachine:vm-53 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 42144565-c8b2-5fa5-ae22-d018aad51f7e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] with nodeUUID "42144565-c8b2-5fa5-ae22-d018aad51f7e"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.932Z	DEBUG	node/manager.go:245	VM VirtualMachine:vm-53 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 42144565-c8b2-5fa5-ae22-d018aad51f7e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] was successfully renewed with nodeUUID "42144565-c8b2-5fa5-ae22-d018aad51f7e"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.932Z	DEBUG	placementengine/placement.go:172	Node "k8s-node-662-1668629019" with topology map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-2] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-1" 	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.933Z	DEBUG	placementengine/placement.go:172	Node "k8s-node-189-1668629000" with topology map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-2] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-1" 	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.934Z	DEBUG	node/manager.go:238	Renewing virtual machine VirtualMachine:vm-52 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 4214f369-9125-4f62-ce83-27eb89096edb, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] with nodeUUID "4214f369-9125-4f62-ce83-27eb89096edb"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.939Z	DEBUG	node/manager.go:245	VM VirtualMachine:vm-52 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 4214f369-9125-4f62-ce83-27eb89096edb, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] was successfully renewed with nodeUUID "4214f369-9125-4f62-ce83-27eb89096edb"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.939Z	DEBUG	node/manager.go:238	Renewing virtual machine VirtualMachine:vm-50 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 42147e0e-3232-24c9-c7d0-7fae6db0833a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] with nodeUUID "42147e0e-3232-24c9-c7d0-7fae6db0833a"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.944Z	DEBUG	node/manager.go:245	VM VirtualMachine:vm-50 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 42147e0e-3232-24c9-c7d0-7fae6db0833a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] was successfully renewed with nodeUUID "42147e0e-3232-24c9-c7d0-7fae6db0833a"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.944Z	DEBUG	placementengine/placement.go:172	Node "k8s-node-593-1668628978" with topology map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-2] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-1" 	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.944Z	DEBUG	placementengine/placement.go:172	Node "k8s-node-188-1668629000" with topology map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-2] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-1" 	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.944Z	INFO	placementengine/placement.go:40	Obtained list of nodeVMs [VirtualMachine:vm-51 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 4214c828-0e23-5c44-7ec3-bbc95c034eef, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] VirtualMachine:vm-53 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 42144565-c8b2-5fa5-ae22-d018aad51f7e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] VirtualMachine:vm-52 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 4214f369-9125-4f62-ce83-27eb89096edb, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] VirtualMachine:vm-50 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 42147e0e-3232-24c9-c7d0-7fae6db0833a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]]]	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.944Z	DEBUG	vsphere/virtualmachine.go:368	Getting accessible datastores for node VirtualMachine:vm-51	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.962Z	DEBUG	vsphere/virtualmachine.go:368	Getting accessible datastores for node VirtualMachine:vm-53	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.974Z	DEBUG	vsphere/virtualmachine.go:368	Getting accessible datastores for node VirtualMachine:vm-52	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:44.991Z	DEBUG	vsphere/virtualmachine.go:368	Getting accessible datastores for node VirtualMachine:vm-50	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:45.003Z	INFO	placementengine/placement.go:52	Obtained list of shared datastores as [Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/de519b95-ce264274/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/vsan:521949c59c188742-53ac8a3e83b2689f/]	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:45.056Z	INFO	placementengine/placement.go:70	Datastores compatible with storage policy "aa6d5a82-1c88-45da-85d3-3d74b91a5bad" are map[datastore-48:{}]	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:45.056Z	INFO	placementengine/placement.go:131	Shared compatible datastores being considered for volume provisioning are: [Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/vsan:521949c59c188742-53ac8a3e83b2689f/]	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:45.056Z	DEBUG	vanilla/controller.go:471	filterDatastores: dsMap map[ds:///vmfs/volumes/637533ad-80d71981-d420-005056818577/:Datastore: Datastore:datastore-44, datastore URL: ds:///vmfs/volumes/637533ad-80d71981-d420-005056818577/ ds:///vmfs/volumes/637533af-49fbc099-4722-005056818577/:Datastore: Datastore:datastore-45, datastore URL: ds:///vmfs/volumes/637533af-49fbc099-4722-005056818577/ ds:///vmfs/volumes/637533b0-9ccf2e96-24e6-005056811aaf/:Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/637533b0-9ccf2e96-24e6-005056811aaf/ ds:///vmfs/volumes/637533b1-0c730a3c-6d70-005056811aaf/:Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/637533b1-0c730a3c-6d70-005056811aaf/ ds:///vmfs/volumes/637533b2-1ad3c83d-34e0-00505681b529/:Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/637533b2-1ad3c83d-34e0-00505681b529/ ds:///vmfs/volumes/637533b3-0608cc7f-4665-00505681a69f/:Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/637533b3-0608cc7f-4665-00505681a69f/ ds:///vmfs/volumes/637533b3-7c10fbe1-a1b1-00505681b529/:Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/637533b3-7c10fbe1-a1b1-00505681b529/ ds:///vmfs/volumes/637533b4-78e6119f-e93d-00505681a69f/:Datastore: Datastore:datastore-40, datastore URL: ds:///vmfs/volumes/637533b4-78e6119f-e93d-00505681a69f/ ds:///vmfs/volumes/de519b95-ce264274/:Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/de519b95-ce264274/ ds:///vmfs/volumes/vsan:521949c59c188742-53ac8a3e83b2689f/:Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/vsan:521949c59c188742-53ac8a3e83b2689f/] sharedDatastores [Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/vsan:521949c59c188742-53ac8a3e83b2689f/]	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:45.056Z	DEBUG	vanilla/controller.go:480	filterDatastores: filteredDatastores [Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/vsan:521949c59c188742-53ac8a3e83b2689f/]	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:45.056Z	INFO	vsphere/utils.go:581	Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/vsan:521949c59c188742-53ac8a3e83b2689f/]{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:45.056Z	DEBUG	common/vsphereutil.go:420	vSphere CSI driver creating volume pvc-45c0baea-3d98-4a56-af55-acac1f30609f with create spec (*types.CnsVolumeCreateSpec)(0xc0005a0200)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-45c0baea-3d98-4a56-af55-acac1f30609f",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=1 cap=1) {
  (types.ManagedObjectReference) Datastore:datastore-48
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=8) "cluster1",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA",
   ClusterDistribution: (string) (len=11) "CSI-Vanilla"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=8) "cluster1",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA",
    ClusterDistribution: (string) (len=11) "CSI-Vanilla"
   }
  }
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc0006b5e40)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 100
  },
  BackingDiskId: (string) "",
  BackingDiskUrlPath: (string) "",
  BackingDiskObjectId: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) <nil>,
 CreateSpec: (types.BaseCnsBaseCreateSpec) <nil>,
 VolumeSource: (types.BaseCnsVolumeSource) <nil>
})
	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:45.066Z	DEBUG	volume/util.go:205	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:45.066Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:141	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-45c0baea-3d98-4a56-af55-acac1f30609f	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:45.113Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:176	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc000704ac0)({
 Name: (string) (len=40) "pvc-45c0baea-3d98-4a56-af55-acac1f30609f",
 VolumeID: (string) "",
 SnapshotID: (string) "",
 Capacity: (int64) 0,
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc000581b90)({
  TaskInvocationTimestamp: (v1.Time) 2022-11-23 18:16:45.113125104 +0000 UTC m=+499.500787299,
  TaskID: (string) (len=9) "task-1682",
  VCenterServer: (string) (len=30) "sc1-10-78-81-17.eng.vmware.com",
  OpID: (string) "",
  TaskStatus: (string) (len=10) "InProgress",
  Error: (string) ""
 })
})
	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:45.126Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:215	Created CnsVolumeOperationRequest instance vmware-system-csi/pvc-45c0baea-3d98-4a56-af55-acac1f30609f with latest information for task with ID: task-1682	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.503Z	INFO	volume/manager.go:355	CreateVolume: VolumeName: "pvc-45c0baea-3d98-4a56-af55-acac1f30609f", opId: "e2e43c0d"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.506Z	INFO	volume/util.go:329	Volume created successfully. VolumeName: "pvc-45c0baea-3d98-4a56-af55-acac1f30609f", volumeID: "4b4aaf23-b999-4044-b95e-d84311ba8556"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.506Z	DEBUG	volume/util.go:331	CreateVolume volumeId {{} "4b4aaf23-b999-4044-b95e-d84311ba8556"} is placed on datastore "ds:///vmfs/volumes/vsan:521949c59c188742-53ac8a3e83b2689f/"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.507Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:176	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc0008ada00)({
 Name: (string) (len=40) "pvc-45c0baea-3d98-4a56-af55-acac1f30609f",
 VolumeID: (string) (len=36) "4b4aaf23-b999-4044-b95e-d84311ba8556",
 SnapshotID: (string) "",
 Capacity: (int64) 0,
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc000452620)({
  TaskInvocationTimestamp: (v1.Time) 2022-11-23 18:16:45.113125104 +0000 UTC m=+499.500787299,
  TaskID: (string) (len=9) "task-1682",
  VCenterServer: (string) (len=30) "sc1-10-78-81-17.eng.vmware.com",
  OpID: (string) (len=8) "e2e43c0d",
  TaskStatus: (string) (len=7) "Success",
  Error: (string) ""
 })
})
	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.522Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:283	Updated CnsVolumeOperationRequest instance vmware-system-csi/pvc-45c0baea-3d98-4a56-af55-acac1f30609f with latest information for task with ID: task-1682	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.522Z	DEBUG	volume/manager.go:640	internalCreateVolume: returns fault ""	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.524Z	INFO	vanilla/controller.go:1219	volume "4b4aaf23-b999-4044-b95e-d84311ba8556" created in vCenter "sc1-10-78-81-17.eng.vmware.com". Proceeding to calculate accessible topology for the volume	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.524Z	DEBUG	node/manager.go:365	Renewing VM VirtualMachine:vm-53 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 42144565-c8b2-5fa5-ae22-d018aad51f7e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] with new connection: nodeUUID 42144565-c8b2-5fa5-ae22-d018aad51f7e	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.529Z	DEBUG	node/manager.go:375	Updated VM VirtualMachine:vm-53 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 42144565-c8b2-5fa5-ae22-d018aad51f7e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] for node with nodeUUID 42144565-c8b2-5fa5-ae22-d018aad51f7e	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.530Z	DEBUG	node/manager.go:362	Renewing VM VirtualMachine:vm-51 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 4214c828-0e23-5c44-7ec3-bbc95c034eef, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]], no new connection needed: nodeUUID 4214c828-0e23-5c44-7ec3-bbc95c034eef	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.531Z	DEBUG	node/manager.go:375	Updated VM VirtualMachine:vm-51 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 4214c828-0e23-5c44-7ec3-bbc95c034eef, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] for node with nodeUUID 4214c828-0e23-5c44-7ec3-bbc95c034eef	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.531Z	DEBUG	node/manager.go:362	Renewing VM VirtualMachine:vm-52 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 4214f369-9125-4f62-ce83-27eb89096edb, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]], no new connection needed: nodeUUID 4214f369-9125-4f62-ce83-27eb89096edb	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.531Z	DEBUG	node/manager.go:375	Updated VM VirtualMachine:vm-52 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 4214f369-9125-4f62-ce83-27eb89096edb, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] for node with nodeUUID 4214f369-9125-4f62-ce83-27eb89096edb	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.531Z	DEBUG	node/manager.go:362	Renewing VM VirtualMachine:vm-50 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 42147e0e-3232-24c9-c7d0-7fae6db0833a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]], no new connection needed: nodeUUID 42147e0e-3232-24c9-c7d0-7fae6db0833a	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.531Z	DEBUG	node/manager.go:375	Updated VM VirtualMachine:vm-50 [VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com, UUID: 42147e0e-3232-24c9-c7d0-7fae6db0833a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: sc1-10-78-81-17.eng.vmware.com]] for node with nodeUUID 42147e0e-3232-24c9-c7d0-7fae6db0833a	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.574Z	INFO	common/vsphereutil.go:1129	Nodes that have access to datastore "ds:///vmfs/volumes/vsan:521949c59c188742-53ac8a3e83b2689f/" are [VirtualMachine:vm-53 VirtualMachine:vm-50 VirtualMachine:vm-52 VirtualMachine:vm-51]	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.578Z	DEBUG	node/manager.go:186	Retrieved node name "k8s-node-51-1668628264" for node UUID "42144565-c8b2-5fa5-ae22-d018aad51f7e"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.581Z	DEBUG	node/manager.go:186	Retrieved node name "k8s-node-218-1668628248" for node UUID "42147e0e-3232-24c9-c7d0-7fae6db0833a"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.585Z	DEBUG	node/manager.go:186	Retrieved node name "k8s-control-761-1668628229" for node UUID "4214f369-9125-4f62-ce83-27eb89096edb"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.590Z	DEBUG	node/manager.go:186	Retrieved node name "k8s-node-604-1668628281" for node UUID "4214c828-0e23-5c44-7ec3-bbc95c034eef"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.590Z	INFO	placementengine/placement.go:267	Topology segments retrieved from nodes accessible to datastore "ds:///vmfs/volumes/vsan:521949c59c188742-53ac8a3e83b2689f/" are: [map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-1]]	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.590Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:122	creating cnsvolumeinfo for volumeID: "4b4aaf23-b999-4044-b95e-d84311ba8556" and vCenter: "sc1-10-78-81-17.eng.vmware.com" mapping in the namespace: "vmware-system-csi"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.597Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:143	Successfully created CNSVolumeInfo CR for volumeID: "4b4aaf23-b999-4044-b95e-d84311ba8556" and vCenter: "sc1-10-78-81-17.eng.vmware.com" mapping in the namespace: "vmware-system-csi"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.598Z	DEBUG	vanilla/controller.go:1583	createVolumeInternal: returns fault ""	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
2022-11-23T18:16:48.598Z	INFO	vanilla/controller.go:1591	Volume created successfully. Volume Handle: "4b4aaf23-b999-4044-b95e-d84311ba8556", PV Name: "pvc-45c0baea-3d98-4a56-af55-acac1f30609f"	{"TraceId": "2932a875-3210-43e2-ad4e-090f3dfa4e40"}
```

CNSVolumeInfo instance created:
```
root@k8s-control-761-1668628229:~# kc describe cnsvolumeinfo
Name:         4b4aaf23-b999-4044-b95e-d84311ba8556
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CNSVolumeInfo
Metadata:
  Creation Timestamp:  2022-11-23T18:16:48Z
  Generation:          1
  Managed Fields:
    API Version:  cns.vmware.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:vCenterServer:
        f:volumeID:
    Manager:         vsphere-csi
    Operation:       Update
    Time:            2022-11-23T18:16:48Z
  Resource Version:  2081536
  UID:               df107421-521d-4f4c-a0ce-2fe8a8607e03
Spec:
  V Center Server:  sc1-10-78-81-17.eng.vmware.com
  Volume ID:        4b4aaf23-b999-4044-b95e-d84311ba8556
Events:             <none>
```

PVC:
```
Name:          block-pvc
Namespace:     default
StorageClass:  block-sc
Status:        Bound
Volume:        pvc-45c0baea-3d98-4a56-af55-acac1f30609f
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      100Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age    From                                                                                                 Message
  ----    ------                 ----   ----                                                                                                 -------
  Normal  ExternalProvisioning   8m28s  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  Provisioning           8m28s  csi.vsphere.vmware.com_vsphere-csi-controller-77d5c7c7df-pxk52_754cbc18-4509-4a32-bef4-d3c10e7fe6f5  External provisioner is provisioning volume for claim "default/block-pvc"
  Normal  ProvisioningSucceeded  8m24s  csi.vsphere.vmware.com_vsphere-csi-controller-77d5c7c7df-pxk52_754cbc18-4509-4a32-bef4-d3c10e7fe6f5  Successfully provisioned volume pvc-45c0baea-3d98-4a56-af55-acac1f30609f
```

PV:
```
Name:              pvc-45c0baea-3d98-4a56-af55-acac1f30609f
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      block-sc
Status:            Bound
Claim:             default/block-pvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          100Mi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.csi.vmware.com/k8s-zone in [zone-1]
                   topology.csi.vmware.com/k8s-region in [region-1]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      4b4aaf23-b999-4044-b95e-d84311ba8556
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1669226908753-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
CreateVolume changes for multi-VC
```
