### PR TITLE
Fix a bug by checking whether the type of fault is nil or not

### DIFF
--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -362,21 +362,28 @@ func ExtractFaultTypeFromErr(ctx context.Context, err error) string {
 func ExtractFaultTypeFromVolumeResponseResult(ctx context.Context,
 	resp *cnstypes.CnsVolumeOperationResult) string {
 	log := logger.GetLogger(ctx)
+	log.Debugf("Extracting fault type from response: %+v", resp)
 	var faultType string
 	fault := resp.Fault
 	if fault != nil {
 		// faultType has the format like "*type.XXX", XXX is the specific VimFault type.
 		// For example, when CnsVolumeOperationrResult failed with ResourceInUse, faultType will be "*type.ResourceInUse".
-		faultType = reflect.TypeOf(fault.Fault).String()
-		log.Infof("Extract vimfault type: +%v  vimFault: +%v Fault: %+v from resp: +%v",
-			faultType, fault.Fault, fault, resp)
-		slice := strings.Split(faultType, ".")
-		vimFaultType := vimFaultPrefix + slice[1]
-		return vimFaultType
+		if fault.Fault != nil {
+			faultType = reflect.TypeOf(fault.Fault).String()
+			log.Infof("Extract vimfault type: %+v  vimFault: %+v Fault: %+v from resp: %+v",
+				faultType, fault.Fault, fault, resp)
+			slice := strings.Split(faultType, ".")
+			vimFaultType := vimFaultPrefix + slice[1]
+			return vimFaultType
+		} else {
+			faultType = reflect.TypeOf(fault).String()
+			log.Infof("Extract fault: %q from resp: %+v",
+				faultType, resp)
+			return faultType
+		}
 	}
-	log.Info("No fault in resp +%v", resp)
+	log.Info("No fault in resp %+v", resp)
 	return ""
-
 }
 
 // invokeCNSCreateSnapshot invokes CreateSnapshot operation for that volume on CNS.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When I reproduced the issue mentioned in PR: https://bugzilla.eng.vmware.com/show_bug.cgi?id=3064078#c7, 
 according to the steps mentioned in Update #7, the controller pods went into CLBO as there was a panic during Volume Attachment. This is not list volumes issue but an issue seen during Volume Attachment.  (in pkg/common/cns-lib/volume/util.go)

The Panic was happening because the fault was not nil, but fault.Fault was nil. Added a guard to check if fault.Fault is not nil. 

```
<panic>
2022-12-02T21:55:41.169831878Z 2022-12-02T21:55:41.169Z DEBUG   common/vsphereutil.go:579       vSphere CSI driver is attaching volume: "2541ea93-e310-4342-9ed3-59652741ac44" to vm: "VirtualMachine:vm-52 [VirtualCenterHost: 10.186.97.50, UUID: 420533df-1ade-8949-80ed-db3f49f0ef5a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.97.50]]"       {"TraceId": "66b75b9f-981e-46e2-953a-2467e1694d87"}
2022-12-02T21:55:41.222876314Z 2022-12-02T21:55:41.222Z INFO    volume/manager.go:833   AttachVolume: volumeID: "2541ea93-e310-4342-9ed3-59652741ac44", vm: "VirtualMachine:vm-52 [VirtualCenterHost: 10.186.97.50, UUID: 420533df-1ade-8949-80ed-db3f49f0ef5a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.97.50]]", opId: "1dfb8e33"       {"TraceId": "66b75b9f-981e-46e2-953a-2467e1694d87"}
2022-12-02T21:55:41.225465899Z panic: runtime error: invalid memory address or nil pointer dereference
2022-12-02T21:55:41.225491124Z [signal SIGSEGV: segmentation violation code=0x1 addr=0xf8 pc=0x1a3b675]
2022-12-02T21:55:41.225502468Z
2022-12-02T21:55:41.225879835Z goroutine 470 [running]:
2022-12-02T21:55:41.226267550Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume.ExtractFaultTypeFromVolumeResponseResult({0x269de18?, 0xc00075bec0?}, 0xc00087c2a0)
2022-12-02T21:55:41.226739401Z  /build/pkg/common/cns-lib/volume/util.go:370 +0x95
2022-12-02T21:55:41.226762628Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume.(*defaultManager).AttachVolume.func1()
2022-12-02T21:55:41.227095553Z  /build/pkg/common/cns-lib/volume/manager.go:851 +0xa4e
2022-12-02T21:55:41.227413223Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume.(*defaultManager).AttachVolume(0x0?, {0x269de18, 0xc00075bec0}, 0xc0002c8520?, {0xc0009f28d0, 0x24}, 0x34?)
2022-12-02T21:55:41.227834640Z  /build/pkg/common/cns-lib/volume/manager.go:873 +0xe2
2022-12-02T21:55:41.228240491Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.AttachVolumeUtil({0x269de18, 0xc00075bec0}, {0x26adf40, 0xc0007e5920}, 0xc000832ea0, {0xc0009f28d0, 0x24}, 0xf8?)
2022-12-02T21:55:41.228528122Z  /build/pkg/csi/service/common/vsphereutil.go:580 +0x24c
2022-12-02T21:55:41.229017009Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).ControllerPublishVolume.func1()
2022-12-02T21:55:41.229027557Z  /build/pkg/csi/service/vanilla/controller.go:2104 +0xbba
2022-12-02T21:55:41.229720015Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).ControllerPublishVolume(0xc000114640, {0x269de18, 0xc00075b0b0}, 0xc000162e40)
2022-12-02T21:55:41.230144270Z  /build/pkg/csi/service/vanilla/controller.go:2118 +0x14d
2022-12-02T21:55:41.231132026Z github.com/container-storage-interface/spec/lib/go/csi._Controller_ControllerPublishVolume_Handler({0x228dde0?, 0xc000114640}, {0x269de18, 0xc00075b0b0}, 0xc000162de0, 0x0)
2022-12-02T21:55:41.231167085Z  /go/pkg/mod/github.com/container-storage-interface/[spec@v1.6.0](mailto:spec@v1.6.0)/lib/go/csi/csi.pb.go:5707 +0x170
2022-12-02T21:55:41.231715408Z google.golang.org/grpc.(*Server).processUnaryRPC(0xc0003a4540, {0x26a4998, 0xc0007c2820}, 0xc000b00a20, 0xc0005d4a50, 0x38c1650, 0x0)
2022-12-02T21:55:41.231729784Z  /go/pkg/mod/google.golang.org/[grpc@v1.47.0](mailto:grpc@v1.47.0)/server.go:1283 +0xcfe
2022-12-02T21:55:41.232405699Z google.golang.org/grpc.(*Server).handleStream(0xc0003a4540, {0x26a4998, 0xc0007c2820}, 0xc000b00a20, 0x0)
2022-12-02T21:55:41.232415969Z  /go/pkg/mod/google.golang.org/[grpc@v1.47.0](mailto:grpc@v1.47.0)/server.go:1620 +0xa2f
2022-12-02T21:55:41.232422338Z google.golang.org/grpc.(*Server).serveStreams.func1.2()
2022-12-02T21:55:41.232424514Z  /go/pkg/mod/google.golang.org/[grpc@v1.47.0](mailto:grpc@v1.47.0)/server.go:922 +0x98
2022-12-02T21:55:41.232426581Z created by google.golang.org/grpc.(*Server).serveStreams.func1
2022-12-02T21:55:41.232428683Z  /go/pkg/mod/google.golang.org/[grpc@v1.47.0](mailto:grpc@v1.47.0)/server.go:920 +0x28a
<panic>
```


**Testing done**:
After applying patch it is not in CLBO. attach keeps failing for a little more than 'Sync minutes' duration, and then eventually passes after full sync registers the volume:

```
2022-12-02T23:04:22.193808173Z 2022-12-02T23:04:22.193Z ERROR   common/vsphereutil.go:582       failed to attach disk "2541ea93-e310-4342-9ed3-59652741ac44" with VM: "VirtualMachine:vm-52 [VirtualCenterHost: 10.186.97.50, UUID: 420533df-1ade-8949-80ed-db3f49f0ef5a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.97.50]]". err: failed to attach cns volume: "2541ea93-e310-4342-9ed3-59652741ac44" to node vm: "VirtualMachine:vm-52 [VirtualCenterHost: 10.186.97.50, UUID: 420533df-1ade-8949-80ed-db3f49f0ef5a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.97.50]]". fault: "(*types.LocalizedMethodFault)(0xc000683180)({\n DynamicData: (types.DynamicData) {\n },\n Fault: (types.BaseMethodFault) <nil>,\n LocalizedMessage: (string) (len=188) \"Volume with ID 2541ea93-e310-4342-9ed3-59652741ac44 is not registered as CNS Volume. Error message: The input volume 2541ea93-e310-4342-9ed3-59652741ac44 is not registered as a CNS volume.\"\n})\n". opId: "1dfba6db" faultType "*types.LocalizedMethodFault"   {"TraceId": "8253f8e4-8982-4872-9866-f27f02bc5040"}
2022-12-02T23:04:22.193811672Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common.AttachVolumeUtil
2022-12-02T23:04:22.193815263Z  /build/pkg/csi/service/common/vsphereutil.go:582
2022-12-02T23:04:22.193818510Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).ControllerPublishVolume.func1
2022-12-02T23:04:22.193828045Z  /build/pkg/csi/service/vanilla/controller.go:2104
2022-12-02T23:04:22.193831524Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).ControllerPublishVolume
2022-12-02T23:04:22.193834888Z  /build/pkg/csi/service/vanilla/controller.go:2118
2022-12-02T23:04:22.193838116Z github.com/container-storage-interface/spec/lib/go/csi._Controller_ControllerPublishVolume_Handler
2022-12-02T23:04:22.193841257Z  /go/pkg/mod/github.com/container-storage-interface/spec@v1.6.0/lib/go/csi/csi.pb.go:5707
2022-12-02T23:04:22.193844409Z google.golang.org/grpc.(*Server).processUnaryRPC
2022-12-02T23:04:22.193847872Z  /go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1283
2022-12-02T23:04:22.193851272Z google.golang.org/grpc.(*Server).handleStream
2022-12-02T23:04:22.193854594Z  /go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1620
2022-12-02T23:04:22.193858004Z google.golang.org/grpc.(*Server).serveStreams.func1.2
2022-12-02T23:04:22.193861421Z  /go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:922
2022-12-02T23:04:22.194063457Z 2022-12-02T23:04:22.193Z ERROR   vanilla/controller.go:2107      failed to attach disk: "2541ea93-e310-4342-9ed3-59652741ac44" with node: "420533df-1ade-8949-80ed-db3f49f0ef5a" err failed to attach cns volume: "2541ea93-e310-4342-9ed3-59652741ac44" to node vm: "VirtualMachine:vm-52 [VirtualCenterHost: 10.186.97.50, UUID: 420533df-1ade-8949-80ed-db3f49f0ef5a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.186.97.50]]". fault: "(*types.LocalizedMethodFault)(0xc000683180)({\n DynamicData: (types.DynamicData) {\n },\n Fault: (types.BaseMethodFault) <nil>,\n LocalizedMessage: (string) (len=188) \"Volume with ID 2541ea93-e310-4342-9ed3-59652741ac44 is not registered as CNS Volume. Error message: The input volume 2541ea93-e310-4342-9ed3-59652741ac44 is not registered as a CNS volume.\"\n})\n". opId: "1dfba6db"       {"TraceId": "8253f8e4-8982-4872-9866-f27f02bc5040"}
2022-12-02T23:04:22.194080217Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).ControllerPublishVolume.func1
2022-12-02T23:04:22.194084001Z  /build/pkg/csi/service/vanilla/controller.go:2107
2022-12-02T23:04:22.194087000Z sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).ControllerPublishVolume
2022-12-02T23:04:22.194089258Z  /build/pkg/csi/service/vanilla/controller.go:2118
2022-12-02T23:04:22.194091428Z github.com/container-storage-interface/spec/lib/go/csi._Controller_ControllerPublishVolume_Handler
2022-12-02T23:04:22.194093540Z  /go/pkg/mod/github.com/container-storage-interface/spec@v1.6.0/lib/go/csi/csi.pb.go:5707
2022-12-02T23:04:22.194096438Z google.golang.org/grpc.(*Server).processUnaryRPC
2022-12-02T23:04:22.194098483Z  /go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1283
2022-12-02T23:04:22.194100588Z google.golang.org/grpc.(*Server).handleStream
2022-12-02T23:04:22.194102908Z  /go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1620
2022-12-02T23:04:22.194105068Z google.golang.org/grpc.(*Server).serveStreams.func1.2
2022-12-02T23:04:22.194107217Z  /go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:922
```
We can see tha Fault message properly now:
Error message: The input volume 2541ea93-e310-4342-9ed3-59652741ac44 is not registered as a CNS volume

**Special notes for your reviewer**:

