### PR TITLE
Bumping up sidecars

### DIFF
--- a/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
+++ b/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
@@ -84,7 +84,7 @@ spec:
       serviceAccountName: snapshot-webhook
       containers:
         - name: snapshot-validation
-          image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.1.0 # change the image if you wish to use your own custom validation server image
+          image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.2.1 # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/run/secrets/tls/tls.crt', '--tls-private-key-file=/run/secrets/tls/tls.key']
           ports:

--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -59,7 +59,7 @@ else
         exit 1
 fi
 
-qualified_version="v6.1.0"
+qualified_version="v6.2.1"
 volumesnapshotclasses_crd="volumesnapshotclasses.snapshot.storage.k8s.io"
 volumesnapshotcontents_crd="volumesnapshotcontents.snapshot.storage.k8s.io"
 volumesnapshots_crd="volumesnapshots.snapshot.storage.k8s.io"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -244,7 +244,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v4.0.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v4.1.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -259,7 +259,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.7.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -363,7 +363,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.4.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -382,7 +382,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.2.1
           args:
             - "--v=4"
             - "--kube-api-qps=100"
@@ -430,7 +430,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -515,7 +515,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -577,7 +577,7 @@ spec:
       serviceAccountName: vsphere-csi-node
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -657,7 +657,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Bumping up sidecars to latest version

Attacher moves to [v4.1](https://github.com/kubernetes-csi/external-attacher/blob/release-4.1/CHANGELOG/CHANGELOG-4.1.md) 
Provisioner moves to [v3.4](https://github.com/kubernetes-csi/external-provisioner/blob/v3.4.0/CHANGELOG/CHANGELOG-3.4.md)
Resizer to [v1.7](https://github.com/kubernetes-csi/external-resizer/releases/tag/v1.7.0)
Snapshottter to [v6.2.1](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v6.2.1)
Node-driver-registrar to [v2.7](https://github.com/kubernetes-csi/node-driver-registrar/blob/release-2.7/CHANGELOG/CHANGELOG-2.7.md)
Livenessprobe to [v2.9](https://github.com/kubernetes-csi/livenessprobe/blob/release-2.9/CHANGELOG/CHANGELOG-2.9.md)

**Testing done**:
Pipelines to be run

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bumping up sidecars to latest version
```
