### PR TITLE
Nimbus generated passwords read for VC ESXi and K8s VM from env. export variables

### DIFF
--- a/tests/e2e/config_change_test.go
+++ b/tests/e2e/config_change_test.go
@@ -17,11 +17,12 @@ import (
 var _ bool = ginkgo.Describe("[csi-supervisor] config-change-test", func() {
 	f := framework.NewDefaultFramework("e2e-config-change-test")
 	var (
-		client            clientset.Interface
-		namespace         string
-		scParameters      map[string]string
-		storagePolicyName string
-		ctx               context.Context
+		client               clientset.Interface
+		namespace            string
+		scParameters         map[string]string
+		storagePolicyName    string
+		ctx                  context.Context
+		nimbusGeneratedVcPwd string
 	)
 	const (
 		configSecret = "vsphere-config-secret"
@@ -41,6 +42,8 @@ var _ bool = ginkgo.Describe("[csi-supervisor] config-change-test", func() {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithCancel(context.Background())
 		defer cancel()
+
+		nimbusGeneratedVcPwd = GetAndExpectStringEnvVar(nimbusVcPwd)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -96,7 +99,7 @@ var _ bool = ginkgo.Describe("[csi-supervisor] config-change-test", func() {
 		username := vsphereCfg.Global.User
 		currentPassword := vsphereCfg.Global.Password
 		newPassword := e2eTestPassword
-		err = invokeVCenterChangePassword(username, adminPassword, newPassword, vcAddress)
+		err = invokeVCenterChangePassword(username, nimbusGeneratedVcPwd, newPassword, vcAddress)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Modifying the password in the secret")
@@ -111,7 +114,7 @@ var _ bool = ginkgo.Describe("[csi-supervisor] config-change-test", func() {
 
 		defer func() {
 			ginkgo.By("Reverting the password change")
-			err = invokeVCenterChangePassword(username, adminPassword, currentPassword, vcAddress)
+			err = invokeVCenterChangePassword(username, nimbusGeneratedVcPwd, currentPassword, vcAddress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Reverting the secret change back to reflect the original password")

--- a/tests/e2e/csi_snapshot_basic.go
+++ b/tests/e2e/csi_snapshot_basic.go
@@ -50,16 +50,17 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 	f := framework.NewDefaultFramework("volume-snapshot")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
-		client              clientset.Interface
-		c                   clientset.Interface
-		namespace           string
-		scParameters        map[string]string
-		datastoreURL        string
-		pandoraSyncWaitTime int
-		pvclaims            []*v1.PersistentVolumeClaim
-		volumeOpsScale      int
-		restConfig          *restclient.Config
-		snapc               *snapclient.Clientset
+		client                  clientset.Interface
+		c                       clientset.Interface
+		namespace               string
+		scParameters            map[string]string
+		datastoreURL            string
+		pandoraSyncWaitTime     int
+		pvclaims                []*v1.PersistentVolumeClaim
+		volumeOpsScale          int
+		restConfig              *restclient.Config
+		snapc                   *snapclient.Clientset
+		nimbusGeneratedK8sVmPwd string
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -104,6 +105,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			c = remoteC
 		}
+		nimbusGeneratedK8sVmPwd = GetAndExpectStringEnvVar(nimbusK8sVmPwd)
 	})
 
 	/*
@@ -4257,7 +4259,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		sshClientConfig := &ssh.ClientConfig{
 			User: "root",
 			Auth: []ssh.AuthMethod{
-				ssh.Password(k8sVmPasswd),
+				ssh.Password(nimbusGeneratedK8sVmPwd),
 			},
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		}

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -29,7 +29,6 @@ import (
 
 const (
 	adminUser                                  = "Administrator@vsphere.local"
-	adminPassword                              = "Admin!23"
 	apiServerIPs                               = "API_SERVER_IPS"
 	attacherContainerName                      = "csi-attacher"
 	busyBoxImageOnGcr                          = "harbor-repo.vmware.com/csi/busybox:1.35"
@@ -94,7 +93,6 @@ const (
 	envVmdkDiskURL                             = "DISK_URL_PATH"
 	envVolumeOperationsScale                   = "VOLUME_OPS_SCALE"
 	envComputeClusterName                      = "COMPUTE_CLUSTER_NAME"
-	esxPassword                                = "ca$hc0w"
 	execCommand                                = "/bin/df -T /mnt/volume1 | " +
 		"/bin/awk 'FNR == 2 {print $2}' > /mnt/volume1/fstype && while true ; do sleep 2 ; done"
 	execRWXCommandPod1 = "echo 'Hello message from Pod1' > /mnt/volume1/Pod1.html  && " +
@@ -118,7 +116,6 @@ const (
 	invalidFSType                             = "ext10"
 	k8sPodTerminationTimeOut                  = 7 * time.Minute
 	k8sPodTerminationTimeOutLong              = 10 * time.Minute
-	k8sVmPasswd                               = "C$!Fvt#8"
 	kcmManifest                               = "/etc/kubernetes/manifests/kube-controller-manager.yaml"
 	kubeAPIPath                               = "/etc/kubernetes/manifests/"
 	kubeAPIfile                               = "kube-apiserver.yaml"
@@ -261,6 +258,13 @@ var (
 // CSI Internal FSSs
 var (
 	useCsiNodeID = "use-csinode-id"
+)
+
+// Nimbus generated passwords
+var (
+	nimbusK8sVmPwd = "NIMBUS_PWD"
+	nimbusEsxPwd   = "NIMBUS_PWD"
+	nimbusVcPwd    = "NIMBUS_PWD"
 )
 
 // volume allocation types for cns volumes

--- a/tests/e2e/tkgs_ha_utils.go
+++ b/tests/e2e/tkgs_ha_utils.go
@@ -690,9 +690,10 @@ func getClusterNameFromZone(ctx context.Context, availabilityZone string) string
 	clusterName := ""
 	clusterComputeResourceList, _, err := getClusterName(ctx, &e2eVSphere)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	nimbusGeneratedVcPwd := GetAndExpectStringEnvVar(nimbusVcPwd)
 	cmd := fmt.Sprintf("dcli +username %s +password %s +skip +show com vmware "+
 		"vcenter consumptiondomains zones cluster associations get --zone "+
-		"%s", adminUser, adminPassword, availabilityZone)
+		"%s", adminUser, nimbusGeneratedVcPwd, availabilityZone)
 	vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 	framework.Logf("Invoking command %v on vCenter host %v", cmd, vcAddress)
 	result, err := fssh.SSH(cmd, vcAddress, framework.TestContext.Provider)

--- a/tests/e2e/topology_operation_strom_cases.go
+++ b/tests/e2e/topology_operation_strom_cases.go
@@ -59,6 +59,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		powerOffHostsList       []string
 		sshClientConfig         *ssh.ClientConfig
 		k8sVersion              string
+		nimbusGeneratedK8sVmPwd string
 	)
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
@@ -89,10 +90,12 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		topologyClusterNames := GetAndExpectStringEnvVar(topologyCluster)
 		topologyClusterList = ListTopologyClusterNames(topologyClusterNames)
 		readVcEsxIpsViaTestbedInfoJson(GetAndExpectStringEnvVar(envTestbedInfoJsonPath))
+		nimbusGeneratedK8sVmPwd = GetAndExpectStringEnvVar(nimbusK8sVmPwd)
+
 		sshClientConfig = &ssh.ClientConfig{
 			User: "root",
 			Auth: []ssh.AuthMethod{
-				ssh.Password(k8sVmPasswd),
+				ssh.Password(nimbusGeneratedK8sVmPwd),
 			},
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		}

--- a/tests/e2e/topology_site_down_cases.go
+++ b/tests/e2e/topology_site_down_cases.go
@@ -58,6 +58,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		powerOffHostsList       []string
 		noOfHostToBringDown     int
 		sshClientConfig         *ssh.ClientConfig
+		nimbusGeneratedK8sVmPwd string
 	)
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
@@ -82,10 +83,12 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		topologyClusterNames := GetAndExpectStringEnvVar(topologyCluster)
 		topologyClusterList = ListTopologyClusterNames(topologyClusterNames)
 		readVcEsxIpsViaTestbedInfoJson(GetAndExpectStringEnvVar(envTestbedInfoJsonPath))
+		nimbusGeneratedK8sVmPwd = GetAndExpectStringEnvVar(nimbusK8sVmPwd)
+
 		sshClientConfig = &ssh.ClientConfig{
 			User: "root",
 			Auth: []ssh.AuthMethod{
-				ssh.Password(k8sVmPasswd),
+				ssh.Password(nimbusGeneratedK8sVmPwd),
 			},
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		}

--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -72,6 +72,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		defaultDatacenter          *object.Datacenter
 		defaultDatastore           *object.Datastore
 		isVsanHealthServiceStopped bool
+		nimbusGeneratedK8sVmPwd    string
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -83,6 +84,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		defer cancel()
 		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 		readVcEsxIpsViaTestbedInfoJson(GetAndExpectStringEnvVar(envTestbedInfoJsonPath))
+		nimbusGeneratedK8sVmPwd = GetAndExpectStringEnvVar(nimbusK8sVmPwd)
 
 		csiNs = GetAndExpectStringEnvVar(envCSINamespace)
 		isVsanHealthServiceStopped = false
@@ -128,7 +130,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		sshClientConfig = &ssh.ClientConfig{
 			User: "root",
 			Auth: []ssh.AuthMethod{
-				ssh.Password(k8sVmPasswd),
+				ssh.Password(nimbusGeneratedK8sVmPwd),
 			},
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		}

--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -564,10 +564,11 @@ func checkVmStorageCompliance(client clientset.Interface, storagePolicy string) 
 	defer cancel()
 	masterIp := getK8sMasterIPs(ctx, client)
 	vcAddress := e2eVSphere.Config.Global.VCenterHostname
+	nimbusGeneratedK8sVmPwd := GetAndExpectStringEnvVar(nimbusK8sVmPwd)
 	sshClientConfig := &ssh.ClientConfig{
 		User: "root",
 		Auth: []ssh.AuthMethod{
-			ssh.Password(k8sVmPasswd),
+			ssh.Password(nimbusGeneratedK8sVmPwd),
 		},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Nimbus generated passwords read for VC ESXi and K8s VM from env. export variables

**Testing done**:
Yes
[test-e2e-logs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/10496874/test-e2e-logs.txt)


**Release note**:
Nimbus generated passwords read for VC ESXi and K8s VM from env. export variables

Make Check:
sipriya@sipriyaSMD6M vsphere-csi-driver %  golangci-lint run --enable=lll
sipriya@sipriyaSMD6M vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/password-change/vsphere-csi-driver /Users/sipriya/password-change /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (deps|imports|name|compiled_files|exports_file|files|types_sizes) took 1m26.412439399s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 137.449644ms 
INFO [linters context/goanalysis] analyzers took 8m15.918268584s with top 10 stages: buildir: 5m59.40307751s, nilness: 19.669899575s, printf: 15.872374103s, fact_deprecated: 15.50144797s, ctrlflow: 14.653956128s, typedness: 11.13030639s, fact_purity: 11.013372602s, SA5012: 10.288488339s, inspect: 5.487918299s, S1038: 2.651147531s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 113/113, skip_dirs: 113/113, autogenerated_exclude: 24/113, exclude: 24/24, cgo: 113/113, skip_files: 113/113, filename_unadjuster: 113/113, nolint: 0/1, identifier_marker: 24/24, exclude-rules: 1/24 
INFO [runner] processing took 16.025478ms with stages: nolint: 12.346449ms, autogenerated_exclude: 2.874917ms, path_prettifier: 331.8µs, identifier_marker: 282.227µs, skip_dirs: 108.719µs, exclude-rules: 62.355µs, cgo: 8.574µs, filename_unadjuster: 6.1µs, max_same_issues: 1.418µs, skip_files: 519ns, uniq_by_line: 430ns, diff: 276ns, max_from_linter: 270ns, source_code: 246ns, exclude: 230ns, severity-rules: 215ns, path_shortener: 211ns, sort_results: 207ns, max_per_file_from_linter: 207ns, path_prefixer: 108ns 
INFO [runner] linters took 48.358630623s with stages: goanalysis_metalinter: 48.34251996s 
INFO File cache stats: 299 entries of total size 5.7MiB 
INFO Memory: 1260 samples, avg is 659.9MB, max is 2986.5MB 
INFO Execution took 2m14.921034148s               
sipriya@sipriyaSMD6M vsphere-csi-driver % 
