### PR TITLE
[CICD]: Improvisation to CICD scripts & introducing cleanup-dev stage to release testbeds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
   - deploy-staging
   - tests-staging
   - prod-rollout
+  - cleanup-dev
 
 run-unit-tests:
   stage: unit-test
@@ -61,14 +62,9 @@ deploy-images-dev:
   artifacts:
     paths:
       - ./env.json
+      - ./sv_kubeconfig_content.yaml
     reports:
       dotenv: build.env
-  # Return testbed back to pool if the stage fails.
-  after_script:
-    - >
-      if [ $CI_JOB_STATUS != 'success' ]; then
-      curl -X 'PUT' "${CNS_TESTBEDPOOL_SVC_RELEASE_URL}/$(cat ./pipeline/placeholder.id)" -H 'accept: application/json' -u "${CNS_MANAGER_USERNAME}:${CNS_MANAGER_PASSWORD}";
-      fi
 
 e2e-tests-dev:
   stage: e2e-tests-dev
@@ -87,12 +83,9 @@ e2e-tests-dev:
   artifacts:
     paths:
       - ./env.json
+      - ./sv_kubeconfig_content.yaml
     reports:
       dotenv: build.env
-  # Return testbed back to pool.
-  after_script:
-    - |
-      curl -X 'PUT' "${CNS_TESTBEDPOOL_SVC_RELEASE_URL}/$(cat ./pipeline/placeholder.id)" -H 'accept: application/json' -u "${CNS_MANAGER_USERNAME}:${CNS_MANAGER_PASSWORD}"
 
 deploy-images-staging:
   stage: deploy-staging
@@ -152,3 +145,14 @@ patch-prod-images:
     - build-images
   only:
     - master
+
+cleanup-dev:
+  stage: cleanup-dev
+  image: $CNS_IMAGE_CI_DEPLOY_STAGE
+  when: always
+  artifacts:
+    reports:
+      dotenv: build.env
+  script:
+    - chmod 777 pipeline/release-testbed.sh
+    - ./pipeline/release-testbed.sh

--- a/pipeline/release-testbed.sh
+++ b/pipeline/release-testbed.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+set -o errexit
+
+if [ -n "${TESTBED_ID}" ]; then
+    status=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "${TESTBED_POOL_SERVICE_ENDPOINT}/v1/pool/${TESTBED_POOL_ID}/releaseTestbed/${TESTBED_ID}" -H 'accept: application/json' -u "${TESTBED_POOL_SERVICE_BASIC_AUTH_USER}:${TESTBED_POOL_SERVICE_BASIC_AUTH_PASSWORD}")
+
+    if [ "$status" != "200" ] && [ "$status" != "409" ]; then
+        echo "Release testbed API call failed with HTTP status code $status. Retrying in 60 seconds..."
+        retries=0
+        while [ "$status" != "200" ] && [ "$status" != "409" ] && [ "$retries" -lt 5 ]; do
+            retries=$((retries+1))
+            sleep 60
+            echo "Retrying (attempt $retries)..."
+            status=$(curl -s -o /dev/null -w "%{http_code}" -X PUT "${TESTBED_POOL_SERVICE_ENDPOINT}/v1/pool/${TESTBED_POOL_ID}/releaseTestbed/${TESTBED_ID}" -H 'accept: application/json' -u "${TESTBED_POOL_SERVICE_BASIC_AUTH_USER}:${TESTBED_POOL_SERVICE_BASIC_AUTH_PASSWORD}")
+        done
+    fi
+
+    if [ "$status" != "200" ] && [ "$status" != "409" ]; then
+        echo "Release testbed API call failed after $retries attempts. Testbed may still be locked. Raising an alert."
+        bash pipeline/send_slack_notification.sh
+        # Fail the stage forcefully to get attention from maintainers
+        exit 1
+    else
+        echo "Release testbed API call succeeded after $retries attempts."
+    fi
+else
+    echo "Testbed ID is empty or null. Skipping release."
+fi

--- a/pipeline/send_slack_notification.sh
+++ b/pipeline/send_slack_notification.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright 2023 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SLACK_WEBHOOK_URL="${CSI_SLACK_WEBHOOK_URL}"
+USERNAME="${GITLAB_USER_NAME}"
+ICON_EMOJI=":robot_face:"
+CHANNEL="#${CHANNEL_TEST}"
+MAIN_REASON="Release testbed API failed"
+REASON="curl -X 'PUT' -H 'accept: application/json' -u ${TESTBED_POOL_SERVICE_BASIC_AUTH_USER}:${TESTBED_POOL_SERVICE_BASIC_AUTH_PASSWORD} ${TESTBED_POOL_SERVICE_ENDPOINT}/v1/pool/${TESTBED_POOL_ID}/releaseTestbed/${TESTBED_ID}"
+
+JOB_URL="${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}"
+COMMIT_URL="${CI_PROJECT_URL}/-/commit/${CI_COMMIT_SHA}"
+
+JOB_DETAILS="*Job Details:*\n \
+Job Name: ${CI_JOB_NAME}\n \
+Job URL: ${JOB_URL}\n \
+Commit URL: ${COMMIT_URL}\n \
+Commit Message: ${CI_COMMIT_MESSAGE}\n \
+Commit Author: ${GITLAB_USER_NAME}\n \
+Remedy : ${REASON}" 
+
+payload="payload={
+    \"channel\": \"${CHANNEL}\",
+    \"username\": \"${USERNAME}\",
+    \"icon_emoji\": \"${ICON_EMOJI}\",
+    \"attachments\": [
+        {
+            \"color\": \"danger\",
+            \"text\": \"${MAIN_REASON}\",
+            \"fields\": [
+                {
+                    \"title\": \"Pipeline Details\",
+                    \"value\": \"${JOB_DETAILS}\",
+                    \"short\": false
+                }
+            ]
+        }
+    ]
+}"
+
+curl -s -d "${payload}" "${SLACK_WEBHOOK_URL}" > /dev/null


### PR DESCRIPTION
**What this PR does / why we need it**:
[CICD]: Improvisation to CICD scripts & introducing cleanup-dev stage to release testbeds

1. Removed the after_script logic to release the testbed and introduced a new stage "cleanup-dev" with a condition to run "always" to release the borrowed testbed
2. Added a script to send a Slack alert if the release testbed API fails after 5 retries
3. Reuse the kubeconfig artifacts generated in the deploy-dev stage on the e2e-tests-dev stage


**Testing done**:
Yes
1. Cleanup-dev stage works on any failures in the early stages (unit-test or build stage)
5. Cleanup-dev stage works on failure in the deploy-dev stage before borrowing the testbed
6. Cleanup-dev stage works on failure in the deploy-dev stage after borrowing the testbed
7. Cleanup-dev stage works on failure in the e2e stage
8. Cleanup-dev stage triggers a Slack notification on failure to release the testbed

**Special notes for your reviewer**:
NA

**Release note**:
NA
