### PR TITLE
[WIP]Changes in API for creating Tanzu Clusters

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -201,7 +201,7 @@ const (
 	vmOperatorAPI                             = "/apis/vmoperator.vmware.com/v1alpha1/"
 	devopsUser                                = "testuser"
 	zoneKey                                   = "failure-domain.beta.kubernetes.io/zone"
-	tkgAPI                                    = "/apis/run.tanzu.vmware.com/v1alpha1/namespaces" +
+	tkgAPI                                    = "/apis/run.tanzu.vmware.com/v1alpha3/namespaces" +
 		"/test-gc-e2e-demo-ns/tanzukubernetesclusters/"
 	topologykey                                = "topology.csi.vmware.com"
 	topologyMap                                = "TOPOLOGY_MAP"

--- a/tests/e2e/testing-manifests/tkg/tkg.yaml
+++ b/tests/e2e/testing-manifests/tkg/tkg.yaml
@@ -31,3 +31,4 @@ spec:
         cidrBlocks:
         - 192.0.2.0/16
       serviceDomain: cluster.local
+

--- a/tests/e2e/testing-manifests/tkg/tkg.yaml
+++ b/tests/e2e/testing-manifests/tkg/tkg.yaml
@@ -1,27 +1,33 @@
-apiVersion: run.tanzu.vmware.com/v1alpha1
+apiVersion: run.tanzu.vmware.com/v1alpha3
 kind: TanzuKubernetesCluster
 metadata:
   name: test-cluster-e2e-script
   namespace: test-gc-e2e-demo-ns
+  annotations:
+    run.tanzu.vmware.com/resolve-os-image: os-name=replaceOSname 
+    # this will be replaced with os Image Name
 spec:
   topology:
     controlPlane:
-      count: 3
-      class: best-effort-xsmall # vmclass to be used for master(s)
+      tkr:
+        reference:
+          name: replaceImage # this will be replaced with the actual image name by pipeline
+      replicas: 3
+      vmClass: best-effort-xsmall # vmclass to be used for master(s)
       storageClass: gc-storage-profile
-    workers:
-      count: 2
-      class: best-effort-xsmall # vmclass to be used for workers(s)
+    nodePools:
+    - replicas: 2
+      name: np-2
+      vmClass: best-effort-xsmall # vmclass to be used for workers(s)
       storageClass: gc-storage-profile
-  distribution:
-    version: replaceImage # this will be replaced with the actual image name by pipeline
   settings:
     network:
       cni:
-        name: calico
+        name: antrea
       services:
-        cidrBlocks: ["198.51.100.0/12"]
+        cidrBlocks:
+        - 198.51.100.0/12
       pods:
-        cidrBlocks: ["192.0.2.0/16"]
-      serviceDomain: "managedcluster.local" 
-
+        cidrBlocks:
+        - 192.0.2.0/16
+      serviceDomain: cluster.local


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a latest api support for creating Tanzu clusters


**Testing done**:
yes

inamdarm@inamdarmAMD6M vsphere-csi-driver % golangci-lint run --enable=lll
inamdarm@inamdarmAMD6M vsphere-csi-driver% 
inamdarm@inamdarmAMD6M vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/inamdarm/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/inamdarm/Documents/CSIREPO/vsphere-csi-driver-16May /Users/inamdarm/Documents/CSIREPO /Users/inamdarm/Documents /Users/inamdarm /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 

INFO [loader] Go packages loading at mode 575 (exports_file|files|name|types_sizes|compiled_files|deps|imports) took 3m52.667781798s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 747.888768ms 
INFO [linters context/goanalysis] analyzers took 19m43.654769534s with top 10 stages: buildir: 14m40.705992604s, nilness: 42.867386861s, printf: 26.77592969s, ctrlflow: 26.020213571s, fact_deprecated: 25.547737064s, typedness: 23.349257667s, fact_purity: 21.810499917s, SA5012: 19.001307724s, S1038: 10.087377178s, inspect: 9.926185699s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 24/113, nolint: 0/1, exclude-rules: 1/24, skip_files: 113/113, identifier_marker: 24/24, cgo: 113/113, exclude: 24/24, skip_dirs: 113/113, filename_unadjuster: 113/113, path_prettifier: 113/113 
INFO [runner] processing took 73.047177ms with stages: nolint: 54.577989ms, autogenerated_exclude: 15.135937ms, identifier_marker: 1.501256ms, path_prettifier: 1.147022ms, exclude-rules: 337.326µs, skip_dirs: 290.803µs, cgo: 27.803µs, filename_unadjuster: 15.499µs, max_same_issues: 3.608µs, max_from_linter: 1.865µs, uniq_by_line: 1.388µs, diff: 987ns, severity-rules: 906ns, sort_results: 840ns, source_code: 803ns, exclude: 746ns, max_per_file_from_linter: 735ns, skip_files: 726ns, path_shortener: 583ns, path_prefixer: 355ns 
INFO [runner] linters took 2m5.1430183s with stages: goanalysis_metalinter: 2m5.069562093s 
INFO File cache stats: 303 entries of total size 6.0MiB 
INFO Memory: 3288 samples, avg is 653.7MB, max is 3279.5MB 
INFO Execution took 5m58.600328531


