### PR TITLE
set topologyRequirement for volTaskAlreadyRegistered case

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -850,9 +850,9 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		sharedDatastores    []*cnsvsphere.DatastoreInfo
 		topologyRequirement *csi.TopologyRequirement
 	)
+	// Get accessibility.
+	topologyRequirement = req.GetAccessibilityRequirements()
 	if !volTaskAlreadyRegistered {
-		// Get accessibility.
-		topologyRequirement = req.GetAccessibilityRequirements()
 		if topologyRequirement != nil {
 			// Check if topology domains have been provided in the vSphere CSI config secret.
 			// NOTE: We do not support kubernetes.io/hostname as a topology label.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Issue: When Volume is requested with topology requirements, we do not see Node Affinity Rules on the PV.
This regression happened due to optimization made in this PR - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2040 

This PR is fixing the regression and ensuring PV gets node affinity rules when it is requested with topology requirements.



**Testing done**:
Verified the change on the setup where the test was failing.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
set topologyRequirement for volTaskAlreadyRegistered case
```
