### PR TITLE
Fixing -> tar: removing leading '/' from member names, issue with kubectl cp

### DIFF
--- a/tests/e2e/policy_driven_vol_allocation.go
+++ b/tests/e2e/policy_driven_vol_allocation.go
@@ -3163,7 +3163,7 @@ func verifyKnownDataInPod(f *framework.Framework, pod *v1.Pod, testdataFile stri
 			"/bin/sh", "-c", "dd if=/mnt/volume1/f1 of=/mnt/volume1/testdata bs=1M count=100 skip=" + skip}
 		_ = framework.RunKubectlOrDie(pod.Namespace, cmd...)
 		_ = framework.RunKubectlOrDie(pod.Namespace, "cp",
-			fmt.Sprintf("%v/%v:/mnt/volume1/testdata", pod.Namespace, pod.Name),
+			fmt.Sprintf("%v/%v:mnt/volume1/testdata", pod.Namespace, pod.Name),
 			testdataFile+pod.Name)
 		framework.Logf("Running diff with source file and file from pod %v for 100M starting %vM", pod.Name, skip)
 		op, err := exec.Command("diff", testdataFile, testdataFile+pod.Name).Output()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: fixing `tar: removing leading '/' from member names`, issue that we are seeing with `kubectl cp` cmd in test lib

**Testing done**:
```bash
root@k8s-control-687-1686835744:~# kubectl cp pod-4rx8g:/mnt/volume1/testdata /root/podfile
tar: removing leading '/' from member names
root@k8s-control-687-1686835744:~# kubectl exec pod-4rx8g -- pwd
/
root@k8s-control-687-1686835744:~# kubectl cp pod-4rx8g:mnt/volume1/testdata /root/podfile
root@k8s-control-687-1686835744:~#
```
implementing this fix in test code

pipeline results: https://gist.github.com/sashrith/503c2b7889ab0e2bb293da0ac6d65251 (it shows two failures but they are not related to the fix here)
