### PR TITLE
vanilla: specify recommended tls 1.2 ciphers for webhook

### DIFF
--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -168,8 +168,17 @@ func StartWebhookServer(ctx context.Context) error {
 				cfg.WebHookConfig.Port = defaultWebhookServerPort
 			}
 			server = &http.Server{
-				Addr:      fmt.Sprintf(":%v", cfg.WebHookConfig.Port),
-				TLSConfig: &tls.Config{Certificates: []tls.Certificate{certs}},
+				Addr: fmt.Sprintf(":%v", cfg.WebHookConfig.Port),
+				TLSConfig: &tls.Config{
+					Certificates: []tls.Certificate{certs},
+					CipherSuites: []uint16{
+						tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+						tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+						tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+						tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					},
+					MinVersion: tls.VersionTLS12,
+				},
 			}
 			// Define http server and server handler.
 			mux := http.NewServeMux()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Security team has published a list of recommended TLS 1.2 cipher suites that the webhook service needs to 'Accept'.
Similar to https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2468 but for vanilla. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

```
root@k8s-control-281-1689198951:~# ./sslscan https://10.109.130.166:443
Version: 2.0.15-2-gc450fb1-static
OpenSSL 1.1.1t-dev  xx XXX xxxx

Connected to 10.109.130.166

Testing SSL server 10.109.130.166 on port 443 using SNI name 10.109.130.166

  SSL/TLS Protocols:
SSLv2     disabled
SSLv3     disabled
TLSv1.0   disabled
TLSv1.1   disabled
TLSv1.2   enabled
TLSv1.3   enabled

  TLS Fallback SCSV:
Server supports TLS Fallback SCSV

  TLS renegotiation:
Session renegotiation not supported

  TLS Compression:
Compression disabled

  Heartbleed:
TLSv1.3 not vulnerable to heartbleed
TLSv1.2 not vulnerable to heartbleed

  Supported Server Cipher(s):
Preferred TLSv1.3  128 bits  TLS_AES_128_GCM_SHA256        Curve 25519 DHE 253
Accepted  TLSv1.3  256 bits  TLS_AES_256_GCM_SHA384        Curve 25519 DHE 253
Accepted  TLSv1.3  256 bits  TLS_CHACHA20_POLY1305_SHA256  Curve 25519 DHE 253
Preferred TLSv1.2  128 bits  ECDHE-RSA-AES128-GCM-SHA256   Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-GCM-SHA384   Curve 25519 DHE 253

  Server Key Exchange Group(s):
TLSv1.3  128 bits  secp256r1 (NIST P-256)
TLSv1.3  192 bits  secp384r1 (NIST P-384)
TLSv1.3  260 bits  secp521r1 (NIST P-521)
TLSv1.3  128 bits  x25519
TLSv1.2  128 bits  secp256r1 (NIST P-256)
TLSv1.2  192 bits  secp384r1 (NIST P-384)
TLSv1.2  260 bits  secp521r1 (NIST P-521)
TLSv1.2  128 bits  x25519

  SSL Certificate:
Signature Algorithm: sha256WithRSAEncryption
RSA Key Strength:    2048

Subject:  vsphere-webhook-svc.vmware-system-csi.svc
Altnames: DNS:vsphere-webhook-svc, DNS:vsphere-webhook-svc.vmware-system-csi, DNS:vsphere-webhook-svc.vmware-system-csi.svc
Issuer:   vSphere CSI Admission Controller Webhook CA

Not valid before: Jul 14 08:56:05 2023 GMT
Not valid after:  Aug 13 08:56:05 2023 GMT
```

https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2469#issuecomment-1636530096

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
vanilla: specify recommended tls 1.2 ciphers for webhook
```
