### PR TITLE
Preferential topology code fix for verifying pv node affinity details when shared datastore is chosen for preference

### DIFF
--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -2186,7 +2186,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack2)
+			allowedTopologies)
 	})
 
 	/*


### PR DESCRIPTION
**What this PR does / why we need it**:
Preferential topology code fix for veryfing pv node affinity details when shared datastore is chosen for preference

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Preferential topology code fix for veryfing pv node affinity details when shared datastore is chosen for preference

**Testing done**:
Yes
https://gist.githubusercontent.com/sipriyaa/b109829f0ecc032e52f841756035b3c6/raw/6553a77a43b2dec528f3fa65ea901d7a8c4933b9/gistfile1.txt

**Special notes for your reviewer**:

**Release note**:
--> Preferential testcase code fix for veryfing pv node affinity details

Make Check:
sipriya@sipriyaSMD6M vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriyaSMD6M vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/preferential-bug/vsphere-csi-driver /Users/sipriya/preferential-bug /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (files|exports_file|imports|name|types_sizes|compiled_files|deps) took 1m33.877081076s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 144.080124ms 
INFO [linters context/goanalysis] analyzers took 8m25.624725272s with top 10 stages: buildir: 6m2.707500651s, nilness: 19.938404351s, ctrlflow: 18.137501432s, fact_deprecated: 17.565176831s, printf: 17.443807846s, typedness: 12.516414452s, fact_purity: 12.103210027s, SA5012: 11.117369488s, inspect: 4.630993925s, misspell: 2.860179338s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 113/113, autogenerated_exclude: 24/113, identifier_marker: 24/24, skip_dirs: 113/113, exclude-rules: 1/24, nolint: 0/1, cgo: 113/113, path_prettifier: 113/113, skip_files: 113/113, exclude: 24/24 
INFO [runner] processing took 16.71573ms with stages: nolint: 12.31441ms, autogenerated_exclude: 3.605916ms, path_prettifier: 324.412µs, identifier_marker: 272.563µs, skip_dirs: 105.01µs, exclude-rules: 74.692µs, cgo: 8.413µs, filename_unadjuster: 5.913µs, max_same_issues: 1.435µs, uniq_by_line: 515ns, skip_files: 388ns, max_from_linter: 332ns, diff: 309ns, source_code: 258ns, exclude: 230ns, severity-rules: 221ns, max_per_file_from_linter: 200ns, path_shortener: 200ns, sort_results: 198ns, path_prefixer: 115ns 
INFO [runner] linters took 49.535639536s with stages: goanalysis_metalinter: 49.518831739s 
INFO File cache stats: 308 entries of total size 5.6MiB 
INFO Memory: 1350 samples, avg is 645.3MB, max is 3100.3MB 
INFO Execution took 2m23.568438934s               
sipriya@sipriyaSMD6M vsphere-csi-driver % 
