### PR TITLE
collect events from svc test namespace and add GinkgoRecover() to go routines with asserts

### DIFF
--- a/tests/e2e/csi_cns_telemetry_statefulsets.go
+++ b/tests/e2e/csi_cns_telemetry_statefulsets.go
@@ -90,6 +90,11 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor]
 		if vanillaCluster {
 			// Reset the cluster distribution value to default value "CSI-Vanilla".
 			setClusterDistribution(ctx, client, vanillaClusterDistribution)
+		} else if supervisorCluster {
+			dumpSvcNsEventsOnTestFailure(client, namespace)
+		} else {
+			svcClient, svNamespace := getSvcClientAndNamespace()
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 		}
 	})
 

--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -165,6 +165,10 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		if guestCluster {
 			svcClient, svNamespace := getSvcClientAndNamespace()
 			setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
+		}
+		if supervisorCluster {
+			dumpSvcNsEventsOnTestFailure(client, namespace)
 		}
 	})
 

--- a/tests/e2e/data_persistence.go
+++ b/tests/e2e/data_persistence.go
@@ -110,6 +110,10 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		if guestCluster {
 			svcClient, svNamespace := getSvcClientAndNamespace()
 			setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
+		}
+		if supervisorCluster {
+			dumpSvcNsEventsOnTestFailure(client, namespace)
 		}
 	})
 

--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -127,11 +127,16 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		if supervisorCluster {
-			deleteResourceQuota(client, namespace)
-		}
 		if isVsanHealthServiceStopped {
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
+		}
+		if supervisorCluster {
+			deleteResourceQuota(client, namespace)
+			dumpSvcNsEventsOnTestFailure(client, namespace)
+		}
+		if guestCluster {
+			svcClient, svNamespace := getSvcClientAndNamespace()
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 		}
 	})
 

--- a/tests/e2e/gc_block_resize_retain_policy.go
+++ b/tests/e2e/gc_block_resize_retain_policy.go
@@ -161,6 +161,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Tests with reclaimation po
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	// Combined:

--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -146,8 +146,9 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
 
 		if isGCCSIDeploymentPODdown {
-			_ = updateDeploymentReplica(client, 1, vSphereCSIControllerPodNamePrefix, csiSystemNamespace)
+			_ = updateDeploymentReplica(client, 3, vSphereCSIControllerPodNamePrefix, csiSystemNamespace)
 		}
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	// Verify offline expansion triggers FS resize.

--- a/tests/e2e/gc_cns_nodevm_attachment.go
+++ b/tests/e2e/gc_cns_nodevm_attachment.go
@@ -67,6 +67,7 @@ var _ = ginkgo.Describe("[csi-guest] CnsNodeVmAttachment persistence", func() {
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	// Test-1 (Attach/Detach)

--- a/tests/e2e/gc_file_share_negative.go
+++ b/tests/e2e/gc_file_share_negative.go
@@ -59,6 +59,7 @@ var _ = ginkgo.Describe("[csi-guest] File Share on Non File Service enabled setu
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_full_sync.go
+++ b/tests/e2e/gc_full_sync.go
@@ -83,6 +83,7 @@ var _ = ginkgo.Describe("[csi-guest] Guest cluster fullsync tests", func() {
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	// Steps:

--- a/tests/e2e/gc_metadata_syncer.go
+++ b/tests/e2e/gc_metadata_syncer.go
@@ -96,6 +96,7 @@ var _ = ginkgo.Describe("[csi-guest] pvCSI metadata syncer tests", func() {
 			ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	// Steps:

--- a/tests/e2e/gc_rwx_basic.go
+++ b/tests/e2e/gc_rwx_basic.go
@@ -44,6 +44,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] Basic File Volume Provision Test", func()
 		scParameters      map[string]string
 		storagePolicyName string
 	)
+
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
 		namespace = getNamespaceToRunTests(f)
@@ -55,6 +56,11 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] Basic File Volume Provision Test", func()
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
+	})
+
+	ginkgo.AfterEach(func() {
+		svcClient, svNamespace := getSvcClientAndNamespace()
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_deployments.go
+++ b/tests/e2e/gc_rwx_deployments.go
@@ -67,6 +67,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Provision with Deployments", 
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_destructive.go
+++ b/tests/e2e/gc_rwx_destructive.go
@@ -68,6 +68,7 @@ var _ = ginkgo.Describe("[rwm-csi-destructive-tkg] Statefulsets with File Volume
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_multi_gc.go
+++ b/tests/e2e/gc_rwx_multi_gc.go
@@ -69,6 +69,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] Volume Provision Across TKG clusters", fu
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_multi_ns_gc.go
+++ b/tests/e2e/gc_rwx_multi_ns_gc.go
@@ -66,6 +66,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] Volume Provision Across Namespace", func(
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_non_vsan_datastore.go
+++ b/tests/e2e/gc_rwx_non_vsan_datastore.go
@@ -39,6 +39,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Provision with Non-VSAN datas
 		scParameters             map[string]string
 		nonVsanStoragePolicyName string
 	)
+
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
 		namespace = getNamespaceToRunTests(f)
@@ -50,6 +51,11 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Provision with Non-VSAN datas
 		if !(len(nodeList.Items) > 0) {
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
+	})
+
+	ginkgo.AfterEach(func() {
+		svcClient, svNamespace := getSvcClientAndNamespace()
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_operation_storm.go
+++ b/tests/e2e/gc_rwx_operation_storm.go
@@ -74,6 +74,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Operation storm Test", func()
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_parallel_claim.go
+++ b/tests/e2e/gc_rwx_parallel_claim.go
@@ -65,6 +65,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] PVCs claiming the available resource in p
 	ginkgo.AfterEach(func() {
 		svcClient, svcNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svcNamespace, rqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svcNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_readonly.go
+++ b/tests/e2e/gc_rwx_readonly.go
@@ -57,6 +57,11 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Test for ReadOnlyMany", func(
 		}
 	})
 
+	ginkgo.AfterEach(func() {
+		svcClient, svNamespace := getSvcClientAndNamespace()
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
+	})
+
 	/*
 		Test to verify Pod restricts write into PVC
 

--- a/tests/e2e/gc_rwx_reclaim_policy.go
+++ b/tests/e2e/gc_rwx_reclaim_policy.go
@@ -67,6 +67,7 @@ var _ = ginkgo.Describe("File Volume Test for Reclaim Policy", func() {
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_security_context.go
+++ b/tests/e2e/gc_rwx_security_context.go
@@ -65,6 +65,7 @@ var _ = ginkgo.Describe("File Volume Test with security context", func() {
 	ginkgo.AfterEach(func() {
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_service_down.go
+++ b/tests/e2e/gc_rwx_service_down.go
@@ -87,6 +87,7 @@ var _ = ginkgo.Describe("File Volume Test on Service down", func() {
 			vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_statefulsets.go
+++ b/tests/e2e/gc_rwx_statefulsets.go
@@ -81,6 +81,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Provision with Statefulsets",
 		}
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_static_provision.go
+++ b/tests/e2e/gc_rwx_static_provision.go
@@ -57,6 +57,11 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume static Provision Test", func(
 		}
 	})
 
+	ginkgo.AfterEach(func() {
+		svcClient, svNamespace := getSvcClientAndNamespace()
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
+	})
+
 	/*
 		Test to verify static volume provision.
 

--- a/tests/e2e/gc_rwx_syncer.go
+++ b/tests/e2e/gc_rwx_syncer.go
@@ -74,6 +74,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] File Volume Test for label updates", func
 			ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_tkg_scale.go
+++ b/tests/e2e/gc_rwx_tkg_scale.go
@@ -78,6 +78,7 @@ var _ = ginkgo.Describe("[rwm-csi-tkg] TKG RWX for STS with GC worker nodes scal
 		}
 		svcClient, svNamespace := getSvcClientAndNamespace()
 		setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 	})
 
 	/*

--- a/tests/e2e/gc_rwx_volume_health.go
+++ b/tests/e2e/gc_rwx_volume_health.go
@@ -73,6 +73,8 @@ var _ = ginkgo.Describe("File Volume Test volume health plumbing", func() {
 			ginkgo.By(fmt.Sprintf("Starting %v on the vCenter host", vsanhealthServiceName))
 			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
 		}
+		dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
+		dumpSvcNsEventsOnTestFailure(svcClient, csiSystemNamespace)
 	})
 
 	/*

--- a/tests/e2e/improved_csi_idempotency.go
+++ b/tests/e2e/improved_csi_idempotency.go
@@ -839,6 +839,7 @@ func extendVolumeWithServiceDown(serviceName string, namespace string, client cl
 
 // stopHostD is a function for waitGroup to run stop hostd parallelly
 func stopHostD(ctx context.Context, addr string, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	stopHostDOnHost(ctx, addr)
 }

--- a/tests/e2e/improved_csi_idempotency.go
+++ b/tests/e2e/improved_csi_idempotency.go
@@ -124,14 +124,6 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 	ginkgo.AfterEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
-		if supervisorCluster {
-			deleteResourceQuota(client, namespace)
-		}
-		if guestCluster {
-			svcClient, svNamespace := getSvcClientAndNamespace()
-			setResourceQuota(svcClient, svNamespace, defaultrqLimit)
-		}
 		if isServiceStopped {
 			if serviceName == "CSI" {
 				framework.Logf("Starting CSI driver")
@@ -165,6 +157,16 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] "+
 
 		ginkgo.By(fmt.Sprintf("Resetting provisioner time interval to %s sec", defaultProvisionerTimeInSec))
 		updateCSIDeploymentProvisionerTimeout(c, csiSystemNamespace, defaultProvisionerTimeInSec)
+
+		if supervisorCluster {
+			deleteResourceQuota(client, namespace)
+			dumpSvcNsEventsOnTestFailure(client, namespace)
+		}
+		if guestCluster {
+			svcClient, svNamespace := getSvcClientAndNamespace()
+			setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
+		}
 	})
 
 	/*

--- a/tests/e2e/labelupdates.go
+++ b/tests/e2e/labelupdates.go
@@ -116,6 +116,11 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelize
 	ginkgo.AfterEach(func() {
 		if supervisorCluster {
 			deleteResourceQuota(client, namespace)
+			dumpSvcNsEventsOnTestFailure(client, namespace)
+		}
+		if guestCluster {
+			svcClient, svNamespace := getSvcClientAndNamespace()
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 		}
 	})
 

--- a/tests/e2e/multi_master_k8s.go
+++ b/tests/e2e/multi_master_k8s.go
@@ -116,6 +116,13 @@ var _ = ginkgo.Describe("[csi-multi-master-block-e2e]", func() {
 		ginkgo.By("Waiting for old vsphere-csi-controller pod to be removed")
 		err = waitForControllerDeletion(client, controllerNamespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if supervisorCluster {
+			dumpSvcNsEventsOnTestFailure(client, namespace)
+		} else {
+			svcClient, svNamespace := getSvcClientAndNamespace()
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
+		}
 	})
 
 	/*

--- a/tests/e2e/policy_driven_vol_allocation.go
+++ b/tests/e2e/policy_driven_vol_allocation.go
@@ -3121,6 +3121,7 @@ func setVpxdTaskTimeout(ctx context.Context, taskTimeout int) {
 func writeKnownData2PodInParallel(
 	f *framework.Framework, pod *v1.Pod, testdataFile string, wg *sync.WaitGroup, size ...int64) {
 
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	writeKnownData2Pod(f, pod, testdataFile, size...)
 }
@@ -3175,6 +3176,7 @@ func verifyKnownDataInPod(f *framework.Framework, pod *v1.Pod, testdataFile stri
 }
 
 func reconfigPolicyParallel(ctx context.Context, volID string, policyId string, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	err := e2eVSphere.reconfigPolicy(ctx, volID, policyId)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/policy_driven_vol_allocation.go
+++ b/tests/e2e/policy_driven_vol_allocation.go
@@ -97,14 +97,11 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		setVpxdTaskTimeout(ctx, 0) // reset vpxd timeout to default
 
 		if supervisorCluster {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			framework.Logf("Collecting supervisor PVC events before performing PV/PVC cleanup")
-			eventList, err := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			for _, item := range eventList.Items {
-				framework.Logf(fmt.Sprintf(item.Message))
-			}
+			dumpSvcNsEventsOnTestFailure(client, namespace)
+		}
+		if guestCluster {
+			svcClient, svNamespace := getSvcClientAndNamespace()
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 		}
 	})
 

--- a/tests/e2e/raw_block_volume.go
+++ b/tests/e2e/raw_block_volume.go
@@ -153,10 +153,13 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		if !apierrors.IsNotFound(err) {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
-
+		if supervisorCluster {
+			dumpSvcNsEventsOnTestFailure(client, namespace)
+		}
 		if guestCluster {
 			svcClient, svNamespace := getSvcClientAndNamespace()
 			setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 		}
 		if deleteFCDRequired {
 			ginkgo.By(fmt.Sprintf("Deleting FCD: %s", fcdID))

--- a/tests/e2e/storagepolicy.go
+++ b/tests/e2e/storagepolicy.go
@@ -78,10 +78,12 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 	ginkgo.AfterEach(func() {
 		if supervisorCluster {
 			deleteResourceQuota(client, namespace)
+			dumpSvcNsEventsOnTestFailure(client, namespace)
 		}
 		if guestCluster {
 			svcClient, svNamespace := getSvcClientAndNamespace()
 			setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 		}
 	})
 

--- a/tests/e2e/tkgs_ha.go
+++ b/tests/e2e/tkgs_ha.go
@@ -105,6 +105,16 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		}
 	})
 
+	ginkgo.AfterEach(func() {
+		if supervisorCluster {
+			dumpSvcNsEventsOnTestFailure(client, namespace)
+		}
+		if guestCluster {
+			svcClient, svNamespace := getSvcClientAndNamespace()
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
+		}
+	})
+
 	/*
 		Dynamic PVC -  Zonal storage and Immediate binding
 		1. Create a zonal storage policy, on the datastore that is shared only to specific cluster

--- a/tests/e2e/tkgs_ha_site_down.go
+++ b/tests/e2e/tkgs_ha_site_down.go
@@ -95,6 +95,16 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SiteDownTests", func() {
 
 	})
 
+	ginkgo.AfterEach(func() {
+		if supervisorCluster {
+			dumpSvcNsEventsOnTestFailure(client, namespace)
+		}
+		if guestCluster {
+			svcClient, svNamespace := getSvcClientAndNamespace()
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
+		}
+	})
+
 	/*
 		Bring down ESX in AZ1
 		1. Use Zonal storage class of AZ1 with immediate binding

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -893,6 +893,7 @@ func createPVC(client clientset.Interface, pvcnamespace string, pvclaimlabels ma
 // storage class.
 func scaleCreatePVC(client clientset.Interface, pvcnamespace string, pvclaimlabels map[string]string, ds string,
 	storageclass *storagev1.StorageClass, accessMode v1.PersistentVolumeAccessMode, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 
 	pvcspec := getPersistentVolumeClaimSpecWithStorageClass(pvcnamespace, ds, storageclass, pvclaimlabels, accessMode)
@@ -911,6 +912,7 @@ func scaleCreatePVC(client clientset.Interface, pvcnamespace string, pvclaimlabe
 func scaleCreateDeletePVC(client clientset.Interface, pvcnamespace string, pvclaimlabels map[string]string,
 	ds string, storageclass *storagev1.StorageClass, accessMode v1.PersistentVolumeAccessMode,
 	wg *sync.WaitGroup, lock *sync.Mutex, worker int) {
+	defer ginkgo.GinkgoRecover()
 	ctx, cancel := context.WithCancel(context.Background())
 	var totalPVCDeleted int = 0
 	defer cancel()
@@ -2540,6 +2542,7 @@ func verifyIsDetachedInSupervisor(ctx context.Context, f *framework.Framework,
 // namespace. It takes client, namespace, pvc, pv as input.
 func verifyPodCreation(f *framework.Framework, client clientset.Interface, namespace string,
 	pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) {
+	defer ginkgo.GinkgoRecover()
 	ginkgo.By("Create pod and wait for this to be in running phase")
 	pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -5475,6 +5478,7 @@ func getMasterIpFromMasterNodeName(ctx context.Context, client clientset.Interfa
 
 func createParallelStatefulSets(client clientset.Interface, namespace string,
 	statefulset *appsv1.StatefulSet, replicas int32, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	ginkgo.By("Creating statefulset")
 	ctx, cancel := context.WithCancel(context.Background())
@@ -6324,6 +6328,7 @@ func createVsanDPvcAndPod(client clientset.Interface, ctx context.Context,
 // on a given pod in parallel
 func writeDataToMultipleFilesOnPodInParallel(namespace string, podName string, data string,
 	wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	for i := 0; i < 10; i++ {
 		ginkgo.By("write to a file in pod")

--- a/tests/e2e/vc_reboot_volume_lifecycle.go
+++ b/tests/e2e/vc_reboot_volume_lifecycle.go
@@ -65,10 +65,12 @@ var _ bool = ginkgo.Describe("Verify volume life_cycle operations works fine aft
 	ginkgo.AfterEach(func() {
 		if supervisorCluster || guestCluster {
 			deleteResourceQuota(client, namespace)
+			dumpSvcNsEventsOnTestFailure(client, namespace)
 		}
 		if guestCluster {
 			svcClient, svNamespace := getSvcClientAndNamespace()
 			setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 		}
 	})
 

--- a/tests/e2e/volume_health_test.go
+++ b/tests/e2e/volume_health_test.go
@@ -83,6 +83,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		vcAddress := e2eVSphere.Config.Global.VCenterHostname + ":" + sshdPort
 		if supervisorCluster {
 			deleteResourceQuota(client, namespace)
+			dumpSvcNsEventsOnTestFailure(client, namespace)
 		}
 		if pvc != nil {
 			if hostIP != "" {
@@ -112,6 +113,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 		if guestCluster {
 			svcClient, svNamespace := getSvcClientAndNamespace()
 			setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 		}
 		waitForAllHostsToBeUp(ctx, &e2eVSphere)
 	})

--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/vmware/govmomi/find"
 	vsan "github.com/vmware/govmomi/vsan"
@@ -83,6 +84,7 @@ func initialiseFdsVar(ctx context.Context) {
 
 // siteFailureInParallel causes site Failure in multiple hosts of the site in parallel
 func siteFailureInParallel(primarySite bool, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	siteFailover(primarySite)
 }
@@ -266,6 +268,7 @@ func wait4AllK8sNodesToBeUp(
 
 // deletePodsInParallel deletes pods in a given namespace in parallel
 func deletePodsInParallel(client clientset.Interface, namespace string, pods []*v1.Pod, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	for _, pod := range pods {
 		fpod.DeletePodOrFail(client, namespace, pod.Name)
@@ -275,6 +278,7 @@ func deletePodsInParallel(client clientset.Interface, namespace string, pods []*
 // createPvcInParallel creates number of PVC in a given namespace in parallel
 func createPvcInParallel(client clientset.Interface, namespace string, diskSize string, sc *storagev1.StorageClass,
 	ch chan *v1.PersistentVolumeClaim, lock *sync.Mutex, wg *sync.WaitGroup, volumeOpsScale int) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	for i := 0; i < volumeOpsScale; i++ {
 		pvc, err := createPVC(client, namespace, nil, diskSize, sc, "")
@@ -324,6 +328,7 @@ func waitForPodsToBeInErrorOrRunning(c clientset.Interface, podName, namespace s
 
 // runCmdOnHostsInParallel runs command on multiple ESX in parallel
 func runCmdOnHostsInParallel(hostIP string, sshCmd string, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	op, err := runCommandOnESX("root", hostIP, sshCmd)
 	framework.Logf(op)
@@ -375,6 +380,7 @@ func toggleNetworkFailureParallel(hosts []string, causeNetworkFailure bool) {
 // deletePVCInParallel deletes PVC in a given namespace in parallel
 func deletePvcInParallel(client clientset.Interface, pvclaims []*v1.PersistentVolumeClaim,
 	namespace string, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	for _, pvclaim := range pvclaims {
 		err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
@@ -385,6 +391,8 @@ func deletePvcInParallel(client clientset.Interface, pvclaims []*v1.PersistentVo
 // createPodsInParallel creates Pods in a given namespace in parallel
 func createPodsInParallel(client clientset.Interface, namespace string, pvclaims []*v1.PersistentVolumeClaim,
 	ctx context.Context, lock *sync.Mutex, ch chan *v1.Pod, wg *sync.WaitGroup, volumeOpsScale int) {
+
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 
 	for i := 0; i < volumeOpsScale; i++ {
@@ -401,6 +409,7 @@ func createPodsInParallel(client clientset.Interface, namespace string, pvclaims
 // updatePvcLabelsInParallel updates the labels of pvc in a namespace in parallel
 func updatePvcLabelsInParallel(ctx context.Context, client clientset.Interface, namespace string,
 	labels map[string]string, pvclaims []*v1.PersistentVolumeClaim, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	for _, pvc := range pvclaims {
 		framework.Logf(fmt.Sprintf("Updating labels %+v for pvc %s in namespace %s",
@@ -418,6 +427,7 @@ func updatePvcLabelsInParallel(ctx context.Context, client clientset.Interface, 
 // updatePvLabelsInParallel updates the labels of pv in parallel
 func updatePvLabelsInParallel(ctx context.Context, client clientset.Interface, namespace string,
 	labels map[string]string, persistentVolumes []*v1.PersistentVolume, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	for _, pv := range persistentVolumes {
 		framework.Logf("Updating labels %+v for pv %s in namespace %s",
@@ -541,6 +551,7 @@ func changeLeaderOfContainerToComeUpOnMaster(ctx context.Context, client clients
 // the particular CSI container on the master node in parallel
 func invokeDockerPauseNKillOnContainerInParallel(sshClientConfig *ssh.ClientConfig, k8sMasterIp string,
 	csiContainerName string, k8sVersion string, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	err := execDockerPauseNKillOnContainer(sshClientConfig, k8sMasterIp, csiContainerName, k8sVersion)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -843,6 +854,7 @@ func scaleUpStsAndVerifyPodMetadata(ctx context.Context, client clientset.Interf
 
 // deleteCsiPodInParallel deletes csi pod present in csi namespace in parallel
 func deleteCsiPodInParallel(client clientset.Interface, pod *v1.Pod, namespace string, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	framework.Logf("Deleting the pod: %s", pod.Name)
 	err := fpod.DeletePodWithWait(client, pod)
@@ -888,6 +900,7 @@ func hostFailure(esxHost string, hostDown bool) {
 // scaleStsReplicaInParallel scales statefulset's replica up/down in parallel
 func scaleStsReplicaInParallel(client clientset.Interface, stsList []*appsv1.StatefulSet,
 	regex string, replicas int32, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	for _, statefulset := range stsList {
 		if strings.Contains(statefulset.Name, regex) {
@@ -899,6 +912,7 @@ func scaleStsReplicaInParallel(client clientset.Interface, stsList []*appsv1.Sta
 // deletePvInParallel deletes PVs in parallel from k8s cluster
 func deletePvInParallel(client clientset.Interface, persistentVolumes []*v1.PersistentVolume,
 	wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	for _, pv := range persistentVolumes {
 		framework.Logf("Deleting pv %s", pv.Name)
@@ -912,6 +926,7 @@ func deletePvInParallel(client clientset.Interface, persistentVolumes []*v1.Pers
 func createStaticPvAndPvcInParallel(client clientset.Interface, ctx context.Context, fcdIDs []string,
 	ch chan *v1.PersistentVolumeClaim, namespace string, wg *sync.WaitGroup,
 	volumeOpsScale int) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	staticPVLabels := make(map[string]string)
 	for i := 0; i < volumeOpsScale; i++ {
@@ -939,6 +954,7 @@ func createStaticPvAndPvcInParallel(client clientset.Interface, ctx context.Cont
 // using triggerFullSync() here
 func triggerFullSyncInParallel(ctx context.Context, client clientset.Interface,
 	cnsOperatorClient client.Client, wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	err := waitForFullSyncToFinish(client, ctx, cnsOperatorClient)
 	if err != nil {

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -1246,6 +1246,7 @@ func (vs *vSphere) reconfigPolicy(ctx context.Context, volumeID string, profileI
 func cnsRelocateVolumeInParallel(e2eVSphere vSphere, ctx context.Context, fcdID string,
 	dsRefDest vim25types.ManagedObjectReference, waitForRelocateTaskToComplete bool,
 	wg *sync.WaitGroup) {
+	defer ginkgo.GinkgoRecover()
 	defer wg.Done()
 	_, err := e2eVSphere.cnsRelocateVolume(e2eVSphere, ctx, fcdID, dsRefDest, waitForRelocateTaskToComplete)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/vsphere_shared_datastore.go
+++ b/tests/e2e/vsphere_shared_datastore.go
@@ -73,6 +73,15 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
 	})
+	ginkgo.AfterEach(func() {
+		if supervisorCluster {
+			dumpSvcNsEventsOnTestFailure(client, namespace)
+		}
+		if guestCluster {
+			svcClient, svNamespace := getSvcClientAndNamespace()
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
+		}
+	})
 
 	// Shared datastore should be provisioned successfully.
 	ginkgo.It("Verify dynamic provisioning of PV passes with user specified shared datastore and "+

--- a/tests/e2e/vsphere_volume_disksize.go
+++ b/tests/e2e/vsphere_volume_disksize.go
@@ -75,10 +75,12 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-supervisor]
 	ginkgo.AfterEach(func() {
 		if supervisorCluster {
 			deleteResourceQuota(client, namespace)
+			dumpSvcNsEventsOnTestFailure(client, namespace)
 		}
 		if guestCluster {
 			svcClient, svNamespace := getSvcClientAndNamespace()
 			setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 		}
 
 	})

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -124,10 +124,12 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		if supervisorCluster {
 			ginkgo.By("Delete Resource quota")
 			deleteResourceQuota(client, namespace)
+			dumpSvcNsEventsOnTestFailure(client, namespace)
 		}
 		if guestCluster {
 			svcClient, svNamespace := getSvcClientAndNamespace()
 			setResourceQuota(svcClient, svNamespace, defaultrqLimit)
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
 		}
 
 	})

--- a/tests/e2e/vsphere_volume_fsgroup.go
+++ b/tests/e2e/vsphere_volume_fsgroup.go
@@ -75,6 +75,15 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-guest] [csi
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
 	})
+	ginkgo.AfterEach(func() {
+		if supervisorCluster {
+			dumpSvcNsEventsOnTestFailure(client, namespace)
+		}
+		if guestCluster {
+			svcClient, svNamespace := getSvcClientAndNamespace()
+			dumpSvcNsEventsOnTestFailure(svcClient, svNamespace)
+		}
+	})
 
 	// Test for Pod creation works when SecurityContext has FSGroup
 	ginkgo.It("Verify Pod Creation works when SecurityContext has FSGroup", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
collects events from svc test namespace for svc and gc tests and adds GinkgoRecover() to go routines with asserts

**Testing done**:
https://gist.github.com/sashrith/777896b9094b60bceb5931afd4c3a359
