### PR TITLE
[CSI Snapshot] Check for Status field before access and introduce snapshot timeout

### DIFF
--- a/manifests/guestcluster/1.23/pvcsi.yaml
+++ b/manifests/guestcluster/1.23/pvcsi.yaml
@@ -208,6 +208,8 @@ spec:
               value: /etc/cloud/pvcsi-config/cns-csi.conf
             - name: PROVISION_TIMEOUT_MINUTES
               value: "4"
+            - name: SNAPSHOT_TIMEOUT_MINUTES
+              value: "4"
             - name: ATTACHER_TIMEOUT_MINUTES
               value: "4"
             - name: RESIZE_TIMEOUT_MINUTES

--- a/manifests/guestcluster/1.24/pvcsi.yaml
+++ b/manifests/guestcluster/1.24/pvcsi.yaml
@@ -211,6 +211,8 @@ spec:
               value: /etc/cloud/pvcsi-config/cns-csi.conf
             - name: PROVISION_TIMEOUT_MINUTES
               value: "4"
+            - name: SNAPSHOT_TIMEOUT_MINUTES
+              value: "4"
             - name: ATTACHER_TIMEOUT_MINUTES
               value: "4"
             - name: RESIZE_TIMEOUT_MINUTES

--- a/manifests/guestcluster/1.25/pvcsi.yaml
+++ b/manifests/guestcluster/1.25/pvcsi.yaml
@@ -223,6 +223,8 @@ spec:
               value: /etc/cloud/pvcsi-config/cns-csi.conf
             - name: PROVISION_TIMEOUT_MINUTES
               value: "4"
+            - name: SNAPSHOT_TIMEOUT_MINUTES
+              value: "4"
             - name: ATTACHER_TIMEOUT_MINUTES
               value: "4"
             - name: RESIZE_TIMEOUT_MINUTES

--- a/pkg/csi/service/common/common_controller_helper.go
+++ b/pkg/csi/service/common/common_controller_helper.go
@@ -327,14 +327,21 @@ func IsVolumeSnapshotReady(ctx context.Context, client snapshotterClientSet.Inte
 			log.Warnf(msg)
 			return false, logger.LogNewErrorf(log, msg)
 		}
+		if svs == nil || svs.Status == nil || svs.Status.ReadyToUse == nil {
+			log.Infof("Waiting up to %d seconds for VolumeSnapshot %v in namespace %s to be ReadyToUse, %+vs "+
+				"since the start time", timeoutSeconds, supervisorVolumeSnapshotName, namespace,
+				time.Since(startTime).Seconds())
+			return false, nil
+		}
 		isSnapshotReadyToUse := *svs.Status.ReadyToUse
 		if isSnapshotReadyToUse {
 			log.Infof("VolumeSnapshot %s/%s is in ReadyToUse state", namespace, supervisorVolumeSnapshotName)
 			isReadyToUse = true
 			return true, nil
 		} else {
-			log.Warnf("Waiting for VolumeSnapshot %s/%s to be ready since %+vs", namespace,
-				supervisorVolumeSnapshotName, time.Since(startTime).Seconds())
+			log.Infof("Waiting up to %d seconds for VolumeSnapshot %v in namespace %s to be ReadyToUse, %+vs "+
+				"since the start time", timeoutSeconds, supervisorVolumeSnapshotName, namespace,
+				time.Since(startTime).Seconds())
 		}
 		return false, nil
 	})

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -1431,7 +1431,7 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 		// Wait for VolumeSnapshot to be ready to use
 		isReady, vs, err := common.IsVolumeSnapshotReady(ctx, c.supervisorSnapshotterClient,
 			supervisorVolumeSnapshotName, c.supervisorNamespace,
-			time.Duration(getProvisionTimeoutInMin(ctx))*time.Minute)
+			time.Duration(getSnapshotTimeoutInMin(ctx))*time.Minute)
 		if !isReady {
 			msg := fmt.Sprintf("volumesnapshot: %s on namespace: %s in supervisor cluster was not Ready. "+
 				"Error: %+v", supervisorVolumeSnapshotName, c.supervisorNamespace, err)

--- a/pkg/csi/service/wcpguest/controller_helper.go
+++ b/pkg/csi/service/wcpguest/controller_helper.go
@@ -52,6 +52,10 @@ const (
 	// Default timeout for resize, used unless overridden by user in
 	// csi-controller YAML.
 	defaultResizeTimeoutInMin = 4
+
+	// Default timeout for create snapshot, used unless overridden by user in
+	// csi-controller YAML.
+	defaultSnapshotTimeoutInMin = 4
 )
 
 // validateGuestClusterCreateVolumeRequest is the helper function to validate
@@ -342,6 +346,30 @@ func getProvisionTimeoutInMin(ctx context.Context) int {
 		}
 	}
 	return provisionTimeoutInMin
+}
+
+// getSnapshotTimeoutInMin return the timeout for volume snapshot.
+// If environment variable SNAPSHOT_TIMEOUT_MINUTES is set and valid,
+// return the interval value read from environment variable
+// otherwise, use the default timeout 4 mins
+func getSnapshotTimeoutInMin(ctx context.Context) int {
+	log := logger.GetLogger(ctx)
+	snapshotTimeoutInMin := defaultSnapshotTimeoutInMin
+	if v := os.Getenv("SNAPSHOT_TIMEOUT_MINUTES"); v != "" {
+		if value, err := strconv.Atoi(v); err == nil {
+			if value <= 0 {
+				log.Warnf(" snapshotTimeout set in env variable SNAPSHOT_TIMEOUT_MINUTES %s "+
+					"is equal or less than 0, will use the default timeout", v)
+			} else {
+				snapshotTimeoutInMin = value
+				log.Infof("snapshotTimeout is set to %d minutes", snapshotTimeoutInMin)
+			}
+		} else {
+			log.Warnf("snapshotTimeout set in env variable SNAPSHOT_TIMEOUT_MINUTES %s is invalid, "+
+				"will use the default timeout", v)
+		}
+	}
+	return snapshotTimeoutInMin
 }
 
 // getResizeTimeoutInMin returns the timeout for volume resize.


### PR DESCRIPTION
**What this PR does / why we need it**:
The `Status` and `ReadyToUse` fields are optional, ensure to check them for nil before access.
Introduce snapshot timeout parameter and stop relying on provisioning timeout


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
PR: 3179582

**Testing done**:
```
Took a VolumeSnapshot and ensured that the CSI Driver did not go into CLBO state
```
Unit tests:
```
dkinni@dkinniCMD6R vsphere-csi-driver % make unit-test
```
**Special notes for your reviewer**:

**Release note**:
```release-note
```
