### PR TITLE
CSI driver changes to enable webhook on guest cluster 

### DIFF
--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -142,6 +142,9 @@ func StartWebhookServer(ctx context.Context) error {
 		featureGateVolumeHealthEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.VolumeHealth)
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
 		startCNSCSIWebhookManager(ctx)
+	} else if clusterFlavor == cnstypes.CnsClusterFlavorGuest {
+		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
+		startPVCSIWebhookManager(ctx)
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		if cfg == nil {
 			cfg, err = getWebHookConfig(ctx)

--- a/pkg/syncer/admissionhandler/pvcsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/pvcsi_admissionhandler.go
@@ -1,0 +1,98 @@
+package admissionhandler
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crConfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+const (
+	PVCSIValidationWebhookPath            = "/validate"
+	PVCSIDefaultWebhookPort               = 9883
+	PVCSIDefaultWebhookMetricsBindAddress = "0"
+	PVCSIWebhookTlsMinVersion             = "1.2"
+)
+
+func getPVCSIWebhookPort() int {
+	portStr, ok := os.LookupEnv("PVCSI_WEBHOOK_SERVICE_CONTAINER_PORT")
+	if !ok {
+		return DefaultWebhookPort
+	}
+
+	result, err := strconv.ParseInt(portStr, 0, 0)
+	if err != nil {
+		panic(fmt.Sprintf("malformed configuration: PVCSI_WEBHOOK_SERVICE_CONTAINER_PORT, expected int: %v", err))
+	}
+
+	return int(result)
+}
+
+func getPVCSIMetricsBindAddress() string {
+	metricsAddr, ok := os.LookupEnv("PVCSI_WEBHOOK_SERVICE_METRICS_BIND_ADDR")
+	if !ok {
+		return DefaultWebhookMetricsBindAddress
+	}
+
+	return metricsAddr
+}
+
+// startPVCSIWebhookManager starts the webhook server in guest cluster
+func startPVCSIWebhookManager(ctx context.Context) {
+	log := logger.GetLogger(ctx)
+
+	webhookPort := getPVCSIWebhookPort()
+	metricsBindAddress := getPVCSIMetricsBindAddress()
+	log.Infof("setting up webhook manager with webhookPort %v and metricsBindAddress %v",
+		webhookPort, metricsBindAddress)
+	mgr, err := manager.New(crConfig.GetConfigOrDie(), manager.Options{
+		MetricsBindAddress: metricsBindAddress,
+		Port:               webhookPort})
+	if err != nil {
+		log.Fatal(err, "unable to set up overall controller manager")
+	}
+
+	log.Infof("registering validating webhook with the endpoint %v", PVCSIValidationWebhookPath)
+	// we should not allow TLS < 1.2
+	mgr.GetWebhookServer().TLSMinVersion = PVCSIWebhookTlsMinVersion
+	mgr.GetWebhookServer().Register(PVCSIValidationWebhookPath, &webhook.Admission{Handler: &CSIGuestWebhook{
+		Client:       mgr.GetClient(),
+		clientConfig: mgr.GetConfig(),
+	}})
+
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		log.Fatal(err, "unable to run the webhook manager")
+	}
+}
+
+var _ admission.Handler = &CSIGuestWebhook{}
+
+type CSIGuestWebhook struct {
+	client.Client
+	clientConfig *rest.Config
+}
+
+func (h *CSIGuestWebhook) Handle(ctx context.Context, req admission.Request) (resp admission.Response) {
+	log := logger.GetLogger(ctx)
+	log.Debugf("PV-CSI validation webhook handler called with request: %+v", req)
+	defer log.Debugf("PV-CSI validation webhook handler completed for the request: %+v", req)
+
+	resp = admission.Allowed("")
+	if req.Kind.Kind == "PersistentVolumeClaim" {
+		if featureGateBlockVolumeSnapshotEnabled {
+			admissionResp := validatePVC(ctx, &req.AdmissionRequest)
+			resp.AdmissionResponse = *admissionResp.DeepCopy()
+		}
+	}
+	return
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CSI driver changes to enable webhook on guest cluster to prevent DeleteVolume and ExpandVolume operation if volume has snapshots.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified on guest cluster that webhook is working as expected for volumes having volume snapshot. Currently manually added webhook controller on guest cluster for testing purpose. It will be added using tkg-packages and bolt through separate PRs.

```
# kubectl get pvc
NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
example-vanilla-rwo-pvc1   Bound    pvc-3720d155-a4bc-4620-8f59-1be06842a535   1Gi        RWO            example-sc     3m41s

# kubectl get vs
NAME                                      READYTOUSE   SOURCEPVC                  SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                                  SNAPSHOTCONTENT                                    CREATIONTIME   AGE
example-vanilla-rwo-filesystem-snapshot   false        example-vanilla-rwo-pvc1                                         example-vanilla-rwo-filesystem-snapshotclass   snapcontent-23dd76c7-1e39-4c1e-8dd3-60b4915cc3c2                  7m10s

// Volume expansion and deletion is not allowed for volumes having snapshots

# kubectl edit pvc example-vanilla-rwo-pvc1
error: persistentvolumeclaims "example-vanilla-rwo-pvc1" could not be patched: admission webhook "validation.csi.vsphere.vmware.com" denied the request: Expanding volume with snapshots is not allowed
You can run `kubectl replace -f /tmp/kubectl-edit-2764807617.yaml` to try this update again.

# kubectl delete pvc example-vanilla-rwo-pvc1
Error from server (Deleting volume with snapshots is not allowed): admission webhook "validation.csi.vsphere.vmware.com" denied the request: Deleting volume with snapshots is not allowed

# kubectl get pvc
example-vanilla-rwo-pvc2   Bound    pvc-6dfd678d-5176-4d03-ae4e-fe9c2df68903   1Gi        RWO            example-sc     32s

// Volume deletion successful for volume which doesn't have any snapshot

# kubectl delete pvc example-vanilla-rwo-pvc2
persistentvolumeclaim "example-vanilla-rwo-pvc2" deleted
```

**Special notes for your reviewer**:

**Release note**:
```release-note
CSI driver changes to enable webhook on guest cluster 
```
