### PR TITLE
Leader election customisation for vanilla deployments

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -250,6 +250,9 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
           env:
@@ -268,6 +271,9 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -334,6 +340,9 @@ spec:
           image: gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest
           args:
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"
@@ -371,6 +380,9 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
             - "--default-fstype=ext4"
             # needed only for topology aware setup
             #- "--feature-gates=Topology=true"
@@ -390,6 +402,9 @@ spec:
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Leader election customisation options to vanilla deployments as well.

**Testing done**:
Updated vsphere-csi deployment YAML on a vanilla deployment to include the following args for the 5 containers, csi-provisioner, csi-attacher, csi-resizer, vsphere-syncer, csi-snapshotter:

```
            - "--leader-election-lease-duration=120s"
            - "--leader-election-renew-deadline=60s"
            - "--leader-election-retry-period=30s"
```


Lease lock duration value initially:

```
root@k8s-control-878-1673518613:~# kubectl get lease -n vmware-system-csi -oyaml | grep "leaseDurationSeconds"
    leaseDurationSeconds: 15
    leaseDurationSeconds: 15
    leaseDurationSeconds: 15
    leaseDurationSeconds: 15
    leaseDurationSeconds: 15
```

Lease lock duration after updating YAML files:

```
root@k8s-control-878-1673518613:~# kubectl get lease -n vmware-system-csi -oyaml | grep "leaseDurationSeconds"
    leaseDurationSeconds: 120
    leaseDurationSeconds: 120
    leaseDurationSeconds: 120
    leaseDurationSeconds: 120
    leaseDurationSeconds: 120
```
