### PR TITLE
Cross-port PVCSI Detach Volume no-op changes to release-3.0

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -944,63 +944,73 @@ func controllerUnpublishForBlockVolume(ctx context.Context, req *csi.ControllerU
 		}
 		virtualMachine = &vmoperatortypes.VirtualMachine{}
 	}
-
-	// Watch virtual machine object and wait for volume name to be removed from the status field.
-	watchVirtualMachine, err := c.vmWatcher.Watch(metav1.ListOptions{
-		FieldSelector:   fields.SelectorFromSet(fields.Set{"metadata.name": string(virtualMachine.Name)}).String(),
-		ResourceVersion: virtualMachine.ResourceVersion,
-		TimeoutSeconds:  &timeoutSeconds,
-	})
-	if err != nil {
-		msg := fmt.Sprintf("failed to watch VirtualMachine %q with Error: %v", virtualMachine.Name, err)
-		log.Error(msg)
-		return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
+	isVolumePresentInVMStatus := false
+	for _, volume := range virtualMachine.Status.Volumes {
+		if volume.Name == req.VolumeId {
+			isVolumePresentInVMStatus = true
+		}
 	}
-	if watchVirtualMachine == nil {
-		msg := fmt.Sprintf("watchVirtualMachine for %q is nil", virtualMachine.Name)
-		log.Error(msg)
-		return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
-
-	}
-	defer watchVirtualMachine.Stop()
-
-	// Loop until the volume is removed from virtualmachine status
-	isVolumeDetached := false
-	for !isVolumeDetached {
-		log.Debugf("Waiting for update on VirtualMachine: %q", virtualMachine.Name)
-		// Block on update events
-		event := <-watchVirtualMachine.ResultChan()
-		vm, ok := event.Object.(*vmoperatortypes.VirtualMachine)
-		if !ok {
-			msg := fmt.Sprintf("Watch on virtualmachine %q timed out", virtualMachine.Name)
+	if !isVolumePresentInVMStatus {
+		log.Infof("ControllerUnpublishVolume: Volume %q not found in VM %q status field. Assuming it's already detached",
+			req.VolumeId, req.NodeId)
+	} else {
+		// Watch virtual machine object and wait for volume name to be removed from the status field.
+		watchVirtualMachine, err := c.vmWatcher.Watch(metav1.ListOptions{
+			FieldSelector:   fields.SelectorFromSet(fields.Set{"metadata.name": string(virtualMachine.Name)}).String(),
+			ResourceVersion: virtualMachine.ResourceVersion,
+			TimeoutSeconds:  &timeoutSeconds,
+		})
+		if err != nil {
+			msg := fmt.Sprintf("failed to watch VirtualMachine %q with Error: %v", virtualMachine.Name, err)
 			log.Error(msg)
 			return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
 		}
-		if vm.Name != virtualMachine.Name {
-			log.Debugf("Observed vm name: %q, expecting vm name: %q, volumeID: %q",
-				vm.Name, virtualMachine.Name, req.VolumeId)
-			continue
+		if watchVirtualMachine == nil {
+			msg := fmt.Sprintf("watchVirtualMachine for %q is nil", virtualMachine.Name)
+			log.Error(msg)
+			return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
+
 		}
-		switch event.Type {
-		case watch.Added, watch.Modified:
-			isVolumeDetached = true
-			for _, volume := range vm.Status.Volumes {
-				if volume.Name == req.VolumeId {
-					log.Debugf("Volume %q still exists in VirtualMachine %q status", volume.Name, virtualMachine.Name)
-					isVolumeDetached = false
-					if volume.Attached && volume.Error != "" {
-						msg := fmt.Sprintf("failed to detach volume %q from VirtualMachine %q with Error: %v",
-							volume.Name, virtualMachine.Name, volume.Error)
-						log.Error(msg)
-						return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
-					}
-					break
-				}
+		defer watchVirtualMachine.Stop()
+
+		// Loop until the volume is removed from virtualmachine status
+		isVolumeDetached := false
+		for !isVolumeDetached {
+			log.Debugf("Waiting for update on VirtualMachine: %q", virtualMachine.Name)
+			// Block on update events
+			event := <-watchVirtualMachine.ResultChan()
+			vm, ok := event.Object.(*vmoperatortypes.VirtualMachine)
+			if !ok {
+				msg := fmt.Sprintf("Watch on virtualmachine %q timed out", virtualMachine.Name)
+				log.Error(msg)
+				return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
 			}
-		case watch.Deleted:
-			log.Infof("VirtualMachine %s/%s deleted. Assuming volume %s was detached.",
-				c.supervisorNamespace, req.NodeId, req.VolumeId)
-			isVolumeDetached = true
+			if vm.Name != virtualMachine.Name {
+				log.Debugf("Observed vm name: %q, expecting vm name: %q, volumeID: %q",
+					vm.Name, virtualMachine.Name, req.VolumeId)
+				continue
+			}
+			switch event.Type {
+			case watch.Added, watch.Modified:
+				isVolumeDetached = true
+				for _, volume := range vm.Status.Volumes {
+					if volume.Name == req.VolumeId {
+						log.Debugf("Volume %q still exists in VirtualMachine %q status", volume.Name, virtualMachine.Name)
+						isVolumeDetached = false
+						if volume.Attached && volume.Error != "" {
+							msg := fmt.Sprintf("failed to detach volume %q from VirtualMachine %q with Error: %v",
+								volume.Name, virtualMachine.Name, volume.Error)
+							log.Error(msg)
+							return nil, csifault.CSIInternalFault, status.Errorf(codes.Internal, msg)
+						}
+						break
+					}
+				}
+			case watch.Deleted:
+				log.Infof("VirtualMachine %s/%s deleted. Assuming volume %s was detached.",
+					c.supervisorNamespace, req.NodeId, req.VolumeId)
+				isVolumeDetached = true
+			}
 		}
 	}
 	log.Infof("ControllerUnpublishVolume: Volume detached successfully %q", req.VolumeId)


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry-picks PR https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2299 to release-3.0 branch.
This is needed for TKR 1.26 & 1.27 releases.

 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cross-port PVCSI Detach Volume no-op changes to release-3.0
```
