### PR TITLE
cherry-pick-to-release-3.0 - Allow NTFS fsType to be uppercase (#2305)

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -184,7 +184,7 @@ func validateVolumeCapabilities(volCaps []*csi.VolumeCapability,
 			// ext3, ext4, xfs for Linux and ntfs for Windows.
 			if volCap.GetMount() != nil && !(volCap.GetMount().FsType == Ext4FsType ||
 				volCap.GetMount().FsType == Ext3FsType || volCap.GetMount().FsType == XFSType ||
-				volCap.GetMount().FsType == NTFSFsType || volCap.GetMount().FsType == "") {
+				strings.ToLower(volCap.GetMount().FsType) == NTFSFsType || volCap.GetMount().FsType == "") {
 				return fmt.Errorf("fstype %s not supported for ReadWriteOnce volume creation",
 					volCap.GetMount().FsType)
 			}

--- a/pkg/csi/service/common/util_test.go
+++ b/pkg/csi/service/common/util_test.go
@@ -272,6 +272,40 @@ func TestValidVolumeCapabilitiesForFile(t *testing.T) {
 	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
 		t.Errorf("File VolCap = %+v failed validation!", volCap)
 	}
+
+	// fstype=ntfs and mode=SINGLE_NODE_WRITER
+	volCap = []*csi.VolumeCapability{
+		{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{
+					FsType: "ntfs",
+				},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
+		t.Errorf("File VolCap = %+v failed validation!", volCap)
+	}
+
+	// fstype=NTFS and mode=SINGLE_NODE_WRITER
+	volCap = []*csi.VolumeCapability{
+		{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{
+					FsType: "NTFS",
+				},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	if err := IsValidVolumeCapabilities(ctx, volCap); err != nil {
+		t.Errorf("File VolCap = %+v failed validation!", volCap)
+	}
 }
 
 func TestInvalidVolumeCapabilitiesForFile(t *testing.T) {


### PR DESCRIPTION
Cherry picking https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2305 to release-3.0 branch.

* Allow NTFS fsType to be uppercase

It is valid to use "NTFS" or "ntfs" to specify the fsType for an in-tree vSphere volume. This change allows CSI migration to work for cases where an in-tree volume may have been provisioned with an uppercase string used to specify the filesystem type.



* Add unit tests for NTFS/ntfs


```release-note
Allow NTFS fsType to be uppercase
```
