### PR TITLE
Collect final errors while iterating over VCs in a multi-VC CreateVolume call

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -1016,7 +1016,7 @@ func (volTopology *controllerVolumeTopology) getSharedDatastoresInTopology(ctx c
 		log.Infof("Obtained list of nodeVMs %+v", matchingNodeVMs)
 		sharedDatastoresInTopology, err := cnsvsphere.GetSharedDatastoresForVMs(ctx, matchingNodeVMs)
 		if err != nil {
-			log.Errorf("Failed to get shared datastores for nodes: %+v in topology segment %+v. Error: %+v",
+			log.Errorf("failed to get shared datastores for nodes: %+v in topology segment %+v. Error: %+v",
 				matchingNodeVMs, segments, err)
 			return nil, err
 		}

--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -33,7 +33,7 @@ func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
 				segments, err)
 		}
 		if len(matchingNodeVMs) == 0 {
-			log.Warnf("No nodes in the cluster matched the topology requirement provided: %+v",
+			log.Warnf("No nodes in the cluster matched the topology requirement: %+v",
 				segments)
 			continue
 		}
@@ -43,7 +43,7 @@ func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
 		sharedDatastoresInTopology, err := cnsvsphere.GetSharedDatastoresForVMs(ctx, matchingNodeVMs)
 		if err != nil {
 			if err == cnsvsphere.ErrNoSharedDatastoresFound {
-				log.Errorf("no shared datastores found for topology segment: %+v", segments)
+				log.Warnf("no shared datastores found for topology segment: %+v", segments)
 				continue
 			}
 			return nil, logger.LogNewErrorf(log, "failed to get shared datastores for nodes: %+v "+

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -316,7 +316,8 @@ func CreateBlockVolumeUtilForMultiVC(ctx context.Context, reqParams interface{})
 	params.SharedDatastores, err = vsphere.FilterSuspendedDatastores(ctx, params.SharedDatastores)
 	if err != nil {
 		return nil, csifault.CSIInternalFault, logger.LogNewErrorf(log,
-			"received error while filtering suspended datastores. Error: %+v", err)
+			"received error while filtering suspended datastores in vCenter %q. Error: %+v",
+			params.Vcenter.Config.Host, err)
 	}
 	if params.Spec.ScParams.DatastoreURL != "" {
 		// Check if DatastoreURL specified in the StorageClass is present in shared
@@ -332,7 +333,7 @@ func CreateBlockVolumeUtilForMultiVC(ctx context.Context, reqParams interface{})
 			// TODO: Need to figure out which fault need to return when datastore is not accessible to all nodes.
 			// Currently, just return csi.fault.Internal.
 			return nil, csifault.CSIInternalFault, logger.LogNewErrorf(log,
-				"Datastore: %s specified in the storage class is not accessible to all nodes in VC %q.",
+				"Datastore: %s specified in the storage class is not accessible to all nodes in vCenter %q.",
 				params.Spec.ScParams.DatastoreURL, params.Vcenter.Config.Host)
 		}
 		// Check if DatastoreURL specified in the StorageClass is present in any one of the datacenters.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: For a CreateVolume call in a multi-VC environment, we should collect the final errors about why volume provisioning failed on a particular VC and inform the customer about it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
TBD

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Collect final errors while iterating over VCs in a multi-VC CreateVolume call
```
