### PR TITLE
remove securityContext for supervisor

### DIFF
--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -340,10 +340,6 @@ spec:
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -396,10 +392,6 @@ spec:
             - containerPort: 2113
               name: prometheus
               protocol: TCP
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -681,10 +673,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: webhook-certs

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -337,10 +337,6 @@ spec:
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -393,10 +389,6 @@ spec:
             - containerPort: 2113
               name: prometheus
               protocol: TCP
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -675,10 +667,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: webhook-certs

--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -337,10 +337,6 @@ spec:
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -393,10 +389,6 @@ spec:
             - containerPort: 2113
               name: prometheus
               protocol: TCP
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -675,10 +667,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: webhook-certs

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -337,10 +337,6 @@ spec:
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -393,10 +389,6 @@ spec:
             - containerPort: 2113
               name: prometheus
               protocol: TCP
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
           volumeMounts:
             - mountPath: /etc/vmware/wcp
               name: vsphere-config-volume
@@ -675,10 +667,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: webhook-certs


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2444 added fields to vanilla, supervisor, and pvcsi for running CSI pods as non-root. However, this has broken a STIG compliance test in supervisor. 

This change will revert these changes for supervisor only. This will unblock the failing pipelines until we can figure out the next steps. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

Edited the deployment to remove the securityContext
```
root@423424a886dcb88bf116073ed1df6f5a [ ~ ]# k -n vmware-system-csi edit deployment
deployment.apps/vsphere-csi-controller edited
deployment.apps/vsphere-csi-webhook skipped

root@423424a886dcb88bf116073ed1df6f5a [ ~ ]# k -n vmware-system-csi get po
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-66d8c4454c-7rtd6   7/7     Running   0          3m28s
vsphere-csi-controller-66d8c4454c-b2wg7   7/7     Running   0          2m49s
vsphere-csi-controller-66d8c4454c-pmbmq   7/7     Running   0          112s
vsphere-csi-webhook-689fbcdb7c-hx4qn      1/1     Running   0          59m
vsphere-csi-webhook-689fbcdb7c-jhchq      1/1     Running   0          59m
vsphere-csi-webhook-689fbcdb7c-vfhrg      1/1     Running   0          59m

root@423424a886dcb88bf116073ed1df6f5a [ ~ ]# k version
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
Client Version: version.Info{Major:"1", Minor:"26", GitVersion:"v1.26.4+vmware.wcp.1", GitCommit:"431e801e781737a2d1347c449f3c8d284395a5d7", GitTreeState:"clean", BuildDate:"2023-06-22T02:12:35Z", GoVersion:"go1.19.8 X:boringcrypto", Compiler:"gc", Platform:"linux/amd64"}
Kustomize Version: v4.5.7
Server Version: version.Info{Major:"1", Minor:"26", GitVersion:"v1.26.4+vmware.wcp.1", GitCommit:"431e801e781737a2d1347c449f3c8d284395a5d7", GitTreeState:"clean", BuildDate:"2023-06-22T02:08:34Z", GoVersion:"go1.19.8 X:boringcrypto", Compiler:"gc", Platform:"linux/amd64"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
remove securityContext for supervisor
```
