### PR TITLE
Cherrypick PR 2192 - Remove service mode check for consistent fss checking across all CSI containers

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -987,25 +987,23 @@ func (c *K8sOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) 
 				featureName, c.internalFSS.configMapName)
 			return false
 		}
-		if serviceMode != "node" {
-			// Check SV FSS map.
-			if flag, ok := c.supervisorFSS.featureStates[featureName]; ok {
-				supervisorFeatureState, err := strconv.ParseBool(flag)
-				if err != nil {
-					log.Errorf("Error while converting %v feature state value: %v to boolean. "+
-						"Setting the feature state to false", featureName, supervisorFeatureState)
-					return false
-				}
-				if !supervisorFeatureState {
-					// If FSS set to false, return.
-					log.Infof("%s feature state set to false in %s ConfigMap", featureName, c.supervisorFSS.configMapName)
-					return supervisorFeatureState
-				}
-			} else {
-				log.Debugf("Could not find the %s feature state in ConfigMap %s. Setting the feature state to false",
-					featureName, c.supervisorFSS.configMapName)
+		// Check SV FSS map.
+		if flag, ok := c.supervisorFSS.featureStates[featureName]; ok {
+			supervisorFeatureState, err := strconv.ParseBool(flag)
+			if err != nil {
+				log.Errorf("Error while converting %v feature state value: %v to boolean. "+
+					"Setting the feature state to false", featureName, supervisorFeatureState)
 				return false
 			}
+			if !supervisorFeatureState {
+				// If FSS set to false, return.
+				log.Infof("%s feature state set to false in %s ConfigMap", featureName, c.supervisorFSS.configMapName)
+				return supervisorFeatureState
+			}
+		} else {
+			log.Debugf("Could not find the %s feature state in ConfigMap %s. Setting the feature state to false",
+				featureName, c.supervisorFSS.configMapName)
+			return false
 		}
 		return true
 	}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherrypicks #2192 to release-2.7

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Available on the original PR

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherrypicks https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2192 to release-2.7
```
