### PR TITLE
Remove "volume.beta.kubernetes.io/storage-class" references from test code

### DIFF
--- a/tests/e2e/csi_cns_telemetry_statefulsets.go
+++ b/tests/e2e/csi_cns_telemetry_statefulsets.go
@@ -138,7 +138,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor]
 		statefulset := GetStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = sc.Name
+			Spec.StorageClassName = &sc.Name
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready.

--- a/tests/e2e/csi_snapshot_basic.go
+++ b/tests/e2e/csi_snapshot_basic.go
@@ -2298,7 +2298,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		statefulset := GetStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = scName
+			Spec.StorageClassName = &scName
 		*statefulset.Spec.Replicas = 2
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -300,7 +300,6 @@ var (
 	migratedPluginAnnotation        = "storage.alpha.kubernetes.io/migrated-plugins"
 	pvcAnnotationStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
 	pvAnnotationProvisionedBy       = "pv.kubernetes.io/provisioned-by"
-	scAnnotation4Statefulset        = "volume.beta.kubernetes.io/storage-class"
 	nodeMapper                      = &NodeMapper{}
 )
 

--- a/tests/e2e/file_volume_statefulsets.go
+++ b/tests/e2e/file_volume_statefulsets.go
@@ -43,11 +43,9 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 	f := framework.NewDefaultFramework("e2e-vsphere-statefulset")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
-		namespace               string
-		client                  clientset.Interface
-		scParameters            map[string]string
-		sshClientConfig         *ssh.ClientConfig
-		nimbusGeneratedK8sVmPwd string
+		namespace    string
+		client       clientset.Interface
+		scParameters map[string]string
 	)
 	ginkgo.BeforeEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -120,7 +118,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = scName
+			Spec.StorageClassName = &scName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
@@ -286,7 +284,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = scName
+			Spec.StorageClassName = &scName
 		ginkgo.By("Creating statefulset")
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
@@ -445,7 +443,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = scName
+			Spec.StorageClassName = &scName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
@@ -561,7 +559,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = scName
+			Spec.StorageClassName = &scName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
@@ -768,8 +766,8 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 
 		//List volume responses will show up in the interval of every 1 minute.
 		time.Sleep(pollTimeoutShort)
-		nimbusGeneratedK8sVmPwd = GetAndExpectStringEnvVar(nimbusK8sVmPwd)
-		sshClientConfig = &ssh.ClientConfig{
+		nimbusGeneratedK8sVmPwd := GetAndExpectStringEnvVar(nimbusK8sVmPwd)
+		sshClientConfig := &ssh.ClientConfig{
 			User: "root",
 			Auth: []ssh.AuthMethod{
 				ssh.Password(nimbusGeneratedK8sVmPwd),

--- a/tests/e2e/gc_rwx_destructive.go
+++ b/tests/e2e/gc_rwx_destructive.go
@@ -167,10 +167,11 @@ var _ = ginkgo.Describe("[rwm-csi-destructive-tkg] Statefulsets with File Volume
 
 		statefulset := GetStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
+		scName := defaultNginxStorageClassName
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = defaultNginxStorageClassName
+			Spec.StorageClassName = &scName
 		*statefulset.Spec.Replicas = 2
 		CreateStatefulSet(namespace, statefulset, clientNewGc)
 		replicas := *(statefulset.Spec.Replicas)

--- a/tests/e2e/gc_rwx_statefulsets.go
+++ b/tests/e2e/gc_rwx_statefulsets.go
@@ -137,10 +137,11 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Provision with Statefulsets",
 		}()
 		statefulset := GetStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
+		scName := defaultNginxStorageClassName
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = defaultNginxStorageClassName
+			Spec.StorageClassName = &scName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 
@@ -431,11 +432,12 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Provision with Statefulsets",
 		}()
 		statefulset := GetStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
+		scName := defaultNginxStorageClassName
 		statefulset.Spec.PodManagementPolicy = apps.ParallelPodManagement
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = defaultNginxStorageClassName
+			Spec.StorageClassName = &scName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 

--- a/tests/e2e/gc_rwx_tkg_scale.go
+++ b/tests/e2e/gc_rwx_tkg_scale.go
@@ -135,10 +135,11 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] TKG RWX for STS with GC worker nodes scal
 
 		statefulset := GetStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
+		scName := defaultNginxStorageClassName
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = defaultNginxStorageClassName
+			Spec.StorageClassName = &scName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 
@@ -377,11 +378,12 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] TKG RWX for STS with GC worker nodes scal
 		}()
 		statefulset := GetStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
+		scName := defaultNginxStorageClassName
 		statefulset.Spec.PodManagementPolicy = apps.ParallelPodManagement
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 			v1.ReadWriteMany
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = defaultNginxStorageClassName
+			Spec.StorageClassName = &scName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 

--- a/tests/e2e/labelupdates.go
+++ b/tests/e2e/labelupdates.go
@@ -682,7 +682,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelize
 		ginkgo.By("Creating statefulset")
 		statefulset := GetStatefulSetFromManifest(namespace)
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+			Spec.StorageClassName = &storageClassName
 		CreateStatefulSet(namespace, statefulset, client)
 		defer func() {
 			ginkgo.By(fmt.Sprintf("Deleting all statefulsets in namespace: %v", namespace))

--- a/tests/e2e/nodes_scaleup_scaledown.go
+++ b/tests/e2e/nodes_scaleup_scaledown.go
@@ -132,7 +132,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] [csi-block-vanilla-serialized] Nodes
 		}
 
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = scName
+			Spec.StorageClassName = &scName
 		CreateStatefulSet(namespace, statefulset, client)
 
 		defer func() {

--- a/tests/e2e/preupgrade_datasetup.go
+++ b/tests/e2e/preupgrade_datasetup.go
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("PreUpgrade datasetup Test", func() {
 		statefulset := GetStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+			Spec.StorageClassName = &storageClassName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready

--- a/tests/e2e/raw_block_volume.go
+++ b/tests/e2e/raw_block_volume.go
@@ -201,6 +201,7 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		}()
 
 		ginkgo.By("Creating statefulset with raw block volume")
+		scName := defaultNginxStorageClassName
 		statefulset := GetStatefulSetFromManifest(namespace)
 		statefulset.Spec.Template.Spec.Containers[len(statefulset.Spec.Template.Spec.Containers)-1].VolumeMounts = nil
 		statefulset.Spec.Template.Spec.Containers[len(statefulset.Spec.Template.Spec.Containers)-1].
@@ -211,7 +212,7 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 			},
 		}
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = defaultNginxStorageClassName
+			Spec.StorageClassName = &scName
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].ObjectMeta.Name =
 			statefulset_volname
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.VolumeMode =

--- a/tests/e2e/staging_env_basic.go
+++ b/tests/e2e/staging_env_basic.go
@@ -190,7 +190,7 @@ var _ = ginkgo.Describe("[csi-supervisor-staging] Tests for WCP env with minimal
 		statefulset.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = port
 		statefulset.Spec.Template.Spec.Containers[0].Ports[0].Name = "web" + val + strconv.Itoa(min)
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storagePolicyName
+			Spec.StorageClassName = &storagePolicyName
 
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
@@ -423,7 +423,7 @@ var _ = ginkgo.Describe("[csi-supervisor-staging] Tests for WCP env with minimal
 		statefulset.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = port
 		statefulset.Spec.Template.Spec.Containers[0].Ports[0].Name = "web" + val + strconv.Itoa(min)
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storagePolicyName
+			Spec.StorageClassName = &storagePolicyName
 
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
@@ -662,7 +662,7 @@ var _ = ginkgo.Describe("[csi-supervisor-staging] Tests for WCP env with minimal
 		statefulset.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = port
 		statefulset.Spec.Template.Spec.Containers[0].Ports[0].Name = "web" + val + strconv.Itoa(min)
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storagePolicyName
+			Spec.StorageClassName = &storagePolicyName
 
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
@@ -733,7 +733,7 @@ var _ = ginkgo.Describe("[csi-supervisor-staging] Tests for WCP env with minimal
 		statefulset = GetResizedStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storagePolicyName
+			Spec.StorageClassName = &storagePolicyName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas = *(statefulset.Spec.Replicas)
 

--- a/tests/e2e/statefulset_xfs.go
+++ b/tests/e2e/statefulset_xfs.go
@@ -94,7 +94,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] st
 		ginkgo.By("Creating statefulset")
 		statefulset := GetStatefulSetFromManifest(namespace)
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+			Spec.StorageClassName = &storageClassName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready

--- a/tests/e2e/statefulsets.go
+++ b/tests/e2e/statefulsets.go
@@ -64,13 +64,11 @@ var _ = ginkgo.Describe("statefulset", func() {
 	f := framework.NewDefaultFramework("e2e-vsphere-statefulset")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
-		namespace               string
-		client                  clientset.Interface
-		storagePolicyName       string
-		scParameters            map[string]string
-		storageClassName        string
-		sshClientConfig         *ssh.ClientConfig
-		nimbusGeneratedK8sVmPwd string
+		namespace         string
+		client            clientset.Interface
+		storagePolicyName string
+		scParameters      map[string]string
+		storageClassName  string
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -139,7 +137,7 @@ var _ = ginkgo.Describe("statefulset", func() {
 		statefulset := GetStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+			Spec.StorageClassName = &storageClassName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
@@ -337,7 +335,7 @@ var _ = ginkgo.Describe("statefulset", func() {
 		*(statefulset.Spec.Replicas) = 8
 		statefulset.Spec.PodManagementPolicy = apps.ParallelPodManagement
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+			Spec.StorageClassName = &storageClassName
 		ginkgo.By("Creating statefulset")
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
@@ -535,7 +533,7 @@ var _ = ginkgo.Describe("statefulset", func() {
 		statefulset := GetStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+			Spec.StorageClassName = &storageClassName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
@@ -594,7 +592,7 @@ var _ = ginkgo.Describe("statefulset", func() {
 		statefulset = GetResizedStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+			Spec.StorageClassName = &storageClassName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas = *(statefulset.Spec.Replicas)
 
@@ -672,6 +670,7 @@ var _ = ginkgo.Describe("statefulset", func() {
 		defer cancel()
 		var svcMasterPswd string
 		var volumesBeforeScaleUp []string
+		var sshClientConfig *ssh.ClientConfig
 		containerName := "vsphere-csi-controller"
 		ginkgo.By("Creating StorageClass for Statefulset")
 		// decide which test setup is available to run
@@ -718,7 +717,7 @@ var _ = ginkgo.Describe("statefulset", func() {
 		statefulset := GetStatefulSetFromManifest(namespace)
 		ginkgo.By("Creating statefulset")
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageClassName
+			Spec.StorageClassName = &storageClassName
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
@@ -753,7 +752,7 @@ var _ = ginkgo.Describe("statefulset", func() {
 		var logMessage string
 		if vanillaCluster {
 			logMessage = "List volume response: entries:"
-			nimbusGeneratedK8sVmPwd = GetAndExpectStringEnvVar(nimbusK8sVmPwd)
+			nimbusGeneratedK8sVmPwd := GetAndExpectStringEnvVar(nimbusK8sVmPwd)
 			sshClientConfig = &ssh.ClientConfig{
 				User: "root",
 				Auth: []ssh.AuthMethod{

--- a/tests/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
+++ b/tests/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
@@ -25,10 +25,9 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: www
-      annotations:
-        volume.beta.kubernetes.io/storage-class: nginx-sc
     spec:
       accessModes: [ "ReadWriteOnce" ]
+      storageClassName: nginx-sc
       resources:
         requests:
           storage: 1Gi

--- a/tests/e2e/tkgs_ha.go
+++ b/tests/e2e/tkgs_ha.go
@@ -241,7 +241,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		ginkgo.By("Creating statefulset")
 		statefulset.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+			Spec.StorageClassName = &storageclass.Name
 		*statefulset.Spec.Replicas = 3
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
@@ -787,7 +787,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		framework.Logf("allowedTopo: %v", allowedTopologies)
 		statefulset.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+			Spec.StorageClassName = &storageclass.Name
 		statefulset.Spec.Template.Spec.Affinity = new(v1.Affinity)
 		statefulset.Spec.Template.Spec.Affinity.NodeAffinity = new(v1.NodeAffinity)
 		statefulset.Spec.Template.Spec.Affinity.NodeAffinity.
@@ -887,7 +887,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 			statefulset := GetStatefulSetFromManifest(namespace)
 			ginkgo.By("Creating statefulset")
 			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+				Spec.StorageClassName = &storageclass.Name
 			*statefulset.Spec.Replicas = 1
 			replicas := *(statefulset.Spec.Replicas)
 
@@ -1086,7 +1086,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		ginkgo.By("Creating statefulset")
 		statefulset.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+			Spec.StorageClassName = &storageclass.Name
 		*statefulset.Spec.Replicas = 3
 
 		CreateStatefulSet(namespace, statefulset, client)
@@ -1195,7 +1195,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 			statefulset.Spec.Template.Labels["app"] = statefulset.Name
 			statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name
 			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+				Spec.StorageClassName = &storageclass.Name
 			*statefulset.Spec.Replicas = statefulSetReplicaCount
 			CreateStatefulSet(namespace, statefulset, client)
 			stsList = append(stsList, statefulset)
@@ -1307,7 +1307,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 			statefulset.Spec.Template.Labels["app"] = statefulset.Name
 			statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name
 			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+				Spec.StorageClassName = &storageclass.Name
 			*statefulset.Spec.Replicas = statefulSetReplicaCount
 			CreateStatefulSet(namespace, statefulset, client)
 			stsList = append(stsList, statefulset)
@@ -2160,7 +2160,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 			statefulset.Spec.Template.Labels["app"] = statefulset.Name
 			statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name
 			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+				Spec.StorageClassName = &storageclass.Name
 			*statefulset.Spec.Replicas = replicas
 			_, err := client.AppsV1().StatefulSets(namespace).Create(ctx, statefulset, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2452,7 +2452,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		framework.Logf("allowedTopo: %v", allowedTopologies)
 		statefulset.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+			Spec.StorageClassName = &storageclass.Name
 		statefulset.Spec.Template.Spec.Affinity = new(v1.Affinity)
 		statefulset.Spec.Template.Spec.Affinity.NodeAffinity = new(v1.NodeAffinity)
 		statefulset.Spec.Template.Spec.Affinity.NodeAffinity.
@@ -2494,7 +2494,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		framework.Logf("allowedTopo: %v", allowedTopologies)
 		statefulset.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+			Spec.StorageClassName = &storageclass.Name
 		statefulset.Spec.Template.Spec.Affinity = new(v1.Affinity)
 		statefulset.Spec.Template.Spec.Affinity.NodeAffinity = new(v1.NodeAffinity)
 		statefulset.Spec.Template.Spec.Affinity.NodeAffinity.
@@ -2605,7 +2605,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 			statefulset.Spec.Template.Labels["app"] = statefulset.Name
 			statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name
 			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+				Spec.StorageClassName = &storageclass.Name
 			*statefulset.Spec.Replicas = 3
 			CreateStatefulSet(namespace, statefulset, client)
 			stsList = append(stsList, statefulset)

--- a/tests/e2e/tkgs_ha_site_down.go
+++ b/tests/e2e/tkgs_ha_site_down.go
@@ -157,7 +157,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SiteDownTests", func() {
 			statefulset.Spec.Template.Labels["app"] = statefulset.Name
 			statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name
 			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+				Spec.StorageClassName = &storageclass.Name
 			*statefulset.Spec.Replicas = replicas
 			CreateStatefulSet(namespace, statefulset, client)
 			stsList = append(stsList, statefulset)
@@ -301,7 +301,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SiteDownTests", func() {
 			statefulset.Spec.Template.Labels["app"] = statefulset.Name
 			statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name
 			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+				Spec.StorageClassName = &storageclass.Name
 			*statefulset.Spec.Replicas = replicas
 			CreateStatefulSet(namespace, statefulset, client)
 			stsList = append(stsList, statefulset)
@@ -472,7 +472,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SiteDownTests", func() {
 			statefulset.Spec.Template.Labels["app"] = statefulset.Name
 			statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name
 			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+				Spec.StorageClassName = &storageclass.Name
 			*statefulset.Spec.Replicas = replicas
 			CreateStatefulSet(namespace, statefulset, client)
 			stsList = append(stsList, statefulset)
@@ -601,7 +601,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SiteDownTests", func() {
 			statefulset.Spec.Template.Labels["app"] = statefulset.Name
 			statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name
 			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+				Spec.StorageClassName = &storageclass.Name
 			*statefulset.Spec.Replicas = replicas
 			CreateStatefulSet(namespace, statefulset, client)
 			stsList = append(stsList, statefulset)
@@ -722,7 +722,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SiteDownTests", func() {
 			statefulset.Spec.Template.Labels["app"] = statefulset.Name
 			statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name
 			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+				Spec.StorageClassName = &storageclass.Name
 			*statefulset.Spec.Replicas = replicas
 			CreateStatefulSet(namespace, statefulset, client)
 			stsList = append(stsList, statefulset)
@@ -851,7 +851,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SiteDownTests", func() {
 			statefulset.Spec.Template.Labels["app"] = statefulset.Name
 			statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name
 			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-				Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+				Spec.StorageClassName = &storageclass.Name
 			*statefulset.Spec.Replicas = replicas
 			CreateStatefulSet(namespace, statefulset, client)
 			stsList = append(stsList, statefulset)

--- a/tests/e2e/tkgs_ha_utils.go
+++ b/tests/e2e/tkgs_ha_utils.go
@@ -182,7 +182,7 @@ func verifyVolumeProvisioningWithServiceDown(serviceName string, namespace strin
 	statefulset := GetStatefulSetFromManifest(namespace)
 	ginkgo.By("Creating statefulset")
 	statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-		Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+		Spec.StorageClassName = &storageclass.Name
 	*statefulset.Spec.Replicas = 3
 	_, err = client.AppsV1().StatefulSets(namespace).Create(ctx, statefulset, metav1.CreateOptions{})
 	framework.ExpectNoError(err)

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -5676,11 +5676,12 @@ func createParallelStatefulSetSpec(namespace string, no_of_sts int, replicas int
 	var statefulset *appsv1.StatefulSet
 
 	for i := 0; i < no_of_sts; i++ {
+		scName := defaultNginxStorageClassName
 		statefulset = GetStatefulSetFromManifest(namespace)
 		statefulset.Name = "thread-" + strconv.Itoa(i) + "-" + statefulset.Name
 		statefulset.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = defaultNginxStorageClassName
+			Spec.StorageClassName = &scName
 		statefulset.Spec.Replicas = &replicas
 		stss = append(stss, statefulset)
 	}

--- a/tests/e2e/vcp_to_csi_syncer.go
+++ b/tests/e2e/vcp_to_csi_syncer.go
@@ -741,7 +741,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration syncer tests", func(
 
 		statefulset := GetStatefulSetFromManifest(namespace)
 		temp := statefulset.Spec.VolumeClaimTemplates
-		temp[0].Annotations[scAnnotation4Statefulset] = vcpSc.Name
+		temp[0].Spec.StorageClassName = &vcpSc.Name
 		statefulset.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 		ginkgo.By("Creating statefulset and waiting for the replicas to be ready")
 		CreateStatefulSet(namespace, statefulset, client)
@@ -1500,7 +1500,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration syncer tests", func(
 		for i := 0; i < 10; i++ {
 			statefulset := GetStatefulSetFromManifest(ns.Name)
 			temp := statefulset.Spec.VolumeClaimTemplates
-			temp[0].Annotations[scAnnotation4Statefulset] = vcpSc.Name
+			temp[0].Spec.StorageClassName = &vcpSc.Name
 			statefulset.Name = "pre-sts" + strconv.Itoa(i)
 			statefulset.Spec.Template.Labels["app"] = statefulset.Name
 			statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name
@@ -1543,7 +1543,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration syncer tests", func(
 		for i := 0; i < 10; i++ {
 			statefulset := GetStatefulSetFromManifest(ns.Name)
 			temp := statefulset.Spec.VolumeClaimTemplates
-			temp[0].Annotations[scAnnotation4Statefulset] = vcpSc.Name
+			temp[0].Spec.StorageClassName = &vcpSc.Name
 			statefulset.Name = "post-sts" + strconv.Itoa(i)
 			statefulset.Spec.Template.Labels["app"] = statefulset.Name
 			statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -251,7 +251,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		*(statefulset.Spec.Replicas) = 3
 		statefulset.Spec.PodManagementPolicy = apps.ParallelPodManagement
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = sc.Name
+			Spec.StorageClassName = &sc.Name
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 
@@ -339,7 +339,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		*(statefulset.Spec.Replicas) = 3
 		statefulset.Spec.PodManagementPolicy = apps.ParallelPodManagement
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = sc.Name
+			Spec.StorageClassName = &sc.Name
 		ginkgo.By("Creating statefulset")
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
@@ -529,7 +529,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		*(statefulset.Spec.Replicas) = 3
 		statefulset.Spec.PodManagementPolicy = apps.ParallelPodManagement
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-			Annotations["volume.beta.kubernetes.io/storage-class"] = storageclass.Name
+			Spec.StorageClassName = &storageclass.Name
 		ginkgo.By("Creating statefulset")
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)

--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -600,7 +600,7 @@ func createStsDeployment(ctx context.Context, client clientset.Interface, namesp
 	statefulset := GetStatefulSetFromManifest(namespace)
 	framework.Logf("Creating statefulset")
 	statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
-		Annotations["volume.beta.kubernetes.io/storage-class"] = sc.Name
+		Spec.StorageClassName = &sc.Name
 	statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
 		accessMode
 	if modifyStsSpec {


### PR DESCRIPTION
**What this PR does / why we need it**: Removing "volume.beta.kubernetes.io/storage-class" references from test code as it is deprecated in latest k8s. Also fixing namespace deletion created by test framework.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**: https://gist.github.com/Aishwarya-Hebbar/8efb799f4a3ffdb4842a8f5fdaa37935

**Special notes for your reviewer**:
make output:

