### PR TITLE
Adding Script to generate data for upgrade based scenario

### DIFF
--- a/tests/e2e/preupgrade_datasetup.go
+++ b/tests/e2e/preupgrade_datasetup.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+)
+
+var _ = ginkgo.Describe("PreUpgrade datasetup Test", func() {
+
+	f := framework.NewDefaultFramework("preupgrade-setup")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		namespace         string
+		client            clientset.Interface
+		storageClassName  string
+		pvclaim           *v1.PersistentVolumeClaim
+		persistentvolumes []*v1.PersistentVolume
+		podArray          []*v1.Pod
+	)
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		bootstrap()
+
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+		pvclaims = make([]*v1.PersistentVolumeClaim, 3)
+		podArray = make([]*v1.Pod, 3)
+
+	})
+
+	// Test to setup up predata before the Testbed is upgraded
+	// Create sc, Stateful sets.
+
+	// Steps
+	// 1. Create a SC with allowVolumeExpansion set to 'true'
+	// 2. create statefulset with replica 3 using the above created SC
+
+	ginkgo.It("[csi-block-vanilla-preupgradedata] Verify creation of statefulset", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		//var pvcSizeBeforeExpansion int64
+		scParameters := make(map[string]string)
+		scParameters[scParamFsType] = ext4FSType
+		storageClassName = "preupgrade-sc-sts"
+		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+		sharedVSANDatastoreURL := GetAndExpectStringEnvVar(envSharedDatastoreURL)
+		scParameters[scParamDatastoreURL] = sharedVSANDatastoreURL
+
+		namespace1, err := framework.CreateTestingNS(f.BaseName, client, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		namespace = namespace1.Name
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", true)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		framework.Logf("storage class created is : %s", sc.Name)
+
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		// Waiting for pods status to be Ready
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+	})
+
+	// Test to setup up predata before the Testbed is upgraded
+	// Create sc, multiple dynamic pvcs and attach them to pods .
+
+	// Steps
+	// 1. Create StorageClass with allowVolumeExpansion set to true.
+	// 2. Create PVC-1, PVC-2, PVC-3 which uses the StorageClass created in step 1.
+	// 3. Wait for PV-1, PV-2, PV-3  to be provisioned.
+	// 4. Wait for PVC's status to become Bound..
+	// 6. Create pods using PVC's on specific node.
+	// 7. Wait for Disk to be attached to the node.
+
+	ginkgo.It("[csi-block-vanilla-preupgradedata] Verify creation of dynamic pvcs and pods", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		scParameters := make(map[string]string)
+		scParameters[scParamFsType] = ext4FSType
+		// Create Storage class and PVC
+		ginkgo.By("Creating Storage Class and PVC with allowVolumeExpansion = true")
+		var err error
+		storageClassName = "preupgrade-sc-pods"
+
+		namespace, err := framework.CreateTestingNS(f.BaseName, client, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", true)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		framework.Logf("storage class created is : %s", sc.Name)
+
+		count := 0
+		for count < 3 {
+			ginkgo.By("Creating PVCs using the Storage Class")
+			pvclaims[count], err = fpv.CreatePVC(client, namespace.Name,
+				getPersistentVolumeClaimSpecWithStorageClass(namespace.Name, diskSize, sc, nil, ""))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			count++
+		}
+		ginkgo.By("Waiting for all claims to be in bound state")
+		persistentvolumes, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		podCount := 0
+		for podCount < 3 {
+			ginkgo.By("Creating pod to attach PVs to the node")
+			pvclaim = pvclaims[podCount]
+			podArray[podCount], err = createPod(client, namespace.Name, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			podCount++
+		}
+
+		var vmUUID string
+		ginkgo.By("Verify the volumes are attached to the node vm")
+		podCount = 0
+		for podCount < 3 {
+			pvclaim = pvclaims[podCount]
+			pv := getPvFromClaim(client, namespace.Name, pvclaim.Name)
+
+			volumeID := pv.Spec.CSI.VolumeHandle
+			if vanillaCluster {
+				vmUUID = getNodeUUID(ctx, client, podArray[podCount].Spec.NodeName)
+			}
+			ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+				pv.Spec.CSI.VolumeHandle, podArray[podCount].Spec.NodeName))
+			isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volumeID, vmUUID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskAttached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume: %s is not attached to the node: %s",
+					pv.Spec.CSI.VolumeHandle, podArray[podCount].Spec.NodeName))
+			podCount++
+		}
+
+		for _, pv := range persistentvolumes {
+
+			framework.Logf("Volume: %s should be present in the CNS",
+				pv.Spec.CSI.VolumeHandle)
+			volumeID := pv.Spec.CSI.VolumeHandle
+			err = e2eVSphere.waitForCNSVolumeToBeCreated(volumeID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}
+
+	})
+
+	// Test to setup up predata before the Testbed is upgraded
+	// Create sc, multiple dynamic standalone pvcs .
+
+	// Steps
+	// 1. Create StorageClass with allowVolumeExpansion set to true.
+	// 2. Create PVC-1, PVC-2, PVC-3, PVC-4, PVC-5 which uses the StorageClass created in step 1.
+	// 3. Wait for PV-1, PV-2, PV-3  PV-4 PV-5 to be provisioned.
+	// 4. Wait for PVC's status to become Bound.
+
+	ginkgo.It("[csi-block-vanilla-preupgradedata] Verify creation of standalone pvcs", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		scParameters := make(map[string]string)
+		scParameters[scParamFsType] = ext4FSType
+		// Create Storage class and PVC
+		ginkgo.By("Creating Storage Class and PVC with allowVolumeExpansion = true")
+		var err error
+		storageClassName = "preupgrade-sc-pvcs"
+
+		namespace, err := framework.CreateTestingNS(f.BaseName, client, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", true)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		framework.Logf("storage class created is : %s", sc.Name)
+
+		count := 0
+		for count < 5 {
+			ginkgo.By("Creating PVCs using the Storage Class")
+			pvclaims[count], err = fpv.CreatePVC(client, namespace.Name,
+				getPersistentVolumeClaimSpecWithStorageClass(namespace.Name, diskSize, sc, nil, ""))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			count++
+		}
+		ginkgo.By("Waiting for all claims to be in bound state")
+		persistentvolumes, err = fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+})


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds a script to create pre data like pvc, pods and sts pods before the testbed upgrade. This data will be used for post upgrade data verification

Testing done:
YES: https://gist.github.com/inamdarm/c672b7b2230788934ea5a0d60cfcac76


**Special notes for your reviewer**:
inamdarm@inamdarmAMD6M vsphere-csi-driver-May23preupgrade % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/inamdarm/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/inamdarm/Documents/CSIREPO/vsphere-csi-driver-May23preupgrade /Users/inamdarm/Documents/CSIREPO /Users/inamdarm/Documents /Users/inamdarm /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (compiled_files|deps|exports_file|name|types_sizes|files|imports) took 12.12569676s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 165.681202ms 
INFO [linters context/goanalysis] analyzers took 46.337969006s with top 10 stages: buildir: 16.518644516s, S1038: 3.246873163s, misspell: 1.996656098s, unused: 975.409082ms, S1039: 954.88216ms, SA1012: 837.028784ms, SA4030: 805.881518ms, printf: 727.228771ms, S1028: 666.82787ms, SA1004: 648.507127ms 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 24/113, exclude-rules: 1/24, path_prettifier: 113/113, skip_dirs: 113/113, identifier_marker: 24/24, exclude: 24/24, skip_files: 113/113, nolint: 0/1, filename_unadjuster: 113/113, cgo: 113/113 
INFO [runner] processing took 16.353379ms with stages: nolint: 13.152199ms, autogenerated_exclude: 2.324701ms, path_prettifier: 383.936µs, identifier_marker: 291.786µs, skip_dirs: 119.557µs, exclude-rules: 61.68µs, cgo: 9.3µs, filename_unadjuster: 6.421µs, max_same_issues: 1.109µs, uniq_by_line: 481ns, max_from_linter: 321ns, source_code: 260ns, skip_files: 260ns, sort_results: 234ns, diff: 233ns, path_shortener: 210ns, max_per_file_from_linter: 206ns, exclude: 197ns, severity-rules: 183ns, path_prefixer: 105ns 
INFO [runner] linters took 11.624291266s with stages: goanalysis_metalinter: 11.607854182s 
INFO File cache stats: 306 entries of total size 6.0MiB 
INFO Memory: 239 samples, avg is 500.7MB, max is 1845.4MB 
INFO Execution took 23.927922542s    



