### PR TITLE
Update static check tool to latest version

### DIFF
--- a/hack/check-staticcheck.sh
+++ b/hack/check-staticcheck.sh
@@ -19,14 +19,16 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+go version
+
 # Change directories to the parent directory of the one in which this
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-go install honnef.co/go/tools/cmd/staticcheck@2022.1.2
+go install honnef.co/go/tools/cmd/staticcheck@2023.1
+
+GOOS=linux "$(go env GOPATH)"/bin/staticcheck --version
 
 # shellcheck disable=SC2046
 # shellcheck disable=SC1083
-GOOS=linux $(go env GOPATH)/bin/staticcheck $(go list ./... | grep -v /vendor/)
-
-
+GOOS=linux "$(go env GOPATH)"/bin/staticcheck $(go list ./... | grep -v /vendor/)

--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -192,7 +192,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		originalFsSize, err := getFSSizeMb(f, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		rand.Seed(time.Now().Unix())
+		rand.New(rand.NewSource(time.Now().Unix()))
 		testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
 		ginkgo.By(fmt.Sprintf("Creating a 512mb test data file %v", testdataFile))
 		op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),
@@ -1436,7 +1436,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		lastOutput := framework.RunKubectlOrDie(namespace, cmd...)
 		gomega.Expect(strings.Contains(lastOutput, ext4FSType)).NotTo(gomega.BeFalse())
 
-		rand.Seed(time.Now().Unix())
+		rand.New(rand.NewSource(time.Now().Unix()))
 		testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
 		ginkgo.By(fmt.Sprintf("Creating a 512mb test data file %v", testdataFile))
 		op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),

--- a/tests/e2e/policy_driven_vol_allocation.go
+++ b/tests/e2e/policy_driven_vol_allocation.go
@@ -116,7 +116,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 			ginkgo.Skip(fmt.Sprintf("Env %v is missing", envSharedVMFSDatastoreURL))
 		}
 
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		suffix := fmt.Sprintf("-%v-%v", time.Now().UnixNano(), rand.Intn(10000))
 		categoryName := "category" + suffix
 		tagName := "tag" + suffix
@@ -280,7 +280,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		var policyName string
 		var policyID *pbmtypes.PbmProfileId
 
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		suffix := fmt.Sprintf("-%v-%v", time.Now().UnixNano(), rand.Intn(10000))
 		categoryName := "category" + suffix
 		tagName := "tag" + suffix
@@ -430,7 +430,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 
 		scParameters := make(map[string]string)
 
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		suffix := fmt.Sprintf("-%v-%v", time.Now().UnixNano(), rand.Intn(10000))
 		categoryName := "category" + suffix
 		tagName := "tag" + suffix
@@ -568,7 +568,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 
 		scParameters := make(map[string]string)
 
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		suffix := fmt.Sprintf("-%v-%v", time.Now().UnixNano(), rand.Intn(10000))
 		categoryName := "category" + suffix
 		tagName := "tag" + suffix
@@ -772,7 +772,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		var policyName string
 		var policyID *pbmtypes.PbmProfileId
 
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		suffix := fmt.Sprintf("-%v-%v", time.Now().UnixNano(), rand.Intn(10000))
 		categoryName := "category" + suffix
 		tagName := "tag" + suffix
@@ -886,7 +886,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 			deletePodsAndWaitForVolsToDetach(ctx, client, pods, true)
 		}()
 
-		rand.Seed(time.Now().Unix())
+		rand.New(rand.NewSource(time.Now().Unix()))
 		testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
 		ginkgo.By(fmt.Sprintf("Creating a 100mb test data file %v", testdataFile))
 		op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),
@@ -1000,7 +1000,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		pvcs := []*v1.PersistentVolumeClaim{}
 		pvclaims2d := [][]*v1.PersistentVolumeClaim{}
 
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		suffix := fmt.Sprintf("-%v-%v", time.Now().UnixNano(), rand.Intn(10000))
 		categoryName := "category" + suffix
 		tagName := "tag" + suffix
@@ -1170,7 +1170,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		}
 
 		scParameters := make(map[string]string)
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		suffix := fmt.Sprintf("-%v-%v", time.Now().UnixNano(), rand.Intn(10000))
 		categoryName := "category" + suffix
 		tagName := "tag" + suffix

--- a/tests/e2e/svmotion_detached_volume.go
+++ b/tests/e2e/svmotion_detached_volume.go
@@ -203,7 +203,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Re
 
 		ginkgo.By("Creating tag and category to tag datastore")
 
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		suffix := fmt.Sprintf("-%v-%v", time.Now().UnixNano(), rand.Intn(10000))
 		categoryName := "category" + suffix
 		tagName := "tag" + suffix
@@ -357,7 +357,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Re
 		scParameters := make(map[string]string)
 		pvcs := []*v1.PersistentVolumeClaim{}
 
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		suffix := fmt.Sprintf("-%v-%v", time.Now().UnixNano(), rand.Intn(10000))
 		categoryName := "category" + suffix
 		tagName := "tag" + suffix

--- a/tests/e2e/tkgs_ha_utils.go
+++ b/tests/e2e/tkgs_ha_utils.go
@@ -243,7 +243,7 @@ func verifyVolumeProvisioningWithServiceDown(serviceName string, namespace strin
 // verifyOnlineVolumeExpansionOnGc is a util method which helps in verifying online volume expansion on gc
 func verifyOnlineVolumeExpansionOnGc(client clientset.Interface, namespace string, svcPVCName string,
 	volHandle string, pvclaim *v1.PersistentVolumeClaim, pod *v1.Pod, f *framework.Framework) {
-	rand.Seed(time.Now().Unix())
+	rand.New(rand.NewSource(time.Now().Unix()))
 	testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
 	ginkgo.By(fmt.Sprintf("Creating a 512mb test data file %v", testdataFile))
 	op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),
@@ -292,7 +292,7 @@ func verifyOfflineVolumeExpansionOnGc(client clientset.Interface, pvclaim *v1.Pe
 	originalFsSize, err := getFSSizeMb(f, pod)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	rand.Seed(time.Now().Unix())
+	rand.New(rand.NewSource(time.Now().Unix()))
 	testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
 	ginkgo.By(fmt.Sprintf("Creating a 512mb test data file %v", testdataFile))
 	op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),

--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -2973,7 +2973,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		}()
 
 		ginkgo.By("Bring down a host in secondary site")
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		max, min := 3, 0
 		randomValue := rand.Intn(max-min) + min
 		host := fds.secondarySiteHosts[randomValue]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update static check tool to latest version - 2023.1 and removes the usage of rand.Seed() method as it is deprecated since Go 1.20. It is replaced with `rand.New(rand.NewSource())` method

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
make check passes

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update static check tool to latest version - 2023.1
```
