### PR TITLE
Populate supervisor FSS values for node plugin in guest cluster

### DIFF
--- a/manifests/guestcluster/1.25/pvcsi.yaml
+++ b/manifests/guestcluster/1.25/pvcsi.yaml
@@ -504,7 +504,7 @@ data:
   "volume-health": "true"
   "online-volume-extend": "true"
   "file-volume": "true"
-  "csi-sv-feature-states-replication": "false"
+  "csi-sv-feature-states-replication": "false" # Do not enable for guest cluster, Refer PR#2386 for details
   "block-volume-snapshot": "false"
   "tkgs-ha": "true"
   "cnsmgr-suspend-create-volume": "true"

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -528,7 +528,7 @@ func initFSS(ctx context.Context, k8sClient clientset.Interface,
 	// CR is not registered yet.
 	if controllerClusterFlavor == cnstypes.CnsClusterFlavorWorkload ||
 		(controllerClusterFlavor == cnstypes.CnsClusterFlavorGuest &&
-			!getSvFssCRAvailability() && serviceMode != "node") {
+			!getSvFssCRAvailability()) {
 		if k8sOrchestratorInstance.supervisorFSS.configMapName != "" &&
 			k8sOrchestratorInstance.supervisorFSS.configMapNamespace != "" {
 			// Retrieve configmap.
@@ -1013,7 +1013,7 @@ func (c *K8sOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) 
 			return internalFeatureState
 		}
 		c.internalFSS.featureStatesLock.RUnlock()
-		log.Debugf("Could not find the %s feature state in ConfigMap %s. "+
+		log.Infof("Could not find the %s feature state in ConfigMap %s. "+
 			"Setting the feature state to false", featureName, c.internalFSS.configMapName)
 		return false
 	} else if c.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
@@ -1030,7 +1030,7 @@ func (c *K8sOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) 
 			return supervisorFeatureState
 		}
 		c.supervisorFSS.featureStatesLock.RUnlock()
-		log.Debugf("Could not find the %s feature state in ConfigMap %s. "+
+		log.Infof("Could not find the %s feature state in ConfigMap %s. "+
 			"Setting the feature state to false", featureName, c.supervisorFSS.configMapName)
 		return false
 	} else if c.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
@@ -1051,7 +1051,7 @@ func (c *K8sOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) 
 			}
 		} else {
 			c.internalFSS.featureStatesLock.RUnlock()
-			log.Debugf("Could not find the %s feature state in ConfigMap %s. Setting the feature state to false",
+			log.Infof("Could not find the %s feature state in ConfigMap %s. Setting the feature state to false",
 				featureName, c.internalFSS.configMapName)
 			return false
 		}
@@ -1072,7 +1072,7 @@ func (c *K8sOrchestrator) IsFSSEnabled(ctx context.Context, featureName string) 
 			}
 		} else {
 			c.supervisorFSS.featureStatesLock.RUnlock()
-			log.Debugf("Could not find the %s feature state in ConfigMap %s. Setting the feature state to false",
+			log.Infof("Could not find the %s feature state in ConfigMap %s. Setting the feature state to false",
 				featureName, c.supervisorFSS.configMapName)
 			return false
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In case of online expansion of volume in guest cluster, during `NodeExpandVolume()`, we rescan the device to get updated size of the device if `online-expand-volume` FSS is enabled. FSS check here looks at k8sOrchestrator.internalFSS value (populated from internal-feature-state configmap) as well as k8sOrchestrator.supervisorFSS value in `isFSSEnabled() `call. 
k8sOrchestrator.supervisorFSS and k8sOrchestrator.internalFSS values are populated inside `initFSS()` where for guest cluster node plugin, only k8sOrchestrator.internalFSS is populated from internal-feature-state configmap but k8sOrchestrator.supervisorFSS is not populated at all. Due to this,` isFSSEnabled()` returns false when checking for online-expand-volume FSS in` NodeExpandVolume().` This step skips rescan of device during online expand and operation fails.
Basically, supervisorFSS values when referred in node plugin of guest cluster, always return false value, which can fail/affect the functionality of node plugin, since it was not populated initially for node plugin in `initFSS()`.
Hence the change made here populates the supervisor FSS for node plugin from supervisor FSS configmap, so that the values can be used correctly in node plugin during FSS check.
This fixes the regression caused by https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2192/files.
NOTE: Please refer this change before enabling "csi-sv-feature-states-replication" fss for changes to be reworked or revisited.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested online resize on GC, where the resize was consistently failing, which now succeeds with the fix.

```
GC setup :

root@42370ceefaae2c6607e157c12b42d036 [ ~ ]# export KUBECONFIG=gc_kubeconfig
root@42370ceefaae2c6607e157c12b42d036 [ ~ ]# kubectl get pvc
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
block-pvc               Bound    pvc-5595a087-f1c0-4318-bbc5-5da795aa7e07   5Gi        RWO            gc-storage-profile   46h
block-restore           Bound    pvc-7182ce88-ff68-4725-a10b-053aeb91d2e3   10Gi       RWO            gc-storage-profile   46h
example-raw-block-pvc   Bound    pvc-16757e70-5dec-4910-85ac-ddab61cbac39   1Gi        RWO            gc-storage-profile   58m
root@42370ceefaae2c6607e157c12b42d036 [ ~ ]#

Expand 
root@42370ceefaae2c6607e157c12b42d036 [ ~ ]# kubectl edit pvc example-raw-block-pvc
persistentvolumeclaim/example-raw-block-pvc edited

root@42370ceefaae2c6607e157c12b42d036 [ ~ ]# kubectl get pvc
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
block-pvc               Bound    pvc-5595a087-f1c0-4318-bbc5-5da795aa7e07   5Gi        RWO            gc-storage-profile   46h
block-restore           Bound    pvc-7182ce88-ff68-4725-a10b-053aeb91d2e3   10Gi       RWO            gc-storage-profile   46h
example-raw-block-pvc   Bound    pvc-16757e70-5dec-4910-85ac-ddab61cbac39   2Gi        RWO            gc-storage-profile   59m
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Populate supervisor FSS values for node plugin in guest cluster
```
