### PR TITLE
Changes in TKG API for Cluster Creation in VMC

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -96,6 +96,7 @@ const (
 	envVmdkDiskURL                             = "DISK_URL_PATH"
 	envVolumeOperationsScale                   = "VOLUME_OPS_SCALE"
 	envComputeClusterName                      = "COMPUTE_CLUSTER_NAME"
+	envTKGImage                                = "TKG_IMAGE_NAME"
 	execCommand                                = "/bin/df -T /mnt/volume1 | " +
 		"/bin/awk 'FNR == 2 {print $2}' > /mnt/volume1/fstype && while true ; do sleep 2 ; done"
 	execRWXCommandPod1 = "echo 'Hello message from Pod1' > /mnt/volume1/Pod1.html  && " +
@@ -196,8 +197,8 @@ const (
 	waitTimeForCNSNodeVMAttachmentReconciler  = 30 * time.Second
 	wcpServiceName                            = "wcp"
 	vmcWcpHost                                = "10.2.224.24" //This is the LB IP of VMC WCP and its constant
-	devopsTKG                                 = "test-cluster-e2e-script"
-	cloudadminTKG                             = "test-cluster-e2e-script-1"
+	devopsTKG                                 = "test-cluster-e2e-script-2"
+	cloudadminTKG                             = "test-cluster-e2e-script-3"
 	vmOperatorAPI                             = "/apis/vmoperator.vmware.com/v1alpha1/"
 	devopsUser                                = "testuser"
 	zoneKey                                   = "failure-domain.beta.kubernetes.io/zone"

--- a/tests/e2e/testing-manifests/tkg/tkg.yaml
+++ b/tests/e2e/testing-manifests/tkg/tkg.yaml
@@ -1,4 +1,4 @@
-apiVersion: run.tanzu.vmware.com/v1alpha1
+apiVersion: run.tanzu.vmware.com/v1alpha3
 kind: TanzuKubernetesCluster
 metadata:
   name: test-cluster-e2e-script
@@ -6,22 +6,25 @@ metadata:
 spec:
   topology:
     controlPlane:
-      count: 3
-      class: best-effort-xsmall # vmclass to be used for master(s)
+      tkr:
+        reference:
+          name: replaceImage # this will be replaced with the actual image name by pipeline
+      replicas: 3
+      vmClass: best-effort-xsmall # vmclass to be used for master(s)
       storageClass: gc-storage-profile
-    workers:
-      count: 2
-      class: best-effort-xsmall # vmclass to be used for workers(s)
+    nodePools:
+    - replicas: 2
+      name: np-2
+      vmClass: best-effort-xsmall # vmclass to be used for workers(s)
       storageClass: gc-storage-profile
-  distribution:
-    version: replaceImage # this will be replaced with the actual image name by pipeline
   settings:
     network:
       cni:
-        name: calico
+        name: antrea
       services:
-        cidrBlocks: ["198.51.100.0/12"]
+        cidrBlocks:
+        - 198.51.100.0/12
       pods:
-        cidrBlocks: ["192.0.2.0/16"]
-      serviceDomain: "managedcluster.local" 
-
+        cidrBlocks:
+        - 192.0.2.0/16
+      serviceDomain: cluster.local

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -483,6 +483,7 @@ type GetTaskTstatus struct {
 	OrgID           string      `json:"org_id"`
 }
 
+// This Struct is used for Creating tanzu cluster
 type TanzuCluster struct {
 	APIVersion string `yaml:"apiVersion"`
 	Kind       string `yaml:"kind"`

--- a/tests/e2e/vmc_create_gc.go
+++ b/tests/e2e/vmc_create_gc.go
@@ -17,6 +17,9 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
+	"os"
+
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -42,6 +45,11 @@ var _ = ginkgo.Describe("Create GC", func() {
 
 	ginkgo.It("[vmc] Create GC using devops user", func() {
 
+		tkgImageName := os.Getenv(envTKGImage)
+		if tkgImageName == "" {
+			ginkgo.Skip(fmt.Sprintf("Env %v is missing", envTKGImage))
+		}
+
 		ginkgo.By("Get WCP session id")
 		gomega.Expect((e2eVSphere.Config.Global.VmcDevopsUser)).NotTo(gomega.BeEmpty(), "Devops user is not set")
 		wcpToken := getWCPSessionId(vmcWcpHost, e2eVSphere.Config.Global.VmcDevopsUser,
@@ -49,7 +57,7 @@ var _ = ginkgo.Describe("Create GC", func() {
 		framework.Logf("vmcWcpHost %s", vmcWcpHost)
 
 		ginkgo.By("Creating Guest Cluster with Devops User")
-		createGC(vmcWcpHost, wcpToken)
+		createGC(vmcWcpHost, wcpToken, tkgImageName, devopsTKG)
 		ginkgo.By("Validate the Guest Cluster is up and running")
 		err := getGC(vmcWcpHost, wcpToken, devopsTKG)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -66,6 +74,11 @@ var _ = ginkgo.Describe("Create GC", func() {
 
 	ginkgo.It("[vmc] Create GC using cloudadmin user", func() {
 
+		tkgImageName := os.Getenv(envTKGImage)
+		if tkgImageName == "" {
+			ginkgo.Skip(fmt.Sprintf("Env %v is missing", envTKGImage))
+		}
+
 		ginkgo.By("Get WCP session id")
 		gomega.Expect((e2eVSphere.Config.Global.VmcCloudUser)).NotTo(gomega.BeEmpty(), "VmcCloudUser is not set")
 		wcpToken := getWCPSessionId(vmcWcpHost, e2eVSphere.Config.Global.VmcCloudUser,
@@ -73,7 +86,7 @@ var _ = ginkgo.Describe("Create GC", func() {
 		framework.Logf("vmcWcpHost %s", vmcWcpHost)
 
 		ginkgo.By("Creating Guest Cluster with cloudadmin User")
-		createGC(vmcWcpHost, wcpToken)
+		createGC(vmcWcpHost, wcpToken, tkgImageName, cloudadminTKG)
 		ginkgo.By("Validate the Guest Cluster is up and running")
 		err := getGC(vmcWcpHost, wcpToken, cloudadminTKG)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR add new API version support for TKG Creation. and also makes changes in creating tanzu cluster in vmc environments


**Testing done**:
yes: https://gist.github.com/inamdarm/dc8e7f8bb56a0691c0dc48f99be4fbb9

**Special notes for your reviewer**:
Lint Check:
inamdarm@inamdarmAMD6M vsphere-csi-driver-17may % golangci-lint run --enable=lll
inamdarm@inamdarmAMD6M vsphere-csi-driver-17may %  make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/inamdarm/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/inamdarm/Documents/CSIREPO/vsphere-csi-driver-17may /Users/inamdarm/Documents/CSIREPO /Users/inamdarm/Documents /Users/inamdarm /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|files|types_sizes|imports|name) took 16.857883384s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 192.571542ms 
INFO [linters context/goanalysis] analyzers took 1m29.45422105s with top 10 stages: buildir: 27.018618134s, S1038: 6.471930449s, misspell: 3.109441247s, unused: 2.756289332s, printf: 1.729867915s, SA4030: 1.667263942s, S1039: 1.629460582s, SA1012: 1.346084336s, S1028: 1.240284034s, ctrlflow: 1.195635628s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 24/113, identifier_marker: 24/24, exclude: 24/24, exclude-rules: 1/24, skip_files: 113/113, path_prettifier: 113/113, cgo: 113/113, filename_unadjuster: 113/113, skip_dirs: 113/113, nolint: 0/1 
INFO [runner] processing took 36.213149ms with stages: nolint: 29.580996ms, autogenerated_exclude: 5.121342ms, path_prettifier: 730.03µs, identifier_marker: 395.397µs, skip_dirs: 276.408µs, exclude-rules: 77.862µs, cgo: 14.643µs, filename_unadjuster: 9.874µs, max_same_issues: 1.57µs, uniq_by_line: 1.249µs, diff: 574ns, source_code: 553ns, sort_results: 505ns, skip_files: 428ns, severity-rules: 372ns, max_from_linter: 345ns, exclude: 341ns, max_per_file_from_linter: 263ns, path_shortener: 256ns, path_prefixer: 141ns 
INFO [runner] linters took 14.376212333s with stages: goanalysis_metalinter: 14.339878394s 
INFO File cache stats: 302 entries of total size 6.0MiB 
INFO Memory: 309 samples, avg is 370.8MB, max is 1717.7MB 
INFO Execution took 31.444087834s      
