### PR TITLE
fix: GenerateDatastoreMapForBlockVolumes fails if there are no entities

### DIFF
--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -242,6 +242,10 @@ func GenerateDatastoreMapForBlockVolumes(ctx context.Context,
 		}
 	}
 
+	if len(entities) == 0 {
+		return map[string]*cnsvsphere.DatastoreInfo{}, nil
+	}
+
 	dsURLToInfoMap, err := getDatastoresWithBlockVolumePrivs(ctx, vc, dsURLs, dsInfos, entities)
 	if err != nil {
 		log.Errorf("failed to get datastores with required priv for vCenter %q. Error: %+v", vc.Config.Host, err)
@@ -372,7 +376,7 @@ func getDatastoresWithBlockVolumePrivs(ctx context.Context, vc *cnsvsphere.Virtu
 
 	userName := vc.Config.Username
 	// Invoke authMgr function HasUserPrivilegeOnEntities.
-	result, err := authMgr.HasUserPrivilegeOnEntities(ctx, entities, userName, privIds)
+	result, err := authMgr.HasUserPrivilegeOnEntities(ctx, entities, userName, privIds) // entities empty -> error
 	if err != nil {
 		log.Errorf("auth manager: failed to check privilege %v on entities %v for user %s and for vCenter %q",
 			privIds, entities, userName, vc.Config.Host)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We have a multi vcenter setup in which all datastores are currently in only one vcenter.
This leads to many errors like the following:
`{"level":"error","time":"2023-06-22T11:14:01.916433945Z","caller":"common/authmanager.go:247","msg":"failed to get datastores with required priv for vCenter \"xxx\". Error: ServerFaultCode: \nRequired parameter entities is missing\n\nwhile parsing call information for method HasUserPrivilegeOnEntities\nat line 2, column 66\n\nwhile parsing SOAP body\nat line 2, column 60\n\nwhile parsing SOAP envelope\nat line 2, column 0\n\nwhile parsing HTTP request for method hasUserPrivilegeOnEntities\non object of type vim.AuthorizationManager\nat line 1, column 0","TraceId":"2b45f0db-1d50-4299-9f15-f6a34f8807ec","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common.GenerateDatastoreMapForBlockVolumes\n\t/build/pkg/csi/service/common/authmanager.go:247\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common.(*AuthManager).refreshDatastoreMapForBlockVolumes\n\t/build/pkg/csi/service/common/authmanager.go:158\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common.ComputeDatastoreMapForBlockVolumes\n\t/build/pkg/csi/service/common/authmanager.go:199"}
{"level":"warn","time":"2023-06-22T11:14:01.916459756Z","caller":"common/authmanager.go:166","msg":"auth manager: failed to get updated datastoreMapForBlockVolumes for vCenter \"xxx\", Err: ServerFaultCode: \nRequired parameter entities is missing\n\nwhile parsing call information for method HasUserPrivilegeOnEntities\nat line 2, column 66\n\nwhile parsing SOAP body\nat line 2, column 60\n\nwhile parsing SOAP envelope\nat line 2, column 0\n\nwhile parsing HTTP request for method hasUserPrivilegeOnEntities\non object of type vim.AuthorizationManager\nat line 1, column 0","TraceId":"2b45f0db-1d50-4299-9f15-f6a34f8807ec"}`

We also suspect this to be responsible for the need to restart the csi vsphere controller from time to time to get volumes provisioned.

**Testing done**:
Not sure if I need to write a test for this. If yes i'd appreciate a hint on where to add it.
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
