### PR TITLE
Update sidecar versions and cve fixes

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -251,7 +251,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -315,7 +315,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -355,7 +355,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -421,7 +421,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.2
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -506,7 +506,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -647,7 +647,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
PR intent to fix reported CVE's for csi sidecars.
This will update sidecar versions.

As reported CVE's fixed, creating new tag v2.7.2
[CVE-2022-41723](https://nvd.nist.gov/vuln/detail/CVE-2022-41723)
[CVE-2022-41721](https://nvd.nist.gov/vuln/detail/CVE-2022-41721)
[CVE-2022-27664](https://nvd.nist.gov/vuln/detail/CVE-2022-27664)
[CVE-2022-28948](https://nvd.nist.gov/vuln/detail/CVE-2022-28948)
[CVE-2022-21698](https://nvd.nist.gov/vuln/detail/CVE-2022-21698)
[CVE-2021-44716](https://nvd.nist.gov/vuln/detail/CVE-2021-44716)

**Testing done**:
running e2e test

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
PR will update sidecar versions.
```
