### PR TITLE
Add cluster identifier to user agent of the vc sessions

### DIFF
--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 
@@ -164,7 +165,12 @@ func (l *ListViewImpl) isClientValid() error {
 		return nil
 	}
 	// If session has expired, create a new instance.
-	client, err := l.virtualCenter.NewClient(l.ctx)
+	useragent, err := config.GetSessionUserAgent(l.ctx)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to get useragent for vCenter session. error: %+v", err)
+	}
+	useragent = useragent + "-listview"
+	client, err := l.virtualCenter.NewClient(l.ctx, useragent)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to create a govmomi client for listView. error: %+v", err)
 	}

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
 	csifault "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/fault"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/prometheus"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
@@ -640,7 +641,13 @@ func (m *defaultManager) initListView() error {
 			return logger.LogNewErrorf(log, "failed to connect to vCenter. err: %v", err)
 		}
 	}
-	govmomiClient, err := m.virtualCenter.NewClient(ctx)
+
+	useragent, err := config.GetSessionUserAgent(ctx)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to get useragent for vCenter session. error: %+v", err)
+	}
+	useragent = useragent + "-listview"
+	govmomiClient, err := m.virtualCenter.NewClient(ctx, useragent)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to create a separate govmomi client for listView. error: %+v", err)
 	}

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -361,6 +361,7 @@ func getConfig(ctx context.Context) (*cnsconfig.Config, error) {
 				"vSphere config secret and in immutable ConfigMap")
 		}
 		cfg.Global.ClusterID = clusterID
+		cnsconfig.GeneratedVanillaClusterID = clusterID
 	} else {
 		if _, err := commonco.ContainerOrchestratorUtility.GetConfigMap(ctx,
 			cnsconfig.ClusterIDConfigMapName, CSINamespace); err == nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
PR will update useragent in order to have unique useragent for every cluster.
useragent name will include supervisor-id, for vanilla useragent will be appended with cluster-id.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
manual testing performed and verified change in useragent name.
executed e2e tests.

**Special notes for your reviewer**:
vCenter session  for vanilla
<img width="558" alt="Screenshot 2023-07-12 at 1 40 07 AM" src="https://github.com/kubernetes-sigs/vsphere-csi-driver/assets/16957059/04f26dff-e02c-4014-9167-a21f3fbd9087">

 vCenter session  for wcp
<img width="558" alt="wcp-vc-sessions" src="https://github.com/kubernetes-sigs/vsphere-csi-driver/assets/16957059/7a035a80-4c1a-45e3-a909-6f0ea015c08a">

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
PR will update useragent in order to have unique useragent for every cluster.
```
