### PR TITLE
Fetch tag information for preferred datastores, using REST call, without connecting to vCenter directly.

### DIFF
--- a/pkg/csi/service/common/topology.go
+++ b/pkg/csi/service/common/topology.go
@@ -135,7 +135,7 @@ func RefreshPreferentialDatastoresForMultiVCenter(ctx context.Context) error {
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to get vCenter manager instance. Error: %+v", err)
 		}
-		vc, err := GetVCenterFromVCHost(ctx, vcMgr, vcConfig.Host)
+		vc, err := vcMgr.GetVirtualCenter(ctx, vcConfig.Host)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to get vCenter instance for host %q. Error: %+v",
 				vcConfig.Host, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
While refreshing preferred datastore map, with multi-VC FSS enabled, RefreshPreferentialDatastoresForMultiVCenter() function tries to fetch the vCenter instance and also establishes a connection using GetVCenterFromHost(). However, if the vCenter is down, we fail to connect to the vCenter and return failure, which terminates following go routine in InitTopologyServiceInController() and controller crashes.

```
func (c *K8sOrchestrator) InitTopologyServiceInController(ctx context.Context) (
	commoncotypes.ControllerTopologyService, error) {
	...
					go func() {
						// Read tags under PreferredDatastoresCategory in 5min interval and store in cache.
						ticker := time.NewTicker(time.Duration(cnsCfg.Global.CSIFetchPreferredDatastoresIntervalInMin) *
							time.Minute)
						for ; true; <-ticker.C {
							ctx, log := logger.GetNewContextWithLogger()
							log.Infof("Refreshing preferred datastores information...")
							if isMultiVCSupportEnabled {
								err = common.RefreshPreferentialDatastoresForMultiVCenter(ctx)   <<< return err if VC/VPXD down
							} else {
								err = refreshPreferentialDatastores(ctx)
							}
							if err != nil {
								log.Errorf("failed to refresh preferential datastores in cluster. Error: %v", err)
								os.Exit(1)
							}
						}
					}()
	...
....

					
```
Whereas in non-multi-VC code, in refreshPreferentialDatastores(), we just get vCenter instance using GetVirtualCenter(), without establishing a connection as we fetch the required information using REST call. 
Hence this change made makes sure we fetch datastore tag information for preferred datastores, without connecting to vCenter.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
CSI File vanilla testcase "create volume when VPXD goes down - idempotency" was always failing without this change with multiple CSI controller restarts seen, however after the change, testcase has been passing consistently, without any regression on other testcases as well.

Ran 1 of 703 Specs in 738.994 seconds
1 Passed | 0 Failed | 0 Pending | 702 Skipped
 PASS Ginkgo ran 1 suite in 13m33.17870315s Test Suite Passed


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fetch tag information for preferred datastores, using REST call, without connecting to vCenter directly.
```
