### PR TITLE
Changes to disable snapshot operations directly initiated from the Supervisor cluster

### DIFF
--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -506,6 +506,11 @@ webhooks:
         operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
+      - apiGroups:   ["snapshot.storage.k8s.io"]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
+        resources:   ["volumesnapshots"]
+        scope:       "Namespaced"
     sideEffects: None
     admissionReviewVersions: ["v1"]
     failurePolicy: Fail

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -515,6 +515,11 @@ webhooks:
         operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
+     - apiGroups:   ["snapshot.storage.k8s.io"]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
+        resources:   ["volumesnapshots"]
+        scope:       "Namespaced"
     sideEffects: None
     admissionReviewVersions: ["v1"]
     failurePolicy: Fail

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -519,6 +519,11 @@ webhooks:
         operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
+      - apiGroups:   ["snapshot.storage.k8s.io"]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
+        resources:   ["volumesnapshots"]
+        scope:       "Namespaced"
     sideEffects: None
     admissionReviewVersions: ["v1"]
     failurePolicy: Fail

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -522,6 +522,11 @@ webhooks:
         operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
+      - apiGroups:   ["snapshot.storage.k8s.io"]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
+        resources:   ["volumesnapshots"]
+        scope:       "Namespaced"
     sideEffects: None
     admissionReviewVersions: ["v1"]
     failurePolicy: Fail

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -519,6 +519,11 @@ webhooks:
         operations:  ["CREATE", "UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"
+      - apiGroups:   ["snapshot.storage.k8s.io"]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
+        resources:   ["volumesnapshots"]
+        scope:       "Namespaced"
     sideEffects: None
     admissionReviewVersions: ["v1"]
     failurePolicy: Fail

--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -97,10 +97,17 @@ func (h *CSISupervisorWebhook) Handle(ctx context.Context, req admission.Request
 		}
 		if featureGateVolumeHealthEnabled {
 			resp = validatePVCAnnotationForVolumeHealth(ctx, req)
+			if !resp.Allowed {
+				return
+			}
 		}
 		if featureGateBlockVolumeSnapshotEnabled {
 			admissionResp := validatePVC(ctx, &req.AdmissionRequest)
 			resp.AdmissionResponse = *admissionResp.DeepCopy()
+		}
+	} else if req.Kind.Kind == "VolumeSnapshot" {
+		if featureGateBlockVolumeSnapshotEnabled {
+			resp = validateSnapshotOperationSupervisorRequest(ctx, req)
 		}
 	}
 	return

--- a/pkg/syncer/admissionhandler/validatesnapshotoperationsupervisorrequest.go
+++ b/pkg/syncer/admissionhandler/validatesnapshotoperationsupervisorrequest.go
@@ -1,0 +1,44 @@
+package admissionhandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+
+	snap "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+)
+
+const (
+	SnapshotOperationNotAllowed = "Snapshot operation initiated directly from the Supervisor cluster by user " +
+		"%s is not supported. Please initiate snapshot operation from the Guest cluster."
+)
+
+// Disallow any opertion on volume snapshot initiated by user directly on the supervisor cluster.
+// Currently we only allow snapshot operation initiated from the guest cluster.
+func validateSnapshotOperationSupervisorRequest(ctx context.Context, request admission.Request) admission.Response {
+	log := logger.GetLogger(ctx)
+	username := request.UserInfo.Username
+	isCSIServiceAccount := validateCSIServiceAccount(request.UserInfo.Username)
+	log.Debugf("validateSnapshotOperationSupervisorRequest called with the request %v by user: %v", request, username)
+	newVS := snap.VolumeSnapshot{}
+	if err := json.Unmarshal(request.Object.Raw, &newVS); err != nil {
+		reason := "Failed to deserialize VolumeSnapshot from new request object"
+		log.Warn(reason)
+		return admission.Denied(reason)
+	}
+
+	if request.Operation == admissionv1.Create || request.Operation == admissionv1.Update ||
+		request.Operation == admissionv1.Delete {
+		if !isCSIServiceAccount {
+			return admission.Denied(fmt.Sprintf(SnapshotOperationNotAllowed, username))
+		}
+	}
+
+	log.Debugf("validateSnapshotOperationSupervisorRequest completed for the request %v", request)
+	return admission.Allowed("")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes to disable snapshot creation operation directly from the Supervisor cluster. Currently we want to block snapshot operations if attempted directly from Supervisor cluster.
When we create a VolumeSnapshot CR in supervisor cluster from guest cluster, adding a special annotation on this CR. And in CreateSnapshot on Supervisor cluster, checking if this annotation is set or not. If annotation is not set, then return error, since it is directly attempted from supervisor cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
All unit tests ran using "make test" are passing. Verified that we get expected error when manually updated IsVolumeSnapshotAnnotationPresent() in unittestcommon/utils.go to return false.

Verified changes on supervisor cluster. Tried to create a snapshot, getting expected error:
```
# kubectl get pvc -A
NAMESPACE              NAME                 STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                       AGE
storage-class-test-2   wcp-profile          Bound    pvc-3b6db1b3-c865-4e27-88e5-671ae293b3e6   1Gi        RWO            test-storage-class-update-policy   4h32m

# kubectl create -f example-raw-block-snapshot.yaml 
Error from server (Snapshot operation initiated directly from the Supervisor cluster by user kubernetes-admin is not supported. Please initiate snapshot operation from the Guest cluster.): error when creating "example-raw-block-snapshot.yaml": admission webhook "validation.csi.vsphere.vmware.com" denied the request: Snapshot operation initiated directly from the Supervisor cluster by user kubernetes-admin is not supported. Please initiate snapshot operation from the Guest cluster.
...
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Changes to disable snapshot creation operation directly from the Supervisor cluster
```
