### PR TITLE
For CICD jobs - Cleanup namespace created by test framework mainly in static provisioning and volume expansion tests

### DIFF
--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 
 	f := framework.NewDefaultFramework("e2e-csistaticprovision")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-
+	framework.TestContext.DeleteNamespace = true
 	var (
 		client                     clientset.Interface
 		namespace                  string

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -57,6 +57,7 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 
 	f := framework.NewDefaultFramework("volume-expansion")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	framework.TestContext.DeleteNamespace = true
 	var (
 		client                     clientset.Interface
 		namespace                  string


### PR DESCRIPTION
What this PR does / why we need it: For CICD jobs - Cleanup namespace created by test framework mainly in static provisioning and volume expansion tests

Testing done:
Yes

Special notes for your reviewer:
