### PR TITLE
Added e2e-tests-dev, deploy-images-staging, e2e-tests-staging, system-tests-staging, and perf-tests-staging jobs.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,9 @@ stages:
   - unit-test
   - build
   - deploy-dev
+  - e2e-tests-dev
+  - deploy-staging
+  - tests-staging
 
 run-unit-tests:
   stage: unit-test
@@ -48,7 +51,7 @@ deploy-images-dev:
   stage: deploy-dev
   # This resource group is configured with process_mode=oldest_first to make sure the pipelines are run serially.
   resource_group: production
-  # Image built from https://gitlab.eng.vmware.com/calatrava/cd-infra/-/blob/main/images/ci-deploy/Dockerfile
+  # Image built from cd-infra/images/ci-deploy/Dockerfile from Calatrava project.
   image: $CNS_IMAGE_CI_DEPLOY_STAGE
   script:
     - ./pipeline/deploy.sh
@@ -57,3 +60,60 @@ deploy-images-dev:
   artifacts:
     reports:
       dotenv: build.env
+
+e2e-tests-dev:
+  stage: e2e-tests-dev
+  # This resource group is configured with process_mode=oldest_first to make sure the pipelines are run serially.
+  resource_group: production
+  image: $CNS_IMAGE_GOLANG
+  dependencies:
+    - deploy-images-dev
+  script:
+    - ./pipeline/e2e-tests.sh
+
+deploy-images-staging:
+  stage: deploy-staging
+  # Image built from cd-infra/images/ci-deploy/Dockerfile from Calatrava project.
+  image: $CNS_IMAGE_CI_DEPLOY_STAGE
+  script:
+    - ./pipeline/deploy-staging.sh
+  dependencies:
+    - build-images
+  only:
+    - master
+  artifacts:
+    reports:
+      dotenv: build.env
+
+e2e-tests-staging:
+  stage: tests-staging
+  # Image built from cd-infra//images/ci-e2e/Dockerfile from Calatrava project.
+  image: $CNS_IMAGE_E2E
+  dependencies:
+    - deploy-images-staging
+  script:
+    - ./pipeline/e2e-tests-staging.sh
+  only:
+    - master
+
+system-tests-staging:
+  stage: tests-staging
+  # Image built from cd-infra//images/ci-e2e/Dockerfile from Calatrava project.
+  image: $CNS_IMAGE_E2E
+  dependencies:
+    - deploy-images-staging
+  script:
+    - echo "TODO - Add system tests."
+  only:
+    - master
+
+perf-tests-staging:
+  stage: tests-staging
+  # Image built from cd-infra//images/ci-e2e/Dockerfile from Calatrava project.
+  image: $CNS_IMAGE_E2E
+  dependencies:
+    - deploy-images-staging
+  script:
+    - echo "TODO - Add perf tests."
+  only:
+    - master

--- a/pipeline/deploy-staging.sh
+++ b/pipeline/deploy-staging.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set +x
+
+if [[ -z "${VSPHERE_CSI_CONTROLLER_IMAGE}" ]]
+then
+	echo "Env variable unset: VSPHERE_CSI_CONTROLLER_IMAGE"
+	exit 1
+fi
+
+if [[ -z "${VSPHERE_SYNCER_IMAGE}" ]]
+then
+	echo "Env variable unset: VSPHERE_SYNCER_IMAGE"
+	exit 1
+fi
+
+if [[ -z "${CNS_CSI_STAGING_REPO}" ]]
+then
+	echo "Env variable unset: CNS_CSI_STAGING_REPO"
+	exit 1
+fi
+
+git clone "$CNS_CSI_STAGING_REPO" || exit 1
+cd staging-cd || exit 1
+
+# Patch the yaml file with the driver and syncer images from build job.
+yq -i '(.spec.template.spec.containers[0].image = env(VSPHERE_CSI_CONTROLLER_IMAGE)) | (.spec.template.spec.containers[1].image = env(VSPHERE_SYNCER_IMAGE))' staging/patch.yaml || exit 1
+
+# If there are any changes, then commit the code changes and push it to the repo.
+if git diff | grep diff;
+then
+	echo "Code changes to be pushed:"
+	git diff
+	git add . || exit 1
+	git config user.email "svc.bot-cns@vmware.com" || exit 1
+	git config user.name "svc.bot-cns" || exit 1
+	git commit -m "Pipeline updated staging/patch.yaml with images $VSPHERE_CSI_CONTROLLER_IMAGE and $VSPHERE_SYNCER_IMAGE" || exit 1
+	git push origin main || exit 1
+else
+	echo "No code changes pushed to the staging repo."
+fi
+
+# TODO: Add code to wait for the CD infra to update the CSI in the staging environment.
+
+echo "Completed deploying CSI images to the staging environment."

--- a/pipeline/e2e-tests-staging.sh
+++ b/pipeline/e2e-tests-staging.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -x
+
+echo "Running e2e tests in the staging environment..."
+# TODO: Implement the script to run the e2e tests.
+
+echo "Completed running e2e tests."

--- a/pipeline/e2e-tests.sh
+++ b/pipeline/e2e-tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -x
+
+echo "Running e2e tests..."
+# TODO: Implement the script to run the e2e tests.
+
+echo "Completed running e2e tests."


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**What this PR does / why we need it**:
Added e2e-tests-dev, deploy-images-staging, e2e-tests-staging, system-tests-staging, and perf-tests-staging jobs. Most of these jobs are empty implementation except for deploy-images-staging that commits the built CSI images to the staging CD repo. Since we do not have a staging CD tool configured, this is a safe operation as the code is not deployed to the staging environment today.
Configured GitLab CI to run the staging jobs only for commits to master branch as only those will be deployed continuously.

**Testing done**:
1. Tested that the pipeline was successful on an internal test branch. 
![Screenshot 2023-01-26 at 10 05 15 AM](https://user-images.githubusercontent.com/17838923/214915869-70c0cfe5-02c2-47a9-aa9e-270348f231e8.png)

2. Verified that the pipeline updated the staging CD repo  with the new CSI images.


**Special notes for your reviewer**:
I do not plan to run the E2E regression tests as this code change does not touch CSI functionality.

**Release note**:

```release-note
Added e2e-tests-dev, deploy-images-staging, e2e-tests-staging, system-tests-staging, and perf-tests-staging jobs.
```
