### PR TITLE
bump up CSI sidecar containers for CSI 3.0 release

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -244,7 +244,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v4.1.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v4.2.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -329,7 +329,7 @@ spec:
             periodSeconds: 180
             failureThreshold: 3
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We updated CSI sidecar containers for CSI 3.0 in this PR - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2151
We have some more updates and we missed to update liveness probe upgrade at one place.



**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
bump up CSI sidecar containers for CSI 3.0 release
```
