### PR TITLE
support non-topology single vCenter deployment when multi-vcenter-csi-topology enabled

### DIFF
--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -61,14 +61,14 @@ func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
 			compat, err := params.Vcenter.PbmCheckCompatibility(ctx, sharedDSMoRef, params.StoragePolicyID)
 			if err != nil {
 				return nil, logger.LogNewErrorf(log, "failed to find datastore compatibility "+
-					"with storage policy ID %q. Error: %+v", params.StoragePolicyID, err)
+					"with storage policy ID %q. vCenter: %q  Error: %+v", params.StoragePolicyID, params.Vcenter.Config.Host, err)
 			}
 			compatibleDsMoids := make(map[string]struct{})
 			for _, ds := range compat.CompatibleDatastores() {
 				compatibleDsMoids[ds.HubId] = struct{}{}
 			}
-			log.Infof("Datastores compatible with storage policy %q are %+v", params.StoragePolicyID,
-				compatibleDsMoids)
+			log.Infof("Datastores compatible with storage policy %q are %+v for vCenter: %q", params.StoragePolicyID,
+				compatibleDsMoids, params.Vcenter.Config.Host)
 
 			// Filter compatible datastores from shared datastores list.
 			var compatibleDatastores []*cnsvsphere.DatastoreInfo
@@ -78,8 +78,8 @@ func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
 				}
 			}
 			if len(compatibleDatastores) == 0 {
-				log.Errorf("No compatible shared datastores found for storage policy %q",
-					params.StoragePolicyID)
+				log.Errorf("No compatible shared datastores found for storage policy %q on vCenter: %q",
+					params.StoragePolicyID, params.Vcenter.Config.Host)
 				continue
 			}
 			sharedDatastoresInTopology = compatibleDatastores
@@ -128,8 +128,8 @@ func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
 		}
 	}
 	if len(sharedDatastores) != 0 {
-		log.Infof("Shared compatible datastores being considered for volume provisioning are: %+v",
-			sharedDatastores)
+		log.Infof("Shared compatible datastores being considered for volume provisioning on vCenter: %q are: %+v",
+			sharedDatastores, params.Vcenter.Config.Host)
 	}
 	return sharedDatastores, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support non-topology single vCenter deployment when multi-vcenter-csi-topology enabled.
Currently with non-topology single vCenter deployment when multi-vcenter-csi-topology is enabled, CreateVolume Operation is failing.


**Testing done**:
Created Volume on the single VC Setup without topology where Volume Creation was failing previously when multi-vcenter-csi-topology enabled.


```
# kubectl logs vsphere-csi-controller-587f9b59fb-2zms5 --namespace=vmware-system-csi -c vsphere-csi-controller | grep "5bae24f2-b777-4305-8260-e6c884afde81"
Error from server (NotFound): pods "vsphere-csi-controller-587f9b59fb-2zms5" not found
root@k8s-control-39-1670830700:~/test-yaml# kubectl logs vsphere-csi-controller-7f64977746-bxdc8 --namespace=vmware-system-csi -c vsphere-csi-controller | grep "5bae24f2-b777-4305-8260-e6c884afde81"
2022-12-14T21:40:52.993Z	INFO	vanilla/controller.go:1867	CreateVolume: called with args {Name:pvc-b9350205-ce05-4d00-8057-f032b35e4de9 CapacityRange:required_bytes:5368709120  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:52.994Z	DEBUG	vanilla/controller.go:1207	Checking if vCenter task for volume pvc-b9350205-ce05-4d00-8057-f032b35e4de9 is already registered.	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:52.994Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:141	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-b9350205-ce05-4d00-8057-f032b35e4de9	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.006Z	DEBUG	vanilla/controller.go:1232	CreateVolume task details for block volume pvc-b9350205-ce05-4d00-8057-f032b35e4de9 are not found.	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.009Z	DEBUG	node/manager.go:295	Renewing VM VirtualMachine:vm-55 [VirtualCenterHost: 10.78.89.128, UUID: 4216a549-3ea6-deb5-cad4-18f561cceb99, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.89.128]] with new connection: nodeUUID 4216a549-3ea6-deb5-cad4-18f561cceb99	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.012Z	DEBUG	node/manager.go:305	Updated VM VirtualMachine:vm-55 [VirtualCenterHost: 10.78.89.128, UUID: 4216a549-3ea6-deb5-cad4-18f561cceb99, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.89.128]] for node with nodeUUID 4216a549-3ea6-deb5-cad4-18f561cceb99	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.012Z	DEBUG	node/manager.go:292	Renewing VM VirtualMachine:vm-50 [VirtualCenterHost: 10.78.89.128, UUID: 421643ea-26d0-0eca-84ed-235c4ab9456a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.89.128]], no new connection needed: nodeUUID 421643ea-26d0-0eca-84ed-235c4ab9456a	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.012Z	DEBUG	node/manager.go:305	Updated VM VirtualMachine:vm-50 [VirtualCenterHost: 10.78.89.128, UUID: 421643ea-26d0-0eca-84ed-235c4ab9456a, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.89.128]] for node with nodeUUID 421643ea-26d0-0eca-84ed-235c4ab9456a	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.012Z	DEBUG	node/manager.go:292	Renewing VM VirtualMachine:vm-53 [VirtualCenterHost: 10.78.89.128, UUID: 421695a2-f82d-b923-ae8b-4c4883cb1769, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.89.128]], no new connection needed: nodeUUID 421695a2-f82d-b923-ae8b-4c4883cb1769	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.012Z	DEBUG	node/manager.go:305	Updated VM VirtualMachine:vm-53 [VirtualCenterHost: 10.78.89.128, UUID: 421695a2-f82d-b923-ae8b-4c4883cb1769, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.89.128]] for node with nodeUUID 421695a2-f82d-b923-ae8b-4c4883cb1769	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.012Z	DEBUG	node/manager.go:292	Renewing VM VirtualMachine:vm-51 [VirtualCenterHost: 10.78.89.128, UUID: 4216a130-8124-915f-4a71-52723c7f85b6, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.89.128]], no new connection needed: nodeUUID 4216a130-8124-915f-4a71-52723c7f85b6	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.012Z	DEBUG	node/manager.go:305	Updated VM VirtualMachine:vm-51 [VirtualCenterHost: 10.78.89.128, UUID: 4216a130-8124-915f-4a71-52723c7f85b6, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.89.128]] for node with nodeUUID 4216a130-8124-915f-4a71-52723c7f85b6	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.012Z	DEBUG	node/manager.go:292	Renewing VM VirtualMachine:vm-52 [VirtualCenterHost: 10.78.89.128, UUID: 4216aec7-c1ba-8e3d-4d86-af07b9bc2d02, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.89.128]], no new connection needed: nodeUUID 4216aec7-c1ba-8e3d-4d86-af07b9bc2d02	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.012Z	DEBUG	node/manager.go:305	Updated VM VirtualMachine:vm-52 [VirtualCenterHost: 10.78.89.128, UUID: 4216aec7-c1ba-8e3d-4d86-af07b9bc2d02, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.89.128]] for node with nodeUUID 4216aec7-c1ba-8e3d-4d86-af07b9bc2d02	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.012Z	DEBUG	node/manager.go:292	Renewing VM VirtualMachine:vm-54 [VirtualCenterHost: 10.78.89.128, UUID: 4216dd0a-f709-048e-ebac-075d53c262ca, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.89.128]], no new connection needed: nodeUUID 4216dd0a-f709-048e-ebac-075d53c262ca	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.012Z	DEBUG	node/manager.go:305	Updated VM VirtualMachine:vm-54 [VirtualCenterHost: 10.78.89.128, UUID: 4216dd0a-f709-048e-ebac-075d53c262ca, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.78.89.128]] for node with nodeUUID 4216dd0a-f709-048e-ebac-075d53c262ca	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.012Z	DEBUG	vsphere/virtualmachine.go:368	Getting accessible datastores for node VirtualMachine:vm-55	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.024Z	DEBUG	vsphere/virtualmachine.go:368	Getting accessible datastores for node VirtualMachine:vm-50	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.030Z	DEBUG	vsphere/virtualmachine.go:368	Getting accessible datastores for node VirtualMachine:vm-53	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.036Z	DEBUG	vsphere/virtualmachine.go:368	Getting accessible datastores for node VirtualMachine:vm-51	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.042Z	DEBUG	vsphere/virtualmachine.go:368	Getting accessible datastores for node VirtualMachine:vm-52	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.047Z	DEBUG	vsphere/virtualmachine.go:368	Getting accessible datastores for node VirtualMachine:vm-54	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.053Z	DEBUG	node/nodes.go:237	sharedDatastores : [Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/5bb95ee3-52adb601/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:5203776874b73357-a62d3b2414975c7c/]	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.053Z	DEBUG	vanilla/controller.go:619	filterDatastores: dsMap map[ds:///vmfs/volumes/5bb95ee3-52adb601/:Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/5bb95ee3-52adb601/ ds:///vmfs/volumes/6396cf5e-e8f6326b-b138-00505681c4a5/:Datastore: Datastore:datastore-43, datastore URL: ds:///vmfs/volumes/6396cf5e-e8f6326b-b138-00505681c4a5/ ds:///vmfs/volumes/6396cf5f-4c879a77-8028-00505681c4a5/:Datastore: Datastore:datastore-44, datastore URL: ds:///vmfs/volumes/6396cf5f-4c879a77-8028-00505681c4a5/ ds:///vmfs/volumes/6396cf60-7759771f-a0c0-005056817301/:Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/6396cf60-7759771f-a0c0-005056817301/ ds:///vmfs/volumes/6396cf61-1e61e9f4-c505-0050568135ab/:Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/6396cf61-1e61e9f4-c505-0050568135ab/ ds:///vmfs/volumes/6396cf61-b832b173-3f15-005056817301/:Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/6396cf61-b832b173-3f15-005056817301/ ds:///vmfs/volumes/6396cf62-73b4c330-46e3-0050568135ab/:Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/6396cf62-73b4c330-46e3-0050568135ab/ ds:///vmfs/volumes/6396cf63-19c4b1fa-0dfa-00505681a156/:Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/6396cf63-19c4b1fa-0dfa-00505681a156/ ds:///vmfs/volumes/6396cf63-d73ac744-2121-00505681a156/:Datastore: Datastore:datastore-40, datastore URL: ds:///vmfs/volumes/6396cf63-d73ac744-2121-00505681a156/ ds:///vmfs/volumes/vsan:5203776874b73357-a62d3b2414975c7c/:Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:5203776874b73357-a62d3b2414975c7c/] sharedDatastores [Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/5bb95ee3-52adb601/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:5203776874b73357-a62d3b2414975c7c/]	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.054Z	DEBUG	vanilla/controller.go:628	filterDatastores: filteredDatastores [Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/5bb95ee3-52adb601/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:5203776874b73357-a62d3b2414975c7c/]	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.054Z	INFO	vsphere/utils.go:581	Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/5bb95ee3-52adb601/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:5203776874b73357-a62d3b2414975c7c/]	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.058Z	DEBUG	volume/util.go:205	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.058Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:141	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-b9350205-ce05-4d00-8057-f032b35e4de9	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:53.093Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:215	Created CnsVolumeOperationRequest instance vmware-system-csi/pvc-b9350205-ce05-4d00-8057-f032b35e4de9 with latest information for task with ID: task-14931	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:59.099Z	INFO	volume/manager.go:404	CreateVolume: VolumeName: "pvc-b9350205-ce05-4d00-8057-f032b35e4de9", opId: "0c36065d"	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:59.101Z	INFO	volume/util.go:329	Volume created successfully. VolumeName: "pvc-b9350205-ce05-4d00-8057-f032b35e4de9", volumeID: "b5cb127b-d705-4ca8-878a-7cb0c4d5191a"	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:59.101Z	DEBUG	volume/util.go:331	CreateVolume volumeId {{} "b5cb127b-d705-4ca8-878a-7cb0c4d5191a"} is placed on datastore "ds:///vmfs/volumes/vsan:5203776874b73357-a62d3b2414975c7c/"	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:59.122Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:283	Updated CnsVolumeOperationRequest instance vmware-system-csi/pvc-b9350205-ce05-4d00-8057-f032b35e4de9 with latest information for task with ID: task-14931	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:59.122Z	DEBUG	volume/manager.go:768	internalCreateVolume: returns fault ""	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:59.122Z	INFO	vanilla/controller.go:1528	volume "b5cb127b-d705-4ca8-878a-7cb0c4d5191a" created in vCenter "10.78.89.128"	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:59.122Z	DEBUG	vanilla/controller.go:1901	createVolumeInternal: returns fault ""	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
2022-12-14T21:40:59.122Z	INFO	vanilla/controller.go:1909	Volume created successfully. Volume Handle: "b5cb127b-d705-4ca8-878a-7cb0c4d5191a", PV Name: "pvc-b9350205-ce05-4d00-8057-f032b35e4de9"	{"TraceId": "5bae24f2-b777-4305-8260-e6c884afde81"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
support non-topology single vCenter deployment when multi-vcenter-csi-topology enabled
```
