### PR TITLE
Create clientmutex as part of VC object

### DIFF
--- a/pkg/common/cns-lib/volume/listview_test.go
+++ b/pkg/common/cns-lib/volume/listview_test.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -124,8 +125,9 @@ func getVirtualCenterForTest(ctx context.Context, s *simulator.Server) (*vsphere
 	}
 
 	virtualCenter := &vsphere.VirtualCenter{
-		Client:    newClient,
-		CnsClient: cnsClient,
+		Client:      newClient,
+		CnsClient:   cnsClient,
+		ClientMutex: &sync.Mutex{},
 	}
 	return virtualCenter, nil
 }

--- a/pkg/common/cns-lib/vsphere/virtualcentermanager.go
+++ b/pkg/common/cns-lib/vsphere/virtualcentermanager.go
@@ -117,7 +117,7 @@ func (m *defaultVirtualCenterManager) RegisterVirtualCenter(ctx context.Context,
 	}
 
 	// Note that the Client isn't initialized here.
-	vc := &VirtualCenter{Config: config}
+	vc := &VirtualCenter{Config: config, ClientMutex: &sync.Mutex{}}
 	m.virtualCenters.Store(config.Host, vc)
 	// Adding the port to the message here so errors are more obvious
 	log.Infof("Successfully registered VC %s:%d", vc.Config.Host, vc.Config.Port)

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/vmware/govmomi/vim25/types"
@@ -324,7 +325,7 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 
 			// Verify if new configuration has valid credentials by connecting to
 			// vCenter. Proceed only if the connection succeeds, else return error.
-			newVC := &cnsvsphere.VirtualCenter{Config: newVCConfig}
+			newVC := &cnsvsphere.VirtualCenter{Config: newVCConfig, ClientMutex: &sync.Mutex{}}
 			if err = newVC.Connect(ctx); err != nil {
 				return logger.LogNewErrorf(log, "failed to connect to VirtualCenter host: %q, Err: %+v",
 					newVCConfig.Host, err)

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -546,7 +546,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 							log.Infof("CSI full sync failed with error: %+v", err)
 						}
 					} else {
-						vcconfigs, err := cnsvsphere.GetVirtualCenterConfigs(ctx, configInfo.Cfg)
+						vcconfigs, err := cnsvsphere.GetVirtualCenterConfigs(ctx, metadataSyncer.configInfo.Cfg)
 						if err != nil {
 							log.Errorf("Failed to get all virtual configs for CSI full sync. Error: %+v", err)
 						}
@@ -1032,7 +1032,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 				// Verify if new configuration has valid credentials by connecting
 				// to vCenter. Proceed only if the connection succeeds, else return
 				// error.
-				newVC := &cnsvsphere.VirtualCenter{Config: newVCConfig}
+				newVC := &cnsvsphere.VirtualCenter{Config: newVCConfig, ClientMutex: &sync.Mutex{}}
 				if err = newVC.Connect(ctx); err != nil {
 					return logger.LogNewErrorf(log,
 						"failed to connect to VirtualCenter host: %s using new credentials, Err: %+v",


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently ClientMutex map is being initialised when we call connect method. It is possible that due to a race condition between 2 goroutines, we end up overwriting the mutex value for a given VC.

In this PR, we are fixing that by making clientMutex a part of VC object so that each VC has its own mutex.

**Testing done**:
Replaced controller and syncer images and added helper logs to make sure that the lock is being acquired correctly.

Controller:

```
root@k8s-control-64-1676239241:~# kubectl logs vsphere-csi-controller-77df4c9c6-cc9jr -n vmware-system-csi -c vsphere-csi-controller | grep "ACQUIRING LOCK"
2023-02-13T09:42:16.165Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "46c3bb58-a521-4b28-bd81-c7ed0d0e6d58"}
2023-02-13T09:42:16.263Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "e6a32e54-c560-4f35-9f41-5a45dcbbc415"}
2023-02-13T09:42:16.268Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "a86142bf-ac43-47cd-9f34-c6d41c675d86"}
2023-02-13T09:42:16.277Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "1ae79041-df55-43ca-bce0-b0c6c331bc0c"}
2023-02-13T09:42:16.292Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "a86142bf-ac43-47cd-9f34-c6d41c675d86"}
2023-02-13T09:42:16.313Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "eff1a5d4-064c-47a0-8ab0-c6de73c5f4dc"}
2023-02-13T09:42:16.349Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "a86142bf-ac43-47cd-9f34-c6d41c675d86"}
2023-02-13T09:42:16.366Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "4eacd7c9-2faf-4036-836d-bbceef649ae5"}
2023-02-13T09:42:16.427Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "33409298-fc89-4202-b385-ce66a7581c35"}
2023-02-13T09:42:16.545Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "165ac21f-5b57-41a9-a6c7-db28916e08c6"}
2023-02-13T09:42:16.598Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "9b5c8be9-0ce7-4c3c-ab27-251cb930e2b4"}
2023-02-13T09:47:16.268Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "3d330809-5d5c-45b2-a4f4-f26bc2c9256c"}
2023-02-13T09:47:16.296Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "72d9f7e7-88d6-42ce-9e7a-acd37f5671d6"}
2023-02-13T09:47:16.322Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "72d9f7e7-88d6-42ce-9e7a-acd37f5671d6"}
2023-02-13T09:47:16.362Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "72d9f7e7-88d6-42ce-9e7a-acd37f5671d6"}
```


Syncer:

```
root@k8s-control-64-1676239241:~# kubectl logs vsphere-csi-controller-77df4c9c6-cc9jr -n vmware-system-csi -c vsphere-csi-controller | grep "ACQUIRING LOCK"
2023-02-13T09:42:16.165Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "46c3bb58-a521-4b28-bd81-c7ed0d0e6d58"}
2023-02-13T09:42:16.263Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "e6a32e54-c560-4f35-9f41-5a45dcbbc415"}
2023-02-13T09:42:16.268Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "a86142bf-ac43-47cd-9f34-c6d41c675d86"}
2023-02-13T09:42:16.277Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "1ae79041-df55-43ca-bce0-b0c6c331bc0c"}
2023-02-13T09:42:16.292Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "a86142bf-ac43-47cd-9f34-c6d41c675d86"}
2023-02-13T09:42:16.313Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "eff1a5d4-064c-47a0-8ab0-c6de73c5f4dc"}
2023-02-13T09:42:16.349Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "a86142bf-ac43-47cd-9f34-c6d41c675d86"}
2023-02-13T09:42:16.366Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "4eacd7c9-2faf-4036-836d-bbceef649ae5"}
2023-02-13T09:42:16.427Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "33409298-fc89-4202-b385-ce66a7581c35"}
2023-02-13T09:42:16.545Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "165ac21f-5b57-41a9-a6c7-db28916e08c6"}
2023-02-13T09:42:16.598Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "9b5c8be9-0ce7-4c3c-ab27-251cb930e2b4"}
2023-02-13T09:47:16.268Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "3d330809-5d5c-45b2-a4f4-f26bc2c9256c"}
2023-02-13T09:47:16.296Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "72d9f7e7-88d6-42ce-9e7a-acd37f5671d6"}
2023-02-13T09:47:16.322Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "72d9f7e7-88d6-42ce-9e7a-acd37f5671d6"}
2023-02-13T09:47:16.362Z	INFO	vsphere/virtualcenter.go:278	ACQUIRING LOCK	{"TraceId": "72d9f7e7-88d6-42ce-9e7a-acd37f5671d6"}
```

VANILLA:

Changed VC IP to FQDN and then tested the following scenarios (with both FSS enabled and disabled):

1. Checked logs to make sure full sync is happening.
2. Created a new volume and it got provisioned successfully.
3. Deleted CNS volume from VC and observed full sync could re-create it successfully.

WCP and GC:

1. Checked logs to make sure full sync is happening.
2. Created a new volume and it got provisioned successfully.
