### PR TITLE
Determine cluster distribution server version & type using kubernetes API server version

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -22,11 +22,14 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/node"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -211,6 +214,46 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 			if err != nil {
 				log.Errorf("failed to initialize nodeManager. Error: %+v", err)
 				os.Exit(1)
+			}
+			if configInfo.Cfg.Global.ClusterDistribution == "" {
+				config, err := rest.InClusterConfig()
+				if err != nil {
+					log.Errorf("failed to get InClusterConfig: %v", err)
+				}
+				clientset, err := kubernetes.NewForConfig(config)
+				if err != nil {
+					log.Errorf("failed to create kubernetes client with err: %v", err)
+				}
+
+				// Get the version info for the Kubernetes API server
+				versionInfo, err := clientset.Discovery().ServerVersion()
+				if err != nil {
+					log.Errorf("failed to fetch versionInfo with err: %v", err)
+				}
+
+				// Extract the version string from the version info
+				version := versionInfo.GitVersion
+				var ClusterDistNameToServerVersion = map[string]string{
+					"gke":       "Anthos",
+					"racher":    "Rancher",
+					"rke":       "Rancher",
+					"docker":    "DockerEE",
+					"dockeree":  "DockerEE",
+					"openshift": "Openshift",
+					"wcp":       "Supervisor",
+					"vmware":    "TanzuKubernetesCluster",
+					"unknown":   "VanillaK8S",
+				}
+				distributionUnknown := true
+				for distServerVersion, distName := range ClusterDistNameToServerVersion {
+					if strings.Contains(version, distServerVersion) {
+						configInfo.Cfg.Global.ClusterDistribution = distName
+						distributionUnknown = false
+					}
+				}
+				if distributionUnknown {
+					configInfo.Cfg.Global.ClusterDistribution = ClusterDistNameToServerVersion["unknown"]
+				}
 			}
 		}
 		go func() {

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -252,6 +252,7 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 					if strings.Contains(version, distServerVersion) {
 						configInfo.Cfg.Global.ClusterDistribution = distName
 						distributionUnknown = false
+						break
 					}
 				}
 				if distributionUnknown {

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -219,16 +219,19 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 				config, err := rest.InClusterConfig()
 				if err != nil {
 					log.Errorf("failed to get InClusterConfig: %v", err)
+					os.Exit(1)
 				}
 				clientset, err := kubernetes.NewForConfig(config)
 				if err != nil {
 					log.Errorf("failed to create kubernetes client with err: %v", err)
+					os.Exit(1)
 				}
 
 				// Get the version info for the Kubernetes API server
 				versionInfo, err := clientset.Discovery().ServerVersion()
 				if err != nil {
 					log.Errorf("failed to fetch versionInfo with err: %v", err)
+					os.Exit(1)
 				}
 
 				// Extract the version string from the version info
@@ -242,7 +245,7 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 					"openshift": "Openshift",
 					"wcp":       "Supervisor",
 					"vmware":    "TanzuKubernetesCluster",
-					"unknown":   "VanillaK8S",
+					"nativek8s": "VanillaK8S",
 				}
 				distributionUnknown := true
 				for distServerVersion, distName := range ClusterDistNameToServerVersion {
@@ -252,7 +255,7 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 					}
 				}
 				if distributionUnknown {
-					configInfo.Cfg.Global.ClusterDistribution = ClusterDistNameToServerVersion["unknown"]
+					configInfo.Cfg.Global.ClusterDistribution = ClusterDistNameToServerVersion["nativek8s"]
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is attempting to set cluster distribution type based on the k8s API server version by fetching it from the k8s cluster.
This PR is still in-works. Please do not review.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Here is a cluster with the cluster-distribution field set to empty string:
```
[Global]
insecure-flag = "true"
cluster-id = "cluster1"
cluster-distribution = ""

[VirtualCenter "10.186.63.186"]
user = "****"
password = "****"
datacenters = "VSAN-DC"
port = "443"
```
With the changes from this PR, the cluster distribution is set dynamically to Vanillak8s as the API server version is empty

![FieldSetDynamically](https://github.com/kubernetes-sigs/vsphere-csi-driver/assets/14131348/0b5a6370-6aca-4cfc-a2b4-14298d2aacc9)


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Determine cluster distribution server version & type using kubernetes API server version
```
