### PR TITLE
Acquire lock in public Connect method

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -251,6 +251,10 @@ func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client) erro
 // If credentials are invalid then it fails the connection.
 func (vc *VirtualCenter) Connect(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
+
+	vc.ClientMutex.Lock()
+	defer vc.ClientMutex.Unlock()
+
 	// Set up the vc connection.
 	err := vc.connect(ctx, false)
 	if err != nil {
@@ -272,9 +276,6 @@ func (vc *VirtualCenter) Connect(ctx context.Context) error {
 // connect creates a connection to the virtual center host.
 func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) error {
 	log := logger.GetLogger(ctx)
-
-	vc.ClientMutex.Lock()
-	defer vc.ClientMutex.Unlock()
 
 	// If client was never initialized, initialize one.
 	var err error


### PR DESCRIPTION
**What this PR does / why we need it**:

As we acquire lock in the private connect method currently, it is possible that there are 2 goroutines trying to connect to the VC. One of them fails and before it can logout on [line 261](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/common/cns-lib/vsphere/virtualcenter.go#L261), the other goroutine comes in and is successfully able to connect to the VC. The first goroutine, gets back control and logs out from the same VC object. However, the second goroutine is still not aware that VC logout has happened.

To fix this, we need to make sure that we acquire the lock in the public Connect method and hence prevent such scenarios.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2155

**Testing done**:

ONLY TESTED ON VANILLA SO FAR
1. Checked that full sync is happening correctly.
2. Created a new volume and it got created successfully.
