### PR TITLE
[WIP] Topology pvc creation timeout fix

### DIFF
--- a/tests/e2e/binding_modes_with_topology.go
+++ b/tests/e2e/binding_modes_with_topology.go
@@ -99,9 +99,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By("Expect claim status to be in Pending state")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to find the volume in pending "+
+			"state with err: "+err.Error())
 
 		ginkgo.By("Creating a pod")
 		pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
@@ -109,8 +109,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By("Expect claim to be in Bound state and provisioning volume passes")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume with err: "+err.Error())
 
 		pv = getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",

--- a/tests/e2e/invalid_topology_values.go
+++ b/tests/e2e/invalid_topology_values.go
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
 		expectedErrMsg := "No compatible datastores found for accessibility requirements"
 		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Expected error: "+expectedErrMsg)
 	})
 
 	/*
@@ -128,7 +128,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
 		expectedErrMsg := "No compatible datastores found for accessibility requirements"
 		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Expected error: "+expectedErrMsg)
 
 	})
 
@@ -164,7 +164,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
 		expectedErrMsg := "No compatible datastores found for accessibility requirements"
 		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Expected error: "+expectedErrMsg)
 
 	})
 })

--- a/tests/e2e/invalid_topology_values.go
+++ b/tests/e2e/invalid_topology_values.go
@@ -91,10 +91,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		}()
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
 		expectedErrMsg := "No compatible datastores found for accessibility requirements"
-		isFailureFound, err := waitForEventWithReason(client, namespace, pvclaim.Name, expectedErrMsg)
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(isFailureFound).To(
-			gomega.BeTrue(), "Expected error %v, to occur but did not occur", expectedErrMsg)
 	})
 
 	/*
@@ -129,10 +127,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
 		expectedErrMsg := "No compatible datastores found for accessibility requirements"
-		isFailureFound, err := waitForEventWithReason(client, namespace, pvclaim.Name, expectedErrMsg)
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(isFailureFound).To(
-			gomega.BeTrue(), "Expected error %v, to occur but did not occur", expectedErrMsg)
 
 	})
 
@@ -167,10 +163,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		}()
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
 		expectedErrMsg := "No compatible datastores found for accessibility requirements"
-		isFailureFound, err := waitForEventWithReason(client, namespace, pvclaim.Name, expectedErrMsg)
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(isFailureFound).To(
-			gomega.BeTrue(), "Expected error %v, to occur but did not occur", expectedErrMsg)
 
 	})
 })

--- a/tests/e2e/invalid_topology_values.go
+++ b/tests/e2e/invalid_topology_values.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -91,14 +90,11 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
-		framework.ExpectError(fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound,
-			client, pvclaim.Namespace, pvclaim.Name, framework.PollShortTimeout, pollTimeoutShort))
-		// Get the event list and verify if it contains expected error message
-		eventList, _ := client.CoreV1().Events(pvclaim.Namespace).List(ctx, metav1.ListOptions{})
-		gomega.Expect(eventList.Items).NotTo(gomega.BeEmpty())
 		expectedErrMsg := "No compatible datastores found for accessibility requirements"
-		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+		isFailureFound, err := waitForEventWithReason(client, namespace, pvclaim.Name, expectedErrMsg)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isFailureFound).To(
+			gomega.BeTrue(), "Expected error %v, to occur but did not occur", expectedErrMsg)
 	})
 
 	/*
@@ -132,14 +128,12 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		}()
 
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
-		framework.ExpectError(fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound,
-			client, pvclaim.Namespace, pvclaim.Name, pollTimeoutShort, framework.PollShortTimeout))
-		// Get the event list and verify if it contains expected error message
-		eventList, _ := client.CoreV1().Events(pvclaim.Namespace).List(ctx, metav1.ListOptions{})
-		gomega.Expect(eventList.Items).NotTo(gomega.BeEmpty())
 		expectedErrMsg := "No compatible datastores found for accessibility requirements"
-		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+		isFailureFound, err := waitForEventWithReason(client, namespace, pvclaim.Name, expectedErrMsg)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isFailureFound).To(
+			gomega.BeTrue(), "Expected error %v, to occur but did not occur", expectedErrMsg)
+
 	})
 
 	/*
@@ -172,13 +166,11 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
-		framework.ExpectError(fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, pollTimeoutShort, framework.PollShortTimeout))
-		// Get the event list and verify if it contains expected error message
-		eventList, _ := client.CoreV1().Events(pvclaim.Namespace).List(ctx, metav1.ListOptions{})
-		gomega.Expect(eventList.Items).NotTo(gomega.BeEmpty())
 		expectedErrMsg := "No compatible datastores found for accessibility requirements"
-		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error %q", expectedErrMsg))
+		isFailureFound, err := waitForEventWithReason(client, namespace, pvclaim.Name, expectedErrMsg)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isFailureFound).To(
+			gomega.BeTrue(), "Expected error %v, to occur but did not occur", expectedErrMsg)
+
 	})
 })

--- a/tests/e2e/partial_topology_values.go
+++ b/tests/e2e/partial_topology_values.go
@@ -98,8 +98,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By("Expect claim to pass provisioning volume")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, pollTimeoutShort)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume with err: "+err.Error())
 
 		ginkgo.By("Verify if volume is provisioned in specified region")
 		pv := getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)
@@ -175,8 +175,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By("Expect claim to pass provisioning volume")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, pollTimeoutShort)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume with err: ", err)
 
 		ginkgo.By("Verify if volume is provisioned in specified zone")
 		pv := getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)

--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -1848,10 +1848,8 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
 		expectedErrMsg := "failed to create volume"
-		isFailureFound, err := waitForEventWithReason(client, namespace, pvclaim.Name, expectedErrMsg)
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(isFailureFound).To(
-			gomega.BeTrue(), "Expected error %v, to occur but did not occur", expectedErrMsg)
 
 	})
 
@@ -2380,10 +2378,8 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 
 		ginkgo.By("Expect claim to fail provisioning volume")
 		expectedErrMsg := "failed to create volume"
-		isFailureFound, err := waitForEventWithReason(client, namespace, pvclaim.Name, expectedErrMsg)
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(isFailureFound).To(
-			gomega.BeTrue(), "Expected error %v, to occur but did not occur", expectedErrMsg)
 
 	})
 

--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -1847,11 +1847,12 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		}()
 
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
-		framework.ExpectError(fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound,
-			client, pvclaim.Namespace, pvclaim.Name, pollTimeoutShort, framework.PollShortTimeout))
 		expectedErrMsg := "failed to create volume"
-		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+		isFailureFound, err := waitForEventWithReason(client, namespace, pvclaim.Name, expectedErrMsg)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isFailureFound).To(
+			gomega.BeTrue(), "Expected error %v, to occur but did not occur", expectedErrMsg)
+
 	})
 
 	/*
@@ -2378,11 +2379,12 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		}()
 
 		ginkgo.By("Expect claim to fail provisioning volume")
-		framework.ExpectError(fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound,
-			client, pvclaim.Namespace, pvclaim.Name, pollTimeoutShort, framework.PollShortTimeout))
 		expectedErrMsg := "failed to create volume"
-		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+		isFailureFound, err := waitForEventWithReason(client, namespace, pvclaim.Name, expectedErrMsg)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isFailureFound).To(
+			gomega.BeTrue(), "Expected error %v, to occur but did not occur", expectedErrMsg)
+
 	})
 
 	/*
@@ -2483,9 +2485,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 
 		ginkgo.By("Expect claim status to be in Pending state since sps service is down")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
-			pvc.Namespace, pvc.Name, framework.Poll, time.Minute)
+			pvc.Namespace, pvc.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+			"Failed to find the volume in pending state with err: "+err.Error())
 
 		ginkgo.By("Bringup SPS service")
 		startVCServiceWait4VPs(ctx, vcAddress, spsServiceName, &isSPSServiceStopped)

--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -1849,7 +1849,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
 		expectedErrMsg := "failed to create volume"
 		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Expected error: "+expectedErrMsg)
 
 	})
 
@@ -2379,7 +2379,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Expect claim to fail provisioning volume")
 		expectedErrMsg := "failed to create volume"
 		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Expected error: "+expectedErrMsg)
 
 	})
 

--- a/tests/e2e/preferential_topology_snapshot.go
+++ b/tests/e2e/preferential_topology_snapshot.go
@@ -448,7 +448,8 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		gomega.Expect(err).To(gomega.HaveOccurred())
 		expectedErrMsg := "failed to get the compatible shared datastore for create volume from snapshot"
 		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim2.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Expected error: "+expectedErrMsg)
+
 		defer func() {
 			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/provision_with_multiple_zones.go
+++ b/tests/e2e/provision_with_multiple_zones.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -110,8 +109,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		}()
 		ginkgo.By("Expect claim to pass provisioning volume")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume with err: "+err.Error())
 
 		ginkgo.By("Verify if volume is provisioned in specified zone and region")
 		pv = getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)

--- a/tests/e2e/topology_new_node_with_different_labels.go
+++ b/tests/e2e/topology_new_node_with_different_labels.go
@@ -99,7 +99,7 @@ var _ = ginkgo.Describe("[csi-topology-for-new-node] Topology-Provisioning-For-N
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
 		expectedErrMsg := "failed to get shared datastores for topology requirement"
 		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Expected error: "+expectedErrMsg)
 	})
 
 	/*

--- a/tests/e2e/topology_new_node_with_different_labels.go
+++ b/tests/e2e/topology_new_node_with_different_labels.go
@@ -98,10 +98,8 @@ var _ = ginkgo.Describe("[csi-topology-for-new-node] Topology-Provisioning-For-N
 		// Expect claim to fail provisioning volume within the topology
 		ginkgo.By("Expect claim to fail provisioning volume within the topology")
 		expectedErrMsg := "failed to get shared datastores for topology requirement"
-		isFailureFound, err := waitForEventWithReason(client, namespace, pvclaim.Name, expectedErrMsg)
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(isFailureFound).To(
-			gomega.BeTrue(), "Expected error %v, to occur but did not occur", expectedErrMsg)
 	})
 
 	/*

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -817,7 +817,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		expectedErrMsg := "volume topology feature for file volumes is not supported."
 		framework.Logf("Expected failure message: %+q", expectedErrMsg)
 		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvc.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Expected error: "+expectedErrMsg)
 	})
 
 	/*

--- a/tests/e2e/volume_provisioning_with_topology.go
+++ b/tests/e2e/volume_provisioning_with_topology.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -101,8 +100,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 
 		ginkgo.By("Expect claim to pass provisioning volume")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume with err: "+err.Error())
 
 		ginkgo.By("Verify if volume is provisioned in specified zone and region")
 		pv := getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)
@@ -147,7 +146,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 		}()
 		framework.Logf("Expected failure message: %+q", expectedErrMsg)
 		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Expected error: "+expectedErrMsg)
+
 	}
 
 	/*


### PR DESCRIPTION
**What this PR does / why we need it**:
Topology pvc creation timeout fix, earlier default wait time for PVC creation was set to 1 min, making it uniform to 5 mins default wait time for pvc creation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Topology pvc creation timeout fix, earlier default wait time for PVC creation was set to 1 min, making it uniform to 5 mins default wait time for pvc creation.

**Testing done**:
Yes, regression results uploaded

**Special notes for your reviewer**:
Make Check:
sipriya@sipriyaSMD6M vsphere-csi-driver % golangci-lint run --enable=lll 
sipriya@sipriyaSMD6M vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/topology-l2-timeout-fix/vsphere-csi-driver /Users/sipriya/topology-l2-timeout-fix /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (deps|exports_file|imports|types_sizes|compiled_files|files|name) took 11.794013588s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 160.16307ms 

