### PR TITLE
support shared datastores across datacenters

### DIFF
--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -306,6 +306,7 @@ func getCnsVolumeInfoFromTaskResult(ctx context.Context, virtualCenter *cnsvsphe
 	log := logger.GetLogger(ctx)
 	var datastoreURL string
 	volumeCreateResult := interface{}(taskResult).(*cnstypes.CnsVolumeCreateResult)
+	log.Debugf("volumeCreateResult.PlacementResults :%v", volumeCreateResult.PlacementResults)
 	if volumeCreateResult.PlacementResults != nil {
 		var datastoreMoRef types.ManagedObjectReference
 		for _, placementResult := range volumeCreateResult.PlacementResults {

--- a/pkg/common/cns-lib/vsphere/datacenter.go
+++ b/pkg/common/cns-lib/vsphere/datacenter.go
@@ -72,6 +72,8 @@ func (dc *Datacenter) GetDatastoreInfoByURL(ctx context.Context, datastoreURL st
 	}
 	for _, dsMo := range dsMoList {
 		if dsMo.Info.GetDatastoreInfo().Url == datastoreURL {
+			log.Debugf("Found datastore MoRef %v for datastoreURL: %q in datacenter: %q on vCenter: %q",
+				dsMo.Reference(), datastoreURL, dc.InventoryPath, dc.VirtualCenterHost)
 			return &DatastoreInfo{
 				&Datastore{object.NewDatastore(dc.Client(), dsMo.Reference()),
 					dc},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is adding support for provisioning volume on the shared datastore mounted across multiple datacenters with Node VMs spread across multiple datacenters in the vCenter server.

**Which issue this PR fixes**

Fixes following issues

1. if nodes span across multiple Datacenters, the vSphere CSI driver cannot find shared datastores accessible to all nodes correctly because shared datastore across Datacenters have different datastore MoRefs but the same datastore URL. 

2. For topology setup, if we have multiple AZs across Datacenters with shared datastores across AZs, and if the volume gets provisioned on that shared datastore, we may end up publishing Node Affinity rules of a different AZ than what the user has requested in the StorgeClass.

3. Volume Provisioning using datastoreURL parameter in StorageClass will not work correctly if we have multiple datastore with same URL but with different MoRef on the system.

4. If volume is provisioned using Preferential datastore URL specified in the vSphere Config Secret. We will end up the same issue mentioned in Issue 2.






**Testing done**:
Yes.

Without this fix when the volume is requested for region 1, zone 2, and level 4, we don't see the requested segment in Node Affinity rules on the provisioned PV.

```
root@k8s-control1:~# kubectl describe pv
Name:              pvc-4c661209-b2b9-4344-b284-ef6ab8f230c6
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      sc-r1-z2-l4
Status:            Bound
Claim:             default/pvc1
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.csi.vmware.com/k8s-zone in [zone-1]
                   topology.csi.vmware.com/k8s-level in [level-2]
                   topology.csi.vmware.com/k8s-region in [region-1]
    Term 1:        topology.csi.vmware.com/k8s-region in [region-1]
                   topology.csi.vmware.com/k8s-zone in [zone-1]
                   topology.csi.vmware.com/k8s-level in [level-1]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      f824a689-8b31-468f-94cd-aa6eba85c998
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1675102042943-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
root@k8s-control1:~# 
```


After this fix when the volume is requested for region 1, zone 2, and level 4, we see the requested segment in Node Affinity rules on the provisioned PV along with all other segments where PV is accessible to.

```
root@k8s-control1:~/divyen# kubectl describe pv pvc-14cb97bf-9e2f-4f25-9f88-7a1a2be15e18
Name:              pvc-14cb97bf-9e2f-4f25-9f88-7a1a2be15e18
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      sc-r1-z2-l4
Status:            Bound
Claim:             default/pvc1
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          50Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.csi.vmware.com/k8s-level in [level-2]
                   topology.csi.vmware.com/k8s-region in [region-1]
                   topology.csi.vmware.com/k8s-zone in [zone-1]
    Term 1:        topology.csi.vmware.com/k8s-zone in [zone-1]
                   topology.csi.vmware.com/k8s-level in [level-1]
                   topology.csi.vmware.com/k8s-region in [region-1]
    Term 2:        topology.csi.vmware.com/k8s-level in [level-4]
                   topology.csi.vmware.com/k8s-region in [region-1]
                   topology.csi.vmware.com/k8s-zone in [zone-2]
    Term 3:        topology.csi.vmware.com/k8s-region in [region-1]
                   topology.csi.vmware.com/k8s-zone in [zone-2]
                   topology.csi.vmware.com/k8s-level in [level-3]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      7a0125e8-05b2-47fc-b275-aceb0b58777f
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1675383116830-8081-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>

```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
6. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
support shared datastores across datacenters
```
