### PR TITLE
Customise Leader Election for Syncer container

### DIFF
--- a/manifests/guestcluster/1.23/pvcsi.yaml
+++ b/manifests/guestcluster/1.23/pvcsi.yaml
@@ -239,6 +239,9 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
             - "--supervisor-fss-name=csi-feature-states"
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/guestcluster/1.24/pvcsi.yaml
+++ b/manifests/guestcluster/1.24/pvcsi.yaml
@@ -242,6 +242,9 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
             - "--supervisor-fss-name=csi-feature-states"
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -356,6 +356,9 @@ spec:
           image: localhost:5000/vmware/syncer:<syncer_ver>
           args:
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -359,6 +359,9 @@ spec:
           image: localhost:5000/vmware/syncer:<syncer_ver>
           args:
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -356,6 +356,9 @@ spec:
           image: localhost:5000/vmware/syncer:<syncer_ver>
           args:
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"


### PR DESCRIPTION
**What this PR does / why we need it**:
 Support leader-election lease customization for syncer container.

**Testing done**:

On an SV cluster, update vsphere syncer args in deployment YAML with the args:
 
"--leader-election-lease-duration=120s"
 "--leader-election-renew-deadline=60s"
 "--leader-election-retry-period=30s"

Observed that the lease was acquired successsfully:

```
root@42107c9ecfa60424bcf22f5dde541431 [ ~ ]# kubectl logs vsphere-csi-controller-c64f88b66-j6g5f -n vmware-system-csi -c vsphere-syncer | grep "leaderelection"
I0113 06:46:05.178034       1 leaderelection.go:248] attempting to acquire leader lease vmware-system-csi/vsphere-syncer...
I0113 06:48:23.274435       1 leaderelection.go:258] successfully acquired lease vmware-system-csi/vsphere-syncer
```

Lease duration is also set to 120s instead of the default 15s:

```
root@42107c9ecfa60424bcf22f5dde541431 [ ~ ]# kubectl get lease -n vmware-system-csi vsphere-syncer -oyaml
apiVersion: coordination.k8s.io/v1
kind: Lease
metadata:
  creationTimestamp: "2023-01-12T16:24:07Z"
  name: vsphere-syncer
  namespace: vmware-system-csi
  resourceVersion: "524976"
  uid: e5a7a573-70bf-45ed-b12c-cb630eaca3ea
spec:
  acquireTime: "2023-01-13T06:48:23.215751Z"
  holderIdentity: 42107c9ecfa60424bcf22f5dde541431
  leaseDurationSeconds: 120
  leaseTransitions: 2
  renewTime: "2023-01-13T07:51:04.535295Z"
```


After this, changed deployment file to extend lease duration to 200s and saw the changes reflected in the lease object also:

```
root@42107c9ecfa60424bcf22f5dde541431 [ ~ ]# kubectl get lease -n vmware-system-csi vsphere-syncer -oyaml
apiVersion: coordination.k8s.io/v1
kind: Lease
metadata:
  creationTimestamp: "2023-01-12T16:24:07Z"
  name: vsphere-syncer
  namespace: vmware-system-csi
  resourceVersion: "576580"
  uid: e5a7a573-70bf-45ed-b12c-cb630eaca3ea
spec:
  acquireTime: "2023-01-13T08:05:11.906194Z"
  holderIdentity: 42105e489e2f8a87d26c175673ac6ba2
  leaseDurationSeconds: 200
  leaseTransitions: 4
  renewTime: "2023-01-13T09:24:40.185294Z"
```


NOT TESTED FOR GC YET as the deployment is getting overwritten very fast.