### PR TITLE
Implemented deploy images stage in the pipeline to deploy the built images to a testbed to run E2E tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ deploy-images-dev:
   # This resource group is configured with process_mode=oldest_first to make sure the pipelines are run serially.
   resource_group: production
   # Image built from https://gitlab.eng.vmware.com/calatrava/cd-infra/-/blob/main/images/ci-deploy/Dockerfile
-  image: harbor-repo.vmware.com/calatrava/ci-deploy-stage:v4
+  image: $CNS_IMAGE_CI_DEPLOY_STAGE
   script:
     - ./pipeline/deploy.sh
   dependencies:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,12 @@
 stages:
   - unit-test
   - build
+  - deploy-dev
 
 run-unit-tests:
   stage: unit-test
+  # This resource group is configured with process_mode=oldest_first to make sure the pipelines are run serially.
+  resource_group: production
   # A copy of golang image in dockerhub.
   image: $CNS_IMAGE_GOLANG
   script:
@@ -11,6 +14,8 @@ run-unit-tests:
 
 build-images:
   stage: build
+  # This resource group is configured with process_mode=oldest_first to make sure the pipelines are run serially.
+  resource_group: production
   # A copy of docker image in dockerhub.
   image: $CNS_IMAGE_DOCKER
   services:
@@ -35,6 +40,20 @@ build-images:
     - docker push $CNS_CSI_SYNCER_REPO:$CI_COMMIT_SHORT_SHA
     - echo "VSPHERE_CSI_CONTROLLER_IMAGE=$CNS_CSI_DRIVER_REPO:$CI_COMMIT_SHORT_SHA" >> build.env
     - echo "VSPHERE_SYNCER_IMAGE=$CNS_CSI_SYNCER_REPO:$CI_COMMIT_SHORT_SHA" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
+deploy-images-dev:
+  stage: deploy-dev
+  # This resource group is configured with process_mode=oldest_first to make sure the pipelines are run serially.
+  resource_group: production
+  # Image built from https://gitlab.eng.vmware.com/calatrava/cd-infra/-/blob/main/images/ci-deploy/Dockerfile
+  image: harbor-repo.vmware.com/calatrava/ci-deploy-stage:v4
+  script:
+    - ./pipeline/deploy.sh
+  dependencies:
+    - build-images
   artifacts:
     reports:
       dotenv: build.env

--- a/manifests/supervisorcluster/1.22/kustomization.yaml
+++ b/manifests/supervisorcluster/1.22/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cns-csi.yaml

--- a/pipeline/deploy.sh
+++ b/pipeline/deploy.sh
@@ -15,16 +15,14 @@ then
 fi
 
 # Borrow a testbed from CSI Testbed Pool Svc.
-testbed=`curl -X 'GET' ${CNS_TESTBEDPOOL_SVC_URL}`
-if [ $? -ne 0 ]
+if ! testbed=$(curl -X 'GET' "${CNS_TESTBEDPOOL_SVC_URL}");
 then
 	echo "Unable to borrow a testbed!"
 	exit 1
 fi
 echo "TestbedInfo: $testbed"
 
-vcIp=`echo $testbed | jq '.vcIp'|tr -d '"'`
-if [ $? -ne 0 ]
+if ! vcIp=$(echo "$testbed" | jq '.vcIp'|tr -d '"');
 then
 	echo "Error getting the vcIp!"
 	exit 1
@@ -32,19 +30,17 @@ fi
 
 echo "VC_IP=$vcIp" >> build.env
 
-svAdminCreds=`echo $testbed | jq '.svAdminCreds'|tr -d '"'|base64 -d`
-if [ $? -ne 0 ]
+if ! svAdminCreds=$(echo "$testbed" | jq '.svAdminCreds'|tr -d '"'|base64 -d);
 then
 	echo "Error getting the svAdminCreds!"
 	exit 1
 fi
 echo "svAdminCreds = $svAdminCreds"
 SV_KUBECONFIG=/tmp/$$
-echo $testbed | jq '.svAdminCreds'|tr -d '"'|base64 -d > $SV_KUBECONFIG
+echo "$testbed" | jq '.svAdminCreds'|tr -d '"'|base64 -d > $SV_KUBECONFIG
 export KUBECONFIG=$SV_KUBECONFIG
 
-kustomize build pipeline/dev | envsubst | kubectl apply -f -
-if [ $? -ne 0 ]
+if ! kustomize build pipeline/dev | envsubst | kubectl apply -f -;
 then
 	echo "Error patching the CSI images in the testbed!"
 	exit 1
@@ -55,19 +51,10 @@ echo "Sleeping for 60 seconds..."
 sleep 60
 
 # Wait for 2 mins for the CSI deployment to be ready.
-kubectl wait deployment -n vmware-system-csi vsphere-csi-controller --for=jsonpath="{.status.readyReplicas}"=3 --timeout=120s
-if [ $? -ne 0 ]
+if ! kubectl wait deployment -n vmware-system-csi vsphere-csi-controller --for=jsonpath="{.status.readyReplicas}"=3 --timeout=120s;
 then
 	echo "CSI deployment is not ready within 120s."
 	exit 1
 fi
-
-# Wait for 2 mins for the CSI webhook to be ready.
-#kubectl wait deployment -n vmware-system-csi vsphere-csi-webhook --for=jsonpath="{.status.readyReplicas}"=3 --timeout=120s
-#if [ $? -ne 0 ]
-#then
-#	echo "CSI webhook is not ready within 120s."
-#	exit 1
-#fi
 
 echo "Successfully patched the CSI images."

--- a/pipeline/deploy.sh
+++ b/pipeline/deploy.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set +x
+
+if [[ -z "${VSPHERE_CSI_CONTROLLER_IMAGE}" ]]
+then
+	echo "Env variable unset: VSPHERE_CSI_CONTROLLER_IMAGE"
+	exit 1
+fi
+
+if [[ -z "${VSPHERE_SYNCER_IMAGE}" ]]
+then
+	echo "Env variable unset: VSPHERE_SYNCER_IMAGE"
+	exit 1
+fi
+
+# Borrow a testbed from CSI Testbed Pool Svc.
+testbed=`curl -X 'GET' ${CNS_TESTBEDPOOL_SVC_URL}`
+if [ $? -ne 0 ]
+then
+	echo "Unable to borrow a testbed!"
+	exit 1
+fi
+echo "TestbedInfo: $testbed"
+
+vcIp=`echo $testbed | jq '.vcIp'|tr -d '"'`
+if [ $? -ne 0 ]
+then
+	echo "Error getting the vcIp!"
+	exit 1
+fi
+
+echo "VC_IP=$vcIp" >> build.env
+
+svAdminCreds=`echo $testbed | jq '.svAdminCreds'|tr -d '"'|base64 -d`
+if [ $? -ne 0 ]
+then
+	echo "Error getting the svAdminCreds!"
+	exit 1
+fi
+echo "svAdminCreds = $svAdminCreds"
+SV_KUBECONFIG=/tmp/$$
+echo $testbed | jq '.svAdminCreds'|tr -d '"'|base64 -d > $SV_KUBECONFIG
+export KUBECONFIG=$SV_KUBECONFIG
+
+kustomize build pipeline/dev | envsubst | kubectl apply -f -
+if [ $? -ne 0 ]
+then
+	echo "Error patching the CSI images in the testbed!"
+	exit 1
+fi
+
+# Sleep for 60 seconds so that k8s can act on the applied changes.
+echo "Sleeping for 60 seconds..."
+sleep 60
+
+# Wait for 2 mins for the CSI deployment to be ready.
+kubectl wait deployment -n vmware-system-csi vsphere-csi-controller --for=jsonpath="{.status.readyReplicas}"=3 --timeout=120s
+if [ $? -ne 0 ]
+then
+	echo "CSI deployment is not ready within 120s."
+	exit 1
+fi
+
+# Wait for 2 mins for the CSI webhook to be ready.
+#kubectl wait deployment -n vmware-system-csi vsphere-csi-webhook --for=jsonpath="{.status.readyReplicas}"=3 --timeout=120s
+#if [ $? -ne 0 ]
+#then
+#	echo "CSI webhook is not ready within 120s."
+#	exit 1
+#fi
+
+echo "Successfully patched the CSI images."

--- a/pipeline/dev/kustomization.yaml
+++ b/pipeline/dev/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../manifests/supervisorcluster/1.22
+patchesStrategicMerge:
+- patch.yaml

--- a/pipeline/dev/patch.yaml
+++ b/pipeline/dev/patch.yaml
@@ -1,0 +1,47 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: vmware-system-csi
+spec:
+  template:
+    spec:
+      containers:
+      - name: vsphere-csi-controller
+        image: ${VSPHERE_CSI_CONTROLLER_IMAGE}
+      - name: vsphere-syncer
+        image: ${VSPHERE_SYNCER_IMAGE}
+      - name: csi-provisioner
+        image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.1.0_vmware.2
+      - name: csi-attacher
+        image: localhost:5000/vmware.io/csi-attacher:v3.4.0_vmware.1
+      - name: csi-resizer
+        image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.4.0_vmware.1
+      - name: liveness-probe
+        image: localhost:5000/vmware.io/csi-livenessprobe:v2.6.0_vmware.1
+---
+---
+apiVersion: v1
+data:
+  "volume-extend": "true"
+  "volume-health": "true"
+  "online-volume-extend": "true"
+  "file-volume": "true"
+  "csi-auth-check": "true"
+  "vsan-direct-disk-decommission": "true"
+  "trigger-csi-fullsync": "false"
+  "csi-sv-feature-states-replication": "true"
+  "fake-attach": "true"
+  "async-query-volume": "true"
+  "improved-csi-idempotency": "true"
+  "block-volume-snapshot": "false"
+  "sibling-replica-bound-pvc-check": "true"
+# Set tkgs-ha to false, else csi-controller and csi-syncer containers do not start.
+  "tkgs-ha": "false"
+  "list-volumes": "false"
+  "cnsmgr-suspend-create-volume": "true"
+  "listview-tasks": "false"
+kind: ConfigMap
+metadata:
+  name: csi-feature-states
+  namespace: vmware-system-csi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR introduces deploy images stage in the CI/CD pipeline to deploy the built images to a testbed. This is part of the CI/CD pipeline.

Summary:
1. Implemented deploy images stage in the pipeline to deploy the built images to a testbed to run E2E tests.
2. Fixed the pipeline to run serially, also fixed the curl command that borrows the testbed.
3. Added kustomization.yaml in manifests/supervisorcluster/1.22 for Kustomize to work for Calatrava that uses 1.22 version of supervisor.
4. Added the patch.yaml file in pipeline/dev to work with vSphere 7.0u3f WCP release of CSI for Calatrava.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
1. Successfully ran the pipeline that borrows a testbed from testbed pool svc and deploys the built images to the testbed. 
![image](https://user-images.githubusercontent.com/17838923/214694141-8129e79c-5781-4d06-8d44-fc1ecb8872e8.png)


2. I do not plan to run the precheckin E2E tests as this PR is not touching CSI functionality. The changes are related to only the CI/CD pipeline.
 

**Special notes for your reviewer**:

**Release note**:
```
Implemented deploy images stage in the pipeline to deploy the built images to a testbed to run E2E tests.
```
