### PR TITLE
edit info log to print vc host only

### DIFF
--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -87,7 +87,8 @@ func (l *ListViewImpl) createListView(ctx context.Context, tasks []types.Managed
 		return err
 	}
 	l.listView = listView
-	log.Infof("created listView object %+v for virtualCenter: %+v", l.listView.Reference(), l.virtualCenter)
+	log.Infof("created listView object %+v for virtualCenter: %+v",
+		l.listView.Reference(), l.virtualCenter.Config.Host)
 	return nil
 }
 
@@ -225,7 +226,8 @@ func (l *ListViewImpl) listenToTaskUpdates() {
 		// we want to immediately return a fault for all the pending tasks in the map
 		// note: this is not a task error but an error from the vc
 		if err != nil {
-			log.Errorf("WaitForUpdates returned err: %v for vc: %+v", err, l.virtualCenter)
+			log.Errorf("WaitForUpdates returned err: %v for vc: %+v", err,
+				l.virtualCenter.Config.Host)
 			recreateView = true
 			l.reportErrorOnAllPendingTasks(err)
 		}

--- a/pkg/common/cns-lib/volume/listview_test.go
+++ b/pkg/common/cns-lib/volume/listview_test.go
@@ -18,9 +18,10 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
+const testVCHost = "testVCHost"
+
 func TestAddRemoveListView(t *testing.T) {
 	ctx := logger.NewContextWithLogger(context.Background())
-
 	model := simulator.VPX()
 	defer model.Remove()
 	if err := model.Create(); err != nil {
@@ -36,6 +37,9 @@ func TestAddRemoveListView(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	config := vsphere.VirtualCenterConfig{Host: testVCHost}
+	virtualCenter.Config = &config
 
 	listViewImpl, err := NewListViewImpl(ctx, virtualCenter, virtualCenter.Client)
 	assert.NoError(t, err)
@@ -82,6 +86,9 @@ func TestMarkForDeletion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	config := vsphere.VirtualCenterConfig{Host: testVCHost}
+	virtualCenter.Config = &config
 
 	listViewImpl, err := NewListViewImpl(ctx, virtualCenter, virtualCenter.Client)
 	assert.NoError(t, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Printing the entire VC object isn't required as it also contains the VC password. We can only print the host name. 

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Modify info log to print only the VC host name
```
