### PR TITLE
Update logic for disabling snapshot creation directly initiated on supervisor cluster

### DIFF
--- a/manifests/supervisorcluster/1.21/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.21/cns-csi.yaml
@@ -508,7 +508,7 @@ webhooks:
         scope: "Namespaced"
       - apiGroups:   ["snapshot.storage.k8s.io"]
         apiVersions: ["v1"]
-        operations:  ["CREATE", "UPDATE", "DELETE"]
+        operations:  ["CREATE"]
         resources:   ["volumesnapshots"]
         scope:       "Namespaced"
     sideEffects: None

--- a/manifests/supervisorcluster/1.22/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.22/cns-csi.yaml
@@ -517,7 +517,7 @@ webhooks:
         scope: "Namespaced"
       - apiGroups:   ["snapshot.storage.k8s.io"]
         apiVersions: ["v1"]
-        operations:  ["CREATE", "UPDATE", "DELETE"]
+        operations:  ["CREATE"]
         resources:   ["volumesnapshots"]
         scope:       "Namespaced"
     sideEffects: None

--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -521,7 +521,7 @@ webhooks:
         scope: "Namespaced"
       - apiGroups:   ["snapshot.storage.k8s.io"]
         apiVersions: ["v1"]
-        operations:  ["CREATE", "UPDATE", "DELETE"]
+        operations:  ["CREATE"]
         resources:   ["volumesnapshots"]
         scope:       "Namespaced"
     sideEffects: None

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -524,7 +524,7 @@ webhooks:
         scope: "Namespaced"
       - apiGroups:   ["snapshot.storage.k8s.io"]
         apiVersions: ["v1"]
-        operations:  ["CREATE", "UPDATE", "DELETE"]
+        operations:  ["CREATE"]
         resources:   ["volumesnapshots"]
         scope:       "Namespaced"
     sideEffects: None

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -521,7 +521,7 @@ webhooks:
         scope: "Namespaced"
       - apiGroups:   ["snapshot.storage.k8s.io"]
         apiVersions: ["v1"]
-        operations:  ["CREATE", "UPDATE", "DELETE"]
+        operations:  ["CREATE"]
         resources:   ["volumesnapshots"]
         scope:       "Namespaced"
     sideEffects: None

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -312,6 +312,11 @@ const (
 	// on the VolumeSnapshot CR
 	VolumeSnapshotInfoKey = "csi.vsphere.volume/snapshot"
 
+	// SupervisorVolumeSnapshotAnnotationKey represents the annotation key on VolumeSnapshot CR
+	// in Supervisor cluster which is used to indicate that snapshot operation is initiated from
+	// Guest cluster.
+	SupervisorVolumeSnapshotAnnotationKey = "csi.vsphere.guest-initiated-csi-snapshot"
+
 	// AttributeSupervisorVolumeSnapshotClass represents name of VolumeSnapshotClass
 	AttributeSupervisorVolumeSnapshotClass = "svvolumesnapshotclass"
 

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -1403,8 +1403,12 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 		if err != nil {
 			if errors.IsNotFound(err) {
 				// New createSnapshot request on the guest
+				// Add "csi.vsphere.guest-initiated-csi-snapshot" annotation on VolumeSnapshot CR in
+				// the supervisor cluster to indicate that snapshot creation is initiated from Guest cluster
+				annotation := make(map[string]string)
+				annotation[common.SupervisorVolumeSnapshotAnnotationKey] = "true"
 				supVolumeSnapshot := constructVolumeSnapshotWithVolumeSnapshotClass(supervisorVolumeSnapshotName,
-					c.supervisorNamespace, supervisorVolumeSnapshotClass, supervisorPVCName)
+					c.supervisorNamespace, supervisorVolumeSnapshotClass, supervisorPVCName, annotation)
 				log.Infof("Supervisosr VolumeSnapshot Spec: %+v", supVolumeSnapshot)
 				_, err = c.supervisorSnapshotterClient.SnapshotV1().VolumeSnapshots(
 					c.supervisorNamespace).Create(ctx, supVolumeSnapshot, metav1.CreateOptions{})

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -228,11 +228,12 @@ func getPersistentVolumeClaimSpecWithStorageClass(pvcName string, namespace stri
 }
 
 func constructVolumeSnapshotWithVolumeSnapshotClass(volumeSnapshotName string, namespace string,
-	volumeSnapshotClassName string, pvcName string) *snap.VolumeSnapshot {
+	volumeSnapshotClassName string, pvcName string, annotation map[string]string) *snap.VolumeSnapshot {
 	volumeSnapshot := &snap.VolumeSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      volumeSnapshotName,
-			Namespace: namespace,
+			Name:        volumeSnapshotName,
+			Namespace:   namespace,
+			Annotations: annotation,
 		},
 		Spec: snap.VolumeSnapshotSpec{
 			Source: snap.VolumeSnapshotSource{

--- a/pkg/syncer/admissionhandler/validatesnapshotoperationsupervisorrequest.go
+++ b/pkg/syncer/admissionhandler/validatesnapshotoperationsupervisorrequest.go
@@ -3,28 +3,26 @@ package admissionhandler
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 
 	snap "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 )
 
 const (
-	SnapshotOperationNotAllowed = "Snapshot operation initiated directly from the Supervisor cluster by user " +
-		"%s is not supported. Please initiate snapshot operation from the Guest cluster."
+	SnapshotOperationNotAllowed = "Snapshot creation initiated directly from the Supervisor cluster " +
+		"is not supported. Please initiate snapshot creation from the Guest cluster."
 )
 
 // Disallow any opertion on volume snapshot initiated by user directly on the supervisor cluster.
 // Currently we only allow snapshot operation initiated from the guest cluster.
 func validateSnapshotOperationSupervisorRequest(ctx context.Context, request admission.Request) admission.Response {
 	log := logger.GetLogger(ctx)
-	username := request.UserInfo.Username
-	isCSIServiceAccount := validateCSIServiceAccount(request.UserInfo.Username)
-	log.Debugf("validateSnapshotOperationSupervisorRequest called with the request %v by user: %v", request, username)
+	log.Debugf("validateSnapshotOperationSupervisorRequest called with the request %v", request)
 	newVS := snap.VolumeSnapshot{}
 	if err := json.Unmarshal(request.Object.Raw, &newVS); err != nil {
 		reason := "Failed to deserialize VolumeSnapshot from new request object"
@@ -32,10 +30,9 @@ func validateSnapshotOperationSupervisorRequest(ctx context.Context, request adm
 		return admission.Denied(reason)
 	}
 
-	if request.Operation == admissionv1.Create || request.Operation == admissionv1.Update ||
-		request.Operation == admissionv1.Delete {
-		if !isCSIServiceAccount {
-			return admission.Denied(fmt.Sprintf(SnapshotOperationNotAllowed, username))
+	if request.Operation == admissionv1.Create {
+		if _, annotationFound := newVS.Annotations[common.SupervisorVolumeSnapshotAnnotationKey]; !annotationFound {
+			return admission.Denied(SnapshotOperationNotAllowed)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We disabled snapshot operations directly initiated from supervisor cluster by adding changes in the webhook.
In webhook, we were checking if username performing snapshot operation matches with the CSI service account regex "system:serviceaccount:vmware-system-csi". But while testing on guest cluster (we couldn't test it earlier), found that username that we get on supervisor cluster is like "system:serviceaccount:test-ns:tkc-k6p8v-pvcsi", so this logic is not working.
So, updating the logic by adding annotation on VolumeSnapshot CR in supervisor cluster. This annotation is added by the guest cluster while creating VolumeSnapshot CR on supervisor.
Checking this annotation in the supervisor webhook to decide if snapshot creation is attempted from guest or directly from supervisor.
Also, adding webhook changes only for Create operation. In case whole namespace is deleted on supervisor cluster, api server will invoke volume snapshot delete operation, hence not blocking delete operation on supervisor.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Volume snapshot creation is failing as expected if this operation is directly initiated from Supervisor cluster:
```
# k get pvc -n test-ns
NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
ec0f014c-efbf-49ae-905f-8075901e2a9c-d01bfb5a-df92-4cd7-8383-d81ce934af2c   Bound    pvc-fe6abf0a-d13f-4cc5-a7b2-749f2e46b52d   1Gi        RWO            wcpglobal-storage-profile   21m

# k create -f vs-wcp.yaml 
Error from server (Snapshot creation initiated directly from the Supervisor cluster is not supported. Please initiate snapshot creation from the Guest cluster.): error when creating "vs-wcp.yaml": admission webhook "validation.csi.vsphere.vmware.com" denied the request: Snapshot creation initiated directly from the Supervisor cluster is not supported. Please initiate snapshot creation from the Guest cluster.
```

Volume snapshot creation is successful if operation is initiated from Guest cluster:
```
# kubectl --kubeconfig guest-config get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
example-guest-block-pvc   Bound    pvc-d01bfb5a-df92-4cd7-8383-d81ce934af2c   1Gi        RWO            wcpglobal-storage-profile   24m

# kubectl --kubeconfig guest-config apply -f vs-guest.yaml 
volumesnapshot.snapshot.storage.k8s.io/example-guest-block-snapshot-1 created

// Volume snapshot on Guest
# kubectl --kubeconfig guest-config get vs
NAME                             READYTOUSE   SOURCEPVC                 SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
example-guest-block-snapshot-1   false        example-guest-block-pvc                                         volumesnapshotclass-delete   snapcontent-ebca8661-1f7c-4cd9-b078-e166bf4356bd                  3h7m

# kubectl --kubeconfig guest-config get vsc
NAME                                               READYTOUSE   RESTORESIZE   DELETIONPOLICY   DRIVER                   VOLUMESNAPSHOTCLASS          VOLUMESNAPSHOT                   VOLUMESNAPSHOTNAMESPACE   AGE
snapcontent-ebca8661-1f7c-4cd9-b078-e166bf4356bd   false                      Delete           csi.vsphere.vmware.com   volumesnapshotclass-delete   example-guest-block-snapshot-1   default                   3h9m


// Volume snapshot on supervisor
# k get vs -n test-ns
NAME                                                                        READYTOUSE   SOURCEPVC                                                                   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
ec0f014c-efbf-49ae-905f-8075901e2a9c-ebca8661-1f7c-4cd9-b078-e166bf4356bd   true         ec0f014c-efbf-49ae-905f-8075901e2a9c-d01bfb5a-df92-4cd7-8383-d81ce934af2c                           1Gi           volumesnapshotclass-delete   snapcontent-34e2dc40-3ec6-43c4-955c-79b0fa5e0adf   169m           169m

# k get vsc -n test-ns
NAME                                               READYTOUSE   RESTORESIZE   DELETIONPOLICY   DRIVER                   VOLUMESNAPSHOTCLASS          VOLUMESNAPSHOT                                                              VOLUMESNAPSHOTNAMESPACE   AGE
snapcontent-34e2dc40-3ec6-43c4-955c-79b0fa5e0adf   true         1073741824    Delete           csi.vsphere.vmware.com   volumesnapshotclass-delete   ec0f014c-efbf-49ae-905f-8075901e2a9c-ebca8661-1f7c-4cd9-b078-e166bf4356bd   test-ns                   172m
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Update logic for disabling snapshot creation directly initiated on supervisor cluster
```
