### PR TITLE
Use correct function in testcase to fetch VM UUID in case of guest cluster setup

### DIFF
--- a/tests/e2e/raw_block_volume.go
+++ b/tests/e2e/raw_block_volume.go
@@ -339,7 +339,13 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 						volumeID, sspod.Spec.NodeName))
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
-					vmUUID := getNodeUUID(ctx, client, sspod.Spec.NodeName)
+					var vmUUID string
+					if vanillaCluster {
+						vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
+					} else if guestCluster {
+						vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
 					isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volumeID, vmUUID)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Disk is not attached to the node")
 					gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached")
@@ -899,8 +905,9 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 
 		var vmUUID string
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID, pod.Spec.NodeName))
-		vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
-		if guestCluster {
+		if vanillaCluster {
+			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
+		} else if guestCluster {
 			vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
@@ -1001,8 +1008,9 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 
 		ginkgo.By(fmt.Sprintf("Verify volume after expansion: %s is attached to the node: %s",
 			volumeID, pod.Spec.NodeName))
-		vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
-		if guestCluster {
+		if vanillaCluster {
+			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
+		} else if guestCluster {
 			vmUUID, err = getVMUUIDFromNodeName(pod.Spec.NodeName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
@@ -1133,6 +1141,9 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		nodeName := pod1.Spec.NodeName
 		if vanillaCluster {
 			vmUUID = getNodeUUID(ctx, client, pod1.Spec.NodeName)
+		} else if guestCluster {
+			vmUUID, err = getVMUUIDFromNodeName(pod1.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID, nodeName))
 		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volumeID, vmUUID)
@@ -1249,7 +1260,12 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		nodeName = pod2.Spec.NodeName
-		vmUUID = getNodeUUID(ctx, client, pod2.Spec.NodeName)
+		if vanillaCluster {
+			vmUUID = getNodeUUID(ctx, client, pod2.Spec.NodeName)
+		} else if guestCluster {
+			vmUUID, err = getVMUUIDFromNodeName(pod2.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volumeID2, nodeName))
 		isDiskAttached, err = e2eVSphere.isVolumeAttachedToVM(client, volumeID2, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In case of guest cluster, to get VM UUID, instead of using `getNodeUUID()`, we need to use `getVMUUIDFromNodeName()`. Fixing all such occurrences in raw_block_volume.go

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran tc with the changes on GC setup and it passed successfully

```
FAIL! -- 4 Passed | 2 Failed | 0 Pending | 737 Skipped
--- 
FAIL: TestE2E (1550.16s) FAIL 
Ginkgo ran 1 suite in 27m24.790636054s 
Test Suite Failed
```
TC failures are expected as those are vanilla CSI specific tcs, which fail on GC setup.

details : https://gist.github.com/akankshapanse/06e3bbf1b0f0507a9860d16ffcfe0a14


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use correct function in testcase to fetch VM UUID in case of guest cluster setup
```
