### PR TITLE
Storing failed delete volume and delete snapshot operation details in CnsVolumeOperationRequest CR

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -1206,12 +1206,20 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 				volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
 					metav1.Now(), "", "",
 					"", taskInvocationStatusSuccess, "")
+				err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
+				if err != nil {
+					log.Warnf("failed to store DeleteVolume details with error: %v", err)
+				}
 				return "", nil
 			}
 			log.Errorf("CNS DeleteVolume failed from the  vCenter %q with err: %v", m.virtualCenter.Config.Host, err)
 			volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
 				metav1.Now(), "", "",
 				"", taskInvocationStatusError, err.Error())
+			err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails)
+			if err != nil {
+				log.Warnf("failed to store DeleteVolume details with error: %v", err)
+			}
 			return faultType, err
 		}
 		volumeOperationDetails = createRequestDetails(instanceName, "", "", 0, metav1.Now(),
@@ -2410,6 +2418,9 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 				if m.idempotencyHandlingEnabled {
 					volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
 						metav1.Now(), "", "", "", taskInvocationStatusSuccess, "")
+					if err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails); err != nil {
+						log.Warnf("failed to store DeleteSnapshot operation details with error: %v", err)
+					}
 				}
 				return nil
 			}
@@ -2417,8 +2428,10 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 			if m.idempotencyHandlingEnabled {
 				volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,
 					metav1.Now(), "", "", "", taskInvocationStatusError, err.Error())
+				if err := m.operationStore.StoreRequestDetails(ctx, volumeOperationDetails); err != nil {
+					log.Warnf("failed to store DeleteSnapshot operation details with error: %v", err)
+				}
 			}
-
 			return logger.LogNewErrorf(log, "CNS DeleteSnapshot failed from the vCenter %q with err: %v",
 				m.virtualCenter.Config.Host, err)
 		}


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherrypicks https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2235 to release-3.0

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Available on the original PR 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherrypicks https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2235 to release-3.0
```
