### PR TITLE
Fix minor bugs in raw block volume testcase, causing failures intermittently.

### DIFF
--- a/tests/e2e/nodes_scaleup_scaledown.go
+++ b/tests/e2e/nodes_scaleup_scaledown.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
-	"strings"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -168,7 +167,9 @@ var _ = ginkgo.Describe("[csi-file-vanilla] [csi-block-vanilla-serialized] Nodes
 
 		var nodeToCordon *v1.Node
 		for _, node := range nodes.Items {
-			if strings.Contains(node.Name, "master") || strings.Contains(node.Name, "control") {
+			if _, ok := node.Labels["node-role.kubernetes.io/control-plane"]; ok {
+				continue
+			} else if _, ok := node.Labels["node-role.kubernetes.io/master"]; ok {
 				continue
 			} else {
 				nodeToCordon = &node

--- a/tests/e2e/raw_block_volume.go
+++ b/tests/e2e/raw_block_volume.go
@@ -470,10 +470,10 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Verify volume is detached from the node")
 		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
-			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			volumeID, pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
-			fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			fmt.Sprintf("Volume %q is not detached from the node %q", volumeID, pod.Spec.NodeName))
 		if guestCluster {
 			ginkgo.By("Waiting for CnsNodeVMAttachment controller to reconcile resource")
 			verifyCRDInSupervisorWithWait(ctx, f, pod.Spec.NodeName+"-"+svcPVCName,
@@ -485,7 +485,7 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
-			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			volumeID, pod.Spec.NodeName))
 
 		if vanillaCluster {
 			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
@@ -518,10 +518,10 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 
 		ginkgo.By("Verify volume is detached from the node")
 		isDiskDetached, err = e2eVSphere.waitForVolumeDetachedFromNode(client,
-			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			volumeID, pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
-			fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			fmt.Sprintf("Volume %q is not detached from the node %q", volumeID, pod.Spec.NodeName))
 		if guestCluster {
 			ginkgo.By("Waiting for 30 seconds to allow CnsNodeVMAttachment controller to reconcile resource")
 			time.Sleep(waitTimeForCNSNodeVMAttachmentReconciler)
@@ -650,7 +650,7 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		ginkgo.By("Deleting the Pod")
 		framework.ExpectNoError(fpod.DeletePodWithWait(client, pod), "Failed to delete pod", pod.Name)
 
-		ginkgo.By(fmt.Sprintf("Verify volume is detached from the node: %s", pod.Spec.NodeName))
+		ginkgo.By(fmt.Sprintf("Verify volume %q is detached from the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskDetached).To(gomega.BeTrue(), "Volume is not detached from the node")
@@ -775,10 +775,10 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
-				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+				volumeID, pod.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
-				fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+				fmt.Sprintf("Volume %q is not detached from the node %q", volumeID, pod.Spec.NodeName))
 			if guestCluster {
 				ginkgo.By("Waiting for 30 seconds to allow CnsNodeVMAttachment controller to reconcile resource")
 				time.Sleep(waitTimeForCNSNodeVMAttachmentReconciler)
@@ -898,7 +898,7 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		var vmUUID string
-		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID, pod.Spec.NodeName))
 		vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
 		if guestCluster {
 			vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
@@ -937,10 +937,10 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 
 		ginkgo.By("Verify volume is detached from the node")
 		isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(
-			client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			client, volumeID, pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
-			fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			fmt.Sprintf("Volume %q is not detached from the node %q", volumeID, pod.Spec.NodeName))
 		if guestCluster {
 			ginkgo.By("Waiting for 30 seconds to allow CnsNodeVMAttachment controller to reconcile resource")
 			time.Sleep(waitTimeForCNSNodeVMAttachmentReconciler)
@@ -1042,10 +1042,10 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify volume is detached from the node after expansion")
-		isDiskDetached, err = e2eVSphere.waitForVolumeDetachedFromNode(client, pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+		isDiskDetached, err = e2eVSphere.waitForVolumeDetachedFromNode(client, volumeID, pod.Spec.NodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
-			fmt.Sprintf("Volume %q is not detached from the node %q", pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			fmt.Sprintf("Volume %q is not detached from the node %q", volumeID, pod.Spec.NodeName))
 		if guestCluster {
 			ginkgo.By("Waiting for 30 seconds to allow CnsNodeVMAttachment controller to reconcile resource")
 			time.Sleep(waitTimeForCNSNodeVMAttachmentReconciler)
@@ -1260,12 +1260,11 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 			err = fpod.DeletePodWithWait(client, pod2)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By("Verify volume is detached from the node after expansion")
-			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client,
-				pvs[0].Spec.CSI.VolumeHandle, pod2.Spec.NodeName)
+			ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID2, nodeName))
+			isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(client, volumeID2, nodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
-				fmt.Sprintf("Volume %q is not detached from the node %q", pvs[0].Spec.CSI.VolumeHandle, pod2.Spec.NodeName))
+				fmt.Sprintf("Volume %q is not detached from the node %q", volumeID2, nodeName))
 			if guestCluster {
 				ginkgo.By("Waiting for 30 seconds to allow CnsNodeVMAttachment controller to reconcile resource")
 				time.Sleep(waitTimeForCNSNodeVMAttachmentReconciler)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Snapshot workflow failed in TKGm scenario due to volume not getting detached. When checked, observed that certain testcases are not passing correct volumeID to detach/attach in vanilla vs guest cluster setup, which may cause the failures.
Hence updated tc to pass correct volumeID as needed.
Also updated "Statefulset with Nodes Scale-up and Scale-down" tc since the tc was cordoning control-plane nodes due to incorrect check, causing failures in execution. Corrected the check for master node using role label, instead of checking node name.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
TC passed on block vanilla setup, details can be found at https://gist.github.com/akankshapanse/ddd6f984956c550deeed2eec5c749fc0

Also verified that testcases pass on TKGm setup, where the issue was originally seen.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix minor bugs in testcases, causing failures in TKGm setup.
```
