### PR TITLE
fix: GenerateDatastoreMapForBlockVolumes fails if there are no ManagedObjectReferences (#2443)

### DIFF
--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -242,6 +242,10 @@ func GenerateDatastoreMapForBlockVolumes(ctx context.Context,
 		}
 	}
 
+	if len(entities) == 0 {
+		return map[string]*cnsvsphere.DatastoreInfo{}, nil
+	}
+
 	dsURLToInfoMap, err := getDatastoresWithBlockVolumePrivs(ctx, vc, dsURLs, dsInfos, entities)
 	if err != nil {
 		log.Errorf("failed to get datastores with required priv for vCenter %q. Error: %+v", vc.Config.Host, err)
@@ -372,7 +376,7 @@ func getDatastoresWithBlockVolumePrivs(ctx context.Context, vc *cnsvsphere.Virtu
 
 	userName := vc.Config.Username
 	// Invoke authMgr function HasUserPrivilegeOnEntities.
-	result, err := authMgr.HasUserPrivilegeOnEntities(ctx, entities, userName, privIds)
+	result, err := authMgr.HasUserPrivilegeOnEntities(ctx, entities, userName, privIds) // entities empty -> error
 	if err != nil {
 		log.Errorf("auth manager: failed to check privilege %v on entities %v for user %s and for vCenter %q",
 			privIds, entities, userName, vc.Config.Host)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Cherry pick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2443 to release 3.0 branch

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
NA

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix: GenerateDatastoreMapForBlockVolumes fails if there are no ManagedObjectReferences
```
