### PR TITLE
TKGS-HA static provisioning across GC 

### DIFF
--- a/tests/e2e/tkgs_ha.go
+++ b/tests/e2e/tkgs_ha.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -59,6 +60,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		isSPSServiceStopped        bool
 		sshWcpConfig               *ssh.ClientConfig
 		svcMasterIp                string
+		clientNewGc                clientset.Interface
 	)
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
@@ -101,7 +103,6 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 			svcClient, svNamespace := getSvcClientAndNamespace()
 			setResourceQuota(svcClient, svNamespace, rqLimit)
 		}
-
 	})
 
 	/*
@@ -2768,4 +2769,268 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 				volumeHandles[i], pods[i], pvs[i], f)
 		}
 	})
+
+	/*
+		Static volume provisioning using zonal storage
+		1. Create a zonal storage policy, on the datastore that is shared only to specific cluster
+		2. Use the Zonal storage class and Immediate binding mode
+		3. Create svcpvc and wait for it to bound
+		4. switch to gc1 and statically create PV and PVC pointing to svc-pvc
+		5. Verify topology details on PV
+		6. Delete GC1 PVC
+		7. switch to GC2
+		8. Create static pvc on gc2PVC point to svc-pvc
+		9. Verify the node affinity of gc1-pv and svc-pv
+		9. Create POD, verify the status.
+		10. Wait  for the PODs to reach running state - make sure Pod scheduled on
+		   appropriate nodes preset in the availability zone
+		10. Delete pod, gc1-pv and gc1-pvc and svc pvc.
+	*/
+	ginkgo.It("tkgs-ha Verify static provisioning across Guest Clusters", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		newGcKubconfigPath := os.Getenv("NEW_GUEST_CLUSTER_KUBE_CONFIG")
+		if newGcKubconfigPath == "" {
+			ginkgo.Skip("Env NEW_GUEST_CLUSTER_KUBE_CONFIG is missing")
+		}
+
+		svClient, svNamespace := getSvcClientAndNamespace()
+		pvcAnnotations := make(map[string]string)
+		annotationVal := "["
+		var topoList []string
+
+		for key, val := range allowedTopologyHAMap {
+			for _, topoVal := range val {
+				str := `{"` + key + `":"` + topoVal + `"}`
+				topoList = append(topoList, str)
+			}
+		}
+		framework.Logf("topoList: %v", topoList)
+		annotationVal += strings.Join(topoList, ",") + "]"
+		pvcAnnotations[tkgHARequestedAnnotationKey] = annotationVal
+		framework.Logf("annotationVal :%s, pvcAnnotations: %v", annotationVal, pvcAnnotations)
+
+		ginkgo.By("Creating Pvc with Immediate topology storageclass")
+		createResourceQuota(client, namespace, rqLimit, zonalPolicy)
+		scParameters[svStorageClassName] = zonalPolicy
+		storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		pvcSpec := getPersistentVolumeClaimSpecWithStorageClass(svNamespace, "", storageclass, nil, "")
+		pvcSpec.Annotations = pvcAnnotations
+		svPvclaim, err := svClient.CoreV1().PersistentVolumeClaims(svNamespace).Create(context.TODO(),
+			pvcSpec, metav1.CreateOptions{})
+		svcPVCName := svPvclaim.Name
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isSVCPvcCreated := true
+
+		ginkgo.By("Wait for SV PVC to come to bound state")
+		svcPv, err := fpv.WaitForPVClaimBoundPhase(svClient, []*v1.PersistentVolumeClaim{svPvclaim},
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		volumeID := svPvclaim.Name
+		staticPVLabels := make(map[string]string)
+		staticPVLabels["fcd-id"] = volumeID
+
+		framework.Logf("PVC name in SV " + svcPVCName)
+		pvcUID := string(svPvclaim.GetUID())
+		framework.Logf("PVC UUID in GC " + pvcUID)
+		gcClusterID := strings.Replace(svcPVCName, pvcUID, "", -1)
+
+		framework.Logf("gcClusterId " + gcClusterID)
+		pv := getPvFromClaim(svClient, svPvclaim.Namespace, svPvclaim.Name)
+		pvUID := string(pv.UID)
+		framework.Logf("PV uuid " + pvUID)
+
+		defer func() {
+			if isSVCPvcCreated {
+				err := fpv.DeletePersistentVolumeClaim(svClient, svcPVCName, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = fpv.DeletePersistentVolume(svClient, pv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			isSVCPvcCreated = false
+		}()
+
+		// Get allowed topologies for zonal storage
+		allowedTopologies := getTopologySelector(allowedTopologyHAMap, categories,
+			tkgshaTopologyLevels)
+
+		ginkgo.By("Creating the PV")
+		staticPv := getPersistentVolumeSpecWithStorageClassFCDNodeSelector(volumeID,
+			v1.PersistentVolumeReclaimRetain, storageclass.Name, staticPVLabels,
+			diskSize, allowedTopologies)
+		staticPv, err = client.CoreV1().PersistentVolumes().Create(ctx, staticPv, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Creating the PVC")
+		staticPvc := getPersistentVolumeClaimSpec(namespace, staticPVLabels, staticPv.Name)
+		staticPvc.Spec.StorageClassName = &storageclass.Name
+		staticPvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, staticPvc, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isGC1PvcCreated := true
+
+		// Wait for PV and PVC to Bind.
+		framework.ExpectNoError(fpv.WaitOnPVandPVC(client, framework.NewTimeoutContextWithDefaults(),
+			namespace, staticPv, staticPvc))
+
+		defer func() {
+			if isGC1PvcCreated {
+				err := fpv.DeletePersistentVolumeClaim(client, staticPvc.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = fpv.DeletePersistentVolume(client, staticPv.Name)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				ginkgo.By("Verify PVs, volumes are deleted from CNS")
+				err = fpv.WaitForPersistentVolumeDeleted(client, staticPv.Name, framework.Poll,
+					framework.PodDeleteTimeout)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(volumeID)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+					fmt.Sprintf("Volume: %s should not be present in the CNS after it is deleted from "+
+						"kubernetes", volumeID))
+				ginkgo.By("Verify volume is deleted in Supervisor Cluster")
+				volumeExists := verifyVolumeExistInSupervisorCluster(svcPv[0].Spec.CSI.VolumeHandle)
+				gomega.Expect(volumeExists).To(gomega.BeFalse())
+			}
+			isGC1PvcCreated = false
+
+		}()
+
+		ginkgo.By("Verify SV storageclass points to GC storageclass")
+		gomega.Expect(*svPvclaim.Spec.StorageClassName == storageclass.Name).To(
+			gomega.BeTrue(), "SV storageclass does not match with gc storageclass")
+		framework.Logf("GC PVC's storageclass matches SVC PVC's storageclass")
+
+		ginkgo.By("Verify GV PV has has required PV node affinity details")
+		_, err = verifyVolumeTopologyForLevel5(staticPv, allowedTopologyHAMap)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		framework.Logf("GC PV: %s has required Pv node affinity details", staticPv.Name)
+
+		ginkgo.By("Verify SV PV has has required PV node affinity details")
+		_, err = verifyVolumeTopologyForLevel5(svcPv[0], allowedTopologyHAMap)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		framework.Logf("SVC PV: %s has required PV node affinity details", svcPv[0].Name)
+		time.Sleep(time.Duration(60) * time.Second)
+
+		ginkgo.By("Delete PVC in GC1")
+		err = fpv.DeletePersistentVolumeClaim(client, staticPvc.Name, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isGC1PvcCreated = false
+
+		err = fpv.DeletePersistentVolume(client, staticPv.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verifying if volume still exists in the Supervisor Cluster")
+		// svcPVCName refers to PVC Name in the supervisor cluster.
+		volumeID = getVolumeIDFromSupervisorCluster(svPvclaim.Name)
+		gomega.Expect(volumeID).NotTo(gomega.BeEmpty())
+		pvAnnotations := svcPv[0].Annotations
+		pvSpec := svcPv[0].Spec.CSI
+		pvStorageClass := svcPv[0].Spec.StorageClassName
+
+		newGcKubconfigPath = os.Getenv("NEW_GUEST_CLUSTER_KUBE_CONFIG")
+		if newGcKubconfigPath == "" {
+			ginkgo.Skip("Env NEW_GUEST_CLUSTER_KUBE_CONFIG is missing")
+		}
+		clientNewGc, err = createKubernetesClientFromConfig(newGcKubconfigPath)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			fmt.Sprintf("Error creating k8s client with %v: %v", newGcKubconfigPath, err))
+		ginkgo.By("Creating namespace on second GC")
+		ns, err := framework.CreateTestingNS(f.BaseName, clientNewGc, map[string]string{
+			"e2e-framework": f.BaseName,
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Error creating namespace on second GC")
+
+		namespaceNewGC := ns.Name
+		framework.Logf("Created namespace on second GC %v", namespaceNewGC)
+		defer func() {
+			err := clientNewGc.CoreV1().Namespaces().Delete(ctx, namespaceNewGC, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Getting ready nodes on GC 2")
+		nodeList, err := fnodes.GetReadySchedulableNodes(clientNewGc)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		gomega.Expect(len(nodeList.Items)).NotTo(gomega.BeZero(), "Unable to find ready and schedulable Node")
+
+		ginkgo.By("Creating PVC in New GC with the vol handle from SVC")
+		scParameters = make(map[string]string)
+		scParameters[scParamFsType] = ext4FSType
+		scParameters[svStorageClassName] = storageclass.Name
+		storageclassNewGC, err := clientNewGc.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		pvcNew, err := createPVC(clientNewGc, namespaceNewGC, nil, "", storageclassNewGC, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var pvcs []*v1.PersistentVolumeClaim
+		pvcs = append(pvcs, pvcNew)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(clientNewGc, pvcs, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pvNewGC := getPvFromClaim(clientNewGc, pvcNew.Namespace, pvcNew.Name)
+		volumeIDNewGC := pvNewGC.Spec.CSI.VolumeHandle
+		svcNewPVCName := volumeIDNewGC
+		volumeIDNewGC = getVolumeIDFromSupervisorCluster(svcNewPVCName)
+		gomega.Expect(volumeIDNewGC).NotTo(gomega.BeEmpty())
+
+		framework.Logf("PVC name in SV " + svcNewPVCName)
+		pvcNewUID := string(pvcNew.GetUID())
+		framework.Logf("pvcNewUID in GC " + pvcNewUID)
+		gcNewClusterID := strings.Replace(svcNewPVCName, pvcNewUID, "", -1)
+		framework.Logf("pvNew uuid " + gcNewClusterID)
+
+		ginkgo.By("Creating PV in new guest cluster with volume handle from SVC")
+		pvNew := getPersistentVolumeSpec(svPvclaim.Name, v1.PersistentVolumeReclaimDelete, nil, ext4FSType)
+		pvNew.Annotations = pvAnnotations
+		pvNew.Spec.StorageClassName = pvStorageClass
+		pvNew.Spec.CSI = pvSpec
+		pvNew.Spec.CSI.VolumeHandle = svPvclaim.Name
+		pvNew, err = clientNewGc.CoreV1().PersistentVolumes().Create(ctx, pvNew, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pvNewUID := string(pvNew.UID)
+		framework.Logf("pvNew uuid " + pvNewUID)
+
+		defer func() {
+			ginkgo.By("Delete PVC in GC2")
+			err = fpv.DeletePersistentVolumeClaim(clientNewGc, pvcNew.Name, namespaceNewGC)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = fpv.DeletePersistentVolume(clientNewGc, pvNew.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create a pod and verify pod gets scheduled on appropriate " +
+			"nodes preset in the availability zone")
+		pod, err := createPod(clientNewGc, namespaceNewGC, nil, []*v1.PersistentVolumeClaim{pvcNew}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		_, err = verifyPodLocationLevel5(pod, nodeList, allowedTopologyHAMap)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer func() {
+			ginkgo.By("Delete pod")
+			err = fpod.DeletePodWithWait(clientNewGc, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify volume is detached from the node")
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(clientNewGc,
+				staticPv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q",
+					staticPv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		}()
+
+	})
+
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
TKGS-HA static provisioning across GC


**Testing done**:
Yes 
https://gist.github.com/kavyashree-r/e6d5ce4235dceb13c772e60f2f94ccfa

```
kramachandFJGH5:vsphere-csi-driver kramachandra$ make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/kramachandra/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/kramachandra/github/2ndSet/vsphere-csi-driver /Users/kramachandra/github/2ndSet /Users/kramachandra/github /Users/kramachandra /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (name|deps|exports_file|files|imports|types_sizes|compiled_files) took 9.609091519s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 168.227813ms 
INFO [linters context/goanalysis] analyzers took 1m59.304932287s with top 10 stages: buildir: 1m15.981626294s, S1038: 2.942536353s, misspell: 2.329383418s, nilness: 1.690210191s, printf: 1.204045895s, unused: 1.168309393s, S1039: 1.135791122s, SA4030: 1.082607539s, SA1012: 944.585409ms, S1028: 896.554827ms 
INFO [runner] Issues before processing: 55, after processing: 0 
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 55/55, nolint: 0/1, skip_dirs: 55/55, identifier_marker: 24/24, path_prettifier: 55/55, autogenerated_exclude: 24/55, exclude-rules: 1/24, cgo: 55/55, skip_files: 55/55, exclude: 24/24 
INFO [runner] processing took 17.662688ms with stages: nolint: 14.112813ms, autogenerated_exclude: 2.482984ms, path_prettifier: 590.286µs, identifier_marker: 288.159µs, skip_dirs: 111.689µs, exclude-rules: 61.06µs, cgo: 7.322µs, filename_unadjuster: 3.849µs, max_same_issues: 1.43µs, uniq_by_line: 578ns, max_from_linter: 329ns, skip_files: 290ns, path_shortener: 290ns, source_code: 285ns, diff: 257ns, max_per_file_from_linter: 237ns, severity-rules: 222ns, exclude: 222ns, sort_results: 212ns, path_prefixer: 174ns 
INFO [runner] linters took 17.66367405s with stages: goanalysis_metalinter: 17.645919868s 
INFO File cache stats: 305 entries of total size 5.9MiB 
INFO Memory: 270 samples, avg is 683.0MB, max is 1746.5MB 
INFO Execution took 27.456643014s         
```        

**Special notes for your reviewer**:

