### PR TITLE
fix listvolume for migrated volumes

### DIFF
--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -65,6 +65,7 @@ type COCommonInterface interface {
 	// GetAllVolumes returns list of volumes in a bound state
 	GetAllVolumes() []string
 	// GetAllK8sVolumes returns list of volumes in a bound state, in the K8s cluster
+	// list Includes Migrated vSphere Volumes VMDK Paths and CSI Volume IDs
 	GetAllK8sVolumes() []string
 	// AnnotateVolumeSnapshot annotates the volumesnapshot CR in k8s cluster with the snapshot-id and fcd-id
 	AnnotateVolumeSnapshot(ctx context.Context, volumeSnapshotName string,

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -2551,7 +2551,6 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 				CNSVolumesforListVolume = cnsQueryResult.Volumes
 			}
 		}
-
 		// Step 3: If the difference between number of K8s volumes and CNS volumes is greater than threshold,
 		// fail the operation, as it can result in too many attach calls.
 		if len(volIDsInK8s)-len(CNSVolumesforListVolume) > cfg.Global.ListVolumeThreshold {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fixes the bug causing csi controller pods to crash. The CSI spec in the PV is nil when PV is in-tree migrated PV which is causing the crash.

**Testing done**:
In progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix listvolume for migrated volumes
```
