### PR TITLE
Wait for 2 full sync cycles to delete volumeInfo CRs

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -221,6 +221,8 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 	cnsCreationMap = make(map[string]map[string]bool)
 	// Initialize volumeOperationsLock map
 	volumeOperationsLock = make(map[string]*sync.Mutex)
+	// Initialize volumeInfoCrDeletionMap used by Full Sync.
+	volumeInfoCrDeletionMap = make(map[string]map[string]bool)
 
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		// Initialize client to supervisor cluster, if metadata syncer is being
@@ -250,6 +252,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 
 		cnsDeletionMap[metadataSyncer.host] = make(map[string]bool)
 		cnsCreationMap[metadataSyncer.host] = make(map[string]bool)
+		volumeInfoCrDeletionMap[metadataSyncer.host] = make(map[string]bool)
 		volumeOperationsLock[metadataSyncer.host] = &sync.Mutex{}
 
 		volumeManager, err := volumes.GetManager(ctx, vCenter, nil,
@@ -289,6 +292,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 
 			cnsDeletionMap[metadataSyncer.host] = make(map[string]bool)
 			cnsCreationMap[metadataSyncer.host] = make(map[string]bool)
+			volumeInfoCrDeletionMap[metadataSyncer.host] = make(map[string]bool)
 			volumeOperationsLock[metadataSyncer.host] = &sync.Mutex{}
 
 			volumeManager, err := volumes.GetManager(ctx, vCenter, nil, false, false, false, tasksListViewEnabled)
@@ -322,6 +326,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				metadataSyncer.volumeManagers[vcconfig.Host] = volumeManager
 				cnsDeletionMap[vcconfig.Host] = make(map[string]bool)
 				cnsCreationMap[vcconfig.Host] = make(map[string]bool)
+				volumeInfoCrDeletionMap[vcconfig.Host] = make(map[string]bool)
 				volumeOperationsLock[vcconfig.Host] = &sync.Mutex{}
 			}
 			// If it is a multi VC deployment, initialize volumeInfoService

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -87,6 +87,11 @@ var (
 	// static provisioning of volumes
 	// There is a separate lock for each VC.
 	volumeOperationsLock map[string]*sync.Mutex
+
+	// volumeInfoCrDeletionMap tracks CRs for volumes that exist in
+	// the cluster but the corresponding PV for that volume does not exist.
+	// A separate map is maintained for each VC.
+	volumeInfoCrDeletionMap map[string]map[string]bool
 )
 
 type (


### PR DESCRIPTION
**What this PR does / why we need it**:
It is possible that a PV gets created during full sync. In such a case we must not assume that a PV does not exist (because full sync has stale values) and end up deleting its CR. It should instead wait for 2 full sync cycles and only then delete it.

**Testing done**:
VANILLA:


To test volumeInfoCR full sync, followed the following steps:
DeleteCR testing:
1. Create a volume -> this automatically created its volumeInfo CR.
2. Disable multi VC FSS and delete the above created PV. The CR will not get deleted yet as the FSSis disabled.
3. Enable the FSS and check that the CR gets deleted after 2 full sync cycles.

CreateCR testing:
1. Disable multi VC FSS and create a volume. CR will not be created as the FSS is diabled.
2. Now enable the FSS and make sure the CR is created immediately by the full sync.



Tested full sync create by deleting a volume from CNS:

```
2023-04-11T12:52:39.831Z	DEBUG	syncer/fullsync.go:286	FullSync for VC 10.218.140.70: cnsCreationMap at end of cycle: map[10.218.140.70:map[62b0c7cf-1b1a-4738-a809-849966fcbf30:true]]
 (string) (len=36) "62b0c7cf-1b1a-4738-a809-849966fcbf30": ([]types.BaseCnsEntityMetadata) (len=2 cap=2) {
2023-04-11T12:54:39.843Z	INFO	syncer/fullsync.go:741	FullSync for VC 10.218.140.70: create is required for volume: "62b0c7cf-1b1a-4738-a809-849966fcbf30"
2023-04-11T12:54:39.848Z	DEBUG	syncer/fullsync.go:418	FullSync for VC 10.218.140.70: Calling CreateVolume for volume id: "62b0c7cf-1b1a-4738-a809-849966fcbf30" with createSpec (types.CnsVolumeCreateSpec) {
  BackingDiskId: (string) (len=36) "62b0c7cf-1b1a-4738-a809-849966fcbf30",
2023-04-11T12:54:44.461Z	INFO	volume/util.go:326	Volume created successfully. VolumeName: "pvc-346aab3d-0dbd-41e3-ba25-6891af6e3871", volumeID: "62b0c7cf-1b1a-4738-a809-849966fcbf30"
2023-04-11T12:54:44.461Z	DEBUG	volume/util.go:328	CreateVolume volumeId {{} "62b0c7cf-1b1a-4738-a809-849966fcbf30"} is placed on datastore ""
2023-04-11T12:54:44.462Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:152	creating cnsvolumeinfo for volumeID: "62b0c7cf-1b1a-4738-a809-849966fcbf3" and vCenter: "10.218.140.70" mapping in the namespace: "vmware-system-csi"
2023-04-11T12:54:44.497Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:170	cnsvolumeInfo CR already exists for VolumeID: "62b0c7cf-1b1a-4738-a809-849966fcbf30"
```

Tested full sync delete volume:

```
root@k8s-control-806-1680773753:~# kubectl logs vsphere-csi-controller-548b654fc7-zjb2l -n vmware-system-csi -c vsphere-syncer | grep "7e547c58-2d2b-43d0-a1e0-bacbbe651465"
2023-04-11T12:46:39.873Z	INFO	syncer/fullsync.go:907	FullSync for VC 10.218.140.70: Volume with id "7e547c58-2d2b-43d0-a1e0-bacbbe651465" added to cnsDeletionMap
2023-04-11T12:46:39.875Z	DEBUG	syncer/fullsync.go:285	FullSync for VC 10.218.140.70: cnsDeletionMap at end of cycle: map[10.218.140.70:map[7e547c58-2d2b-43d0-a1e0-bacbbe651465:true]]
2023-04-11T12:48:39.866Z	DEBUG	syncer/fullsync.go:900	FullSync for VC 10.218.140.70: Volume with id 7e547c58-2d2b-43d0-a1e0-bacbbe651465 added to delete list
2023-04-11T12:48:39.868Z	DEBUG	syncer/util.go:158	FullSync: fullSyncGetQueryResults is called with volumeIds [{{} 7e547c58-2d2b-43d0-a1e0-bacbbe651465}] for clusterID 
    Id: (string) (len=36) "7e547c58-2d2b-43d0-a1e0-bacbbe651465"
    BackingDiskId: (string) (len=36) "7e547c58-2d2b-43d0-a1e0-bacbbe651465",
2023-04-11T12:48:39.976Z	INFO	syncer/fullsync.go:515	FullSync for VC 10.218.140.70: fullSyncDeleteVolumes: Calling DeleteVolume for volume 7e547c58-2d2b-43d0-a1e0-bacbbe651465 with delete disk false
2023-04-11T12:48:41.893Z	INFO	volume/manager.go:1102	DeleteVolume: volumeID: "7e547c58-2d2b-43d0-a1e0-bacbbe651465", opId: "05d91485"
2023-04-11T12:48:41.895Z	INFO	volume/manager.go:1121	DeleteVolume: Volume deleted successfully. volumeID: "7e547c58-2d2b-43d0-a1e0-bacbbe651465", opId: "05d91485"
2023-04-11T12:48:41.895Z	DEBUG	volume/manager.go:1052	internalDeleteVolume: returns fault "" for volume "7e547c58-2d2b-43d0-a1e0-bacbbe651465"
2023-04-11T12:48:41.929Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:190	volumeInfoCR is already deleted for volumeID: "7e547c58-2d2b-43d0-a1e0-bacbbe651465"
```