### PR TITLE
Fix error messages to start with non-capitalized letters

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -88,7 +88,7 @@ func main() {
 	// Set CO agnostic init params.
 	clusterFlavor, err := config.GetClusterFlavor(ctx)
 	if err != nil {
-		log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
+		log.Errorf("failed retrieving cluster flavor. Error: %v", err)
 	}
 	commonco.SetInitParams(ctx, clusterFlavor, &syncer.COInitParams, *supervisorFSSName, *supervisorFSSNamespace,
 		*internalFSSName, *internalFSSNamespace, "")

--- a/cmd/vsphere-csi/main.go
+++ b/cmd/vsphere-csi/main.go
@@ -54,7 +54,7 @@ func main() {
 	// Set CO Init params.
 	clusterFlavor, err := csiconfig.GetClusterFlavor(ctx)
 	if err != nil {
-		log.Errorf("Failed retrieving cluster flavor. Error: %v", err)
+		log.Errorf("failed retrieving cluster flavor. Error: %v", err)
 	}
 	serviceMode := os.Getenv(csitypes.EnvVarMode)
 	commonco.SetInitParams(ctx, clusterFlavor, &service.COInitParams, *supervisorFSSName, *supervisorFSSNamespace,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix error messages for csi and syncer package to make sure errors start with non-capitalized letters

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix error messages to start with non-capitalized letters
```
