### PR TITLE
skip creating new govmomi client for listview_if for ReloadConfig in Vanilla

### DIFF
--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -92,15 +92,18 @@ func (l *ListViewImpl) createListView(ctx context.Context, tasks []types.Managed
 }
 
 // SetVirtualCenter is a setter method for vc. use case: ReloadConfiguration
-func (l *ListViewImpl) SetVirtualCenter(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter) error {
+func (l *ListViewImpl) SetVirtualCenter(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter,
+	createNewClientForListView bool) error {
 	log := logger.GetLogger(ctx)
 	l.virtualCenter = virtualCenter
-	client, err := virtualCenter.NewClient(ctx)
-	if err != nil {
-		return logger.LogNewErrorf(log, "failed to create a govmomiClient for listView. error: %+v", err)
+	if createNewClientForListView {
+		client, err := virtualCenter.NewClient(ctx)
+		if err != nil {
+			return logger.LogNewErrorf(log, "failed to create a govmomiClient for listView. error: %+v", err)
+		}
+		client.Timeout = noTimeout
+		l.govmomiClient = client
 	}
-	client.Timeout = noTimeout
-	l.govmomiClient = client
 	return nil
 }
 

--- a/pkg/common/cns-lib/volume/listview_if.go
+++ b/pkg/common/cns-lib/volume/listview_if.go
@@ -17,7 +17,7 @@ type ListViewIf interface {
 	RemoveTask(ctx context.Context, taskMoRef types.ManagedObjectReference) error
 	// SetVirtualCenter is a setter method for the reference to the global vcenter object.
 	// use case: ReloadConfiguration
-	SetVirtualCenter(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter) error
+	SetVirtualCenter(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter, createNewClientForListView bool) error
 	// MarkTaskForDeletion marks a given task MoRef for deletion by a cleanup goroutine
 	// use case: failure to remove task due to a vc issue
 	MarkTaskForDeletion(ctx context.Context, taskMoRef types.ManagedObjectReference) error

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -428,7 +428,7 @@ func (c *controller) ReloadConfiguration() error {
 				return logger.LogNewErrorf(log, "failed to get VirtualCenter. err=%v", err)
 			}
 			vcenter.Config = newVCConfig
-			err := c.managers.VolumeManagers[newVCConfig.Host].ResetManager(ctx, vcenter)
+			err := c.managers.VolumeManagers[newVCConfig.Host].ResetManager(ctx, vcenter, false)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to reset updated VC object in volumemanager for vCenter: %q "+
 					"err=%v", newVCConfig.Host, err)
@@ -480,7 +480,7 @@ func (c *controller) ReloadConfiguration() error {
 				c.authMgr.ResetvCenterInstance(ctx, vcenter)
 				log.Info("Updated vCenter in auth manager")
 			}
-			err = c.manager.VolumeManager.ResetManager(ctx, vcenter)
+			err = c.manager.VolumeManager.ResetManager(ctx, vcenter, true)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to reset volume manager. err=%v", err)
 			}

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -364,7 +364,7 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 				return err
 			}
 		}
-		err := c.manager.VolumeManager.ResetManager(ctx, vcenter)
+		err := c.manager.VolumeManager.ResetManager(ctx, vcenter, true)
 		if err != nil {
 			return logger.LogNewErrorf(log, "failed to reset volume manager. err=%v", err)
 		}

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -970,7 +970,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 						return logger.LogNewErrorf(log, "failed to get VirtualCenter. err=%v", err)
 					}
 					vcenter.Config = newVCConfig
-					err := metadataSyncer.volumeManagers[newVCConfig.Host].ResetManager(ctx, vcenter)
+					err := metadataSyncer.volumeManagers[newVCConfig.Host].ResetManager(ctx, vcenter, false)
 					if err != nil {
 						return logger.LogNewErrorf(log, "failed to reset updated VC object in volumemanager for vCenter: %q "+
 							"err=%v", newVCConfig.Host, err)
@@ -1005,7 +1005,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 					return logger.LogNewErrorf(log, "failed to get VirtualCenter. err=%v", err)
 				}
 				vcenter.Config = newVCConfig
-				err := metadataSyncer.volumeManager.ResetManager(ctx, vcenter)
+				err := metadataSyncer.volumeManager.ResetManager(ctx, vcenter, true)
 				if err != nil {
 					return logger.LogNewErrorf(log, "failed to reset volume manager. err=%v", err)
 				}
@@ -1055,7 +1055,7 @@ func ReloadConfiguration(metadataSyncer *metadataSyncInformer, reconnectToVCFrom
 				}
 				vcenter.Config = newVCConfig
 			}
-			err := metadataSyncer.volumeManager.ResetManager(ctx, vcenter)
+			err := metadataSyncer.volumeManager.ResetManager(ctx, vcenter, true)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to reset volume manager. err=%v", err)
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For the Vanilla flavor we have made change in the ReloadConfig and we no longer create a new VC client upon password rotation.

Following this pattern we do not need to create new client for listview_if during ReloadConfig.

This PR is skipping creation of new govmomi client during ReloadConfig for vanilla flavor when multi-vcenter-csi-topology feature gate is enabled.





**Testing done**:
In progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
skip creating new govmomi client for listview_if for ReloadConfig in Vanilla
```
