### PR TITLE
Skip creating new client for listview in case of ReloadConfig

### DIFF
--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -92,16 +92,10 @@ func (l *ListViewImpl) createListView(ctx context.Context, tasks []types.Managed
 }
 
 // SetVirtualCenter is a setter method for vc. use case: ReloadConfiguration
-func (l *ListViewImpl) SetVirtualCenter(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter) error {
+func (l *ListViewImpl) SetVirtualCenter(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter) {
 	log := logger.GetLogger(ctx)
 	l.virtualCenter = virtualCenter
-	client, err := virtualCenter.NewClient(ctx)
-	if err != nil {
-		return logger.LogNewErrorf(log, "failed to create a govmomiClient for listView. error: %+v", err)
-	}
-	client.Timeout = noTimeout
-	l.govmomiClient = client
-	return nil
+	log.Debugf("New virtualCenter object stored for use by ListView")
 }
 
 func getListViewWaitFilter(listView *view.ListView) *property.WaitFilter {

--- a/pkg/common/cns-lib/volume/listview_if.go
+++ b/pkg/common/cns-lib/volume/listview_if.go
@@ -17,7 +17,7 @@ type ListViewIf interface {
 	RemoveTask(ctx context.Context, taskMoRef types.ManagedObjectReference) error
 	// SetVirtualCenter is a setter method for the reference to the global vcenter object.
 	// use case: ReloadConfiguration
-	SetVirtualCenter(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter) error
+	SetVirtualCenter(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter)
 	// MarkTaskForDeletion marks a given task MoRef for deletion by a cleanup goroutine
 	// use case: failure to remove task due to a vc issue
 	MarkTaskForDeletion(ctx context.Context, taskMoRef types.ManagedObjectReference) error

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -305,10 +305,7 @@ func (m *defaultManager) ResetManager(ctx context.Context, vcenter *cnsvsphere.V
 	log.Infof("Re-initializing defaultManager.virtualCenter")
 	managerInstance.virtualCenter = vcenter
 	if m.tasksListViewEnabled {
-		err := m.listViewIf.SetVirtualCenter(ctx, managerInstance.virtualCenter)
-		if err != nil {
-			return logger.LogNewErrorf(log, "failed to set virtual center to listView instance. err: %v", err)
-		}
+		m.listViewIf.SetVirtualCenter(ctx, managerInstance.virtualCenter)
 	}
 	if m.virtualCenter.Client != nil {
 		m.virtualCenter.Client.Timeout = time.Duration(vcenter.Config.VCClientTimeout) * time.Minute


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

ListView uses a separate VC client as it requires a longer request timeout than the rest of the driver operations. 

Currently, when a password rotation happened, we created a new vc client for listview and started using that one. 

#2195 and #2221 brought changes to skip new vc client creation used by the driver and restart the driver in case of VC server change. 

#2279 can be improved by doing something similar. In case of password rotation, we will simply save the reference to the new VC object but will continue using the same client until we get a failure on it and we decide to recreate the client. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

#### Vanilla
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2300#issuecomment-1496877915

and

```
Build #2038 (Apr 4, 2023, 11:49:11 PM)
adkulkarni
PR 2300
------------------------------ Ran 2 of 719 Specs in 952.828 seconds SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 717 Skipped PASS Ginkgo ran 1 suite in 17m41.294981045s Test Suite Passed
```

#### WCP
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2300#issuecomment-1496862452

and

```
Build #846 (Apr 4, 2023, 11:47:11 PM)
adkulkarni
PR 2300
Ran 1 of 719 Specs in 580.637 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 718 Skipped PASS Ginkgo ran 1 suite in 11m5.740402341s Test Suite Passed make: Leaving directory `/home/worker/workspace/csi-wcp-pre-check-in/Results/846/vsphere-csi-driver'
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
