### PR TITLE
Update csi snapshot deployment script to use qualified version for snapshot-controller

### DIFF
--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -161,6 +161,7 @@ deploy_snapshot_controller(){
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/"${qualified_version}"/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml 2>/dev/null || true
 	echo -e "✅ Created  RBACs for snapshot-controller"
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/"${qualified_version}"/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml 2>/dev/null || true
+	kubectl -n kube-system set image deployment/snapshot-controller snapshot-controller=registry.k8s.io/sig-storage/snapshot-controller:"${qualified_version}"
 	kubectl patch deployment -n kube-system snapshot-controller --patch '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/control-plane": ""}, "tolerations": [{"key":"node-role.kubernetes.io/master","operator":"Exists", "effect":"NoSchedule"},{"key":"node-role.kubernetes.io/control-plane","operator":"Exists", "effect":"NoSchedule"}]}}}}'
 	kubectl patch deployment -n kube-system snapshot-controller --type=json \
 	-p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-qps=100"},{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-burst=100"}]'


### PR DESCRIPTION
**What this PR does / why we need it**:
Update csi snapshot deployment script to use qualified version for snapshot-controller

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Fresh Deploy:
```
dkinni@dkinniCMD6R vanilla % ./deploy-csi-snapshot-components.sh
✅ Verified that block-volume-snapshot feature is enabled
Checking CRDs...
Supported version v1 of crd volumesnapshotclasses.snapshot.storage.k8s.io present
Supported version v1 of crd volumesnapshotcontents.snapshot.storage.k8s.io present
Supported version v1 of crd volumesnapshots.snapshot.storage.k8s.io present

✅ Deployed VolumeSnapshot CRDs

No existing snapshot-controller Deployment found, deploying it now..
Start snapshot-controller deployment...
serviceaccount/snapshot-controller unchanged
clusterrole.rbac.authorization.k8s.io/snapshot-controller-runner unchanged
clusterrolebinding.rbac.authorization.k8s.io/snapshot-controller-role unchanged
role.rbac.authorization.k8s.io/snapshot-controller-leaderelection unchanged
rolebinding.rbac.authorization.k8s.io/snapshot-controller-leaderelection unchanged
✅ Created  RBACs for snapshot-controller
deployment.apps/snapshot-controller created
deployment.apps/snapshot-controller image updated
deployment.apps/snapshot-controller patched
deployment.apps/snapshot-controller patched
Waiting for deployment "snapshot-controller" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 out of 2 new replicas have been updated...
Waiting for deployment "snapshot-controller" rollout to finish: 1 of 2 updated replicas are available...
Waiting for deployment "snapshot-controller" rollout to finish: 1 of 2 updated replicas are available...
deployment "snapshot-controller" successfully rolled out

✅ Successfully deployed snapshot-controller
```
Re-Deploy:
```
dkinni@dkinniCMD6R vanilla % ./deploy-csi-snapshot-components.sh
✅ Verified that block-volume-snapshot feature is enabled
Checking CRDs...
Supported version v1 of crd volumesnapshotclasses.snapshot.storage.k8s.io present
Supported version v1 of crd volumesnapshotcontents.snapshot.storage.k8s.io present
Supported version v1 of crd volumesnapshots.snapshot.storage.k8s.io present

✅ Deployed VolumeSnapshot CRDs

snapshot-controller Deployment already exists, verifying version..
snapshot-controller image : registry.k8s.io/sig-storage/snapshot-controller:v6.2.1
snapshot-controller version : v6.2.1
✅ Verified that running snapshot-controller is using the qualified version v6.2.1
snapshot-validation-deployment Deployment already exists, verifying version..
snapshot-validation-deployment image : k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.2.1
snapshot-validation-deployment version : v6.2.1
✅ Verified that running snapshot-validation-deployment is using the qualified version v6.2.1
✅ vSphere CSI Driver already running the qualified version of csi-snapshotter.

✅ Successfully deployed all components for CSI Snapshot feature!
```


**Special notes for your reviewer**:

**Release note**:
```release-note
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>