### PR TITLE
Allow NTFS fsType to be uppercase

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -184,7 +184,7 @@ func validateVolumeCapabilities(volCaps []*csi.VolumeCapability,
 			// ext3, ext4, xfs for Linux and ntfs for Windows.
 			if volCap.GetMount() != nil && !(volCap.GetMount().FsType == Ext4FsType ||
 				volCap.GetMount().FsType == Ext3FsType || volCap.GetMount().FsType == XFSType ||
-				volCap.GetMount().FsType == NTFSFsType || volCap.GetMount().FsType == "") {
+				strings.ToLower(volCap.GetMount().FsType) == NTFSFsType || volCap.GetMount().FsType == "") {
 				return fmt.Errorf("fstype %s not supported for ReadWriteOnce volume creation",
 					volCap.GetMount().FsType)
 			}

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -272,6 +272,40 @@ func TestValidVolumeCapabilitiesForFile(t *testing.T) {
 	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("File VolCap = %+v failed validation!", volCap)
 	}
+
+	// fstype=ntfs and mode=SINGLE_NODE_WRITER
+	volCap = []*csi.VolumeCapability{
+		{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{
+					FsType: "ntfs",
+				},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
+		t.Errorf("File VolCap = %+v failed validation!", volCap)
+	}
+
+	// fstype=NTFS and mode=SINGLE_NODE_WRITER
+	volCap = []*csi.VolumeCapability{
+		{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{
+					FsType: "NTFS",
+				},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
+		t.Errorf("File VolCap = %+v failed validation!", volCap)
+	}
 }
 
 func TestInvalidVolumeCapabilitiesForFile(t *testing.T) {


### PR DESCRIPTION
It is valid to use "NTFS" or "ntfs" to specify the fsType for an in-tree vSphere volume. This change allows CSI migration to work for cases where an in-tree volume may have been provisioned with an uppercase string used to specify the filesystem type.

**What this PR does / why we need it**:
I created a PV using the in-tree vSphere driver in a cluster at k8s version `1.25` for some Windows workloads. In the `StorageClass` for this PV I used `NTFS` as the `fsType` instead of `ntfs`. This worked fine, as my volume was provisioned, attached, and mounted. After upgrading my Kubernetes cluster version to `1.26` and deploying the vSphere CSI driver on my Windows nodes I noticed this:

```
  Warning  FailedAttachVolume  18s (x7 over 53s)  attachdetach-controller  AttachVolume.Attach failed for volume "pvc-15f4f4ba-d746-45ed-81e5-62d511d27672" : rpc error: code = Internal desc = validation for PublishVolume Request: {VolumeId:[vsanDatastore] 548b5a60-38ca-d0d1-633c-bc97e1269700/kubernetes-dynamic-pvc-15f4f4ba-d746-45ed-81e5-62d511d27672.vmdk NodeId:649cbb988-lp75b VolumeCapability:mount:<fs_type:"NTFS" > access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} has failed. Error: rpc error: code = InvalidArgument desc = volume capability not supported. Err: fstype NTFS not supported for ReadWriteOnce volume creation
```

The vSphere driver expects the fstype to be lowercase `ntfs`. This change makes this check more permissive to allow for CSI migration to occur in a broader set of configurations.

**Which issue this PR fixes**: N/A

**Testing done**:
1. Set up a Kubernetes `1.25` cluster and create two `StorageClasses`, one that uses `NTFS` as the `fsType` and one that uses `ntfs`

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: standard-win-ntfs
parameters:
  datastore: vsanDatastore
  fstype: ntfs
provisioner: kubernetes.io/vsphere-volume
reclaimPolicy: Delete
volumeBindingMode: Immediate
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: standard-win-ntfs-caps
parameters:
  datastore: vsanDatastore
  fstype: NTFS
provisioner: kubernetes.io/vsphere-volume
reclaimPolicy: Delete
volumeBindingMode: Immediate
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: example-win-in-tree-ntfs
spec:
  selector:
    matchLabels:
      app: example-win-in-tree-ntfs
  serviceName: "nginx"
  replicas: 1
  template:
    metadata:
      labels:
        app: example-win-in-tree-ntfs
    spec:
      nodeSelector:
        kubernetes.io/os: windows
      containers:
        - name: test-container
          image: mcr.microsoft.com/windows/servercore:ltsc2019
          command:
            - "powershell.exe"
            - "-Command"
            - "while (1) { Add-Content -Encoding Ascii C:\\test\\data.txt $(Get-Date -Format u); sleep 1 }"
          volumeMounts:
          - name: test-volume
            mountPath: "/test/"
            readOnly: false
  volumeClaimTemplates:
  - metadata:
      name: test-volume
    spec:
      accessModes:
      - ReadWriteOnce
      storageClassName: standard-win-ntfs
      resources:
        requests:
          storage: 5Gi
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: example-win-in-tree-ntfs-caps
spec:
  selector:
    matchLabels:
      app: example-win-in-tree-ntfs-caps
  serviceName: "nginx"
  replicas: 1
  template:
    metadata:
      labels:
        app: example-win-in-tree-ntfs-caps
    spec:
      nodeSelector:
        kubernetes.io/os: windows
      containers:
        - name: test-container
          image: mcr.microsoft.com/windows/servercore:ltsc2019
          command:
            - "powershell.exe"
            - "-Command"
            - "while (1) { Add-Content -Encoding Ascii C:\\test\\data.txt $(Get-Date -Format u); sleep 1 }"
          volumeMounts:
          - name: test-volume
            mountPath: "/test/"
            readOnly: false
  volumeClaimTemplates:
  - metadata:
      name: test-volume
    spec:
      accessModes:
      - ReadWriteOnce
      storageClassName: standard-win-ntfs-caps
      resources:
        requests:
          storage: 5Gi
```

```
$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl get nodes -o wide
NAME                      STATUS   ROLES    AGE   VERSION           INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION      CONTAINER-RUNTIME
575ddcd9f-fxvt5           Ready    <none>   39m   v1.25.5   21.1.3.3      21.1.3.3      Windows Server 2019 Datacenter   10.0.17763.2114     containerd://1.6.13
575ddcd9f-rpc9f           Ready    <none>   39m   v1.25.5   21.1.1.86     21.1.1.86     Windows Server 2019 Datacenter   10.0.17763.2114     containerd://1.6.13
575ddcd9f-vgsz6           Ready    <none>   38m   v1.25.5   21.1.2.235    21.1.2.235    Windows Server 2019 Datacenter   10.0.17763.2114     containerd://1.6.13
pool-1-6858948975-bhbls   Ready    <none>   40m   v1.25.5  21.1.0.157    21.1.0.157    Ubuntu 20.04.5 LTS               5.15.0-1015   containerd://1.6.12
pool-1-6858948975-h5jsg   Ready    <none>   40m   v1.25.5   21.1.2.228    21.1.2.228    Ubuntu 20.04.5 LTS               5.15.0-1015   containerd://1.6.12
pool-1-6858948975-ttznl   Ready    <none>   41m   v1.25.5   21.1.1.81     21.1.1.81     Ubuntu 20.04.5 LTS               5.15.0-1015   containerd://1.6.12
$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl get pods -o wide
NAME                              READY   STATUS    RESTARTS   AGE     IP            NODE              NOMINATED NODE   READINESS GATES
example-win-in-tree-ntfs-0        1/1     Running   0          11m     192.168.3.5   575ddcd9f-rpc9f   <none>           <none>
example-win-in-tree-ntfs-caps-0   1/1     Running   0          9m13s   192.168.4.7   575ddcd9f-fxvt5   <none>           <none>
$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl get pv -o wide
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                 STORAGECLASS             REASON   AGE    VOLUMEMODE
pvc-0df49d33-9781-48a1-8fd6-b2085285e6a3   5Gi        RWO            Delete           Bound    default/test-volume-example-win-in-tree-ntfs-0        standard-win-ntfs                 11m    Filesystem
pvc-2f38b6e7-7026-4af0-8217-27f12d96bbc7   5Gi        RWO            Delete           Bound    default/test-volume-example-win-in-tree-ntfs-caps-0   standard-win-ntfs-caps            9m3s   Filesystem
$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl get pv pvc-0df49d33-9781-48a1-8fd6-b2085285e6a3 -o yaml | grep fsType
    fsType: ntfs
$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl get pv pvc-2f38b6e7-7026-4af0-8217-27f12d96bbc7 -o yaml | grep fsType
    fsType: NTFS
$ 
```

2. Upgrade to k8s `1.26` and deploy vSphere CSI driver at `v3.0.0`
```
$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl get nodes -o wide
NAME                      STATUS   ROLES    AGE   VERSION            INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION      CONTAINER-RUNTIME
74566474f-4wjrr           Ready    <none>   40m   v1.26.2-gke.1000   21.1.1.71     21.1.1.71     Windows Server 2019 Datacenter   10.0.17763.2114     containerd://1.6.13-gke.1
74566474f-njnll           Ready    <none>   33m   v1.26.2-gke.1000   21.1.2.231    21.1.2.231    Windows Server 2019 Datacenter   10.0.17763.2114     containerd://1.6.13-gke.1
74566474f-sbncv           Ready    <none>   46m   v1.26.2-gke.1000   21.1.0.53     21.1.0.53     Windows Server 2019 Datacenter   10.0.17763.2114     containerd://1.6.13-gke.1
pool-1-6668f49f56-7sml6   Ready    <none>   45m   v1.26.1-gke.1501   21.1.0.253    21.1.0.253    Ubuntu 20.04.5 LTS               5.15.0-1015-gkeop   containerd://1.6.12
pool-1-6668f49f56-mbc99   Ready    <none>   30m   v1.26.1-gke.1501   21.1.0.193    21.1.0.193    Ubuntu 20.04.5 LTS               5.15.0-1015-gkeop   containerd://1.6.12
pool-1-6668f49f56-vmqfz   Ready    <none>   38m   v1.26.1-gke.1501   21.1.3.79     21.1.3.79     Ubuntu 20.04.5 LTS               5.15.0-1015-gkeop   containerd://1.6.12
$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl get pods -o wide
NAME                              READY   STATUS              RESTARTS   AGE     IP            NODE              NOMINATED NODE   READINESS GATES
example-win-in-tree-ntfs-0        1/1     Running             0          2m35s   192.168.8.9   74566474f-4wjrr   <none>           <none>
example-win-in-tree-ntfs-caps-0   0/1     ContainerCreating   0          33m     <none>        74566474f-sbncv   <none>           <none>
$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl describe pods example-win-in-tree-ntfs-caps-0
...
Events:
  Type     Reason              Age                   From                     Message
  ----     ------              ----                  ----                     -------
  Normal   Scheduled           33m                   default-scheduler        Successfully assigned default/example-win-in-tree-ntfs-caps-0 to 74566474f-sbncv
  Warning  FailedAttachVolume  21m (x14 over 33m)    attachdetach-controller  AttachVolume.Attach failed for volume "pvc-2f38b6e7-7026-4af0-8217-27f12d96bbc7" : rpc error: code = Internal desc = validation for PublishVolume Request: {VolumeId:[vsanDatastore] 548b5a60-38ca-d0d1-633c-bc97e1269700/kubernetes-dynamic-pvc-2f38b6e7-7026-4af0-8217-27f12d96bbc7.vmdk NodeId:74566474f-sbncv VolumeCapability:mount:<fs_type:"NTFS" > access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} has failed. Error: rpc error: code = InvalidArgument desc = volume capability not supported. Err: fstype NTFS not supported for ReadWriteOnce volume creation
  Warning  FailedMount         6m46s (x2 over 11m)   kubelet                  Unable to attach or mount volumes: unmounted volumes=[test-volume], unattached volumes=[kube-api-access-s8lcl test-volume]: timed out waiting for the condition
  Warning  FailedMount         2m12s (x12 over 31m)  kubelet                  Unable to attach or mount volumes: unmounted volumes=[test-volume], unattached volumes=[test-volume kube-api-access-s8lcl]: timed out waiting for the condition
  Warning  FailedAttachVolume  42s (x17 over 19m)    attachdetach-controller  AttachVolume.Attach failed for volume "pvc-2f38b6e7-7026-4af0-8217-27f12d96bbc7" : rpc error: code = Internal desc = validation for PublishVolume Request: {VolumeId:[vsanDatastore] 548b5a60-38ca-d0d1-633c-bc97e1269700/kubernetes-dynamic-pvc-2f38b6e7-7026-4af0-8217-27f12d96bbc7.vmdk NodeId:74566474f-sbncv VolumeCapability:mount:<fs_type:"NTFS" > access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} has failed. Error: rpc error: code = InvalidArgument desc = volume capability not supported. Err: fstype NTFS not supported for ReadWriteOnce volume creation
```

3. Deploy patched vSphere CSI driver. Now `example-win-in-tree-ntfs-caps-0` can start up.
```
$ KUBECONFIG=env/jrife-win-1/jrife-win-1-kubeconfig kubectl get pods -o wide
NAME                              READY   STATUS              RESTARTS   AGE   IP            NODE              NOMINATED NODE   READINESS GATES
example-win-in-tree-ntfs-0        1/1     Running             0          64m   192.168.8.9   74566474f-4wjrr   <none>           <none>
example-win-in-tree-ntfs-caps-0   1/1     Running             0          76s   192.168.6.8   74566474f-sbncv   <none>           <none>
```

**Special notes for your reviewer**: N/A

**Release note**: N/A