### PR TITLE
Return volume content source in CreateVolumeResponse whenever applicable

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -717,6 +717,17 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		}
 	}
 
+	// Set the Snapshot VolumeContentSource in the CreateVolumeResponse
+	if contentSourceSnapshotID != "" {
+		resp.Volume.ContentSource = &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Snapshot{
+				Snapshot: &csi.VolumeContentSource_SnapshotSource{
+					SnapshotId: contentSourceSnapshotID,
+				},
+			},
+		}
+	}
+
 	return resp, "", nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In case of volume restored from snapshot, we need to return volume content source in CreateVolumeResponse. This PR adds the change for same in WCP CSI controller, similar to vanilla. Without this change, restored volume remains in pending state with error below

` Warning  ProvisioningFailed    7m4s (x23 over 62m)   csi.vsphere.vmware.com_421e244f355f8c1679f7f7cc8d452eb9_379207c4-74b4-4767-8cee-8785a92b15f0  failed to provision volume with StorageClass "gc-storage-profile": volume content source missing`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested the change on WCP setup with snapshot changes present and found that volume restore from snapshot is successful after this change.

Before change: 

Created snapshot and restored it from GC and checked on supervisor control VM:

```
root@421e332f730a8f784e3fc5dadc81229e [ ~ ]# export KUBECONFIG=./guest_kubeconfig
root@421e332f730a8f784e3fc5dadc81229e [ ~ ]# kubectl get pvc -A
default     example-vanilla-rwo-filesystem-restore   Pending                                                                   RWO            gc-storage-profile   90s
default     example-vanilla-rwo-pvc                  Bound    pvc-5d98c4c6-a2e2-4558-9d17-d80b52cac258   20Mi       RWO            gc-storage-profile   90m

root@421e332f730a8f784e3fc5dadc81229e [ ~ ]# export KUBECONFIG=/root/.kube/config
root@421e332f730a8f784e3fc5dadc81229e [ ~ ]# kubectl get pvc -A
NAMESPACE             NAME                                                                        STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
test-gc-e2e-demo-ns   2618f131-5935-4bbb-92fc-51e05ee6f0fc-5d98c4c6-a2e2-4558-9d17-d80b52cac258   Bound     pvc-08932532-f576-4f39-8497-21908460bcbd   20Mi       RWO            gc-storage-profile   90m
test-gc-e2e-demo-ns   2618f131-5935-4bbb-92fc-51e05ee6f0fc-f778dab3-0aa6-4a11-8f6b-0057512761dd   Pending                                                                        gc-storage-profile   61s                 <<<< restored volume
```

After adding change to CSI controller on WCP/Supervisor cluster:

```
root@421e332f730a8f784e3fc5dadc81229e [ ~ ]# export KUBECONFIG=./guest_kubeconfig
root@421e332f730a8f784e3fc5dadc81229e [ ~ ]# kubectl get pvc -A
default     example-vanilla-rwo-filesystem-restore   Bound    pvc-f778dab3-0aa6-4a11-8f6b-0057512761dd   20Mi       RWO            gc-storage-profile   168m
default     example-vanilla-rwo-pvc                  Bound    pvc-5d98c4c6-a2e2-4558-9d17-d80b52cac258   20Mi       RWO            gc-storage-profile   170m

root@421e332f730a8f784e3fc5dadc81229e [ ~ ]# export KUBECONFIG=/root/.kube/config
root@421e332f730a8f784e3fc5dadc81229e [ ~ ]# kubectl get pvc -A
NAMESPACE             NAME                                                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
test-gc-e2e-demo-ns   2618f131-5935-4bbb-92fc-51e05ee6f0fc-5d98c4c6-a2e2-4558-9d17-d80b52cac258   Bound    pvc-08932532-f576-4f39-8497-21908460bcbd   20Mi       RWO            gc-storage-profile   176m
test-gc-e2e-demo-ns   2618f131-5935-4bbb-92fc-51e05ee6f0fc-f778dab3-0aa6-4a11-8f6b-0057512761dd   Bound    pvc-0f596554-4189-4aaa-b422-36b8f6b0ddac   20Mi       RWO            gc-storage-profile   83m

```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Return volume content source in CreateVolumeResponse whenever applicable.
```
