### PR TITLE
TC to verify static volume provisioning workflow with XFS filesystem

### DIFF
--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -286,7 +286,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		staticPVLabels["fcd-id"] = fcdID
 
 		ginkgo.By("Creating the PV")
-		pv = getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimDelete, staticPVLabels)
+		pv = getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimDelete, staticPVLabels, ext4FSType)
 		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 		if err != nil {
 			return
@@ -358,6 +358,127 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		pv = nil
 	})
 
+	// This test verifies the static provisioning workflow with XFS filesystem.
+	//
+	// Test Steps:
+	// 1. Create FCD and wait for fcd to allow syncing with pandora.
+	// 2. Create PV Spec with volumeID set to FCDID created in Step-1, and
+	//    PersistentVolumeReclaimPolicy is set to Delete, also mention fstype as xfs.
+	// 3. Create PVC with the storage request set to PV's storage capacity.
+	// 4. Wait for PV and PVC to bound.
+	// 5. Create a POD.
+	// 6. Verify volume is attached to the node and volume is accessible in the pod.
+	// 7. Verify filesystem used inside pod to mount volume is xfs.
+	// 7. Verify container volume metadata is present in CNS cache.
+	// 8. Delete POD.
+	// 9. Verify volume is detached from the node.
+	// 10. Delete PVC.
+	// 11. Verify PV is deleted automatically.
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Verify basic static provisioning workflow "+
+		"with XFS filesystem", func() {
+		var err error
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ginkgo.By("Creating FCD Disk")
+		fcdID, err := e2eVSphere.createFCD(ctx, "BasicStaticFCD", diskSizeInMb, defaultDatastore.Reference())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		deleteFCDRequired = true
+
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow newly created FCD:%s to sync with pandora",
+			pandoraSyncWaitTime, fcdID))
+		time.Sleep(time.Duration(pandoraSyncWaitTime) * time.Second)
+
+		// Creating label for PV.
+		// PVC will use this label as Selector to find PV.
+		staticPVLabels := make(map[string]string)
+		staticPVLabels["fcd-id"] = fcdID
+
+		ginkgo.By("Creating the PV with fstype as xfs")
+		pv = getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimDelete, staticPVLabels, xfsFSType)
+		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
+		if err != nil {
+			return
+		}
+		err = e2eVSphere.waitForCNSVolumeToBeCreated(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Creating the PVC")
+		pvc = getPersistentVolumeClaimSpec(namespace, staticPVLabels, pv.Name)
+		pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Wait for PV and PVC to Bind.
+		framework.ExpectNoError(fpv.WaitOnPVandPVC(client, framework.NewTimeoutContextWithDefaults(), namespace, pv, pvc))
+
+		// Set deleteFCDRequired to false.
+		// After PV, PVC is in the bind state, Deleting PVC should delete
+		// container volume. So no need to delete FCD directly using vSphere
+		// API call.
+		deleteFCDRequired = false
+
+		ginkgo.By("Verifying CNS entry is present in cache")
+		_, err = e2eVSphere.queryCNSVolumeWithResult(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Creating the Pod")
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaims = append(pvclaims, pvc)
+		pod, err := createPod(client, namespace, nil, pvclaims, false, execCommand)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
+
+		// Verify that fstype used to mount volume inside pod is xfs.
+		ginkgo.By("Verify that filesystem type used to mount volume is xfs as expected")
+		_, err = framework.LookForStringInPodExec(namespace, pod.Name, []string{"/bin/cat", "/mnt/volume1/fstype"},
+			xfsFSType, time.Minute)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify that write and read is successful at mountpath.
+		ginkgo.By(fmt.Sprintf("Creating file file.txt at mountpath inside pod: %v", pod.Name))
+		data := "This file file.txt is written by pod " + pod.Name
+		filePath := "/mnt/volume1/file.txt"
+		writeDataOnFileFromPod(namespace, pod.Name, filePath, data)
+
+		ginkgo.By("Verify that data can be successfully read from file.txt")
+		output := readFileFromPod(namespace, pod.Name, filePath)
+		gomega.Expect(output == data+"\n").To(gomega.BeTrue(), "Pod is not able to read file.txt")
+
+		ginkgo.By("Verify container volume metadata is present in CNS cache")
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolume with VolumeID: %s", pv.Spec.CSI.VolumeHandle))
+		_, err = e2eVSphere.queryCNSVolumeWithResult(pv.Spec.CSI.VolumeHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		labels := []types.KeyValue{{Key: "fcd-id", Value: fcdID}}
+		ginkgo.By("Verify container volume metadata is matching the one in CNS cache")
+		err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+			pvc.Name, pv.ObjectMeta.Name, pod.Name, labels...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Deleting the Pod")
+		framework.ExpectNoError(fpod.DeletePodWithWait(client, pod), "Failed to delete pod", pod.Name)
+
+		ginkgo.By(fmt.Sprintf("Verify volume is detached from the node: %s", pod.Spec.NodeName))
+		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskDetached).To(gomega.BeTrue(), "Volume is not detached from the node")
+
+		ginkgo.By("Deleting the PVC")
+		framework.ExpectNoError(fpv.DeletePersistentVolumeClaim(client, pvc.Name, namespace),
+			"Failed to delete PVC", pvc.Name)
+		pvc = nil
+
+		ginkgo.By("Verify PV should be deleted automatically")
+		framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeout))
+		pv = nil
+	})
+
 	// This test verifies the static provisioning workflow by creating the PV
 	// by same name twice.
 	//
@@ -392,7 +513,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		staticPVLabels["fcd-id"] = fcdID
 
 		ginkgo.By("Create PV Spec")
-		pvSpec := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimRetain, staticPVLabels)
+		pvSpec := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimRetain, staticPVLabels, ext4FSType)
 
 		curtime := time.Now().Unix()
 		randomValue := rand.Int()
@@ -511,7 +632,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		staticPVLabels["fcd-id"] = volumeID
 
 		ginkgo.By("Creating the PV")
-		pv = getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, staticPVLabels)
+		pv = getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, staticPVLabels, ext4FSType)
 		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -594,7 +715,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 
 		svcPVCName := volumeID
 		ginkgo.By("Creating the PV in guest cluster")
-		pv = getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, staticPVLabels)
+		pv = getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, staticPVLabels, ext4FSType)
 		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -180,7 +180,7 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		ginkgo.By(fmt.Sprintf("Creating the PV with the fcdID %s", fcdID))
 		staticPVLabels := make(map[string]string)
 		staticPVLabels["fcd-id"] = fcdID
-		pv := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimRetain, staticPVLabels)
+		pv := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimRetain, staticPVLabels, ext4FSType)
 		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 		if err != nil {
 			return
@@ -551,7 +551,7 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		ginkgo.By(fmt.Sprintf("Creating the PV with the fcdID %s", fcdID))
 		staticPVLabels := make(map[string]string)
 		staticPVLabels["fcd-id"] = fcdID
-		pv := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimDelete, staticPVLabels)
+		pv := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimDelete, staticPVLabels, ext4FSType)
 		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 		if err != nil {
 			return
@@ -628,7 +628,7 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		ginkgo.By(fmt.Sprintf("Creating the PV with the fcdID %s", fcdID))
 		staticPVLabels := make(map[string]string)
 		staticPVLabels["fcd-id"] = fcdID
-		pv := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimRetain, staticPVLabels)
+		pv := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimRetain, staticPVLabels, ext4FSType)
 		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 		if err != nil {
 			return
@@ -740,7 +740,7 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		ginkgo.By(fmt.Sprintf("Creating the PV with the fcdID %s", fcdID))
 		staticPVLabels := make(map[string]string)
 		staticPVLabels["fcd-id"] = fcdID
-		pv := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimRetain, staticPVLabels)
+		pv := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimRetain, staticPVLabels, ext4FSType)
 		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/tests/e2e/gc_block_resize_retain_policy.go
+++ b/tests/e2e/gc_block_resize_retain_policy.go
@@ -463,7 +463,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		gomega.Expect(volumeID).NotTo(gomega.BeEmpty())
 
 		ginkgo.By("Creating the PV")
-		pvNew := getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, nil)
+		pvNew := getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, nil, ext4FSType)
 		pvNew.Annotations = pvtemp.Annotations
 		pvNew.Spec.StorageClassName = pvtemp.Spec.StorageClassName
 		pvNew.Spec.CSI = pvtemp.Spec.CSI

--- a/tests/e2e/gc_cns_nodevm_attachment.go
+++ b/tests/e2e/gc_cns_nodevm_attachment.go
@@ -722,7 +722,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 		gomega.Expect(volumeID).NotTo(gomega.BeEmpty())
 
 		ginkgo.By("Creating PV in guest cluster 2")
-		pvNew := getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, nil)
+		pvNew := getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, nil, ext4FSType)
 		pvNew.Annotations = pvtemp.Annotations
 		pvNew.Spec.StorageClassName = pvtemp.Spec.StorageClassName
 		pvNew.Spec.CSI = pvtemp.Spec.CSI

--- a/tests/e2e/gc_metadata_syncer.go
+++ b/tests/e2e/gc_metadata_syncer.go
@@ -1275,7 +1275,7 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 		gcNewClusterID := strings.Replace(svcNewPVCName, pvcNewUID, "", -1)
 
 		ginkgo.By("Creating PV in new guest cluster with volume handle from SVC")
-		pvNew := getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, nil)
+		pvNew := getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, nil, ext4FSType)
 		pvNew.Annotations = pvAnnotations
 		pvNew.Spec.StorageClassName = pvStorageClass
 		pvNew.Spec.CSI = pvSpec
@@ -1454,7 +1454,7 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 		svcNamespace := os.Getenv("SVC_NAMESPACE")
 
 		ginkgo.By("Creating PV in guest cluster with volume handle from SVC")
-		pvNew := getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, nil)
+		pvNew := getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, nil, ext4FSType)
 		pvNew.Annotations = pvAnnotations
 		pvNew.Spec.StorageClassName = "gc-storage-profile"
 		pvNew.Spec.CSI = pvSpec

--- a/tests/e2e/labelupdates.go
+++ b/tests/e2e/labelupdates.go
@@ -558,7 +558,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelize
 		ginkgo.By(fmt.Sprintf("Creating the PV with the fcdID %s", fcdID))
 		staticPVLabels := make(map[string]string)
 		staticPVLabels["fcd-id"] = fcdID
-		pv := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimRetain, staticPVLabels)
+		pv := getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimRetain, staticPVLabels, ext4FSType)
 		pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 		if err != nil {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -1191,7 +1191,7 @@ func getPersistentVolumeClaimSpec(namespace string, labels map[string]string, pv
 
 // Create PV volume spec with given FCD ID, Reclaim Policy and labels.
 func getPersistentVolumeSpec(fcdID string, persistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy,
-	labels map[string]string) *v1.PersistentVolume {
+	labels map[string]string, fstype string) *v1.PersistentVolume {
 	var (
 		pvConfig fpv.PersistentVolumeConfig
 		pv       *v1.PersistentVolume
@@ -1204,7 +1204,7 @@ func getPersistentVolumeSpec(fcdID string, persistentVolumeReclaimPolicy v1.Pers
 				Driver:       e2evSphereCSIDriverName,
 				VolumeHandle: fcdID,
 				ReadOnly:     false,
-				FSType:       "ext4",
+				FSType:       fstype,
 			},
 		},
 		Prebind: nil,
@@ -4042,7 +4042,7 @@ func createPodForFSGroup(client clientset.Interface, namespace string,
 func getPersistentVolumeSpecForFileShare(fileshareID string,
 	persistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy, labels map[string]string,
 	accessMode v1.PersistentVolumeAccessMode) *v1.PersistentVolume {
-	pv := getPersistentVolumeSpec(fileshareID, persistentVolumeReclaimPolicy, labels)
+	pv := getPersistentVolumeSpec(fileshareID, persistentVolumeReclaimPolicy, labels, nfs4FSType)
 	pv.Spec.AccessModes = []v1.PersistentVolumeAccessMode{accessMode}
 	return pv
 }

--- a/tests/e2e/vmc_delete_tkg.go
+++ b/tests/e2e/vmc_delete_tkg.go
@@ -213,7 +213,7 @@ var _ = ginkgo.Describe("Delete TKG", func() {
 		}()
 
 		ginkgo.By("creating PV in GC1")
-		pvNew := getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, nil)
+		pvNew := getPersistentVolumeSpec(svcPVCName, v1.PersistentVolumeReclaimDelete, nil, ext4FSType)
 		pvNew.Annotations = pv.Annotations
 		pvNew.Spec.StorageClassName = pv.Spec.StorageClassName
 		pvNew.Spec.CSI = pv.Spec.CSI

--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -3469,7 +3469,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 			staticPVLabels["fcd-id"] = volHandles[i]
 
 			ginkgo.By("Creating static PV")
-			pv := getPersistentVolumeSpec(volHandles[i], v1.PersistentVolumeReclaimDelete, staticPVLabels)
+			pv := getPersistentVolumeSpec(volHandles[i], v1.PersistentVolumeReclaimDelete, staticPVLabels, ext4FSType)
 			pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			staticPvs = append(staticPvs, pv)
@@ -3801,7 +3801,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 			staticPVLabels["fcd-id"] = volHandles[i]
 
 			ginkgo.By("Creating static PV")
-			pv := getPersistentVolumeSpec(volHandles[i], v1.PersistentVolumeReclaimDelete, staticPVLabels)
+			pv := getPersistentVolumeSpec(volHandles[i], v1.PersistentVolumeReclaimDelete, staticPVLabels, ext4FSType)
 			pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			staticPvs = append(staticPvs, pv)

--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -908,7 +908,7 @@ func createStaticPvAndPvcInParallel(client clientset.Interface, ctx context.Cont
 		// PVC will use this label as Selector to find PV.
 		staticPVLabels["fcd-id"] = fcdIDs[i]
 		framework.Logf("Creating the PV from fcd ID: %s", fcdIDs[i])
-		pv := getPersistentVolumeSpec(fcdIDs[i], v1.PersistentVolumeReclaimRetain, staticPVLabels)
+		pv := getPersistentVolumeSpec(fcdIDs[i], v1.PersistentVolumeReclaimRetain, staticPVLabels, ext4FSType)
 		pv, err := client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = e2eVSphere.waitForCNSVolumeToBeCreated(pv.Spec.CSI.VolumeHandle)

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -3226,7 +3226,7 @@ func invokeTestForInvalidVolumeExpansionStaticProvision(f *framework.Framework,
 	staticPVLabels["fcd-id"] = fcdID
 
 	ginkgo.By("Creating the PV")
-	pv = getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimDelete, staticPVLabels)
+	pv = getPersistentVolumeSpec(fcdID, v1.PersistentVolumeReclaimDelete, staticPVLabels, ext4FSType)
 	pv, err = client.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
 	if err != nil {
 		return


### PR DESCRIPTION
\**What this PR does / why we need it**:
TC to verify static provisioning workflow with XFS filesystem

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
TC passed when ran with block vanilla pre-check-in job:
https://container-dp.svc.eng.vmware.com/view/Pre-Checkin-CSI/job/csi-block-vanilla-pre-check-in/1747/artifact/1747/test-e2e-logs.txt


I also ran few TCs where I made parameter changes (ext4FStype), TCs relevant to block-vanilla passed. All failed TCs are related to GC, supervisor or file vanilla as I ran it on block vanilla setup. So, looks like parameter change is not causing any problem.
https://container-dp.svc.eng.vmware.com/view/Pre-Checkin-CSI/job/csi-block-vanilla-pre-check-in/1763/artifact/1763/test-e2e-logs.txt

**Special notes for your reviewer**:

**Release note**:
```release-note
TC to verify static provisioning workflow with XFS filesystem
```
