### PR TITLE
Avoid GET call for CSINodeTopology instance in GC nodes

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -730,42 +730,49 @@ func (c *K8sOrchestrator) InitTopologyServiceInNode(ctx context.Context) (
 func (volTopology *nodeVolumeTopology) GetNodeTopologyLabels(ctx context.Context, nodeInfo *commoncotypes.NodeInfo) (
 	map[string]string, error) {
 	log := logger.GetLogger(ctx)
-
 	var err error
-	csiNodeTopology := &csinodetopologyv1alpha1.CSINodeTopology{}
-	csiNodeTopologyKey := types.NamespacedName{
-		Name: nodeInfo.NodeName,
-	}
-	err = volTopology.csiNodeTopologyK8sClient.Get(ctx, csiNodeTopologyKey, csiNodeTopology)
-	csiNodeTopologyFound := true
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			msg := fmt.Sprintf("failed to get CsiNodeTopology for the node: %q. Error: %+v", nodeInfo.NodeName, err)
-			return nil, logger.LogNewErrorCodef(log, codes.Internal, msg)
-		}
-		csiNodeTopologyFound = false
+
+	if volTopology.clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		err = createCSINodeTopologyInstance(ctx, volTopology, nodeInfo)
 		if err != nil {
 			return nil, logger.LogNewErrorCodef(log, codes.Internal, err.Error())
 		}
+	} else {
+		csiNodeTopology := &csinodetopologyv1alpha1.CSINodeTopology{}
+		csiNodeTopologyKey := types.NamespacedName{
+			Name: nodeInfo.NodeName,
+		}
+		err = volTopology.csiNodeTopologyK8sClient.Get(ctx, csiNodeTopologyKey, csiNodeTopology)
+		csiNodeTopologyFound := true
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				msg := fmt.Sprintf("failed to get CsiNodeTopology for the node: %q. Error: %+v", nodeInfo.NodeName, err)
+				return nil, logger.LogNewErrorCodef(log, codes.Internal, msg)
+			}
+			csiNodeTopologyFound = false
+			err = createCSINodeTopologyInstance(ctx, volTopology, nodeInfo)
+			if err != nil {
+				return nil, logger.LogNewErrorCodef(log, codes.Internal, err.Error())
+			}
+		}
+		// There is an already existing topology.
+		if csiNodeTopologyFound {
+			newCSINodeTopology := csiNodeTopology.DeepCopy()
+			newCSINodeTopology = volTopology.updateNodeIDForTopology(ctx, nodeInfo, newCSINodeTopology)
+			// reset the status so as syncer can sync the object again
+			newCSINodeTopology.Status.Status = ""
+			_, err = volTopology.patchCSINodeTopology(ctx, csiNodeTopology, newCSINodeTopology)
+			if err != nil {
+				msg := fmt.Sprintf("Fail to patch CsiNodeTopology for the node: %q "+
+					"with nodeUUID: %s. Error: %+v",
+					nodeInfo.NodeName, nodeInfo.NodeID, err)
+				return nil, logger.LogNewErrorCodef(log, codes.Internal, msg)
+			}
+			log.Infof("Successfully patched CSINodeTopology instance: %q with Uuid: %q",
+				nodeInfo.NodeName, nodeInfo.NodeID)
+		}
 	}
 
-	// there is an already existing topology
-	if csiNodeTopologyFound && volTopology.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-		newCSINodeTopology := csiNodeTopology.DeepCopy()
-		newCSINodeTopology = volTopology.updateNodeIDForTopology(ctx, nodeInfo, newCSINodeTopology)
-		// reset the status so as syncer can sync the object again
-		newCSINodeTopology.Status.Status = ""
-		_, err = volTopology.patchCSINodeTopology(ctx, csiNodeTopology, newCSINodeTopology)
-		if err != nil {
-			msg := fmt.Sprintf("Fail to patch CsiNodeTopology for the node: %q "+
-				"with nodeUUID: %s. Error: %+v",
-				nodeInfo.NodeName, nodeInfo.NodeID, err)
-			return nil, logger.LogNewErrorCodef(log, codes.Internal, msg)
-		}
-		log.Infof("Successfully patched CSINodeTopology instance: %q with Uuid: %q",
-			nodeInfo.NodeName, nodeInfo.NodeID)
-	}
 	// Create a watcher for CSINodeTopology CRs.
 	timeoutSeconds := int64((time.Duration(getCSINodeTopologyWatchTimeoutInMin(ctx)) * time.Minute).Seconds())
 	watchCSINodeTopology, err := volTopology.csiNodeTopologyWatcher.Watch(metav1.ListOptions{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2362 PR introduced changes which led to GC nodes crashing as the node daemonset does not have RBAC privileges to GET CSINodeTopology instances. This PR resolves this issue.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before the change:
```
root@4236abd388b26cc437726c2802f53f1c [ ~ ]# kc get pods -w
NAME                                      READY   STATUS             RESTARTS          AGE
vsphere-csi-controller-6cf9d89577-fj2n5   7/7     Running            0                 8h
vsphere-csi-node-f9dqr                    2/3     CrashLoopBackOff   278 (109s ago)    23h
vsphere-csi-node-gkw7q                    2/3     CrashLoopBackOff   278 (3m35s ago)   23h
vsphere-csi-node-px655                    2/3     CrashLoopBackOff   278 (3m33s ago)   23h
vsphere-csi-node-sfnxt                    2/3     CrashLoopBackOff   277 (4m30s ago)   23h
vsphere-csi-node-v9vhg                    2/3     CrashLoopBackOff   101 (25s ago)     8h
```

After the change:
```
root@4236abd388b26cc437726c2802f53f1c [ ~ ]# kc get pods 
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-6cf9d89577-fj2n5   7/7     Running   0          8h
vsphere-csi-node-24m68                    3/3     Running   0          5m41s
vsphere-csi-node-bsh4w                    3/3     Running   0          5m41s
vsphere-csi-node-gd2pv                    3/3     Running   0          5m42s
vsphere-csi-node-nrxqn                    3/3     Running   0          5m42s
vsphere-csi-node-sw2jm                    3/3     Running   0          10m
```

Logs of one of the nodes:
```
{"level":"info","time":"2023-07-20T05:37:51.964822995Z","caller":"service/node.go:338","msg":"NodeGetInfo: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"bfb3a169-09fa-41fb-be0a-731e78b2d206"}
{"level":"info","time":"2023-07-20T05:37:51.965002365Z","caller":"osutils/linux_os_utils.go:859","msg":"UUID is 4236b298-d5b8-62eb-cab6-c58259c46b99","TraceId":"bfb3a169-09fa-41fb-be0a-731e78b2d206"}
{"level":"info","time":"2023-07-20T05:37:51.96504473Z","caller":"k8sorchestrator/k8sorchestrator.go:1054","msg":"Could not find the max-pvscsi-targets-per-vm feature state in ConfigMap internal-feature-states.csi.vsphere.vmware.com. Setting the feature state to false","TraceId":"bfb3a169-09fa-41fb-be0a-731e78b2d206"}
{"level":"info","time":"2023-07-20T05:37:51.965065148Z","caller":"service/node.go:378","msg":"NodeGetInfo: MAX_VOLUMES_PER_NODE is set to 59","TraceId":"bfb3a169-09fa-41fb-be0a-731e78b2d206"}
{"level":"info","time":"2023-07-20T05:37:51.96508065Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config","TraceId":"bfb3a169-09fa-41fb-be0a-731e78b2d206"}
{"level":"info","time":"2023-07-20T05:37:51.965216411Z","caller":"kubernetes/kubernetes.go:382","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"bfb3a169-09fa-41fb-be0a-731e78b2d206"}
{"level":"info","time":"2023-07-20T05:37:51.965230949Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config","TraceId":"bfb3a169-09fa-41fb-be0a-731e78b2d206"}
{"level":"info","time":"2023-07-20T05:37:51.965290619Z","caller":"kubernetes/kubernetes.go:382","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"bfb3a169-09fa-41fb-be0a-731e78b2d206"}
{"level":"info","time":"2023-07-20T05:37:52.080906378Z","caller":"k8sorchestrator/topology.go:721","msg":"Topology service initiated successfully","TraceId":"bfb3a169-09fa-41fb-be0a-731e78b2d206"}
{"level":"info","time":"2023-07-20T05:37:52.805562664Z","caller":"k8sorchestrator/topology.go:962","msg":"Successfully created a CSINodeTopology instance for NodeName: \"test-cluster-e2e-script-4xzkj-fkks5\"","TraceId":"bfb3a169-09fa-41fb-be0a-731e78b2d206"}
{"level":"info","time":"2023-07-20T05:37:53.071832478Z","caller":"service/node.go:442","msg":"NodeGetInfo response: node_id:\"4236b298-d5b8-62eb-cab6-c58259c46b99\" max_volumes_per_node:59 accessible_topology:<segments:<key:\"topology.kubernetes.io/zone\" value:\"domain-c9\" > > ","TraceId":"bfb3a169-09fa-41fb-be0a-731e78b2d206"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Avoid GET call for CSINodeTopology instance in GC nodes
```
