### PR TITLE
Fix use of GetNodeByName when using node's VMUUID (#2387)

### DIFF
--- a/pkg/common/cns-lib/node/manager_test.go
+++ b/pkg/common/cns-lib/node/manager_test.go
@@ -1,0 +1,50 @@
+package node
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDefaultManager_GetNodeByName(t *testing.T) {
+	nodeName := "foobar.dev.lan"
+	m := defaultManager{
+		nodeVMs:        sync.Map{},
+		nodeNameToUUID: sync.Map{},
+		k8sClient:      nil,
+		useNodeUuid:    false,
+	}
+
+	k8sClient := k8sClientWithNodes(nodeName)
+	m.SetKubernetesClient(k8sClient)
+
+	vm, _ := m.GetNodeByName(context.TODO(), nodeName)
+	if vm != nil {
+		t.Errorf("Unexpected vm found:%v", vm)
+	}
+
+	nodeUUID, ok := m.nodeNameToUUID.Load(nodeName)
+	if !ok {
+		t.Errorf("node name should be loaded into nodeUUID map")
+	}
+	assert.Equal(t, "foobar", nodeUUID)
+}
+
+func k8sClientWithNodes(nodeName string) clientset.Interface {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+		Spec: v1.NodeSpec{
+			ProviderID: "vsphere://foobar",
+		},
+	}
+	client := fake.NewSimpleClientset(node)
+	return client
+}

--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -190,6 +190,13 @@ func (nodes *Nodes) GetNodeByName(ctx context.Context, nodeName string) (
 	return nodes.cnsNodeManager.GetNodeByName(ctx, nodeName)
 }
 
+// GetNodeByNameOrUUID returns VirtualMachine object for given nodeName
+// This function can be called either using nodeName or nodeUID.
+func (nodes *Nodes) GetNodeByNameOrUUID(
+	ctx context.Context, nodeNameOrUUID string) (*cnsvsphere.VirtualMachine, error) {
+	return nodes.cnsNodeManager.GetNodeByNameOrUUID(ctx, nodeNameOrUUID)
+}
+
 // GetNodeNameByUUID fetches the name of the node given the VM UUID.
 func (nodes *Nodes) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (
 	string, error) {

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -61,6 +61,7 @@ type NodeManagerInterface interface {
 	Initialize(ctx context.Context, useNodeUuid bool) error
 	GetSharedDatastoresInK8SCluster(ctx context.Context) ([]*cnsvsphere.DatastoreInfo, error)
 	GetNodeByName(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
+	GetNodeByNameOrUUID(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
 	GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error)
 	GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error)
 	GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachine, error)
@@ -2115,7 +2116,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
 				// if node is not yet updated to run the release of the driver publishing Node VM UUID as Node ID
 				// look up Node by name
-				nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+				nodevm, err = c.nodeMgr.GetNodeByNameOrUUID(ctx, req.NodeId)
 				if err == node.ErrNodeNotFound {
 					log.Infof("Performing node VM lookup using node VM UUID: %q", req.NodeId)
 					nodevm, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
@@ -2256,7 +2257,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
 			// if node is not yet updated to run the release of the driver publishing Node VM UUID as Node ID
 			// look up Node by name
-			nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+			nodevm, err = c.nodeMgr.GetNodeByNameOrUUID(ctx, req.NodeId)
 			if err == node.ErrNodeNotFound {
 				log.Infof("Performing node VM lookup using node VM UUID: %q", req.NodeId)
 				nodevm, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -246,6 +246,11 @@ func (f *FakeNodeManager) GetNodeByName(ctx context.Context, nodeName string) (*
 	return vm, nil
 }
 
+func (f *FakeNodeManager) GetNodeByNameOrUUID(
+	ctx context.Context, nodeNameOrUUID string) (*cnsvsphere.VirtualMachine, error) {
+	return f.GetNodeByName(ctx, nodeNameOrUUID)
+}
+
 func (f *FakeNodeManager) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
Fix for https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/2373

Back-porting it to 3.0 release.
