### PR TITLE
set max 5 vcenter server limit for multi vCenter deployment

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -143,6 +143,11 @@ var (
 	// Multi vCenter deployment
 	ErrMissingTopologyCategoriesForMultiVCenterSetup = errors.New("vsphere CSI config requires " +
 		"topology-categories to be specified for multi vCenter deployment")
+
+	// ErrMaxVCenterSupportedForMultiVCenterSetup is returned when vSphere config secret has more than 5 vCenter
+	// servers
+	ErrMaxVCenterSupportedForMultiVCenterSetup = errors.New("max 5 vCenters are supported for multi " +
+		"vCenter deployment")
 )
 
 // GeneratedVanillaClusterID is used to save unique cluster ID generated
@@ -328,6 +333,10 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 	if len(cfg.VirtualCenter) == 0 {
 		log.Error(ErrMissingVCenter)
 		return ErrMissingVCenter
+	}
+	if len(cfg.VirtualCenter) > 5 {
+		log.Error(ErrMaxVCenterSupportedForMultiVCenterSetup)
+		return ErrMaxVCenterSupportedForMultiVCenterSetup
 	}
 	// Cluster ID should not exceed 64 characters.
 	if len(cfg.Global.ClusterID) > 64 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
set max 5 vcenter servers limit for multi vCenter deployment


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
set max 5 vcenter server limit for multi vCenter deployment
```
