### PR TITLE
Fix the PR: 3082728,add NodeUpdate function to initNodeIDToNameMap

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1338,7 +1338,9 @@ func initNodeIDToNameMap(ctx context.Context) {
 		func(obj interface{}) { // Add.
 			nodeAdd(obj)
 		},
-		nil,
+		func(oldObj interface{}, newObj interface{}) { // Update.
+			nodeUpdate(oldObj, newObj)
+		},
 		func(obj interface{}) { // Delete.
 			nodeRemove(obj)
 		})
@@ -1361,6 +1363,37 @@ func nodeAdd(obj interface{}) {
 		return
 	}
 	k8sOrchestratorInstance.nodeIDToNameMap.add(nodeMoID, node.Name)
+}
+
+// nodeUpdate updates an entry into nodeIDToNameMap. The node MoID is retrieved from the
+// node annotation vmware-system-esxi-node-moid
+func nodeUpdate(oldObject interface{}, newObject interface{}) {
+	log := logger.GetLogger(context.Background())
+	oldnode, ok := oldObject.(*v1.Node)
+	if oldnode == nil || !ok {
+		log.Warnf("nodeUpdate: unrecognized object %+v", oldObject)
+		return
+	}
+
+	newnode, ok := newObject.(*v1.Node)
+	if newnode == nil || !ok {
+		log.Warnf("nodeUpdate: unrecognized object %+v", newObject)
+		return
+	}
+
+	log.Debugf("nodeUpdate: oldnode=%+v newnode=%+v", oldnode, newnode)
+	_, oldOk := oldnode.ObjectMeta.Annotations[common.HostMoidAnnotationKey]
+	newNodeMoID, newOk := newnode.ObjectMeta.Annotations[common.HostMoidAnnotationKey]
+
+	if !newOk {
+		log.Debugf("nodeUpdate: %s annotation not found on the new node %s", common.HostMoidAnnotationKey, newnode.Name)
+		return
+	}
+
+	if !oldOk && newOk {
+		// If annotation is not found on the old node but found on the new one, add it to the map.
+		k8sOrchestratorInstance.nodeIDToNameMap.add(newNodeMoID, newnode.Name)
+	}
 }
 
 // nodeRemove removes an entry from nodeIDToNameMap. The node MoID is retrieved from the

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1381,17 +1381,12 @@ func nodeUpdate(oldObject interface{}, newObject interface{}) {
 		return
 	}
 
-	log.Debugf("nodeUpdate: oldnode=%+v newnode=%+v", oldnode, newnode)
 	_, oldOk := oldnode.ObjectMeta.Annotations[common.HostMoidAnnotationKey]
 	newNodeMoID, newOk := newnode.ObjectMeta.Annotations[common.HostMoidAnnotationKey]
 
-	if !newOk {
-		log.Debugf("nodeUpdate: %s annotation not found on the new node %s", common.HostMoidAnnotationKey, newnode.Name)
-		return
-	}
-
 	if !oldOk && newOk {
 		// If annotation is not found on the old node but found on the new one, add it to the map.
+		log.Debugf("Adding nodeMoid %s and node name %s to the map.", newNodeMoID, newnode.Name)
 		k8sOrchestratorInstance.nodeIDToNameMap.add(newNodeMoID, newnode.Name)
 	}
 }

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
 	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
 	csifault "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault"
@@ -77,8 +78,10 @@ var getCandidateDatastores = cnsvsphere.GetCandidateDatastoresInCluster
 // Contains list of clusterComputeResourceMoIds on which supervisor cluster is deployed.
 var clusterComputeResourceMoIds = make([]string, 0)
 
+// list volume global variable
 var expectedStartingIndex = 0
 var cnsVolumeIDs = make([]string, 0)
+var hostSystems []*vsphere.HostSystem
 
 type controller struct {
 	manager     *common.Manager

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -542,7 +542,7 @@ func (c *controller) GetVolumeToHostMapping(ctx context.Context) (map[string]str
 	}
 
 	// Get all the hosts belonging to the cluster
-	hostSystems, err := vc.GetHostsByCluster(ctx, c.manager.CnsConfig.Global.SupervisorID)
+	hostSystems, err := vc.GetHostsByCluster(ctx, c.manager.CnsConfig.Global.ClusterID)
 	if err != nil {
 		log.Errorf("failed to get hosts for cluster %v, err:%v", c.manager.CnsConfig.Global.ClusterID, err)
 		return nil, nil, fmt.Errorf("failed to get hosts for cluster %v, err:%v", c.manager.CnsConfig.Global.ClusterID, err)
@@ -635,10 +635,10 @@ func getVolumeIDToVMMap(ctx context.Context, c *controller, volumeIDs []string) 
 
 	hostNames := commonco.ContainerOrchestratorUtility.GetNodeIDtoNameMap(ctx)
 	if len(hostNames) == 0 {
-		log.Errorf("There are no hostnames in the NodeIDtoName map")
-		return nil, fmt.Errorf("there are no hostnames in the NodeIDtoName map")
+		log.Errorf("no hostnames found in the NodeIDtoName map")
+		return nil, fmt.Errorf("no hostnames found in the NodeIDtoName map")
 	}
-	// Check len(hostnames) == 0 return err
+
 	for volumeID, VMMoID := range volumeIDToVMMap {
 		isFakeAttached, exists := allFakeAttachMarkedVolumes[volumeID]
 		// If we do not find this entry in the input list obtained from CNS


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
https://jira.eng.vmware.com/browse/CNAS-5818
This is seen in only on bootstrapped clusters, where the "vmware-system-esxi-node-moid" annotation takes a while to get added to the nodes. Since we don't have a NodeUpdate method, the map that List Volumes consumes(nodeIDToNameMap)  is never populated with host names. 
Therefore this line in listVolumes implementation returns empty hostnames:
        hostNames := commonco.ContainerOrchestratorUtility.GetNodeIDtoNameMap(ctx)
As a result, the List Volume response is empty.

The solution here is:
1. to add a NodeUpdate listener method inside "initNodeIDToNameMap" just like we have nodeRemove and nodeAdd listeners. 
2. We should also check if hostNames list in getVolumeIDToVMMap method is empty and return error if it is.

**Testing done**:

1. Added a debug log to check if nodeUpdate is getting invoked.
2. Created a sample instance with 3 replicas, and checked that list volumes was being called and Response is being populated.
```
2023-02-08T06:09:45.546420232Z 2023-02-08T06:09:45.546Z DEBUG   wcp/controller.go:1296  ListVolumes called with args {MaxEntries:0 StartingToken: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}, expectedStartingIndex 0 {"TraceId": "3143af3b-c46d-4318-ad0e-de39af5b2140"}
2023-02-08T06:09:45.564700394Z 2023-02-08T06:09:45.564Z DEBUG   wcp/controller.go:1360  ListVolumes: cnsVolumeIDs [f062f92d-5426-423a-bb58-54ed7e347b04 26621eec-4cdc-40b0-a020-e0176b73eddb c7df8dea-a2ed-4280-8df0-8452d01e1247], startingIdx 0, queryLimit 3 {"TraceId": "3143af3b-c46d-4318-ad0e-de39af5b2140"}
2023-02-08T06:09:45.564970804Z 2023-02-08T06:09:45.564Z DEBUG   k8sorchestrator/k8sorchestrator_helper.go:41    Getting annotations on pvc corresponding to volume: f062f92d-5426-423a-bb58-54ed7e347b04        {"TraceId": "3143af3b-c46d-4318-ad0e-de39af5b2140"}
2023-02-08T06:09:45.565456243Z 2023-02-08T06:09:45.565Z DEBUG   k8sorchestrator/k8sorchestrator_helper.go:41    Getting annotations on pvc corresponding to volume: 26621eec-4cdc-40b0-a020-e0176b73eddb        {"TraceId": "3143af3b-c46d-4318-ad0e-de39af5b2140"}
2023-02-08T06:09:45.565689899Z 2023-02-08T06:09:45.565Z DEBUG   k8sorchestrator/k8sorchestrator_helper.go:41    Getting annotations on pvc corresponding to volume: c7df8dea-a2ed-4280-8df0-8452d01e1247        {"TraceId": "3143af3b-c46d-4318-ad0e-de39af5b2140"}
2023-02-08T06:09:45.565868090Z 2023-02-08T06:09:45.565Z DEBUG   wcp/controller_helper.go:613    Fake attached volumes []        {"TraceId": "3143af3b-c46d-4318-ad0e-de39af5b2140"}
2023-02-08T06:09:45.613362162Z 2023-02-08T06:09:45.613Z DEBUG   wcp/controller.go:1381  ListVolumes: Response entries entries:<volume:<volume_id:"f062f92d-5426-423a-bb58-54ed7e347b04" > status:<published_node_ids:"sc2-10-185-236-172.eng.vmware.com" > > entries:<volume:<volume_id:"c7df8dea-a2ed-4280-8df0-8452d01e1247" > status:<published_node_ids:"sc2-10-185-236-58.eng.vmware.com" > > entries:<volume:<volume_id:"26621eec-4cdc-40b0-a020-e0176b73eddb" > status:<published_node_ids:"sc2-10-185-235-103.eng.vmware.com" > >       {"TraceId": "3143af3b-c46d-4318-ad0e-de39af5b2140"}
```
