### PR TITLE
restart CSI controller and syncer container when new vCenter is observed in the config secret

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -657,20 +657,19 @@ func GetVirtualCenterInstanceForVCenterConfig(ctx context.Context,
 	return vCenterInstances[vcconfig.Host], nil
 }
 
-// UnregisterVirtualCenter helps delete vCenterServer instance for specified host
-func UnregisterVirtualCenter(ctx context.Context, vcHost string) error {
+// UnregisterAllVirtualCenters helps unregister and logout all registered vCenter instances
+// This function is called before exiting container to logout current sessions
+func UnregisterAllVirtualCenters(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
 	vCenterInstancesLock.Lock()
 	defer vCenterInstancesLock.Unlock()
 
 	// Initialize the virtual center manager.
 	virtualcentermanager := GetVirtualCenterManager(ctx)
-	// Unregister the VC from virtual center manager.
-	if err := virtualcentermanager.UnregisterVirtualCenter(ctx, vcHost); err != nil {
-		return logger.LogNewErrorf(log, "failed to unregister VirtualCenter %q with "+
-			"virtualCenterManager. Err: %+v", vcHost, err)
+	// Unregister all vCenters from virtual center manager.
+	if err := virtualcentermanager.UnregisterAllVirtualCenters(ctx); err != nil {
+		return logger.LogNewErrorf(log, "failed to unregister all VirtualCenter servers. Err: %+v", err)
 	}
-	delete(vCenterInstances, vcHost)
 	return nil
 }
 

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -302,9 +302,6 @@ func (f *FakeAuthManager) ResetvCenterInstance(ctx context.Context, vCenter *cns
 	f.vcenter = vCenter
 }
 
-func (f *FakeAuthManager) Stop() {
-}
-
 func getControllerTest(t *testing.T) *controllerTest {
 	onceForControllerTest.Do(func() {
 		// Create context.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Dynamic reloading of the new vCenter config has lot of issues with cached vCenter instances and configs in multiple services.
It is better to restart the controller and syncer container when this happens.

**Testing done**:
Verified CSI controller and syncer is getting restarted when new VC is observed in the config secret

Controller exit Logs

```
2023-02-21T23:40:45.373Z	INFO	vanilla/controller.go:415	Observed new vCenter server: "10.78.141.185" in the config secret. Exiting vSphere CSI Controller Container for re-initialization	{"TraceId": "09ebb923-5f83-4f9d-838d-7b0603771ea0"}
2023-02-21T23:40:45.373Z	INFO	vsphere/pbm.go:77	PbmClient wasn't connected, ignoring	{"TraceId": "09ebb923-5f83-4f9d-838d-7b0603771ea0"}
2023-02-21T23:40:45.416Z	INFO	vsphere/virtualcentermanager.go:145	Successfully unregistered VC sc1-10-78-141-185.nimbus.eng.vmware.com	{"TraceId": "09ebb923-5f83-4f9d-838d-7b0603771ea0"}
```

Syncer exit logs

```
2023-02-21T23:40:45.344Z	INFO	syncer/metadatasyncer.go:958	Observed new vCenter server: "10.78.141.185" in the config secret. Exiting vSphere CSI Controller Container for re-initialization	{"TraceId": "a42242ba-f270-4461-ac6f-7af45a2de0df"}
2023-02-21T23:40:45.346Z	INFO	vsphere/pbm.go:77	PbmClient wasn't connected, ignoring	{"TraceId": "a42242ba-f270-4461-ac6f-7af45a2de0df"}
2023-02-21T23:40:45.383Z	INFO	vsphere/virtualcentermanager.go:145	Successfully unregistered VC sc1-10-78-141-185.nimbus.eng.vmware.com	{"TraceId": "a42242ba-f270-4461-ac6f-7af45a2de0df"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
restart CSI controller and syncer container when new vCenter is observed in the config secret
```
