### PR TITLE
Add snapshot restore testcase for raw block volume and fix bug for vcp-csi migration tc of raw block volume

### DIFF
--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -306,6 +306,21 @@ func TestInvalidVolumeCapabilitiesForFile(t *testing.T) {
 	if err := IsValidVolumeCapabilities(ctx, volCap); err == nil {
 		t.Errorf("Invalid file VolCap = %+v passed validation!", volCap)
 	}
+
+	// Invalid case: volumeMode=block and accessMode=MULTI_NODE_READER_ONLY
+	volCap = []*csi.VolumeCapability{
+		{
+			AccessType: &csi.VolumeCapability_Block{
+				Block: &csi.VolumeCapability_BlockVolume{},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+			},
+		},
+	}
+	if err := IsValidVolumeCapabilities(ctx, volCap); err == nil {
+		t.Errorf("Invalid file VolCap = %+v passed validation!", volCap)
+	}
 }
 
 func isStorageClassParamsEqual(expected *StorageClassParams, actual *StorageClassParams) bool {

--- a/tests/e2e/vcp_to_csi_syncer.go
+++ b/tests/e2e/vcp_to_csi_syncer.go
@@ -1480,8 +1480,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration syncer tests", func(
 	   26. Disable CSIMigration and CSIMigrationvSphere feature gates on
 	       kube-controller-manager (& restart).
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Test VCP-to-CSI migration "+
-		"with raw block volume", func() {
+	ginkgo.It("Test VCP-to-CSI migration with raw block volume", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating VCP SC")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add snapshot restore testcase for raw block volume.
Also, there is additional change to remove csi-block-vanilla & csi-block-vanilla-parallelized tags from vcp-to-csi migration tc of raw block volume, since it causes pipeline to fail, as the tags are not needed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
TC passes successfully with the new subtc for snapshot added.
Ran 6 of 717 Specs in 767.096 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 711 Skipped
PASS

Ginkgo ran 1 suite in 14m26.720955322s
Test Suite Passed

Detailed logs can be found at https://gist.github.com/akankshapanse/b3572542fd7cd422c63e876fe0407132

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add snapshot restore testcase for raw block volume
```
