### PR TITLE
Add test to validate alpha feature pv-to-backingdiskobjectid-mapping

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -54,6 +54,16 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 				"tkgs-ha":                           "true",
 				"list-volumes":                      "true",
 				"csi-internal-generated-cluster-id": "true",
+				"online-volume-extend":              "true",
+				"async-query-volume":                "true",
+				"csi-windows-support":               "true",
+				"use-csinode-id":                    "true",
+				"pv-to-backingdiskobjectid-mapping": "false",
+				"cnsmgr-suspend-create-volume":      "true",
+				"topology-preferential-datastores":  "true",
+				"max-pvscsi-targets-per-vm":         "true",
+				"multi-vcenter-csi-topology":        "true",
+				"listview-tasks":                    "false",
 			},
 		}
 		return fakeCO, nil

--- a/tests/e2e/vsphere_volume_with_alpha_feature.go
+++ b/tests/e2e/vsphere_volume_with_alpha_feature.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = ginkgo.Describe("Alpha feature check", func() {
+
+	f := framework.NewDefaultFramework("alpha-features")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		client                      clientset.Interface
+		namespace                   string
+		scParameters                map[string]string
+		pvtoBackingdiskidAnnotation string = "cns.vmware.com/pv-to-backingdiskobjectid-mapping"
+		datastoreURL                string
+	)
+	ginkgo.BeforeEach(func() {
+		bootstrap()
+		client = f.ClientSet
+		namespace = getNamespaceToRunTests(f)
+		scParameters = make(map[string]string)
+		datastoreURL = GetAndExpectStringEnvVar(envSharedDatastoreURL)
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+	})
+
+	// Verify pvc is annotated in block vanilla setup.
+	// Steps
+	// Create a Storage Class.
+	// Create a PVC using above SC.
+	// Wait for PVC to be in Bound phase.
+	// Verify annotation is not added on the PVC.
+	// Delete PVC.
+	// Verify PV entry is deleted from CNS.
+	// Delete the SC.
+
+	ginkgo.It("[csi-block-vanilla-alpha-feature][pv-to-backingdiskobjectid-mapping] Verify pvc is annotated", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		featureEnabled := isCsiFssEnabled(ctx, client, GetAndExpectStringEnvVar(envCSINamespace), "pv-to-backingdiskobjectid-mapping")
+		gomega.Expect(featureEnabled).To(gomega.BeTrue())
+		ginkgo.By("Invoking Test volume status")
+		var storageclass *storagev1.StorageClass
+		var pvclaim *v1.PersistentVolumeClaim
+		var pvclaims []*v1.PersistentVolumeClaim
+		var err error
+
+		ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+		scParameters[scParamDatastoreURL] = datastoreURL
+		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+			nil, scParameters, diskSize, nil, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		pvclaims = append(pvclaims, pvclaim)
+
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
+		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if len(queryResult.Volumes) == 0 {
+			err = fmt.Errorf("QueryCNSVolumeWithResult returned no volume")
+		}
+		ginkgo.By("Expect annotation is added on the pvc")
+		waitErr := wait.PollImmediate(pollTimeoutShort, pollTimeoutSixMin*3, func() (bool, error) {
+			var err error
+			ginkgo.By(fmt.Sprintf("Sleeping for %v minutes", pollTimeoutShort))
+			pvc, err := client.CoreV1().PersistentVolumeClaims(pvclaim.Namespace).Get(ctx, pvclaim.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, fmt.Errorf("error fetching pvc %q for checking pvtobackingdisk annotation: %v", pvc.Name, err)
+			}
+			pvbackingAnnotation := pvc.Annotations[pvtoBackingdiskidAnnotation]
+			if pvbackingAnnotation != "" {
+				return true, nil
+			}
+			return false, nil
+		})
+
+		gomega.Expect(waitErr).NotTo(gomega.HaveOccurred())
+	})
+
+	// Verify pvc is not annotated in file vanilla setup.
+	// Steps
+	// Create a Storage Class.
+	// Create a PVC using above SC.
+	// Wait for PVC to be in Bound phase.
+	// Verify annotation is not added on the PVC.
+	// Delete PVC.
+	// Verify PV entry is deleted from CNS.
+	// Delete the SC.
+
+	ginkgo.It("[csi-file-vanilla-alpha-feature][pv-to-backingdiskobjectid-mapping] File Vanilla Verify pvc is not annotated", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		featureEnabled := isCsiFssEnabled(ctx, client, GetAndExpectStringEnvVar(envCSINamespace), "pv-to-backingdiskobjectid-mapping")
+		gomega.Expect(featureEnabled).To(gomega.BeTrue())
+		scParameters := make(map[string]string)
+		scParameters[scParamFsType] = nfs4FSType
+		accessMode := v1.ReadWriteMany
+		// Create Storage class and PVC.
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q", accessMode, nfs4FSType))
+		var storageclass *storagev1.StorageClass
+		var pvclaim *v1.PersistentVolumeClaim
+		var err error
+
+		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace,
+			nil, scParameters, "", nil, "", false, accessMode)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Waiting for PVC to be bound.
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaims = append(pvclaims, pvclaim)
+		ginkgo.By("Waiting for all claims to be in bound state")
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(volHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
+		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(queryResult.Volumes).ShouldNot(gomega.BeEmpty())
+
+		ginkgo.By(fmt.Sprintf("volume Name:%s , capacity:%d volumeType:%s", queryResult.Volumes[0].Name,
+			queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb,
+			queryResult.Volumes[0].VolumeType))
+
+		ginkgo.By("Verifying volume type specified in PVC is honored")
+		if queryResult.Volumes[0].VolumeType != testVolumeType {
+			err = fmt.Errorf("volume type is not %q", testVolumeType)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By(fmt.Sprintf("Sleeping for %v minutes", pollTimeoutSixMin))
+		time.Sleep(pollTimeoutSixMin)
+		ginkgo.By("Expect annotation is not added on the pvc")
+		pvc, err := client.CoreV1().PersistentVolumeClaims(pvclaim.Namespace).Get(ctx, pvclaim.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for describe := range pvc.Annotations {
+			gomega.Expect(pvc.Annotations[describe]).ShouldNot(gomega.BeEquivalentTo(pvtoBackingdiskidAnnotation))
+		}
+	})
+})

--- a/tests/e2e/vsphere_volume_with_alpha_feature.go
+++ b/tests/e2e/vsphere_volume_with_alpha_feature.go
@@ -72,7 +72,8 @@ var _ = ginkgo.Describe("Alpha feature check", func() {
 	ginkgo.It("[csi-block-vanilla-alpha-feature][pv-to-backingdiskobjectid-mapping] Verify pvc is annotated", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		featureEnabled := isCsiFssEnabled(ctx, client, GetAndExpectStringEnvVar(envCSINamespace), "pv-to-backingdiskobjectid-mapping")
+		featureEnabled := isCsiFssEnabled(ctx, client, GetAndExpectStringEnvVar(envCSINamespace),
+			"pv-to-backingdiskobjectid-mapping")
 		gomega.Expect(featureEnabled).To(gomega.BeTrue())
 		ginkgo.By("Invoking Test volume status")
 		var storageclass *storagev1.StorageClass
@@ -111,6 +112,7 @@ var _ = ginkgo.Describe("Alpha feature check", func() {
 		if len(queryResult.Volumes) == 0 {
 			err = fmt.Errorf("QueryCNSVolumeWithResult returned no volume")
 		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Expect annotation is added on the pvc")
 		waitErr := wait.PollImmediate(pollTimeoutShort, pollTimeoutSixMin*3, func() (bool, error) {
 			var err error
@@ -139,10 +141,12 @@ var _ = ginkgo.Describe("Alpha feature check", func() {
 	// Verify PV entry is deleted from CNS.
 	// Delete the SC.
 
-	ginkgo.It("[csi-file-vanilla-alpha-feature][pv-to-backingdiskobjectid-mapping] File Vanilla Verify pvc is not annotated", func() {
+	ginkgo.It("[csi-file-vanilla-alpha-feature][pv-to-backingdiskobjectid-mapping] "+
+		"File Vanilla Verify pvc is not annotated", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		featureEnabled := isCsiFssEnabled(ctx, client, GetAndExpectStringEnvVar(envCSINamespace), "pv-to-backingdiskobjectid-mapping")
+		featureEnabled := isCsiFssEnabled(ctx, client, GetAndExpectStringEnvVar(envCSINamespace),
+			"pv-to-backingdiskobjectid-mapping")
 		gomega.Expect(featureEnabled).To(gomega.BeTrue())
 		scParameters := make(map[string]string)
 		scParameters[scParamFsType] = nfs4FSType


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add e2e tests to validate volume provisioning with fss "pv-to-backingdiskobjectid-mapping" enabled

**Testing done**:
 run e2e tests

logs:
``` logs
nbargeV0Q4L:vsphere-csi-driver nbarge$ make test-e2e
hack/run-e2e-test.sh
  W0601 00:54:07.389394   12804 test_context.go:508] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  Jun  1 00:54:07.389: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CNS CSI Driver End-to-End Tests - /Users/nbarge/nik/vsphere-csi-driver/tests/e2e
===============================================================================================
Random Seed: 1685561027

Will run 1 of 740 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
Alpha feature check [csi-block-vanilla-alpha-feature] [pv-to-backingdiskobjectid-mapping] Verify pvc is annotated
/Users/nbarge/nik/vsphere-csi-driver/tests/e2e/vsphere_volume_with_alpha_feature.go:72
  STEP: Creating a kubernetes client @ 06/01/23 00:54:07.403
  Jun  1 00:54:07.403: INFO: >>> kubeConfig: /Users/nbarge/nik/vsphere-csi-driver/tests/e2e/kube.config
  STEP: Building a namespace api object, basename alpha-features @ 06/01/23 00:54:07.406
  STEP: Waiting for a default service account to be provisioned in namespace @ 06/01/23 00:54:08.691
  STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 06/01/23 00:54:09.185
  Jun  1 00:54:09.690: INFO: Creating new VC session
  STEP: Invoking Test volume status @ 06/01/23 00:54:12.555
  STEP: CNS_TEST: Running for vanilla k8s setup @ 06/01/23 00:54:12.555
  STEP: Creating StorageClass  with scParameters: map[DatastoreURL:ds:///vmfs/volumes/vsan:52f36fef4c26d5eb-a67b1db12a7b19cc/] and allowedTopologies: [] and ReclaimPolicy:  and allowVolumeExpansion: false @ 06/01/23 00:54:12.555
  STEP: Creating PVC using the Storage Class sc-pqq8q with disk size 2Gi and labels: map[] accessMode:  @ 06/01/23 00:54:12.861
  Jun  1 00:54:13.169: INFO: PVC created: pvc-4xqkj in namespace: alpha-features-5608
  Jun  1 00:54:13.169: INFO: Waiting up to timeout=5m0s for PersistentVolumeClaims [pvc-4xqkj] to have phase Bound
  Jun  1 00:54:13.422: INFO: PersistentVolumeClaim pvc-4xqkj found but phase is Pending instead of Bound.
  Jun  1 00:54:15.727: INFO: PersistentVolumeClaim pvc-4xqkj found but phase is Pending instead of Bound.
  Jun  1 00:54:18.080: INFO: PersistentVolumeClaim pvc-4xqkj found and phase=Bound (4.910018375s)
  STEP: Invoking QueryCNSVolumeWithResult with VolumeID: 781f6ed4-d6ba-43e3-a649-fff90dcc965f @ 06/01/23 00:54:18.691
  STEP: Expect annotation is added on the pvc @ 06/01/23 00:54:20.27
  STEP: Sleeping for 1m0s minutes @ 06/01/23 00:54:20.27
  STEP: Sleeping for 1m0s minutes @ 06/01/23 00:55:20.761
  STEP: Sleeping for 1m0s minutes @ 06/01/23 00:56:20.765
  STEP: Sleeping for 1m0s minutes @ 06/01/23 00:57:20.764
  STEP: Sleeping for 1m0s minutes @ 06/01/23 00:58:20.765
  STEP: Sleeping for 1m0s minutes @ 06/01/23 00:59:20.766
  STEP: Sleeping for 1m0s minutes @ 06/01/23 01:00:20.767
  Jun  1 01:00:21.128: INFO: Deleting PersistentVolumeClaim "pvc-4xqkj"
  Jun  1 01:00:25.673: INFO: volume "781f6ed4-d6ba-43e3-a649-fff90dcc965f" has successfully deleted
  Jun  1 01:00:25.933: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
  STEP: Destroying namespace "alpha-features-5608" for this suite. @ 06/01/23 01:00:26.428
• [379.278 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.027 seconds]
------------------------------

Ran 1 of 740 Specs in 379.291 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 739 Skipped
PASS

Ginkgo ran 1 suite in 6m38.891940541s
Test Suite Passed
```
**Special notes for your reviewer**:

**Release note**:

```release-note
Validated volume provisioning with fss "pv-to-backingdiskobjectid-mapping" enabled
```
