### PR TITLE
Avoid unnecessary map creation for webhook server, removing unneccessary RBAC.

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -91,7 +91,7 @@ func main() {
 		log.Errorf("failed retrieving cluster flavor. Error: %v", err)
 	}
 	commonco.SetInitParams(ctx, clusterFlavor, &syncer.COInitParams, *supervisorFSSName, *supervisorFSSNamespace,
-		*internalFSSName, *internalFSSNamespace, "")
+		*internalFSSName, *internalFSSNamespace, "", *operationMode)
 	admissionhandler.COInitParams = &syncer.COInitParams
 
 	if *operationMode == operationModeWebHookServer {

--- a/cmd/vsphere-csi/main.go
+++ b/cmd/vsphere-csi/main.go
@@ -58,7 +58,7 @@ func main() {
 	}
 	serviceMode := os.Getenv(csitypes.EnvVarMode)
 	commonco.SetInitParams(ctx, clusterFlavor, &service.COInitParams, *supervisorFSSName, *supervisorFSSNamespace,
-		*internalFSSName, *internalFSSNamespace, serviceMode)
+		*internalFSSName, *internalFSSNamespace, serviceMode, "")
 
 	// If no endpoint is set then exit the program.
 	CSIEndpoint := os.Getenv(csitypes.EnvVarEndpoint)

--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -56,13 +56,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/csi/service/common/commonco/utils.go
+++ b/pkg/csi/service/common/commonco/utils.go
@@ -30,7 +30,8 @@ import (
 // SetInitParams initializes the parameters required to create a container
 // agnostic orchestrator instance.
 func SetInitParams(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, initParams *interface{},
-	supervisorFSSName, supervisorFSSNamespace, internalFSSName, internalFSSNamespace, serviceMode string) {
+	supervisorFSSName, supervisorFSSNamespace, internalFSSName, internalFSSNamespace, serviceMode,
+	operationMode string) {
 	log := logger.GetLogger(ctx)
 	// Set default values for FSS, if not given and initiate CO-agnostic init
 	// params.
@@ -49,7 +50,8 @@ func SetInitParams(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
 				Name:      supervisorFSSName,
 				Namespace: supervisorFSSNamespace,
 			},
-			ServiceMode: serviceMode,
+			ServiceMode:   serviceMode,
+			OperationMode: operationMode,
 		}
 	case cnstypes.CnsClusterFlavorVanilla:
 		if strings.TrimSpace(internalFSSName) == "" {
@@ -65,7 +67,8 @@ func SetInitParams(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
 				Name:      internalFSSName,
 				Namespace: internalFSSNamespace,
 			},
-			ServiceMode: serviceMode,
+			ServiceMode:   serviceMode,
+			OperationMode: operationMode,
 		}
 	case cnstypes.CnsClusterFlavorGuest:
 		if strings.TrimSpace(supervisorFSSName) == "" {
@@ -94,7 +97,8 @@ func SetInitParams(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
 				Name:      supervisorFSSName,
 				Namespace: supervisorFSSNamespace,
 			},
-			ServiceMode: serviceMode,
+			ServiceMode:   serviceMode,
+			OperationMode: operationMode,
 		}
 	default:
 		log.Fatalf("Unrecognised cluster flavor %q. Container orchestrator init params not initialized.", clusterFlavor)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR skips unnecessary map creation, that involves informer creation, in case of vSphere CSI webhook container, based on operation mode of container. This avoids adding extra RBAC permissions to webhook cluster role.
Refer https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2216#issuecomment-1439501838 for details.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested the scenario manually on setup where the issue was originally seen. PVC creation-deletion was successful, without any error in webhook logs

```
root@k8s-control-58-1676508751:~# kubectl get pods -n vmware-system-csi
NAME                                     READY   STATUS    RESTARTS      AGE
vsphere-csi-controller-9dd7b697f-b6jw6   7/7     Running   0             12m
vsphere-csi-controller-9dd7b697f-cf5h5   7/7     Running   0             12m
vsphere-csi-controller-9dd7b697f-htwzk   7/7     Running   0             11m
vsphere-csi-node-4g7sf                   3/3     Running   0             7d9h
vsphere-csi-node-npcrt                   3/3     Running   3 (20h ago)   7d9h
vsphere-csi-node-pdfvl                   3/3     Running   5 (8h ago)    7d9h
vsphere-csi-node-pvdfx                   3/3     Running   8 (8h ago)    7d9h
vsphere-csi-node-qx2k9                   3/3     Running   2 (8h ago)    7d9h
vsphere-csi-node-wf627                   3/3     Running   2 (20h ago)   7d9h
vsphere-csi-webhook-85fc68d495-ms8pg      1/1     Running   0             30m
```

```
root@k8s-control-58-1676508751:~# kubectl get clusterrole vsphere-csi-webhook-cluster-role -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"annotations":{},"name":"vsphere-csi-webhook-cluster-role"},"rules":[{"apiGroups":["snapshot.storage.k8s.io"],"resources":["volumesnapshots"],"verbs":["get","list"]},{"apiGroups":[""],"resources":["persistentvolumes"],"verbs":["get"]}]}
  creationTimestamp: "2023-02-23T10:51:38Z"
  name: vsphere-csi-webhook-cluster-role
  resourceVersion: "1864591"
  uid: 931ee01d-9b06-472b-92db-dcbe9be4f88c
rules:
- apiGroups:
  - snapshot.storage.k8s.io
  resources:
  - volumesnapshots
  verbs:
  - get
  - list
- apiGroups:
  - ""
  resources:
  - persistentvolumes
  verbs:
  - get
```
  
```
  root@k8s-control-58-1676508751:~# kubectl create -f pvc.yaml
persistentvolumeclaim/example-vanilla-rwo-pvc created   <<<< PVC creation successful
root@k8s-control-58-1676508751:~#

root@k8s-control-58-1676508751:~# kubectl get pvc -A
NAMESPACE   NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
default     example-pvc-1             Bound    pvc-a17f4d42-cc36-40b1-98c3-5d863a82ed29   1Gi        RWO            sc-6nmdk                            6d21h
default     example-pvc-2             Bound    pvc-25ba22b6-1a45-4b2c-a2a7-a1ba4e0b5d84   1Gi        RWO            sc-6nmdk                            6d4h
default     example-vanilla-rwo-pvc   Bound    pvc-adc9673d-7dee-414a-ba2e-b6f097d9a6b8   5Gi        RWO            example-vanilla-rwo-filesystem-sc   3s
```

vSphere CSI Webhook logs:

```
root@k8s-control-58-1676508751:~# kubectl logs -n vmware-system-csi vsphere-csi-webhook-85fc68d495-ms8pg
{"level":"info","time":"2023-02-23T10:51:43.319774886Z","caller":"logger/logger.go:41","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2023-02-23T10:51:43.321002181Z","caller":"syncer/main.go:86","msg":"Version : v2.1.0-rc.1-1593-g74b42e95","TraceId":"d0f547f9-b65d-452f-a7e3-d4d296302575"}
{"level":"info","time":"2023-02-23T10:51:43.321172784Z","caller":"syncer/main.go:98","msg":"Starting container with operation mode: WEBHOOK_SERVER","TraceId":"d0f547f9-b65d-452f-a7e3-d4d296302575"}
{"level":"info","time":"2023-02-23T10:51:43.321197209Z","caller":"k8sorchestrator/k8sorchestrator.go:251","msg":"Initializing k8sOrchestratorInstance","TraceId":"d0f547f9-b65d-452f-a7e3-d4d296302575"}
{"level":"info","time":"2023-02-23T10:51:43.32124111Z","caller":"kubernetes/kubernetes.go:86","msg":"k8s client using in-cluster config","TraceId":"d0f547f9-b65d-452f-a7e3-d4d296302575"}
{"level":"info","time":"2023-02-23T10:51:43.321443059Z","caller":"kubernetes/kubernetes.go:395","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"d0f547f9-b65d-452f-a7e3-d4d296302575"}
{"level":"info","time":"2023-02-23T10:51:43.321940823Z","caller":"kubernetes/kubernetes.go:86","msg":"k8s client using in-cluster config","TraceId":"d0f547f9-b65d-452f-a7e3-d4d296302575"}
{"level":"info","time":"2023-02-23T10:51:43.322099721Z","caller":"kubernetes/kubernetes.go:395","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"d0f547f9-b65d-452f-a7e3-d4d296302575"}
{"level":"info","time":"2023-02-23T10:51:43.322803405Z","caller":"kubernetes/informers.go:85","msg":"Created new informer factory for in-cluster client","TraceId":"d0f547f9-b65d-452f-a7e3-d4d296302575"}
{"level":"info","time":"2023-02-23T10:51:43.342561924Z","caller":"k8sorchestrator/k8sorchestrator.go:407","msg":"New internal feature states values stored successfully: map[async-query-volume:true block-volume-snapshot:true cnsmgr-suspend-create-volume:true csi-auth-check:true csi-internal-generated-cluster-id:false csi-migration:true csi-windows-support:false list-volumes:true listview-tasks:false max-pvscsi-targets-per-vm:true multi-vcenter-csi-topology:false online-volume-extend:true pv-to-backingdiskobjectid-mapping:false topology-preferential-datastores:true trigger-csi-fullsync:false use-csinode-id:true]","TraceId":"d0f547f9-b65d-452f-a7e3-d4d296302575"}
{"level":"info","time":"2023-02-23T10:51:43.342777788Z","caller":"k8sorchestrator/k8sorchestrator.go:322","msg":"k8sOrchestratorInstance initialized","TraceId":"d0f547f9-b65d-452f-a7e3-d4d296302575"}
{"level":"info","time":"2023-02-23T10:51:43.343379753Z","caller":"admissionhandler/admissionhandler.go:186","msg":"Webhook server started","TraceId":"d0f547f9-b65d-452f-a7e3-d4d296302575"}
{"level":"info","time":"2023-02-23T10:51:43.350496807Z","caller":"k8sorchestrator/k8sorchestrator.go:644","msg":"configMapAdded: Internal feature state values from \"internal-feature-states.csi.vsphere.vmware.com\" stored successfully: map[async-query-volume:true block-volume-snapshot:true cnsmgr-suspend-create-volume:true csi-auth-check:true csi-internal-generated-cluster-id:false csi-migration:true csi-windows-support:false list-volumes:true listview-tasks:false max-pvscsi-targets-per-vm:true multi-vcenter-csi-topology:false online-volume-extend:true pv-to-backingdiskobjectid-mapping:false topology-preferential-datastores:true trigger-csi-fullsync:false use-csinode-id:true]","TraceId":"c2e36364-9cbb-4b85-9f76-9d448a9e0e65"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Avoid unnecessary map creation for webhook server, removing unnecessary cluster RBAC.
```
