### PR TITLE
move clientMutex lock to public VC Connect method from private VC connect method - release-2.7

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -243,6 +243,8 @@ func (vc *VirtualCenter) login(ctx context.Context, client *govmomi.Client) erro
 func (vc *VirtualCenter) Connect(ctx context.Context) error {
 	log := logger.GetLogger(ctx)
 	// Set up the vc connection.
+	clientMutex.Lock()
+	defer clientMutex.Unlock()
 	err := vc.connect(ctx, false)
 	if err != nil {
 		log.Errorf("Cannot connect to vCenter with err: %v", err)
@@ -263,8 +265,6 @@ func (vc *VirtualCenter) Connect(ctx context.Context) error {
 // connect creates a connection to the virtual center host.
 func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) error {
 	log := logger.GetLogger(ctx)
-	clientMutex.Lock()
-	defer clientMutex.Unlock()
 	// If client was never initialized, initialize one.
 	var err error
 	if vc.Client == nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Refer to https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/2155 for more detail.

**Testing done**:
In progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fixes for not authenticated session in release-2.7 branch
```
