### PR TITLE
ListVolumes optimizations

### DIFF
--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -598,7 +598,8 @@ func (c *controller) GetVolumeToHostMapping(ctx context.Context) (map[string]str
 
 // getVolumeIDToVMMap returns the csi list volume response by computing the volumeID to nodeNames map for
 // fake attached volumes and non-fake attached volumes.
-func getVolumeIDToVMMap(ctx context.Context, c *controller, volumeIDs []string) (*csi.ListVolumesResponse, error) {
+func getVolumeIDToVMMap(ctx context.Context, volumeIDs []string, vmMoidToHostMoid,
+	volumeIDToVMMap map[string]string) (*csi.ListVolumesResponse, error) {
 	log := logger.GetLogger(ctx)
 	response := &csi.ListVolumesResponse{}
 
@@ -609,6 +610,7 @@ func getVolumeIDToVMMap(ctx context.Context, c *controller, volumeIDs []string) 
 			fakeAttachedVolumes = append(fakeAttachedVolumes, volumeID)
 		}
 	}
+
 	// Process fake attached volumes
 	log.Debugf("Fake attached volumes %v", fakeAttachedVolumes)
 	volumeIDToNodesMap := commonco.ContainerOrchestratorUtility.GetNodesForVolumes(ctx, fakeAttachedVolumes)
@@ -624,13 +626,6 @@ func getVolumeIDToVMMap(ctx context.Context, c *controller, volumeIDs []string) 
 			Status: volumeStatus,
 		}
 		response.Entries = append(response.Entries, entry)
-	}
-
-	// Process remaining volumes
-	vmMoidToHostMoid, volumeIDToVMMap, err := c.GetVolumeToHostMapping(ctx)
-	if err != nil {
-		log.Errorf("failed to get VM MoID to Host MoID map, err:%v", err)
-		return nil, fmt.Errorf("failed to get VM MoID to Host MoID map, err: %v", err)
 	}
 
 	hostNames := commonco.ContainerOrchestratorUtility.GetNodeIDtoNameMap(ctx)
@@ -672,6 +667,5 @@ func getVolumeIDToVMMap(ctx context.Context, c *controller, volumeIDs []string) 
 		}
 		response.Entries = append(response.Entries, entry)
 	}
-
 	return response, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

This PR includes optimization to list-volumes features. Instead of querying for every single paginated request, we call it once per resync interval.

**Testing done**:
Output of make check:
```
msmruthi@msmruthiVLVDL vsphere-csi-driver % make check
hack/check-format.sh
hack/check-mdlint.sh
hack/check-shell.sh
hack/check-staticcheck.sh
+ go version
go version go1.19.4 darwin/amd64
++ dirname hack/check-staticcheck.sh
+ cd hack/..
+ go install honnef.co/go/tools/cmd/staticcheck@2023.1
++ go env GOPATH
+ GOOS=linux
+ /Users/msmruthi/go/bin/staticcheck --version
staticcheck 2023.1 (v0.4.0)
++ go env GOPATH
++ go list ./...
++ grep -v /vendor/
+ GOOS=linux
+ /Users/msmruthi/go/bin/staticcheck sigs.k8s.io/vsphere-csi-driver/v2/cmd/syncer sigs.k8s.io/vsphere-csi-driver/v2/cmd/vsphere-csi sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsnodevmattachment/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/cnsvolumemetadata/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/migration/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/cns/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/apis/storagepool/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/node sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/volume sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/cns-lib/vsphere sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/fault sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/unittestcommon sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/utils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/placementengine sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/logger sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/mounter sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/osutils sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/vanilla sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcp sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/wcpguest sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/cnsfilevolumeclient/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsoperator/triggercsifullsync/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeinfo sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeinfo/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeinfo/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/csinodetopology/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/config sigs.k8s.io/vsphere-csi-driver/v2/pkg/internalapis/featurestates/v1alpha1 sigs.k8s.io/vsphere-csi-driver/v2/pkg/kubernetes sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/admissionhandler sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsnodevmattachment sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsregistervolume sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/cnsvolumemetadata sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/csinodetopology sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/controller/triggercsifullsync sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/manager sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/types sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/cnsoperator/util sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/k8scloudoperator sigs.k8s.io/vsphere-csi-driver/v2/pkg/syncer/storagepool sigs.k8s.io/vsphere-csi-driver/v2/tests/e2e
hack/check-vet.sh
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/msmruthi/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/msmruthi/k8s/vsphere-csi-driver /Users/msmruthi/k8s /Users/msmruthi /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|imports|types_sizes|exports_file|files|name) took 1.256277132s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 138.033645ms 
INFO [linters context/goanalysis] analyzers took 6.824491314s with top 10 stages: buildir: 4.696526232s, S1038: 172.246074ms, misspell: 165.079473ms, unused: 130.14791ms, printf: 88.252638ms, S1039: 72.066396ms, fact_deprecated: 60.752013ms, S1025: 60.612901ms, S1024: 60.063654ms, SA1012: 58.134628ms 
INFO [runner] Issues before processing: 55, after processing: 0 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 55/55, skip_dirs: 55/55, autogenerated_exclude: 24/55, cgo: 55/55, filename_unadjuster: 55/55, skip_files: 55/55, identifier_marker: 24/24, exclude: 24/24, nolint: 0/1, exclude-rules: 1/24 
INFO [runner] processing took 14.985215ms with stages: nolint: 12.325201ms, autogenerated_exclude: 1.877122ms, path_prettifier: 314.315µs, identifier_marker: 295.178µs, skip_dirs: 93.536µs, exclude-rules: 63.617µs, cgo: 8.426µs, filename_unadjuster: 3.625µs, max_same_issues: 1.253µs, uniq_by_line: 506ns, max_from_linter: 370ns, skip_files: 344ns, source_code: 287ns, exclude: 267ns, diff: 258ns, max_per_file_from_linter: 233ns, severity-rules: 220ns, path_shortener: 192ns, sort_results: 144ns, path_prefixer: 121ns 
INFO [runner] linters took 4.168775661s with stages: goanalysis_metalinter: 4.153708655s 
INFO File cache stats: 43 entries of total size 659.9KiB 
INFO Memory: 57 samples, avg is 264.1MB, max is 605.8MB 
INFO Execution took 5.573889377s                  

```
Output of list-volumes with 1 volume:
```
2023-02-28T19:55:11.615Z	DEBUG	wcp/controller.go:1304	ListVolumes called with args {MaxEntries:0 StartingToken: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}, expectedStartingIndex 0	{"TraceId": "e20d3a57-7f6a-4585-ab4c-4dd24c200650"}
2023-02-28T19:55:11.755Z	DEBUG	wcp/controller.go:1375	ListVolumes: cnsVolumeIDs [de7eacf6-1c2f-4f7d-a821-de39111e9ff0 5f16d2e7-0009-4af9-a89b-a90dcf58d177], startingIdx 0, queryLimit 2	{"TraceId": "e20d3a57-7f6a-4585-ab4c-4dd24c200650"}
2023-02-28T19:55:11.756Z	DEBUG	wcp/controller.go:1396	ListVolumes: Response entries entries:<volume:<volume_id:"de7eacf6-1c2f-4f7d-a821-de39111e9ff0" > status:<published_node_ids:"sc2-10-212-6-105.nimbus.eng.vmware.com" > > 	{"TraceId": "e20d3a57-7f6a-4585-ab4c-4dd24c200650"}
```
Output of list-volumes with 2 volumes:
```
2023-02-28T19:44:03.072Z	DEBUG	wcp/controller.go:1304	ListVolumes called with args {MaxEntries:0 StartingToken: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}, expectedStartingIndex 0	{"TraceId": "73903479-8c70-4a30-b2d5-ad33c216aff2"}
2023-02-28T19:44:03.182Z	DEBUG	wcp/controller.go:1375	ListVolumes: cnsVolumeIDs [de7eacf6-1c2f-4f7d-a821-de39111e9ff0 5f16d2e7-0009-4af9-a89b-a90dcf58d177], startingIdx 0, queryLimit 2	{"TraceId": "73903479-8c70-4a30-b2d5-ad33c216aff2"}
2023-02-28T19:44:03.183Z	DEBUG	wcp/controller.go:1396	ListVolumes: Response entries entries:<volume:<volume_id:"de7eacf6-1c2f-4f7d-a821-de39111e9ff0" > status:<published_node_ids:"sc2-10-212-6-105.nimbus.eng.vmware.com" > > entries:<volume:<volume_id:"5f16d2e7-0009-4af9-a89b-a90dcf58d177" > status:<published_node_ids:"sc2-10-212-1-185.nimbus.eng.vmware.com" > > 	{"TraceId": "73903479-8c70-4a30-b2d5-ad33c216aff2"}

```