### PR TITLE
Classify InvalidHostState & HostNotConnected faults as non-storage faults

### DIFF
--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -37,10 +37,6 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
-const (
-	vimFaultPrefix = "vim.fault."
-)
-
 func validateManager(ctx context.Context, m *defaultManager) error {
 	log := logger.GetLogger(ctx)
 	if m.virtualCenter == nil {
@@ -350,7 +346,7 @@ func ExtractFaultTypeFromErr(ctx context.Context, err error) string {
 		faultType = reflect.TypeOf(soapFault.VimFault()).String()
 		log.Infof("Extract vimfault type: +%v. SoapFault Info: +%v from err +%v", faultType, soapFault, err)
 		slice := strings.Split(faultType, ".")
-		vimFaultType := vimFaultPrefix + slice[1]
+		vimFaultType := csifault.VimFaultPrefix + slice[1]
 		return vimFaultType
 	}
 	log.Infof("err %+v is not a SoapFault\n", err)
@@ -374,7 +370,7 @@ func ExtractFaultTypeFromVolumeResponseResult(ctx context.Context,
 			log.Infof("Extract vimfault type: %+v  vimFault: %+v Fault: %+v from resp: %+v",
 				faultType, fault.Fault, fault, resp)
 			slice := strings.Split(faultType, ".")
-			vimFaultType := vimFaultPrefix + slice[1]
+			vimFaultType := csifault.VimFaultPrefix + slice[1]
 			return vimFaultType
 		} else {
 			faultType = reflect.TypeOf(fault).String()

--- a/pkg/common/fault/constants.go
+++ b/pkg/common/fault/constants.go
@@ -19,6 +19,11 @@ const (
 	// CSITaskInfoEmptyFault is the fault type when taskInfo is empty.
 	CSITaskInfoEmptyFault = "csi.fault.TaskInfoEmpty"
 
+	// CSINonStorageFaultPrefix is the prefix used for faults originating due to components other than
+	// downstream vSphere storage stack.
+	CSINonStorageFaultPrefix = "csi.fault.nonstorage."
+	// VimFaultPrefix is the prefix used for vim faults from downstream components.
+	VimFaultPrefix = "vim.fault."
 	// CSIVmUuidNotFoundFault is the fault type when Pod VMs do not have the vmware-system-vm-uuid annotation.
 	CSIVmUuidNotFoundFault = "csi.fault.nonstorage.VmUuidNotFound"
 	// CSIVmNotFoundFault is the fault type when VM object is not found in the VC
@@ -63,4 +68,13 @@ const (
 	CSIUnimplementedFault = "csi.fault.Unimplemented"
 	// CSIInvalidStoragePolicyConfigurationFault is the fault type returned when the user provides invalid storage policy.
 	CSIInvalidStoragePolicyConfigurationFault = "csi.fault.invalidconfig.InvalidStoragePolicyConfiguration"
+
+	// Below is the list of faults coming from downstream vCenter components that we want to classify
+	// as non-storage faults.
+
+	// VimFaultInvalidHostState is the fault returned from CNS when host is not in a state to perform the volume
+	// operation e.g. maintenance mode.
+	VimFaultInvalidHostState = VimFaultPrefix + "InvalidHostState"
+	// VimFaultHostNotConnected is the fault returned from CNS when host is not connected.
+	VimFaultHostNotConnected = VimFaultPrefix + "HostNotConnected"
 )

--- a/pkg/common/fault/util.go
+++ b/pkg/common/fault/util.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package fault
+
+import (
+	"context"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+var (
+	// VimNonStorageFaultsList contains the list of faults that needs to classified as non-storage faults.
+	VimNonStorageFaultsList = []string{VimFaultInvalidHostState, VimFaultHostNotConnected}
+)
+
+// IsNonStorageFault checks if the fault type is in a pre-defined list of non-storage faults
+// and returns a bool value accordingly.
+func IsNonStorageFault(fault string) bool {
+	for _, nonStorageFault := range VimNonStorageFaultsList {
+		if nonStorageFault == fault {
+			return true
+		}
+	}
+	return false
+}
+
+// AddCsiNonStoragePrefix adds "csi.fault.nonstorage." prefix to the faults.
+func AddCsiNonStoragePrefix(ctx context.Context, fault string) string {
+	log := logger.GetLogger(ctx)
+	if fault != "" {
+		log.Infof("Adding %q prefix to fault %q", CSINonStorageFaultPrefix, fault)
+		return CSINonStorageFaultPrefix + fault
+	}
+	return fault
+}

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1859,6 +1859,9 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	resp, faultType, err := createVolumeInternal()
 	log.Debugf("createVolumeInternal: returns fault %q", faultType)
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusCreateVolumeOpType, volumeType, faultType)
@@ -1999,6 +2002,9 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	resp, faultType, err := deleteVolumeInternal()
 	log.Debugf("deleteVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusDeleteVolumeOpType, volumeType, faultType)
@@ -2148,6 +2154,9 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	resp, faultType, err := controllerPublishVolumeInternal()
 	log.Debugf("controllerPublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusAttachVolumeOpType, volumeType, faultType)
@@ -2286,6 +2295,9 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	resp, faultType, err := controllerUnpublishVolumeInternal()
 	log.Debugf("controllerUnpublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusDetachVolumeOpType, volumeType, faultType)
@@ -2418,6 +2430,9 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	resp, faultType, err := controllerExpandVolumeInternal()
 	if err != nil {
 		log.Debugf("controllerExpandVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusExpandVolumeOpType, volumeType, faultType)
@@ -2570,6 +2585,9 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 	listVolResponse, faultType, err := listVolumesInternal()
 	log.Debugf("List volume response: %+v", listVolResponse)
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusListVolumeOpType, volumeType, faultType)

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -863,6 +863,9 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	log.Debugf("createVolumeInternal: returns fault %q", faultType)
 
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusCreateVolumeOpType, volumeType, faultType)
@@ -945,6 +948,9 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	log.Debugf("deleteVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusDeleteVolumeOpType, volumeType, faultType)
@@ -1100,6 +1106,9 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	log.Debugf("controllerPublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusAttachVolumeOpType, volumeType, faultType)
@@ -1249,6 +1258,9 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	log.Debugf("controllerUnpublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusDetachVolumeOpType, volumeType, faultType)
@@ -1398,6 +1410,9 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 	}
 	resp, faultType, err := controllerListVolumeInternal()
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusListVolumeOpType, volumeType, faultType)
@@ -1724,6 +1739,9 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	log.Debugf("controllerExpandVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusExpandVolumeOpType, volumeType, faultType)

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -423,6 +423,9 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	resp, faultType, err := createVolumeInternal()
 	log.Debugf("createVolumeInternal: returns fault %q", faultType)
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusCreateVolumeOpType, volumeType, faultType)
@@ -499,6 +502,9 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	resp, faultType, err := deleteVolumeInternal()
 	log.Debugf("deleteVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusDeleteVolumeOpType, volumeType, faultType)
@@ -560,6 +566,9 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	resp, faultType, err := controllerPublishVolumeInternal()
 	if err != nil {
 		log.Debugf("controllerPublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusAttachVolumeOpType, volumeType, faultType)
@@ -903,6 +912,9 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 	resp, faultType, err := controllerUnpublishVolumeInternal()
 	log.Debugf("controllerUnpublishVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusDetachVolumeOpType, volumeType, faultType)
@@ -1271,6 +1283,9 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	resp, faultType, err := controllerExpandVolumeInternal()
 	log.Debugf("controllerExpandVolumeInternal: returns fault %q for volume %q", faultType, req.VolumeId)
 	if err != nil {
+		if csifault.IsNonStorageFault(faultType) {
+			faultType = csifault.AddCsiNonStoragePrefix(ctx, faultType)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			prometheus.PrometheusExpandVolumeOpType, volumeType, faultType)

--- a/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsnodevmattachment/cnsnodevmattachment_controller.go
@@ -630,6 +630,9 @@ func (r *ReconcileCnsNodeVMAttachment) Reconcile(ctx context.Context,
 		// This can happen when reconciler returns reconcile.Result{RequeueAfter: timeout}, the err will be set to nil,
 		// and corresponding faulttype will be set
 		// for this case, we need count it as an attach/detach failure
+		if csifault.IsNonStorageFault(faulttype) {
+			faulttype = csifault.AddCsiNonStoragePrefix(ctx, faulttype)
+		}
 		log.Errorf("Operation failed, reporting failure status to Prometheus."+
 			" Operation Type: %q, Volume Type: %q, Fault Type: %q",
 			volumeOpType, volumeType, faulttype)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR classifies `*types.InvalidHostState` & `*types. HostNotConnected` faults from downstream vCenter layer as a non-storage fault by prefixing it with string `csi.fault.nonstorage.`.  
This is needed so that all the faults originating out of storage stack can be filtered out in dashboards for CSI API success rate, by filtering faulttype labels starting with `csi.fault.nonstorage.`. We currently emit other nonstorage faults also and this list can grow in the future.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
1. Created a storageclass, pvc & pod. Get the k8s worker node on which the pod is scheduled.
2. Get the host for the k8s worker node, and put it in maintenance mode from vSphere UI.
3. Delete the pod created in step 1, which will invoke a `detach-volume` operation on the volume. The operation fails in CNS with `*types.InvalidHostState` error.

vSphere CSI controller logs before this change:
```
2023-03-20T20:37:53.628Z	DEBUG	vanilla/controller.go:2286	controllerUnpublishVolumeInternal: returns fault "vim.fault.InvalidHostState" for volume "fe10d189-c8c2-451b-8803-63ca740f32e2"	{"TraceId": "73c4677e-6c8b-4f83-8c80-9f18e8b62e00"}
2023-03-20T20:37:53.628Z	ERROR	vanilla/controller.go:2288	Operation failed, reporting failure status to Prometheus. Operation Type: "detach-volume", Volume Type: "block", Fault Type: "vim.fault.InvalidHostState"	{"TraceId": "73c4677e-6c8b-4f83-8c80-9f18e8b62e00"}
```

vSphere CSI controller logs after this change:
```
2023-04-03T23:23:44.148Z	ERROR	vanilla/controller.go:2289	failed to detach disk: "fe10d189-c8c2-451b-8803-63ca740f32e2" from node: "4204968a-55f4-0450-abb3-a9202425e282" err failed to detach cns volume: "fe10d189-c8c2-451b-8803-63ca740f32e2" from node vm: VirtualMachine:vm-53 [VirtualCenterHost: 10.185.71.120, UUID: 4204968a-55f4-0450-abb3-a9202425e282, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.71.120]]. fault: (*types.LocalizedMethodFault)(0xc0002aa2c0)({
 DynamicData: (types.DynamicData) {
 },
 Fault: (*types.InvalidHostState)(0xc0006f2480)({
  InvalidState: (types.InvalidState) {
   VimFault: (types.VimFault) {
    MethodFault: (types.MethodFault) {
     FaultCause: (*types.LocalizedMethodFault)(<nil>),
     FaultMessage: ([]types.LocalizableMessage) <nil>
    }
   }
  },
  Host: (*types.ManagedObjectReference)(0xc0002aa2e0)(HostSystem:host-32)
 }),
 LocalizedMessage: (string) (len=62) "The operation is not allowed in the current state of the host."
})
, opId: "1c3792a7"	{"TraceId": "985dbcb0-f56d-4844-ac25-e85c71f1b6fd"}
sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/vanilla.(*controller).ControllerUnpublishVolume.func1
	/build/pkg/csi/service/vanilla/controller.go:2289
sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/vanilla.(*controller).ControllerUnpublishVolume
	/build/pkg/csi/service/vanilla/controller.go:2295
github.com/container-storage-interface/spec/lib/go/csi._Controller_ControllerUnpublishVolume_Handler
	/go/pkg/mod/github.com/container-storage-interface/spec@v1.7.0/lib/go/csi/csi.pb.go:5725
google.golang.org/grpc.(*Server).processUnaryRPC
	/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1283
google.golang.org/grpc.(*Server).handleStream
	/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1620
google.golang.org/grpc.(*Server).serveStreams.func1.2
	/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:922
	
2023-04-03T23:23:44.148Z	DEBUG	vanilla/controller.go:2296	controllerUnpublishVolumeInternal: returns fault "vim.fault.InvalidHostState" for volume "fe10d189-c8c2-451b-8803-63ca740f32e2"	{"TraceId": "985dbcb0-f56d-4844-ac25-e85c71f1b6fd"}
2023-04-03T23:23:44.148Z	INFO	fault/util.go:44	Adding `csi.fault.nonstorage.` prefix to fault `vim.fault.InvalidHostState`	{"TraceId": "985dbcb0-f56d-4844-ac25-e85c71f1b6fd"}
2023-04-03T23:23:44.148Z	ERROR	vanilla/controller.go:2301	Operation failed, reporting failure status to Prometheus. Operation Type: "detach-volume", Volume Type: "block", Fault Type: "csi.fault.nonstorage.vim.fault.InvalidHostState"	{"TraceId": "985dbcb0-f56d-4844-ac25-e85c71f1b6fd"}
```

Checking the `vsphere_csi_volume_ops_histogram` metrics:
```
oot@k8s-control-338-1679023027:~# kubectl exec -it vsphere-csi-controller-5d7f8dcc4d-6mvgp -c vsphere-csi-controller -n vmware-system-csi -- curl localhost:2112/metrics | grep vsphere_csi_volume_ops
# HELP vsphere_csi_volume_ops_histogram Histogram vector for CSI volume operations.
# HELP vsphere_csi_volume_ops_histogram Histogram vector for CSI volume operations.
# TYPE vsphere_csi_volume_ops_histogram histogram
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="list-volume",status="pass",voltype="block",le="2"} 15
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="list-volume",status="pass",voltype="block",le="5"} 15
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="list-volume",status="pass",voltype="block",le="10"} 15
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="list-volume",status="pass",voltype="block",le="15"} 15
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="list-volume",status="pass",voltype="block",le="20"} 15
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="list-volume",status="pass",voltype="block",le="25"} 15
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="list-volume",status="pass",voltype="block",le="30"} 15
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="list-volume",status="pass",voltype="block",le="60"} 15
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="list-volume",status="pass",voltype="block",le="120"} 15
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="list-volume",status="pass",voltype="block",le="180"} 15
vsphere_csi_volume_ops_histogram_bucket{faulttype="",optype="list-volume",status="pass",voltype="block",le="+Inf"} 15
vsphere_csi_volume_ops_histogram_sum{faulttype="",optype="list-volume",status="pass",voltype="block"} 2.0221696340000004
vsphere_csi_volume_ops_histogram_count{faulttype="",optype="list-volume",status="pass",voltype="block"} 15
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block",le="2"} 12            <<<<<<<<<<<<<<<<-------------------
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block",le="5"} 12           <<<<<<<<<<<<<<<<-------------------
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block",le="10"} 12        <<<<<<<<<<<<<<<<-------------------
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block",le="15"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block",le="20"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block",le="25"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block",le="30"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block",le="60"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block",le="120"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block",le="180"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block",le="+Inf"} 12
vsphere_csi_volume_ops_histogram_sum{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block"} 7.3289978819999995
vsphere_csi_volume_ops_histogram_count{faulttype="csi.fault.nonstorage.vim.fault.InvalidHostState",optype="detach-volume",status="fail",voltype="block"} 12
vsphere_csi_volume_ops_histogram_bucket{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block",le="2"} 11
vsphere_csi_volume_ops_histogram_bucket{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block",le="5"} 11
vsphere_csi_volume_ops_histogram_bucket{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block",le="10"} 11
vsphere_csi_volume_ops_histogram_bucket{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block",le="15"} 11
vsphere_csi_volume_ops_histogram_bucket{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block",le="20"} 11
vsphere_csi_volume_ops_histogram_bucket{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block",le="25"} 11
vsphere_csi_volume_ops_histogram_bucket{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block",le="30"} 11
vsphere_csi_volume_ops_histogram_bucket{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block",le="60"} 11
vsphere_csi_volume_ops_histogram_bucket{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block",le="120"} 11
vsphere_csi_volume_ops_histogram_bucket{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block",le="180"} 11
vsphere_csi_volume_ops_histogram_bucket{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block",le="+Inf"} 11
vsphere_csi_volume_ops_histogram_sum{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block"} 5.572458694999999
vsphere_csi_volume_ops_histogram_count{faulttype="vim.fault.ResourceInUse",optype="attach-volume",status="fail",voltype="block"} 11
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Classify InvalidHostState & HostNotConnected faults as non-storage faults
```
