### PR TITLE
Skip creating new vc client upon config secret change

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -187,7 +187,7 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 				os.Exit(1)
 			}
 		} else {
-			configInfo, err = common.InitConfigInfo(ctx)
+			configInfo, err = config.InitConfigInfo(ctx)
 			if err != nil {
 				log.Errorf("failed to initialize the configInfo. Err: %+v", err)
 				os.Exit(1)

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -60,7 +60,6 @@ const (
 
 	// maxLengthOfVolumeNameInCNS is the maximum length of CNS volume name.
 	maxLengthOfVolumeNameInCNS = 80
-
 	// Alias for TaskInvocationStatus constants.
 	taskInvocationStatusInProgress = cnsvolumeoperationrequest.TaskInvocationStatusInProgress
 	taskInvocationStatusSuccess    = cnsvolumeoperationrequest.TaskInvocationStatusSuccess
@@ -1503,7 +1502,7 @@ func (m *defaultManager) expandVolumeWithImprovedIdempotency(ctx context.Context
 		if volumeOperationDetails.OperationDetails != nil {
 			if volumeOperationDetails.OperationDetails.TaskStatus == taskInvocationStatusSuccess &&
 				volumeOperationDetails.Capacity >= size {
-				log.Infof("Volume with ID %s already expanded to size %s", volumeID, size)
+				log.Infof("Volume with ID %s already expanded to size %v", volumeID, size)
 				return "", nil
 			}
 			if volumeOperationDetails.OperationDetails.TaskStatus == taskInvocationStatusInProgress &&

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -32,7 +32,6 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vsan"
 	"github.com/vmware/govmomi/vslm"
-
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger"
 
@@ -137,6 +136,9 @@ type VirtualCenterConfig struct {
 	// MigrationDataStore specifies datastore which is set as default datastore in legacy cloud-config
 	// and hence should be used as default datastore.
 	MigrationDataStoreURL string
+	// when ReloadVCConfigForNewClient is set to true it forces re-read config secret when
+	// new vc client needs to be created
+	ReloadVCConfigForNewClient bool
 }
 
 // NewClient creates a new govmomi Client instance.
@@ -306,7 +308,31 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 		}
 	}
 	// If session has expired, create a new instance.
-	log.Warnf("Creating a new client session as the existing one isn't valid or not authenticated")
+	log.Infof("Creating a new client session as the existing one isn't valid or not authenticated")
+	if vc.Config.ReloadVCConfigForNewClient {
+		log.Info("Reloading latest VC config from vSphere Config Secret")
+		cfg, err := config.GetConfig(ctx)
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to read config. Error: %+v", err)
+		}
+		var foundVCConfig bool
+		newVcenterConfigs, err := GetVirtualCenterConfigs(ctx, cfg)
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to get VirtualCenterConfigs. err=%v", err)
+		}
+		for _, newvcconfig := range newVcenterConfigs {
+			if newvcconfig.Host == vc.Config.Host {
+				newvcconfig.ReloadVCConfigForNewClient = true
+				vc.Config = newvcconfig
+				log.Infof("Successfully set latest VC config for vcenter: %q", vc.Config.Host)
+				foundVCConfig = true
+				break
+			}
+		}
+		if !foundVCConfig {
+			return logger.LogNewErrorf(log, "failed to get vCenter config for Host: %q", vc.Config.Host)
+		}
+	}
 	if vc.Client, err = vc.NewClient(ctx); err != nil {
 		log.Errorf("failed to create govmomi client with err: %v", err)
 		if !vc.Config.Insecure {
@@ -612,6 +638,9 @@ func GetVirtualCenterInstanceForVCenterConfig(ctx context.Context,
 		// Register with virtual center manager.
 		vcInstance, err := virtualcentermanager.RegisterVirtualCenter(ctx, vcconfig)
 		if err != nil {
+			if err == ErrVCAlreadyRegistered {
+				return nil, ErrVCAlreadyRegistered
+			}
 			return nil, logger.LogNewErrorf(log, "failed to register VirtualCenter %q Err: %+v",
 				vcconfig.Host, err)
 		}
@@ -628,8 +657,26 @@ func GetVirtualCenterInstanceForVCenterConfig(ctx context.Context,
 	return vCenterInstances[vcconfig.Host], nil
 }
 
+// UnregisterVirtualCenter helps delete vCenterServer instance for specified host
+func UnregisterVirtualCenter(ctx context.Context, vcHost string) error {
+	log := logger.GetLogger(ctx)
+	vCenterInstancesLock.Lock()
+	defer vCenterInstancesLock.Unlock()
+
+	// Initialize the virtual center manager.
+	virtualcentermanager := GetVirtualCenterManager(ctx)
+	// Unregister the VC from virtual center manager.
+	if err := virtualcentermanager.UnregisterVirtualCenter(ctx, vcHost); err != nil {
+		return logger.LogNewErrorf(log, "failed to unregister VirtualCenter %q with "+
+			"virtualCenterManager. Err: %+v", vcHost, err)
+	}
+	delete(vCenterInstances, vcHost)
+	return nil
+}
+
 // GetVirtualCenterInstanceForVCenterHost returns the vcenter object for given vCenter host.
-func GetVirtualCenterInstanceForVCenterHost(ctx context.Context, vcHost string) (*VirtualCenter, error) {
+func GetVirtualCenterInstanceForVCenterHost(ctx context.Context, vcHost string,
+	reconnect bool) (*VirtualCenter, error) {
 	log := logger.GetLogger(ctx)
 	vCenterInstancesLock.RLock()
 	defer vCenterInstancesLock.RUnlock()
@@ -638,10 +685,12 @@ func GetVirtualCenterInstanceForVCenterHost(ctx context.Context, vcHost string) 
 	if !found || vc == nil {
 		return nil, logger.LogNewErrorf(log, "failed to get VirtualCenter instance for host %q.", vcHost)
 	}
-	err := vc.Connect(ctx)
-	if err != nil {
-		return nil, logger.LogNewErrorf(log, "failed to connect to VirtualCenter host: %q. Error: %v",
-			vcHost, err)
+	if reconnect {
+		err := vc.Connect(ctx)
+		if err != nil {
+			return nil, logger.LogNewErrorf(log, "failed to connect to VirtualCenter host: %q. Error: %v",
+				vcHost, err)
+		}
 	}
 	return vc, nil
 }

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -183,3 +183,6 @@ type SnapshotConfig struct {
 	// per volume in VVOL datastores.
 	GranularMaxSnapshotsPerBlockVolumeInVVOL int `gcfg:"granular-max-snapshots-per-block-volume-vvol"`
 }
+
+// EnvClusterFlavor is the k8s cluster type on which CSI Driver is being deployed
+const EnvClusterFlavor = "CLUSTER_FLAVOR"

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -405,7 +405,7 @@ func initFSS(ctx context.Context, k8sClient clientset.Interface,
 				log.Errorf("failed to retrieve supervisor cluster namespace from config. Error: %+v", err)
 				return err
 			}
-			cfg, err := common.GetConfig(ctx)
+			cfg, err := cnsconfig.GetConfig(ctx)
 			if err != nil {
 				log.Errorf("failed to read config. Error: %+v", err)
 				return err

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -202,7 +202,7 @@ func (c *K8sOrchestrator) InitTopologyServiceInController(ctx context.Context) (
 				// Set isMultivCenterCluster if the K8s cluster is a multi-VC cluster.
 				isMultiVCSupportEnabled = c.IsFSSEnabled(ctx, common.MultiVCenterCSITopology)
 				if isMultiVCSupportEnabled {
-					cfg, err := common.GetConfig(ctx)
+					cfg, err := cnsconfig.GetConfig(ctx)
 					if err != nil {
 						return nil, logger.LogNewErrorf(log, "failed to read config. Error: %+v", err)
 					}
@@ -223,7 +223,7 @@ func (c *K8sOrchestrator) InitTopologyServiceInController(ctx context.Context) (
 
 				if controllerVolumeTopologyInstance.isTopologyPreferentialDatastoresFSSEnabled {
 					// Get CNS config.
-					cnsCfg, err := common.GetConfig(ctx)
+					cnsCfg, err := cnsconfig.GetConfig(ctx)
 					if err != nil {
 						return nil, logger.LogNewErrorf(log, "failed to fetch CNS config. Error: %+v", err)
 					}
@@ -297,7 +297,7 @@ func (c *K8sOrchestrator) InitTopologyServiceInController(ctx context.Context) (
 func refreshPreferentialDatastores(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
 	// Get VC instance.
-	cnsCfg, err := common.GetConfig(ctx)
+	cnsCfg, err := cnsconfig.GetConfig(ctx)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to fetch CNS config. Error: %+v", err)
 	}

--- a/pkg/csi/service/common/topology.go
+++ b/pkg/csi/service/common/topology.go
@@ -7,6 +7,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
 
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere"
@@ -59,8 +60,8 @@ func GetAccessibilityRequirementsByVC(ctx context.Context, topoReq *csi.Topology
 		segments := topology.GetSegments()
 		vcHost, err := getVCForTopologySegments(ctx, segments)
 		if err != nil {
-			return nil, logger.LogNewErrorf(log, "failed to fetch vCenter associated with topology segments %+v",
-				segments)
+			return nil, logger.LogNewErrorf(log, "failed to fetch vCenter associated with topology segments: %+v , err: %v",
+				segments, err)
 		}
 		vcTopoSegmentsMap[vcHost] = append(vcTopoSegmentsMap[vcHost], segments)
 	}
@@ -120,7 +121,7 @@ func getVCForTopologySegments(ctx context.Context, topologySegments map[string]s
 // with the latest information on the preferential datastores for each topology domain across all vCenter Servers
 func RefreshPreferentialDatastoresForMultiVCenter(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
-	cnsCfg, err := GetConfig(ctx)
+	cnsCfg, err := config.GetConfig(ctx)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to fetch CNS config. Error: %+v", err)
 	}

--- a/pkg/csi/service/driver.go
+++ b/pkg/csi/service/driver.go
@@ -82,7 +82,7 @@ func NewDriver() Driver {
 
 func (driver *vsphereCSIDriver) GetController() csi.ControllerServer {
 	// Check which controller type to use.
-	clusterFlavor = cnstypes.CnsClusterFlavor(os.Getenv(csitypes.EnvClusterFlavor))
+	clusterFlavor = cnstypes.CnsClusterFlavor(os.Getenv(cnsconfig.EnvClusterFlavor))
 	switch clusterFlavor {
 	case cnstypes.CnsClusterFlavorWorkload:
 		driver.cnscs = wcp.New()
@@ -134,7 +134,7 @@ func (driver *vsphereCSIDriver) BeforeServe(ctx context.Context) error {
 
 	if !strings.EqualFold(driver.mode, "node") {
 		// Controller service is needed.
-		cfg, err = common.GetConfig(ctx)
+		cfg, err = cnsconfig.GetConfig(ctx)
 		if err != nil {
 			log.Errorf("failed to read config. Error: %+v", err)
 			return err

--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -280,3 +280,15 @@ func getVCenterManagerForVCenter(ctx context.Context, controller *controller) vs
 	}
 	return vCenterManager
 }
+
+// GetVolumeManagerFromVCHost retreives the volume manager associated with
+// vCenterHost under managers. Error out if the vCenterHost does not exist.
+func GetVolumeManagerFromVCHost(ctx context.Context, managers *common.Managers, vCenterHost string) (
+	cnsvolume.Manager, error) {
+	log := logger.GetLogger(ctx)
+	volumeMgr, exists := managers.VolumeManagers[vCenterHost]
+	if !exists {
+		return nil, logger.LogNewErrorf(log, "failed to find vCenter %q under volume managers.", vCenterHost)
+	}
+	return volumeMgr, nil
+}

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -302,6 +302,9 @@ func (f *FakeAuthManager) ResetvCenterInstance(ctx context.Context, vCenter *cns
 	f.vcenter = vCenter
 }
 
+func (f *FakeAuthManager) Stop() {
+}
+
 func getControllerTest(t *testing.T) *controllerTest {
 	onceForControllerTest.Do(func() {
 		// Create context.

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -177,7 +177,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 	if tasksListViewEnabled {
 		go cnsvolume.ClearInvalidTasksFromListView(false)
 	}
-	cfgPath := common.GetConfigPath(ctx)
+	cfgPath := cnsconfig.GetConfigPath(ctx)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Errorf("failed to create fsnotify watcher. err=%v", err)
@@ -300,7 +300,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Info("Reloading Configuration")
-	cfg, err := common.GetConfig(ctx)
+	cfg, err := cnsconfig.GetConfig(ctx)
 	if err != nil {
 		log.Errorf("failed to read config. Error: %+v", err)
 		return err

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -47,7 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator"
 	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
-	cnsconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
+	commonconfig "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
 	csifault "sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
@@ -83,12 +83,12 @@ func New() csitypes.CnsController {
 }
 
 // Init is initializing controller struct
-func (c *controller) Init(config *cnsconfig.Config, version string) error {
+func (c *controller) Init(config *commonconfig.Config, version string) error {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Infof("Initializing WCPGC CSI controller")
 	var err error
 	// connect to the CSI controller in supervisor cluster
-	c.supervisorNamespace, err = cnsconfig.GetSupervisorNamespace(ctx)
+	c.supervisorNamespace, err = commonconfig.GetSupervisorNamespace(ctx)
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		return err
 	}
 
-	pvcsiConfigPath := common.GetConfigPath(ctx)
+	pvcsiConfigPath := commonconfig.GetConfigPath(ctx)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Errorf("failed to create fsnotify watcher. err=%v", err)
@@ -166,10 +166,10 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		log.Errorf("failed to watch on path: %q. err=%v", cfgDirPath, err)
 		return err
 	}
-	log.Infof("Adding watch on path: %q", cnsconfig.DefaultpvCSIProviderPath)
-	err = watcher.Add(cnsconfig.DefaultpvCSIProviderPath)
+	log.Infof("Adding watch on path: %q", commonconfig.DefaultpvCSIProviderPath)
+	err = watcher.Add(commonconfig.DefaultpvCSIProviderPath)
 	if err != nil {
-		log.Errorf("failed to watch on path: %q. err=%v", cnsconfig.DefaultpvCSIProviderPath, err)
+		log.Errorf("failed to watch on path: %q. err=%v", commonconfig.DefaultpvCSIProviderPath, err)
 		return err
 	}
 	// Go module to keep the metrics http server running all the time.
@@ -193,7 +193,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 func (c *controller) ReloadConfiguration() error {
 	ctx, log := logger.GetNewContextWithLogger()
 	log.Info("Reloading Configuration")
-	cfg, err := common.GetConfig(ctx)
+	cfg, err := commonconfig.GetConfig(ctx)
 	if err != nil {
 		log.Errorf("failed to read config. Error: %+v", err)
 		return err

--- a/pkg/csi/types/envvars.go
+++ b/pkg/csi/types/envvars.go
@@ -17,9 +17,6 @@ limitations under the License.
 package types
 
 const (
-	// EnvClusterFlavor is the k8s cluster type on which CSI Driver is being deployed
-	EnvClusterFlavor = "CLUSTER_FLAVOR"
-
 	// EnvSupervisorClientQPS  is the QPS for all clients to the supervisor cluster API server
 	EnvSupervisorClientQPS = "SUPERVISOR_CLIENT_QPS"
 

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -477,7 +477,7 @@ func getNodeTopologyInfo(ctx context.Context, nodeVM *cnsvsphere.VirtualMachine,
 	)
 	// Get VC instance.
 	if isMultiVCFSSEnabled {
-		vcenter, err = cnsvsphere.GetVirtualCenterInstanceForVCenterHost(ctx, nodeVM.VirtualCenterHost)
+		vcenter, err = cnsvsphere.GetVirtualCenterInstanceForVCenterHost(ctx, nodeVM.VirtualCenterHost, true)
 		if err != nil {
 			return nil, logger.LogNewErrorf(log, "failed to get vCenterInstance for vCenter Host: %q, err: %v",
 				nodeVM.VirtualCenterHost, err)

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -345,7 +345,7 @@ func InitCommonModules(ctx context.Context, clusterFlavor cnstypes.CnsClusterFla
 // container.
 func watcher(ctx context.Context, cnsOperator *cnsOperator) error {
 	log := logger.GetLogger(ctx)
-	cfgPath := common.GetConfigPath(ctx)
+	cfgPath := commonconfig.GetConfigPath(ctx)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Errorf("Failed to create fsnotify watcher. Err: %+v", err)
@@ -391,7 +391,7 @@ func watcher(ctx context.Context, cnsOperator *cnsOperator) error {
 // with the latest configInfo.
 func reloadConfiguration(ctx context.Context, cnsOperator *cnsOperator) error {
 	log := logger.GetLogger(ctx)
-	cfg, err := common.GetConfig(ctx)
+	cfg, err := commonconfig.GetConfig(ctx)
 	if err != nil {
 		log.Errorf("Failed to read config. Error: %+v", err)
 		return err

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -242,7 +242,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 	var vcenter *cnsvsphere.VirtualCenter
 	// Get VC instance.
 	if isMultiVCenterFssEnabled {
-		vcenter, err = cnsvsphere.GetVirtualCenterInstanceForVCenterHost(ctx, vc)
+		vcenter, err = cnsvsphere.GetVirtualCenterInstanceForVCenterHost(ctx, vc, true)
 		if err != nil {
 			log.Errorf("failed to get virtual center instance for VC: %s. Error: %v", vc, err)
 			return err

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -343,7 +343,7 @@ func getConfig(ctx context.Context) (*cnsconfig.Config, error) {
 	var clusterID string
 	log := logger.GetLogger(ctx)
 
-	cfg, err := common.GetConfig(ctx)
+	cfg, err := cnsconfig.GetConfig(ctx)
 	if err != nil {
 		log.Errorf("failed to read config. Error: %+v", err)
 		return nil, err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is skipping creating a new vCenter client upon config secret changes.

We don't need to immediately drop existing connections made by the driver to vCenter when password rotation happens and create a new connection.
We just need to read the latest config secret only when the existing session is expired and a new vCenter client needs to be created.



**Testing done**:
@sipriyaa has validated password rotation, wrong password in the config secret, and session killing test cases with this change.

I have performed the following testing with both multi-vCenter feature gates enabled and disabled on the Vanilla setup.

- change config parameter other than VC credentials and VC Host.
- change VC IP to FQDN
- change VC FQDN to IP
- change VC password
- set wrong VC password

Also performance basic sanity testing on WCP supervisor. No regression observed.
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Skip creating new vc client upon config secret change
```
