### PR TITLE
Added unit test job in the pipeline.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+stages:
+  - unit-test
+
+run-unit-tests:
+  stage: unit-test
+  # A copy of golang image in dockerhub.
+  image: $CNS_IMAGE_GOLANG_1_19
+  script:
+  - make test
+  rules:
+    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds support for GitLab CI that is configured to run in VMware on-prem infrastructure(internal to VMware). This PR adds unit test job in the pipeline that runs all the unit tests in the CSI driver.

**Testing done**:
GitLab CI successfully ran the pipeline with the unit test job - https://gitlab.eng.vmware.com/core-build/mirrors_github_vsphere-csi-driver/-/pipelines/5457926

Note that I'm not running any pre-check in tests as this PR is not touching the CSI functionality.

**Special notes for your reviewer**:
The GitLab CI configuration and pipeline do not affect the CSI driver functionality. On the contrary, the pipeline tests the code commits and makes sure that it is not breaking any CSI functionality. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Added support for GitLab CI for testing.
```
