### PR TITLE
Skip PVC annotation validations for PVC deletes

### DIFF
--- a/pkg/syncer/admissionhandler/validatepvc.go
+++ b/pkg/syncer/admissionhandler/validatepvc.go
@@ -48,7 +48,7 @@ func validatePVC(ctx context.Context, req *admissionv1.AdmissionRequest) *admiss
 		log.Debugf("JSON req.OldObject.Raw: %v", string(req.OldObject.Raw))
 		// req.OldObject is null for CREATE and CONNECT operations.
 		if err := json.Unmarshal(req.OldObject.Raw, &oldPVC); err != nil {
-			log.Warnf("error deserializing old pvc: %v. skipping validation.", err)
+			log.Errorf("error deserializing old pvc: %v. skipping validation.", err)
 			return &admissionv1.AdmissionResponse{
 				// skip validation if there is pvc deserialization error
 				Allowed: true,
@@ -70,7 +70,7 @@ func validatePVC(ctx context.Context, req *admissionv1.AdmissionRequest) *admiss
 			log.Debugf("JSON req.Object.Raw: %v", string(req.Object.Raw))
 			// req.Object is null for DELETE operations.
 			if err := json.Unmarshal(req.Object.Raw, &newPVC); err != nil {
-				log.Warnf("error deserializing old pvc: %v. skipping validation.", err)
+				log.Errorf("error deserializing old pvc: %v. skipping validation.", err)
 				return &admissionv1.AdmissionResponse{
 					// skip validation if there is pvc deserialization error
 					Allowed: true,
@@ -151,7 +151,7 @@ func getPVReclaimPolicyForPVC(ctx context.Context, pvc corev1.PersistentVolumeCl
 	pv, err := kubeClient.CoreV1().PersistentVolumes().Get(ctx, pvc.Spec.VolumeName, metav1.GetOptions{})
 	if err != nil {
 		return result, logger.LogNewErrorf(log, "failed to get PV %v with error: %v. "+
-			"Stopping getting reclaim policy for PVC, %s/%s", err, pvc.Spec.VolumeName, pvc.Namespace, pvc.Name)
+			"Stopping getting reclaim policy for PVC, %s/%s", pvc.Spec.VolumeName, err, pvc.Namespace, pvc.Name)
 	}
 
 	return pv.Spec.PersistentVolumeReclaimPolicy, nil

--- a/pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth.go
+++ b/pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth.go
@@ -26,8 +26,13 @@ func validatePVCAnnotationForVolumeHealth(ctx context.Context, request admission
 	username := request.UserInfo.Username
 	isCSIServiceAccount := validateCSIServiceAccount(request.UserInfo.Username)
 	log.Debugf("validatePVCAnnotationForVolumeHealth called with the request %v by user: %v", request, username)
+	if request.Operation == admissionv1.Delete {
+		// PVC volume health annotation validation is not required for delete PVC calls
+		return admission.Allowed("")
+	}
 	newPVC := corev1.PersistentVolumeClaim{}
 	if err := json.Unmarshal(request.Object.Raw, &newPVC); err != nil {
+		log.Errorf("error unmarshalling pvc: %v", err)
 		reason := "skipped validation when failed to deserialize PVC from new request object"
 		log.Warn(reason)
 		return admission.Allowed(reason)
@@ -41,6 +46,7 @@ func validatePVCAnnotationForVolumeHealth(ctx context.Context, request admission
 	} else if request.Operation == admissionv1.Update {
 		oldPVC := corev1.PersistentVolumeClaim{}
 		if err := json.Unmarshal(request.OldObject.Raw, &oldPVC); err != nil {
+			log.Errorf("error unmarshalling pvc: %v", err)
 			reason := "skipped validation when failed to deserialize PVC from old request object"
 			log.Warn(reason)
 			return admission.Allowed(reason)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Currently, validatePVCAnnotationForTKGSHA and validatePVCAnnotationForVolumeHealth are triggered for PVC deletes
- Request has `request.Object` as nil for delete calls, this causes an error during unmarshalling
- The webhook seems to have been originally written to handle create and update calls only


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before fix:
```
{"level":"error","time":"2023-05-05T07:04:03.300653068Z","caller":"admissionhandler/validatepvcannotationfortkgsha.go:28","msg":"validatePVCAnnotationForTKGSHA: Unmarshal failed with the error: unexpected end of JSON input","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/admissionhandler.validatePVCAnnotationForTKGSHA\n\t/build/pkg/syncer/admissionhandler/validatepvcannotationfortkgsha.go:28\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer/admissionhandler.(*CSISupervisorWebhook).Handle\n\t/build/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go:93\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle\n\t/go/pkg/mod/sigs.k8s.io/[controller-runtime@v0.13.0](mailto:controller-runtime@v0.13.0)/pkg/webhook/admission/webhook.go:169\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP\n\t/go/pkg/mod/sigs.k8s.io/[controller-runtime@v0.13.0](mailto:controller-runtime@v0.13.0)/pkg/webhook/admission/http.go:98\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1\n\t/go/pkg/mod/github.com/prometheus/[client_golang@v1.14.0](mailto:client_golang@v1.14.0)/prometheus/promhttp/instrument_server.go:60\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2122\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1\n\t/go/pkg/mod/github.com/prometheus/[client_golang@v1.14.0](mailto:client_golang@v1.14.0)/prometheus/promhttp/instrument_server.go:146\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2122\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2\n\t/go/pkg/mod/github.com/prometheus/[client_golang@v1.14.0](mailto:client_golang@v1.14.0)/prometheus/promhttp/instrument_server.go:108\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2122\nnet/http.(*ServeMux).ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2500\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2936\nnet/http.(*conn).serve\n\t/usr/local/go/src/net/http/server.go:1995"}
```

Don't observe the error after the fix
Ran `make tests`, and no regression was observed.

**Special notes for your reviewer**:

**Release note**:
```release-note
```
