### PR TITLE
Have a separate volume lock for each VC

### DIFF
--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -348,8 +348,8 @@ func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVo
 	log := logger.GetLogger(ctx)
 	defer wg.Done()
 	currentK8sPVMap := make(map[string]bool)
-	volumeOperationsLock.Lock()
-	defer volumeOperationsLock.Unlock()
+	volumeOperationsLock[vc].Lock()
+	defer volumeOperationsLock[vc].Unlock()
 	// Get all K8s PVs in the given VC.
 	currentK8sPV, err := getPVsInBoundAvailableOrReleasedForVc(ctx, metadataSyncer, vc)
 	if err != nil {
@@ -428,8 +428,8 @@ func fullSyncDeleteVolumes(ctx context.Context, volumeIDDeleteArray []cnstypes.C
 	log := logger.GetLogger(ctx)
 	deleteDisk := false
 	currentK8sPVMap := make(map[string]bool)
-	volumeOperationsLock.Lock()
-	defer volumeOperationsLock.Unlock()
+	volumeOperationsLock[vc].Lock()
+	defer volumeOperationsLock[vc].Unlock()
 	// Get all K8s PVs.
 	currentK8sPV, err := getPVsInBoundAvailableOrReleasedForVc(ctx, metadataSyncer, vc)
 	if err != nil {

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -207,6 +208,8 @@ func TestSyncerWorkflows(t *testing.T) {
 		t.Fatalf("failed to create an instance of volume manager. err=%v", err)
 	}
 	metadataSyncer.host = virtualCenter.Config.Host
+	volumeOperationsLock = make(map[string]*sync.Mutex)
+	volumeOperationsLock[metadataSyncer.host] = &sync.Mutex{}
 
 	// Create the kubernetes client from config or env.
 	// Here we should use a faked client to avoid test inteference with running

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -73,17 +73,20 @@ var (
 	// cnsDeletionMap tracks volumes that exist in CNS but not in K8s
 	// If a volume exists in this map across two fullsync cycles,
 	// the volume is deleted from CNS
+	// A separate map is maintained for each VC.
 	cnsDeletionMap map[string]map[string]bool
 
 	// cnsCreationMap tracks volumes that exist in K8s but not in CNS
 	// If a volume exists in this map across two fullsync cycles,
 	// the volume is created in CNS
+	// A separate map is maintained for each VC.
 	cnsCreationMap map[string]map[string]bool
 
 	// Metadata syncer and full sync share a global lock
 	// to mitigate race conditions related to
 	// static provisioning of volumes
-	volumeOperationsLock sync.Mutex
+	// There is a separate lock for each VC.
+	volumeOperationsLock map[string]*sync.Mutex
 )
 
 type (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently we have single global lock across all VCs because of which full sync is not running concurrently.
As part of this change, we are creating a separate lock for each VC.


**Testing done**:

Tested for vanilla (FSS enabled as well as disabled) :

Create CNS volume

1. Create a PV via CSI and then delete the corresponding CNS volume from VC.
2. Observed that CNSCreationMap got populated.
3. In the next full sync cycle, the CNS volume re-appreaed on VC UI.

Delete CNS volume

1. Created CNS volume on VC.
2. Observed that CNSDeletionMap got populated.
3. In the next full sync cycle, the CNS volume got deleted - confirmed the same from UI.

Also tested the following in metadatasyncer:
1. Static volume provisioning.
2. PV deleted workflow when volume is RWO and when volume is RWX.

NOT TESTED ON SV CLUSTER YET.