### PR TITLE
Add PVC validation handling for snapshots during ExpandVolume and DeleteVolume operation in WCP

### DIFF
--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -503,7 +503,7 @@ webhooks:
     rules:
       - apiGroups:   [""]
         apiVersions: ["v1", "v1beta1"]
-        operations:  ["CREATE", "UPDATE"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
     sideEffects: None
@@ -518,6 +518,9 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -80,7 +80,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list" ]
+    verbs: [ "get", "list", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]
@@ -512,7 +512,7 @@ webhooks:
     rules:
       - apiGroups:   [""]
         apiVersions: ["v1", "v1beta1"]
-        operations:  ["CREATE", "UPDATE"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
     sideEffects: None
@@ -527,6 +527,9 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -80,7 +80,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list" ]
+    verbs: [ "get", "list", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]
@@ -516,7 +516,7 @@ webhooks:
     rules:
       - apiGroups:   [""]
         apiVersions: ["v1", "v1beta1"]
-        operations:  ["CREATE", "UPDATE"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
     sideEffects: None
@@ -531,6 +531,9 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -80,7 +80,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list" ]
+    verbs: [ "get", "list", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]
@@ -519,7 +519,7 @@ webhooks:
     rules:
       - apiGroups:   [""]
         apiVersions: ["v1", "v1beta1"]
-        operations:  ["CREATE", "UPDATE"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
     sideEffects: None
@@ -534,6 +534,9 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -80,7 +80,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list" ]
+    verbs: [ "get", "list", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]
@@ -516,7 +516,7 @@ webhooks:
     rules:
       - apiGroups:   [""]
         apiVersions: ["v1", "v1beta1"]
-        operations:  ["CREATE", "UPDATE"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
     sideEffects: None
@@ -531,6 +531,9 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -140,6 +140,7 @@ func StartWebhookServer(ctx context.Context) error {
 	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		featureGateTKGSHaEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
 		featureGateVolumeHealthEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.VolumeHealth)
+		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 		startCNSCSIWebhookManager(ctx)
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		if cfg == nil {
@@ -255,7 +256,7 @@ func validationHandler(w http.ResponseWriter, r *http.Request) {
 			case "StorageClass":
 				admissionResponse = validateStorageClass(ctx, &ar)
 			case "PersistentVolumeClaim":
-				admissionResponse = validatePVC(ctx, &ar)
+				admissionResponse = validatePVC(ctx, ar.Request)
 			default:
 				log.Infof("Skipping validation for resource type: %q", ar.Request.Kind.Kind)
 				admissionResponse = &admissionv1.AdmissionResponse{

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -98,6 +98,10 @@ func (h *CSISupervisorWebhook) Handle(ctx context.Context, req admission.Request
 		if featureGateVolumeHealthEnabled {
 			resp = validatePVCAnnotationForVolumeHealth(ctx, req)
 		}
+		if featureGateBlockVolumeSnapshotEnabled {
+			admissionResp := validatePVC(ctx, &req.AdmissionRequest)
+			resp.AdmissionResponse = *admissionResp.DeepCopy()
+		}
 	}
 	return
 }

--- a/pkg/syncer/admissionhandler/validatepvc.go
+++ b/pkg/syncer/admissionhandler/validatepvc.go
@@ -21,7 +21,7 @@ const (
 )
 
 // validatePVC helps validate AdmissionReview requests for PersistentVolumeClaim.
-func validatePVC(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func validatePVC(ctx context.Context, req *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	if !featureGateBlockVolumeSnapshotEnabled {
 		// If CSI block volume snapshot is disabled and webhook is running,
 		// skip validation for PersistentVolumeClaim.
@@ -30,7 +30,7 @@ func validatePVC(ctx context.Context, ar *admissionv1.AdmissionReview) *admissio
 		}
 	}
 
-	if ar.Request.Operation != admissionv1.Update && ar.Request.Operation != admissionv1.Delete {
+	if req.Operation != admissionv1.Update && req.Operation != admissionv1.Delete {
 		// If AdmissionReview request operation is out of expectation,
 		// skip validation for PersistentVolumeClaim.
 		return &admissionv1.AdmissionResponse{
@@ -39,7 +39,6 @@ func validatePVC(ctx context.Context, ar *admissionv1.AdmissionReview) *admissio
 	}
 
 	log := logger.GetLogger(ctx)
-	req := ar.Request
 	var result *metav1.Status
 	allowed := true
 

--- a/pkg/syncer/admissionhandler/validatepvc_test.go
+++ b/pkg/syncer/admissionhandler/validatepvc_test.go
@@ -429,7 +429,7 @@ func TestValidatePVC(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			actualResponse := validatePVC(ctx, test.admissionReview)
+			actualResponse := validatePVC(ctx, test.admissionReview.Request)
 			assert.Equal(t, actualResponse, test.expectedResponse)
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add PVC validation handling to admission webhook running on supervisor cluster to check for any snapshots associated with PVC being deleted/expanded.
Currently for vanilla CSI, we have a handling in admission webhook to disallow PVC expand and delete operations if the corresponding PVC has snapshot(s) associated. This PR extends the same check for WCP as a part of feature - Snapshot support in WCP.
Also updated RBAC permissions in validatingwebhookconfiguration, csi-controller-role and csi-webhook-role to allow required snapshot operations.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested change on SV cluster with WCP changes for snapshot CRD installation in place. 

Create PVC and volumesnapshot of that PVC

```
root@422b5c27ba44d9eb279bb89fbdfcf25d [ ~ ]# kubectl create -f pvc.yaml
persistentvolumeclaim/example-raw-block-pvc created

root@422b5c27ba44d9eb279bb89fbdfcf25d [ ~ ]# kubectl get pvc -A
NAMESPACE            NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
utkg-crs-rbac-test   example-raw-block-pvc   Bound    pvc-8dd40381-26df-40e3-9279-3a29a62b0e66   10Mi       RWO            namespace-service-storage-profile   9s

root@422b5c27ba44d9eb279bb89fbdfcf25d [ ~ ]# kubectl create -f snap.yaml
volumesnapshot.snapshot.storage.k8s.io/example-raw-block-snapshot created

root@422b5c27ba44d9eb279bb89fbdfcf25d [ ~ ]# kubectl get vs -A
NAMESPACE            NAME                         READYTOUSE   SOURCEPVC               SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                     SNAPSHOTCONTENT                                    CREATIONTIME   AGE
utkg-crs-rbac-test   example-raw-block-snapshot   true         example-raw-block-pvc                           10Mi          example-raw-block-snapshotclass   snapcontent-38088d39-f91a-4af3-8f22-177a85a86e78   1s             12s
```

Try to delete the PVC and check if webhook fails the operation

```
root@422b5c27ba44d9eb279bb89fbdfcf25d [ ~ ]# kubectl delete pvc -n utkg-crs-rbac-test example-raw-block-pvc
Error from server (Deleting volume with snapshots is not allowed): admission webhook "validation.csi.vsphere.vmware.com" denied the request: Deleting volume with snapshots is not allowed
```

Try to expand the PVC and check if webhook fails the operation

```
root@422b5c27ba44d9eb279bb89fbdfcf25d [ ~ ]# kubectl edit pvc -n utkg-crs-rbac-test
error: persistentvolumeclaims "example-raw-block-pvc" could not be patched: admission webhook "validation.csi.vsphere.vmware.com" denied the request: Expanding volume with snapshots is not allowed
You can run `kubectl replace -f /tmp/kubectl-edit-978983614.yaml` to try this update again.

```
**Special notes for your reviewer**:
Added changes to all K8S version cns-csi manifest files now. We may want to limit the change to specific K8S version supported with next CSI release.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add PVC validation handling for snapshots during ExpandVolume and DeleteVolume operation in WCP
```
