### PR TITLE
fss: disable listview-tasks feature for vanilla

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -163,7 +163,7 @@ data:
   "max-pvscsi-targets-per-vm": "true"
   "multi-vcenter-csi-topology": "true"
   "csi-internal-generated-cluster-id": "true"
-  "listview-tasks": "true"
+  "listview-tasks": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Targeting listview-tasks FSS for 3.1 instead

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Disabled listview-tasks on the configmap and created a pvc and pod
```
root@k8s-control-884-1678302178:~# k get cm internal-feature-states.csi.vsphere.vmware.com -n vmware-system-csi -o json | jq '.data' | grep listview
  "listview-tasks": "false",

root@k8s-control-884-1678302178:~# k get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
example-vanilla-rwo-pvc   Bound    pvc-75490a6d-c854-4fb0-bebe-93772274d77e   5Gi        RWO            example-vanilla-rwo-filesystem-sc   3m6s

root@k8s-control-884-1678302178:~# k get po
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   1/1     Running   0          2m6s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
disable listview-tasks feature for vanilla
```
