### PR TITLE
[CSI Snapshot]Fix variable shadowing issue

### DIFF
--- a/manifests/guestcluster/1.22/pvcsi.yaml
+++ b/manifests/guestcluster/1.22/pvcsi.yaml
@@ -62,7 +62,7 @@ rules:
     verbs: ["get", "update", "watch", "list"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list" ]
+    verbs: [ "get", "list", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]

--- a/manifests/guestcluster/1.23/pvcsi.yaml
+++ b/manifests/guestcluster/1.23/pvcsi.yaml
@@ -62,7 +62,7 @@ rules:
     verbs: ["get", "update", "watch", "list"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list" ]
+    verbs: [ "get", "list", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]

--- a/manifests/guestcluster/1.24/pvcsi.yaml
+++ b/manifests/guestcluster/1.24/pvcsi.yaml
@@ -62,7 +62,7 @@ rules:
     verbs: ["get", "update", "watch", "list"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list" ]
+    verbs: [ "get", "list", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]

--- a/manifests/guestcluster/1.25/pvcsi.yaml
+++ b/manifests/guestcluster/1.25/pvcsi.yaml
@@ -64,7 +64,7 @@ rules:
     verbs: ["get", "update", "watch", "list"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]
-    verbs: [ "get", "list" ]
+    verbs: [ "get", "list", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "watch", "get", "list" ]

--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -318,7 +318,7 @@ func IsVolumeSnapshotReady(ctx context.Context, client snapshotterClientSet.Inte
 	var svs *snap.VolumeSnapshot
 
 	waitErr := wait.PollImmediate(5*time.Second, timeout, func() (done bool, err error) {
-		svs, err := client.SnapshotV1().VolumeSnapshots(namespace).
+		svs, err = client.SnapshotV1().VolumeSnapshots(namespace).
 			Get(ctx, supervisorVolumeSnapshotName, metav1.GetOptions{})
 		if err != nil {
 			msg := fmt.Sprintf("unable to fetch volumesnapshot %q/%q "+


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fix variable shadowing issue, the variable was defined and later initialized again, which caused nil pointer error in some cases
- Add "patch" permission on volumesnapshots.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Created VolumeSnapshot, followed by Deleting VolumeSnapshots

```
root@422a371e8c085a7386227dda0da468b3 [ ~ ]# kubectl --kubeconfig guest-config get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
example-guest-block-pvc   Bound    pvc-3628235a-c1e6-4bb1-b97a-be1015179a4f   1Gi        RWO            wcpglobal-storage-profile   85m
 
root@422a371e8c085a7386227dda0da468b3 [ ~ ]# cat volumesnapshot-guest.yaml
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: example-guest-block-snapshot-1
spec:
  volumeSnapshotClassName: volumesnapshotclass-delete
  source:
    persistentVolumeClaimName: example-guest-block-pvc
root@422a371e8c085a7386227dda0da468b3 [ ~ ]# kubectl --kubeconfig guest-config apply -f volumesnapshot-guest.yaml
volumesnapshot.snapshot.storage.k8s.io/example-guest-block-snapshot-1 created
 
root@422a0648f1a93acabeb7556d547544c7 [ ~ ]# kubectl --kubeconfig guest-config get volumesnapshot
NAME                             READYTOUSE   SOURCEPVC                 SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
example-guest-block-snapshot-1   true         example-guest-block-pvc                           1Gi           volumesnapshotclass-delete   snapcontent-ce1d8d29-8d62-4e95-91d5-6fc995d12c5e   15m            66m
 
root@422a0648f1a93acabeb7556d547544c7 [ ~ ]# kubectl --kubeconfig guest-config delete volumesnapshot example-guest-block-snapshot-1
volumesnapshot.snapshot.storage.k8s.io "example-guest-block-snapshot-1" deleted
root@422a0648f1a93acabeb7556d547544c7 [ ~ ]# kubectl --kubeconfig guest-config get volumesnapshot
No resources found in default namespace.
```

**Special notes for your reviewer**:

**Release note**:
```release-note
```
