### PR TITLE
 [cherrypick 2454 to release-3.0] Fetch vcHost and cnsVolMgr in case migrated volumes to process further

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -1573,6 +1573,12 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 				"with error %+v", migrationVolumeSpec, err)
 			return
 		}
+		vcHost, cnsVolumeMgr, err = getVcHostAndVolumeManagerForVolumeID(ctx, metadataSyncer, volumeHandle)
+		if err != nil {
+			log.Errorf("PVCUpdated: Failed to get VC host and volume manager for the given volume: %v. "+
+				"Error occoured: %+v", volumeHandle, err)
+			return
+		}
 	} else {
 		volumeFound := false
 		volumeHandle = pv.Spec.CSI.VolumeHandle


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is cherry picking commit from https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2454 to release-3.0 branch.

cc: @akankshapanse 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
 Fetch vcHost and cnsVolMgr in case migrated volumes to process further
```
