### PR TITLE
 Collect final errors while iterating over VCs in a multi-VC CreateVolume call

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -1016,7 +1016,7 @@ func (volTopology *controllerVolumeTopology) getSharedDatastoresInTopology(ctx c
 		log.Infof("Obtained list of nodeVMs %+v", matchingNodeVMs)
 		sharedDatastoresInTopology, err := cnsvsphere.GetSharedDatastoresForVMs(ctx, matchingNodeVMs)
 		if err != nil {
-			log.Errorf("Failed to get shared datastores for nodes: %+v in topology segment %+v. Error: %+v",
+			log.Errorf("failed to get shared datastores for nodes: %+v in topology segment %+v. Error: %+v",
 				matchingNodeVMs, segments, err)
 			return nil, err
 		}

--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -33,7 +33,7 @@ func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
 				segments, err)
 		}
 		if len(matchingNodeVMs) == 0 {
-			log.Warnf("No nodes in the cluster matched the topology requirement provided: %+v",
+			log.Warnf("No nodes in the cluster matched the topology requirement: %+v",
 				segments)
 			continue
 		}
@@ -43,7 +43,7 @@ func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
 		sharedDatastoresInTopology, err := cnsvsphere.GetSharedDatastoresForVMs(ctx, matchingNodeVMs)
 		if err != nil {
 			if err == cnsvsphere.ErrNoSharedDatastoresFound {
-				log.Errorf("no shared datastores found for topology segment: %+v", segments)
+				log.Warnf("no shared datastores found for topology segment: %+v", segments)
 				continue
 			}
 			return nil, logger.LogNewErrorf(log, "failed to get shared datastores for nodes: %+v "+

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -316,7 +316,8 @@ func CreateBlockVolumeUtilForMultiVC(ctx context.Context, reqParams interface{})
 	params.SharedDatastores, err = vsphere.FilterSuspendedDatastores(ctx, params.SharedDatastores)
 	if err != nil {
 		return nil, csifault.CSIInternalFault, logger.LogNewErrorf(log,
-			"received error while filtering suspended datastores. Error: %+v", err)
+			"received error while filtering suspended datastores in vCenter %q. Error: %+v",
+			params.Vcenter.Config.Host, err)
 	}
 	if params.Spec.ScParams.DatastoreURL != "" {
 		// Check if DatastoreURL specified in the StorageClass is present in shared
@@ -332,7 +333,7 @@ func CreateBlockVolumeUtilForMultiVC(ctx context.Context, reqParams interface{})
 			// TODO: Need to figure out which fault need to return when datastore is not accessible to all nodes.
 			// Currently, just return csi.fault.Internal.
 			return nil, csifault.CSIInternalFault, logger.LogNewErrorf(log,
-				"Datastore: %s specified in the storage class is not accessible to all nodes in VC %q.",
+				"Datastore: %s specified in the storage class is not accessible to all nodes in vCenter %q.",
 				params.Spec.ScParams.DatastoreURL, params.Vcenter.Config.Host)
 		}
 		// Check if DatastoreURL specified in the StorageClass is present in any one of the datacenters.

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -18,6 +18,7 @@ package vanilla
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -94,6 +95,10 @@ var (
 	volIDsInK8s               = make([]string, 0)
 	CNSVolumesforListVolume   = make([]cnstypes.CnsVolume, 0)
 	checkCompatibleDataStores = true
+
+	// errAllDSFilteredOut is an error thrown by auth service when it
+	// filters out all the potential shared datastores in a volume provisioning call.
+	errAllDSFilteredOut = errors.New("auth service could not find datastore for block volume provisioning")
 )
 
 // New creates a CNS controller.
@@ -587,7 +592,7 @@ func (c *controller) filterDatastores(ctx context.Context, sharedDatastores []*c
 	}
 	log.Debugf("filterDatastores: filteredDatastores %v", filteredDatastores)
 	if len(filteredDatastores) == 0 {
-		return nil, logger.LogNewError(log, "auth service could not find datastore for block volume provisioning")
+		return nil, errAllDSFilteredOut
 	}
 	return filteredDatastores, nil
 }
@@ -1033,7 +1038,6 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 	}
 	volSizeMB := int64(common.RoundUpSize(volSizeBytes, common.MbInBytes))
 
-	// Fetching the feature state for csi-migration before parsing storage class params.
 	scParams, err := common.ParseStorageClassParams(ctx, req.Parameters, csiMigrationEnabled)
 	// TODO: Need to figure out the fault returned by ParseStorageClassParams.
 	// Currently, just return "csi.fault.Internal".
@@ -1042,7 +1046,7 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 			"parsing storage class parameters failed with error: %+v", err)
 	}
 
-	// Check if requested volume size and source snapshot size matches
+	// Check if requested volume size and source snapshot size matches.
 	volumeSource := req.GetVolumeContentSource()
 	var contentSourceSnapshotID, snapshotDatastoreURL string
 	if volumeSource != nil {
@@ -1224,6 +1228,7 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 	var (
 		sharedDatastores    []*cnsvsphere.DatastoreInfo
 		topologyRequirement *csi.TopologyRequirement
+		combinedErrMssgs    []string
 	)
 	// Get accessibility requirements.
 	topologyRequirement = req.GetAccessibilityRequirements()
@@ -1267,17 +1272,21 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 					// TODO: As govmomi doesn't support locale and all error messages are
 					// in English, we are temporarily resorting to a error message check.
 					// In future, we need to change govmomi to throw a NotFound error and catch that instead.
-					errMssg := fmt.Sprintf("no pbm profile found with name: %q", scParams.StoragePolicyName)
-					if err.Error() == errMssg {
-						log.Warnf("storage policy name %q not found in VC %q", scParams.StoragePolicyName, vcHost)
+					errMssgFromPBM := fmt.Sprintf("no pbm profile found with name: %q",
+						scParams.StoragePolicyName)
+					if err.Error() == errMssgFromPBM {
+						errMsg := fmt.Sprintf("Storage policy name %q not found in VC %q",
+							scParams.StoragePolicyName, vcHost)
+						log.Warn(errMsg)
+						combinedErrMssgs = append(combinedErrMssgs, errMsg)
 						continue
 					}
 					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 						"failed to get policy ID for storage policy name %q. Error: %+v",
 						scParams.StoragePolicyName, err)
 				}
-				log.Infof("Found ID %q for storage policy name %q", storagePolicyID,
-					scParams.StoragePolicyName)
+				log.Infof("Found ID %q for storage policy name %q in vCenter %q", storagePolicyID,
+					scParams.StoragePolicyName, vcHost)
 			}
 
 			// Get shared accessible datastores for topology segments associated with the vcHost.
@@ -1293,22 +1302,34 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 					topologySegmentsList, vcHost, err)
 			}
 			if len(sharedDatastores) == 0 {
-				log.Warnf("no shared datastores found for accessibility requirements pertaining to vCenter %q",
-					vcHost)
+				errMsg := fmt.Sprintf("No compatible datastores found for accessibility requirements %+v "+
+					"pertaining to vCenter %q", topologySegmentsList, vcHost)
+				log.Warn(errMsg)
+				combinedErrMssgs = append(combinedErrMssgs, errMsg)
 				continue
 			}
 			// Filter datastores based on user access.
 			sharedDatastores, err = c.filterDatastores(ctx, sharedDatastores, vcHost)
 			if err != nil {
+				if err == errAllDSFilteredOut {
+					errMsg := fmt.Sprintf("authorization service filtered out all the compatible "+
+						"datastores found for accessibility requirements %+v associated with vCenter %q",
+						topologySegmentsList, vcHost)
+					log.Warn(errMsg)
+					combinedErrMssgs = append(combinedErrMssgs, errMsg)
+					continue
+				}
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to filter datastores based on authorisation check in vCenter %q. Error: %+v",
 					vcHost, err)
 			}
-			// Call CreateVolume.
 			volumeMgr, err = common.GetVolumeManagerFromVCHost(ctx, c.managers, vcHost)
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCode(log, codes.Internal, err.Error())
 			}
+			// Call CreateVolume.
+			// TODO: Few errors encountered  in CreateBlockVolumeUtilForMultiVC can be
+			// retried instead of moving unto next VC. Need to throw a custom error for such scenarios.
 			volumeInfo, faultType, err = common.CreateBlockVolumeUtilForMultiVC(ctx,
 				common.VanillaCreateBlockVolParamsForMultiVC{
 					Vcenter:              vcenter,
@@ -1321,7 +1342,8 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 					ClusterFlavor:        cnstypes.CnsClusterFlavorVanilla,
 				})
 			if err != nil {
-				log.Errorf("failed to create volume. Error: %+v", err)
+				log.Error(err)
+				combinedErrMssgs = append(combinedErrMssgs, err.Error())
 				continue
 			}
 			log.Infof("volume %q created in vCenter %q. Proceeding to calculate "+
@@ -1330,9 +1352,11 @@ func (c *controller) createBlockVolumeWithPlacementEngineForMultiVC(ctx context.
 		}
 	}
 	if volumeInfo == nil {
+		if faultType == "" {
+			faultType = csifault.CSIInternalFault
+		}
 		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
-			"failed to create volume with accessibility requirements %+v on any vCenter. Error: %+v",
-			topologyRequirement, err)
+			"failed to create volume. Errors encountered: %+v", combinedErrMssgs)
 	}
 
 	attributes := make(map[string]string)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is collecting and returning final errors while integrating over VCs for volume creation on multi-vCenter deployment.
commit is taken from this PR - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2107

**Testing**

Created SC with wrong policy name which is not present in both the vCenter servers.
observed CSI controller has returned collected logs on the PVC after attempting to create volume on both vCenter servers.


 >Warning  ProvisioningFailed    4s (x3 over 7s)  csi.vsphere.vmware.com_vsphere-csi-controller-75fc75c546-s99n4_1c0fd856-b4e3-4fab-a86c-1390931e4a16  failed to provision volume with StorageClass "block-sc": rpc error: code = Internal desc = failed to create volume. Errors encountered: [Storage policy name "wrong-policy-name" not found in VC "sc1-10-78-81-17.eng.vmware.com" Storage policy name "wrong-policy-name" not found in VC "sc2-10-185-105-221.nimbus.eng.vmware.com"]


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
 Collect final errors while iterating over VCs in a multi-VC CreateVolume call
```
