### PR TITLE
Config secret - Verifying vol attachment by updating config secret with different testuser credentials

### DIFF
--- a/tests/e2e/config_secret.go
+++ b/tests/e2e/config_secret.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -54,6 +55,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		vCenterUIPassword         string
 		propagateVal              string
 		revertOriginalvCenterUser bool
+		vCenterIP                 string
+		vCenterPort               string
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -74,6 +77,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		masterIp = allMasterIps[0]
 		vCenterUIUser = e2eVSphere.Config.Global.User
 		vCenterUIPassword = e2eVSphere.Config.Global.Password
+		vCenterIP = e2eVSphere.Config.Global.VCenterHostname
+		vCenterPort = e2eVSphere.Config.Global.VCenterPort
 		propagateVal = "false"
 		revertOriginalvCenterUser = false
 		configSecretUser1Alias = configSecretTestUser1 + "@vsphere.local"
@@ -105,14 +110,14 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		if !revertOriginalvCenterUser {
 			ginkgo.By("Reverting back csi-vsphere.conf with its original vcenter user " +
 				"and its credentials")
-			createCsiVsphereSecret(client, ctx, vCenterUIUser, vCenterUIPassword, csiNamespace)
+			createCsiVsphereSecret(client, ctx, vCenterUIUser, vCenterUIPassword, csiNamespace, vCenterIP,
+				vCenterPort, "")
 
 			ginkgo.By("Restart CSI driver")
 			restartSuccess, err := restartCSIDriver(ctx, client, namespace, csiReplicas)
 			gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
-
 	})
 
 	/*
@@ -136,9 +141,9 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		ginkgo.By("Create testuser1 and assign required roles and privileges to testuser1")
 		createTestUserAndAssignRolesPrivileges(masterIp, configSecretTestUser1,
 			configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
-			dataCenters, clusters, hosts, vms, datastores)
+			dataCenters, clusters, hosts, vms, datastores, "createUser", "createRoles")
 		defer func() {
-			ginkgo.By("Delete testuser1 and remove assigned roles and privileges to testuser1")
+			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, configSecretTestUser1,
 				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
@@ -147,16 +152,17 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		ginkgo.By("Create testuser2 and assign required roles and privileges to testuser2")
 		createTestUserAndAssignRolesPrivileges(masterIp, configSecretTestUser2,
 			configSecretTestUser1Password, configSecretUser2Alias, propagateVal,
-			dataCenters, clusters, hosts, vms, datastores)
+			dataCenters, clusters, hosts, vms, datastores, "createUser", "createRoles")
 		defer func() {
-			ginkgo.By("Delete testuser2 and remove assigned roles and privileges to testuser2")
+			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, configSecretTestUser2,
 				configSecretTestUser1Password, configSecretUser2Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
 		ginkgo.By("Create vsphere-config-secret file with testuser1 credentials")
-		createCsiVsphereSecret(client, ctx, configSecretUser1Alias, configSecretTestUser1Password, csiNamespace)
+		createCsiVsphereSecret(client, ctx, configSecretUser1Alias, configSecretTestUser1Password,
+			csiNamespace, vCenterIP, vCenterPort, "")
 
 		ginkgo.By("Restart CSI driver")
 		restartSuccess, err := restartCSIDriver(ctx, client, namespace, csiReplicas)
@@ -206,11 +212,13 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Create vsphere-config-secret file with testuser2 credentials")
-		createCsiVsphereSecret(client, ctx, configSecretUser2Alias, configSecretTestUser1Password, csiNamespace)
+		createCsiVsphereSecret(client, ctx, configSecretUser2Alias, configSecretTestUser1Password, csiNamespace,
+			vCenterIP, vCenterPort, "")
 		defer func() {
 			ginkgo.By("Reverting back csi-vsphere.conf with its original vcenter user " +
 				"and its credentials")
-			createCsiVsphereSecret(client, ctx, vCenterUIUser, vCenterUIPassword, csiNamespace)
+			createCsiVsphereSecret(client, ctx, vCenterUIUser, vCenterUIPassword, csiNamespace, vCenterIP,
+				vCenterPort, "")
 			revertOriginalvCenterUser = true
 
 			ginkgo.By("Restart CSI driver")
@@ -259,6 +267,557 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 
 		ginkgo.By("Verify volume metadata for POD, PVC and PV")
 		err = waitAndVerifyCnsVolumeMetadata(pv2.Spec.CSI.VolumeHandle, pvclaim2, pv2, pod2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/*
+		TESTCASE-2
+		Change VC user's password
+		Steps:
+		1. Create a user, user1, with required roles and privileges
+		2. Create csi-vsphere.conf with user1's credentials and create vsphere-config-secret
+		in turn using that file
+		3. Install CSI driver
+		4. Verify we can create a PVC and attach it to pod
+		5. Change password for user1
+		6. try to create a PVC and verify it gets bound successfully
+		7. Restart CSI controller pod
+		8. Try to create a PVC verify that it is stuck in pending state
+		9. Change csi-vsphere.conf with updated user1's credentials and re-create
+		vsphere-config-secret in turn using that file
+		10. Verify we can create a PVC and attach it to pod
+		11. Verify PVC created in step 6 gets bound eventually
+		12. Cleanup all objects created during the test
+	*/
+
+	ginkgo.It("[csi-config-secret-block][csi-config-secret-file] Change vcenter user password "+
+		"and restart csi controller pod", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		testUser1NewPassword := "Admin!123"
+		ignoreLabels := make(map[string]string)
+
+		ginkgo.By("Create testuser1 and assign required roles and privileges to testuser1")
+		createTestUserAndAssignRolesPrivileges(masterIp, configSecretTestUser1,
+			configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+			dataCenters, clusters, hosts, vms, datastores, "createUser", "createRoles")
+		defer func() {
+			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
+			deleteTestUserAndRemoveRolesPrivileges(masterIp, configSecretTestUser1,
+				testUser1NewPassword, configSecretUser1Alias, propagateVal,
+				dataCenters, clusters, hosts, vms, datastores)
+		}()
+
+		ginkgo.By("Create testuser2 and assign required roles and privileges to testuser2")
+		createTestUserAndAssignRolesPrivileges(masterIp, configSecretTestUser2,
+			configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+			dataCenters, clusters, hosts, vms, datastores, "createUser", "createRoles")
+		defer func() {
+			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
+			deleteTestUserAndRemoveRolesPrivileges(masterIp, configSecretTestUser2,
+				configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+				dataCenters, clusters, hosts, vms, datastores)
+		}()
+
+		ginkgo.By("Update vsphere-config-secret with testuser1 credentials")
+		createCsiVsphereSecret(client, ctx, configSecretUser1Alias, configSecretTestUser1Password, csiNamespace,
+			vCenterIP, vCenterPort, "")
+
+		ginkgo.By("Restart CSI driver")
+		restartSuccess, err := restartCSIDriver(ctx, client, namespace, csiReplicas)
+		gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Delete Storage Class")
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating PVC")
+		pvclaim1, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvclaims1 []*v1.PersistentVolumeClaim
+		pvclaims1 = append(pvclaims1, pvclaim1)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		pvs1, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims1, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs1).NotTo(gomega.BeEmpty())
+		pv1 := pvs1[0]
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv1.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}()
+
+		ginkgo.By("Creating pod")
+		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim1}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod1.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume metadata for POD, PVC and PV")
+		err = waitAndVerifyCnsVolumeMetadata(pv1.Spec.CSI.VolumeHandle, pvclaim1, pv1, pod1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Change password for testuser1")
+		err = changeTestUserPassword(masterIp, configSecretTestUser1, testUser1NewPassword)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Try to create a PVC and verify it gets bound successfully")
+		pvclaim2, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvclaims2 []*v1.PersistentVolumeClaim
+		pvclaims2 = append(pvclaims2, pvclaim2)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims2, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Deleting the PVC")
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Restart CSI controller pod")
+		err = updateDeploymentReplicawithWait(client, 0, vSphereCSIControllerPodNamePrefix, csiNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = updateDeploymentReplicawithWait(client, csiReplicas, vSphereCSIControllerPodNamePrefix, csiNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Try to create a PVC verify that it is stuck in pending state")
+		pvclaim3, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Expect claim status to be in Pending state")
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
+			pvclaim3.Namespace, pvclaim3.Name, framework.Poll, time.Minute)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+		defer func() {
+			ginkgo.By("Deleting the PVC")
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim3.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Update vsphere-config-secret file with testuser1 updated credentials")
+		createCsiVsphereSecret(client, ctx, configSecretUser1Alias, testUser1NewPassword, csiNamespace,
+			vCenterIP, vCenterPort, "")
+		defer func() {
+			ginkgo.By("Reverting back csi-vsphere.conf with its original vcenter user " +
+				"and its credentials")
+			createCsiVsphereSecret(client, ctx, vCenterUIUser, vCenterUIPassword, csiNamespace,
+				vCenterIP, vCenterPort, "")
+			revertOriginalvCenterUser = true
+
+			ginkgo.By("Restart CSI driver")
+			restartSuccess, err = restartCSIDriver(ctx, client, namespace, csiReplicas)
+			gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Restart CSI driver")
+		restartSuccess, err = restartCSIDriver(ctx, client, namespace, csiReplicas)
+		gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Wait for csi controller pods to be in running state")
+		list_of_pods, err := fpod.GetPodsInNamespace(client, csiNamespace, ignoreLabels)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		num_csi_pods := len(list_of_pods)
+		err = fpod.WaitForPodsRunningReady(client, csiNamespace, int32(num_csi_pods), 0, pollTimeout, ignoreLabels)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim4, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvclaims4 []*v1.PersistentVolumeClaim
+		pvclaims4 = append(pvclaims4, pvclaim4)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims4, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim4.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim4}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod2.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify the PVC which was stuck in Pending state should gets bound eventually")
+		pvclaim3, err = client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvclaim3.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvclaim3.Status.Phase == v1.ClaimBound).To(gomega.BeTrue())
+	})
+
+	/*
+		TESTCASE-3
+		Change VC user and password
+		Steps:
+		1. Create two users (user1 and user2) with required roles and privileges and with different passwords
+		2. Create csi-vsphere.conf with user1's credentials and create vsphere-config-secret
+		 in turn using that file
+		3. Install CSI driver
+		4. Verify we can create a PVC and attach it to pod
+		5. Change csi-vsphere.conf with user2's credentials and re-create vsphere-config-secret
+		in turn using that file
+		6. Verify we can create a PVC and attach it to pod
+		7. Cleanup all objects created during the test
+	*/
+
+	ginkgo.It("[csi-config-secret-block][csi-config-secret-file] Update user credentials in vsphere config "+
+		"secret keeping password different for both test users", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ginkgo.By("Create testuser1 and assign required roles and privileges to testuser1")
+		createTestUserAndAssignRolesPrivileges(masterIp, configSecretTestUser1,
+			configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+			dataCenters, clusters, hosts, vms, datastores, "createUser", "createRoles")
+		defer func() {
+			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
+			deleteTestUserAndRemoveRolesPrivileges(masterIp, configSecretTestUser1,
+				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+				dataCenters, clusters, hosts, vms, datastores)
+		}()
+
+		ginkgo.By("Create testuser2 and assign required roles and privileges to testuser2")
+		createTestUserAndAssignRolesPrivileges(masterIp, configSecretTestUser2,
+			configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+			dataCenters, clusters, hosts, vms, datastores, "createUser", "createRoles")
+		defer func() {
+			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
+			deleteTestUserAndRemoveRolesPrivileges(masterIp, configSecretTestUser2,
+				configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+				dataCenters, clusters, hosts, vms, datastores)
+		}()
+
+		ginkgo.By("Update vsphere-config-secret with testuser1 credentials")
+		createCsiVsphereSecret(client, ctx, configSecretUser1Alias, configSecretTestUser1Password, csiNamespace,
+			vCenterIP, vCenterPort, "")
+
+		ginkgo.By("Restart CSI driver")
+		restartSuccess, err := restartCSIDriver(ctx, client, namespace, csiReplicas)
+		gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Delete Storage Class")
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating PVC")
+		pvclaim1, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvclaims1 []*v1.PersistentVolumeClaim
+		pvclaims1 = append(pvclaims1, pvclaim1)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		pvs1, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims1, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs1).NotTo(gomega.BeEmpty())
+		pv1 := pvs1[0]
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv1.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}()
+
+		ginkgo.By("Creating pod")
+		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim1}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod1.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume metadata for POD, PVC and PV")
+		err = waitAndVerifyCnsVolumeMetadata(pv1.Spec.CSI.VolumeHandle, pvclaim1, pv1, pod1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Update vsphere-config-secret with testuser2 credentials")
+		createCsiVsphereSecret(client, ctx, configSecretUser2Alias, configSecretTestUser2Password, csiNamespace,
+			vCenterIP, vCenterPort, "")
+		defer func() {
+			ginkgo.By("Reverting back csi-vsphere.conf with its original vcenter user " +
+				"and its credentials")
+			createCsiVsphereSecret(client, ctx, vCenterUIUser, vCenterUIPassword, csiNamespace,
+				vCenterIP, vCenterPort, "")
+			revertOriginalvCenterUser = true
+
+			ginkgo.By("Restart CSI driver")
+			restartSuccess, err = restartCSIDriver(ctx, client, namespace, csiReplicas)
+			gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Restart CSI driver")
+		restartSuccess, err = restartCSIDriver(ctx, client, namespace, csiReplicas)
+		gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim2, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvclaims2 []*v1.PersistentVolumeClaim
+		pvclaims2 = append(pvclaims2, pvclaim2)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		pvs2, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims2, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs2).NotTo(gomega.BeEmpty())
+		pv2 := pvs2[0]
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			err = fpv.WaitForPersistentVolumeDeleted(client, pv2.Name, poll, pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv2.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				"Volume: %s should not be present in the CNS after it is deleted from "+
+					"kubernetes", pv2.Spec.CSI.VolumeHandle)
+		}()
+
+		ginkgo.By("Creating pod")
+		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim2}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod2.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume metadata for POD, PVC and PV")
+		err = waitAndVerifyCnsVolumeMetadata(pv2.Spec.CSI.VolumeHandle, pvclaim2, pv2, pod2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/*
+		TESTCASE-4
+		Change IP to host name and vice versa
+		Steps:
+		1. Create two users (user1 and user2) with required roles and privileges and with different passwords
+		2. Create csi-vsphere.conf with user1's credentials and VC IP and then
+		create vsphere-config-secret in turn using that file
+		3. Install CSI driver
+		4. Verify we can create a PVC and attach it to pod
+		5. Change csi-vsphere.conf to use VC hostname instead of VC IP and re-create
+		vsphere-config-secret in turn using that file
+		6. Verify we can create a PVC and attach it to pod
+		7. Change csi-vsphere.conf to use VC IP instead of VC hostname and re-create
+		vsphere-config-secret in turn using that file
+		8. Verify we can create a PVC and attach it to pod
+		9. Cleanup all objects created during the test
+	*/
+
+	ginkgo.It("[csi-config-secret-block][csi-config-secret-file] Change vcenter ip to hostname and "+
+		"viceversa in vsphere config secret", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ginkgo.By("Create testuser1 and assign required roles and privileges to testuser1")
+		createTestUserAndAssignRolesPrivileges(masterIp, configSecretTestUser1,
+			configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+			dataCenters, clusters, hosts, vms, datastores, "createUser", "createRoles")
+		defer func() {
+			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
+			deleteTestUserAndRemoveRolesPrivileges(masterIp, configSecretTestUser1,
+				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+				dataCenters, clusters, hosts, vms, datastores)
+		}()
+
+		ginkgo.By("Create testuser2 and assign required roles and privileges to testuser2")
+		createTestUserAndAssignRolesPrivileges(masterIp, configSecretTestUser2,
+			configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+			dataCenters, clusters, hosts, vms, datastores, "createUser", "createRoles")
+		defer func() {
+			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
+			deleteTestUserAndRemoveRolesPrivileges(masterIp, configSecretTestUser2,
+				configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+				dataCenters, clusters, hosts, vms, datastores)
+		}()
+
+		ginkgo.By("Update vsphere-config-secret with testuser1 credentials using vcenter IP")
+		createCsiVsphereSecret(client, ctx, configSecretUser1Alias, configSecretTestUser1Password, csiNamespace,
+			vCenterIP, vCenterPort, "")
+
+		ginkgo.By("Restart CSI driver")
+		restartSuccess, err := restartCSIDriver(ctx, client, namespace, csiReplicas)
+		gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Storage Class")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Delete Storage Class")
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating PVC")
+		pvclaim1, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvclaims1 []*v1.PersistentVolumeClaim
+		pvclaims1 = append(pvclaims1, pvclaim1)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		pvs1, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims1, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs1).NotTo(gomega.BeEmpty())
+		pv1 := pvs1[0]
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv1.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}()
+
+		ginkgo.By("Creating pod")
+		pod1, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim1}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod1.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume metadata for POD, PVC and PV")
+		err = waitAndVerifyCnsVolumeMetadata(pv1.Spec.CSI.VolumeHandle, pvclaim1, pv1, pod1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Fetch vcenter hotsname")
+		vCenterHostName := getVcenterHostName(vCenterIP)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Update vsphere-config-secret to use vcenter hostname")
+		createCsiVsphereSecret(client, ctx, configSecretUser1Alias, configSecretTestUser1Password, csiNamespace,
+			vCenterHostName, vCenterPort, "")
+
+		ginkgo.By("Restart CSI driver")
+		restartSuccess, err = restartCSIDriver(ctx, client, namespace, csiReplicas)
+		gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim2, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvclaims2 []*v1.PersistentVolumeClaim
+		pvclaims2 = append(pvclaims2, pvclaim2)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		pvs2, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims2, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs2).NotTo(gomega.BeEmpty())
+		pv2 := pvs2[0]
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			err = fpv.WaitForPersistentVolumeDeleted(client, pv2.Name, poll, pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv2.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				"Volume: %s should not be present in the CNS after it is deleted from "+
+					"kubernetes", pv2.Spec.CSI.VolumeHandle)
+		}()
+
+		ginkgo.By("Creating pod")
+		pod2, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim2}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod2.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume metadata for POD, PVC and PV")
+		err = waitAndVerifyCnsVolumeMetadata(pv2.Spec.CSI.VolumeHandle, pvclaim2, pv2, pod2)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Update vsphere-config-secret to use vcenter IP")
+		createCsiVsphereSecret(client, ctx, configSecretUser1Alias, configSecretTestUser1Password, csiNamespace,
+			vCenterIP, vCenterPort, "")
+		defer func() {
+			ginkgo.By("Reverting back csi-vsphere.conf with its original vcenter user " +
+				"and its credentials")
+			createCsiVsphereSecret(client, ctx, vCenterUIUser, vCenterUIPassword, csiNamespace, vCenterIP, vCenterPort, "")
+			revertOriginalvCenterUser = true
+
+			ginkgo.By("Restart CSI driver")
+			restartSuccess, err = restartCSIDriver(ctx, client, namespace, csiReplicas)
+			gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Restart CSI driver")
+		restartSuccess, err = restartCSIDriver(ctx, client, namespace, csiReplicas)
+		gomega.Expect(restartSuccess).To(gomega.BeTrue(), "csi driver restart not successful")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify we can create a PVC and attach it to pod")
+		ginkgo.By("Creating Pvc")
+		pvclaim3, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvclaims3 []*v1.PersistentVolumeClaim
+		pvclaims3 = append(pvclaims3, pvclaim3)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		pvs3, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims3, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvs3).NotTo(gomega.BeEmpty())
+		pv3 := pvs3[0]
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim3.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify PVs, volumes are deleted from CNS")
+			err = fpv.WaitForPersistentVolumeDeleted(client, pv3.Name, poll, pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv3.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				"Volume: %s should not be present in the CNS after it is deleted from "+
+					"kubernetes", pv3.Spec.CSI.VolumeHandle)
+		}()
+
+		ginkgo.By("Creating pod")
+		pod3, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim3}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod3.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod3)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume metadata for POD, PVC and PV")
+		err = waitAndVerifyCnsVolumeMetadata(pv3.Spec.CSI.VolumeHandle, pvclaim3, pv3, pod3)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 })

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -253,6 +253,7 @@ var (
 // Config secret testuser credentials
 var (
 	configSecretTestUser1Password = "VMware!23"
+	configSecretTestUser2Password = "VMware!234"
 	configSecretTestUser1         = "testuser1"
 	configSecretTestUser2         = "testuser2"
 )

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -2890,6 +2890,8 @@ func readConfigFromSecretString(cfg string) (e2eTestConfig, error) {
 		case "csi-fetch-preferred-datastores-intervalinmin":
 			config.Global.CSIFetchPreferredDatastoresIntervalInMin, strconvErr = strconv.Atoi(value)
 			gomega.Expect(strconvErr).NotTo(gomega.HaveOccurred())
+		case "targetvSANFileShareDatastoreURLs":
+			config.Global.TargetvSANFileShareDatastoreURLs = value
 		default:
 			return config, fmt.Errorf("unknown key %s in the input string", key)
 		}
@@ -2902,13 +2904,14 @@ func readConfigFromSecretString(cfg string) (e2eTestConfig, error) {
 func writeConfigToSecretString(cfg e2eTestConfig) (string, error) {
 	result := fmt.Sprintf("[Global]\ninsecure-flag = \"%t\"\ncluster-id = \"%s\"\ncluster-distribution = \"%s\"\n"+
 		"csi-fetch-preferred-datastores-intervalinmin = %d\n\n"+
-		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"\n\n"+
+		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"\n"+
+		"targetvSANFileShareDatastoreURLs = \"%s\"\n\n"+
 		"[Snapshot]\nglobal-max-snapshots-per-block-volume = %d\n\n"+
 		"[Labels]\ntopology-categories = \"%s\"",
 		cfg.Global.InsecureFlag, cfg.Global.ClusterID, cfg.Global.ClusterDistribution,
 		cfg.Global.CSIFetchPreferredDatastoresIntervalInMin,
 		cfg.Global.VCenterHostname, cfg.Global.User, cfg.Global.Password,
-		cfg.Global.Datacenters, cfg.Global.VCenterPort,
+		cfg.Global.Datacenters, cfg.Global.VCenterPort, cfg.Global.TargetvSANFileShareDatastoreURLs,
 		cfg.Snapshot.GlobalMaxSnapshotsPerBlockVolume,
 		cfg.Labels.TopologyCategories)
 	return result, nil


### PR DESCRIPTION

What this PR does / why we need it:
Config secret - Verifying vol attachment by updating config secret with different testuser credentials

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

What this PR does / why we need it:
Config secret automation

Part2 of this review - This PR consists of testcases which updates vsphere conf file with different user credentials and later verifying the volume creation and attachment with different user credentials.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

Special notes for your reviewer:

Release note:

Config secret - Verifying vol attachment by updating config secret with different testuser credentials


Testing done:
Yes
[test-e2e-logs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/10105481/test-e2e-logs.txt)


Make Check:
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/config-secret-part1/vsphere-csi-driver /Users/sipriya/config-secret-part1 /Users/sipriya /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (files|name|compiled_files|deps|exports_file|imports|types_sizes) took 14.984900079s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 113.656634ms
INFO [linters context/goanalysis] analyzers took 2m57.886424992s with top 10 stages: buildir: 2m2.46025757s, nilness: 6.152616367s, printf: 5.954271202s, ctrlflow: 5.748861574s, fact_deprecated: 4.836142805s, fact_purity: 3.670024276s, typedness: 3.556831s, SA5012: 3.260623103s, misspell: 2.121718061s, inspect: 1.918346598s
INFO [runner] Issues before processing: 113, after processing: 0
INFO [runner] Processors filtering stat (out/in): exclude-rules: 1/24, path_prettifier: 113/113, skip_files: 113/113, identifier_marker: 24/24, filename_unadjuster: 113/113, autogenerated_exclude: 24/113, exclude: 24/24, nolint: 0/1, cgo: 113/113, skip_dirs: 113/113
INFO [runner] processing took 15.245112ms with stages: nolint: 13.064929ms, autogenerated_exclude: 1.315278ms, path_prettifier: 352.836µs, identifier_marker: 274.882µs, skip_dirs: 116.481µs, exclude-rules: 100.665µs, cgo: 7.582µs, filename_unadjuster: 7.513µs, max_same_issues: 1.373µs, uniq_by_line: 930ns, max_from_linter: 387ns, source_code: 364ns, diff: 343ns, skip_files: 303ns, exclude: 270ns, max_per_file_from_linter: 235ns, severity-rules: 212ns, path_shortener: 210ns, sort_results: 201ns, path_prefixer: 118ns
INFO [runner] linters took 21.986160685s with stages: goanalysis_metalinter: 21.970825273s
INFO File cache stats: 284 entries of total size 4.6MiB
INFO Memory: 359 samples, avg is 792.4MB, max is 1963.5MB
INFO Execution took 37.095787165s
sipriya@sipriya-a01 vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriya-a01 vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.40.1'
golangci/golangci-lint info found version: 1.40.1 for v1.40.1/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/config-secret-part1/vsphere-csi-driver /Users/sipriya/config-secret-part1 /Users/sipriya /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 12 linters: [deadcode errcheck gosimple govet ineffassign lll misspell staticcheck structcheck typecheck unused varcheck]
INFO [loader] Go packages loading at mode 575 (exports_file|types_sizes|imports|name|compiled_files|deps|files) took 3.585686559s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 127.746358ms
INFO [linters context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 113, after processing: 0
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 113/113, autogenerated_exclude: 24/113, cgo: 113/113, skip_dirs: 113/113, exclude-rules: 1/24, path_prettifier: 113/113, identifier_marker: 24/24, skip_files: 113/113, nolint: 0/1, exclude: 24/24
INFO [runner] processing took 14.136991ms with stages: nolint: 11.931427ms, autogenerated_exclude: 1.212911ms, path_prettifier: 445.349µs, identifier_marker: 282.234µs, skip_dirs: 115.285µs, exclude-rules: 96.962µs, filename_unadjuster: 32.238µs, cgo: 15.904µs, max_same_issues: 1.192µs, max_from_linter: 648ns, source_code: 597ns, uniq_by_line: 511ns, diff: 308ns, skip_files: 287ns, exclude: 226ns, severity-rules: 225ns, max_per_file_from_linter: 195ns, path_shortener: 193ns, sort_results: 188ns, path_prefixer: 111ns
INFO [runner] linters took 2.022114876s with stages: goanalysis_metalinter: 2.007892754s
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 59 samples, avg is 97.6MB, max is 140.9MB
INFO Execution took 5.74771753s
sipriya@sipriya-a01 vsphere-csi-driver %
sipriya@sipriya-a01 vsphere-csi-driver %
sipriya@sipriya-a01 vsphere-csi-driver % git status


