### PR TITLE
Removed rule to trigger the pipeline on all commits and not just on merge request events.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,5 +7,3 @@ run-unit-tests:
   image: $CNS_IMAGE_GOLANG_1_19
   script:
   - make test
-  rules:
-    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Removed rule to trigger the pipeline on all commits and not just on merge request events.

**Testing done**:
Successful pipeline run - https://gitlab.eng.vmware.com/core-build/mirrors_github_vsphere-csi-driver/-/pipelines/5458210

