### PR TITLE
Use faulttype to determine the attach/detach operation succeeded or not.

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -621,8 +621,14 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 	}
 	resp, faulttype, err := reconcileCnsNodeVMAttachmentInternal()
 
-	if (err != nil || resp != reconcile.Result{}) {
-		// When reconciler returns reconcile.Result{RequeueAfter: timeout}, the err will be set to nil,
+	if err != nil || faulttype != "" {
+		// When faultype is set, it indicates the attach/detach failure
+		// Case 1:
+		// both err and faultype are set
+		// Case 2:
+		// err is nil but faultype type is set
+		// This can happen when reconciler returns reconcile.Result{RequeueAfter: timeout}, the err will be set to nil,
+		// and corresponding faulttype will be set
 		// for this case, we need count it as an attach/detach failure
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When guest cluster attach/detach volume failed, our code rely on the following check to determine whether the attach/detach volume operation is succeed or not.

```
resp, faulttype, err := reconcileCnsNodeVMAttachmentInternal()
if (err != nil || resp != reconcile.Result{}) {
 // consider attach/detach operation failed
}
```
However, we found in some condition, when attach/detach volume op failed, but for some unknown reason, the retry time out is set to 0. In this case, even the attach/detach volume op failed,  the returned resp is equal to "reconcile.Result{}"
(reconcile.Result{} == reconcile.Result{RequeueAfter: time.Second * 0}) and cause it to update the prometheus counter to be updated incorrectly. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This change is to make the fix to use faulttype to determine the attach/detach operation succeeded or not.

**Testing done**:
1. create a pvc in guest cluster
2. stop vsan-health service
3. create a pod to using the pvc created in step 1, pod stuck in pending state
4. check the prometheus metric, see attach volume failed
```
vsphere_csi_volume_ops_histogram_sum{faulttype="",optype="attach-volume",status="pass",voltype="block"} 2.9652333669999997
vsphere_csi_volume_ops_histogram_count{faulttype="",optype="attach-volume",status="pass",voltype="block"} 1
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block",le="2"} 5
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block",le="5"} 5
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block",le="10"} 5
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block",le="15"} 5
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block",le="20"} 5
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block",le="25"} 5
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block",le="30"} 5
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block",le="60"} 5
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block",le="120"} 5
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block",le="180"} 5
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block",le="+Inf"} 5
vsphere_csi_volume_ops_histogram_sum{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block"} 0.8530135050000001
vsphere_csi_volume_ops_histogram_count{faulttype="csi.fault.Internal",optype="attach-volume",status="fail",voltype="block"} 5
```

See the related attach volume failure in vsphere-syncer log
```
{"level":"error","time":"2022-12-12T23:52:53.241534477Z","caller":"cnsnodevmattachment/cnsnodevmattachment_controller.go:628","msg":"Operation failed, reporting failure status to Prometheus. Operation Type: \"attach-volume\", Volume Type: \"block\", Fault Type: \"csi.fault.Internal\"","TraceId":"ab581599-e7b0-4396-b105-55a32e8bab18","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment.(*ReconcileCnsNodeVMAttachment).Reconcile\n\t/build/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go:628\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:121\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:320\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:234"}

```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
6. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```Use faulttype to determine the attach/detach operation succeeded or not.
```
