### PR TITLE
Initialise clientMutex at startup for each VC.

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -83,9 +83,9 @@ var (
 	vCenterInstanceLock = &sync.RWMutex{}
 	// vCenterInstancesLock makes sure only one vCenter being initialized for specific host
 	vCenterInstancesLock = &sync.RWMutex{}
-	// clientMutex is used for exclusive connection creation.
+	// ClientMutex is used for exclusive connection creation.
 	// There is a separate lock for each VC.
-	clientMutex = make(map[string]*sync.Mutex)
+	ClientMutex = make(map[string]*sync.Mutex)
 )
 
 func (vc *VirtualCenter) String() string {
@@ -272,11 +272,8 @@ func (vc *VirtualCenter) Connect(ctx context.Context) error {
 func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) error {
 	log := logger.GetLogger(ctx)
 
-	if _, ok := clientMutex[vc.Config.Host]; !ok {
-		clientMutex[vc.Config.Host] = &sync.Mutex{}
-	}
-	clientMutex[vc.Config.Host].Lock()
-	defer clientMutex[vc.Config.Host].Unlock()
+	ClientMutex[vc.Config.Host].Lock()
+	defer ClientMutex[vc.Config.Host].Unlock()
 
 	// If client was never initialized, initialize one.
 	var err error


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently ClientMutex map is being initialised when we call connect method. It is possible that due to a race condition between 2 goroutines, we end up overwriting the mutex value for a given VC.

In this PR, we are fixing that by initialising the clientMutex map once, when the containers start.

**Testing done**:
Replaced controller and syncer images and added helper logs to make sure that the lock is being acquired correctly.

Controller:

```
root@k8s-control-64-1676239241:~# kubectl logs vsphere-csi-controller-58d49699bf-22rtt -n vmware-system-csi -c vsphere-csi-controller | grep "CHECK"
2023-02-13T08:57:21.803Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "e33319bc-74bf-47ef-be34-b2d64c1b5589"}
2023-02-13T08:57:21.879Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "ffece44c-8bcf-4290-bf74-5ef1ac389d9b"}
2023-02-13T08:57:21.883Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "c92b15f3-f829-41d1-b0ac-d1bddcbf055c"}
2023-02-13T08:57:21.895Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "be631578-a4dd-4421-a530-a1487c3ae331"}
2023-02-13T08:57:21.902Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "ffece44c-8bcf-4290-bf74-5ef1ac389d9b"}
2023-02-13T08:57:21.926Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "d94a48e2-6b79-40b6-a693-51a3b8b73fe6"}
2023-02-13T08:57:21.939Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "ffece44c-8bcf-4290-bf74-5ef1ac389d9b"}
2023-02-13T08:57:21.960Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "ad83f722-0050-4984-ad69-dea3641b0465"}
2023-02-13T08:57:21.995Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "c8214232-eaee-45f9-8002-25ce17824824"}
2023-02-13T08:57:22.043Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "180b8940-27d7-42b2-8e23-e73be28649c6"}
2023-02-13T08:57:22.072Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "7e14b7a3-17ee-4f3e-a0f5-cdb405c3c5cb"}
```


Syncer:

```
root@k8s-control-64-1676239241:~# kubectl logs vsphere-csi-controller-58d49699bf-22rtt -n vmware-system-csi -c vsphere-syncer | grep "CHECK"
2023-02-13T09:00:27.199Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK
2023-02-13T09:00:27.270Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "abc0c340-f1a4-4412-8a7c-1985bf3d4841"}
2023-02-13T09:00:27.288Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "f63814a1-ad1a-4107-bed6-12c20db8332a"}
2023-02-13T09:00:27.309Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "b98e95a9-1a54-4c03-8af2-efcdfdb9a906"}
2023-02-13T09:00:27.334Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "a4cf5835-9bdc-40b5-9f5e-66ac5c8f4649"}
2023-02-13T09:00:27.355Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "9b54b1ec-e649-421b-92be-0652e0011e53"}
2023-02-13T09:00:27.376Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK	{"TraceId": "3bdcaf14-4835-4ac3-aabc-4716e3377b24"}
2023-02-13T09:00:27.472Z	INFO	vsphere/virtualcenter.go:281	CHECK ACQUIRING LOCK

```