### PR TITLE
Multi vCenters different test scenarios automation

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -344,6 +344,16 @@ var (
 	datastoreClusterMap                   = "DATASTORE_CLUSTER_MAP"
 )
 
+// For multivc
+var (
+	envSharedDatastoreURLVC1          = "SHARED_VSPHERE_DATASTORE_URL_VC1"
+	envSharedDatastoreURLVC2          = "SHARED_VSPHERE_DATASTORE_URL_VC2"
+	envStoragePolicyNameToDeleteLater = "STORAGE_POLICY_TO_DELETE_LATER"
+	envMultiVCSetupType               = "MULTI_VC_SETUP_TYPE"
+	envStoragePolicyNameVC1           = "STORAGE_POLICY_VC1"
+	envStoragePolicyNameInVC1VC2      = "STORAGE_POLICY_NAME_COMMON_IN_VC1_VC2"
+)
+
 // VolumeSnapshotClass env variables for tkg-snapshot
 var (
 	envVolSnapClassDel = "VOLUME_SNAPSHOT_CLASS_DELETE"

--- a/tests/e2e/multi_vc.go
+++ b/tests/e2e/multi_vc.go
@@ -1,0 +1,1777 @@
+/*
+	Copyright 2023 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"golang.org/x/crypto/ssh"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
+	f := framework.NewDefaultFramework("csi-multi-vc")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		client                      clientset.Interface
+		namespace                   string
+		allowedTopologies           []v1.TopologySelectorLabelRequirement
+		bindingMode                 storagev1.VolumeBindingMode
+		allowedTopologyLen          int
+		nodeAffinityToSet           bool
+		parallelStatefulSetCreation bool
+		stsReplicas                 int32
+		parallelPodPolicy           bool
+		scParameters                map[string]string
+		topValStartIndex            int
+		topValEndIndex              int
+		topkeyStartIndex            int
+		datastoreURLVC1             string
+		datastoreURLVC2             string
+		podAntiAffinityToSet        bool
+		sshClientConfig             *ssh.ClientConfig
+		nimbusGeneratedK8sVmPwd     string
+		allMasterIps                []string
+		masterIp                    string
+		scaleUpReplicaCount         int32
+		scaleDownReplicaCount       int32
+		multiVCSetupType            string
+		isVsanHealthServiceStopped  bool
+		stsScaleUp                  bool
+		stsScaleDown                bool
+		verifyTopologyAffinity      bool
+		storagePolicyInVc1          string
+		storagePolicyInVc1Vc2       string
+		storagePolicyToDelete       string
+		isSPSServiceStopped         bool
+	)
+	ginkgo.BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+
+		multiVCbootstrap()
+
+		stsScaleUp = true
+		stsScaleDown = true
+		verifyTopologyAffinity = true
+
+		sc, err := client.StorageV1().StorageClasses().Get(ctx, defaultNginxStorageClassName, metav1.GetOptions{})
+		if err == nil && sc != nil {
+			gomega.Expect(client.StorageV1().StorageClasses().Delete(ctx, sc.Name,
+				*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+		}
+
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		topologyMap := GetAndExpectStringEnvVar(topologyMap)
+		allowedTopologies = createAllowedTopolgies(topologyMap, topologyLength)
+		bindingMode = storagev1.VolumeBindingWaitForFirstConsumer
+		scParameters = make(map[string]string)
+		storagePolicyInVc1 = GetAndExpectStringEnvVar(envStoragePolicyNameVC1)
+		storagePolicyInVc1Vc2 = GetAndExpectStringEnvVar(envStoragePolicyNameInVC1VC2)
+		storagePolicyToDelete = GetAndExpectStringEnvVar(envStoragePolicyNameToDeleteLater)
+		datastoreURLVC1 = GetAndExpectStringEnvVar(envSharedDatastoreURLVC1)
+		datastoreURLVC2 = GetAndExpectStringEnvVar(envSharedDatastoreURLVC2)
+		nimbusGeneratedK8sVmPwd = GetAndExpectStringEnvVar(nimbusK8sVmPwd)
+		multiVCSetupType = GetAndExpectStringEnvVar(envMultiVCSetupType)
+
+		sshClientConfig = &ssh.ClientConfig{
+			User: "root",
+			Auth: []ssh.AuthMethod{
+				ssh.Password(nimbusGeneratedK8sVmPwd),
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+
+		// fetching k8s master ip
+		allMasterIps = getK8sMasterIPs(ctx, client)
+		masterIp = allMasterIps[0]
+
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By(fmt.Sprintf("Deleting all statefulsets in namespace: %v", namespace))
+		fss.DeleteAllStatefulSets(client, namespace)
+		ginkgo.By(fmt.Sprintf("Deleting service nginx in namespace: %v", namespace))
+		err := client.CoreV1().Services(namespace).Delete(ctx, servicename, *metav1.NewDeleteOptions(0))
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		framework.Logf("Perform cleanup of any left over stale PVs")
+		allPvs, err := client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, pv := range allPvs.Items {
+			err := client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		if isVsanHealthServiceStopped {
+			vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+			vcAddress := vCenterHostname[0] + ":" + sshdPort
+			framework.Logf("Bringing vsanhealth up before terminating the test")
+			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
+		}
+
+		if isSPSServiceStopped {
+			vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+			vcAddress := vCenterHostname[0] + ":" + sshdPort
+			framework.Logf("Bringing sps up before terminating the test")
+			startVCServiceWait4VPs(ctx, vcAddress, spsServiceName, &isSPSServiceStopped)
+			isSPSServiceStopped = false
+		}
+	})
+
+	/* TESTCASE-1
+
+	Stateful set with SC contains default parameters and WFC binding mode and
+	specific nodeaffinity details in statefullset
+
+	Steps:
+	1. Create SC default values so all the AZ's should be consided for provisioning.
+	2. Create Statefulset with parallel pod management policy
+	3. Wait for PVC to reach bound state and POD to reach Running state
+	4. Volumes should get distributed among the nodes which are mentioned in node affinity of
+	Statefullset yaml
+	5. Make sure common validation points are met
+	a) Verify the PV node affinity details should have appropriate node details
+	b) The Pods should be running on the appropriate nodes
+	c) CNS metadata
+	6. Scale-up /Scale-down the statefulset and verify the common validation points on newly
+	created statefullset
+	7. Clean up the data
+	*/
+
+	ginkgo.It("Workload creation on a multivc environment with sts specified with node affinity "+
+		"and SC with no allowed topology", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		parallelPodPolicy = true
+		nodeAffinityToSet = true
+		stsReplicas = 3
+		scaleUpReplicaCount = 5
+		scaleDownReplicaCount = 2
+
+		if multiVCSetupType == "multi-2vc-setup" {
+			/* here in 2-VC setup statefulset node affinity is taken as k8s-zone -> zone-1,zone-2,zone-3
+			i.e VC1 allowed topology and VC2 partial allowed topology
+			*/
+			allowedTopologyLen = 3
+			topValStartIndex = 0
+			topValEndIndex = 3
+		} else if multiVCSetupType == "multi-3vc-setup" {
+			/* here in 3-VC setup, statefulset node affinity is taken as  k8s-zone -> zone-3
+			i.e only VC3 allowed topology
+			*/
+			allowedTopologyLen = 1
+			topValStartIndex = 2
+			topValEndIndex = 3
+		}
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StorageClass with no allowed topolgies specified and with WFC binding mode")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil, "",
+			bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, statefulset := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace,
+			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen,
+			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+		defer func() {
+			fss.DeleteAllStatefulSets(client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulset, parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+
+	})
+
+	/* TESTCASE-2
+
+	Deploy workload with allowed topology details in SC which should contain all the AZ's
+	so that workload will get distributed among all the VC's
+
+	Steps:
+	1. Create SC with allowedTopology details contains more than one Availability zone details
+	2. Create statefulset with replica-5
+	3. Wait for PVC to reach bound state and POD to reach Running state
+	4. Volumes should get distributed among all the Availability zones
+	5. Make sure common validation points are met
+	a) Verify the PV node affinity details should have appropriate Node details
+	b) The Pods should be running on the appropriate nodes
+	c) CNS metadata
+	6. Scale-up/Scale-down the statefulset and verify the common validation points on newly
+	created statefullset
+	7. Clean up the data
+	*/
+
+	ginkgo.It("Workload creation when all allowed topology specified in SC on a "+
+		"multivc environment", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		/* here we are considering all the allowed topologies of VC1 and VC2 in case of 2-VC setup.
+		i.e. k8s-zone -> zone-1,zone-2,zone-3,zone-4,zone-5
+
+		And, all the allowed topologies of VC1, VC2 and VC3 are considered in case of 3-VC setup
+		i.e k8s-zone -> zone-1,zone-2,zone-3
+		*/
+
+		stsReplicas = 5
+		scaleUpReplicaCount = 7
+		scaleDownReplicaCount = 3
+
+		ginkgo.By("Create StorageClass with specific allowed topolgies details")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, statefulset := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
+			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+		defer func() {
+			fss.DeleteAllStatefulSets(client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulset, parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+
+	/*
+		TESTCASE-3
+		Deploy workload with Specific storage policy name available in Single VC
+
+		Steps:
+		1. Create a SC with storage policy name available in single VC
+		2. Create statefulset with replica-5
+		3. Wait for PVC to reach bound state and POD to reach Running state
+		4. Volumes should get created under appropriate nodes which is accessible to  the storage Policy
+		5. Make sure common verification Points met in PVC, PV ad POD
+		a) Verify the PV node affinity details should have appropriate Node details
+		b) The Pods should be running on the appropriate nodes
+		c) CNS metadata
+		6. Scale-up/Scale-down the statefulset and verify the common validation points on newly created statefullset
+		7. Clean up the data
+	*/
+
+	ginkgo.It("Workload creation when specific storage policy of any single VC is given in SC", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		/* here we are considering storage policy of VC1 and the allowed topology is k8s-zone -> zone-1
+		in case of 2-VC setup and 3-VC setup
+		*/
+
+		stsReplicas = 5
+		scParameters[scParamStoragePolicyName] = storagePolicyInVc1
+		topValStartIndex = 0
+		topValEndIndex = 1
+		scaleUpReplicaCount = 9
+		scaleDownReplicaCount = 2
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StorageClass with storage policy specified")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, statefulset := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
+			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+		defer func() {
+			fss.DeleteAllStatefulSets(client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulset, parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+
+	/* TESTCASE-4
+	Same Policy  is available in two VC's
+
+	Steps:
+	1. Create a SC with Storage policy name available in VC1 and VC2
+	2. Create  two Statefulset with replica-3
+	3. Wait for PVC to reach bound state and POD to reach Running state
+	4. Since both the VCs have the same storage policy, volume should get distributed among all the
+	availability zones
+	5. Make sure common verification Points met in PVC, PV ad POD
+	a) Verify the PV node affinity details should have appropriate Node details
+	b) The POD's should be running on the appropriate nodes
+	c) CNS metadata
+	6. Scale-up/scale-down the statefulset and verify the common validation points on newly
+	created statefullset
+	7. Clean up the data
+	*/
+
+	ginkgo.It("Workload creation when storage policy available in multivc setup is given in SC", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		/* In case of 2-VC setup, we are considering storage policy of VC1 and VC2 and the allowed
+				topology is k8s-zone -> zone-1, zone-2 i.e VC1 allowed topology and partial allowed topology
+				of VC2
+
+		In case of 3-VC setup, we are considering storage policy of VC1 and VC2 and the allowed
+				topology is k8s-zone -> zone-1, zone-2 i.e VC1 and VC2 allowed topologies.
+		*/
+
+		stsReplicas = 3
+		scParameters[scParamStoragePolicyName] = storagePolicyInVc1Vc2
+		topValStartIndex = 0
+		topValEndIndex = 2
+		sts_count := 2
+		parallelStatefulSetCreation = true
+		scaleUpReplicaCount = 7
+		scaleDownReplicaCount = 2
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StorageClass with storage policy specified")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Create 2 StatefulSet with replica count 5")
+		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, stsReplicas)
+		var wg sync.WaitGroup
+		wg.Add(sts_count)
+		for i := 0; i < len(statefulSets); i++ {
+			go createParallelStatefulSets(client, namespace, statefulSets[i],
+				stsReplicas, &wg)
+
+		}
+		wg.Wait()
+
+		ginkgo.By("Waiting for StatefulSets Pods to be in Ready State")
+		err = waitForStsPodsToBeInReadyRunningState(ctx, client, namespace, statefulSets)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			deleteAllStsAndPodsPVCsInNamespace(ctx, client, namespace)
+		}()
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		for i := 0; i < len(statefulSets); i++ {
+			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulSets[i],
+				namespace, allowedTopologies, parallelStatefulSetCreation, true)
+		}
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulset and " +
+			"verify pv and pod affinity details")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulSets[0], parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+
+	/* TESTCASE-5
+	Pod affiity tests
+
+	Steps:
+	1. Create SC default values so all the AZ's should be considered for provisioning.
+	2. Create statefulset with Pod affinity rules such a way that each AZ should get atleast 1 statefulset
+	3. Wait for PVC to bound and POD to reach running state
+	4. Verify the stateful set distribution
+	5. Make sure common verification Points met in PVC, PV ad POD
+	a) Verify the PV node affinity details should have appropriate Node details
+	b) The Pods should be running on the appropriate nodes
+	c) CNS metadata
+	6. Scale-up/Scale-down the statefulset and verify the common validation points on newly created
+	statefullset
+	7. Clean up data
+	*/
+
+	ginkgo.It("Workload creation on a multivc environment with sts specified with pod affinity "+
+		"and SC with no allowed topology", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stsReplicas = 5
+		podAntiAffinityToSet = true
+		scaleUpReplicaCount = 8
+		scaleDownReplicaCount = 1
+
+		ginkgo.By("Create StorageClass with storage policy specified")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, statefulset := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
+			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+		defer func() {
+			fss.DeleteAllStatefulSets(client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulset, parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+
+	/* TESTCASE-6
+	Deploy workload with allowed topology and Datastore URL
+
+	Steps:
+	1. Create a SC with allowed topology and appropriate datastore url
+	2. Create Statefulset with replica-5
+	3. Wait for PVC to reach bound state and POD to reach Running state
+	4. Volumes should get created under appropriate availability zone and on the specified datastore
+	5. Make sure common validation points are met
+	6. Verify the PV node affinity details should have appropriate node details
+	7. The Pods should be running on the appropriate nodes
+	8. Scale-up/Scale-down the statefulset
+	9. Verify the node affinity details also verify the Pod details
+	10. Clean up the data
+	*/
+
+	ginkgo.It("Deploy workload with allowed topology and datastore url on a multivc environment", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		/* here, we are considering datastore url of VC1 in case of both 2-VC and 3-VC multi setup
+		so the allowed topology will be considered as - k8s-zone -> zone-1
+		*/
+
+		stsReplicas = 5
+		scParameters[scParamDatastoreURL] = datastoreURLVC1
+		topValStartIndex = 0
+		topValEndIndex = 1
+		scaleDownReplicaCount = 3
+		scaleUpReplicaCount = 6
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StorageClass with allowed topology, storage-policy and with datastore url")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, allowedTopologies, "",
+			bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, statefulset := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
+			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+		defer func() {
+			fss.DeleteAllStatefulSets(client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulset, parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+
+	/* TESTCASE-7
+	Deploy workload with allowed topology details in SC specific to VC1  with Immediate Binding
+
+	Steps:
+	1. Create SC with allowedTopology details set to VC1 availability zone
+	2. Create statefulset with replica-3
+	3. Wait for PVC to reach bound state and POD to reach Running state
+	4. Make sure common validation points are met
+	a) Verify the PV node affinity details should have appropriate Node details
+	b) The POD's should be running on the appropriate nodes which are present in VC1
+	5. Scale-up/scale-down the statefulset
+	6. Verify the node affinity details. Verify the POD details. All the pods should come up on the
+	nodes of VC1
+	7. Clean up the data
+	*/
+
+	ginkgo.It("Deploy workload with allowed topology details in SC specific "+
+		"to VC1 with Immediate Binding", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		/* here, we are considering allowed topology of VC1 in case of both 2-VC and 3-VC multi setup
+		so the allowed topology will be considered as - k8s-zone -> zone-1
+		*/
+
+		stsReplicas = 3
+		topValStartIndex = 0
+		topValEndIndex = 1
+		scaleDownReplicaCount = 0
+		scaleUpReplicaCount = 6
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StorageClass with allowed topology details of VC1")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, statefulset := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
+			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+		defer func() {
+			fss.DeleteAllStatefulSets(client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulset, parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+
+	/* TESTCASE-8
+	Deploy workload with allowed topology details in SC specific to VC2  + WFC binding mode +
+	default pod management policy
+
+	Steps:
+	1. Create SC with allowedTopology details set to VC2's Availability Zone
+	2. Create statefulset with replica-3
+	3. Wait for PVC to reach bound state and Pod to reach running state
+	4. Make sure common validation points are met
+	a) Verify the PV node affinity details should have appropriate node details
+	b) The Pods should be running on the appropriate nodes which are present in VC2
+	5. Scale-up/scale-down the statefulset
+	6. Verify the node affinity details. Verify the pod details. All the pods should come up on the nodes of
+	VC2
+	7. Validate CNS metadata on appropriate VC
+	8. Clean up the data
+	*/
+
+	ginkgo.It("Deploy workload with allowed topology details in SC specific to VC2 with WFC "+
+		"binding mode and with default pod management policy", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stsReplicas = 3
+		scaleDownReplicaCount = 2
+		scaleUpReplicaCount = 5
+
+		if multiVCSetupType == "multi-2vc-setup" {
+			// here, we are considering partial allowed topology of VC2 i.e k8s-zone -> zone-3,zone-4, zone-5
+			topValStartIndex = 2
+			topValEndIndex = 5
+		} else if multiVCSetupType == "multi-3vc-setup" {
+			// here, we are considering  allowed topology of VC2 i.e k8s-zone -> zone-2
+			topValStartIndex = 1
+			topValEndIndex = 2
+		}
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StorageClass with allowed topology details of VC2")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "",
+			bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, statefulset := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
+			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+		defer func() {
+			fss.DeleteAllStatefulSets(client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulset, parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+
+	/* TESTCASE-9
+	Deploy workload with allowed topology details in SC specific to VC3 + parallel pod management policy
+
+	Steps:
+	1. Create SC with allowedTopology details set to VC3 availability zone
+	2. Create statefulset with replica-3
+	3. Wait for PVC to reach bound state and POD to reach Running state
+	4. Make sure common validation points are met
+	a) Verify the PV node affinity details should have appropriate Node details
+	b) The Pod should be running on the appropriate nodes which are present in VC3
+	5. Scale-up /scale-down the statefulset
+	6. Verify the node affinity details and also verify the pod details. All the pods should come up on the nodes of
+	VC3
+	7. Clean up the data
+	*/
+
+	ginkgo.It("Deploy workload with allowed topology details in SC specific to VC3 with "+
+		"parallel pod management policy", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stsReplicas = 3
+		parallelPodPolicy = true
+		scaleDownReplicaCount = 1
+		scaleUpReplicaCount = 6
+
+		if multiVCSetupType == "multi-2vc-setup" {
+			/* here, For 2-VC setup we will consider all allowed topology of VC1 and VC2
+			i.e. k8s-zone -> zone-1,zone-2,zone-3,zone-4,zone-5 */
+			topValStartIndex = 0
+			topValEndIndex = 5
+		} else if multiVCSetupType == "multi-3vc-setup" {
+			/* here, For 3-VC setup we will consider allowed topology of VC3
+			i.e. k8s-zone ->zone-3 */
+			topValStartIndex = 2
+			topValEndIndex = 3
+		}
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StorageClass with allowed topology details of VC3")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "",
+			bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, statefulset := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
+			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+		defer func() {
+			fss.DeleteAllStatefulSets(client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulset, parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+
+	/*
+		TESTCASE-10
+		Deploy workload with default SC parameters with WaitForFirstConsumer
+
+		Steps:
+		1. Create a storage class with default parameters
+		a) SC1 with WFC
+		b) SC2 with Immediate
+		2. Create statefulset with replica-5 using SC1
+		3. Cretate few dynamic PVCs using SC2 and create Pods using the same PVCs
+		4. Wait for PVC to reach bound state and POD to reach Running state
+		5. Make sure common validation points are met
+		a) Volumes should get distributed among all the availability zones
+		b) Verify the PV node affinity details should have appropriate Node details
+		c) The Pods should be running on the appropriate nodes
+		6. Scale-up/scale-down the statefulset
+		7. Clean up the data
+	*/
+
+	ginkgo.It("Deploy workload with default SC parameters with WaitForFirstConsumer", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stsReplicas = 5
+		pvcCount := 5
+		var podList []*v1.Pod
+		scaleDownReplicaCount = 3
+		scaleUpReplicaCount = 7
+		parallelPodPolicy = true
+		parallelStatefulSetCreation = true
+
+		/* here, For 2-VC setup, we are considering all the allowed topologies of VC1 and VC2
+		i.e. k8s-zone -> zone-1,zone-2,zone-3,zone-4,zone-5
+
+		For 3-VC setup, we are considering all the allowed topologies of VC1, VC2 and VC3
+		i.e. k8s-zone -> zone-1,zone-2,zone-3
+		*/
+
+		ginkgo.By("Create StorageClass with default parameters using WFC binding mode")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil, "",
+			bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, statefulset := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace,
+			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen,
+			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+		defer func() {
+			deleteAllStsAndPodsPVCsInNamespace(ctx, client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Create StorageClass with default parameters using Immediate binding mode")
+		storageclass, err := createStorageClass(client, nil, nil, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By("Delete Storage Class")
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Trigger multiple PVCs")
+		pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount, nil)
+
+		ginkgo.By("Verify PVC claim to be in bound phase and create POD for each PVC")
+		for i := 0; i < len(pvclaimsList); i++ {
+			var pvclaims []*v1.PersistentVolumeClaim
+			pvc, err := fpv.WaitForPVClaimBoundPhase(client,
+				[]*v1.PersistentVolumeClaim{pvclaimsList[i]}, framework.ClaimProvisionTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pvc).NotTo(gomega.BeEmpty())
+
+			pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+
+			ginkgo.By("Creating Pod")
+			pvclaims = append(pvclaims, pvclaimsList[i])
+			pod, err := createPod(client, namespace, nil, pvclaims, false, "")
+			podList = append(podList, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
+			vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
+			isDiskAttached, err := multiVCe2eVSphere.verifyVolumeIsAttachedToVMInMultiVC(client,
+				pv.Spec.CSI.VolumeHandle, vmUUID)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
+		}
+		defer func() {
+			ginkgo.By("Deleting PVC's and PV's")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				err = fpv.DeletePersistentVolumeClaim(client, pvclaimsList[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
+				err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err = fpod.DeletePodWithWait(client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			ginkgo.By("Verify volume is detached from the node")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				isDiskDetached, err := multiVCe2eVSphere.waitForVolumeDetachedFromNodeInMultiVC(client,
+					pv.Spec.CSI.VolumeHandle, podList[i].Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+					fmt.Sprintf("Volume %q is not detached from the node", pv.Spec.CSI.VolumeHandle))
+			}
+		}()
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		for i := 0; i < len(podList); i++ {
+			verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, podList[i],
+				namespace, allowedTopologies, true)
+		}
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulset, parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+
+	/* TESTCASE-11
+	Create SC with single AllowedTopologyLabel
+
+	Steps:
+	1. Create a SC with specific topology details which is available in any one VC
+	2. Create statefulset with replica-5
+	3. Wait for PVC to reach Bound state and Pod to reach Running state
+	4. Make sure common validation points are met
+	a) Volumes should get created under appropriate zone
+	b) Verify the PV node affinity details should have appropriate node details
+	c) The Pods should be running on the appropriate nodes
+	5. Scale-up/scale-down the statefulset
+	6. Verify the node affinity details and also verify the pod details
+	7. Clean up the data
+	*/
+
+	ginkgo.It("Create SC with single allowed topology label on a multivc environment", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		/* Considering partial allowed topology of VC2 in case of 2-VC setup i.e. k8s-zone -> zone-2
+		And, allowed topology of VC2 in case of 3-VC setup i.e. k8s-zone -> zone-2
+		*/
+
+		stsReplicas = 5
+		topValStartIndex = 1
+		topValEndIndex = 2
+		parallelPodPolicy = true
+		scaleDownReplicaCount = 2
+		scaleUpReplicaCount = 5
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StorageClass with allowed topology details of VC2")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "",
+			bindingMode, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, statefulset := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
+			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+		defer func() {
+			fss.DeleteAllStatefulSets(client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulset, parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+
+	/* TESTCASE-12
+	Create PVC using the wrong StoragePolicy name. Consider partially matching storage policy
+
+	Steps:
+	1. Use the partially matching storage policy and create PVC
+	2. PVC should not go to bound, appropriate error should be shown
+	3. Perform cleanup
+	*/
+
+	ginkgo.It("PVC creation failure when wrong storage policy name is specified in SC", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		storagePolicyName := "shared-ds-polic"
+		scParameters[scParamStoragePolicyName] = storagePolicyName
+
+		storageclass, pvclaim, err := createPVCAndStorageClass(client,
+			namespace, nil, scParameters, "", nil, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Expect claim to fail as invalid storage policy is specified in Storage Class")
+		framework.ExpectError(fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound,
+			client, pvclaim.Namespace, pvclaim.Name, pollTimeoutShort, framework.PollShortTimeout))
+		expectedErrMsg := "failed to create volume"
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+	})
+
+	/*
+		TESTCASE-13
+		Deploy workload With allowed topology of VC1 and datastore url which is in VC2
+
+		Steps:
+		1. Create SC with allowed topology which matches VC1 details and datastore url which is in VC2
+		2. PVC should not go to bound, appropriate error should be shown
+	*/
+
+	ginkgo.It("Deploy workload with allowed topology of VC1 and datastore url of VC2", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		topValStartIndex = 0
+		topValEndIndex = 1
+		scParameters[scParamDatastoreURL] = datastoreURLVC2
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		storageclass, pvclaim, err := createPVCAndStorageClass(client,
+			namespace, nil, scParameters, "", allowedTopologies, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Expect claim to fail as non-compatible datastore url is specified in Storage Class")
+		framework.ExpectError(fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound,
+			client, pvclaim.Namespace, pvclaim.Name, pollTimeoutShort, framework.PollShortTimeout))
+		expectedErrMsg := "failed to create volume"
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+	})
+
+	/*
+		TESTCASE-14
+		Create storage policy in VC1 and VC2 and create storage class with the same and delete Storage policy
+		in VC1, expected to go to VC2
+
+		Steps:
+		1. Create Storage policy in VC1 and VC2
+		2. Create Storage class with above policy
+		3. Delete storage policy from VC1
+		4. Create statefulSet
+		5. Expected to provision volume on VC2
+		6. Make sure common validation points are met
+		7. Clear data
+	*/
+
+	ginkgo.It("Create storage policy in multivc and later delete storage policy from one of the VC", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		topValStartIndex = 1
+		topValEndIndex = 2
+		stsReplicas = 3
+
+		scParameters[scParamStoragePolicyName] = storagePolicyToDelete
+
+		/* Considering partial allowed topology of VC2 in case of 2-VC setup i.e. k8s-zone -> zone-2
+		And, allowed topology of VC2 in case of 3-VC setup i.e. k8s-zone -> zone-2
+		*/
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex,
+			topValStartIndex, topValEndIndex)
+
+		ginkgo.By("Create StorageClass")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Delete Storage Policy created in VC1")
+		err = deleteStorageProfile(masterIp, sshClientConfig, storagePolicyToDelete)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, _ := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
+			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+		defer func() {
+			fss.DeleteAllStatefulSets(client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+	})
+
+	/*
+		TESTCASE-16
+		Create Deployment pod using SC with allowed topology set to Specific VC
+
+		Steps:
+		1. Create SC with allowedTopology details set to any one VC with Availability Zone
+		2. Create PVC using above SC
+		3. Wait for PVC to reach bound state
+		4. Create deployment and wait for  POD to reach Running state
+		5. Make sure common validation points are met on PV,PVC and POD
+			a) Verify the PV node affinity details should have appropriate Node details
+			b) The POD's should be running on the appropriate nodes which are present in VC1
+			c) Verify the node affinity details also verify the POD details.
+			 All the POd's should come up on the nodes of VC
+		6. Clean up the data
+	*/
+
+	ginkgo.It("Create Deployment pod using SC with allowed topology set to specific VC", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		topValStartIndex = 2
+		topValEndIndex = 3
+		var lables = make(map[string]string)
+		lables["app"] = "nginx"
+		replica := 1
+
+		/* here considering partial allowed topology of VC2 in case of 2VC setup i.e k8s-zone -> zone-3
+		here considering allowed topology of VC3 in case of 3VC setup i.e k8s-zone -> zone-3
+		*/
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StorageClass and PVC for Deployment")
+		sc, pvclaim, err := createPVCAndStorageClass(client, namespace, nil,
+			nil, diskSize, allowedTopologies, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Wait for PVC to be in Bound phase
+		pvclaims = append(pvclaims, pvclaim)
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims,
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
+		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(volHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pvclaim = nil
+		}()
+
+		ginkgo.By("Create Deployments")
+		deployment, err := createDeployment(ctx, client, int32(replica), lables,
+			nil, namespace, pvclaims, "", false, nginxImage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			framework.Logf("Delete deployment set")
+			err := client.AppsV1().Deployments(namespace).Delete(ctx, deployment.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running " +
+			"on appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5(ctx, client, deployment,
+			namespace, allowedTopologies, false, true)
+	})
+
+	/*
+		TESTCASE-17
+		Create SC with invalid allowed topology details - NEGETIVE
+
+		Steps:
+		1. Create SC with invalid label details
+		2. Create PVC, Pvc should not reach bound state. It should throuw error
+	*/
+
+	ginkgo.It("Create SC with invalid allowed topology details", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		topValStartIndex = 1
+		topValEndIndex = 1
+
+		ginkgo.By("Set invalid allowed topology for SC")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+		allowedTopologies[0].Values = []string{"new-zone"}
+
+		storageclass, err := createStorageClass(client, nil, allowedTopologies, "", "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		pvc, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			if pvc != nil {
+				ginkgo.By("Delete the PVC")
+				err = fpv.DeletePersistentVolumeClaim(client, pvc.Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Expect claim to fail as invalid topology label is specified in Storage Class")
+		framework.ExpectError(fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound,
+			client, pvc.Namespace, pvc.Name, pollTimeoutShort, framework.PollShortTimeout))
+		expectedErrMsg := "failed to fetch vCenter associated with topology segments"
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvc.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+	})
+
+	/*
+		TESTCASE-18
+		Verify online and offline Volume expansion
+
+			Steps:
+			1. Create SC default values, so all the AZ's should be considered for provisioning.
+			2. Create PVC  and wait for it to bound
+			3. Edit PVC and trigger offline volume expansion
+			4. Create POD , Wait for POD to reach running state
+			5. Describe PVC and verify that new size should be updated on PVC
+			6. Edit the same PVC again to test Online volume expansion
+			7. Wait for resize to complete
+			8. Verify the newly updated size on PV and PVC
+			9. Clean up the data
+	*/
+
+	ginkgo.It("Offline and online volume expansion on a multivc setup", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var pvclaims []*v1.PersistentVolumeClaim
+
+		ginkgo.By("Create StorageClass")
+		storageclass, pvclaim, err := createPVCAndStorageClass(client, namespace, nil, nil, "",
+			nil, "", true, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Expect claim to provision volume successfully")
+		pvclaims = append(pvclaims, pvclaim)
+		pv, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volHandle := pv[0].Spec.CSI.VolumeHandle
+		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(volHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Perform offline volume expansion on PVC")
+		performOfflineVolumeExpansin(client, pvclaim, volHandle, namespace)
+
+		ginkgo.By("Creating pod to attach PV to the node")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		var vmUUID string
+		nodeName := pod.Spec.NodeName
+
+		if vanillaCluster {
+			vmUUID = getNodeUUID(ctx, client, pod.Spec.NodeName)
+		}
+
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volHandle, nodeName))
+		isDiskAttached, err := multiVCe2eVSphere.verifyVolumeIsAttachedToVMInMultiVC(client, volHandle, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify volume is detached from the node")
+			isDiskDetached, err := multiVCe2eVSphere.waitForVolumeDetachedFromNodeInMultiVC(client,
+				pv[0].Spec.CSI.VolumeHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node", pv[0].Spec.CSI.VolumeHandle))
+		}()
+
+		ginkgo.By("Perform online volume expansion on PVC")
+		performOnlineVolumeExpansin(f, client, pvclaim, namespace, pod)
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running " +
+			"on appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod,
+			namespace, allowedTopologies, true)
+	})
+
+	/*
+		TESTCASE-19
+		Create a workload and try to reboot one of the VC - NEGETIVE
+
+			Steps:
+			1. Create SC default values, so all the AZ's should be considered for provisioning.
+			2. Reboot  any one VC1
+			3. Create 3 statefulset each with 5 replica
+			4. Since one VC1 is rebooting, volume should get provisioned on another VC till the VC1 Comes up
+			5. Wait for the statefulset, PVC's and POD's  should be in up and running state
+			6. After the VC came to running state scale up/down the statefull sets
+			7. Newly created statefull set should get distributed among both the VC's
+			8. Make sure common validation points are met on PV,PVC and POD
+			9. Perform Cleanup
+	*/
+
+	ginkgo.It("Create workload and reboot one of the VC", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stsReplicas = 5
+		sts_count := 3
+		parallelStatefulSetCreation = true
+		scaleUpReplicaCount = 9
+		scaleDownReplicaCount = 1
+
+		ginkgo.By("Create StorageClass")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Rebooting VC1")
+		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+		vcAddress := vCenterHostname[1] + ":" + sshdPort
+		framework.Logf("vcAddress - %s ", vcAddress)
+		err = invokeVCenterReboot(vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = waitForHostToBeUp(vCenterHostname[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Done with reboot")
+
+		ginkgo.By("Create 3 StatefulSet with replica count 5")
+		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, stsReplicas)
+		var wg sync.WaitGroup
+		wg.Add(sts_count)
+		for i := 0; i < len(statefulSets); i++ {
+			go createParallelStatefulSets(client, namespace, statefulSets[i],
+				stsReplicas, &wg)
+
+		}
+		wg.Wait()
+
+		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
+		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
+
+		//After reboot
+		multiVCbootstrap()
+
+		ginkgo.By("Waiting for StatefulSets Pods to be in Ready State")
+		err = waitForStsPodsToBeInReadyRunningState(ctx, client, namespace, statefulSets)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			deleteAllStsAndPodsPVCsInNamespace(ctx, client, namespace)
+		}()
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		for i := 0; i < len(statefulSets); i++ {
+			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulSets[i],
+				namespace, allowedTopologies, parallelStatefulSetCreation, true)
+		}
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulSets[0], parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+
+	/* TESTCASE-20
+		Storage policy is present in VC1 and VC1 is under reboot
+
+		Steps:
+	    1. Create SC with specific storage policy , Which is present in VC1
+	    2. Create Statefulsets using the above SC and reboot VC1 at the same time
+	    3. Since VC1 is under reboot , volume creation should be in pendig state till the VC1 is up
+	    4. Once the VC1 is up , all the volumes should come up on the worker nodes which is in VC1
+	    5. Make sure common validation points are met on PV,PVC and POD
+	    6. Clean up the data
+	*/
+
+	ginkgo.It("Storage policy is present in VC1 and VC1 is under reboot", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stsReplicas = 3
+		scParameters[scParamStoragePolicyName] = storagePolicyInVc1
+		parallelStatefulSetCreation = true
+		scaleDownReplicaCount = 2
+		scaleUpReplicaCount = 7
+		topValStartIndex = 0
+		topValEndIndex = 1
+		sts_count := 2
+
+		// here, we are considering the allowed topology of VC1 i.e. k8s-zone -> zone-1
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StorageClass with storage policy specified")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Rebooting VC")
+		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+		vcAddress := vCenterHostname[1] + ":" + sshdPort
+		framework.Logf("vcAddress - %s ", vcAddress)
+		err = invokeVCenterReboot(vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = waitForHostToBeUp(vCenterHostname[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Done with reboot")
+
+		ginkgo.By("Create 3 StatefulSet with replica count 3")
+		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, stsReplicas)
+		var wg sync.WaitGroup
+		wg.Add(sts_count)
+		for i := 0; i < len(statefulSets); i++ {
+			go createParallelStatefulSets(client, namespace, statefulSets[i],
+				stsReplicas, &wg)
+
+		}
+		wg.Wait()
+
+		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
+		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
+
+		//After reboot
+		multiVCbootstrap()
+
+		ginkgo.By("Waiting for StatefulSets Pods to be in Ready State")
+		err = waitForStsPodsToBeInReadyRunningState(ctx, client, namespace, statefulSets)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			deleteAllStsAndPodsPVCsInNamespace(ctx, client, namespace)
+		}()
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		for i := 0; i < len(statefulSets); i++ {
+			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulSets[i],
+				namespace, allowedTopologies, parallelStatefulSetCreation, true)
+		}
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		for i := 0; i < len(statefulSets); i++ {
+			performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+				scaleDownReplicaCount, statefulSets[i], parallelStatefulSetCreation, namespace,
+				allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+		}
+	})
+
+	/* TESTCASE-21
+			VSAN-health down on VC1
+
+		Steps:
+	    1. Create SC default values, so all the AZ's should be considered for provisioning.
+	    2. Create dynamic PVC's and Add labels to PVC's and PV's
+	    3. Bring down the VSAN-health on VC1
+	    4. Create two statefulset each with replica 5
+	    5. Since VSAN-health on VC1 is down all the volumes should get created under VC2 availability zones
+	    6. Verify the PV node affinity and the nodes on which Pods have come  should be appropriate
+	    7. Update the label on PV and PVC
+	    8. Bring up the VSAN-health
+	    9. Scale up both the statefull set to 10
+	    10. Wait for 2 Full sync cycle
+	    11. Verify CNS-metadata for the volumes that are created
+	    12. Verify that the volume provisioning should resume on VC1 as well
+	    13. Make sure common validation points are met on PV,PVC and POD
+	    14. Scale down the statefull sets to 1
+	    15. Clean up the data
+	*/
+
+	ginkgo.It("Create workloads when VSAN-health is down on VC1", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stsReplicas = 5
+		pvcCount := 3
+		scaleDownReplicaCount = 1
+		scaleUpReplicaCount = 10
+		parallelPodPolicy = true
+		parallelStatefulSetCreation = true
+		labelKey := "volId"
+		labelValue := "pvcVolume"
+		labels := make(map[string]string)
+		labels[labelKey] = labelValue
+		sts_count := 2
+		var fullSyncWaitTime int
+		var err error
+
+		// Read full-sync value.
+		if os.Getenv(envFullSyncWaitTime) != "" {
+			fullSyncWaitTime, err = strconv.Atoi(os.Getenv(envFullSyncWaitTime))
+			framework.Logf("Full-Sync interval time value is = %v", fullSyncWaitTime)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		/* here, For 2-VC setup, we are considering all the allowed topologies of VC1 and VC2
+		i.e. k8s-zone -> zone-1,zone-2,zone-3,zone-4,zone-5
+
+		For 3-VC setup, we are considering all the allowed topologies of VC1, VC2 and VC3
+		i.e. k8s-zone -> zone-1,zone-2,zone-3
+		*/
+
+		ginkgo.By("Create StorageClass with default parameters")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Trigger multiple PVCs")
+		pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, sc, pvcCount, labels)
+
+		ginkgo.By("Verify PVC claim to be in bound phase and create POD for each PVC")
+		for i := 0; i < len(pvclaimsList); i++ {
+			pvc, err := fpv.WaitForPVClaimBoundPhase(client,
+				[]*v1.PersistentVolumeClaim{pvclaimsList[i]}, framework.ClaimProvisionTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(pvc).NotTo(gomega.BeEmpty())
+
+		}
+		defer func() {
+			ginkgo.By("Deleting PVC's and PV's")
+			for i := 0; i < len(pvclaimsList); i++ {
+				pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+				err = fpv.DeletePersistentVolumeClaim(client, pvclaimsList[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				framework.ExpectNoError(fpv.WaitForPersistentVolumeDeleted(client, pv.Name, poll, pollTimeoutShort))
+				err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+
+			deleteAllStsAndPodsPVCsInNamespace(ctx, client, namespace)
+		}()
+
+		ginkgo.By("Bring down Vsan-health service on VC1")
+		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+		vcAddress := vCenterHostname[0] + ":" + sshdPort
+		framework.Logf("vcAddress - %s ", vcAddress)
+		err = invokeVCenterServiceControl(stopOperation, vsanhealthServiceName, vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isVsanHealthServiceStopped = true
+		defer func() {
+			if isVsanHealthServiceStopped {
+				framework.Logf("Bringing vsanhealth up before terminating the test")
+				startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
+			}
+		}()
+
+		ginkgo.By("Create 2 StatefulSet with replica count 5 when vsan-health is down")
+		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, stsReplicas)
+		var wg sync.WaitGroup
+		wg.Add(sts_count)
+		for i := 0; i < len(statefulSets); i++ {
+			go createParallelStatefulSets(client, namespace, statefulSets[i],
+				stsReplicas, &wg)
+		}
+		wg.Wait()
+
+		labelKey = "volIdNew"
+		labelValue = "pvcVolumeNew"
+		labels = make(map[string]string)
+		labels[labelKey] = labelValue
+
+		ginkgo.By("Updating labels for PVC and PV")
+		for i := 0; i < len(pvclaimsList); i++ {
+			pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+			framework.Logf("Updating labels %+v for pvc %s in namespace %s", labels, pvclaimsList[i].Name,
+				pvclaimsList[i].Namespace)
+			pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvclaimsList[i].Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pvc.Labels = labels
+			_, err = client.CoreV1().PersistentVolumeClaims(namespace).Update(ctx, pvc, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			framework.Logf("Updating labels %+v for pv %s", labels, pv.Name)
+			pv.Labels = labels
+			_, err = client.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
+
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow full sync finish", fullSyncWaitTime))
+		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
+
+		ginkgo.By("Waiting for labels to be updated for PVC and PV")
+		for i := 0; i < len(pvclaimsList); i++ {
+			pv := getPvFromClaim(client, pvclaimsList[i].Namespace, pvclaimsList[i].Name)
+
+			framework.Logf("Waiting for labels %+v to be updated for pvc %s in namespace %s",
+				labels, pvclaimsList[i].Name, pvclaimsList[i].Namespace)
+			err = multiVCe2eVSphere.waitForLabelsToBeUpdatedInMultiVC(pv.Spec.CSI.VolumeHandle, labels,
+				string(cnstypes.CnsKubernetesEntityTypePVC), pvclaimsList[i].Name, pvclaimsList[i].Namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			framework.Logf("Waiting for labels %+v to be updated for pv %s", labels, pv.Name)
+			err = multiVCe2eVSphere.waitForLabelsToBeUpdatedInMultiVC(pv.Spec.CSI.VolumeHandle, labels,
+				string(cnstypes.CnsKubernetesEntityTypePV), pv.Name, pv.Namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By("Waiting for StatefulSets Pods to be in Ready State")
+		err = waitForStsPodsToBeInReadyRunningState(ctx, client, namespace, statefulSets)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		for i := 0; i < len(statefulSets); i++ {
+			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulSets[i],
+				namespace, allowedTopologies, parallelStatefulSetCreation, true)
+		}
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulSets[0], parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+
+	/* TESTCASE-22
+	SPS down on VC2 + use storage policy while creating statefulset
+
+	Steps:
+	1. Create SC with storage policy which is in both VCs i.e. VC1 and VC2
+	2. Create Statefulset using  the same storage policy
+	3. Bring down the SPS  on VC1
+	4. create two statefulset each with replica 5
+	5. Since SPS on VC1 is down all the volumes should get created under VC2 availability zones
+	[Note: if any VC or its service is down, volume provisioning will no go through on those
+	Pods which are provisioned on the VC where service is down]
+	till all VCs came to up and running state]
+	6. Verify the PV node affinity and the nodes on which Pods have come should be appropriate
+	7. Bring up the SPS service
+	8. Scale up both the Statefulset to 10
+	9. Verify that the volume provisioning should resume on VC1 as well
+	10. Make sure common validation points are met on PV,PVC and POD
+	11. Scale down the statefull sets to 1
+	12. Clean up the data
+	*/
+
+	ginkgo.It("Create workloads with storage policy given in SC and when sps service is down", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		/* here we are considering storage policy of VC1 and VC2 so
+		the allowed topology to be considered as for 2-VC and 3-VC setup is k8s-zone -> zone-1,zone-2
+
+		*/
+
+		stsReplicas = 5
+		scParameters[scParamStoragePolicyName] = storagePolicyInVc1Vc2
+		topValStartIndex = 0
+		topValEndIndex = 2
+		scaleUpReplicaCount = 10
+		scaleDownReplicaCount = 1
+		sts_count := 2
+		parallelStatefulSetCreation = true
+		parallelPodPolicy = true
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StorageClass with storage policy specified")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, statefulset := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
+			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+		defer func() {
+			deleteAllStsAndPodsPVCsInNamespace(ctx, client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, parallelStatefulSetCreation, true)
+
+		ginkgo.By("Bring down SPS service")
+		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+		vcAddress := vCenterHostname[0] + ":" + sshdPort
+		framework.Logf("vcAddress - %s ", vcAddress)
+		err = invokeVCenterServiceControl(stopOperation, spsServiceName, vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isSPSServiceStopped = true
+		err = waitVCenterServiceToBeInState(spsServiceName, vcAddress, svcStoppedMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			if isSPSServiceStopped {
+				framework.Logf("Bringing sps up before terminating the test")
+				startVCServiceWait4VPs(ctx, vcAddress, spsServiceName, &isSPSServiceStopped)
+				isSPSServiceStopped = false
+			}
+		}()
+
+		ginkgo.By("Create 2 StatefulSet with replica count 5 when sps-service is down")
+		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, stsReplicas)
+		var wg sync.WaitGroup
+		wg.Add(sts_count)
+		for i := 0; i < len(statefulSets); i++ {
+			go createParallelStatefulSets(client, namespace, statefulSets[i],
+				stsReplicas, &wg)
+		}
+		wg.Wait()
+
+		ginkgo.By("Bringup SPS service")
+		startVCServiceWait4VPs(ctx, vcAddress, spsServiceName, &isSPSServiceStopped)
+
+		framework.Logf("Waiting for %v seconds for testbed to be in the normal state", pollTimeoutShort)
+		time.Sleep(pollTimeoutShort)
+
+		ginkgo.By("Waiting for StatefulSets Pods to be in Ready State")
+		err = waitForStsPodsToBeInReadyRunningState(ctx, client, namespace, statefulSets)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		for i := 0; i < len(statefulSets); i++ {
+			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulSets[i],
+				namespace, allowedTopologies, parallelStatefulSetCreation, true)
+		}
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulSets[0], parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+	})
+})

--- a/tests/e2e/multi_vc_bootstrap.go
+++ b/tests/e2e/multi_vc_bootstrap.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	"github.com/onsi/gomega"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/testfiles"
+)
+
+var multiVCe2eVSphere multiVCvSphere
+var multiVCtestConfig *e2eTestConfig
+
+/*
+multiVCbootstrap function takes care of initializing necessary tests context for e2e tests
+*/
+func multiVCbootstrap(withoutDc ...bool) {
+	var err error
+	multiVCtestConfig, err = getConfig()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	if len(withoutDc) > 0 {
+		if withoutDc[0] {
+			(*multiVCtestConfig).Global.Datacenters = ""
+		}
+	}
+	multiVCe2eVSphere = multiVCvSphere{
+		multivcConfig: multiVCtestConfig,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// connects and verifies multiple VC connections
+	connectMultiVC(ctx, &multiVCe2eVSphere)
+
+	if framework.TestContext.RepoRoot != "" {
+		testfiles.AddFileSource(testfiles.RootFileSource{Root: framework.TestContext.RepoRoot})
+	}
+	framework.TestContext.Provider = "vsphere"
+}

--- a/tests/e2e/multi_vc_connection.go
+++ b/tests/e2e/multi_vc_connection.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	neturl "net/url"
+	"strings"
+
+	gomega "github.com/onsi/gomega"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+/*
+connectMultiVC helps make a connection to a multiple vCenter Server. No actions are taken if a connection
+exists and alive. Otherwise, a new client will be created.
+*/
+func connectMultiVC(ctx context.Context, vs *multiVCvSphere) {
+	clientLock.Lock()
+	defer clientLock.Unlock()
+	if vs.multiVcClient == nil {
+		framework.Logf("Creating new VC session")
+		vs.multiVcClient = newClientForMultiVC(ctx, vs)
+	}
+	for i := 0; i < len(vs.multiVcClient); i++ {
+		manager := session.NewManager(vs.multiVcClient[i].Client)
+		userSession, err := manager.UserSession(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if userSession != nil {
+			continue
+		} else {
+			framework.Logf("Current session is not valid or not authenticated, trying to logout from it")
+			err = vs.multiVcClient[i].Logout(ctx)
+			if err != nil {
+				framework.Logf("Ignoring the log out error: %v", err)
+			}
+			framework.Logf("Creating new client session after attempting to logout from existing session")
+			vs.multiVcClient = newClientForMultiVC(ctx, vs)
+		}
+	}
+}
+
+/*
+newClientForMultiVC creates a new client for vSphere connection on a multivc environment
+*/
+func newClientForMultiVC(ctx context.Context, vs *multiVCvSphere) []*govmomi.Client {
+	var clients []*govmomi.Client
+	configUser := strings.Split(vs.multivcConfig.Global.User, ",")
+	configPwd := strings.Split(vs.multivcConfig.Global.Password, ",")
+	configvCenterHostname := strings.Split(vs.multivcConfig.Global.VCenterHostname, ",")
+	configvCenterPort := strings.Split(vs.multivcConfig.Global.VCenterPort, ",")
+	for i := 0; i < len(configvCenterHostname); i++ {
+		framework.Logf("https://%s:%s/sdk", configvCenterHostname[i], configvCenterPort[i])
+		url, err := neturl.Parse(fmt.Sprintf("https://%s:%s/sdk",
+			configvCenterHostname[i], configvCenterPort[i]))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		url.User = neturl.UserPassword(configUser[i], configPwd[i])
+		client, err := govmomi.NewClient(ctx, url, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = client.UseServiceVersion(vsanNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		client.RoundTripper = vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(roundTripperDefaultCount))
+		clients = append(clients, client)
+	}
+	return clients
+}
+
+/*
+connectMultiVcCns creates a CNS client for the virtual center for a multivc environment
+*/
+func connectMultiVcCns(ctx context.Context, vs *multiVCvSphere) error {
+	var err error
+	clientMutex.Lock()
+	defer clientMutex.Unlock()
+	if vs.multiVcCnsClient == nil {
+		vs.multiVcCnsClient = make([]*cnsClient, len(vs.multiVcClient))
+		for i := 0; i < len(vs.multiVcClient); i++ {
+			vs.multiVcCnsClient[i], err = newCnsClient(ctx, vs.multiVcClient[i].Client)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	}
+	return nil
+}

--- a/tests/e2e/multi_vc_utils.go
+++ b/tests/e2e/multi_vc_utils.go
@@ -1,0 +1,434 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	vim25types "github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/crypto/ssh"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fssh "k8s.io/kubernetes/test/e2e/framework/ssh"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+)
+
+/*
+createCustomisedStatefulSets util methods creates statefulset as per the user's
+specific requirement and returns the customised statefulset
+*/
+func createCustomisedStatefulSets(client clientset.Interface, namespace string,
+	isParallelPodMgmtPolicy bool, replicas int32, nodeAffinityToSet bool,
+	allowedTopologies []v1.TopologySelectorLabelRequirement, allowedTopologyLen int,
+	podAntiAffinityToSet bool, modifyStsSpec bool, stsName string,
+	accessMode v1.PersistentVolumeAccessMode, sc *storagev1.StorageClass) *appsv1.StatefulSet {
+	framework.Logf("Preparing StatefulSet Spec")
+	statefulset := GetStatefulSetFromManifest(namespace)
+
+	if accessMode == "" {
+		// If accessMode is not specified, set the default accessMode.
+		accessMode = v1.ReadWriteOnce
+	}
+
+	if modifyStsSpec {
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Annotations["volume.beta.kubernetes.io/storage-class"] = sc.Name
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].Spec.AccessModes[0] =
+			accessMode
+		statefulset.Name = stsName
+		statefulset.Spec.Template.Labels["app"] = statefulset.Name
+		statefulset.Spec.Selector.MatchLabels["app"] = statefulset.Name
+	}
+	if nodeAffinityToSet {
+		nodeSelectorTerms := getNodeSelectorTerms(allowedTopologies)
+		statefulset.Spec.Template.Spec.Affinity = new(v1.Affinity)
+		statefulset.Spec.Template.Spec.Affinity.NodeAffinity = new(v1.NodeAffinity)
+		statefulset.Spec.Template.Spec.Affinity.NodeAffinity.
+			RequiredDuringSchedulingIgnoredDuringExecution = new(v1.NodeSelector)
+		statefulset.Spec.Template.Spec.Affinity.NodeAffinity.
+			RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = nodeSelectorTerms
+	}
+	if podAntiAffinityToSet {
+		statefulset.Spec.Template.Spec.Affinity = &v1.Affinity{
+			PodAntiAffinity: &v1.PodAntiAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"key": "app",
+							},
+						},
+						TopologyKey: "topology.kubernetes.io/zone",
+					},
+				},
+			},
+		}
+
+	}
+	if isParallelPodMgmtPolicy {
+		statefulset.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+	}
+	statefulset.Spec.Replicas = &replicas
+
+	framework.Logf("Creating statefulset")
+	CreateStatefulSet(namespace, statefulset, client)
+
+	framework.Logf("Wait for StatefulSet pods to be in up and running state")
+	fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+	gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+	ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+	gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+		fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+	gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+		"Number of Pods in the statefulset should match with number of replicas")
+
+	return statefulset
+}
+
+/*
+setSpecificAllowedTopology returns topology map with specific topology fields and values
+in a multi-vc setup
+*/
+func setSpecificAllowedTopology(allowedTopologies []v1.TopologySelectorLabelRequirement,
+	topkeyStartIndex int, startIndex int, endIndex int) []v1.TopologySelectorLabelRequirement {
+	var allowedTopologiesMap []v1.TopologySelectorLabelRequirement
+	specifiedAllowedTopology := v1.TopologySelectorLabelRequirement{
+		Key:    allowedTopologies[topkeyStartIndex].Key,
+		Values: allowedTopologies[topkeyStartIndex].Values[startIndex:endIndex],
+	}
+	allowedTopologiesMap = append(allowedTopologiesMap, specifiedAllowedTopology)
+
+	return allowedTopologiesMap
+}
+
+/*
+If we have multiple statefulsets, deployment Pods, PVCs/PVs created on a given namespace and for performing
+cleanup of these multiple sts creation, deleteAllStsAndPodsPVCsInNamespace is used
+*/
+func deleteAllStsAndPodsPVCsInNamespace(ctx context.Context, c clientset.Interface, ns string) {
+	StatefulSetPoll := 10 * time.Second
+	StatefulSetTimeout := 10 * time.Minute
+	ssList, err := c.AppsV1().StatefulSets(ns).List(context.TODO(),
+		metav1.ListOptions{LabelSelector: labels.Everything().String()})
+	framework.ExpectNoError(err)
+	errList := []string{}
+	for i := range ssList.Items {
+		ss := &ssList.Items[i]
+		var err error
+		if ss, err = scaleStatefulSetPods(c, ss, 0); err != nil {
+			errList = append(errList, fmt.Sprintf("%v", err))
+		}
+		fss.WaitForStatusReplicas(c, ss, 0)
+		framework.Logf("Deleting statefulset %v", ss.Name)
+		if err := c.AppsV1().StatefulSets(ss.Namespace).Delete(context.TODO(), ss.Name,
+			metav1.DeleteOptions{OrphanDependents: new(bool)}); err != nil {
+			errList = append(errList, fmt.Sprintf("%v", err))
+		}
+	}
+	pvNames := sets.NewString()
+	pvcPollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout, func() (bool, error) {
+		pvcList, err := c.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(),
+			metav1.ListOptions{LabelSelector: labels.Everything().String()})
+		if err != nil {
+			framework.Logf("WARNING: Failed to list pvcs, retrying %v", err)
+			return false, nil
+		}
+		for _, pvc := range pvcList.Items {
+			pvNames.Insert(pvc.Spec.VolumeName)
+			framework.Logf("Deleting pvc: %v with volume %v", pvc.Name, pvc.Spec.VolumeName)
+			if err := c.CoreV1().PersistentVolumeClaims(ns).Delete(context.TODO(), pvc.Name,
+				metav1.DeleteOptions{}); err != nil {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if pvcPollErr != nil {
+		errList = append(errList, "Timeout waiting for pvc deletion.")
+	}
+
+	pollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout, func() (bool, error) {
+		pvList, err := c.CoreV1().PersistentVolumes().List(context.TODO(),
+			metav1.ListOptions{LabelSelector: labels.Everything().String()})
+		if err != nil {
+			framework.Logf("WARNING: Failed to list pvs, retrying %v", err)
+			return false, nil
+		}
+		waitingFor := []string{}
+		for _, pv := range pvList.Items {
+			if pvNames.Has(pv.Name) {
+				waitingFor = append(waitingFor, fmt.Sprintf("%v: %+v", pv.Name, pv.Status))
+			}
+		}
+		if len(waitingFor) == 0 {
+			return true, nil
+		}
+		framework.Logf("Still waiting for pvs of statefulset to disappear:\n%v", strings.Join(waitingFor, "\n"))
+		return false, nil
+	})
+	if pollErr != nil {
+		errList = append(errList, "Timeout waiting for pv provisioner to delete pvs, this might mean the test leaked pvs.")
+
+	}
+	if len(errList) != 0 {
+		framework.ExpectNoError(fmt.Errorf("%v", strings.Join(errList, "\n")))
+	}
+
+	framework.Logf("Deleting Deployment Pods and its PVCs")
+	depList, err := c.AppsV1().Deployments(ns).List(
+		ctx, metav1.ListOptions{LabelSelector: labels.Everything().String()})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	for _, deployment := range depList.Items {
+		dep := &deployment
+		err = updateDeploymentReplicawithWait(c, 0, dep.Name, ns)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		deletePolicy := metav1.DeletePropagationForeground
+		err = c.AppsV1().Deployments(ns).Delete(ctx, dep.Name, metav1.DeleteOptions{PropagationPolicy: &deletePolicy})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return
+			} else {
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+	}
+}
+
+/*
+verifyVolumeMetadataInCNSForMultiVC verifies container volume metadata is matching the
+one is CNS cache on a multivc environment.
+*/
+func verifyVolumeMetadataInCNSForMultiVC(vs *multiVCvSphere, volumeID string,
+	PersistentVolumeClaimName string, PersistentVolumeName string,
+	PodName string, Labels ...vim25types.KeyValue) error {
+	queryResult, err := vs.queryCNSVolumeWithResultInMultiVC(volumeID)
+	if err != nil {
+		return err
+	}
+	gomega.Expect(queryResult.Volumes).ShouldNot(gomega.BeEmpty())
+	if len(queryResult.Volumes) != 1 || queryResult.Volumes[0].VolumeId.Id != volumeID {
+		return fmt.Errorf("failed to query cns volume %s", volumeID)
+	}
+	for _, metadata := range queryResult.Volumes[0].Metadata.EntityMetadata {
+		kubernetesMetadata := metadata.(*cnstypes.CnsKubernetesEntityMetadata)
+		if kubernetesMetadata.EntityType == "POD" && kubernetesMetadata.EntityName != PodName {
+			return fmt.Errorf("entity Pod with name %s not found for volume %s", PodName, volumeID)
+		} else if kubernetesMetadata.EntityType == "PERSISTENT_VOLUME" &&
+			kubernetesMetadata.EntityName != PersistentVolumeName {
+			return fmt.Errorf("entity PV with name %s not found for volume %s", PersistentVolumeName, volumeID)
+		} else if kubernetesMetadata.EntityType == "PERSISTENT_VOLUME_CLAIM" &&
+			kubernetesMetadata.EntityName != PersistentVolumeClaimName {
+			return fmt.Errorf("entity PVC with name %s not found for volume %s", PersistentVolumeClaimName, volumeID)
+		}
+	}
+	labelMap := make(map[string]string)
+	for _, e := range queryResult.Volumes[0].Metadata.EntityMetadata {
+		if e == nil {
+			continue
+		}
+		if e.GetCnsEntityMetadata().Labels == nil {
+			continue
+		}
+		for _, al := range e.GetCnsEntityMetadata().Labels {
+			labelMap[al.Key] = al.Value
+		}
+		for _, el := range Labels {
+			if val, ok := labelMap[el.Key]; ok {
+				gomega.Expect(el.Value == val).To(gomega.BeTrue(),
+					fmt.Sprintf("Actual label Value of the statically provisioned PV is %s but expected is %s",
+						val, el.Value))
+			} else {
+				return fmt.Errorf("label(%s:%s) is expected in the provisioned PV but its not found", el.Key, el.Value)
+			}
+		}
+	}
+	ginkgo.By(fmt.Sprintf("successfully verified metadata of the volume %q", volumeID))
+	return nil
+}
+
+// govc login cmd for multivc setups
+func govcLoginCmdForMultiVC() string {
+	configUser := strings.Split(multiVCe2eVSphere.multivcConfig.Global.User, ",")
+	configPwd := strings.Split(multiVCe2eVSphere.multivcConfig.Global.Password, ",")
+	configvCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+	configvCenterPort := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterPort, ",")
+
+	loginCmd := "export GOVC_INSECURE=1;"
+	loginCmd += fmt.Sprintf("export GOVC_URL='https://%s:%s@%s:%s';",
+		configUser[0], configPwd[0], configvCenterHostname[0], configvCenterPort[0])
+	return loginCmd
+}
+
+/*deletes storage profile deletes the storage profile*/
+func deleteStorageProfile(masterIp string, sshClientConfig *ssh.ClientConfig,
+	storagePolicyName string) error {
+	removeStoragePolicy := govcLoginCmdForMultiVC() +
+		"govc storage.policy.rm " + storagePolicyName
+	framework.Logf("Remove storage policy: %s ", removeStoragePolicy)
+	removeStoragePolicytRes, err := sshExec(sshClientConfig, masterIp, removeStoragePolicy)
+	if err != nil && removeStoragePolicytRes.Code != 0 {
+		fssh.LogResult(removeStoragePolicytRes)
+		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+			removeStoragePolicy, masterIp, err)
+	}
+	return nil
+}
+
+/*
+performScalingOnStatefulSetAndVerifyPvNodeAffinity accepts 3 bool values - one for scaleup,
+second for scale down and third bool value to check node and pod topology affinites
+*/
+func performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx context.Context, client clientset.Interface,
+	scaleUpReplicaCount int32, scaleDownReplicaCount int32, statefulset *appsv1.StatefulSet,
+	parallelStatefulSetCreation bool, namespace string,
+	allowedTopologies []v1.TopologySelectorLabelRequirement, stsScaleUp bool, stsScaleDown bool,
+	verifyTopologyAffinity bool) {
+
+	if stsScaleUp {
+		framework.Logf("Scale down statefulset replica count to 1")
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, scaleDownReplicaCount,
+			parallelStatefulSetCreation, true)
+	}
+
+	if stsScaleDown {
+		framework.Logf("Scale up statefulset replica count to 4")
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, scaleUpReplicaCount,
+			parallelStatefulSetCreation, true)
+	}
+
+	if verifyTopologyAffinity {
+		framework.Logf("Verify PV node affinity and that the PODS are running on appropriate node")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, parallelStatefulSetCreation, true)
+	}
+}
+
+/*
+createStafeulSetAndVerifyPVAndPodNodeAffinty creates user specified statefulset and
+further checks the node and volumes affinities
+*/
+func createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx context.Context, client clientset.Interface,
+	namespace string, parallelPodPolicy bool, replicas int32, nodeAffinityToSet bool,
+	allowedTopologies []v1.TopologySelectorLabelRequirement, allowedTopologyLen int,
+	podAntiAffinityToSet bool, parallelStatefulSetCreation bool, modifyStsSpec bool,
+	stsName string, accessMode v1.PersistentVolumeAccessMode,
+	sc *storagev1.StorageClass, verifyTopologyAffinity bool) (*v1.Service, *appsv1.StatefulSet) {
+
+	ginkgo.By("Create service")
+	service := CreateService(namespace, client)
+
+	framework.Logf("Create StatefulSet")
+	statefulset := createCustomisedStatefulSets(client, namespace, parallelPodPolicy,
+		replicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet, modifyStsSpec,
+		"", "", nil)
+
+	if verifyTopologyAffinity {
+		framework.Logf("Verify PV node affinity and that the PODS are running on appropriate node")
+		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
+			namespace, allowedTopologies, parallelStatefulSetCreation, true)
+	}
+
+	return service, statefulset
+}
+
+/*
+performOfflineVolumeExpansin performs offline volume expansion on the PVC passed as an input
+*/
+func performOfflineVolumeExpansin(client clientset.Interface,
+	pvclaim *v1.PersistentVolumeClaim, volHandle string, namespace string) {
+
+	ginkgo.By("Expanding current pvc, performing offline volume expansion")
+	currentPvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
+	newSize := currentPvcSize.DeepCopy()
+	newSize.Add(resource.MustParse("1Gi"))
+	framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
+	pvclaim, err := expandPVCSize(pvclaim, newSize, client)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+
+	pvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
+	if pvcSize.Cmp(newSize) != 0 {
+		framework.Failf("error updating pvc size %q", pvclaim.Name)
+	}
+
+	ginkgo.By("Waiting for controller volume resize to finish")
+	err = waitForPvResizeForGivenPvc(pvclaim, client, totalResizeWaitPeriod)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By("Checking for conditions on pvc")
+	_, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
+	queryResult, err := multiVCe2eVSphere.queryCNSVolumeWithResultInMultiVC(volHandle)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	if len(queryResult.Volumes) == 0 {
+		err = fmt.Errorf("queryCNSVolumeWithResult returned no volume")
+	}
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	ginkgo.By("Verifying disk size requested in volume expansion is honored")
+	newSizeInMb := int64(3072)
+	if queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).CapacityInMb != newSizeInMb {
+		err = fmt.Errorf("got wrong disk size after volume expansion")
+	}
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+/*
+performOnlineVolumeExpansin performs online volume expansion on the Pod passed as an input
+*/
+func performOnlineVolumeExpansin(f *framework.Framework, client clientset.Interface,
+	pvclaim *v1.PersistentVolumeClaim, namespace string, pod *v1.Pod) {
+
+	ginkgo.By("Waiting for file system resize to finish")
+	pvclaim, err := waitForFSResize(pvclaim, client)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	pvcConditions := pvclaim.Status.Conditions
+	expectEqual(len(pvcConditions), 0, "pvc should not have conditions")
+
+	var fsSize int64
+
+	ginkgo.By("Verify filesystem size for mount point /mnt/volume1")
+	fsSize, err = getFSSizeMb(f, pod)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	framework.Logf("File system size after expansion : %s", fsSize)
+
+	if fsSize < diskSizeInMb {
+		framework.Failf("error updating filesystem size for %q. Resulting filesystem size is %d", pvclaim.Name, fsSize)
+	}
+	ginkgo.By("File system resize finished successfully")
+
+}

--- a/tests/e2e/multi_vc_vsphere.go
+++ b/tests/e2e/multi_vc_vsphere.go
@@ -1,0 +1,380 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/onsi/gomega"
+	"github.com/vmware/govmomi"
+	cnsmethods "github.com/vmware/govmomi/cns/methods"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// multiVCvSphere struct accepts multiple VC and CNS client details
+type multiVCvSphere struct {
+	multivcConfig    *e2eTestConfig
+	multiVcClient    []*govmomi.Client
+	multiVcCnsClient []*cnsClient
+}
+
+/*
+queryCNSVolumeWithResultInMultiVC Call CnsQueryVolume and returns CnsQueryResult to client in
+a multiVC setup
+*/
+func (vs *multiVCvSphere) queryCNSVolumeWithResultInMultiVC(fcdID string) (*cnstypes.CnsQueryResult, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var res *cnstypes.CnsQueryVolumeResponse
+	// Connects to multiple VCs
+	connectMultiVC(ctx, vs)
+	var volumeIds []cnstypes.CnsVolumeId
+	volumeIds = append(volumeIds, cnstypes.CnsVolumeId{
+		Id: fcdID,
+	})
+	queryFilter := cnstypes.CnsQueryFilter{
+		VolumeIds: volumeIds,
+		Cursor: &cnstypes.CnsCursor{
+			Offset: 0,
+			Limit:  100,
+		},
+	}
+	req := cnstypes.CnsQueryVolume{
+		This:   cnsVolumeManagerInstance,
+		Filter: queryFilter,
+	}
+	// Connects to multiple CNS clients
+	err := connectMultiVcCns(ctx, vs)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(vs.multiVcCnsClient); i++ {
+		res, err = cnsmethods.CnsQueryVolume(ctx, vs.multiVcCnsClient[i].Client, &req)
+		if res.Returnval.Volumes == nil {
+			continue
+		}
+
+		if res.Returnval.Volumes != nil && err == nil {
+			return &res.Returnval, nil
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &res.Returnval, nil
+}
+
+/* getAllDatacentersForMultiVC returns all the DataCenter Objects in a multivc environment */
+func (vs *multiVCvSphere) getAllDatacentersForMultiVC(ctx context.Context) ([]*object.Datacenter, error) {
+	connectMultiVC(ctx, vs)
+	var finder *find.Finder
+	for i := 0; i < len(vs.multiVcClient); i++ {
+		soapClient := vs.multiVcClient[i].Client.Client
+		if soapClient == nil {
+			return nil, fmt.Errorf("soapClient is nil")
+		}
+		vimClient, err := convertToVimClient(ctx, soapClient)
+		if err != nil {
+			return nil, err
+		}
+		finder = find.NewFinder(vimClient, false)
+	}
+	return finder.DatacenterList(ctx, "*")
+}
+
+/*
+convertToVimClient converts soap client to vim client
+*/
+func convertToVimClient(ctx context.Context, soapClient *soap.Client) (*vim25.Client, error) {
+	// Create a new *vim25.Client using the *soap.Client, context, and a RoundTripper
+	vimClient, err := vim25.NewClient(ctx, soapClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return vimClient, nil
+}
+
+/*
+getVMByUUIDForMultiVC gets the VM object Reference from the given vmUUID in a multivc environment
+*/
+func (vs *multiVCvSphere) getVMByUUIDForMultiVC(ctx context.Context, vmUUID string) (object.Reference, error) {
+	connectMultiVC(ctx, vs)
+	dcList, err := vs.getAllDatacentersForMultiVC(ctx)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	for _, dc := range dcList {
+		for i := 0; i < len(vs.multiVcClient); i++ {
+			soapClient := vs.multiVcClient[i].Client.Client
+			vimClient, err := vim25.NewClient(ctx, soapClient)
+			if err != nil {
+				continue
+			}
+			datacenter := object.NewDatacenter(vimClient, dc.Reference())
+			s := object.NewSearchIndex(vimClient)
+			vmUUID = strings.ToLower(strings.TrimSpace(vmUUID))
+			instanceUUID := !(vanillaCluster || guestCluster)
+			vmMoRef, err := s.FindByUuid(ctx, datacenter, vmUUID, true, &instanceUUID)
+
+			if err != nil || vmMoRef == nil {
+				continue
+			}
+			return vmMoRef, nil
+		}
+	}
+	framework.Logf("err in getVMByUUID is %+v for vmuuid: %s", err, vmUUID)
+	return nil, fmt.Errorf("node VM with UUID:%s is not found", vmUUID)
+}
+
+/*
+getVMByUUIDWithWaitForMultiVC gets the VM object Reference from the given vmUUID with a given
+wait timeout on a multivc environment
+*/
+func (vs *multiVCvSphere) getVMByUUIDWithWaitForMultiVC(ctx context.Context,
+	vmUUID string, timeout time.Duration) (object.Reference, error) {
+	connectMultiVC(ctx, vs)
+	dcList, err := vs.getAllDatacentersForMultiVC(ctx)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	var vmMoRefForvmUUID object.Reference
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
+		var vmMoRefFound bool
+		for _, dc := range dcList {
+			for i := 0; i < len(vs.multiVcClient); i++ {
+				soapClient := vs.multiVcClient[i].Client.Client
+				vimClient, err := vim25.NewClient(ctx, soapClient)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				datacenter := object.NewDatacenter(vimClient, dc.Reference())
+				s := object.NewSearchIndex(vimClient)
+				vmUUID = strings.ToLower(strings.TrimSpace(vmUUID))
+				instanceUUID := !(vanillaCluster || guestCluster)
+				vmMoRef, err := s.FindByUuid(ctx, datacenter, vmUUID, true, &instanceUUID)
+
+				if err != nil || vmMoRef == nil {
+					continue
+				}
+				if vmMoRef != nil {
+					vmMoRefFound = true
+					vmMoRefForvmUUID = vmMoRef
+				}
+			}
+		}
+
+		if vmMoRefFound {
+			framework.Logf("vmuuid: %s still exists", vmMoRefForvmUUID)
+			continue
+		} else {
+			return nil, fmt.Errorf("node VM with UUID:%s is not found", vmUUID)
+		}
+	}
+	return vmMoRefForvmUUID, nil
+}
+
+/*
+verifyVolumeIsAttachedToVMInMultiVC checks volume is attached to the VM by vmUUID.
+This function returns true if volume is attached to the VM, else returns false
+*/
+func (vs *multiVCvSphere) verifyVolumeIsAttachedToVMInMultiVC(client clientset.Interface, volumeID string,
+	vmUUID string) (bool, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vmRef, err := vs.getVMByUUIDForMultiVC(ctx, vmUUID)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	framework.Logf("vmRef: %v for the VM uuid: %s", vmRef, vmUUID)
+	gomega.Expect(vmRef).NotTo(gomega.BeNil(), "vmRef should not be nil")
+
+	for i := 0; i < len(vs.multiVcClient); i++ {
+		soapClient := vs.multiVcClient[i].Client.Client
+		vimClient, err := vim25.NewClient(ctx, soapClient)
+		if err != nil {
+			return false, err
+		}
+
+		// Retrieve all virtual machines from the current client
+		vms, err := getAllVMsInClient(ctx, vimClient)
+		if err != nil {
+			return false, err
+		}
+
+		// Loop through all the VMs in the current client
+		for _, vm := range vms {
+			device, err := getVirtualDeviceByDiskID(ctx, vm, volumeID)
+			if err == nil && device == nil {
+				continue
+			}
+			if device != nil && err != nil {
+				framework.Logf("failed to determine whether disk %q is still attached to the VM with UUID: %q", volumeID, vmUUID)
+				continue
+			}
+			if device != nil && err == nil {
+				framework.Logf("Found the disk %q is attached to the VM with UUID: %q", volumeID, vmUUID)
+				return true, nil
+			}
+
+			if device == nil && err != nil {
+				continue
+			}
+		}
+	}
+	return false, nil
+}
+
+// Helper function to retrieve all virtual machines in a client
+func getAllVMsInClient(ctx context.Context, vimClient *vim25.Client) ([]*object.VirtualMachine, error) {
+	// Create a new finder
+	finder := find.NewFinder(vimClient)
+
+	// Find all virtual machines
+	vms, err := finder.VirtualMachineList(ctx, "*")
+	if err != nil {
+		return nil, err
+	}
+
+	return vms, nil
+}
+
+/*
+waitForVolumeDetachedFromNodeInMultiVC checks volume is detached from the node on a multivc environment.
+This function checks disks status every 3 seconds until detachTimeout, which is set to 360 seconds
+*/
+func (vs *multiVCvSphere) waitForVolumeDetachedFromNodeInMultiVC(client clientset.Interface,
+	volumeID string, nodeName string) (bool, error) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if supervisorCluster {
+		_, err := multiVCe2eVSphere.getVMByUUIDWithWaitForMultiVC(ctx, nodeName, supervisorClusterOperationsTimeout)
+		if err == nil {
+			return false, fmt.Errorf(
+				"PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM", nodeName, volumeID)
+		} else if strings.Contains(err.Error(), "is not found") {
+			return true, nil
+		}
+		return false, err
+	}
+	err := wait.Poll(poll, pollTimeout, func() (bool, error) {
+		var vmUUID string
+		if vanillaCluster {
+			vmUUID = getNodeUUID(ctx, client, nodeName)
+		} else {
+			vmUUID, _ = getVMUUIDFromNodeName(nodeName)
+		}
+		diskAttached, err := vs.verifyVolumeIsAttachedToVMInMultiVC(client, volumeID, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if !diskAttached {
+			framework.Logf("Disk: %s successfully detached", volumeID)
+			return true, nil
+		}
+		framework.Logf("Waiting for disk: %q to be detached from the node :%q", volumeID, nodeName)
+		return false, nil
+	})
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+/*
+waitForCNSVolumeToBeDeletedInMultiVC executes QueryVolume API on vCenter and verifies
+volume entries are deleted from vCenter Database
+*/
+func (vs *multiVCvSphere) waitForCNSVolumeToBeDeletedInMultiVC(volumeID string) error {
+	err := wait.Poll(poll, pollTimeout, func() (bool, error) {
+		queryResult, err := vs.queryCNSVolumeWithResultInMultiVC(volumeID)
+		if err != nil {
+			return true, err
+		}
+
+		if len(queryResult.Volumes) == 0 {
+			framework.Logf("volume %q has successfully deleted", volumeID)
+			return true, nil
+		}
+		framework.Logf("waiting for Volume %q to be deleted.", volumeID)
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+/*
+waitForLabelsToBeUpdatedInMultiVC executes QueryVolume API on vCenter and verifies
+volume labels are updated by metadata-syncer
+*/
+func (vs *multiVCvSphere) waitForLabelsToBeUpdatedInMultiVC(volumeID string, matchLabels map[string]string,
+	entityType string, entityName string, entityNamespace string) error {
+	err := wait.Poll(poll, pollTimeout, func() (bool, error) {
+		err := vs.verifyLabelsAreUpdatedInMultiVC(volumeID, matchLabels, entityType, entityName, entityNamespace)
+		if err == nil {
+			return true, nil
+		} else {
+			return false, nil
+		}
+	})
+	if err != nil {
+		if err == wait.ErrWaitTimeout {
+			return fmt.Errorf("labels are not updated to %+v for %s %q for volume %s",
+				matchLabels, entityType, entityName, volumeID)
+		}
+		return err
+	}
+
+	return nil
+}
+
+/*
+verifyLabelsAreUpdatedInMultiVC executes cns QueryVolume API on vCenter and verifies if
+volume labels are updated by metadata-syncer
+*/
+func (vs *multiVCvSphere) verifyLabelsAreUpdatedInMultiVC(volumeID string, matchLabels map[string]string,
+	entityType string, entityName string, entityNamespace string) error {
+
+	queryResult, err := vs.queryCNSVolumeWithResultInMultiVC(volumeID)
+	framework.Logf("queryResult: %s", spew.Sdump(queryResult))
+	if err != nil {
+		return err
+	}
+	if len(queryResult.Volumes) != 1 || queryResult.Volumes[0].VolumeId.Id != volumeID {
+		return fmt.Errorf("failed to query cns volume %s", volumeID)
+	}
+	gomega.Expect(queryResult.Volumes[0].Metadata).NotTo(gomega.BeNil())
+	for _, metadata := range queryResult.Volumes[0].Metadata.EntityMetadata {
+		if metadata == nil {
+			continue
+		}
+		kubernetesMetadata := metadata.(*cnstypes.CnsKubernetesEntityMetadata)
+		k8sEntityName := kubernetesMetadata.EntityName
+		if guestCluster {
+			k8sEntityName = kubernetesMetadata.CnsEntityMetadata.EntityName
+		}
+		if kubernetesMetadata.EntityType == entityType && k8sEntityName == entityName &&
+			kubernetesMetadata.Namespace == entityNamespace {
+			if matchLabels == nil {
+				return nil
+			}
+			labelsMatch := reflect.DeepEqual(getLabelsMapFromKeyValue(kubernetesMetadata.Labels), matchLabels)
+			if guestCluster {
+				labelsMatch = reflect.DeepEqual(getLabelsMapFromKeyValue(kubernetesMetadata.CnsEntityMetadata.Labels),
+					matchLabels)
+			}
+			if labelsMatch {
+				return nil
+			} else {
+				return fmt.Errorf("labels are not updated to %+v for %s %q for volume %s",
+					matchLabels, entityType, entityName, volumeID)
+			}
+		}
+	}
+	return nil
+}

--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -299,7 +299,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false)
+			namespace, allowedTopologyForRack2, false, false)
 
 		// choose preferred datastore in rack-1
 		ginkgo.By("Tag preferred datatstore for volume provisioning in rack-1(cluster-1))")
@@ -371,7 +371,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack1)
+			allowedTopologyForRack1, false)
 	})
 
 	/*
@@ -472,12 +472,12 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack3, false)
+			namespace, allowedTopologyForRack3, false, false)
 
 		// perform statefulset scaleup
 		replicas = 10
 		ginkgo.By("Scale up statefulset replica count from 3 to 10")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -488,7 +488,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack3, false)
+			namespace, allowedTopologyForRack3, false, false)
 	})
 
 	/*
@@ -594,12 +594,12 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false)
+			namespace, allowedTopologyForRack2, false, false)
 
 		// perform statefulset scaleup
 		replicas = 10
 		ginkgo.By("Scale up statefulset replica count from 3 to 10")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -610,12 +610,12 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false)
+			namespace, allowedTopologyForRack2, false, false)
 
 		// perform statefulset scaledown
 		replicas = 5
 		ginkgo.By("Scale down statefulset replica count from 10 to 5")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -705,7 +705,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 	})
 
 	/*
@@ -799,7 +799,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false)
+			namespace, allowedTopologyForRack2, false, false)
 	})
 
 	/*
@@ -896,7 +896,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 	})
 
 	/*
@@ -982,7 +982,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 	})
 
 	/*
@@ -1071,7 +1071,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack1, true)
+			namespace, allowedTopologyForRack1, true, false)
 
 		ginkgo.By("Remove preferred datatsore tag which is chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
@@ -1143,7 +1143,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack1)
+			allowedTopologyForRack1, false)
 
 	})
 
@@ -1240,7 +1240,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack3, false)
+			namespace, allowedTopologyForRack3, false, false)
 
 		ginkgo.By("Remove preferred datatsore tag chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
@@ -1314,13 +1314,13 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack3)
+			allowedTopologyForRack3, false)
 
 		// perform statefulset scaleup
 		sts1Replicas = 10
 		ginkgo.By("Scale up statefulset replica count from 3 to 10")
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
-		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		//verifying volume is provisioned on the preferred datastore
 		ginkgo.By("Verify volume is provisioned on the specified datatsore")
@@ -1331,7 +1331,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack3, true)
+			namespace, allowedTopologyForRack3, true, false)
 	})
 
 	/*
@@ -1432,7 +1432,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack1, false)
+			namespace, allowedTopologyForRack1, false, false)
 
 		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
@@ -1452,7 +1452,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 13
 		ginkgo.By("Scale up statefulset replica count from 3 to 13")
-		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the specified datatsore")
@@ -1463,12 +1463,12 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack1, false)
+			namespace, allowedTopologyForRack1, false, false)
 
 		// perform statefulset scaledown
 		sts1Replicas = 6
 		ginkgo.By("Scale down statefulset replica count from 13 to 6")
-		scaleDownStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleDownStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[1],
@@ -1496,7 +1496,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 20
 		ginkgo.By("Scale up statefulset replica count from 6 to 20")
-		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the specified datatsore")
@@ -1507,7 +1507,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack1, false)
+			namespace, allowedTopologyForRack1, false, false)
 	})
 
 	/*
@@ -1617,7 +1617,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		ginkgo.By("Remove preferred datatsore tag which was chosen for volume provisioning in rack-1")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
@@ -1636,7 +1636,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 7
 		ginkgo.By("Scale up statefulset replica count from 3 to 7")
-		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		//verify volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -1647,7 +1647,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		ginkgo.By("Remove the datastore preference chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
@@ -1673,7 +1673,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 13
 		ginkgo.By("Scale up statefulset replica count from 7 to 13")
-		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		// verify volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -1684,7 +1684,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 	})
 
 	/*
@@ -1784,7 +1784,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// Verify affinity details
 		ginkgo.By("Verify node and pv topology affinity details")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack2, false)
+			namespace, allowedTopologyForRack2, false, false)
 	})
 
 	/*
@@ -1962,7 +1962,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack2)
+			allowedTopologyForRack2, false)
 	})
 
 	/*
@@ -2086,12 +2086,12 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// Verify affinity details
 		ginkgo.By("Verify node and pv topology affinity details")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		// perform statefulset scaleup
 		sts1Replicas = 13
 		ginkgo.By("Scale up statefulset replica count from 7 to 13")
-		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
+		scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -2102,7 +2102,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// Verify affinity details
 		ginkgo.By("Verify node and pv topology affinity details")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 	})
 
 	/*
@@ -2209,7 +2209,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies)
+			allowedTopologies, false)
 	})
 
 	/*
@@ -2326,7 +2326,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack2)
+			allowedTopologyForRack2, false)
 	})
 
 	/*
@@ -2559,7 +2559,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		ginkgo.By("Verify pv and pod node affinity details for pv-1/pod-1 and pv-2/pod-2")
 		for i := 0; i < len(podList); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, podList[i],
-				namespace, allowedTopologyForRack2)
+				namespace, allowedTopologyForRack2, false)
 		}
 	})
 

--- a/tests/e2e/preferential_topology_disruptive.go
+++ b/tests/e2e/preferential_topology_disruptive.go
@@ -308,7 +308,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
 		for i := 0; i < len(allowedTopologyRacks); i++ {
@@ -373,7 +373,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 
 		ginkgo.By("Scale up statefulset replica and verify the replica count")
 		replicas = 10
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, true)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulset)
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -387,7 +387,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		ginkgo.By("Remove preferred datastore tag in rack-2(cluster-2)")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[4],
@@ -409,7 +409,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// Scale down statefulSets replica count
 		replicas = 5
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, true)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, true, false)
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulset)
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -436,7 +436,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// Scale up statefulSets replicas count
 		ginkgo.By("Scale up statefulset replica and verify the replica count")
 		replicas = 13
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, true)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, true, false)
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulset)
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -450,7 +450,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 	})
 
 	/*
@@ -563,7 +563,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false)
+			namespace, allowedTopologyForRack2, false, false)
 
 		ginkgo.By("Migrate the worker vms residing on the nfs datatsore before " +
 			"making datastore inaccessible")
@@ -620,12 +620,12 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack2)
+			allowedTopologyForRack2, false)
 
 		// perform statefulset scaleup
 		replicas = 15
 		ginkgo.By("Scale up statefulset replica count from 10 to 15")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -636,7 +636,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false)
+			namespace, allowedTopologyForRack2, false, false)
 
 		ginkgo.By("Power on the inaccessible datastore")
 		datastoreOp = "on"
@@ -653,7 +653,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// perform statefulset scaleup
 		replicas = 20
 		ginkgo.By("Scale up statefulset replica count from 15 to 20")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -664,7 +664,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false)
+			namespace, allowedTopologyForRack2, false, false)
 	})
 
 	/*
@@ -778,7 +778,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack1, false)
+			namespace, allowedTopologyForRack1, false, false)
 
 		ginkgo.By("Migrate all the worker vms residing on the preferred datatsore before " +
 			"putting it into maintenance mode")
@@ -840,12 +840,12 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack1)
+			allowedTopologyForRack1, false)
 
 		// perform statefulset scaleup
 		replicas = 15
 		ginkgo.By("Scale up statefulset replica count from 10 to 15")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -856,7 +856,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack1, false)
+			namespace, allowedTopologyForRack1, false, false)
 
 		ginkgo.By("Exit datastore from Maintenance mode")
 		err = exitDatastoreFromMaintenanceMode(masterIp, sshClientConfig, dataCenters, preferredDatastore1[0])
@@ -874,7 +874,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// perform statefulset scaleup
 		replicas = 20
 		ginkgo.By("Scale up statefulset replica count from 15 to 20")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -885,7 +885,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack1, false)
+			namespace, allowedTopologyForRack1, false, false)
 	})
 
 	/*
@@ -1001,7 +1001,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false)
+			namespace, allowedTopologyForRack2, false, false)
 
 		ginkgo.By("Migrate all the worker vms residing on the nfs datatsore before " +
 			"making datastore inaccessible")
@@ -1059,12 +1059,12 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack2)
+			allowedTopologyForRack2, false)
 
 		// perform statefulset scaleup
 		replicas = 15
 		ginkgo.By("Scale up statefulset replica count from 10 to 15")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -1075,7 +1075,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false)
+			namespace, allowedTopologyForRack2, false, false)
 
 		ginkgo.By("Power on the suspended datastore")
 		datastoreOp = "on"
@@ -1092,7 +1092,7 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		// perform statefulset scaleup
 		replicas = 20
 		ginkgo.By("Scale up statefulset replica count from 15 to 20")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
@@ -1103,6 +1103,6 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false)
+			namespace, allowedTopologyForRack2, false, false)
 	})
 })

--- a/tests/e2e/preferential_topology_snapshot.go
+++ b/tests/e2e/preferential_topology_snapshot.go
@@ -337,7 +337,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack1)
+			allowedTopologyForRack1, false)
 	})
 
 	/*
@@ -680,7 +680,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 			"appropriate node as specified in the allowed topologies of SC")
 		for i := 0; i < len(podList); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, podList[i],
-				namespace, allowedTopologies)
+				namespace, allowedTopologies, false)
 		}
 
 		ginkgo.By("Create volume snapshot class, volume snapshot")
@@ -739,7 +739,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod3, namespace,
-			allowedTopologies)
+			allowedTopologies, false)
 
 		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
 		for i := 0; i < len(allowedTopologyRacks); i++ {
@@ -833,7 +833,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod4, namespace,
-			allowedTopologies)
+			allowedTopologies, false)
 
 		volumeSnapshot2, volumeSnapshotClass2, snapshotId2 := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
 			pvclaim4, volHandle4, false)
@@ -885,7 +885,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod5, namespace,
-			allowedTopologies)
+			allowedTopologies, false)
 	})
 
 	/*
@@ -976,7 +976,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack3, false)
+			namespace, allowedTopologyForRack3, false, false)
 
 		framework.Logf("Fetching pod 3, pvc3 and pv3 details")
 		pod3, err := client.CoreV1().Pods(namespace).Get(ctx,
@@ -1050,6 +1050,6 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack3, false)
+			namespace, allowedTopologyForRack3, false, false)
 	})
 })

--- a/tests/e2e/tkgs_ha.go
+++ b/tests/e2e/tkgs_ha.go
@@ -1510,7 +1510,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
-		pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, volumeOpsScale)
+		pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, volumeOpsScale, nil)
 		_, err = fpv.WaitForPVClaimBoundPhase(client,
 			pvclaimsList, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1712,7 +1712,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
-			pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, volumeOpsScale)
+			pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, volumeOpsScale, nil)
 			_, err = fpv.WaitForPVClaimBoundPhase(client,
 				pvclaimsList, framework.ClaimProvisionTimeout)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2260,7 +2260,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
-		pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, volumeOpsScale)
+		pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, volumeOpsScale, nil)
 		pvs, err := fpv.WaitForPVClaimBoundPhase(client,
 			pvclaimsList, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/topology_multi_replica.go
+++ b/tests/e2e/topology_multi_replica.go
@@ -308,7 +308,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(statefulSets); i++ {
 				verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-					statefulSets[i], namespace, allowedTopologies, true)
+					statefulSets[i], namespace, allowedTopologies, true, false)
 			}
 
 			/* Get current leader Csi-Controller-Pod where CSI Attacher is running" +
@@ -328,7 +328,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 2
 			ginkgo.By("Scale down statefulset replica and verify the replica count")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 				ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 				gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 					"Number of Pods in the statefulset should match with number of replicas")
@@ -357,7 +357,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 0
 			ginkgo.By("Scale down statefulset replica count to 0")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 				ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 				gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 					"Number of Pods in the statefulset should match with number of replicas")
@@ -506,14 +506,14 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(statefulSets); i++ {
 				verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-					statefulSets[i], namespace, allowedTopologies, true)
+					statefulSets[i], namespace, allowedTopologies, true, false)
 			}
 
 			// Scale down StatefulSets replicas count
 			statefulSetReplicaCount = 2
 			ginkgo.By("Scale down statefulset replica count")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 				ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 				gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 					"Number of Pods in the statefulset should match with number of replicas")
@@ -539,7 +539,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 0
 			ginkgo.By("Scale down statefulset replica count to 0")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 				ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 				gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 					"Number of Pods in the statefulset should match with number of replicas")
@@ -684,7 +684,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(statefulSets); i++ {
 				verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-					statefulSets[i], namespace, allowedTopologies, true)
+					statefulSets[i], namespace, allowedTopologies, true, false)
 			}
 
 			// Fetch the number of CSI pods running before restart
@@ -712,7 +712,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Scale up StaefulSets replicas in parallel")
 			statefulSetReplicaCount = 5
 			for i := 0; i < len(statefulSets); i++ {
-				scaleUpStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleUpStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			}
 
 			/* Verify PV nde affinity and that the pods are running on appropriate nodes
@@ -720,14 +720,14 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(statefulSets); i++ {
 				verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-					statefulSets[i], namespace, allowedTopologies, true)
+					statefulSets[i], namespace, allowedTopologies, true, false)
 			}
 
 			// Scale down statefulset to 0 replicas
 			statefulSetReplicaCount = 0
 			ginkgo.By("Scale down statefulset replica count to 0")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			}
 		})
 
@@ -790,7 +790,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 
 			// Creating multiple PVCs
 			ginkgo.By("Trigger multiple PVCs")
-			pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount)
+			pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount, nil)
 
 			// Verify PVC claim to be in bound phase and create POD for each PVC
 			ginkgo.By("Verify PVC claim to be in bound phase and create POD for each PVC")
@@ -935,7 +935,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(podList); i++ {
 				verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, podList[i],
-					namespace, allowedTopologies)
+					namespace, allowedTopologies, false)
 			}
 		})
 
@@ -990,7 +990,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 
 			// Creating multiple PVCs
 			ginkgo.By("Trigger multiple PVCs")
-			pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount)
+			pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount, nil)
 
 			// Verify PVC claim to be in bound phase and create POD for each PVC
 			ginkgo.By("Verify PVC claim to be in bound phase and create POD for each PVC")
@@ -1140,7 +1140,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(podList); i++ {
 				verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, podList[i],
-					namespace, allowedTopologies)
+					namespace, allowedTopologies, false)
 			}
 		})
 
@@ -1199,7 +1199,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 
 			// Creating multiple PVCs
 			ginkgo.By("Trigger multiple PVCs")
-			pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount)
+			pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount, nil)
 
 			/* Verifying if all PVCs are in Bound phase and trigger Deployment Pods
 			for each created PVC.
@@ -1224,7 +1224,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 				/* Verify PV nde affinity and that the pods are running on appropriate nodes
 				for each StatefulSet pod */
 				verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5(ctx, client, deployment,
-					namespace, allowedTopologies, true)
+					namespace, allowedTopologies, true, false)
 				deploymentList = append(deploymentList, deployment)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// Delete elected leader Csi-Controller-Pod where CSi-Attacher is running
@@ -1414,7 +1414,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(statefulSets); i++ {
 				verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-					statefulSets[i], namespace, allowedTopologies, true)
+					statefulSets[i], namespace, allowedTopologies, true, false)
 			}
 
 			/* Get elected current leader Csi-Controller-Pod where CSI Attacher is running" +
@@ -1432,7 +1432,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 2
 			ginkgo.By("Scale down statefulset replica count")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 				if i == 1 {
 					/* Delete newly elected leader CSi-Controller-Pod where CSI-Attacher is running */
 					ginkgo.By("Delete elected leader CSi-Controller-Pod where CSI-Attacher is running")
@@ -1455,7 +1455,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 0
 			ginkgo.By("Scale down statefulset replica count to 0")
 			for i := 0; i < len(statefulSets); i++ {
-				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+				scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			}
 
 			// Verify that the StatefulSet Pods, PVC's are deleted successfully
@@ -1638,7 +1638,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(podList); i++ {
 				verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, podList[i],
-					namespace, allowedTopologies)
+					namespace, allowedTopologies, false)
 			}
 		})
 
@@ -1875,7 +1875,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(podList); i++ {
 				verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, podList[i],
-					namespace, allowedTopologies)
+					namespace, allowedTopologies, false)
 			}
 		})
 		// TESTCASE-6
@@ -2041,7 +2041,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 				"appropriate node as specified in the allowed topologies of SC")
 			for i := 0; i < len(podList); i++ {
 				verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, podList[i], namespace,
-					allowedTopologies)
+					allowedTopologies, false)
 			}
 
 			// Deleting Pod's
@@ -2216,7 +2216,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 
 			// Creating multiple PVCs
 			ginkgo.By("Trigger multiple PVCs")
-			pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount)
+			pvclaimsList := createMultiplePVCsInParallel(ctx, client, namespace, storageclass, pvcCount, nil)
 			defer func() {
 				// cleanup code for deleting PVC
 				ginkgo.By("Deleting PVC's and PV's")

--- a/tests/e2e/topology_operation_strom_cases.go
+++ b/tests/e2e/topology_operation_strom_cases.go
@@ -205,7 +205,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Bring down few esxi hosts that belongs to zone3
@@ -236,7 +236,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		// Scale up statefulSets replicas count
 		ginkgo.By("Scale up statefulset replica and verify the replica count")
 		statefulSetReplicaCount = 35
-		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -244,7 +244,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		// Scale down statefulSets replica count
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleDownStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount, true)
+		scaleDownStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulSets[1])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -289,7 +289,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		// Scale down statefulSets replicas count
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleDownStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleDownStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -297,7 +297,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		// Scale up statefulSets replica count
 		statefulSetReplicaCount = 35
 		ginkgo.By("Scale up statefulset replica and verify the replica count")
-		scaleUpStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulSets[1])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -307,7 +307,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Bring up all ESXi host which were powered off in zone2
@@ -350,7 +350,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -571,7 +571,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		/* Get current leader Csi-Controller-Pod where CSI Attacher is running and " +
@@ -599,7 +599,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -625,7 +625,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 			// Scale up statefulSets replicas count
 			statefulSetReplicaCount = 20
 			ginkgo.By("Scale up statefulset replica and verify the replica count")
-			scaleUpStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleUpStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -636,14 +636,14 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Scale down statefulSets replica count
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")

--- a/tests/e2e/topology_site_down_cases.go
+++ b/tests/e2e/topology_site_down_cases.go
@@ -189,7 +189,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Bring down 1 ESXi's that belongs to zone1 and Bring down 1 ESXi's that belongs to zone2
@@ -230,14 +230,14 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Scale up statefulSets replicas count
 		ginkgo.By("Scaleup any one StatefulSets replica")
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -246,7 +246,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -276,7 +276,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// verifyVolumeMetadataInCNS
@@ -300,7 +300,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -390,7 +390,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Bring down 1 ESXi's that belongs to Cluster2 and Bring down 1 ESXi's that belongs to Cluster3
@@ -430,14 +430,14 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Scale up statefulSets replicas count
 		ginkgo.By("Scaleup any one StatefulSets replica")
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -446,7 +446,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -468,7 +468,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// verifyVolumeMetadataInCNS
@@ -492,7 +492,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -582,7 +582,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Bring down ESXi host that belongs to zone1, zone2 and zone3
@@ -618,7 +618,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Bring up
@@ -637,7 +637,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Scaleup any one StatefulSets replica")
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -646,7 +646,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -657,7 +657,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// verifyVolumeMetadataInCNS
@@ -681,7 +681,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -774,7 +774,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Bring down ESXi hosts that belongs to zone2
@@ -805,14 +805,14 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Scale up statefulSets replicas count
 		ginkgo.By("Scaleup any one StatefulSets replica")
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -821,7 +821,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -843,7 +843,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// verifyVolumeMetadataInCNS
@@ -867,7 +867,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -960,7 +960,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Bring down ESXi hosts that belongs to zone3
@@ -995,14 +995,14 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Scale up statefulSets replicas count
 		ginkgo.By("Scaleup any one StatefulSets replica")
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -1011,7 +1011,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -1033,7 +1033,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// verifyVolumeMetadataInCNS
@@ -1057,7 +1057,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")
@@ -1148,7 +1148,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// Bring down ESXi hosts that belongs to zone2
@@ -1243,7 +1243,8 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		// Scale down statefulSets replica count
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
-		scaleDownStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
+		scaleDownStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount,
+			true, false)
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
@@ -1261,7 +1262,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true)
+				statefulSets[i], namespace, allowedTopologies, true, false)
 		}
 
 		// verifyVolumeMetadataInCNS
@@ -1285,7 +1286,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
+			scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
 				"Number of Pods in the statefulset should match with number of replicas")

--- a/tests/e2e/topology_snapshot.go
+++ b/tests/e2e/topology_snapshot.go
@@ -273,7 +273,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies)
+			allowedTopologies, false)
 
 		defer func() {
 			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
@@ -369,7 +369,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		// Verify PV node affinity and that the PODS are running on appropriate nodes
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		framework.Logf("Fetching pod 3, pvc3 and pv3 details")
 		pod3, err := client.CoreV1().Pods(namespace).Get(ctx,
@@ -473,7 +473,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		ginkgo.By("Verify newly created PV node affinity and that the new PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		ginkgo.By("Delete volume snapshot and verify the snapshot content is deleted")
 		deleteVolumeSnapshotWithPandoraWait(ctx, snapc, namespace, volumeSnapshot3.Name, pandoraSyncWaitTime)

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -4704,7 +4704,8 @@ which PV is provisioned.
 */
 func verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx context.Context,
 	client clientset.Interface, statefulset *appsv1.StatefulSet, namespace string,
-	allowedTopologies []v1.TopologySelectorLabelRequirement, parallelStatefulSetCreation bool) {
+	allowedTopologies []v1.TopologySelectorLabelRequirement,
+	parallelStatefulSetCreation bool, isMultiVCSetup bool) {
 	allowedTopologiesMap := createAllowedTopologiesMap(allowedTopologies)
 	var ssPodsBeforeScaleDown *v1.PodList
 	if parallelStatefulSetCreation {
@@ -4748,9 +4749,15 @@ func verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx context.Cont
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// Verify the attached volume match the one in CNS cache
-				error := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
-					volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
-				gomega.Expect(error).NotTo(gomega.HaveOccurred())
+				if !isMultiVCSetup {
+					error := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(error).NotTo(gomega.HaveOccurred())
+				} else {
+					error := verifyVolumeMetadataInCNSForMultiVC(&multiVCe2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(error).NotTo(gomega.HaveOccurred())
+				}
 			}
 		}
 	}
@@ -4834,7 +4841,8 @@ func scaleStatefulSetPods(c clientset.Interface, ss *appsv1.StatefulSet, count i
 scaleDownStatefulSetPod is a utility method which is used to scale down the count of StatefulSet replicas.
 */
 func scaleDownStatefulSetPod(ctx context.Context, client clientset.Interface,
-	statefulset *appsv1.StatefulSet, namespace string, replicas int32, parallelStatefulSetCreation bool) {
+	statefulset *appsv1.StatefulSet, namespace string, replicas int32, parallelStatefulSetCreation bool,
+	isMultiVCSetup bool) {
 	ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas))
 	var ssPodsAfterScaleDown *v1.PodList
 	if parallelStatefulSetCreation {
@@ -4874,10 +4882,17 @@ func scaleDownStatefulSetPod(ctx context.Context, client clientset.Interface,
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		for _, volumespec := range sspod.Spec.Volumes {
 			if volumespec.PersistentVolumeClaim != nil {
-				pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
-				err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
-					volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				if !isMultiVCSetup {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				} else {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					err := verifyVolumeMetadataInCNSForMultiVC(&multiVCe2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
 			}
 		}
 	}
@@ -4887,7 +4902,8 @@ func scaleDownStatefulSetPod(ctx context.Context, client clientset.Interface,
 scaleUpStatefulSetPod is a utility method which is used to scale up the count of StatefulSet replicas.
 */
 func scaleUpStatefulSetPod(ctx context.Context, client clientset.Interface,
-	statefulset *appsv1.StatefulSet, namespace string, replicas int32, parallelStatefulSetCreation bool) {
+	statefulset *appsv1.StatefulSet, namespace string, replicas int32,
+	parallelStatefulSetCreation bool, isMultiVCSetup bool) {
 	ginkgo.By(fmt.Sprintf("Scaling up statefulsets to number of Replica: %v", replicas))
 	var ssPodsAfterScaleUp *v1.PodList
 	if parallelStatefulSetCreation {
@@ -4936,16 +4952,32 @@ func scaleUpStatefulSetPod(ctx context.Context, client clientset.Interface,
 					annotations := pod.Annotations
 					vmUUID, exists = annotations[vmUUIDLabel]
 					gomega.Expect(exists).To(gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
-					_, err := e2eVSphere.getVMByUUID(ctx, vmUUID)
+					if !isMultiVCSetup {
+						_, err := e2eVSphere.getVMByUUID(ctx, vmUUID)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					} else {
+						_, err := multiVCe2eVSphere.getVMByUUIDForMultiVC(ctx, vmUUID)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+				}
+				if !isMultiVCSetup {
+					isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Disk is not attached to the node")
+					gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached")
+					ginkgo.By("After scale up, verify the attached volumes match those in CNS Cache")
+					err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				} else {
+					isDiskAttached, err := multiVCe2eVSphere.verifyVolumeIsAttachedToVMInMultiVC(client,
+						pv.Spec.CSI.VolumeHandle, vmUUID)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Disk is not attached to the node")
+					gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached")
+					ginkgo.By("After scale up, verify the attached volumes match those in CNS Cache")
+					err = verifyVolumeMetadataInCNSForMultiVC(&multiVCe2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
-				isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Disk is not attached to the node")
-				gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached")
-				ginkgo.By("After scale up, verify the attached volumes match those in CNS Cache")
-				err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
-					volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}
 	}
@@ -5053,7 +5085,8 @@ PV is provisioned.
 */
 func verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5(ctx context.Context,
 	client clientset.Interface, deployment *appsv1.Deployment, namespace string,
-	allowedTopologies []v1.TopologySelectorLabelRequirement, parallelDeplCreation bool) {
+	allowedTopologies []v1.TopologySelectorLabelRequirement,
+	parallelDeplCreation bool, isMultiVCSetup bool) {
 	allowedTopologiesMap := createAllowedTopologiesMap(allowedTopologies)
 	var pods *v1.PodList
 	var err error
@@ -5100,9 +5133,15 @@ func verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5(ctx context.Co
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// Verify the attached volume match the one in CNS cache
-				error := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
-					volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
-				gomega.Expect(error).NotTo(gomega.HaveOccurred())
+				if !isMultiVCSetup {
+					error := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(error).NotTo(gomega.HaveOccurred())
+				} else {
+					error := verifyVolumeMetadataInCNSForMultiVC(&multiVCe2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(error).NotTo(gomega.HaveOccurred())
+				}
 			}
 		}
 	}
@@ -5110,14 +5149,14 @@ func verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5(ctx context.Co
 
 /*
 For Standalone Pod
-verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5 for Standalone Pod verifies that PV
+verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5 for Standalone Pod verifies that PV
 node Affinity rules should match the topology constraints specified in the storage class.
 Also it verifies that a pod is scheduled on a node that belongs to the topology on which PV
 is provisioned.
 */
 func verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx context.Context,
 	client clientset.Interface, pod *v1.Pod, namespace string,
-	allowedTopologies []v1.TopologySelectorLabelRequirement) {
+	allowedTopologies []v1.TopologySelectorLabelRequirement, isMultiVCSetup bool) {
 	allowedTopologiesMap := createAllowedTopologiesMap(allowedTopologies)
 	for _, volumespec := range pod.Spec.Volumes {
 		if volumespec.PersistentVolumeClaim != nil {
@@ -5151,10 +5190,16 @@ func verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx context.Cont
 				"specified in allowed topolgies of Storage Class", pod.Name)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			// Verify the attached volume match the one in CNS cache
-			error := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
-				volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, pod.Name)
-			gomega.Expect(error).NotTo(gomega.HaveOccurred())
+			//Verify the attached volume match the one in CNS cache
+			if !isMultiVCSetup {
+				error := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+					volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, pod.Name)
+				gomega.Expect(error).NotTo(gomega.HaveOccurred())
+			} else {
+				error := verifyVolumeMetadataInCNSForMultiVC(&multiVCe2eVSphere, pv.Spec.CSI.VolumeHandle,
+					volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, pod.Name)
+				gomega.Expect(error).NotTo(gomega.HaveOccurred())
+			}
 		}
 	}
 }
@@ -5216,6 +5261,7 @@ func getPersistentVolumeSpecWithStorageClassFCDNodeSelector(volumeHandle string,
 func getNodeSelectorTerms(allowedTopologies []v1.TopologySelectorLabelRequirement) []v1.NodeSelectorTerm {
 	var nodeSelectorRequirements []v1.NodeSelectorRequirement
 	var nodeSelectorTerms []v1.NodeSelectorTerm
+	rackTopology := allowedTopologies[len(allowedTopologies)-1]
 
 	for i := 0; i < len(allowedTopologies)-1; i++ {
 		topologySelector := allowedTopologies[i]
@@ -5225,7 +5271,7 @@ func getNodeSelectorTerms(allowedTopologies []v1.TopologySelectorLabelRequiremen
 		nodeSelectorRequirement.Values = topologySelector.Values
 		nodeSelectorRequirements = append(nodeSelectorRequirements, nodeSelectorRequirement)
 	}
-	rackTopology := allowedTopologies[len(allowedTopologies)-1]
+
 	for i := 0; i < len(rackTopology.Values); i++ {
 		var nodeSelectorTerm v1.NodeSelectorTerm
 		var nodeSelectorRequirement v1.NodeSelectorRequirement
@@ -5235,6 +5281,7 @@ func getNodeSelectorTerms(allowedTopologies []v1.TopologySelectorLabelRequiremen
 		nodeSelectorTerm.MatchExpressions = append(nodeSelectorRequirements, nodeSelectorRequirement)
 		nodeSelectorTerms = append(nodeSelectorTerms, nodeSelectorTerm)
 	}
+
 	return nodeSelectorTerms
 }
 
@@ -5641,7 +5688,7 @@ func createParallelStatefulSetSpec(namespace string, no_of_sts int, replicas int
 }
 
 func createMultiplePVCsInParallel(ctx context.Context, client clientset.Interface, namespace string,
-	storageclass *storagev1.StorageClass, count int) []*v1.PersistentVolumeClaim {
+	storageclass *storagev1.StorageClass, count int, pvclaimlabels map[string]string) []*v1.PersistentVolumeClaim {
 	var pvclaims []*v1.PersistentVolumeClaim
 	for i := 0; i < count; i++ {
 		pvclaim, err := createPVC(client, namespace, nil, "", storageclass, "")

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -192,12 +192,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Verify PV node affinity and that the PODS are running on appropriate nodes
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		// Scale down statefulset to 0 replicas
 		replicas -= 3
 		ginkgo.By("Scale down statefulset replica count to 0")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -267,27 +267,27 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Verify PV node affinity and that the PODS are running on appropriate node
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate nodes")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-			statefulset, namespace, allowedTopologies, false)
+			statefulset, namespace, allowedTopologies, false, false)
 
 		// Scale up statefulset replica count to 5
 		replicas += 5
 		ginkgo.By("Scale up statefulset replica count to 5")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		// Scale down statefulset replica count to 1
 		replicas -= 1
 		ginkgo.By("Scale down statefulset replica count to 1")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		// Verify newly created PV node affinity details  and that the new PODS are running on appropriate nodes
 		ginkgo.By("Verify newly created PV node affinity details  and that the new PODS are running on appropriate nodes")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		// Scale down statefulset replicas to 0
 		replicas = 0
 		ginkgo.By("Scale down statefulset replica count to 0")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -358,24 +358,24 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		// Scale up statefulset replicas to 5
 		replicas += 5
 		ginkgo.By("Scale up statefulset replica count to 5")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		/* Verify newly created PV node affinity and that the news PODS are running
 		on appropriate node as specified in the allowed topologies of SC */
 		ginkgo.By("Verify newly created PV node affinity and that the news PODS " +
 			"are running on appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		// Scale down statefulset replicas to 0
 		replicas = 0
 		ginkgo.By("Scale down statefulset replica count to 0")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -446,29 +446,29 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		// Scale up statefulset replicas to 5
 		replicas += 5
 		ginkgo.By("Scale up statefulset replica count to 5")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		// Scale down statefulset replicas to 1
 		replicas -= 1
 		ginkgo.By("Scale down statefulset replica count to 1")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		/* "Verify newly created PV node affinity and that the new PODS are
 		running on appropriate node as specified in the allowed topologies of SC */
 		ginkgo.By("Verify newly created PV node affinity and that the new PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		// Scale down statefulset replicas to 0
 		replicas = 0
 		ginkgo.By("Scale down statefulset replica count to 0")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -548,29 +548,29 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		// Scale up statefulset replicas to 5
 		replicas += 5
 		ginkgo.By("Scale up statefulset replica count to 5")
-		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		// Scale down statefulset replicas to 1
 		replicas -= 1
 		ginkgo.By("Scale down statefulset replica count to 1")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 
 		/* Verify newly created PV node affinity and that the new PODS are running on
 		appropriate node as specified in the allowed topologies of SC */
 		ginkgo.By("Verify newly created PV node affinity and that the new PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		// Scale down statefulset replicas to 0
 		replicas = 0
 		ginkgo.By("Scale down statefulset replica count to 0")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -648,7 +648,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5(ctx, client, deployment,
-			namespace, allowedTopologyForSC, false)
+			namespace, allowedTopologyForSC, false, false)
 	})
 
 	/*
@@ -715,12 +715,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false)
+			namespace, allowedTopologies, false, false)
 
 		// Scale down statefulset to 0 replicas
 		replicas -= 3
 		ginkgo.By("Scale down statefulset replica count to 0")
-		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
+		scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
 	})
 
 	/*
@@ -910,7 +910,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies)
+			allowedTopologies, false)
 	})
 
 	/*
@@ -995,7 +995,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies)
+			allowedTopologies, false)
 	})
 
 	/*
@@ -1122,7 +1122,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies)
+			allowedTopologies, false)
 
 	})
 
@@ -1264,7 +1264,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies)
+			allowedTopologies, false)
 
 		// Deleting Pod
 		ginkgo.By("Deleting the Pod")
@@ -1330,7 +1330,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies)
+			allowedTopologies, false)
 
 		// Verify volume metadata for POD, PVC and PV
 		ginkgo.By("Verify volume metadata for POD, PVC and PV")


### PR DESCRIPTION
**What this PR does / why we need it**:
In this PR, the code covers Multi vCenter's different test scenarios automation and its supporting utils.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Automation for different test coverage for multi vCenters 

**Testing done**:
Yes

MultiVC: 
[multi-vc-sanity.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/11955054/multi-vc-sanity.txt)

topology:
[topology-e2e-test-logs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/12037230/topology-e2e-test-logs.txt)

Preferential:

[preferential-test-e2e-logs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/12037234/preferential-test-e2e-logs.txt)

**Special notes for your reviewer**:
Make Check:

sipriya@sipriyaSMD6M vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriyaSMD6M vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/multi-vc-automation-code-1/vsphere-csi-driver /Users/sipriya/multi-vc-automation-code-1 /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (compiled_files|files|imports|name|types_sizes|deps|exports_file) took 1m13.008369208s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 164.942728ms 