### PR TITLE
support file volume creation on non-topology enabled single vCenter deployment with multi-vcenter-csi-topology gate enabled

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -776,8 +776,13 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 	}
 	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 	isTKGSHAEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
-	volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorWorkload,
-		c.manager, &createVolumeSpec, filteredDatastores,
+	vc, err := c.manager.VcenterManager.GetVirtualCenter(ctx, c.manager.VcenterConfig.Host)
+	if err != nil {
+		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to get vCenter. Error: %+v", err)
+	}
+	volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorWorkload, vc,
+		c.manager.VolumeManager, c.manager.CnsConfig, &createVolumeSpec, filteredDatastores,
 		filterSuspendedDatastores, isTKGSHAEnabled, checkCompatibleDataStores)
 	if err != nil {
 		return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
when `multi-vcenter-csi-topology` feature gate is enabled, but we have a single vCenter deployment, file volume creation fails with the following panic.

```
{"level":"info","time":"2023-01-13T17:42:11.238898973Z","caller":"vanilla/controller.go:1868","msg":"CreateVolume: called with args {Name:pvc-d4428310-903c-436f-8fda-4b551010ed75 CapacityRange:required_bytes:5368709120  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"73917123-2796-4eda-9aeb-edff687e7cf9"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1b1b988]

goroutine 442 [running]:
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).CreateVolume.func1()
 /build/pkg/csi/service/vanilla/controller.go:1882 +0x1e8
sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla.(*controller).CreateVolume(0xc0001aa000, {0x26a1518, 0xc000bafbc0}, 0xc000261ea0)
 /build/pkg/csi/service/vanilla/controller.go:1901 +0x1bb
github.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler({0x2290560?, 0xc0001aa000}, {0x26a1518, 0xc000bafbc0}, 0xc000bac9c0, 0x0)
 /go/pkg/mod/github.com/container-storage-interface/[spec@v1.7.0](mailto:spec@v1.7.0)/lib/go/csi/csi.pb.go:5671 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00017fc00, {0x26a80d8, 0xc0002c84e0}, 0xc0008da480, 0xc0009dd110, 0x38c4660, 0x0)
 /go/pkg/mod/google.golang.org/[grpc@v1.47.0](mailto:grpc@v1.47.0)/server.go:1283 +0xcfe
google.golang.org/grpc.(*Server).handleStream(0xc00017fc00, {0x26a80d8, 0xc0002c84e0}, 0xc0008da480, 0x0)
 /go/pkg/mod/google.golang.org/[grpc@v1.47.0](mailto:grpc@v1.47.0)/server.go:1620 +0xa2f
google.golang.org/grpc.(*Server).serveStreams.func1.2()
 /go/pkg/mod/google.golang.org/[grpc@v1.47.0](mailto:grpc@v1.47.0)/server.go:922 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
 /go/pkg/mod/google.golang.org/[grpc@v1.47.0](mailto:grpc@v1.47.0)/server.go:920 +0x28a
```

We need to support the creation of file volume when `multi-vcenter-csi-topology` gate enabled but single vCenter server is used without topology configuration.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Vanilla setup with `multi-vcenter-csi-topology` gate enabled, with single VC deployment without topology configuration.

```
{"level":"info","time":"2023-01-13T22:12:04.553490741Z","caller":"vanilla/controller.go:1899","msg":"CreateVolume: called with args {Name:pvc-d4428310-903c-436f-8fda-4b551010ed75 CapacityRange:required_bytes:5368709120  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"3e6fd49d-c334-419b-abe4-420e256fdda7"}
{"level":"info","time":"2023-01-13T22:12:04.65580009Z","caller":"vsphere/utils.go:581","msg":"Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:52d66c5f88bec764-ace2e0ab833d428c/]","TraceId":"3e6fd49d-c334-419b-abe4-420e256fdda7"}
{"level":"info","time":"2023-01-13T22:12:18.432002636Z","caller":"volume/manager.go:404","msg":"CreateVolume: VolumeName: \"pvc-d4428310-903c-436f-8fda-4b551010ed75\", opId: \"13e0f9b9\"","TraceId":"3e6fd49d-c334-419b-abe4-420e256fdda7"}
{"level":"info","time":"2023-01-13T22:12:18.435358179Z","caller":"volume/util.go:329","msg":"Volume created successfully. VolumeName: \"pvc-d4428310-903c-436f-8fda-4b551010ed75\", volumeID: \"file:12416fe0-c9a7-4fe1-8c33-fb025147cf48\"","TraceId":"3e6fd49d-c334-419b-abe4-420e256fdda7"}
{"level":"info","time":"2023-01-13T22:12:18.475959968Z","caller":"vanilla/controller.go:1961","msg":"Volume created successfully. Volume Handle: \"file:12416fe0-c9a7-4fe1-8c33-fb025147cf48\", PV Name: \"pvc-d4428310-903c-436f-8fda-4b551010ed75\"","TraceId":"3e6fd49d-c334-419b-abe4-420e256fdda7"}
{"level":"info","time":"2023-01-13T22:12:58.928046731Z","caller":"config/config.go:405","msg":"No Net Permissions given in Config. Using default permissions.","TraceId":"c373ffad-4de0-4732-9d32-f9decc1af0d5"}
```



**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
support file volume creation on non-topology enabled single vCenter deployment with multi-vcenter-csi-topology gate enabled
```
