### PR TITLE
Remove service mode check for consistent fss checking across all CSI containers

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1024,28 +1024,26 @@ func (c *K8sOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) 
 				featureName, c.internalFSS.configMapName)
 			return false
 		}
-		if serviceMode != "node" {
-			// Check SV FSS map.
-			c.supervisorFSS.featureStatesLock.RLock()
-			if flag, ok := c.supervisorFSS.featureStates[featureName]; ok {
-				c.supervisorFSS.featureStatesLock.RUnlock()
-				supervisorFeatureState, err := strconv.ParseBool(flag)
-				if err != nil {
-					log.Errorf("Error while converting %v feature state value: %v to boolean. "+
-						"Setting the feature state to false", featureName, supervisorFeatureState)
-					return false
-				}
-				if !supervisorFeatureState {
-					// If FSS set to false, return.
-					log.Infof("%s feature state set to false in %s ConfigMap", featureName, c.supervisorFSS.configMapName)
-					return supervisorFeatureState
-				}
-			} else {
-				c.supervisorFSS.featureStatesLock.RUnlock()
-				log.Debugf("Could not find the %s feature state in ConfigMap %s. Setting the feature state to false",
-					featureName, c.supervisorFSS.configMapName)
+		// Check SV FSS map.
+		c.supervisorFSS.featureStatesLock.RLock()
+		if flag, ok := c.supervisorFSS.featureStates[featureName]; ok {
+			c.supervisorFSS.featureStatesLock.RUnlock()
+			supervisorFeatureState, err := strconv.ParseBool(flag)
+			if err != nil {
+				log.Errorf("Error while converting %v feature state value: %v to boolean. "+
+					"Setting the feature state to false", featureName, supervisorFeatureState)
 				return false
 			}
+			if !supervisorFeatureState {
+				// If FSS set to false, return.
+				log.Infof("%s feature state set to false in %s ConfigMap", featureName, c.supervisorFSS.configMapName)
+				return supervisorFeatureState
+			}
+		} else {
+			c.supervisorFSS.featureStatesLock.RUnlock()
+			log.Debugf("Could not find the %s feature state in ConfigMap %s. Setting the feature state to false",
+				featureName, c.supervisorFSS.configMapName)
+			return false
 		}
 		return true
 	}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is removing service mode check for consistent fss checking across all CSI containers controller/syncer/node.

TKGs-HA has been enabled in ToT main. Going forward, any new pre-unified TKRs created from main branch will not be able to run on vSphere builds lesser than 8.0. This is because TKGs-HA FSS is checked in the nodes by just looking at the internal FSS map whereas the syncer which reconciles the CSINodeTopology CRs reads the FSS from both the internal map and the replicated csi-feature-states map. Nodes will keep waiting for the CSINodeTopology CRs to get reconciled whereas the syncer will not run the reconciler assuming that the combined FSS is set to False. We need to change this behavior and make sure the FSS is read consistently across both the controller/syncer and the nodes. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running e2e pipelines

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove service mode check for consistent fss checking across all CSI containers
```
