### PR TITLE
[In Progress] Config secret - Verifying vol attachment by updating config secret with different testuser credentials

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -253,6 +253,7 @@ var (
 // Config secret testuser credentials
 var (
 	configSecretTestUser1Password = "VMware!23"
+	configSecretTestUser2Password = "VMware!234"
 	configSecretTestUser1         = "testuser1"
 	configSecretTestUser2         = "testuser2"
 )

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -2868,6 +2868,8 @@ func readConfigFromSecretString(cfg string) (e2eTestConfig, error) {
 		case "csi-fetch-preferred-datastores-intervalinmin":
 			config.Global.CSIFetchPreferredDatastoresIntervalInMin, strconvErr = strconv.Atoi(value)
 			gomega.Expect(strconvErr).NotTo(gomega.HaveOccurred())
+		case "targetvSANFileShareDatastoreURLs":
+			config.Global.TargetvSANFileShareDatastoreURLs = value
 		default:
 			return config, fmt.Errorf("unknown key %s in the input string", key)
 		}
@@ -2880,13 +2882,14 @@ func readConfigFromSecretString(cfg string) (e2eTestConfig, error) {
 func writeConfigToSecretString(cfg e2eTestConfig) (string, error) {
 	result := fmt.Sprintf("[Global]\ninsecure-flag = \"%t\"\ncluster-id = \"%s\"\ncluster-distribution = \"%s\"\n"+
 		"csi-fetch-preferred-datastores-intervalinmin = %d\n\n"+
-		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"\n\n"+
+		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"\n"+
+		"targetvSANFileShareDatastoreURLs = \"%s\"\n\n"+
 		"[Snapshot]\nglobal-max-snapshots-per-block-volume = %d\n\n"+
 		"[Labels]\ntopology-categories = \"%s\"",
 		cfg.Global.InsecureFlag, cfg.Global.ClusterID, cfg.Global.ClusterDistribution,
 		cfg.Global.CSIFetchPreferredDatastoresIntervalInMin,
 		cfg.Global.VCenterHostname, cfg.Global.User, cfg.Global.Password,
-		cfg.Global.Datacenters, cfg.Global.VCenterPort,
+		cfg.Global.Datacenters, cfg.Global.VCenterPort, cfg.Global.TargetvSANFileShareDatastoreURLs,
 		cfg.Snapshot.GlobalMaxSnapshotsPerBlockVolume,
 		cfg.Labels.TopologyCategories)
 	return result, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
 Config secret - Verifying vol attachment by updating config secret with different testuser credentials

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

 Config secret - Verifying vol attachment by updating config secret with different testuser credentials

**Testing done**:
Yes
https://gist.githubusercontent.com/sipriyaa/4eee473d6e028c802d9de48b62cc3765/raw/45098ee13af0a9ce346fd0d07dd3b0ae536b71a7/gistfile1.txt

https://gist.githubusercontent.com/sipriyaa/95899c4fb64e778a485f7583482fc245/raw/eeef2a6ef83735304519e06437978fef37e27c2b/gistfile1.txt

**Special notes for your reviewer**:

sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/configsecret-automation-part2/vsphere-csi-driver /Users/sipriya/configsecret-automation-part2 /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|files|name|exports_file|imports|types_sizes) took 1m23.911510469s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 142.264303ms 
INFO [linters context/goanalysis] analyzers took 7m25.590914484s with top 10 stages: buildir: 5m22.000119906s, nilness: 17.426123872s, ctrlflow: 15.010413757s, printf: 14.137850244s, fact_deprecated: 13.528103751s, typedness: 10.776251118s, fact_purity: 9.908436062s, SA5012: 9.784738458s, inspect: 5.492940523s, S1038: 2.159168471s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude-rules: 1/24, nolint: 0/1, skip_files: 113/113, cgo: 113/113, path_prettifier: 113/113, exclude: 24/24, filename_unadjuster: 113/113, skip_dirs: 113/113, autogenerated_exclude: 24/113, identifier_marker: 24/24 
INFO [runner] processing took 15.02124ms with stages: nolint: 11.252529ms, autogenerated_exclude: 2.961315ms, path_prettifier: 356.491µs, identifier_marker: 270.089µs, skip_dirs: 104.077µs, exclude-rules: 58.103µs, cgo: 7.977µs, filename_unadjuster: 6.084µs, max_same_issues: 1.375µs, uniq_by_line: 564ns, max_from_linter: 394ns, skip_files: 324ns, diff: 310ns, source_code: 284ns, max_per_file_from_linter: 253ns, severity-rules: 247ns, path_shortener: 242ns, exclude: 240ns, sort_results: 233ns, path_prefixer: 109ns 
INFO [runner] linters took 45.046575623s with stages: goanalysis_metalinter: 45.031459329s 
INFO File cache stats: 295 entries of total size 5.5MiB 
INFO Memory: 1253 samples, avg is 701.1MB, max is 2991.7MB 
INFO Execution took 2m9.113730633s                
sipriya@sipriya-a01 vsphere-csi-driver % 
