### PR TITLE
fix push manifest issue and removing EOL windows versions

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -21,6 +21,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -x
 
 DO_WINDOWS_BUILD=${DO_WINDOWS_BUILD_ENV:-true}
 
@@ -60,8 +61,8 @@ GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.19
 
 ARCH=amd64
 OSVERSION=1809
-# OS Version for the Windows images: 1809, 1903, 1909 2004, 20H2, ltsc2022
-OSVERSION_WIN=(1809 1903 1909 2004 20H2 ltsc2022)
+# OS Version for the Windows images: 1809, 20H2, ltsc2022
+OSVERSION_WIN=(1809 20H2 ltsc2022)
 # The output type could either be docker (local), or registry.
 # If it is registry, it will also allow us to push the Windows images.
 WINDOWS_IMAGE_OUTPUT="type=tar,dest=.build/windows-driver.tar"
@@ -125,7 +126,7 @@ function fatal() {
 
 
 function build_driver_images_windows() {
-  docker buildx use vsphere-csi-builder-win || docker buildx create --name vsphere-csi-builder-win --platform windows/amd64 --use
+  docker buildx use vsphere-csi-builder-win || docker buildx create --driver-opt image=moby/buildkit:v0.10.6 --name vsphere-csi-builder-win --platform windows/amd64 --use
   echo "building ${CSI_IMAGE_NAME}:${VERSION} for windows"
   # some registry do not allow uppercase tags
   osv=$(lcase ${OSVERSION})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
push manifest  got broken due to the latest buildkit
Removed EOL windows versions.


**Testing done**:
Verified pushing images from mac.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix push manifest issue and removing EOL windows versions
```
