### PR TITLE
Changes to handle NodeExpandVolume() API correctly for raw-block volumes

### DIFF
--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -1097,3 +1097,14 @@ func unescape(ctx context.Context, in string) string {
 	}
 	return string(out)
 }
+
+// Check if device at given path is block device or not
+func (osUtils *OsUtils) IsBlockDevice(ctx context.Context, volumePath string) (bool, error) {
+	log := logger.GetLogger(ctx)
+
+	deviceInfo, err := os.Stat(volumePath)
+	if err != nil {
+		return false, logger.LogNewErrorf(log, "IsBlockDevice: could not get device info for path %s", volumePath)
+	}
+	return deviceInfo.Mode()&os.ModeDevice == os.ModeDevice, nil
+}

--- a/pkg/csi/service/osutils/windows_os_utils.go
+++ b/pkg/csi/service/osutils/windows_os_utils.go
@@ -511,3 +511,8 @@ func (osUtils *OsUtils) ShouldContinue(ctx context.Context) {
 	}
 	return
 }
+
+// Check if device at given path is block device or not
+func (osUtils *OsUtils) IsBlockDevice(ctx context.Context, volumePath string) (bool, error) {
+	return false, nil
+}

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -2497,6 +2497,8 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 		if _, ok := req.GetVolumeCapability().GetAccessType().(*csi.VolumeCapability_Block); ok {
 			nodeExpansionRequired = false
 		}
+		log.Debugf("ControllerExpandVolumeInternal: returns %v as capacity and %v as NodeExpansionRequired",
+			int64(units.FileSize(volSizeMB*common.MbInBytes)), nodeExpansionRequired)
 		resp := &csi.ControllerExpandVolumeResponse{
 			CapacityBytes:         int64(units.FileSize(volSizeMB * common.MbInBytes)),
 			NodeExpansionRequired: nodeExpansionRequired,


### PR DESCRIPTION
**What this PR does / why we need it**:
In case of expansion of raw-block volumes, we expand the underlying block device in ControllerExpandVolume() call, but we do not need any file system resize. Due to known issue https://github.com/kubernetes/kubernetes/issues/115294, vSphere CSI driver does get NodeExpandVolume() call, which should just rescan the devices if required, or should act as a NOOP for raw-block volumes. These changes satisfy the same requirement.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested online expansion of raw block volume with the fix here on block vanilla and observed that in NodeExpandVolume(), we skip resizing FS/target path for raw-block volume case.

CSI controller logs:

```
2023-01-23T06:55:15.939Z        INFO    vanilla/controller.go:2416      ControllerExpandVolume: called with args {VolumeId:a0486075-128b-4808-a801-35cb6b9b28af CapacityRange:required_bytes:2147483648  Secrets:map[] VolumeCapability:block:<> access_mode:<mode:SINGLE_NODE_WRITER >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}   {"TraceId": "a8e59b5e-a6f7-4a99-8fbb-030e6f199575"}
...
2023-01-23T06:55:22.951Z        DEBUG   volume/manager.go:1403  internalExpandVolume: returns fault "" for volume "a0486075-128b-4808-a801-35cb6b9b28af"        {"TraceId": "a8e59b5e-a6f7-4a99-8fbb-030e6f199575"}
2023-01-23T06:55:22.951Z        INFO    common/vsphereutil.go:658       Successfully expanded volume for volumeID "a0486075-128b-4808-a801-35cb6b9b28af" to new size 2048 Mb.   {"TraceId": "a8e59b5e-a6f7-4a99-8fbb-030e6f199575"}
2023-01-23T06:55:22.951Z        DEBUG   vanilla/controller.go:2498      ControllerExpandVolumeInternal: returns 2147483648 as capacity and false as NodeExpansionRequired       {"TraceId": "a8e59b5e-a6f7-4a99-8fbb-030e6f199575"}
2023-01-23T06:55:22.951Z        INFO    vanilla/controller.go:2516      Volume "a0486075-128b-4808-a801-35cb6b9b28af" expanded successfully.    {"TraceId": "a8e59b5e-a6f7-4a99-8fbb-030e6f199575"}
```

CSI node logs:

```
2023-01-23T06:55:56.256Z        INFO    service/node.go:473     NodeExpandVolume: called with args {VolumeId:a0486075-128b-4808-a801-35cb6b9b28af VolumePath:/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-5ce85d2e-088d-4068-987c-b6c7013ad150/4038d386-6773-4bea-9d9a-13ae48e1d70a CapacityRange:required_bytes:2147483648  StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc-5ce85d2e-088d-4068-987c-b6c7013ad150 VolumeCapability:block:<> access_mode:<mode:SINGLE_NODE_WRITER >  Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}   {"TraceId": "ef74d7dc-004a-4a76-9dec-b1a8fc957010"}
2023-01-23T06:55:56.256Z        DEBUG   service/node.go:509     NodeExpandVolume: staging target path /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-5ce85d2e-088d-4068-987c-b6c7013ad150/4038d386-6773-4bea-9d9a-13ae48e1d70a, getDevFromMount {FullPath:/dev/sdb Name:sdb RealDev:/dev/sdb}     {"TraceId": "ef74d7dc-004a-4a76-9dec-b1a8fc957010"}
2023-01-23T06:55:56.257Z        INFO    service/node.go:553     NodeExpandVolume: called for block device a0486075-128b-4808-a801-35cb6b9b28af at volumePath specified /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-5ce85d2e-088d-4068-987c-b6c7013ad150/4038d386-6773-4bea-9d9a-13ae48e1d70a, ignoring..       {"TraceId": "ef74d7dc-004a-4a76-9dec-b1a8fc957010"}
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Changes to handle NodeExpandVolume() API correctly for raw-block volumes
```
