### PR TITLE
Made changes in fstype validation e2e TC based on XFS filesystem support

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -101,6 +101,7 @@ const (
 		"chmod o+rX /mnt /mnt/volume1/Pod2.html && while true ; do sleep 2 ; done"
 	ext3FSType                                = "ext3"
 	ext4FSType                                = "ext4"
+	xfsFSType                                 = "xfs"
 	evacMModeType                             = "evacuateAllData"
 	fcdName                                   = "BasicStaticFCD"
 	fileSizeInMb                              = int64(2048)


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Added XFS filesystem validation in existing fstype validation TC
2. Fixed behaviour with invalid fstype as per current code changes merged through https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2173

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before changes, TC is failing for invalid fstype as expected:
https://container-dp.svc.eng.vmware.com/view/Pre-Checkin-CSI/job/csi-block-vanilla-pre-check-in-vmware/1/artifact/1/test-e2e-logs.txt

After changes, this TC is passing for XFS filesystem and for invalid fstype:
https://container-dp.svc.eng.vmware.com/view/Pre-Checkin-CSI/job/csi-block-vanilla-pre-check-in/1702/consoleFull

**Special notes for your reviewer**:

**Release note**:
```release-note
Made changes in fstype validation e2e TC based on XFS filesystem support
```
