### PR TITLE
Cherry Pick PV to backing disk ID

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -582,18 +582,55 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		defer pvToBackingDiskObjectIdMappingTicker.Stop()
 
 		var pvToBackingDiskObjectIdSupportCheck bool
-		vCenter, err := cnsvsphere.GetVirtualCenterInstance(ctx, configInfo, false)
-		if err != nil {
-			return err
+		if !isMultiVCenterFssEnabled {
+			vCenter, err := cnsvsphere.GetVirtualCenterInstance(ctx, configInfo, false)
+			if err != nil {
+				return err
+			}
+			pvToBackingDiskObjectIdSupportCheck = common.CheckPVtoBackingDiskObjectIdSupport(ctx, vCenter)
+
+		} else {
+			vcconfigs, err := cnsvsphere.GetVirtualCenterConfigs(ctx, configInfo.Cfg)
+			if err != nil {
+				return logger.LogNewErrorf(log, "failed to get VirtualCenterConfigs. err: %v", err)
+			}
+			var pvToBackingDiskObjectIdSupportedByVc bool
+			for _, vcconfig := range vcconfigs {
+				vCenter, err := cnsvsphere.GetVirtualCenterInstanceForVCenterConfig(ctx, vcconfig, false)
+				if err != nil {
+					return logger.LogNewErrorf(log, "failed to get vCenterInstance for vCenter Host: %q, err: %v", vcconfig.Host, err)
+				}
+				// All VCs in the deployment must support PV to Backing Disk Object ID feature.
+				pvToBackingDiskObjectIdSupportedByVc = common.CheckPVtoBackingDiskObjectIdSupport(ctx, vCenter)
+				if !pvToBackingDiskObjectIdSupportedByVc {
+					pvToBackingDiskObjectIdSupportCheck = false
+					break
+				} else {
+					pvToBackingDiskObjectIdSupportCheck = true
+				}
+			}
 		}
-		pvToBackingDiskObjectIdSupportCheck = common.CheckPVtoBackingDiskObjectIdSupport(ctx, vCenter)
 
 		if pvToBackingDiskObjectIdSupportCheck {
 			go func() {
 				for ; true; <-pvToBackingDiskObjectIdMappingTicker.C {
 					ctx, log = logger.GetNewContextWithLogger()
 					log.Info("get pv to backingDiskObjectId mapping is triggered")
-					csiGetPVtoBackingDiskObjectIdMapping(ctx, k8sClient, metadataSyncer)
+
+					if !isMultiVCenterFssEnabled {
+						csiGetPVtoBackingDiskObjectIdMapping(ctx, k8sClient, metadataSyncer,
+							metadataSyncer.configInfo.Cfg.Global.VCenterIP)
+					} else {
+						vcconfigs, err := cnsvsphere.GetVirtualCenterConfigs(ctx, configInfo.Cfg)
+						if err != nil {
+							log.Error(log, "failed to get VirtualCenterConfigs. err: %v", err)
+							return
+						}
+						// Update mapping for all VCs.
+						for _, vcconfig := range vcconfigs {
+							csiGetPVtoBackingDiskObjectIdMapping(ctx, k8sClient, metadataSyncer, vcconfig.Host)
+						}
+					}
 				}
 			}()
 		}


### PR DESCRIPTION
Support PV to Backing disk object ID for multi VC deployment.

Cherry Pick PR 2379

**Testing done**:

Created a PV on a multi VC cluster and observed that PV to backing disk object ID mapping was stamped on it.

```
root@k8s-control-13-1685439380:~# kubectl logs vsphere-csi-controller-b69f6999f-v4xbp -n vmware-system-csi -c vsphere-syncer | grep "csiGetPVtoBackingDiskObjectIdMapping"
2023-06-06T10:58:58.950Z	DEBUG	syncer/pv_to_backingdiskobjectid_mapping.go:36	csiGetPVtoBackingDiskObjectIdMapping for 10.192.252.235: start	{"TraceId": "774200fc-ed1d-4976-b87b-c5b58cb0ff2f"}
2023-06-06T10:58:58.991Z	DEBUG	syncer/pv_to_backingdiskobjectid_mapping.go:86	csiGetPVtoBackingDiskObjectIdMapping for 10.192.252.235: pvc default/example-vanilla-block-pvc is backed by pv pvc-a768837c-c619-4986-845b-fb6a84c565fd volumeHandle e642c006-1b77-479f-996c-14339b65cf0e, pv uid is 1fd2126f-02fa-4fc4-ba06-72e29581f44d	{"TraceId": "774200fc-ed1d-4976-b87b-c5b58cb0ff2f"}
2023-06-06T10:58:59.031Z	INFO	syncer/pv_to_backingdiskobjectid_mapping.go:123	csiGetPVtoBackingDiskObjectIdMapping for 10.192.252.235: pvc example-vanilla-block-pvc is updated with pv to backingDiskObjectId mapping 1fd2126f-02fa-4fc4-ba06-72e29581f44d:d70f7f64-b1e5-68c0-5553-02003ad5107c	{"TraceId": "774200fc-ed1d-4976-b87b-c5b58cb0ff2f"}
2023-06-06T10:58:59.031Z	DEBUG	syncer/pv_to_backingdiskobjectid_mapping.go:128	csiGetPVtoBackingDiskObjectIdMapping for 10.192.252.235: end	{"TraceId": "774200fc-ed1d-4976-b87b-c5b58cb0ff2f"}
2023-06-06T10:58:59.031Z	DEBUG	syncer/pv_to_backingdiskobjectid_mapping.go:36	csiGetPVtoBackingDiskObjectIdMapping for 10.186.2.142: start	{"TraceId": "774200fc-ed1d-4976-b87b-c5b58cb0ff2f"}
2023-06-06T10:58:59.052Z	DEBUG	syncer/pv_to_backingdiskobjectid_mapping.go:86	csiGetPVtoBackingDiskObjectIdMapping for 10.186.2.142: pvc default/example-vanilla-block-pvc is backed by pv pvc-a768837c-c619-4986-845b-fb6a84c565fd volumeHandle e642c006-1b77-479f-996c-14339b65cf0e, pv uid is 1fd2126f-02fa-4fc4-ba06-72e29581f44d	{"TraceId": "774200fc-ed1d-4976-b87b-c5b58cb0ff2f"}
2023-06-06T10:58:59.053Z	DEBUG	syncer/pv_to_backingdiskobjectid_mapping.go:110	csiGetPVtoBackingDiskObjectIdMapping for 10.186.2.142: Skipping vol e642c006-1b77-479f-996c-14339b65cf0e as it is not found on this VC.	{"TraceId": "774200fc-ed1d-4976-b87b-c5b58cb0ff2f"}
2023-06-06T10:58:59.053Z	DEBUG	syncer/pv_to_backingdiskobjectid_mapping.go:128	csiGetPVtoBackingDiskObjectIdMapping for 10.186.2.142: end	{"TraceId": "774200fc-ed1d-4976-b87b-c5b58cb0ff2f"}
```

```
root@k8s-control-13-1685439380:~# kubectl describe pvc
Name:          example-vanilla-block-pvc
Namespace:     default
StorageClass:  example-vanilla-block-sc
Status:        Bound
Volume:        pvc-a768837c-c619-4986-845b-fb6a84c565fd
Labels:        <none>
Annotations:   cns.vmware.com/pv-to-backingdiskobjectid-mapping: 1fd2126f-02fa-4fc4-ba06-72e29581f44d:d70f7f64-b1e5-68c0-5553-02003ad5107c
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
```

