### PR TITLE
New TC for statefulset creation and scale up, scale down scenario testing with XFS filesystem

### DIFF
--- a/tests/e2e/statefulset_xfs.go
+++ b/tests/e2e/statefulset_xfs.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+/*
+	Test performs following operations
+
+	Steps
+	1. Create a storage class with fstype set to "xfs".
+	2. Create nginx service.
+	3. Create nginx statefulset with 3 replicas.
+	4. Wait until all Pods are ready and PVCs are bounded with PV.
+	5. Verify that filesystem used is xfs for volumes mounted inside pod.
+	6. Scale down statefulset to 2 replicas.
+	7. Scale up statefulset to 3 replicas.
+	8. Scale down statefulset to 0 replicas and delete all pods.
+	9. Delete all PVCs from the test's namespace.
+	10. Delete the storage class.
+*/
+
+var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] statefulset with XFS filesystem", func() {
+
+	f := framework.NewDefaultFramework("e2e-vsphere-statefulset")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		namespace        string
+		client           clientset.Interface
+		scParameters     map[string]string
+		storageClassName string
+	)
+	ginkgo.BeforeEach(func() {
+		namespace = getNamespaceToRunTests(f)
+		client = f.ClientSet
+		bootstrap()
+		scParameters = make(map[string]string)
+	})
+
+	ginkgo.AfterEach(func() {
+		ginkgo.By(fmt.Sprintf("Deleting statefulset from namespace: %v", namespace))
+		fss.DeleteAllStatefulSets(client, namespace)
+	})
+
+	ginkgo.It("Statefulset testing with XFS filesystem", func() {
+		framework.Logf("CNS_TEST: Running for vanilla k8s setup")
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass for Statefulset with fstype set to xfs")
+		scParameters[scParamFsType] = xfsFSType
+		storageClassName = "nginx-sc-default"
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Creating statefulset")
+		statefulset := GetStatefulSetFromManifest(namespace)
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		// Waiting for pods status to be Ready
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			"Unable to get list of Pods from the Statefulset: %v", statefulset.Name)
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// Get the list of Volumes attached to Pods before scale down
+		var volumesBeforeScaleDown []string
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Check filesystem used to mount volume inside pod is as expeted
+			ginkgo.By("Verify if filesystem used to mount volume is xfs as expected")
+			cmd := []string{"exec", sspod.Name, "--", "/bin/sh", "-c", "mount | grep /usr/share/nginx/html"}
+			output := framework.RunKubectlOrDie(namespace, cmd...)
+			ginkgo.By(fmt.Sprintf("Mount information: %s", output))
+			gomega.Expect(strings.Contains(output, xfsFSType)).NotTo(gomega.BeFalse(), "filesystem used should be xfs")
+
+			// Get list of volumes attached to pods
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					volumesBeforeScaleDown = append(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)
+					// Verify the attached volume match the one in CNS cache
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas-1))
+		_, scaledownErr := fss.Scale(client, statefulset, replicas-1)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas-1)
+		ssPodsAfterScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas-1)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// After scale down, verify vSphere volumes are detached from deleted pods
+		ginkgo.By("Verify Volumes are detached from Nodes after Statefulsets is scaled down")
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			if err != nil {
+				gomega.Expect(apierrors.IsNotFound(err), gomega.BeTrue())
+				for _, volumespec := range sspod.Spec.Volumes {
+					if volumespec.PersistentVolumeClaim != nil {
+						pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+						isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(
+							client, pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+							fmt.Sprintf("Volume %q is not detached from the node %q",
+								pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+					}
+				}
+			}
+		}
+
+		// After scale down, verify the attached volumes match those in CNS Cache
+		for _, sspod := range ssPodsAfterScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By(fmt.Sprintf("Scaling up statefulsets to number of Replica: %v", replicas))
+		_, scaleupErr := fss.Scale(client, statefulset, replicas)
+		gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+
+		ssPodsAfterScaleUp := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
+			"Unable to get list of Pods from the Statefulset: %v", statefulset.Name)
+		gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// After scale up, verify all vSphere volumes are attached to node VMs.
+		ginkgo.By("Verify all volumes are attached to Nodes after Statefulsets is scaled up")
+		for _, sspod := range ssPodsAfterScaleUp.Items {
+			err := fpod.WaitTimeoutForPodReadyInNamespace(client, sspod.Name, statefulset.Namespace, pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range pod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					ginkgo.By("Verify scale up operation should not introduce new volume")
+					gomega.Expect(contains(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)).To(gomega.BeTrue())
+					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+					var vmUUID string
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					vmUUID = getNodeUUID(ctx, client, sspod.Spec.NodeName)
+
+					isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Disk is not attached to the node")
+					gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached")
+					ginkgo.By("After scale up, verify the attached volumes match those in CNS Cache")
+					err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+		replicas = 0
+		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas))
+		_, scaledownErr = fss.Scale(client, statefulset, replicas)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		ssPodsAfterScaleDown = fss.GetPodList(client, statefulset)
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+	})
+})

--- a/tests/e2e/vsphere_volume_fstype.go
+++ b/tests/e2e/vsphere_volume_fstype.go
@@ -52,14 +52,9 @@ import (
 // creation.
 //
 // Steps
-// 1. Create StorageClass with inavlid.
+// 1. Create StorageClass with inavlid fstype.
 // 2. Create PVC which uses the StorageClass created in step 1.
-// 3. Wait for PV to be provisioned.
-// 4. Wait for PVC's status to become Bound.
-// 5. Create pod using PVC.
-// 6. Verify if the pod creation fails.
-// 7. Verify if the MountVolume.MountDevice fails because it is unable to find
-//    the file system executable file on the node.
+// 3. Make sure that PVC remains in pending state with proper error message.
 
 var _ = ginkgo.Describe("[csi-block-vanilla] Volume Filesystem Type Test", func() {
 


### PR DESCRIPTION
**What this PR does / why we need it**:
New TC for statefulset creation with XFS filesystem. It also verifies that scale up and scale down operations are successful.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
New TC is passing when ran with block-vanilla-pre-check-in job:
https://container-dp.svc.eng.vmware.com/view/Pre-Checkin-CSI/job/csi-block-vanilla-pre-check-in/1752/artifact/1752/test-e2e-logs.txt

**Special notes for your reviewer**:

**Release note**:
```release-note
New TC for statefulset creation and scale up, scale down scenario testing with XFS filesystem
```
