### PR TITLE
Run vSphere CSI controller pod with non-root user

### DIFF
--- a/manifests/guestcluster/1.24/pvcsi.yaml
+++ b/manifests/guestcluster/1.24/pvcsi.yaml
@@ -231,6 +231,10 @@ spec:
               value: {{ .PVCSINamespace }}
             - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
               value: 3m
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/cloud/pvcsi-provider
               name: pvcsi-provider-volume
@@ -267,6 +271,10 @@ spec:
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: CSI_NAMESPACE
               value: {{ .PVCSINamespace }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
           - mountPath: /etc/cloud/pvcsi-provider
             name: pvcsi-provider-volume

--- a/manifests/guestcluster/1.25/pvcsi.yaml
+++ b/manifests/guestcluster/1.25/pvcsi.yaml
@@ -243,6 +243,10 @@ spec:
               value: {{ .PVCSINamespace }}
             - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
               value: 3m
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/cloud/pvcsi-provider
               name: pvcsi-provider-volume
@@ -279,6 +283,10 @@ spec:
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: CSI_NAMESPACE
               value: {{ .PVCSINamespace }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
           - mountPath: /etc/cloud/pvcsi-provider
             name: pvcsi-provider-volume

--- a/manifests/guestcluster/1.26/pvcsi.yaml
+++ b/manifests/guestcluster/1.26/pvcsi.yaml
@@ -243,6 +243,10 @@ spec:
               value: {{ .PVCSINamespace }}
             - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
               value: 3m
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/cloud/pvcsi-provider
               name: pvcsi-provider-volume
@@ -279,6 +283,10 @@ spec:
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: CSI_NAMESPACE
               value: {{ .PVCSINamespace }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
           - mountPath: /etc/cloud/pvcsi-provider
             name: pvcsi-provider-volume

--- a/manifests/guestcluster/1.27/pvcsi.yaml
+++ b/manifests/guestcluster/1.27/pvcsi.yaml
@@ -243,6 +243,10 @@ spec:
               value: {{ .PVCSINamespace }}
             - name: X_CSI_SERIAL_VOL_ACCESS_TIMEOUT
               value: 3m
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/cloud/pvcsi-provider
               name: pvcsi-provider-volume
@@ -279,6 +283,10 @@ spec:
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: CSI_NAMESPACE
               value: {{ .PVCSINamespace }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
           - mountPath: /etc/cloud/pvcsi-provider
             name: pvcsi-provider-volume

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -340,6 +340,10 @@ spec:
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -392,6 +396,10 @@ spec:
             - containerPort: 2113
               name: prometheus
               protocol: TCP
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -673,6 +681,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: webhook-certs

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -337,6 +337,10 @@ spec:
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -389,6 +393,10 @@ spec:
             - containerPort: 2113
               name: prometheus
               protocol: TCP
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -667,6 +675,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: webhook-certs

--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -337,6 +337,10 @@ spec:
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -389,6 +393,10 @@ spec:
             - containerPort: 2113
               name: prometheus
               protocol: TCP
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -667,6 +675,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: webhook-certs

--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -149,6 +149,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /run/secrets/tls
               name: webhook-certs

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -306,6 +306,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
@@ -366,6 +370,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 On Kubernetes environment, it is recommended to run the pods with non-root user wherever applicable, providing the least privileges possible. Currently vSphere CSI driver/webhook pods (vsphere-csi-controller and syncer container specifically) run without any pod level security settings, which makes them vulnerable to possible security vulnerabilities or threats.
Customers have raised the concern about this at https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/2062.
Due to OS related functionality, CSI node plugin cannot run with non-root user and all CSI sidecars already run as non-root user containers. 
This PR addresses the issue by running the CSI driver/webhook containers (csi-controller & syncer) with specific non-root user.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/2062

**Testing done**:
Testing in progress.

**Special notes for your reviewer**:
This change will be enabled for all CSI flavors including vanilla CSI, CNS-CSI and PVCSI

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Run vSphere CSI controller pod with non-root user
```
