### PR TITLE
fix preferredDatastore calculation on multi vCenter setup

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -236,7 +236,7 @@ func (c *K8sOrchestrator) InitTopologyServiceInController(ctx context.Context) (
 							ctx, log := logger.GetNewContextWithLogger()
 							log.Infof("Refreshing preferred datastores information...")
 							if isMultiVCSupportEnabled {
-								err = common.RefreshPreferentialDatastores(ctx)
+								err = common.RefreshPreferentialDatastoresForMultiVCenter(ctx)
 							} else {
 								err = refreshPreferentialDatastores(ctx)
 							}

--- a/pkg/csi/service/common/placementengine/types.go
+++ b/pkg/csi/service/common/placementengine/types.go
@@ -35,8 +35,4 @@ type VanillaSharedDatastoresParams struct {
 	// StoragePolicyID represents the unique ID of the storage policy
 	// name given in the Storage Class on the attempted VC.
 	StoragePolicyID string
-	// IsCSINodeIdFeatureEnabled is the FSS state for use-csinode-id.
-	IsCSINodeIdFeatureEnabled bool
-	// IsTopologyPreferentialDatastoresFSSEnabled is the FSS state for topology-preferential-datastores.
-	IsTopologyPreferentialDatastoresFSSEnabled bool
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The preferential datastore feature allows preference to the datastore for volume provisioning by filtering other datastores in the requested topology segment.

The preferential datastore feature in the CSI topology feature does not work in the multi-vCenter setup when the preferential category tag is just assigned on one of the vCenter servers.

This PR is fixing the workflow to honor the Preferential datastore on the multi-vCenter setup and removing the requirement of having a preferential datastore on all vCenter servers.


**Testing done**:
Created Volume on the preferred datastore.

log

```
2023-02-08T19:21:46.456Z	INFO	vanilla/controller.go:1904	CreateVolume: called with args {Name:pvc-4587b217-fef4-40f7-9a57-bed715981233 CapacityRange:required_bytes:5368709120  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone1" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-region" value:"region1" > segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone1" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.456Z	DEBUG	vanilla/controller.go:1213	Checking if vCenter task for volume pvc-4587b217-fef4-40f7-9a57-bed715981233 is already registered.	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.457Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:141	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-4587b217-fef4-40f7-9a57-bed715981233	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.468Z	DEBUG	vanilla/controller.go:1238	CreateVolume task details for block volume pvc-4587b217-fef4-40f7-9a57-bed715981233 are not found.	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.468Z	INFO	common/topology.go:112	Topology segment(s) map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-zone:zone1] belong to vCenter: "10.187.150.152"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.468Z	DEBUG	vanilla/controller.go:1353	Topology accessibility requirements per VC are map[10.187.150.152:[map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-zone:zone1]]]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.472Z	INFO	placementengine/placement.go:25	GetSharedDatastores called with policyID: "" , Topology Segment List: [map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-zone:zone1]]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.474Z	DEBUG	node/manager.go:238	Renewing virtual machine VirtualMachine:vm-50 [VirtualCenterHost: 10.187.150.152, UUID: 42238bfb-5dce-80e2-4bc6-3005981964f9, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.187.150.152]] with nodeUUID "42238bfb-5dce-80e2-4bc6-3005981964f9"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.477Z	DEBUG	node/manager.go:245	VM VirtualMachine:vm-50 [VirtualCenterHost: 10.187.150.152, UUID: 42238bfb-5dce-80e2-4bc6-3005981964f9, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] was successfully renewed with nodeUUID "42238bfb-5dce-80e2-4bc6-3005981964f9"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.477Z	DEBUG	node/manager.go:238	Renewing virtual machine VirtualMachine:vm-1020 [VirtualCenterHost: 10.187.150.152, UUID: 4223c945-c6b2-07ad-807f-b37b6a78775e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.187.150.152]] with nodeUUID "4223c945-c6b2-07ad-807f-b37b6a78775e"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.480Z	DEBUG	node/manager.go:245	VM VirtualMachine:vm-1020 [VirtualCenterHost: 10.187.150.152, UUID: 4223c945-c6b2-07ad-807f-b37b6a78775e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] was successfully renewed with nodeUUID "4223c945-c6b2-07ad-807f-b37b6a78775e"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.480Z	DEBUG	placementengine/placement.go:178	Node "win-work-3" with topology map[topology.csi.vmware.com/k8s-region:region2 topology.csi.vmware.com/k8s-zone:zone2] did not match the topology requirement - "topology.csi.vmware.com/k8s-region": "region1" 	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.481Z	DEBUG	node/manager.go:238	Renewing virtual machine VirtualMachine:vm-55 [VirtualCenterHost: 10.187.150.152, UUID: 42237db4-08bf-737a-95db-d267ff009f54, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.187.150.152]] with nodeUUID "42237db4-08bf-737a-95db-d267ff009f54"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.483Z	DEBUG	node/manager.go:245	VM VirtualMachine:vm-55 [VirtualCenterHost: 10.187.150.152, UUID: 42237db4-08bf-737a-95db-d267ff009f54, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] was successfully renewed with nodeUUID "42237db4-08bf-737a-95db-d267ff009f54"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.483Z	DEBUG	node/manager.go:238	Renewing virtual machine VirtualMachine:vm-56 [VirtualCenterHost: 10.187.150.152, UUID: 422392f9-e821-d060-9477-113583a9e023, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] with nodeUUID "422392f9-e821-d060-9477-113583a9e023"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.486Z	DEBUG	node/manager.go:245	VM VirtualMachine:vm-56 [VirtualCenterHost: 10.187.150.152, UUID: 422392f9-e821-d060-9477-113583a9e023, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] was successfully renewed with nodeUUID "422392f9-e821-d060-9477-113583a9e023"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.486Z	INFO	placementengine/placement.go:41	Obtained list of nodeVMs [VirtualMachine:vm-50 [VirtualCenterHost: 10.187.150.152, UUID: 42238bfb-5dce-80e2-4bc6-3005981964f9, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] VirtualMachine:vm-1020 [VirtualCenterHost: 10.187.150.152, UUID: 4223c945-c6b2-07ad-807f-b37b6a78775e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] VirtualMachine:vm-55 [VirtualCenterHost: 10.187.150.152, UUID: 42237db4-08bf-737a-95db-d267ff009f54, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] VirtualMachine:vm-56 [VirtualCenterHost: 10.187.150.152, UUID: 422392f9-e821-d060-9477-113583a9e023, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]]]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.486Z	DEBUG	placementengine/placement.go:42	completeTopologySegments [map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-zone:zone1]]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.486Z	DEBUG	vsphere/virtualmachine.go:376	Getting accessible datastores for node VirtualMachine:vm-50	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.498Z	DEBUG	vsphere/virtualmachine.go:95	Accessible datastores for node "VirtualMachine:vm-50" on host "HostSystem:host-14": [Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/63da0c59-7173e3e7-ba42-0200a52f70aa/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/63da0c5a-b6d56ae5-87e6-0200a52f70aa/ Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/c4d88514-fa4cc8af/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:52b4ea83bd4ec064-f7426ef705d6bd35/]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.498Z	DEBUG	vsphere/virtualmachine.go:376	Getting accessible datastores for node VirtualMachine:vm-1020	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.506Z	DEBUG	vsphere/virtualmachine.go:95	Accessible datastores for node "VirtualMachine:vm-1020" on host "HostSystem:host-32": [Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/c4d88514-fa4cc8af/ Datastore: Datastore:datastore-43, datastore URL: ds:///vmfs/volumes/63da0c5e-73426168-b3ea-0200a56d4273/ Datastore: Datastore:datastore-44, datastore URL: ds:///vmfs/volumes/63da0c5f-da0038b6-6d1f-0200a56d4273/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:52b4ea83bd4ec064-f7426ef705d6bd35/]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.506Z	DEBUG	vsphere/virtualmachine.go:376	Getting accessible datastores for node VirtualMachine:vm-55	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.512Z	DEBUG	vsphere/virtualmachine.go:95	Accessible datastores for node "VirtualMachine:vm-55" on host "HostSystem:host-14": [Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/63da0c59-7173e3e7-ba42-0200a52f70aa/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/63da0c5a-b6d56ae5-87e6-0200a52f70aa/ Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/c4d88514-fa4cc8af/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:52b4ea83bd4ec064-f7426ef705d6bd35/]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.512Z	DEBUG	vsphere/virtualmachine.go:376	Getting accessible datastores for node VirtualMachine:vm-56	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.519Z	DEBUG	vsphere/virtualmachine.go:95	Accessible datastores for node "VirtualMachine:vm-56" on host "HostSystem:host-26": [Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/c4d88514-fa4cc8af/ Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/63da0c5d-3afa6d97-ada5-0200a59a3196/ Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/63da0c5d-a067140b-b370-0200a59a3196/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:52b4ea83bd4ec064-f7426ef705d6bd35/]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.519Z	INFO	placementengine/placement.go:53	Obtained list of shared datastores as [Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/c4d88514-fa4cc8af/ Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:52b4ea83bd4ec064-f7426ef705d6bd35/]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.519Z	INFO	common/topology.go:228	Found preferred datastores [ds:///vmfs/volumes/c4d88514-fa4cc8af/] for topology domain "zone1" in vCenter "10.187.150.152"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.519Z	INFO	placementengine/placement.go:95	Preferential datastores: map[ds:///vmfs/volumes/c4d88514-fa4cc8af/:{}] for topology segment: map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-zone:zone1] on vCenter: "10.187.150.152"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.519Z	INFO	placementengine/placement.go:105	filtering preferential datastores from compatible datastores	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.520Z	INFO	placementengine/placement.go:114	Using preferred datastores: [Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/c4d88514-fa4cc8af/]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.520Z	INFO	placementengine/placement.go:137	Shared compatible datastores being considered for volume provisioning on vCenter: ["Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/c4d88514-fa4cc8af/"] are: 10.187.150.152	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.520Z	DEBUG	vanilla/controller.go:619	filterDatastores: dsMap map[ds:///vmfs/volumes/63da0c59-7173e3e7-ba42-0200a52f70aa/:Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/63da0c59-7173e3e7-ba42-0200a52f70aa/ ds:///vmfs/volumes/63da0c5a-a1cb36ec-5f98-0200a5598328/:Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/63da0c5a-a1cb36ec-5f98-0200a5598328/ ds:///vmfs/volumes/63da0c5a-b6d56ae5-87e6-0200a52f70aa/:Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/63da0c5a-b6d56ae5-87e6-0200a52f70aa/ ds:///vmfs/volumes/63da0c5b-f197da1e-e379-0200a5598328/:Datastore: Datastore:datastore-40, datastore URL: ds:///vmfs/volumes/63da0c5b-f197da1e-e379-0200a5598328/ ds:///vmfs/volumes/63da0c5d-3afa6d97-ada5-0200a59a3196/:Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/63da0c5d-3afa6d97-ada5-0200a59a3196/ ds:///vmfs/volumes/63da0c5d-a067140b-b370-0200a59a3196/:Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/63da0c5d-a067140b-b370-0200a59a3196/ ds:///vmfs/volumes/63da0c5e-73426168-b3ea-0200a56d4273/:Datastore: Datastore:datastore-43, datastore URL: ds:///vmfs/volumes/63da0c5e-73426168-b3ea-0200a56d4273/ ds:///vmfs/volumes/63da0c5f-da0038b6-6d1f-0200a56d4273/:Datastore: Datastore:datastore-44, datastore URL: ds:///vmfs/volumes/63da0c5f-da0038b6-6d1f-0200a56d4273/ ds:///vmfs/volumes/c4d88514-fa4cc8af/:Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/c4d88514-fa4cc8af/ ds:///vmfs/volumes/vsan:52b4ea83bd4ec064-f7426ef705d6bd35/:Datastore: Datastore:datastore-47, datastore URL: ds:///vmfs/volumes/vsan:52b4ea83bd4ec064-f7426ef705d6bd35/] sharedDatastores [Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/c4d88514-fa4cc8af/]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.520Z	DEBUG	vanilla/controller.go:628	filterDatastores: filteredDatastores [Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/c4d88514-fa4cc8af/]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.520Z	INFO	vsphere/utils.go:582	Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/c4d88514-fa4cc8af/]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.525Z	DEBUG	volume/util.go:205	Update VSphereUser from administrator@vsphere.local to VSPHERE.LOCAL\Administrator	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.525Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:141	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-4587b217-fef4-40f7-9a57-bed715981233	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.586Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:215	Created CnsVolumeOperationRequest instance vmware-system-csi/pvc-4587b217-fef4-40f7-9a57-bed715981233 with latest information for task with ID: task-6365	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.985Z	INFO	volume/manager.go:404	CreateVolume: VolumeName: "pvc-4587b217-fef4-40f7-9a57-bed715981233", opId: "0ef71cba"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.985Z	DEBUG	volume/util.go:309	volumeCreateResult.PlacementResults :[{Datastore:datastore-37 []}]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.989Z	INFO	volume/util.go:330	Volume created successfully. VolumeName: "pvc-4587b217-fef4-40f7-9a57-bed715981233", volumeID: "7df931a3-d2f6-43a8-ab94-9127ce869d7a"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:46.989Z	DEBUG	volume/util.go:332	CreateVolume volumeId {{} "7df931a3-d2f6-43a8-ab94-9127ce869d7a"} is placed on datastore "ds:///vmfs/volumes/c4d88514-fa4cc8af/"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.018Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:283	Updated CnsVolumeOperationRequest instance vmware-system-csi/pvc-4587b217-fef4-40f7-9a57-bed715981233 with latest information for task with ID: task-6365	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.018Z	DEBUG	volume/manager.go:768	internalCreateVolume: returns fault ""	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.019Z	INFO	vanilla/controller.go:1471	volume "7df931a3-d2f6-43a8-ab94-9127ce869d7a" created in vCenter "10.187.150.152". Proceeding to calculate accessible topology for the volume	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.020Z	DEBUG	node/manager.go:365	Renewing VM VirtualMachine:vm-56 [VirtualCenterHost: 10.187.150.152, UUID: 422392f9-e821-d060-9477-113583a9e023, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] with new connection: nodeUUID 422392f9-e821-d060-9477-113583a9e023	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.025Z	DEBUG	node/manager.go:375	Updated VM VirtualMachine:vm-56 [VirtualCenterHost: 10.187.150.152, UUID: 422392f9-e821-d060-9477-113583a9e023, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] for node with nodeUUID 422392f9-e821-d060-9477-113583a9e023	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.025Z	DEBUG	node/manager.go:362	Renewing VM VirtualMachine:vm-55 [VirtualCenterHost: 10.187.150.152, UUID: 42237db4-08bf-737a-95db-d267ff009f54, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]], no new connection needed: nodeUUID 42237db4-08bf-737a-95db-d267ff009f54	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.025Z	DEBUG	node/manager.go:375	Updated VM VirtualMachine:vm-55 [VirtualCenterHost: 10.187.150.152, UUID: 42237db4-08bf-737a-95db-d267ff009f54, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] for node with nodeUUID 42237db4-08bf-737a-95db-d267ff009f54	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.025Z	DEBUG	node/manager.go:362	Renewing VM VirtualMachine:vm-1020 [VirtualCenterHost: 10.187.150.152, UUID: 4223c945-c6b2-07ad-807f-b37b6a78775e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]], no new connection needed: nodeUUID 4223c945-c6b2-07ad-807f-b37b6a78775e	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.025Z	DEBUG	node/manager.go:375	Updated VM VirtualMachine:vm-1020 [VirtualCenterHost: 10.187.150.152, UUID: 4223c945-c6b2-07ad-807f-b37b6a78775e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] for node with nodeUUID 4223c945-c6b2-07ad-807f-b37b6a78775e	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.025Z	DEBUG	node/manager.go:362	Renewing VM VirtualMachine:vm-50 [VirtualCenterHost: 10.187.150.152, UUID: 42238bfb-5dce-80e2-4bc6-3005981964f9, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]], no new connection needed: nodeUUID 42238bfb-5dce-80e2-4bc6-3005981964f9	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.025Z	DEBUG	node/manager.go:375	Updated VM VirtualMachine:vm-50 [VirtualCenterHost: 10.187.150.152, UUID: 42238bfb-5dce-80e2-4bc6-3005981964f9, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.187.150.152]] for node with nodeUUID 42238bfb-5dce-80e2-4bc6-3005981964f9	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.043Z	DEBUG	vsphere/datacenter.go:75	Found datastore MoRef Datastore:datastore-37 for datastoreURL: "ds:///vmfs/volumes/c4d88514-fa4cc8af/" in datacenter: "/VSAN-DC" on vCenter: "10.187.150.152"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.051Z	INFO	common/vsphereutil.go:1139	Nodes that have access to datastore "ds:///vmfs/volumes/c4d88514-fa4cc8af/" are [VirtualMachine:vm-56 VirtualMachine:vm-1020 VirtualMachine:vm-55 VirtualMachine:vm-50]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.054Z	DEBUG	node/manager.go:186	Retrieved node name "k8s-control-428-1675237141" for node UUID "422392f9-e821-d060-9477-113583a9e023"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.056Z	DEBUG	node/manager.go:186	Retrieved node name "k8s-windows22" for node UUID "4223c945-c6b2-07ad-807f-b37b6a78775e{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.058Z	DEBUG	node/manager.go:186	Retrieved node name "k8s-control-744-1675237132" for node UUID "42237db4-08bf-737a-95db-d267ff009f54"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.061Z	DEBUG	node/manager.go:186	Retrieved node name "k8s-control-411-1675237123" for node UUID "42238bfb-5dce-80e2-4bc6-3005981964f9"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.061Z	INFO	placementengine/placement.go:273	Topology segments retrieved from nodes accessible to datastore "ds:///vmfs/volumes/c4d88514-fa4cc8af/" are: [map[topology.csi.vmware.com/k8s-region:region1 topology.csi.vmware.com/k8s-zone:zone1]]	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.062Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:152	creating cnsvolumeinfo for volumeID: "7df931a3-d2f6-43a8-ab94-9127ce869d7a" and vCenter: "10.187.150.152" mapping in the namespace: "vmware-system-csi"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.079Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:173	Successfully created CNSVolumeInfo CR for volumeID: "7df931a3-d2f6-43a8-ab94-9127ce869d7a" and vCenter: "10.187.150.152" mapping in the namespace: "vmware-system-csi"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.079Z	DEBUG	vanilla/controller.go:1958	createVolumeInternal: returns fault ""	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}
2023-02-08T19:21:47.081Z	INFO	vanilla/controller.go:1966	Volume created successfully. Volume Handle: "7df931a3-d2f6-43a8-ab94-9127ce869d7a", PV Name: "pvc-4587b217-fef4-40f7-9a57-bed715981233"	{"TraceId": "4bdb73c7-a827-4110-81f3-e1c7c41cbc44"}

```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix preferredDatastore calculation on multi vCenter setup
```
