### PR TITLE
fss: enable listview-tasks on supervisor from 1.23 to 1.26

### DIFF
--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -431,7 +431,7 @@ data:
   "tkgs-ha": "true"
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
-  "listview-tasks": "false"
+  "listview-tasks": "true"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -434,7 +434,7 @@ data:
   "tkgs-ha": "true"
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
-  "listview-tasks": "false"
+  "listview-tasks": "true"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -431,7 +431,7 @@ data:
   "tkgs-ha": "true"
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
-  "listview-tasks": "false"
+  "listview-tasks": "true"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -431,7 +431,7 @@ data:
   "tkgs-ha": "true"
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
-  "listview-tasks": "false"
+  "listview-tasks": "true"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -63,7 +63,7 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 				"topology-preferential-datastores":  "true",
 				"max-pvscsi-targets-per-vm":         "true",
 				"multi-vcenter-csi-topology":        "true",
-				"listview-tasks":                    "false",
+				"listview-tasks":                    "true",
 			},
 		}
 		return fakeCO, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Enable `listview-tasks` on supervisor from 1.23 to 1.26

**Testing done**:
Validation performed by QE. 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fss: enable listview-tasks on supervisor from 1.23 to 1.26
```
