### PR TITLE
simplify not found fault handling during delete volume

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -1112,9 +1112,9 @@ func (m *defaultManager) deleteVolume(ctx context.Context, volumeID string, dele
 	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
 	if volumeOperationRes.Fault != nil {
 		faultType = ExtractFaultTypeFromVolumeResponseResult(ctx, volumeOperationRes)
-		// If volume is not found on host, but is present in CNS DB, we will get NotFound fault.
+		// If volume is not found on host, but is present in CNS DB, we will get vim.fault.NotFound fault.
 		// Send back success as the volume is already deleted.
-		if IsNotFoundError(faultType) {
+		if IsNotFoundFault(ctx, faultType) {
 			log.Infof("DeleteVolume: VolumeID %q, not found, thus returning success", volumeID)
 			return "", nil
 		}
@@ -1279,9 +1279,9 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 	if volumeOperationRes.Fault != nil {
 		faultType = ExtractFaultTypeFromVolumeResponseResult(ctx, volumeOperationRes)
 
-		// If volume is not found on host, but is present in CNS DB, we will get NotFound fault.
+		// If volume is not found on host, but is present in CNS DB, we will get vim.fault.NotFound fault.
 		// In such a case, send back success as the volume is already deleted.
-		if IsNotFoundError(faultType) {
+		if IsNotFoundFault(ctx, faultType) {
 			log.Infof("DeleteVolume: VolumeID %q, not found, thus returning success", volumeID)
 			return "", nil
 		}

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -547,19 +547,10 @@ func queryCreatedSnapshotByName(ctx context.Context, m *defaultManager, volumeID
 	return nil, false
 }
 
-// IsNotFoundError returns true if a given faulType is of type NotFound
-func IsNotFoundError(faultType string) bool {
-	// Extract error name from faultType
-	faultTypeErrSplitString := strings.Split(faultType, ".")
-	faultTypeErr := faultTypeErrSplitString[len(faultTypeErrSplitString)-1]
+// IsNotFoundFault returns true if a given faultType value is vim.fault.NotFound
+func IsNotFoundFault(ctx context.Context, faultType string) bool {
+	log := logger.GetLogger(ctx)
+	log.Infof("Checking fault type: %q is vim.fault.NotFound", faultType)
+	return faultType == "vim.fault.NotFound"
 
-	// Get NotFound error name from CNS vim25 types.
-	notFoundErrSplitString := strings.Split(((reflect.TypeOf(types.NotFound{})).String()), ".")
-	// vim25types gives value of format *type.XXX.
-	// In this case it will be *type.NotFound
-	// Extract Notfound from the vim25types error.
-	notFoundErr := notFoundErrSplitString[len(notFoundErrSplitString)-1]
-
-	// Check weather the faultTye is NotFound
-	return notFoundErr == faultTypeErr
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
simplify not found fault handling during delete volume


**Testing done**:
Yes. Deleted VMDK of provisioned PVC and then attempted to delete PVC.

Logs

```
2023-04-24T22:13:02.682Z	INFO	volume/manager.go:1263	DeleteVolume: volumeID: "bd6f44ac-fb62-41a5-9642-0e038bbf5128", opId: "8314783e"	{"TraceId": "5f44f140-b082-4278-8db6-cfcfdafc395f"}
2023-04-24T22:13:02.683Z	DEBUG	volume/util.go:362	Extracting fault type from response: &{DynamicData:{} VolumeId:{DynamicData:{} Id:} Fault:0xc000b7d360}	{"TraceId": "5f44f140-b082-4278-8db6-cfcfdafc395f"}
2023-04-24T22:13:02.683Z	INFO	volume/util.go:370	Extract vimfault type: *types.NotFound  vimFault: &{VimFault:{MethodFault:{FaultCause:<nil> FaultMessage:[]}}} Fault: &{DynamicData:{} Fault:0xc000b7d380 LocalizedMessage:The object or item referred to could not be found.} from resp: &{DynamicData:{} VolumeId:{DynamicData:{} Id:} Fault:0xc000b7d360}	{"TraceId": "5f44f140-b082-4278-8db6-cfcfdafc395f"}
2023-04-24T22:13:02.683Z	INFO	volume/util.go:553	Checking fault type: "vim.fault.NotFound" is vim.fault.NotFound	{"TraceId": "5f44f140-b082-4278-8db6-cfcfdafc395f"}
2023-04-24T22:13:02.683Z	INFO	volume/manager.go:1285	DeleteVolume: VolumeID "bd6f44ac-fb62-41a5-9642-0e038bbf5128", not found, thus returning success	{"TraceId": "5f44f140-b082-4278-8db6-cfcfdafc395f"}
2023-04-24T22:13:02.683Z	DEBUG	volume/manager.go:1049	internalDeleteVolume: returns fault "" for volume "bd6f44ac-fb62-41a5-9642-0e038bbf5128"	{"TraceId": "5f44f140-b082-4278-8db6-cfcfdafc395f"}
2023-04-24T22:13:02.683Z	DEBUG	common/vsphereutil.go:623	Successfully deleted disk for volumeid: bd6f44ac-fb62-41a5-9642-0e038bbf5128, deleteDisk flag: true	{"TraceId": "5f44f140-b082-4278-8db6-cfcfdafc395f"}
2023-04-24T22:13:02.683Z	DEBUG	vanilla/controller.go:2003	deleteVolumeInternal: returns fault "" for volume "bd6f44ac-fb62-41a5-9642-0e038bbf5128"	{"TraceId": "5f44f140-b082-4278-8db6-cfcfdafc395f"}
2023-04-24T22:13:02.683Z	INFO	vanilla/controller.go:2014	Volume "bd6f44ac-fb62-41a5-9642-0e038bbf5128" deleted successfully{"TraceId": "5f44f140-b082-4278-8db6-cfcfdafc395f"}
2023-04-24T22:13:02.732Z	DEBUG	k8sorchestrator/k8sorchestrator.go:965	PV: pvc-d608fc0a-0cf0-4dea-9609-7252a629fbbe deleted. Removing entry from volumeIDToPvcMap	{"TraceId": "cc92c554-6267-4670-8ff1-cec811910f5e"}
2023-04-24T22:13:02.732Z	DEBUG	k8sorchestrator/k8sorchestrator.go:969	k8sorchestrator: Deleted key bd6f44ac-fb62-41a5-9642-0e038bbf5128 from volumeIDToPvcMap	{"TraceId": "cc92c554-6267-4670-8ff1-cec811910f5e"}
2023-04-24T22:13:02.732Z	DEBUG	k8sorchestrator/k8sorchestrator.go:971	k8sorchestrator: Deleted key bd6f44ac-fb62-41a5-9642-0e038bbf5128 from volumeIDToNameMap	{"TraceId": "cc92c554-6267-4670-8ff1-cec811910f5e"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
simplify not found fault handling during delete volume
```
