### PR TITLE
Add fsType parameter in static provisioning PV example

### DIFF
--- a/example/vanilla-k8s-RWO-filesystem-volumes/example-static-rwo-volume.yaml
+++ b/example/vanilla-k8s-RWO-filesystem-volumes/example-static-rwo-volume.yaml
@@ -18,6 +18,7 @@ spec:
     name: static-vanilla-rwo-filesystem-pvc
   csi:
     driver: csi.vsphere.vmware.com
+    fsType: ext4  # Change fstype to xfs or ntfs based on the requirement.
     volumeAttributes:
       type: "vSphere CNS Block Volume"
     volumeHandle: 0c75d40e-7576-4fe7-8aaa-a92946e2805d  # First Class Disk (Improved Virtual Disk) ID


### PR DESCRIPTION
**What this PR does / why we need it**:
In case of static provisioning, even if fsType is specified in StorageClass, it is not provided to CSI driver APIs and we need to mention fsType in PV spec (https://kubernetes.io/docs/concepts/storage/volumes/#csi). If nothing is provided in PV spec, then by default ext4 is used as fsType.
So, in case of xfs or NTFS we need to mention it explicitly in PV spec.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

When we specify xfs as fsType in PV spec, then disk gets formatted with xfs. Otherwise, disk gets formatted with ext4 filesystem.

```
# kubectl describe sc
Name:                  example-vanilla-rwo-filesystem-sc
IsDefaultClass:        Yes
Annotations:           storageclass.kubernetes.io/is-default-class=true
Provisioner:           csi.vsphere.vmware.com
Parameters:            csi.storage.k8s.io/fstype=xfs
AllowVolumeExpansion:  True
MountOptions:          <none>
ReclaimPolicy:         Delete
VolumeBindingMode:     Immediate
Events:                <none>

# kubectl create -f example-static-rwo-volume.yaml 
persistentvolume/static-vanilla-rwo-filesystem-pv created
persistentvolumeclaim/static-vanilla-rwo-filesystem-pvc created
 
# kubectl get pv,pvc
NAME                                                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                       STORAGECLASS                        REASON   AGE
persistentvolume/static-vanilla-rwo-filesystem-pv   2Gi        RWO            Delete           Bound    default/static-vanilla-rwo-filesystem-pvc   example-vanilla-rwo-filesystem-sc            8s

NAME                                                      STATUS   VOLUME                             CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
persistentvolumeclaim/static-vanilla-rwo-filesystem-pvc   Bound    static-vanilla-rwo-filesystem-pv   2Gi        RWO            example-vanilla-rwo-filesystem-sc   8s

# kubectl create -f pod1.yaml 
pod/pod1 created

# kubectl get pods
NAME   READY   STATUS    RESTARTS   AGE
pod1   1/1     Running   0          63s

# kubectl exec -it pod1 -- bash
root@pod1:/# mount | grep xfs
/dev/sdb on /mnt/volume1 type xfs (rw,relatime,nouuid,attr2,inode64,logbufs=8,logbsize=32k,noquota)
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Add fsType parameter in static provisioning PV example
```
