### PR TITLE
Adding Ginkgo labels to testcases specific to its type

### DIFF
--- a/tests/e2e/config_secret.go
+++ b/tests/e2e/config_secret.go
@@ -150,8 +150,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		7. Cleanup all objects created during the test
 	*/
 
-	ginkgo.It("[csi-config-secret-block][csi-config-secret-file] Update user credentials in vsphere config "+
-		"secret keeping password same for both test users", func() {
+	ginkgo.It("Update user credentials in vsphere config secret keeping password same "+
+		"for both test users", ginkgo.Label(p1, vsphereConfigSecret, block, file, vanilla), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -249,8 +249,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		12. Cleanup all objects created during the test
 	*/
 
-	ginkgo.It("[csi-config-secret-block][csi-config-secret-file] Change vcenter user password "+
-		"and restart csi controller pod", func() {
+	ginkgo.It("Change vcenter user password and restart csi controller pod", ginkgo.Label(p0,
+		vsphereConfigSecret, block, file, vanilla), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		testUser1NewPassword := "Admin!123"
@@ -406,8 +406,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		7. Cleanup all objects created during the test
 	*/
 
-	ginkgo.It("[csi-config-secret-block][csi-config-secret-file] Update user credentials in vsphere config "+
-		"secret keeping password different for both test users", func() {
+	ginkgo.It("Update user credentials in vsphere config secret keeping password different for both test "+
+		"users", ginkgo.Label(p0, vsphereConfigSecret, block, file, vanilla), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -503,8 +503,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		9. Cleanup all objects created during the test
 	*/
 
-	ginkgo.It("[csi-config-secret-block][csi-config-secret-file] Change vcenter ip to hostname and "+
-		"viceversa in vsphere config secret", func() {
+	ginkgo.It("Change vcenter ip to hostname and viceversa in vsphere config "+
+		"secret", ginkgo.Label(p0, vsphereConfigSecret, block, file, vanilla), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -619,8 +619,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		9. Cleanup all objects created during the test
 	*/
 
-	ginkgo.It("[csi-config-secret-block][csi-config-secret-file] Change vcenter user to wrong dummy "+
-		"user and later switch back to correct one", func() {
+	ginkgo.It("Change vcenter user to wrong dummy user and later switch back to "+
+		"correct one", ginkgo.Label(p0, vsphereConfigSecret, block, file, vanilla), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		dummyTestUser := "dummyUser@vsphere.local"
@@ -748,8 +748,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		10. Cleanup all objects created during the test
 	*/
 
-	ginkgo.It("[csi-config-secret-block][csi-config-secret-file] Add a user without adding required "+
-		"roles and privileges and switch back to the correct one", func() {
+	ginkgo.It("Add a user without adding required roles and privileges and switch back "+
+		"to the correct one", ginkgo.Label(p0, vsphereConfigSecret, block, file, vanilla), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -869,8 +869,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		8. Cleanup all objects created during the test
 	*/
 
-	ginkgo.It("[csi-config-secret-block][csi-config-secret-file] Add necessary roles and privileges "+
-		"to the user post CSI driver creation", func() {
+	ginkgo.It("Add necessary roles and privileges to the user post CSI driver "+
+		"creation", ginkgo.Label(p0, vsphereConfigSecret, block, file, vanilla), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -981,8 +981,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		10. Cleanup all objects created during the test
 	*/
 
-	ginkgo.It("[csi-config-secret-block][csi-config-secret-file] Add wrong datacenter and switch back "+
-		"to the correct datacenter in vsphere config secret file", func() {
+	ginkgo.It("Add wrong datacenter and switch back to the correct datacenter in vsphere "+
+		"config secret file", ginkgo.Label(p1, vsphereConfigSecret, block, file, vanilla), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1112,8 +1112,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		10. Cleanup all objects created during the test
 	*/
 
-	ginkgo.It("[csi-config-secret-file] Add wrong targetvSANFileShareDatastoreURLs and switch back to the correct "+
-		"targetvSANFileShareDatastoreURLs", func() {
+	ginkgo.It("Add wrong targetvSANFileShareDatastoreURLs and switch back to the correct "+
+		"targetvSANFileShareDatastoreURLs", ginkgo.Label(p1, vsphereConfigSecret, file), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		targetDsURL := GetAndExpectStringEnvVar(envSharedDatastoreURL)
@@ -1207,7 +1207,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 	    9. Cleanup all objects created during the test
 	*/
 
-	ginkgo.It("[vc-custom-port] VC with Custom Port", func() {
+	ginkgo.It("VC with Custom Port", ginkgo.Label(p1, vsphereConfigSecret, file, block, customPort), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		defaultvCenterPort := "443"
@@ -1334,7 +1334,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		10. Cleanup all objects created during the test
 	*/
 
-	ginkgo.It("[vc-custom-port] Modify VC Port and validate the workloads", func() {
+	ginkgo.It("Modify VC Port and validate the workloads", ginkgo.Label(p1, vsphereConfigSecret, file, block,
+		customPort), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		dummyvCenterPort := "4444"

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -223,6 +223,57 @@ const (
 		"/api-tokens/authorize"
 )
 
+/*
+// test suite labels
+
+flaky -> label include the testcases which fails intermittently
+disruptive -> label include the testcases which are disruptive in nature
+vanilla -> label include the testcases for block, file, configSecret, topology etc.
+stable -> label include the testcases which do not fail
+longRunning -> label include the testcases which takes longer time for completion
+p0 -> label include the testcases which are P0
+p1 -> label include the testcases which are P1
+p2 -> label include the testcases which are P2
+semiAutomated -> label include the testcases which are semi-automated
+newTests -> label include the testcases which are newly automated
+core -> label include the testcases specific to block or file
+level2 -> label include the level-2 topology testcases or pipeline specific
+level5 -> label include the level-5 topology testcases
+customPort -> label include the testcases running on vCenter custom port <VC:444>
+deprecated ->label include the testcases which are no longer in execution
+*/
+const (
+	flaky               = "flaky"
+	disruptive          = "disruptive"
+	wcp                 = "wcp"
+	tkg                 = "tkg"
+	vanilla             = "vanilla"
+	topology            = "topology"
+	preferential        = "preferential"
+	vsphereConfigSecret = "vsphereConfigSecret"
+	snapshot            = "snapshot"
+	stable              = "stable"
+	newTests            = "newTests"
+	multiVc             = "multiVc"
+	block               = "block"
+	file                = "file"
+	core                = "core"
+	p0                  = "p0"
+	p1                  = "p1"
+	p2                  = "p2"
+	vsanStretch         = "vsanStretch"
+	longRunning         = "longRunning"
+	deprecated          = "deprecated"
+	vmc                 = "vmc"
+	tkgsHA              = "tkgsHA"
+	thickThin           = "thickThin"
+	customPort          = "customPort"
+	windows             = "windows"
+	semiAutomated       = "semiAutomated"
+	level2              = "level2"
+	level5              = "level5"
+)
+
 // The following variables are required to know cluster type to run common e2e
 // tests. These variables will be set once during test suites initialization.
 var (

--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -230,7 +230,8 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			18. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
 			19. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Tag single preferred datastore each in rack-1 and rack-2 and verify it is honored", func() {
+	ginkgo.It("Tag single preferred datastore each in rack-1 and rack-2 "+
+		"and verify it is honored", ginkgo.Label(p0, topology, preferential, block, vanilla, level5), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -154,7 +154,8 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 	*/
 
 	ginkgo.It("Provisioning volume when no topology details specified in storage class "+
-		"and using default pod management policy for statefulset", func() {
+		"and using default pod management policy for statefulset", ginkgo.Label(p0, topology, block,
+		vanilla, level5), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		// Creating StorageClass when no topology details are specified using WFC Binding mode
@@ -671,7 +672,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 
 	ginkgo.It("Provisioning volume when storage class specified with multiple labels "+
 		"without specifying datastore url and using default pod management policy "+
-		"for statefulset", func() {
+		"for statefulset", ginkgo.Label(p2, topology, block, vanilla, level5), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		// Get allowed topologies for Storage Class rack > (rack1,rack2,rack3)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR holds code changes for assigning ginkgo labels to tectcase specific to its type. The code in this PR will distinguish which testcases are P0/P1 or P2 and belongs to which flavour.


**Testing done**:
Yes

[test-e2e-logs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/12024242/test-e2e-logs.txt)

**Special notes for your reviewer**:

Make Check:
sipriya@sipriyaSMD6M vsphere-csi-driver % golangci-lint run --enable=lll 
sipriya@sipriyaSMD6M vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/adding-labels/vsphere-csi-driver /Users/sipriya/adding-labels /Users/sipriya /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (compiled_files|exports_file|imports|deps|files|name|types_sizes) took 1m17.315425624s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 160.730237ms 
