### PR TITLE
Delete stale CnsVSphereVolumeMigration CR only when PV is not found in k8s

### DIFF
--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -606,11 +606,15 @@ func (volumeMigration *volumeMigration) cleanupStaleCRDInstances() {
 					if pv.Spec.VsphereVolume != nil &&
 						pv.Spec.VsphereVolume.VolumePath == volumeMigrationResource.Spec.VolumePath {
 						pvFound = true
+						log.Infof("PV %s with VolumePath %s is found in k8s, but CNS does not have an entry."+
+							"Skipping the %s CR deletion.",
+							pv.Name, pv.Spec.VsphereVolume.VolumePath, volumeMigrationResource.Name)
 						break
 					}
 				}
 				// Delete the CnsVSphereVolumeMigration CR only when there is no corresponding PV in k8s
 				if !pvFound {
+					log.Debugf("Deleting CnsVSphereVolumeMigration CR: %s", volumeMigrationResource.Name)
 					err = volumeMigrationInstance.DeleteVolumeInfo(ctx, volumeMigrationResource.Name)
 					if err != nil {
 						log.Warnf("failed to delete volume mapping CR for %s with error %+v", volumeMigrationResource.Name, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is a scenario where the routine cleanupStaleCRDInstances may delete CnsVSphereVolumeMigration CR when the VCP PV is still present in the k8s cluster, due to the temporary loss of the FCD from the CNS DB. This situation requires a re-registration of the CR during the CSI full sync process and until that volume operations like attach/detach and delete will be put on hold. 

By implementing this improvement, we can enhance the reliability of the CnsVSphereVolumeMigration CR cleanup process while minimizing the need for manual intervention and re-creation of Migration CR manually.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
[e2e test result](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2470#issuecomment-1634831036)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Delete stale CnsVSphereVolumeMigration CR only when PV is not found in k8s
```
