### PR TITLE
wcp: specify recommended tls 1.2 ciphers for webhook

### DIFF
--- a/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
+++ b/pkg/syncer/admissionhandler/cnscsi_admissionhandler.go
@@ -2,6 +2,7 @@ package admissionhandler
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"os"
 	"strconv"
@@ -65,6 +66,13 @@ func startCNSCSIWebhookManager(ctx context.Context) {
 	log.Infof("registering validating webhook with the endpoint %v", ValidationWebhookPath)
 	// we should not allow TLS < 1.2
 	mgr.GetWebhookServer().TLSMinVersion = WebhookTlsMinVersion
+	// CipherSuites allows us to specify TLS 1.2 cipher suites that have been recommended by the Security team
+	mgr.GetWebhookServer().TLSOpts = []func(*tls.Config){
+		func(t *tls.Config) {
+			t.CipherSuites = []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384}
+		},
+	}
 	mgr.GetWebhookServer().Register(ValidationWebhookPath, &webhook.Admission{Handler: &CSISupervisorWebhook{
 		Client:       mgr.GetClient(),
 		clientConfig: mgr.GetConfig(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Security team has published a list of recommended TLS 1.2 cipher suites that the webhook service needs to 'Accept'. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2468#issuecomment-1631737135

#### Before change

```
root@420c04622f75b3992f59e8a255707bd8 [ ~ ]# ./sslscan https://172.24.188.202:443
Version: 2.0.15-2-gc450fb1-static
OpenSSL 1.1.1t-dev  xx XXX xxxx

Connected to 172.24.188.202

Testing SSL server 172.24.188.202 on port 443 using SNI name 172.24.188.202

  SSL/TLS Protocols:
SSLv2     disabled
SSLv3     disabled
TLSv1.0   disabled
TLSv1.1   disabled
TLSv1.2   enabled
TLSv1.3   enabled

  TLS Fallback SCSV:
Server supports TLS Fallback SCSV

  TLS renegotiation:
Session renegotiation not supported

  TLS Compression:
Compression disabled

  Heartbleed:
TLSv1.3 not vulnerable to heartbleed
TLSv1.2 not vulnerable to heartbleed

  Supported Server Cipher(s):
Preferred TLSv1.3  128 bits  TLS_AES_128_GCM_SHA256        Curve 25519 DHE 253
Accepted  TLSv1.3  256 bits  TLS_AES_256_GCM_SHA384        Curve 25519 DHE 253
Accepted  TLSv1.3  256 bits  TLS_CHACHA20_POLY1305_SHA256  Curve 25519 DHE 253
Preferred TLSv1.2  128 bits  ECDHE-RSA-AES128-GCM-SHA256   Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-GCM-SHA384   Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  ECDHE-RSA-CHACHA20-POLY1305   Curve 25519 DHE 253
Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-SHA          Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-SHA          Curve 25519 DHE 253
Accepted  TLSv1.2  128 bits  AES128-GCM-SHA256
Accepted  TLSv1.2  256 bits  AES256-GCM-SHA384
Accepted  TLSv1.2  128 bits  AES128-SHA
Accepted  TLSv1.2  256 bits  AES256-SHA
Accepted  TLSv1.2  112 bits  ECDHE-RSA-DES-CBC3-SHA        Curve 25519 DHE 253
Accepted  TLSv1.2  112 bits  DES-CBC3-SHA

  Server Key Exchange Group(s):
TLSv1.3  128 bits  secp256r1 (NIST P-256)
TLSv1.3  192 bits  secp384r1 (NIST P-384)
TLSv1.3  260 bits  secp521r1 (NIST P-521)
TLSv1.3  128 bits  x25519
TLSv1.2  128 bits  secp256r1 (NIST P-256)
TLSv1.2  192 bits  secp384r1 (NIST P-384)
TLSv1.2  260 bits  secp521r1 (NIST P-521)
TLSv1.2  128 bits  x25519

  SSL Certificate:
Signature Algorithm: sha256WithRSAEncryption
RSA Key Strength:    2048

Subject:
Altnames: DNS:vmware-system-csi-webhook-service.vmware-system-csi.svc, DNS:vmware-system-csi-webhook-service.vmware-system-csi.svc.cluster.local
Issuer:
Not valid before: Jul 10 23:18:30 2023 GMT
Not valid after:  Oct  8 23:18:30 2023 GMT
```


#### After change

```
root@420c04622f75b3992f59e8a255707bd8 [ ~ ]# ./sslscan https://172.24.188.202:443
Version: 2.0.15-2-gc450fb1-static
OpenSSL 1.1.1t-dev  xx XXX xxxx

Connected to 172.24.188.202

Testing SSL server 172.24.188.202 on port 443 using SNI name 172.24.188.202

  SSL/TLS Protocols:
SSLv2     disabled
SSLv3     disabled
TLSv1.0   disabled
TLSv1.1   disabled
TLSv1.2   enabled
TLSv1.3   enabled

  TLS Fallback SCSV:
Server supports TLS Fallback SCSV

  TLS renegotiation:
Session renegotiation not supported

  TLS Compression:
Compression disabled

  Heartbleed:
TLSv1.3 not vulnerable to heartbleed
TLSv1.2 not vulnerable to heartbleed

  Supported Server Cipher(s):
Preferred TLSv1.3  128 bits  TLS_AES_128_GCM_SHA256        Curve 25519 DHE 253
Accepted  TLSv1.3  256 bits  TLS_AES_256_GCM_SHA384        Curve 25519 DHE 253
Accepted  TLSv1.3  256 bits  TLS_CHACHA20_POLY1305_SHA256  Curve 25519 DHE 253
Preferred TLSv1.2  256 bits  ECDHE-RSA-AES256-GCM-SHA384   Curve 25519 DHE 253

  Server Key Exchange Group(s):
TLSv1.3  128 bits  secp256r1 (NIST P-256)
TLSv1.3  192 bits  secp384r1 (NIST P-384)
TLSv1.3  260 bits  secp521r1 (NIST P-521)
TLSv1.3  128 bits  x25519
TLSv1.2  128 bits  secp256r1 (NIST P-256)
TLSv1.2  192 bits  secp384r1 (NIST P-384)
TLSv1.2  260 bits  secp521r1 (NIST P-521)
TLSv1.2  128 bits  x25519

  SSL Certificate:
Signature Algorithm: sha256WithRSAEncryption
RSA Key Strength:    2048

Subject:
Altnames: DNS:vmware-system-csi-webhook-service.vmware-system-csi.svc, DNS:vmware-system-csi-webhook-service.vmware-system-csi.svc.cluster.local
Issuer:
Not valid before: Jul 10 23:18:30 2023 GMT
Not valid after:  Oct  8 23:18:30 2023 GMT
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
wcp: specify recommended tls 1.2 ciphers for webhook
```
