### PR TITLE
Disable Disk Decommission FSS references as it is enabled by default

### DIFF
--- a/manifests/supervisorcluster/1.15/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.15/cns-csi.yaml
@@ -252,8 +252,6 @@ spec:
           emptyDir: {}
 ---
 apiVersion: v1
-data:
-  "vsan-direct-disk-decommission": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.16/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.16/cns-csi.yaml
@@ -281,8 +281,6 @@ spec:
           emptyDir: {}
 ---
 apiVersion: v1
-data:
-  "vsan-direct-disk-decommission": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.17/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.17/cns-csi.yaml
@@ -316,7 +316,6 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "vsan-direct-disk-decommission": "false"
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"

--- a/manifests/supervisorcluster/1.18/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.18/cns-csi.yaml
@@ -319,7 +319,6 @@ apiVersion: v1
 data:
   "volume-extend": "true"
   "volume-health": "true"
-  "vsan-direct-disk-decommission": "false"
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"

--- a/manifests/supervisorcluster/1.19/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.19/cns-csi.yaml
@@ -344,7 +344,6 @@ data:
   "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
-  "vsan-direct-disk-decommission": "false"
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"

--- a/manifests/supervisorcluster/1.20/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.20/cns-csi.yaml
@@ -385,7 +385,6 @@ data:
   "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
-  "vsan-direct-disk-decommission": "false"
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"

--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -409,7 +409,6 @@ data:
   "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
-  "vsan-direct-disk-decommission": "true"
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -417,7 +417,6 @@ data:
   "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
-  "vsan-direct-disk-decommission": "true"
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -421,7 +421,6 @@ data:
   "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
-  "vsan-direct-disk-decommission": "true"
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -424,7 +424,6 @@ data:
   "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
-  "vsan-direct-disk-decommission": "true"
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -421,7 +421,6 @@ data:
   "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
-  "vsan-direct-disk-decommission": "true"
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"

--- a/pipeline/dev/patch.yaml
+++ b/pipeline/dev/patch.yaml
@@ -28,7 +28,6 @@ data:
   "online-volume-extend": "true"
   "file-volume": "true"
   "csi-auth-check": "true"
-  "vsan-direct-disk-decommission": "true"
   "trigger-csi-fullsync": "false"
   "csi-sv-feature-states-replication": "true"
   "fake-attach": "true"

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -347,8 +347,6 @@ const (
 	// CSISVFeatureStateReplication is feature flag for SV feature state
 	// replication feature.
 	CSISVFeatureStateReplication = "csi-sv-feature-states-replication"
-	// VSANDirectDiskDecommission is feature flag for vsanD disk decommission.
-	VSANDirectDiskDecommission = "vsan-direct-disk-decommission"
 	// FileVolume is feature flag name for file volume support in WCP.
 	FileVolume = "file-volume"
 	// FakeAttach is the feature flag for fake attach support in WCP.

--- a/pkg/syncer/storagepool/service.go
+++ b/pkg/syncer/storagepool/service.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 	"time"
 
-	cnstypes "github.com/vmware/govmomi/cns/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
 	storagepoolconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config"
 
 	spv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1"
@@ -132,26 +132,15 @@ func InitStoragePoolService(ctx context.Context,
 	go func() {
 		diskDecommEnablementTicker := time.NewTicker(common.DefaultFeatureEnablementCheckInterval)
 		defer diskDecommEnablementTicker.Stop()
-		clusterFlavor := cnstypes.CnsClusterFlavorWorkload
 		for ; true; <-diskDecommEnablementTicker.C {
-			coCommonInterface, err := commonco.GetContainerOrchestratorInterface(ctx,
-				common.Kubernetes, clusterFlavor, *coInitParams)
+			_, err := initDiskDecommController(ctx, migrationController)
 			if err != nil {
-				log.Errorf("Failed to create CO agnostic interface. Error: %v", err)
+				log.Warnf("Error while initializing disk decommission controller. Error: %+v. "+
+					"Retry will be triggered at %v",
+					err, time.Now().Add(common.DefaultFeatureEnablementCheckInterval))
 				continue
 			}
-			if !coCommonInterface.IsFSSEnabled(ctx, common.VSANDirectDiskDecommission) {
-				log.Infof("VSANDirectDiskDecommission feature is disabled on the cluster")
-			} else {
-				_, err := initDiskDecommController(ctx, migrationController)
-				if err != nil {
-					log.Warnf("Error while initializing disk decommission controller. Error: %+v. "+
-						"Retry will be triggered at %v",
-						err, time.Now().Add(common.DefaultFeatureEnablementCheckInterval))
-					continue
-				}
-				break
-			}
+			break
 		}
 	}()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Disable Disk Decommission FSS references as it is enabled by default


**Testing done**:

Built sandbox build of VC and ran all disk decomm tests:

```
2023-02-15T21:20:17.383Z [INFO psp_util.py::analyseTestResults::1426::ThreadPoolExecutor-3_0] Results for test module: vSANDiskDecommTest

test01vsanDDiskDecommPos: PASS
test02vsanDDiskDecommNeg: PASS
test03vsanDDiskDecommNoAction: PASS
test04vsanDDiskDecommInstance: PASS
test05insufficientDiskSpace: PASS
test06vsanDDiskDecommPvc: PASS
test07vsanDNewDisk: PASS
test08concurrentDiskDecomm: FAIL:  -- Will retry this but looks like an intermittent error unrelated to the change.
test09DiskDecommWithoutUserPrivilege: PASS
test09DiskDecommWithoutUserPrivilege: PASS
test10IoDataConsistency: PASS
```
