### PR TITLE
Multi-VC Preferential-Topology And Snapshot-Topology different test coverage automation

### DIFF
--- a/tests/e2e/csi_snapshot_basic.go
+++ b/tests/e2e/csi_snapshot_basic.go
@@ -347,7 +347,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Creating volume snapshot content by snapshotHandle %s", snapshothandle))
@@ -481,7 +481,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		}()
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		snapshotHandle := volHandle + "+" + snapshotId
@@ -649,7 +649,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ns, err := framework.CreateTestingNS(f.BaseName, client, nil)
@@ -831,7 +831,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Deleting volume snapshot 1 " + snapshot1.Name)
@@ -847,7 +847,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify snapshot entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify volume snapshot content is not deleted")
@@ -976,7 +976,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Creating volume snapshot content by snapshotHandle %s", snapshothandle))
@@ -1174,7 +1174,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId3 := strings.Split(snapshothandle3, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle2, snapshotId3)
+		err = verifySnapshotIsCreatedInCNS(volHandle2, snapshotId3, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Deleted volume snapshot is created above")
@@ -1206,7 +1206,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotContentCreated = false
 
 		ginkgo.By("Verify snapshot entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -1716,7 +1716,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Delete namespace")
@@ -1840,7 +1840,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotContentCreated = false
 
 		ginkgo.By("Verify snapshot entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -2052,7 +2052,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Delete volume snapshot and verify the snapshot content is deleted")
@@ -2066,7 +2066,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotContentCreated = false
 
 		ginkgo.By("Verify snapshot entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -2172,7 +2172,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Create PVC using the higher size")
@@ -2213,7 +2213,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotContentCreated = false
 
 		ginkgo.By("Verify snapshot entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -2374,7 +2374,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId1 := strings.Split(snapshothandle1, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle1, snapshotId1)
+		err = verifySnapshotIsCreatedInCNS(volHandle1, snapshotId1, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Create a volume snapshot - 2")
@@ -2419,7 +2419,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId2 := strings.Split(snapshothandle2, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle2, snapshotId2)
+		err = verifySnapshotIsCreatedInCNS(volHandle2, snapshotId2, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas-1))
@@ -2529,7 +2529,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotContentCreated2 = false
 
 		ginkgo.By("Verify snapshot 1 entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle1, snapshotId1)
+		err = verifySnapshotIsDeletedInCNS(volHandle1, snapshotId1, false)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2537,7 +2537,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		}
 
 		ginkgo.By("Verify snapshot 2 entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle2, snapshotId2)
+		err = verifySnapshotIsDeletedInCNS(volHandle2, snapshotId2, false)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2858,7 +2858,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		}()
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		snapshotHandle := volHandle + "+" + snapshotId
@@ -3015,7 +3015,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		}()
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		snapshotHandle := volHandle + "+" + snapshotId
@@ -3754,7 +3754,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Identify the host on which the PV resides")
@@ -4131,7 +4131,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Fetching the username and password of the current vcenter session from secret")
@@ -4227,7 +4227,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId3 := strings.Split(snapshothandle3, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId3)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId3, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Reverting the password change")
@@ -4389,7 +4389,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Create PVC from snapshot")
@@ -4431,7 +4431,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify snapshot entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -4532,7 +4532,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 			snapshotId := strings.Split(snapshothandle, "+")[1]
 
 			ginkgo.By("Query CNS and check the volume snapshot entry")
-			err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+			err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -4627,7 +4627,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 			snapshotId := strings.Split(snapshothandle, "+")[1]
 
 			ginkgo.By("Query CNS and check the volume snapshot entry")
-			err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+			err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -4894,7 +4894,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Create PVC from snapshot")
@@ -4926,7 +4926,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotContentCreated = false
 
 		ginkgo.By("Verify snapshot entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -5037,7 +5037,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Create PVC from snapshot")
@@ -5069,7 +5069,7 @@ var _ = ginkgo.Describe("[block-vanilla-snapshot] Volume Snapshot Basic Test", f
 		snapshotContentCreated = false
 
 		ginkgo.By("Verify snapshot entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 

--- a/tests/e2e/csi_snapshot_utils.go
+++ b/tests/e2e/csi_snapshot_utils.go
@@ -166,7 +166,7 @@ func waitForVolumeSnapshotContentToBeDeletedWithPandoraWait(ctx context.Context,
 func waitForCNSSnapshotToBeDeleted(volumeId string, snapshotId string) error {
 	var err error
 	waitErr := wait.PollImmediate(poll, pollTimeout, func() (bool, error) {
-		err = verifySnapshotIsDeletedInCNS(volumeId, snapshotId)
+		err = verifySnapshotIsDeletedInCNS(volumeId, snapshotId, false)
 		if err != nil {
 			if strings.Contains(err.Error(), "snapshot entry is still present") {
 				return false, nil
@@ -335,7 +335,7 @@ func deleteVolumeSnapshot(ctx context.Context, snapc *snapclient.Clientset, name
 	}
 
 	framework.Logf("Verify snapshot entry is deleted from CNS")
-	err = verifySnapshotIsDeletedInCNS(volHandle, snapshotID)
+	err = verifySnapshotIsDeletedInCNS(volHandle, snapshotID, false)
 	if err != nil {
 		return snapshotCreated, snapshotContentCreated, err
 	}
@@ -374,7 +374,7 @@ func getVolumeSnapshotIdFromSnapshotHandle(ctx context.Context, snapshotContent 
 	time.Sleep(time.Duration(pandoraSyncWaitTime) * time.Second)
 
 	ginkgo.By("Query CNS and check the volume snapshot entry")
-	err = verifySnapshotIsCreatedInCNS(volHandle, snapshotID)
+	err = verifySnapshotIsCreatedInCNS(volHandle, snapshotID, false)
 	if err != nil {
 		return "", err
 	}

--- a/tests/e2e/multi_vc.go
+++ b/tests/e2e/multi_vc.go
@@ -1055,6 +1055,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		topValStartIndex = 1
 		topValEndIndex = 2
 		stsReplicas = 3
+		clientIndex := 0
 
 		scParameters[scParamStoragePolicyName] = storagePolicyToDelete
 
@@ -1077,7 +1078,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		}()
 
 		ginkgo.By("Delete Storage Policy created in VC1")
-		err = deleteStorageProfile(masterIp, sshClientConfig, storagePolicyToDelete)
+		err = deleteStorageProfile(masterIp, sshClientConfig, storagePolicyToDelete, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")

--- a/tests/e2e/multi_vc_multi_replica.go
+++ b/tests/e2e/multi_vc_multi_replica.go
@@ -1,0 +1,255 @@
+/*
+	Copyright 2023 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"golang.org/x/crypto/ssh"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC-Replica", func() {
+	f := framework.NewDefaultFramework("csi-multi-vc")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		client                      clientset.Interface
+		namespace                   string
+		allowedTopologies           []v1.TopologySelectorLabelRequirement
+		sshClientConfig             *ssh.ClientConfig
+		nimbusGeneratedK8sVmPwd     string
+		statefulSetReplicaCount     int32
+		k8sVersion                  string
+		stsScaleUp                  bool
+		stsScaleDown                bool
+		verifyTopologyAffinity      bool
+		parallelStatefulSetCreation bool
+		scaleUpReplicaCount         int32
+		scaleDownReplicaCount       int32
+	)
+	ginkgo.BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+
+		multiVCbootstrap()
+
+		stsScaleUp = true
+		stsScaleDown = true
+		verifyTopologyAffinity = true
+		parallelStatefulSetCreation = true
+
+		sc, err := client.StorageV1().StorageClasses().Get(ctx, defaultNginxStorageClassName, metav1.GetOptions{})
+		if err == nil && sc != nil {
+			gomega.Expect(client.StorageV1().StorageClasses().Delete(ctx, sc.Name,
+				*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+		}
+
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		topologyMap := GetAndExpectStringEnvVar(topologyMap)
+		allowedTopologies = createAllowedTopolgies(topologyMap, topologyLength)
+		nimbusGeneratedK8sVmPwd = GetAndExpectStringEnvVar(nimbusK8sVmPwd)
+
+		sshClientConfig = &ssh.ClientConfig{
+			User: "root",
+			Auth: []ssh.AuthMethod{
+				ssh.Password(nimbusGeneratedK8sVmPwd),
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+
+		// fetching k8s version
+		v, err := client.Discovery().ServerVersion()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		k8sVersion = v.Major + "." + v.Minor
+
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By(fmt.Sprintf("Deleting all statefulsets in namespace: %v", namespace))
+		fss.DeleteAllStatefulSets(client, namespace)
+		ginkgo.By(fmt.Sprintf("Deleting service nginx in namespace: %v", namespace))
+		err := client.CoreV1().Services(namespace).Delete(ctx, servicename, *metav1.NewDeleteOptions(0))
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		framework.Logf("Perform cleanup of any left over stale PVs")
+		allPvs, err := client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, pv := range allPvs.Items {
+			err = client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	})
+
+	/*
+		Verify the behaviour when CSI Provisioner, CSI Attacher, Vsphere syncer is deleted repeatedly
+		during workload creation
+
+		1. Identify the CSI-Controller-Pod where CSI Provisioner, CSI Attacher and vsphere-syncer are the leader
+		2. Create SC with allowed topology set to different availability zones  spread across multiple VC's
+		3. Create three Statefulsets each with replica 5
+		4. While the Statefulsets is creating PVCs and Pods, kill CSI-Provisioner, CSI-attacher identified
+		in the step 1
+		5. Wait for some time for all the PVCs and Pods to come up
+		6. Verify the PV node affinity and the nodes on which Pods have come should be appropriate
+		7. Scale-up/Scale-down the Statefulset and kill the vsphere-syncer identified in the step 1
+		8. Wait for some time,  Statefulset workload is patched with proper count
+		9. Make sure common validation points are met on PV,PVC and POD
+		10. Clean up the data
+	*/
+
+	ginkgo.It("Verify behaviour when CSI-Provisioner, CSI-Attacher, Vsphere-Syncer is "+
+		"deleted repeatedly during workload creation in multivc", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sts_count := 3
+		statefulSetReplicaCount = 5
+
+		ginkgo.By("Get current leader where CSI-Provisioner, CSI-Attacher and " +
+			"Vsphere-Syncer is running and find the master node IP where these containers are running")
+		csiProvisionerLeader, csiProvisionerControlIp, err := getK8sMasterNodeIPWhereContainerLeaderIsRunning(ctx,
+			client, sshClientConfig, provisionerContainerName)
+		framework.Logf("CSI-Provisioner is running on Leader Pod %s "+
+			"which is running on master node %s", csiProvisionerLeader, csiProvisionerControlIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		csiAttacherLeaderleader, csiAttacherControlIp, err := getK8sMasterNodeIPWhereContainerLeaderIsRunning(ctx,
+			client, sshClientConfig, attacherContainerName)
+		framework.Logf("CSI-Attacher is running on Leader Pod %s "+
+			"which is running on master node %s", csiAttacherLeaderleader, csiAttacherControlIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		vsphereSyncerLeader, vsphereSyncerControlIp, err := getK8sMasterNodeIPWhereContainerLeaderIsRunning(ctx,
+			client, sshClientConfig, syncerContainerName)
+		framework.Logf("Vsphere-Syncer is running on Leader Pod %s "+
+			"which is running on master node %s", vsphereSyncerLeader, vsphereSyncerControlIp)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Create SC with allowed topology spread across multiple VCs")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Creating multiple StatefulSets specs in parallel")
+		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, statefulSetReplicaCount)
+
+		ginkgo.By("Trigger multiple StatefulSets creation in parallel. During StatefulSets " +
+			"creation, kill CSI-Provisioner, CSI-Attacher container in between")
+		var wg sync.WaitGroup
+		wg.Add(sts_count)
+		for i := 0; i < len(statefulSets); i++ {
+			go createParallelStatefulSets(client, namespace, statefulSets[i], statefulSetReplicaCount, &wg)
+			if i == 1 {
+				ginkgo.By("Kill CSI-Provisioner container")
+				err = execDockerPauseNKillOnContainer(sshClientConfig, csiProvisionerControlIp, provisionerContainerName,
+					k8sVersion)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+
+			if i == 2 {
+				ginkgo.By("Kill CSI-Attacher container")
+				err = execDockerPauseNKillOnContainer(sshClientConfig, csiAttacherControlIp, attacherContainerName,
+					k8sVersion)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+		wg.Wait()
+
+		ginkgo.By("Waiting for StatefulSets Pods to be in Ready State")
+		err = waitForStsPodsToBeInReadyRunningState(ctx, client, namespace, statefulSets)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			deleteAllStsAndPodsPVCsInNamespace(ctx, client, namespace)
+		}()
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		for i := 0; i < len(statefulSets); i++ {
+			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
+				statefulSets[i], namespace, allowedTopologies, parallelStatefulSetCreation, true)
+		}
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulset and verify pv and pod affinity details")
+		for i := 0; i < len(statefulSets); i++ {
+			if i == 0 {
+				stsScaleUp = false
+				scaleDownReplicaCount = 3
+				framework.Logf("Scale down StatefulSet1 replica count to 3")
+				performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+					scaleDownReplicaCount, statefulSets[i], parallelStatefulSetCreation, namespace,
+					allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+			}
+			if i == 1 {
+				scaleUpReplicaCount = 9
+				stsScaleDown = false
+				framework.Logf("Scale up StatefulSet2 replica count to 9 and in between " +
+					"kill vsphere syncer container")
+				performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+					scaleDownReplicaCount, statefulSets[i], parallelStatefulSetCreation, namespace,
+					allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+
+				framework.Logf("Kill Vsphere-Syncer container")
+				err = execDockerPauseNKillOnContainer(sshClientConfig, vsphereSyncerControlIp, syncerContainerName,
+					k8sVersion)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			}
+			if i == 2 {
+				framework.Logf("Scale up StatefulSet3 replica count to 7 and later scale down" +
+					"the replica count to 2")
+				scaleUpReplicaCount = 7
+				scaleDownReplicaCount = 2
+				performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+					scaleDownReplicaCount, statefulSets[i], parallelStatefulSetCreation, namespace,
+					allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+			}
+		}
+	})
+})

--- a/tests/e2e/multi_vc_preferential_topology.go
+++ b/tests/e2e/multi_vc_preferential_topology.go
@@ -1,0 +1,775 @@
+/*
+	Copyright 2023 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"golang.org/x/crypto/ssh"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	snapclient "github.com/kubernetes-csi/external-snapshotter/client/v6/clientset/versioned"
+)
+
+var _ = ginkgo.Describe("[csi-multi-vc-preferential-topology] Multi-VC-Preferential-Topology", func() {
+	f := framework.NewDefaultFramework("multi-vc-preferential-topology")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		client                      clientset.Interface
+		namespace                   string
+		preferredDatastoreChosen    int
+		allMasterIps                []string
+		masterIp                    string
+		preferredDatastorePaths     []string
+		allowedTopologyRacks        []string
+		sshClientConfig             *ssh.ClientConfig
+		nimbusGeneratedK8sVmPwd     string
+		allowedTopologies           []v1.TopologySelectorLabelRequirement
+		ClusterdatastoreListVc      []map[string]string
+		ClusterdatastoreListVc1     map[string]string
+		ClusterdatastoreListVc2     map[string]string
+		ClusterdatastoreListVc3     map[string]string
+		parallelStatefulSetCreation bool
+		stsReplicas                 int32
+		scaleDownReplicaCount       int32
+		scaleUpReplicaCount         int32
+		stsScaleUp                  bool
+		stsScaleDown                bool
+		verifyTopologyAffinity      bool
+		topValStartIndex            int
+		topValEndIndex              int
+		topkeyStartIndex            int
+		scParameters                map[string]string
+		storagePolicyInVc1Vc2       string
+		allowedTopologyLen          int
+		parallelPodPolicy           bool
+		nodeAffinityToSet           bool
+		podAntiAffinityToSet        bool
+		snapc                       *snapclient.Clientset
+		pandoraSyncWaitTime         int
+		err                         error
+	)
+
+	ginkgo.BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+
+		multiVCbootstrap()
+
+		sc, err := client.StorageV1().StorageClasses().Get(ctx, defaultNginxStorageClassName, metav1.GetOptions{})
+		if err == nil && sc != nil {
+			gomega.Expect(client.StorageV1().StorageClasses().Delete(ctx, sc.Name,
+				*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+		}
+		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		nimbusGeneratedK8sVmPwd = GetAndExpectStringEnvVar(nimbusK8sVmPwd)
+		sshClientConfig = &ssh.ClientConfig{
+			User: "root",
+			Auth: []ssh.AuthMethod{
+				ssh.Password(nimbusGeneratedK8sVmPwd),
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+
+		stsScaleUp = true
+		stsScaleDown = true
+		verifyTopologyAffinity = true
+		scParameters = make(map[string]string)
+		storagePolicyInVc1Vc2 = GetAndExpectStringEnvVar(envStoragePolicyNameInVC1VC2)
+		topologyMap := GetAndExpectStringEnvVar(topologyMap)
+		allowedTopologies = createAllowedTopolgies(topologyMap, topologyLength)
+
+		//Get snapshot client using the rest config
+		restConfig = getRestConfigClient()
+		snapc, err = snapclient.NewForConfig(restConfig)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// fetching k8s master ip
+		allMasterIps = getK8sMasterIPs(ctx, client)
+		masterIp = allMasterIps[0]
+
+		// fetching cluster details
+		clientIndex := 0
+		clusterComputeResource, _, err = getClusterNameForMultiVC(ctx, &multiVCe2eVSphere, clientIndex)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// fetching list of datastores available in different VCs
+		ClusterdatastoreListVc1, ClusterdatastoreListVc2,
+			ClusterdatastoreListVc3, err = getDatastoresListFromMultiVCs(masterIp, sshClientConfig,
+			clusterComputeResource[0], true)
+		ClusterdatastoreListVc = append(ClusterdatastoreListVc, ClusterdatastoreListVc1,
+			ClusterdatastoreListVc2, ClusterdatastoreListVc3)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if os.Getenv(envPandoraSyncWaitTime) != "" {
+			pandoraSyncWaitTime, err = strconv.Atoi(os.Getenv(envPandoraSyncWaitTime))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		} else {
+			pandoraSyncWaitTime = defaultPandoraSyncWaitTime
+		}
+
+		allowedTopologyRacks = nil
+		for i := 0; i < len(allowedTopologies); i++ {
+			for j := 0; j < len(allowedTopologies[i].Values); j++ {
+				allowedTopologyRacks = append(allowedTopologyRacks, allowedTopologies[i].Values[j])
+			}
+		}
+
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By(fmt.Sprintf("Deleting all statefulsets in namespace: %v", namespace))
+		fss.DeleteAllStatefulSets(client, namespace)
+		ginkgo.By(fmt.Sprintf("Deleting service nginx in namespace: %v", namespace))
+		err := client.CoreV1().Services(namespace).Delete(ctx, servicename, *metav1.NewDeleteOptions(0))
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		framework.Logf("Perform preferred datastore tags cleanup after test completion")
+		err = deleteTagCreatedForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks,
+			true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		framework.Logf("Recreate preferred datastore tags post cleanup")
+		err = createTagForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	})
+
+	/* Testcase-1:
+		Add preferential tag in all the Availability zone's of VC1 and VC2  → change the preference during
+		execution
+
+	    1. Create SC default parameters without any topology requirement.
+	    2. In each availability zone for any one datastore add preferential tag in VC1 and VC2
+	    3. Create 3 statefulset with 10 replica's
+	    4. Wait for all the  PVC to bound and pods to reach running state
+	    5. Verify that since the preferred datastore is available, Volume should get created on the datastores
+		 which has the preferencce set
+	    6. Make sure common validation points are met on PV,PVC and POD
+	    7. Change the Preference in any 2 datastores
+	    8. Scale up the statefulset to 15 replica
+	    9. The volumes should get provision on the datastores which has the preference
+	    10. Clear the data
+	*/
+	ginkgo.It("Tag one datastore as preferred each in VC1 and VC2 and verify it is honored", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		parallelStatefulSetCreation = true
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+		sts_count := 3
+		stsReplicas = 10
+		var dsUrls []string
+		scaleUpReplicaCount = 15
+		stsScaleDown = false
+
+		ginkgo.By("Create SC with default parameters")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datastore for volume provisioning in VC1 and VC2")
+		for i := 0; i < 2; i++ {
+			paths, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologies[0].Values[i],
+				preferredDatastoreChosen, ClusterdatastoreListVc[i], nil, true, i)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			preferredDatastorePaths = append(preferredDatastorePaths, paths...)
+
+			// Get the length of the paths for the current iteration
+			pathsLen := len(paths)
+
+			for j := 0; j < pathsLen; j++ {
+				// Calculate the index for ClusterdatastoreListVc based on the current iteration
+				index := i + j
+
+				if val, ok := ClusterdatastoreListVc[index][paths[j]]; ok {
+					dsUrls = append(dsUrls, val)
+				}
+			}
+		}
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Create service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Create 3 statefulset with 10 replicas")
+		statefulSets := createParallelStatefulSetSpec(namespace, sts_count, stsReplicas)
+		var wg sync.WaitGroup
+		wg.Add(sts_count)
+		for i := 0; i < len(statefulSets); i++ {
+			go createParallelStatefulSets(client, namespace, statefulSets[i],
+				stsReplicas, &wg)
+
+		}
+		wg.Wait()
+
+		ginkgo.By("Waiting for StatefulSets Pods to be in Ready State")
+		err = waitForStsPodsToBeInReadyRunningState(ctx, client, namespace, statefulSets)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			deleteAllStsAndPodsPVCsInNamespace(ctx, client, namespace)
+		}()
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
+		for i := 0; i < len(statefulSets); i++ {
+			verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulSets[i],
+				namespace, allowedTopologies, parallelStatefulSetCreation, true)
+		}
+
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		for i := 0; i < len(statefulSets); i++ {
+			err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulSets[i], namespace,
+				preferredDatastorePaths, nil, true, true, true, dsUrls)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By("Remove preferred datatsore tag which is chosen for volume provisioning")
+		for i := 0; i < len(preferredDatastorePaths); i++ {
+			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
+				allowedTopologies[0].Values[i], true, i)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		var preferredDatastorePathsNew []string
+		ginkgo.By("Tag new preferred datastore for volume provisioning in VC1 and VC2")
+		for i := 0; i < 2; i++ {
+			paths, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologies[0].Values[i],
+				preferredDatastoreChosen, ClusterdatastoreListVc[i], preferredDatastorePaths, true, i)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			preferredDatastorePathsNew = append(preferredDatastorePathsNew, paths...)
+			pathsLen := len(paths)
+			for j := 0; j < pathsLen; j++ {
+				index := i + j
+				if val, ok := ClusterdatastoreListVc[index][paths[j]]; ok {
+					dsUrls = append(dsUrls, val)
+				}
+			}
+		}
+		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastorePathsNew...)
+		defer func() {
+			ginkgo.By("Remove preferred datastore tag")
+			for i := 0; i < len(preferredDatastorePathsNew); i++ {
+				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePathsNew[i],
+					allowedTopologies[0].Values[i], true, i)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		for i := 0; i < len(statefulSets); i++ {
+			performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+				scaleDownReplicaCount, statefulSets[i], parallelStatefulSetCreation, namespace,
+				allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+		}
+
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		for i := 0; i < len(statefulSets); i++ {
+			err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulSets[i], namespace,
+				preferredDatastorePaths, nil, true, true, true, dsUrls)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	})
+
+	/* Testcase-2:
+	Create SC with storage policy available in VC1 and VC2, set the preference in VC1 datastore only
+
+	Steps//
+	1. Create storage policy with same name on both VC1 and VC2
+	2. Add preference tag on the datastore which is on VC1 only
+	3. Create statefulset using the above policy
+	4. Since the preference tag is added in VC1, volume provisioning should  happned on VC1's datastore only
+	[no, first preference will be given to Storage Policy mentioned in the Storage Class]
+	5. Make sure common validation points are met on PV,PVC and POD
+	6. Reboot VC1
+	7. Scale up the stateful set to replica 15  → What should be the behaviour here
+	8. Since the VC1 is presently in reboot state, new volumes should start coming up on VC2
+	Once VC1  is up again the datastore preference should take preference
+	[no, until all VCs comes up PVC provision will be stuck in Pending state]
+	9. Verify the node affinity on all PV's
+	10. Make sure POD has come up on appropriate nodes .
+	11. Clean up the data
+	*/
+
+	ginkgo.It("Create SC with storage policy available in VC1 and VC2 and set the "+
+		"preference in VC1 datastore only", func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		/* here we are considering storage policy of VC1 and VC2 and the allowed topology is k8s-zone -> zone-1
+		in case of 2-VC setup and 3-VC setup
+		*/
+
+		stsReplicas = 1
+		scParameters[scParamStoragePolicyName] = storagePolicyInVc1Vc2
+		topValStartIndex = 0
+		topValEndIndex = 2
+		var dsUrls []string
+		stsScaleDown = false
+		scaleUpReplicaCount = 7
+		var multiVcClientIndex = 0
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+
+		datastoreURLVC1 := GetAndExpectStringEnvVar(envSharedDatastoreURLVC1)
+		datastoreURLVC2 := GetAndExpectStringEnvVar(envSharedDatastoreURLVC2)
+
+		/*
+			fetching datstore details passed in the storage policy
+			Note: Since storage policy is specified in the SC, the first preference for volume provisioning
+			will be given to the datastore given in the storage profile and second preference will then be
+			given to the preferred datastore chosen
+		*/
+		for _, vCenterList := range ClusterdatastoreListVc {
+			for _, url := range vCenterList {
+				if url == datastoreURLVC1 || url == datastoreURLVC2 {
+					dsUrls = append(dsUrls, url)
+				}
+			}
+		}
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StorageClass with storage policy specified")
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "",
+			"", false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datastore for volume provisioning in VC1")
+		preferredDatastorePaths, err := tagPreferredDatastore(masterIp, sshClientConfig,
+			allowedTopologies[0].Values[0],
+			preferredDatastoreChosen, ClusterdatastoreListVc[0], nil, true, multiVcClientIndex)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pathsLen := len(preferredDatastorePaths)
+		for j := 0; j < pathsLen; j++ {
+			if val, ok := ClusterdatastoreListVc[0][preferredDatastorePaths[j]]; ok {
+				dsUrls = append(dsUrls, val)
+			}
+		}
+		defer func() {
+			ginkgo.By("Remove preferred datastore tag")
+			for i := 0; i < len(preferredDatastorePaths); i++ {
+				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
+					allowedTopologies[0].Values[0], true, i)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
+		service, statefulset := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace,
+			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen,
+			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", "", sc, verifyTopologyAffinity)
+		defer func() {
+			deleteAllStsAndPodsPVCsInNamespace(ctx, client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace,
+			preferredDatastorePaths, nil, false, false, true, dsUrls)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Rebooting VC")
+		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+		vcAddress := vCenterHostname[0] + ":" + sshdPort
+		framework.Logf("vcAddress - %s ", vcAddress)
+		err = invokeVCenterReboot(vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = waitForHostToBeUp(vCenterHostname[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Done with reboot")
+
+		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
+		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
+
+		//After reboot
+		multiVCbootstrap()
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets and " +
+			"verify pv affinity and pod affinity")
+		performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, scaleUpReplicaCount,
+			scaleDownReplicaCount, statefulset, parallelStatefulSetCreation, namespace,
+			allowedTopologies, stsScaleUp, stsScaleDown, verifyTopologyAffinity)
+
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace,
+			preferredDatastorePaths, nil, false, false, true, dsUrls)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/* Testcase-3:
+	Create/Restore Snapshot of PVC using single datastore preference
+
+	Steps//
+
+	1. Assign preferential tag to any one datastore under any one VC
+	2. Create SC with allowed topology set to all the volumes
+	[here, for verification of snapshot, considering single allowed topology of VC3 ]
+	3. Create PVC-1 with the above SC
+	4. Wait for PVC-1 to reach Bound state.
+	5. Describe PV-1 and verify node affinity details
+	6. Verify volume should be provisioned on the selected preferred datastore
+	7. Create SnapshotClass, Snapshot of PVC-1.
+	8. Verify snapshot state. It should be in ready-to-use state.
+	9. Verify snapshot should be created on the preferred datastore.
+	10. Restore snapshot to create PVC-2
+	11. Wait for PVC-2 to reach Bound state.
+	12. Describe PV-2 and verify node affinity details
+	13. Verify volume should be provisioned on the selected preferred datastore
+	14. Create Pod from restored PVC-2.
+	15. Make sure common validation points are met on PV,PVC and POD
+	16. Make sure POD is running on the same node as mentioned in the node affinity details.
+	17. Perform Cleanup. Delete Snapshot, Pod, PVC, SC
+	18. Remove datastore preference tags as part of cleanup.
+	*/
+
+	ginkgo.It("Assign preferred datatsore to any one VC and verify create restore snapshot", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+		var dsUrls []string
+		var multiVcClientIndex = 2
+		topValStartIndex = 2
+		topValEndIndex = 3
+
+		// Considering k8s-zone -> zone-3 i.e. VC3 allowed topology
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datastore for volume provisioning in VC3")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig,
+			allowedTopologies[0].Values[0],
+			preferredDatastoreChosen, ClusterdatastoreListVc[2], nil, true, multiVcClientIndex)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pathsLen := len(preferredDatastorePaths)
+		for j := 0; j < pathsLen; j++ {
+			if val, ok := ClusterdatastoreListVc[2][preferredDatastorePaths[j]]; ok {
+				dsUrls = append(dsUrls, val)
+			}
+		}
+		defer func() {
+			ginkgo.By("Remove preferred datastore tag")
+			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
+				allowedTopologies[0].Values[0], true, multiVcClientIndex)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Create StorageClass and PVC")
+		storageclass, pvclaim, err := createPVCAndStorageClass(client, namespace, nil,
+			nil, diskSize, allowedTopologies, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Wait for PVC to be in Bound phase
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvclaim},
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
+		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(volHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pvclaim = nil
+		}()
+
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
+		queryResult, err := multiVCe2eVSphere.queryCNSVolumeWithResultInMultiVC(volHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(queryResult.Volumes).ShouldNot(gomega.BeEmpty())
+		gomega.Expect(queryResult.Volumes[0].VolumeId.Id).To(gomega.Equal(volHandle))
+
+		ginkgo.By("Create volume snapshot class, volume snapshot")
+		volumeSnapshot, volumeSnapshotClass, snapshotId := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
+			pvclaim, volHandle, false, true)
+		defer func() {
+			ginkgo.By("Perform cleanup of snapshot created")
+			performCleanUpForSnapshotCreated(ctx, snapc, namespace, volHandle, volumeSnapshot, snapshotId,
+				volumeSnapshotClass, pandoraSyncWaitTime, true)
+		}()
+
+		ginkgo.By("Create PVC from snapshot")
+		pvcSpec := getPersistentVolumeClaimSpecWithDatasource(namespace, diskSize, storageclass, nil,
+			v1.ReadWriteOnce, volumeSnapshot.Name, snapshotapigroup)
+		pvclaim2, err := fpv.CreatePVC(client, namespace, pvcSpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		persistentvolumes2, err := fpv.WaitForPVClaimBoundPhase(client,
+			[]*v1.PersistentVolumeClaim{pvclaim2}, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volHandle2 := persistentvolumes2[0].Spec.CSI.VolumeHandle
+		gomega.Expect(volHandle2).NotTo(gomega.BeEmpty())
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(volHandle2)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Creating pod")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim2}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify volume is detached from the node")
+			isDiskDetached, err := multiVCe2eVSphere.waitForVolumeDetachedFromNodeInMultiVC(client,
+				volHandle2, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", volHandle2,
+					pod.Spec.NodeName))
+		}()
+
+		// verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, preferredDatastorePaths,
+			ClusterdatastoreListVc[2], true, dsUrls)
+
+		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
+			"appropriate node as specified in the allowed topologies of SC")
+		verifyPVnodeAffinityAndPODnodedetailsFoStandalonePodLevel5(ctx, client, pod,
+			namespace, allowedTopologies, true)
+	})
+
+	/* Testcase-4
+
+		Create/Restore Snapshot of PVC, datastore preference change
+
+		1. Assign preferential tag to any one datastore under any one VC
+	    2. Create SC with allowed topology set to all the volumes
+	    3. Create PVC-1 with the above SC
+	    4. Wait for PVC-1 to reach Bound state.
+	    5. Describe PV-1 and verify node affinity details
+	    6. Verify volume should be provisioned on the selected preferred datastore
+	    7. Make sure common validation points are met on PV,PVC and POD
+	    8. Change datastore preference(ex- from NFS-2 to vSAN-2)
+	    9. Create SnapshotClass, Snapshot of PVC-1
+	    10. Verify snapshot state. It should be in ready-to-use state.
+	    11. Restore snapshot to create PVC-2
+	    12. PVC-2 should get stuck in Pending state and proper error message should be displayed.
+	    13. Perform Cleanup. Delete Snapshot, Pod, PVC, SC
+	    14. Remove datastore preference tags as part of cleanup.
+	*/
+
+	ginkgo.It("Assign preferred datatsore to any one VC and verify create restore snapshot "+
+		"and later change datastore preference", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		preferredDatastoreChosen = 1
+		preferredDatastorePaths = nil
+		var dsUrls []string
+		var multiVcClientIndex = 2
+		topValStartIndex = 2
+		topValEndIndex = 3
+
+		// Considering k8s-zone -> zone-3 i.e. VC3 allowed topology
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datastore for volume provisioning in VC3")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig,
+			allowedTopologies[0].Values[0],
+			preferredDatastoreChosen, ClusterdatastoreListVc[2], nil, true, multiVcClientIndex)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pathsLen := len(preferredDatastorePaths)
+		for j := 0; j < pathsLen; j++ {
+			if val, ok := ClusterdatastoreListVc[2][preferredDatastorePaths[j]]; ok {
+				dsUrls = append(dsUrls, val)
+			}
+		}
+		defer func() {
+			ginkgo.By("Remove preferred datastore tag")
+			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
+				allowedTopologies[0].Values[0], true, multiVcClientIndex)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Create StorageClass and PVC")
+		storageclass, pvclaim, err := createPVCAndStorageClass(client, namespace, nil,
+			nil, diskSize, allowedTopologies, "", false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
+				*metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Wait for PVC to be in Bound phase
+		persistentvolumes, err := fpv.WaitForPVClaimBoundPhase(client, []*v1.PersistentVolumeClaim{pvclaim},
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volHandle := persistentvolumes[0].Spec.CSI.VolumeHandle
+		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(volHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pvclaim = nil
+		}()
+
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
+		queryResult, err := multiVCe2eVSphere.queryCNSVolumeWithResultInMultiVC(volHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(queryResult.Volumes).ShouldNot(gomega.BeEmpty())
+		gomega.Expect(queryResult.Volumes[0].VolumeId.Id).To(gomega.Equal(volHandle))
+
+		ginkgo.By("Creating pod")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", pod.Name, namespace))
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Verify volume is detached from the node")
+			isDiskDetached, err := multiVCe2eVSphere.waitForVolumeDetachedFromNodeInMultiVC(client,
+				volHandle, pod.Spec.NodeName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+				fmt.Sprintf("Volume %q is not detached from the node %q", volHandle,
+					pod.Spec.NodeName))
+		}()
+
+		// verifying volume provisioning
+		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
+		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, preferredDatastorePaths,
+			ClusterdatastoreListVc[2], true, dsUrls)
+
+		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
+		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
+			allowedTopologyRacks[2], true, multiVcClientIndex)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// choose preferred datastore
+		ginkgo.By("Tag preferred datastore for volume provisioning in VC3")
+		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig,
+			allowedTopologies[0].Values[0], preferredDatastoreChosen, ClusterdatastoreListVc[2],
+			preferredDatastorePaths, true, multiVcClientIndex)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
+			preferredDatastoreTimeOutInterval)
+		time.Sleep(preferredDatastoreTimeOutInterval)
+
+		ginkgo.By("Create volume snapshot class, volume snapshot")
+		volumeSnapshot, volumeSnapshotClass, snapshotId := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
+			pvclaim, volHandle, false, true)
+		defer func() {
+			ginkgo.By("Perform cleanup of snapshot created")
+			performCleanUpForSnapshotCreated(ctx, snapc, namespace, volHandle, volumeSnapshot, snapshotId,
+				volumeSnapshotClass, pandoraSyncWaitTime, true)
+		}()
+
+		ginkgo.By("Create PVC from snapshot")
+		pvcSpec := getPersistentVolumeClaimSpecWithDatasource(namespace, diskSize, storageclass, nil,
+			v1.ReadWriteOnce, volumeSnapshot.Name, snapshotapigroup)
+		pvclaim2, err := fpv.CreatePVC(client, namespace, pvcSpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Expect claim to fail provisioning volume within the topology")
+		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound,
+			client, pvclaim2.Namespace, pvclaim2.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		expectedErrMsg := "failed to get the compatible shared datastore for create volume from snapshot"
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim2.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
+		defer func() {
+			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+	})
+})

--- a/tests/e2e/policy_driven_vol_allocation.go
+++ b/tests/e2e/policy_driven_vol_allocation.go
@@ -1785,7 +1785,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 			snapIDs = append(snapIDs, snapshotId)
 
 			ginkgo.By("Query CNS and check the volume snapshot entry")
-			err = verifySnapshotIsCreatedInCNS(volIds[i], snapshotId)
+			err = verifySnapshotIsCreatedInCNS(volIds[i], snapshotId, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		defer func() {
@@ -3003,7 +3003,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 			}()
 
 			ginkgo.By("Query CNS and check the volume snapshot entry")
-			err = verifySnapshotIsCreatedInCNS(snapToVolIdMap[volumeSnapshot.Name], snapshotId)
+			err = verifySnapshotIsCreatedInCNS(snapToVolIdMap[volumeSnapshot.Name], snapshotId, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 

--- a/tests/e2e/preferential_topology_snapshot.go
+++ b/tests/e2e/preferential_topology_snapshot.go
@@ -81,6 +81,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		csiNamespace                   string
 		sshClientConfig                *ssh.ClientConfig
 		nimbusGeneratedK8sVmPwd        string
+		clientIndex                    int
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -188,6 +189,8 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		//set preferred datatsore time interval
 		setPreferredDatastoreTimeInterval(client, ctx, csiNamespace, namespace, csiReplicas)
+
+		clientIndex = 0
 	})
 
 	ginkgo.AfterEach(func() {
@@ -201,11 +204,11 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		framework.Logf("Perform preferred datastore tags cleanup after test completion")
-		err = deleteTagCreatedForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks)
+		err = deleteTagCreatedForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Recreate preferred datastore tags post cleanup")
-		err = createTagForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks)
+		err = createTagForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -242,12 +245,12 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datastore for volume provisioning in rack-1(cluster-1))")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, false, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			ginkgo.By("Remove preferred datastore tag")
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[0])
+				allowedTopologyRacks[0], false, clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -287,11 +290,11 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		ginkgo.By("Create volume snapshot class, volume snapshot")
 		volumeSnapshot, volumeSnapshotClass, snapshotId := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
-			pvclaim, volHandle, false)
+			pvclaim, volHandle, false, false)
 		defer func() {
 			ginkgo.By("Perform cleanup of snapshot created")
 			performCleanUpForSnapshotCreated(ctx, snapc, namespace, volHandle, volumeSnapshot, snapshotId,
-				volumeSnapshotClass, pandoraSyncWaitTime)
+				volumeSnapshotClass, pandoraSyncWaitTime, false)
 		}()
 
 		ginkgo.By("Create PVC from snapshot")
@@ -332,7 +335,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack1)
+			nonShareddatastoreListMapRack1, false, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
@@ -369,7 +372,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datastore for volume provisioning in rack-2(cluster-2))")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, false, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
@@ -409,26 +412,26 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		ginkgo.By("Create volume snapshot class, volume snapshot")
 		volumeSnapshot, volumeSnapshotClass, snapshotId := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
-			pvclaim, volHandle, false)
+			pvclaim, volHandle, false, false)
 		defer func() {
 			ginkgo.By("Perform cleanup of snapshot created")
 			performCleanUpForSnapshotCreated(ctx, snapc, namespace, volHandle, volumeSnapshot, snapshotId,
-				volumeSnapshotClass, pandoraSyncWaitTime)
+				volumeSnapshotClass, pandoraSyncWaitTime, false)
 		}()
 
 		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-			allowedTopologyRacks[1])
+			allowedTopologyRacks[1], false, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Tag new preferred datatsore for volume provisioning")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack2, preferredDatastorePaths)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, preferredDatastorePaths, false, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			ginkgo.By("Remove preferred datastore tag")
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[1])
+				allowedTopologyRacks[1], false, clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -528,13 +531,13 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		ginkgo.By("Tag different preferred datastore for volume provisioning in different racks")
 		for i := 0; i < len(allowedTopologyRacks); i++ {
 			preferredDatastorePath, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[i],
-				preferredDatastoreChosen, datastorestMap[i], nil)
+				preferredDatastoreChosen, datastorestMap[i], nil, false, clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastorePath...)
 		}
 
 		sharedPreferredDatastorePaths, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, shareddatastoreListMap, nil)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastorePaths = append(preferredDatastorePaths, sharedPreferredDatastorePaths...)
 		for i := 1; i < len(allowedTopologyRacks); i++ {
@@ -545,7 +548,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		defer func() {
 			for i := 0; i < len(allowedTopologyRacks); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, sharedPreferredDatastorePaths[0],
-					allowedTopologyRacks[i])
+					allowedTopologyRacks[i], false, clientIndex)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -673,7 +676,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		for i := 0; i < len(podList); i++ {
 			verifyVolumeProvisioningForStandalonePods(ctx, client, podList[i], namespace,
-				preferredDatastorePaths, allDatastoresListMap)
+				preferredDatastorePaths, allDatastoresListMap, false, nil)
 		}
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
@@ -685,11 +688,11 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		ginkgo.By("Create volume snapshot class, volume snapshot")
 		volumeSnapshot1, volumeSnapshotClass1, snapshotId1 := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
-			pvclaim1, volHandle1, false)
+			pvclaim1, volHandle1, false, false)
 		defer func() {
 			ginkgo.By("Perform cleanup of snapshot created")
 			performCleanUpForSnapshotCreated(ctx, snapc, namespace, volHandle1, volumeSnapshot1, snapshotId1,
-				volumeSnapshotClass1, pandoraSyncWaitTime)
+				volumeSnapshotClass1, pandoraSyncWaitTime, false)
 		}()
 
 		ginkgo.By("Create PVC-3 from snapshot")
@@ -710,7 +713,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Verify snapshot entry is deleted from CNS")
-			err = verifySnapshotIsDeletedInCNS(volHandle3, snapshotId1)
+			err = verifySnapshotIsDeletedInCNS(volHandle3, snapshotId1, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -734,7 +737,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		verifyVolumeProvisioningForStandalonePods(ctx, client, pod3, namespace, preferredDatastorePaths,
-			allDatastoresListMap)
+			allDatastoresListMap, false, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
@@ -744,7 +747,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
 		for i := 0; i < len(allowedTopologyRacks); i++ {
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
-				allowedTopologyRacks[i])
+				allowedTopologyRacks[i], false, clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -752,14 +755,14 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		ginkgo.By("Assign new preferred datastore tags for volume provisioning in different racks")
 		for i := 0; i < len(allowedTopologyRacks); i++ {
 			preferredDatastorePath, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[i],
-				preferredDatastoreChosen, datastorestMap[i], preferredDatastorePaths)
+				preferredDatastoreChosen, datastorestMap[i], preferredDatastorePaths, false, clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			preferredDatastorePathsNew = append(preferredDatastorePathsNew, preferredDatastorePath...)
 		}
 		defer func() {
 			for i := 0; i < len(allowedTopologyRacks); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePathsNew[i],
-					allowedTopologyRacks[i])
+					allowedTopologyRacks[i], false, clientIndex)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
@@ -828,7 +831,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		verifyVolumeProvisioningForStandalonePods(ctx, client, pod4, namespace, preferredDatastorePathsNew,
-			allDatastoresListMap)
+			allDatastoresListMap, false, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
@@ -836,10 +839,10 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 			allowedTopologies, false)
 
 		volumeSnapshot2, volumeSnapshotClass2, snapshotId2 := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
-			pvclaim4, volHandle4, false)
+			pvclaim4, volHandle4, false, false)
 		defer func() {
 			performCleanUpForSnapshotCreated(ctx, snapc, namespace, pv4.Spec.CSI.VolumeHandle, volumeSnapshot2,
-				snapshotId2, volumeSnapshotClass2, pandoraSyncWaitTime)
+				snapshotId2, volumeSnapshotClass2, pandoraSyncWaitTime, false)
 		}()
 
 		ginkgo.By("Create PVC-5 from snapshot")
@@ -880,7 +883,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		verifyVolumeProvisioningForStandalonePods(ctx, client, pod5, namespace, preferredDatastorePathsNew,
-			allDatastoresListMap)
+			allDatastoresListMap, false, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
@@ -921,11 +924,11 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		ginkgo.By("Tag preferred datastore for volume provisioning in rack-3(cluster-3)")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[2],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil, false, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[2])
+				allowedTopologyRacks[2], false, clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -970,7 +973,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack3, false, false)
+			nonShareddatastoreListMapRack3, false, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
@@ -996,11 +999,11 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		ginkgo.By("Create volume snapshot class, volume snapshot")
 		volumeSnapshot, volumeSnapshotClass, snapshotId := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
-			pvclaim3, volHandle3, true)
+			pvclaim3, volHandle3, true, false)
 		defer func() {
 			ginkgo.By("Perform cleanup of snapshot created")
 			performCleanUpForSnapshotCreated(ctx, snapc, namespace, volHandle3, volumeSnapshot, snapshotId,
-				volumeSnapshotClass, pandoraSyncWaitTime)
+				volumeSnapshotClass, pandoraSyncWaitTime, false)
 		}()
 
 		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas-1))
@@ -1044,7 +1047,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack3, false, false)
+			nonShareddatastoreListMapRack3, false, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +

--- a/tests/e2e/preferential_topology_utils.go
+++ b/tests/e2e/preferential_topology_utils.go
@@ -109,24 +109,45 @@ attachTagToPreferredDatastore method is used to attach the  preferred tag to the
 datastore chosen for volume provisioning
 */
 func attachTagToPreferredDatastore(masterIp string, sshClientConfig *ssh.ClientConfig,
-	datastore string, tagName string) error {
-	attachTagCat := govcLoginCmd() +
-		"govc tags.attach -c " + preferredDSCat + " " + tagName + " " + "'" + datastore + "'"
-	framework.Logf("cmd to attach tag to preferred datastore: %s ", attachTagCat)
-	attachTagCatRes, err := sshExec(sshClientConfig, masterIp, attachTagCat)
-	if err != nil && attachTagCatRes.Code != 0 {
-		fssh.LogResult(attachTagCatRes)
-		return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
-			attachTagCat, masterIp, err)
+	datastore string, tagName string, isMultiVC bool, clientIndexForMultiVC int) error {
+	var attachTagCat string
+	if !isMultiVC {
+		attachTagCat = govcLoginCmd() +
+			"govc tags.attach -c " + preferredDSCat + " " + tagName + " " + "'" + datastore + "'"
+		framework.Logf("cmd to attach tag to preferred datastore: %s ", attachTagCat)
+		attachTagCatRes, err := sshExec(sshClientConfig, masterIp, attachTagCat)
+		if err != nil && attachTagCatRes.Code != 0 {
+			fssh.LogResult(attachTagCatRes)
+			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				attachTagCat, masterIp, err)
+		}
+		return nil
+	} else {
+		attachTagCat = govcLoginCmdForMultiVC(clientIndexForMultiVC) +
+			"govc tags.attach -c " + preferredDSCat + " " + tagName + " " + "'" + datastore + "'"
+		framework.Logf("cmd to attach tag to preferred datastore: %s ", attachTagCat)
+		attachTagCatRes, err := sshExec(sshClientConfig, masterIp, attachTagCat)
+		if err != nil && attachTagCatRes.Code != 0 {
+			fssh.LogResult(attachTagCatRes)
+			return fmt.Errorf("couldn't execute command: %s on host: %v , error: %s",
+				attachTagCat, masterIp, err)
+		}
+		return nil
 	}
-	return nil
 }
 
 /* detachTagCreatedOnPreferredDatastore is used to detach the tag created on preferred datastore */
 func detachTagCreatedOnPreferredDatastore(masterIp string, sshClientConfig *ssh.ClientConfig,
-	datastore string, tagName string) error {
-	detachTagCat := govcLoginCmd() +
-		"govc tags.detach -c " + preferredDSCat + " " + tagName + " " + "'" + datastore + "'"
+	datastore string, tagName string, isMultiVCSetup bool, clientIndex int) error {
+	var detachTagCat string
+	if !isMultiVCSetup {
+		detachTagCat = govcLoginCmd() +
+			"govc tags.detach -c " + preferredDSCat + " " + tagName + " " + "'" + datastore + "'"
+
+	} else {
+		detachTagCat = govcLoginCmdForMultiVC(clientIndex) +
+			"govc tags.detach -c " + preferredDSCat + " " + tagName + " " + "'" + datastore + "'"
+	}
 	framework.Logf("cmd to detach the tag assigned to preferred datastore: %s ", detachTagCat)
 	detachTagCatRes, err := sshExec(sshClientConfig, masterIp, detachTagCat)
 	if err != nil && detachTagCatRes.Code != 0 {
@@ -218,7 +239,8 @@ chosen preferred datastore or not for statefulsets
 func verifyVolumeProvisioningForStatefulSet(ctx context.Context,
 	client clientset.Interface, statefulset *appsv1.StatefulSet,
 	namespace string, datastoreNames []string, datastoreListMap map[string]string,
-	multipleAllowedTopology bool, parallelStatefulSetCreation bool) error {
+	multipleAllowedTopology bool, parallelStatefulSetCreation bool,
+	isMultiVCSetup bool, multiVCDsUrls []string) error {
 	counter := 0
 	stsPodCount := 0
 	var dsUrls []string
@@ -229,22 +251,36 @@ func verifyVolumeProvisioningForStatefulSet(ctx context.Context,
 		ssPodsBeforeScaleDown = fss.GetPodList(client, statefulset)
 	}
 	stsPodCount = len(ssPodsBeforeScaleDown.Items)
-	for i := 0; i < len(datastoreNames); i++ {
-		if val, ok := datastoreListMap[datastoreNames[i]]; ok {
-			dsUrls = append(dsUrls, val)
+	if !isMultiVCSetup {
+		for i := 0; i < len(datastoreNames); i++ {
+			if val, ok := datastoreListMap[datastoreNames[i]]; ok {
+				dsUrls = append(dsUrls, val)
+			}
 		}
 	}
 	for _, sspod := range ssPodsBeforeScaleDown.Items {
 		_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		for _, volumespec := range sspod.Spec.Volumes {
+			var isPreferred bool
 			if volumespec.PersistentVolumeClaim != nil {
 				pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
-				isPreferred := e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle, dsUrls)
-				if isPreferred {
-					framework.Logf("volume %s is created on preferred datastore %v", pv.Spec.CSI.VolumeHandle, dsUrls)
-					counter = counter + 1
+				if !isMultiVCSetup {
+					isPreferred = e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle, dsUrls)
+					if isPreferred {
+						framework.Logf("volume %s is created on preferred datastore %v", pv.Spec.CSI.VolumeHandle, dsUrls)
+						counter = counter + 1
+					}
+				} else {
+					isPreferred = multiVCe2eVSphere.verifyPreferredDatastoreMatchInMultiVC(pv.Spec.CSI.VolumeHandle,
+						multiVCDsUrls)
+					if isPreferred {
+						framework.Logf("volume %s is created on preferred datastore %v", pv.Spec.CSI.VolumeHandle,
+							multiVCDsUrls)
+						counter = counter + 1
+					}
 				}
+
 			}
 		}
 	}
@@ -269,7 +305,8 @@ chosen preferred datastore or not for standalone pods
 */
 func verifyVolumeProvisioningForStandalonePods(ctx context.Context,
 	client clientset.Interface, pod *v1.Pod,
-	namespace string, datastoreNames []string, datastoreListMap map[string]string) {
+	namespace string, datastoreNames []string, datastoreListMap map[string]string,
+	isMultiVCSetup bool, multiVCDsUrls []string) {
 	var flag bool = false
 	var dsUrls []string
 	for i := 0; i < len(datastoreNames); i++ {
@@ -280,10 +317,18 @@ func verifyVolumeProvisioningForStandalonePods(ctx context.Context,
 	for _, volumespec := range pod.Spec.Volumes {
 		if volumespec.PersistentVolumeClaim != nil {
 			pv := getPvFromClaim(client, pod.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
-			isPreferred := e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle, dsUrls)
-			if isPreferred {
-				framework.Logf("volume %s is created on preferred datastore %v", pv.Spec.CSI.VolumeHandle, dsUrls)
-				flag = true
+			if !isMultiVCSetup {
+				isPreferred := e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle, dsUrls)
+				if isPreferred {
+					framework.Logf("volume %s is created on preferred datastore %v", pv.Spec.CSI.VolumeHandle, dsUrls)
+					flag = true
+				}
+			} else {
+				isPreferred := multiVCe2eVSphere.verifyPreferredDatastoreMatchInMultiVC(pv.Spec.CSI.VolumeHandle, multiVCDsUrls)
+				if isPreferred {
+					framework.Logf("volume %s is created on preferred datastore %v", pv.Spec.CSI.VolumeHandle, multiVCDsUrls)
+					flag = true
+				}
 			}
 		}
 	}
@@ -301,7 +346,7 @@ func tagSameDatastoreAsPreferenceToDifferentRacks(masterIp string, sshClientConf
 	i := 0
 	for j := 0; j < len(datastoreNames); j++ {
 		i = i + 1
-		err := attachTagToPreferredDatastore(masterIp, sshClientConfig, datastoreNames[j], zoneValue)
+		err := attachTagToPreferredDatastore(masterIp, sshClientConfig, datastoreNames[j], zoneValue, false, 0)
 		if err != nil {
 			return err
 		}
@@ -316,14 +361,22 @@ func tagSameDatastoreAsPreferenceToDifferentRacks(masterIp string, sshClientConf
 tagPreferredDatastore method is used to tag the datastore which is chosen for volume provisioning
 */
 func tagPreferredDatastore(masterIp string, sshClientConfig *ssh.ClientConfig, zoneValue string, itr int,
-	datastoreListMap map[string]string, datastoreNames []string) ([]string, error) {
+	datastoreListMap map[string]string, datastoreNames []string,
+	isMultiVCSetup bool, clientIndex int) ([]string, error) {
 	var preferredDatastorePaths []string
+	var err error
 	i := 0
 	if datastoreNames == nil {
 		for dsName := range datastoreListMap {
 			i = i + 1
 			preferredDatastorePaths = append(preferredDatastorePaths, dsName)
-			err := attachTagToPreferredDatastore(masterIp, sshClientConfig, dsName, zoneValue)
+			if !isMultiVCSetup {
+				err = attachTagToPreferredDatastore(masterIp, sshClientConfig, dsName, zoneValue,
+					false, clientIndex)
+			} else {
+				err = attachTagToPreferredDatastore(masterIp, sshClientConfig, dsName, zoneValue,
+					true, clientIndex)
+			}
 			if err != nil {
 				return preferredDatastorePaths, err
 			}
@@ -336,7 +389,13 @@ func tagPreferredDatastore(masterIp string, sshClientConfig *ssh.ClientConfig, z
 		for dsName := range datastoreListMap {
 			if !slices.Contains(datastoreNames, dsName) {
 				preferredDatastorePaths = append(preferredDatastorePaths, dsName)
-				err := attachTagToPreferredDatastore(masterIp, sshClientConfig, dsName, zoneValue)
+				if !isMultiVCSetup {
+					err = attachTagToPreferredDatastore(masterIp, sshClientConfig, dsName, zoneValue,
+						false, clientIndex)
+				} else {
+					err = attachTagToPreferredDatastore(masterIp, sshClientConfig, dsName, zoneValue,
+						true, clientIndex)
+				}
 				if err != nil {
 					return preferredDatastorePaths, err
 				}
@@ -407,10 +466,15 @@ func getNonSharedDatastoresInCluster(ClusterdatastoreListMap map[string]string,
 }
 
 // deleteTagCreatedForPreferredDatastore method is used to delete the tag created on preferred datastore
-func deleteTagCreatedForPreferredDatastore(masterIp string, sshClientConfig *ssh.ClientConfig, tagName []string) error {
+func deleteTagCreatedForPreferredDatastore(masterIp string, sshClientConfig *ssh.ClientConfig,
+	tagName []string, isMultiVcSetup bool) error {
+	var deleteTagCat string
 	for i := 0; i < len(tagName); i++ {
-		deleteTagCat := govcLoginCmd() +
-			"govc tags.rm -f -c " + preferredDSCat + " " + tagName[i]
+		if !isMultiVcSetup {
+			deleteTagCat = govcLoginCmd() + "govc tags.rm -f -c " + preferredDSCat + " " + tagName[i]
+		} else {
+			deleteTagCat = govcLoginCmdForMultiVC(i) + "govc tags.rm -f -c " + preferredDSCat + " " + tagName[i]
+		}
 		framework.Logf("Deleting tag created for preferred datastore: %s ", deleteTagCat)
 		deleteTagCatRes, err := sshExec(sshClientConfig, masterIp, deleteTagCat)
 		if err != nil && deleteTagCatRes.Code != 0 {
@@ -423,10 +487,18 @@ func deleteTagCreatedForPreferredDatastore(masterIp string, sshClientConfig *ssh
 }
 
 // createTagForPreferredDatastore method is used to create tag required for choosing preferred datastore
-func createTagForPreferredDatastore(masterIp string, sshClientConfig *ssh.ClientConfig, tagName []string) error {
+func createTagForPreferredDatastore(masterIp string, sshClientConfig *ssh.ClientConfig,
+	tagName []string, isMultiVCSetup bool) error {
+	var createTagCat string
 	for i := 0; i < len(tagName); i++ {
-		createTagCat := govcLoginCmd() +
-			"govc tags.create -d '" + preferredTagDesc + "' -c " + preferredDSCat + " " + tagName[i]
+		if !isMultiVCSetup {
+			createTagCat = govcLoginCmd() +
+				"govc tags.create -d '" + preferredTagDesc + "' -c " + preferredDSCat + " " + tagName[i]
+		} else {
+			createTagCat = govcLoginCmdForMultiVC(i) +
+				"govc tags.create -d '" + preferredTagDesc + "' -c " + preferredDSCat + " " + tagName[i]
+			framework.Logf(createTagCat)
+		}
 		framework.Logf("Creating tag for preferred datastore: %s ", createTagCat)
 		createTagCatRes, err := sshExec(sshClientConfig, masterIp, createTagCat)
 		if err != nil && createTagCatRes.Code != 0 {
@@ -444,7 +516,7 @@ volume snapshot and to verify if volume snapshot has created or not
 */
 func createSnapshotClassAndVolSnapshot(ctx context.Context, snapc *snapclient.Clientset,
 	namespace string, pvclaim *v1.PersistentVolumeClaim,
-	volHandle string, stsPvc bool) (*snapV1.VolumeSnapshot, *snapV1.VolumeSnapshotClass, string) {
+	volHandle string, stsPvc bool, isMultiVCSetup bool) (*snapV1.VolumeSnapshot, *snapV1.VolumeSnapshotClass, string) {
 
 	framework.Logf("Create volume snapshot class")
 	volumeSnapshotClass, err := snapc.SnapshotV1().VolumeSnapshotClasses().Create(ctx,
@@ -477,8 +549,13 @@ func createSnapshotClassAndVolSnapshot(ctx context.Context, snapc *snapclient.Cl
 	snapshotId := strings.Split(snapshothandle, "+")[1]
 
 	framework.Logf("Query CNS and check the volume snapshot entry")
-	err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	if !isMultiVCSetup {
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	} else {
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
 
 	return volumeSnapshot, volumeSnapshotClass, snapshotId
 }
@@ -489,7 +566,7 @@ snapshot class, volume snapshot created for pvc post testcase completion
 */
 func performCleanUpForSnapshotCreated(ctx context.Context, snapc *snapclient.Clientset,
 	namespace string, volHandle string, volumeSnapshot *snapV1.VolumeSnapshot, snapshotId string,
-	volumeSnapshotClass *snapV1.VolumeSnapshotClass, pandoraSyncWaitTime int) {
+	volumeSnapshotClass *snapV1.VolumeSnapshotClass, pandoraSyncWaitTime int, isMultiVCSetup bool) {
 
 	framework.Logf("Delete volume snapshot and verify the snapshot content is deleted")
 	deleteVolumeSnapshotWithPandoraWait(ctx, snapc, namespace, volumeSnapshot.Name, pandoraSyncWaitTime)
@@ -498,9 +575,15 @@ func performCleanUpForSnapshotCreated(ctx context.Context, snapc *snapclient.Cli
 	err := waitForVolumeSnapshotContentToBeDeleted(*snapc, ctx, *volumeSnapshot.Status.BoundVolumeSnapshotContentName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	framework.Logf("Verify snapshot entry is deleted from CNS")
-	err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	if !isMultiVCSetup {
+		framework.Logf("Verify snapshot entry is deleted from CNS")
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	} else {
+		framework.Logf("Verify snapshot entry is deleted from CNS")
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
 
 	framework.Logf("Deleting volume snapshot Again to check Not found error")
 	deleteVolumeSnapshotWithPandoraWait(ctx, snapc, namespace, volumeSnapshot.Name, pandoraSyncWaitTime)

--- a/tests/e2e/svmotion_volumes.go
+++ b/tests/e2e/svmotion_volumes.go
@@ -1355,7 +1355,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Re
 		}()
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volumeID, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volumeID, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify the data on the PVCs match what was written in step 7")

--- a/tests/e2e/topology_snapshot.go
+++ b/tests/e2e/topology_snapshot.go
@@ -235,7 +235,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		_, err = snapc.SnapshotV1().VolumeSnapshotContents().Get(ctx,
@@ -299,7 +299,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		snapshotContentCreated = false
 
 		ginkgo.By("Verify snapshot entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Deleting volume snapshot Again to check Not found error")
@@ -443,7 +443,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		snapshotId2 := strings.Split(snapshothandle3, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle3, snapshotId2)
+		err = verifySnapshotIsCreatedInCNS(volHandle3, snapshotId2, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		pvcSpec := getPersistentVolumeClaimSpecWithDatasource(namespace, "1Gi", storageclass, nil,
@@ -486,7 +486,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		snapshotContentCreated = false
 
 		ginkgo.By("Verify snapshot  entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle3, snapshotId2)
+		err = verifySnapshotIsDeletedInCNS(volHandle3, snapshotId2, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -141,10 +141,16 @@ func (vs *vSphere) queryCNSVolumeSnapshotWithResult(fcdID string,
 }
 
 // verifySnapshotIsDeletedInCNS verifies the snapshotId's presence on CNS
-func verifySnapshotIsDeletedInCNS(volumeId string, snapshotId string) error {
+func verifySnapshotIsDeletedInCNS(volumeId string, snapshotId string, isMultiVCSetup bool) error {
 	ginkgo.By(fmt.Sprintf("Invoking queryCNSVolumeSnapshotWithResult with VolumeID: %s and SnapshotID: %s",
 		volumeId, snapshotId))
-	querySnapshotResult, err := e2eVSphere.queryCNSVolumeSnapshotWithResult(volumeId, snapshotId)
+	var querySnapshotResult *cnstypes.CnsSnapshotQueryResult
+	var err error
+	if !isMultiVCSetup {
+		querySnapshotResult, err = e2eVSphere.queryCNSVolumeSnapshotWithResult(volumeId, snapshotId)
+	} else {
+		querySnapshotResult, err = multiVCe2eVSphere.queryCNSVolumeSnapshotWithResultInMultiVC(volumeId, snapshotId)
+	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	ginkgo.By(fmt.Sprintf("Task result is %+v", querySnapshotResult))
 	gomega.Expect(querySnapshotResult.Entries).ShouldNot(gomega.BeEmpty())
@@ -156,10 +162,16 @@ func verifySnapshotIsDeletedInCNS(volumeId string, snapshotId string) error {
 }
 
 // verifySnapshotIsCreatedInCNS verifies the snapshotId's presence on CNS
-func verifySnapshotIsCreatedInCNS(volumeId string, snapshotId string) error {
+func verifySnapshotIsCreatedInCNS(volumeId string, snapshotId string, isMultiVC bool) error {
 	ginkgo.By(fmt.Sprintf("Invoking queryCNSVolumeSnapshotWithResult with VolumeID: %s and SnapshotID: %s",
 		volumeId, snapshotId))
-	querySnapshotResult, err := e2eVSphere.queryCNSVolumeSnapshotWithResult(volumeId, snapshotId)
+	var querySnapshotResult *cnstypes.CnsSnapshotQueryResult
+	var err error
+	if !isMultiVC {
+		querySnapshotResult, err = e2eVSphere.queryCNSVolumeSnapshotWithResult(volumeId, snapshotId)
+	} else {
+		querySnapshotResult, err = multiVCe2eVSphere.queryCNSVolumeSnapshotWithResultInMultiVC(volumeId, snapshotId)
+	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	ginkgo.By(fmt.Sprintf("Task result is %+v", querySnapshotResult))
 	gomega.Expect(querySnapshotResult.Entries).ShouldNot(gomega.BeEmpty())


### PR DESCRIPTION
Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

Multi-VC:  Preferential-Topology and Snapshot-Topology different testcaes coverage automation

This PR holds the testcases of preferential datastore and snapshot related testcases on a multi-vc setup

Testing done:
Yes

https://gist.github.com/sipriyaa/692ae0a4bd5e751f7418aadb4a7c29d8

Preferential Topology test results -
https://gist.github.com/sipriyaa/9933ac815adb8503dd939806e01fd2d1

Snapshot Block Vanilla test results -
https://gist.github.com/sipriyaa/f0e2ea07cc55f62b30baa75f869e4d34

