### PR TITLE
Add k8s 1.24 support to 1.24/pvcsi.yaml

### DIFF
--- a/manifests/guestcluster/1.24/pvcsi.yaml
+++ b/manifests/guestcluster/1.24/pvcsi.yaml
@@ -159,10 +159,13 @@ spec:
     spec:
       serviceAccountName: vsphere-csi-controller
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         - operator: "Exists"
           key: "node-role.kubernetes.io/control-plane"
+          effect: "NoSchedule"
+        - operator: "Exists"
+          key: "node-role.kubernetes.io/master"
           effect: "NoSchedule"
       priorityClassName: system-node-critical # Guarantees scheduling for critical system pods
       containers:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2014 initially added the 1.24/pvcsi.yaml with the `control-plane` toleration. 

This change adds the `master` toleration alongside the `control-plane` toleration. 

We also need the `nodeSelector` to be set to `control-plane` instead of `master`. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
