### PR TITLE
Set initialDelaySeconds to 30 seconds and periodSeconds to 180 for livenessprobe and enable leader election for syncer

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus"
@@ -49,8 +50,17 @@ const operationModeMetaDataSync = "METADATA_SYNC"
 
 var (
 	enableLeaderElection    = flag.Bool("leader-election", false, "Enable leader election.")
-	leaderElectionNamespace = flag.String("leader-election-namespace", "",
-		"Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")
+	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace where the leader "+
+		"election resource lives. Defaults to the pod namespace if not set.")
+	leaderElectionLeaseDuration = flag.Duration("leader-election-lease-duration", 15*time.Second,
+		"Duration, in seconds, that non-leader candidates will wait to force acquire leadership. "+
+			"Defaults to 15 seconds.")
+	leaderElectionRenewDeadline = flag.Duration("leader-election-renew-deadline", 10*time.Second,
+		"Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. "+
+			"Defaults to 10 seconds.")
+	leaderElectionRetryPeriod = flag.Duration("leader-election-retry-period", 5*time.Second,
+		"Duration in seconds, the LeaderElector clients should wait between tries of actions. "+
+			"Defaults to 5 seconds.")
 	printVersion  = flag.Bool("version", false, "Print syncer version and exit")
 	operationMode = flag.String("operation-mode", operationModeMetaDataSync,
 		"specify operation mode METADATA_SYNC or WEBHOOK_SERVER")
@@ -139,6 +149,10 @@ func main() {
 			if *leaderElectionNamespace != "" {
 				le.WithNamespace(*leaderElectionNamespace)
 			}
+
+			le.WithLeaseDuration(*leaderElectionLeaseDuration)
+			le.WithRenewDeadline(*leaderElectionRenewDeadline)
+			le.WithRetryPeriod(*leaderElectionRetryPeriod)
 
 			if err := le.Run(); err != nil {
 				log.Fatalf("Error initializing leader election: %v", err)

--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -194,6 +194,16 @@ spec:
             - containerPort: 2112
               name: prometheus
               protocol: TCP
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 180
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/manifests/guestcluster/1.23/pvcsi.yaml
+++ b/manifests/guestcluster/1.23/pvcsi.yaml
@@ -249,6 +249,9 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
             - "--supervisor-fss-name=csi-feature-states"
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/guestcluster/1.23/pvcsi.yaml
+++ b/manifests/guestcluster/1.23/pvcsi.yaml
@@ -197,6 +197,16 @@ spec:
             - containerPort: 2112
               name: prometheus
               protocol: TCP
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 180
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/manifests/guestcluster/1.24/pvcsi.yaml
+++ b/manifests/guestcluster/1.24/pvcsi.yaml
@@ -200,6 +200,16 @@ spec:
             - containerPort: 2112
               name: prometheus
               protocol: TCP
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 180
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/manifests/guestcluster/1.24/pvcsi.yaml
+++ b/manifests/guestcluster/1.24/pvcsi.yaml
@@ -252,6 +252,9 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
             - "--supervisor-fss-name=csi-feature-states"
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/guestcluster/1.25/pvcsi.yaml
+++ b/manifests/guestcluster/1.25/pvcsi.yaml
@@ -200,6 +200,16 @@ spec:
             - containerPort: 2112
               name: prometheus
               protocol: TCP
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 180
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/manifests/guestcluster/1.25/pvcsi.yaml
+++ b/manifests/guestcluster/1.25/pvcsi.yaml
@@ -252,6 +252,9 @@ spec:
           image: vmware.io/syncer:<image_tag>
           args:
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
             - "--supervisor-fss-name=csi-feature-states"
             - "--supervisor-fss-namespace=$(CSI_NAMESPACE)"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -355,6 +355,9 @@ spec:
           image: localhost:5000/vmware/syncer:<syncer_ver>
           args:
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -353,6 +353,9 @@ spec:
           image: localhost:5000/vmware/syncer:<syncer_ver>
           args:
             - "--leader-election"
+            - "--leader-election-lease-duration=120s"
+            - "--leader-election-renew-deadline=60s"
+            - "--leader-election-retry-period=30s"
           env:
             - name: CLUSTER_FLAVOR
               value: "WORKLOAD"


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Sets initialDelaySeconds to 30 seconds and periodSeconds to 180 for livenessprobe in pvcsi controller container

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
After setting the values in the pvcsi controller:
```
kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS      AGE
vsphere-csi-controller-7ddcf4d5c4-qflkn   6/6     Running   0             116s
vsphere-csi-node-5nbgx                    3/3     Running   0             12d
vsphere-csi-node-cgzcr                    3/3     Running   0             12d
vsphere-csi-node-fzj4v                    3/3     Running   0             11d
vsphere-csi-node-hxb9t                    3/3     Running   2 (12d ago)   12d
vsphere-csi-node-rr5td                    3/3     Running   0             12d
vsphere-csi-node-sfdht                    3/3     Running   0             11d
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Set initialDelaySeconds to 30 seconds and periodSeconds to 180 for livenessprobe in pvcsi controller container
```
