### PR TITLE
fix: list-volume fails in multi-vcenter environment 

### DIFF
--- a/pkg/csi/service/vanilla/controller_helper.go
+++ b/pkg/csi/service/vanilla/controller_helper.go
@@ -182,6 +182,9 @@ func getBlockVolumeIDToNodeUUIDMap(ctx context.Context, c *controller,
 		pc := property.DefaultCollector(vc.Client.Client)
 		// Obtain host MoID and virtual disk ID
 		var vmMoList []mo.VirtualMachine
+		if len(vmRefsPervCenter[vc.Config.Host]) == 0 {
+			continue
+		}
 		err = pc.Retrieve(ctx, vmRefsPervCenter[vc.Config.Host], properties, &vmMoList)
 		if err != nil {
 			log.Errorf("failed to get VM managed objects from VM objects, err: %v", err)


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Skips call to Retrieve if there are no nodes in the corresponding vcenter

**Which issue this PR fixes**: fixes #2393

**Testing done**:
I tested the custom build, but I have not made any automatic tests. 

**Special notes for your reviewer**:

**Release note**:
None