### PR TITLE
Initialise volume migration service for full sync in single VC setup

### DIFF
--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -49,7 +49,10 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 	var err error
 	// Fetch CSI migration feature state, before performing full sync operations.
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-		migrationFeatureStateForFullSync = metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration)
+		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.CSIMigration) &&
+			len(metadataSyncer.configInfo.Cfg.VirtualCenter) == 1 {
+			migrationFeatureStateForFullSync = true
+		}
 	}
 	defer func() {
 		fullSyncStatus := prometheus.PrometheusPassStatus
@@ -69,6 +72,14 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 
 	// k8sPVMap is useful for clean and quicker look up.
 	k8sPVMap := make(map[string]string)
+	// Instantiate volumeMigrationService when migration feature state is True.
+	if migrationFeatureStateForFullSync {
+		// Instantiate volumeMigrationService when migration feature state is True.
+		if err = initVolumeMigrationService(ctx, metadataSyncer); err != nil {
+			log.Errorf("FullSync for VC %s: Failed to initialize migration service. Err: %v", vc, err)
+			return err
+		}
+	}
 
 	// Iterate through all the k8sPVs and use volume id as the key for k8sPVMap
 	// items. For migrated volumes, invoke GetVolumeID from migration service.
@@ -78,17 +89,8 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 			k8sPVMap[pv.Spec.CSI.VolumeHandle] = ""
 		} else if migrationFeatureStateForFullSync && pv.Spec.VsphereVolume != nil {
 			// For vSphere volumes, migration service will register volumes in CNS.
-
 			// Note that we can never reach here in case of a multi VC setup
 			// as we have already filtered out in-tree volumes.
-			if volumeMigrationService == nil {
-				// Instantiate volumeMigrationService when migration feature state is True.
-				if err = initVolumeMigrationService(ctx, metadataSyncer); err != nil {
-					log.Errorf("FullSync for VC %s: Failed to initialize migration service. Err: %v", vc, err)
-					return err
-				}
-			}
-
 			migrationVolumeSpec := &migration.VolumeSpec{
 				VolumePath:        pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix issue #2347 by initialising volume migration service if it is a single VC deployment.
The fix is to initialise voluemMigrationService if it is a single VC setup.

This PR also skips any further operations in podAdded method if it is a multu VC deployment as it only applies to in-line volumes.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2347

**Testing done**:
On single VC setup tested full sync create and delete operations.

Create:
1. Deleted CNS volume from VC mob.
2. Wait for full sync to create it back.

Delete:
1. Create a CNS volume from a script.
2. Waited for full sync to delete it.

I do not have a multi VC deployment so I created an image where migrationFeatureStateForFullSync is set to false (something that we expect in a multi VC env) and tested the above two scenarios on the same.


Also created a new pod to make sure podAdded is getting skipped:

```
2023-04-19T11:00:47.408Z	DEBUG	syncer/metadatasyncer.go:1403	podAdded: Skipping podAdded operation as it is a multi VC deployment	{"TraceId": "219eecad-fcf7-41b3-8b95-470a9be4d3af"}

```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
