### PR TITLE
Update csi-snapshotter version in cns-csi yamls

### DIFF
--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -396,7 +396,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: csi-snapshotter
-          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.1
+          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -399,7 +399,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: csi-snapshotter
-          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.1
+          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -396,7 +396,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: csi-snapshotter
-          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.1
+          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -396,7 +396,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: csi-snapshotter
-          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.1
+          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating the csi-snapshotter sidecar version number.
The internal build system for the csi driver generates version "vmware.2" and not "vmware.1" after recent changes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
No changes in functionality, just bumping the version.
```

**Special notes for your reviewer**:

**Release note**:
```release-note
```
