### PR TITLE
Add more debug log in function "GetAllAccessibleDatastores".

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualmachine.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine.go
@@ -88,7 +88,12 @@ func (vm *VirtualMachine) GetAllAccessibleDatastores(ctx context.Context) ([]*Da
 		HostSystem: object.NewHostSystem(vm.Client(), host.Reference()),
 	}
 	accessibleDatastores, err := hostObj.GetAllAccessibleDatastores(ctx)
-	log.Debugf("Getting accessible datastores for node %s on host %s: %q with err %v", vm.VirtualMachine, hostObj.Reference(), accessibleDatastores, err)
+	if err != nil {
+		log.Errorf("failed to get all accessible datastores for VM %v on host %s with err: %v", vm.VirtualMachine, hostObj.Reference(), err)
+	} else {
+		log.Debugf("Getting accessible datastores for node %s on host %s: %q",
+			vm.VirtualMachine, hostObj.Reference(), accessibleDatastores)
+	}
 	return accessibleDatastores, err
 }
 

--- a/pkg/common/cns-lib/vsphere/virtualmachine.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine.go
@@ -89,9 +89,10 @@ func (vm *VirtualMachine) GetAllAccessibleDatastores(ctx context.Context) ([]*Da
 	}
 	accessibleDatastores, err := hostObj.GetAllAccessibleDatastores(ctx)
 	if err != nil {
-		log.Errorf("failed to get all accessible datastores for VM %v on host %s with err: %v", vm.VirtualMachine, hostObj.Reference(), err)
+		log.Errorf("failed to get all accessible datastores for VM %q on host %q with err: %v",
+			vm.VirtualMachine, hostObj.Reference(), err)
 	} else {
-		log.Debugf("Getting accessible datastores for node %s on host %s: %q",
+		log.Debugf("Accessible datastores for node %q on host %q: %v",
 			vm.VirtualMachine, hostObj.Reference(), accessibleDatastores)
 	}
 	return accessibleDatastores, err

--- a/pkg/common/cns-lib/vsphere/virtualmachine.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine.go
@@ -87,7 +87,9 @@ func (vm *VirtualMachine) GetAllAccessibleDatastores(ctx context.Context) ([]*Da
 	hostObj := &HostSystem{
 		HostSystem: object.NewHostSystem(vm.Client(), host.Reference()),
 	}
-	return hostObj.GetAllAccessibleDatastores(ctx)
+	accessibleDatastores, err := hostObj.GetAllAccessibleDatastores(ctx)
+	log.Debugf("Getting accessible datastores for node %s on host %s: %q with err %v", vm.VirtualMachine, hostObj.Reference(), accessibleDatastores, err)
+	return accessibleDatastores, err
 }
 
 // Renew renews the virtual machine and datacenter information. If reconnect is


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When triaging this  SR , we found that we don't have enough log in function "GetSharedDatastoresForVMs " which can tell us:

for a specific nodeVM, which is the host that node VM is deployed and which datastore this nodeVM can access. 
We need to enhance the DEBUG log to include the info.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Cannot run e2e test since I cannot get a working testbed.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add more debug log in function "GetAllAccessibleDatastores".
```
