### PR TITLE
syncer: fix nil pointer dereference in log message

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1290,7 +1290,7 @@ func podAdded(obj interface{}, metadataSyncer *metadataSyncInformer) {
 						if err != nil {
 							log.Warnf("podAdded: Failed to get VolumeID from "+
 								"volumeMigrationService for static PV: %q volumePath: %q with error %+v",
-								pv.Name, volume.VsphereVolume.VolumePath, err)
+								pv.Name, pv.Spec.VsphereVolume.VolumePath, err)
 							continue
 						}
 						log.Infof("Successfully registered in-tree vSphere inline volume: %q with "+


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

I encountered a nil pointer dereference in the syncer on v2.7.0

```
E1122 22:19:03.493729       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 120 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1e98ae0?, 0x38965b0})
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x2c33bb4?})
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x75
panic({0x1e98ae0, 0x38965b0})
	/usr/lib/golang/src/runtime/panic.go:884 +0x212
sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer.podAdded({0x22c4420?, 0xc000faa400}, 0xc0003c48c0)
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/pkg/syncer/metadatasyncer.go:963 +0x885
sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer.InitMetadataSyncer.func7({0x22c4420?, 0xc000faa400?})
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/pkg/syncer/metadatasyncer.go:354 +0x27
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd(...)
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/vendor/k8s.io/client-go/tools/cache/controller.go:232
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/vendor/k8s.io/client-go/tools/cache/shared_informer.go:818 +0x134
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x0?)
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:157 +0x3e
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00052ff38?, {0x2664020, 0xc0005374d0}, 0x1, 0xc000510c60)
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:158 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x3b9aca00, 0x0, 0x0?, 0xc00052ff88?)
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:135 +0x89
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:92
k8s.io/client-go/tools/cache.(*processorListener).run(0xc00024a300?)
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/vendor/k8s.io/client-go/tools/cache/shared_informer.go:812 +0x6b
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:75 +0x5a
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
	/go/src/github.com/kubernetes-sigs/vsphere-csi-driver/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:73 +0x85
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1b0ee05]
```

It points to this line: https://github.com/kubernetes-sigs/vsphere-csi-driver/blame/release-2.7/pkg/syncer/metadatasyncer.go#L963

Note that the other log messages in this block use `pv.Spec.VsphereVolume.VolumePath` which is safe, but this line uses `volume.VsphereVolume.VolumePath` which could result in nil pointer dereference in the `log.Warnf` call if `GetVolumeID` returns an error.

I simply changed it to use `pv.Spec.VsphereVolume.VolumePath` like the other log statements in this block.

**Testing done**:

I ran a simple build + relying on CI checks. I don't see a good way to trigger this specific log line consistently, it only happened once so far.

**Special notes for your reviewer**:

/cc @divyenpatel

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
