### PR TITLE
fix: return appropriate error message to gc pvc from supervisor

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
 	commonconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -244,7 +245,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 		*csi.CreateVolumeResponse, string, error) {
 
 		log.Infof("CreateVolume: called with args %+v", *req)
-		//TODO: If the err is returned by invoking CNS API, then faultType should be
+		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
 		// If thr reqeust failed due to object not found, "csi.fault.NotFound" will be return.
@@ -332,12 +333,29 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 				c.supervisorNamespace, err)
 			log.Error(msg)
 			eventList, err := c.supervisorClient.CoreV1().Events(c.supervisorNamespace).List(ctx,
-				metav1.ListOptions{FieldSelector: "involvedObject.name=" + pvc.Name})
+				metav1.ListOptions{
+					FieldSelector:        "involvedObject.name=" + pvc.Name,
+					ResourceVersion:      pvc.ResourceVersion,
+					ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
+				})
 			if err != nil {
 				log.Errorf("Unable to fetch events for pvc %q/%q from supervisor cluster with err: %+v",
 					c.supervisorNamespace, pvc.Name, err)
 				return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
 			}
+
+			var failureMessage string
+			for _, svcPvcEvent := range eventList.Items {
+				if svcPvcEvent.Type == corev1.EventTypeWarning {
+					failureMessage = svcPvcEvent.Message
+					break
+				}
+			}
+
+			if failureMessage != "" {
+				msg = fmt.Sprintf("%s. reason: %s", msg, failureMessage)
+			}
+
 			log.Errorf("Last observed events on the pvc %q/%q in supervisor cluster: %+v",
 				c.supervisorNamespace, pvc.Name, spew.Sdump(eventList.Items))
 			return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
@@ -431,7 +449,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	deleteVolumeInternal := func() (
 		*csi.DeleteVolumeResponse, string, error) {
 		log.Infof("DeleteVolume: called with args: %+v", *req)
-		//TODO: If the err is returned by invoking CNS API, then faultType should be
+		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
 		// If thr reqeust failed due to object not found, "csi.fault.NotFound" will be return.
@@ -506,7 +524,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	controllerPublishVolumeInternal := func() (
 		*csi.ControllerPublishVolumeResponse, string, error) {
 		log.Infof("ControllerPublishVolume: called with args %+v", *req)
-		//TODO: If the err is returned by invoking CNS API, then faultType should be
+		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
 		// If thr reqeust failed due to object not found, "csi.fault.NotFound" will be return.
@@ -678,7 +696,7 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 		log.Debugf("disk UUID %v is set for the volume: %q ", diskUUID, req.VolumeId)
 	}
 
-	//return PublishContext with diskUUID of the volume attached to node.
+	// return PublishContext with diskUUID of the volume attached to node.
 	publishInfo := make(map[string]string)
 	publishInfo[common.AttributeDiskType] = common.DiskTypeBlockVolume
 	publishInfo[common.AttributeFirstClassDiskUUID] = common.FormatDiskUUID(diskUUID)
@@ -842,7 +860,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	controllerUnpublishVolumeInternal := func() (
 		*csi.ControllerUnpublishVolumeResponse, string, error) {
 		log.Infof("ControllerUnpublishVolume: called with args %+v", *req)
-		//TODO: If the err is returned by invoking CNS API, then faultType should be
+		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
 		// If thr reqeust failed due to object not found, "csi.fault.NotFound" will be return.
@@ -1121,7 +1139,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 			return nil, csifault.CSIUnimplementedFault, status.Error(codes.Unimplemented, msg)
 		}
 		log.Infof("ControllerExpandVolume: called with args %+v", *req)
-		//TODO: If the err is returned by invoking CNS API, then faultType should be
+		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
 		// If thr reqeust failed due to object not found, "csi.fault.NotFound" will be return.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

What this PR does -> 
Currently, if a PVC created in GC fails with `ProvisioningFailed`, the reason for that failure is not returned from supervisor to guest cluster. Instead, we log all the events in supervisor for that PVC. 

This change goes over those events, checks for one with `ProvisioningFailed` as the `Event.Reason` and appends the `Event.Message` to the failure message. 

Why we need it -> 
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1749 tried to fix two things 
- Returning the failure message from supervisor to GC. 
- Not waiting up to 240 seconds to return the message in case of a failure. 

That change removed the watch() and introduced a wait.PollImmediate() call which would poll at the beginning and then at an interval of 5 seconds. The poll func itself checked pvc.Status.Phase. In case of a Pending phase, events for that Supervisor PVC are listed, and the event.Reason field is compared with “ProvisioningFailed” and if there is any such event, we return failure immediately with the event.Message

Now, this 5 seconds interval is the cause of slower operations. It caused a regression in the pvc creation performance. 

E.g,
T0 - First immediate poll - status is not bound
pvc got bound within 5 seconds interval but need to wait for the next poll to find out about it
T5 - Second poll - status is bound and return success

It was later reverted with https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2149. Now we need to fix the original issue of the PVC failure message from SC not showing up on GC. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

## Manual testing
```
Inducing an error in SC, here are the outputs of describe pvc on SC and GC
---------------------------------------------------------------------------------------------------

### SC

root@4204a638e2ee4c5be921a11ab87bd35f [ ~ ]# k -n test-gc-e2e-demo-ns describe pvc
Name:          77b27e38-5a22-4f4a-b97c-05f67a146f14-9f13b6e5-7a71-4046-b91e-231df53d6374
Namespace:     test-gc-e2e-demo-ns
StorageClass:  gc-storage-profile
Status:        Pending
Volume:
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:
Access Modes:
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age               From                                                                                          Message
  ----     ------                ----              ----                                                                                          -------
  Normal   Provisioning          5s (x5 over 21s)  csi.vsphere.vmware.com_4204a638e2ee4c5be921a11ab87bd35f_7f8e742e-75cc-40d7-8de0-4ed72398fba6  External provisioner is provisioning volume for claim "test-gc-e2e-demo-ns/77b27e38-5a22-4f4a-b97c-05f67a146f14-9f13b6e5-7a71-4046-b91e-231df53d6374"
  Warning  ProvisioningFailed    5s (x5 over 21s)  csi.vsphere.vmware.com_4204a638e2ee4c5be921a11ab87bd35f_7f8e742e-75cc-40d7-8de0-4ed72398fba6  failed to provision volume with StorageClass "gc-storage-profile": rpc error: code = Unknown desc = Validation for CreateVolume Request has failed.
  Normal   ExternalProvisioning  3s (x3 over 21s)  persistentvolume-controller                                                                   waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator


### GC

root@4204a638e2ee4c5be921a11ab87bd35f [ ~ ]# k create -f podpvc.yaml
persistentvolumeclaim/aditya-gc-pvc created
pod/aditya-gc-pvc-block-pod created

root@4204a638e2ee4c5be921a11ab87bd35f [ ~ ]# k get pvc
NAME            STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS         AGE
aditya-gc-pvc   Pending                                      gc-storage-profile   2s


root@4204a638e2ee4c5be921a11ab87bd35f [ ~ ]# k describe pvc
Name:          aditya-gc-pvc
Namespace:     default
StorageClass:  gc-storage-profile
Status:        Pending
Volume:
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:
Access Modes:
VolumeMode:    Block
Used By:       aditya-gc-pvc-block-pod
Events:
  Type    Reason                Age                From                                                                                                Message
  ----    ------                ----               ----                                                                                                -------
  Normal  Provisioning          12s                csi.vsphere.vmware.com_vsphere-csi-controller-f9bcdb454-bnng2_92cffb84-1719-4f55-b3a8-b978cec391df  External provisioner is provisioning volume for claim "default/aditya-gc-pvc"
  Normal  ExternalProvisioning  11s (x2 over 12s)  persistentvolume-controller                                                                         waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator


### GC after 240 seconds

root@4204a638e2ee4c5be921a11ab87bd35f [ ~ ]# k describe pvc
Name:          aditya-gc-pvc
Namespace:     default
StorageClass:  gc-storage-profile
Status:        Pending
Volume:
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:
Access Modes:
VolumeMode:    Block
Used By:       aditya-gc-pvc-block-pod
Events:
  Type     Reason                Age                    From                                                                                                Message
  ----     ------                ----                   ----                                                                                                -------
  Normal   Provisioning          2m55s (x3 over 10m)    csi.vsphere.vmware.com_vsphere-csi-controller-f9bcdb454-bnng2_92cffb84-1719-4f55-b3a8-b978cec391df  External provisioner is provisioning volume for claim "default/aditya-gc-pvc"
  Warning  ProvisioningFailed    2m55s (x2 over 6m56s)  csi.vsphere.vmware.com_vsphere-csi-controller-f9bcdb454-bnng2_92cffb84-1719-4f55-b3a8-b978cec391df  failed to provision volume with StorageClass "gc-storage-profile": rpc error: code = Internal desc = failed to create volume on namespace: test-gc-e2e-demo-ns in supervisor cluster. Error: persistentVolumeClaim 77b27e38-5a22-4f4a-b97c-05f67a146f14-9f13b6e5-7a71-4046-b91e-231df53d6374 in namespace test-gc-e2e-demo-ns not in phase Bound within 240 seconds. reason: failed to provision volume with StorageClass "gc-storage-profile": rpc error: code = Unknown desc = Validation for CreateVolume Request has failed.
  Normal   ExternalProvisioning  56s (x42 over 10m)     persistentvolume-controller                                                                         waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
```

## e2e tests

https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2147#issuecomment-1439278743


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
