### PR TITLE
fix: add task to map first, listview later

### DIFF
--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -116,11 +116,6 @@ func getListViewWaitFilter(listView *view.ListView) *property.WaitFilter {
 func (l *ListViewImpl) AddTask(ctx context.Context, taskMoRef types.ManagedObjectReference, ch chan TaskResult) error {
 	log := logger.GetLogger(ctx)
 	log.Infof("AddTask called for %+v", taskMoRef)
-	err := l.listView.Add(l.ctx, []types.ManagedObjectReference{taskMoRef})
-	if err != nil {
-		return logger.LogNewErrorf(log, "failed to add task to ListView. error: %+v", err)
-	}
-	log.Infof("task %+v added to listView", taskMoRef)
 
 	l.taskMap.Upsert(taskMoRef, TaskDetails{
 		Reference:        taskMoRef,
@@ -128,6 +123,13 @@ func (l *ListViewImpl) AddTask(ctx context.Context, taskMoRef types.ManagedObjec
 		ResultCh:         ch,
 	})
 	log.Debugf("task %+v added to map", taskMoRef)
+
+	err := l.listView.Add(l.ctx, []types.ManagedObjectReference{taskMoRef})
+	if err != nil {
+		l.taskMap.Delete(taskMoRef)
+		return logger.LogNewErrorf(log, "failed to add task to ListView. error: %+v", err)
+	}
+	log.Infof("task %+v added to listView", taskMoRef)
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Problem**: A task got added to the listview but before we could add it to the map, we received a success update for the task and couldn’t find the mapping. 

**Background**: The lock that we use for CRUD operations to the internal task -> channel map uses sync.RWMutex. This can be held by multiple readers or a single writer at any point.

Why we used it -
- We are processing property collector update in goroutines as we can get updates for multiple tasks at the same time. We need to Read() the task -> channel mapping here. We don’t want to lock reads for other tasks while accessing reads for one task. The reads for multiple tasks can thus proceed concurrently.
- For adding a task to the listview, we need a Write() to the map. Write lock will have to wait if there are already multiple Read locks in place. Once a write lock is acquired, any further Read locks will have to wait for the Write lock to be released. This works well as the Read locks will always access the most up-to-date state of the map.

**Solution**: We can insert the task into the map BEFORE adding the task to the listview. In case the task failed to be added to the listview, we can delete the task from the map.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2272#issuecomment-1497926824

and

```
Build #2048 (Apr 5, 2023, 11:31:40 AM)
adkulkarni
PR 2272
Ran 3 of 719 Specs in 711.463 seconds FAIL! -- 2 Passed | 1 Failed | 0 Pending | 716 Skipped --- FAIL: TestE2E (711.54s) FAIL Ginkgo ran 1 suite in 13m30.514771903s Test Suite Failed 

Build #2051 (Apr 5, 2023, 12:27:50 PM)
adkulkarni
PR 2272
------------------------------ Ran 1 of 719 Specs in 853.830 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 718 Skipped PASS Ginkgo ran 1 suite in 16m4.751439822s Test Suite Passed 
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
