### PR TITLE
Add new fault type category  "invalidconfig".

### DIFF
--- a/pkg/common/fault/constants.go
+++ b/pkg/common/fault/constants.go
@@ -48,7 +48,7 @@ const (
 
 	// CSIVSanFileServiceDisabledFault is the fault type when trying to create a RWX volume on a cluster which vsan file
 	// service is disabled.
-	CSIVSanFileServiceDisabledFault = "csi.fault.nonstorage.VSanFileServiceDisabled"
+	CSIVSanFileServiceDisabledFault = "csi.fault.invalidconfig.VSanFileServiceDisabled"
 
 	// CSITaskResultEmptyFault is the fault type when taskResult is empty.
 	CSITaskResultEmptyFault = "csi.fault.TaskResultEmpty"
@@ -62,5 +62,5 @@ const (
 	// CSIUnimplementedFault is the fault type returned when the function is unimplemented.
 	CSIUnimplementedFault = "csi.fault.Unimplemented"
 	// CSIInvalidStoragePolicyConfigurationFault is the fault type returned when the user provides invalid storage policy.
-	CSIInvalidStoragePolicyConfigurationFault = "csi.fault.InvalidStoragePolicyConfiguration"
+	CSIInvalidStoragePolicyConfigurationFault = "csi.fault.invalidconfig.InvalidStoragePolicyConfiguration"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is to change the fault name for the following invalid config faults.
```csi.fault.nonstorage.VSanFileServiceDisabled```  --->  ```csi.fault.invalidconfig.VSanFileServiceDisabled```
```csi.fault.InvalidStoragePolicyConfiguration```  ---> ```csi.fault.invalidconfig.InvalidStoragePolicyConfiguration```

We introduce this new fault type category and apply it at prefix in the faults related to invalid configuration.  This will help us to exclude "invalidconfig" related faults in dashboard definition and alert definition if needed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
WCP pre-checkin test passed
Vanilla pre-checkin test in progress

**Special notes for your reviewer**:

**Release note**:
Add new fault type category  "invalidconfig".
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
