### PR TITLE
Fetch vcHost and cnsVolMgr in case migrated volumes to process further

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1573,6 +1573,12 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 				"with error %+v", migrationVolumeSpec, err)
 			return
 		}
+		vcHost, cnsVolumeMgr, err = getVcHostAndVolumeManagerForVolumeID(ctx, metadataSyncer, volumeHandle)
+		if err != nil {
+			log.Errorf("PVCUpdated: Failed to get VC host and volume manager for the given volume: %v. "+
+				"Error occoured: %+v", volumeHandle, err)
+			return
+		}
 	} else {
 		volumeFound := false
 		volumeHandle = pv.Spec.CSI.VolumeHandle


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
After PVC is updated, csiPVCUpdated() informer function sends the updated metadata to CNS. Here in case of migrated volumes, the CNS metadata was not getting pushed due to vcHost not set correctly. This is due to vcHost and cnsVolMgr were not set correctly for migrated volume during multi-vc changes. After fetching them correctly, the PVC metadata was seen to be updated in CNS correctly.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
The issue was seen in VCP migration pipeline for release-3.0 branch, where the tc failing consistently started passing after the fix. The fix is applicable to master as well. Will run the pipeline across master as well as in release-3.0 after cross port.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fetch vcHost and cnsVolMgr in case migrated volumes to process further
```
