### PR TITLE
Changes for fstype validation

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -79,6 +79,12 @@ const (
 	// Ext4FsType represents the default filesystem type for block volume.
 	Ext4FsType = "ext4"
 
+	// Ext3FsType represents the ext3 filesystem type for block volume.
+	Ext3FsType = "ext3"
+
+	// XFSType represents the xfs filesystem type for block volume.
+	XFSType = "xfs"
+
 	// NfsV4FsType represents nfs4 mount type.
 	NfsV4FsType = "nfs4"
 

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -138,6 +138,36 @@ func TestValidVolumeCapabilitiesForBlock(t *testing.T) {
 	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("Block VolCap = %+v failed validation!", volCap)
 	}
+	// fstype=xfs and mode=SINGLE_NODE_WRITER
+	volCap = []*csi.VolumeCapability{
+		{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{
+					FsType: "xfs",
+				},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
+		t.Errorf("Block VolCap = %+v failed validation!", volCap)
+	}
+	// volumeMode=block and accessMode=SINGLE_NODE_WRITER
+	volCap = []*csi.VolumeCapability{
+		{
+			AccessType: &csi.VolumeCapability_Block{
+				Block: &csi.VolumeCapability_BlockVolume{},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
+		t.Errorf("Block VolCap = %+v failed validation!", volCap)
+	}
 }
 
 func TestInvalidVolumeCapabilitiesForBlock(t *testing.T) {
@@ -194,7 +224,22 @@ func TestValidVolumeCapabilitiesForFile(t *testing.T) {
 		t.Errorf("File VolCap = %+v failed validation!", volCap)
 	}
 
-	// fstype=nfsv4 and mode=MULTI_NODE_READER_ONLY
+	// fstype=empty and mode=MULTI_NODE_MULTI_WRITER
+	volCap = []*csi.VolumeCapability{
+		{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+			},
+		},
+	}
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
+		t.Errorf("File VolCap = %+v failed validation!", volCap)
+	}
+
+	// fstype=nfs and mode=MULTI_NODE_READER_ONLY
 	volCap = []*csi.VolumeCapability{
 		{
 			AccessType: &csi.VolumeCapability_Mount{
@@ -230,16 +275,16 @@ func TestValidVolumeCapabilitiesForFile(t *testing.T) {
 }
 
 func TestInvalidVolumeCapabilitiesForFile(t *testing.T) {
-	// Invalid case: fstype=nfs4 and mode=SINGLE_NODE_WRITER
+	// Invalid case: fstype=xfs and mode=MULTI_NODE_MULTI_WRITER
 	volCap := []*csi.VolumeCapability{
 		{
 			AccessType: &csi.VolumeCapability_Mount{
 				Mount: &csi.VolumeCapability_MountVolume{
-					FsType: "nfs4",
+					FsType: "xfs",
 				},
 			},
 			AccessMode: &csi.VolumeCapability_AccessMode{
-				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 			},
 		},
 	}
@@ -247,16 +292,14 @@ func TestInvalidVolumeCapabilitiesForFile(t *testing.T) {
 		t.Errorf("Invalid file VolCap = %+v passed validation!", volCap)
 	}
 
-	// Invalid case: fstype=nfs and mode=SINGLE_NODE_WRITER
+	// Invalid case: volumeMode=block and accessMode=MULTI_NODE_MULTI_WRITER
 	volCap = []*csi.VolumeCapability{
 		{
-			AccessType: &csi.VolumeCapability_Mount{
-				Mount: &csi.VolumeCapability_MountVolume{
-					FsType: "nfs",
-				},
+			AccessType: &csi.VolumeCapability_Block{
+				Block: &csi.VolumeCapability_BlockVolume{},
 			},
 			AccessMode: &csi.VolumeCapability_AccessMode{
-				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 			},
 		},
 	}

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -87,7 +87,7 @@ func (driver *vsphereCSIDriver) NodeStageVolume(
 		// Mount Volume.
 		// Extract mount volume details.
 		log.Debug("NodeStageVolume: Volume detected as a mount volume")
-		params.FsType, params.MntFlags, err = driver.osUtils.EnsureMountVol(ctx, log, volCap)
+		params.FsType, params.MntFlags, err = driver.osUtils.EnsureMountVol(ctx, volCap)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -390,7 +390,7 @@ func (osUtils *OsUtils) PublishMountVol(
 	log.Infof("PublishMountVolume called with args: %+v", params)
 
 	// Extract fs details.
-	_, mntFlags, err := osUtils.EnsureMountVol(ctx, log, req.GetVolumeCapability())
+	_, mntFlags, err := osUtils.EnsureMountVol(ctx, req.GetVolumeCapability())
 	if err != nil {
 		return nil, err
 	}
@@ -533,7 +533,7 @@ func (osUtils *OsUtils) PublishFileVol(
 	log.Infof("PublishFileVolume called with args: %+v", params)
 
 	// Extract mount details.
-	fsType, mntFlags, err := osUtils.EnsureMountVol(ctx, log, req.GetVolumeCapability())
+	fsType, mntFlags, err := osUtils.EnsureMountVol(ctx, req.GetVolumeCapability())
 	if err != nil {
 		return nil, err
 	}
@@ -954,19 +954,36 @@ func (osUtils *OsUtils) IsTargetInMounts(ctx context.Context, path string) (bool
 // Defaults to nfs4 for file volume and ext4 for block volume when empty string
 // is observed. This function also ignores default ext4 fstype supplied by
 // external-provisioner when none is specified in the StorageClass
-func (osUtils *OsUtils) GetVolumeCapabilityFsType(ctx context.Context, capability *csi.VolumeCapability) string {
+func (osUtils *OsUtils) GetVolumeCapabilityFsType(ctx context.Context,
+	capability *csi.VolumeCapability) (string, error) {
 	log := logger.GetLogger(ctx)
 	fsType := strings.ToLower(capability.GetMount().GetFsType())
-	log.Debugf("FsType received from Volume Capability: %q", fsType)
+	log.Infof("FsType received from Volume Capability: %q", fsType)
 	isFileVolume := common.IsFileVolumeRequest(ctx, []*csi.VolumeCapability{capability})
-	if isFileVolume && (fsType == "" || fsType == "ext4") {
-		log.Infof("empty string or ext4 fstype observed for file volume. Defaulting to: %s", common.NfsV4FsType)
-		fsType = common.NfsV4FsType
-	} else if !isFileVolume && fsType == "" {
-		log.Infof("empty string fstype observed for block volume. Defaulting to: %s", common.Ext4FsType)
-		fsType = common.Ext4FsType
+	if isFileVolume {
+		// For File volumes we only support nfs or nfs4 filesystem. External-provisioner sets default fstype
+		// as ext4 when none is specified in StorageClass, hence overwrite it to nfs4 while mounting the volume.
+		if fsType == "" || fsType == "ext4" {
+			log.Infof("empty string or ext4 fstype observed for file volume. Defaulting to: %s",
+				common.NfsV4FsType)
+			fsType = common.NfsV4FsType
+		} else if !(fsType == common.NfsFsType || fsType == common.NfsV4FsType) {
+			return "", logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+				"unsupported fsType %q observed for file volume", fsType)
+		}
+	} else {
+		// For Block volumes we only support following filesystems:
+		// ext3, ext4 and xfs for Linux.
+		if fsType == "" {
+			log.Infof("empty string fstype observed for block volume. Defaulting to: %s",
+				common.Ext4FsType)
+			fsType = common.Ext4FsType
+		} else if !(fsType == common.Ext4FsType || fsType == common.Ext3FsType || fsType == common.XFSType) {
+			return "", logger.LogNewErrorCodef(log, codes.FailedPrecondition,
+				"unsupported fsType %q observed for block volume", fsType)
+		}
 	}
-	return fsType
+	return fsType, nil
 }
 
 // ResizeVolume resizes the volume

--- a/pkg/csi/service/osutils/os_utils.go
+++ b/pkg/csi/service/osutils/os_utils.go
@@ -82,18 +82,22 @@ func (osUtils *OsUtils) GetDiskID(pubCtx map[string]string, log *zap.SugaredLogg
 
 // EnsureMountVol ensures that VolumeCapability has mount option
 // and returns fstype, mount flags
-func (osUtils *OsUtils) EnsureMountVol(ctx context.Context, log *zap.SugaredLogger,
-	volCap *csi.VolumeCapability) (string, []string, error) {
+func (osUtils *OsUtils) EnsureMountVol(ctx context.Context, volCap *csi.VolumeCapability) (string, []string, error) {
+	log := logger.GetLogger(ctx)
 	mountVol := volCap.GetMount()
 	if mountVol == nil {
 		return "", nil, logger.LogNewErrorCode(log, codes.InvalidArgument, "access type missing")
 	}
-	fs := osUtils.GetVolumeCapabilityFsType(ctx, volCap)
-	mntFlags := mountVol.GetMountFlags()
+	fs, err := osUtils.GetVolumeCapabilityFsType(ctx, volCap)
+	if err != nil {
+		log.Errorf("GetVolumeCapabilityFsType failed with err: %v", err)
+		return "", nil, err
+	}
 
+	mntFlags := mountVol.GetMountFlags()
 	// By default, xfs does not allow mounting of two volumes with the same filesystem uuid.
 	// Force ignore this uuid to be able to mount volume + its clone / restored snapshot on the same node.
-	if fs == "xfs" {
+	if fs == common.XFSType {
 		mntFlags = append(mntFlags, "nouuid")
 	}
 

--- a/tests/e2e/vsphere_file_volume_basic.go
+++ b/tests/e2e/vsphere_file_volume_basic.go
@@ -264,7 +264,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] Basic Testing", func() {
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
 			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute/2)
 		gomega.Expect(err).To(gomega.HaveOccurred())
-		expectedErrMsg := "NFS fstype not supported for ReadWriteOnce volume creation"
+		expectedErrMsg := "fstype nfs4 not supported for ReadWriteOnce volume creation"
 		ginkgo.By(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
 		isFailureFound := checkEventsforError(client, namespace,
 			metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvclaim.Name)}, expectedErrMsg)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
If we try to create PVC with RWM access mode with 
1. XFS filesystem in SC or
2. PVC with Block volume mode
then, proper error message is not thrown to user and it becomes confusing to understand the problem.

Added fstype validation checks in the code, so that volume creation is attempted only for the allowed combinations of access mode, fstype and volume mode.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
After fix proper error message is displayed in describe PVC output.

```
 # kubectl describe pvc example-vanilla-rwo-pvc 
 Name:          example-vanilla-rwo-pvc
 Namespace:     default
 StorageClass:  example-vanilla-rwo-filesystem-sc
 Status:        Pending
 Volume:        
 Labels:        <none>
 Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
                volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      
 Access Modes:  
 VolumeMode:    Filesystem
 Used By:       <none>
 Events:
   Type     Reason                Age                From                                                                                                Message
   ----     ------                ----               ----                                                                                                -------
   Normal   ExternalProvisioning  10s (x2 over 16s)  persistentvolume-controller                                                                         waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
   Normal   Provisioning          1s (x5 over 16s)   csi.vsphere.vmware.com_vsphere-csi-controller-cfbbc56cc-nvkrt_0f91345b-4f12-4d33-b2c8-f00cc44200c4  External provisioner is provisioning volume for claim "default/example-vanilla-rwo-pvc"
   Warning  ProvisioningFailed    1s (x5 over 16s)   csi.vsphere.vmware.com_vsphere-csi-controller-cfbbc56cc-nvkrt_0f91345b-4f12-4d33-b2c8-f00cc44200c4  failed to provision volume with StorageClass "example-vanilla-rwo-filesystem-sc": rpc error: code = InvalidArgument desc = volume capability not supported. Err: fstype xfs not supported for ReadWriteMany or ReadOnlyMany volume creation
```

Unit testing successful for validation TCs:
```
{"level":"info","time":"2023-01-23T18:57:04.487025+05:30","caller":"common/common_controller_helper.go:155","msg":"VC version detected as \"7.0.3.0\" satisfies minimum supported vcenter version 6.7.3."}
...
=== RUN   TestValidVolumeCapabilitiesForBlock
--- PASS: TestValidVolumeCapabilitiesForBlock (0.00s)
=== RUN   TestInvalidVolumeCapabilitiesForBlock
--- PASS: TestInvalidVolumeCapabilitiesForBlock (0.00s)
=== RUN   TestValidVolumeCapabilitiesForFile 
--- PASS: TestValidVolumeCapabilitiesForFile (0.00s)
=== RUN   TestInvalidVolumeCapabilitiesForFile
--- PASS: TestInvalidVolumeCapabilitiesForFile (0.00s)
=== RUN   TestParseStorageClassParamsWithDeprecatedFSType
{"level":"warn","time":"2023-01-23T18:57:04.490048+05:30","caller":"common/util.go:252","msg":"param 'fstype' is deprecated, please use 'csi.storage.k8s.io/fstype' instead"}
...
```

**Special notes for your reviewer**:

**Release note**:
```release-note
fstype validation changes in code to proceed volume creation with only allowed combination of fstype, access mode and volume mode.
```
