### PR TITLE
Fix shared datastore selection for vanilla

### DIFF
--- a/pkg/common/cns-lib/vsphere/cluster_compute_resource.go
+++ b/pkg/common/cns-lib/vsphere/cluster_compute_resource.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+// ClusterComputeResource holds details of a cluster instance.
+type ClusterComputeResource struct {
+	// ClusterComputeResource represents a vSphere cluster.
+	*object.ClusterComputeResource
+	// VirtualCenterHost denotes the virtual center host address.
+	VirtualCenterHost string
+}
+
+// GetHosts fetches the hosts under the ClusterComputeResource.
+func (ccr *ClusterComputeResource) GetHosts(ctx context.Context) ([]*HostSystem, error) {
+	log := logger.GetLogger(ctx)
+	cluster := mo.ClusterComputeResource{}
+	err := ccr.Properties(ctx, ccr.Reference(), []string{"host"}, &cluster)
+	if err != nil {
+		return nil, logger.LogNewErrorf(log,
+			"failed to retrieve host property for cluster %+v", ccr.Reference())
+	}
+	var hostList []*HostSystem
+	for _, host := range cluster.Host {
+		hostList = append(hostList, &HostSystem{HostSystem: object.NewHostSystem(ccr.Client(), host)})
+	}
+	return hostList, nil
+}

--- a/pkg/common/cns-lib/vsphere/hostsystem.go
+++ b/pkg/common/cns-lib/vsphere/hostsystem.go
@@ -19,6 +19,7 @@ package vsphere
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 
@@ -28,6 +29,8 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
+
+var ErrNoSharedDSFound = errors.New("no shared datastores found among given hosts")
 
 // HostSystem holds details of a host instance.
 type HostSystem struct {
@@ -40,8 +43,7 @@ type HostSystem struct {
 func (host *HostSystem) GetAllAccessibleDatastores(ctx context.Context) ([]*DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
 	var hostSystemMo mo.HostSystem
-	s := object.NewSearchIndex(host.Client())
-	err := s.Properties(ctx, host.Reference(), []string{"datastore"}, &hostSystemMo)
+	err := host.Properties(ctx, host.Reference(), []string{"datastore"}, &hostSystemMo)
 	if err != nil {
 		log.Errorf("failed to retrieve datastores for host %v with err: %v", host, err)
 		return nil, err
@@ -181,4 +183,39 @@ func (host *HostSystem) GetHostVsanCapacity(ctx context.Context) (*VsanHostCapac
 		out.CapacityUsed += disk.CapacityUsed
 	}
 	return &out, nil
+}
+
+// GetSharedDatastoresForHosts returns shared datastores accessible to hosts mentioned in the input parameter.
+func GetSharedDatastoresForHosts(ctx context.Context, hosts []*HostSystem) ([]*DatastoreInfo, error) {
+	log := logger.GetLogger(ctx)
+	var sharedDatastores []*DatastoreInfo
+
+	for _, host := range hosts {
+		accessibleDatastores, err := host.GetAllAccessibleDatastores(ctx)
+		if err != nil {
+			return nil, logger.LogNewErrorf(log, "failed to fetch datastores from host %+v. Error: %+v",
+				host, err)
+		}
+		if len(sharedDatastores) == 0 {
+			sharedDatastores = accessibleDatastores
+		} else {
+			var sharedAccessibleDatastores []*DatastoreInfo
+			for _, sharedDs := range sharedDatastores {
+				// Check if sharedDatastores is found in accessibleDatastores.
+				for _, accessibleDs := range accessibleDatastores {
+					// Intersection is performed based on the datastoreUrl as this
+					// uniquely identifies the datastore.
+					if accessibleDs.Info.Url == sharedDs.Info.Url {
+						sharedAccessibleDatastores = append(sharedAccessibleDatastores, sharedDs)
+						break
+					}
+				}
+			}
+			sharedDatastores = sharedAccessibleDatastores
+		}
+		if len(sharedDatastores) == 0 {
+			return nil, ErrNoSharedDSFound
+		}
+	}
+	return sharedDatastores, nil
 }

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1552,7 +1552,7 @@ func (c *controller) calculateAccessibleTopologiesForDatastore(ctx context.Conte
 	log := logger.GetLogger(ctx)
 	var datastoreAccessibleTopology []map[string]string
 
-	// Find out all nodes which have access to the chosen datastore.
+	// Find out all nodeVMs which have access to the chosen datastore among all the nodes in k8s cluster.
 	accessibleNodes, err := common.GetNodeVMsWithAccessToDatastore(ctx, vcenter, datastoreURL, allNodeVMs)
 	if err != nil || len(accessibleNodes) == 0 {
 		return nil, logger.LogNewErrorCodef(log, codes.Internal,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: On a volume provisioning request, the vSphere CSI driver looks for a shared, accessible datastore that can be accessed by all nodes in the Kubernetes cluster. To determine which datastore can be accessed by all nodes, the vSphere Container Storage Plug-in identifies the ESXi hosts where the nodes are placed. It then identifies the datastores that are mounted on those ESXi hosts. 
However, if the nodes are not distributed across all ESXi hosts in the vSphere cluster and are instead placed on a subset of ESXi hosts, and if that subset of ESXi hosts has some shared datastores, the volume might get provisioned on those datastores. Later, when you add a new node to another ESXi host that does not have access to the shared datastore accessible to the subset of ESXi hosts, the provisioned volume cannot be used on the newly added node.
This situation also applies to topology-aware setups.

To avoid this issue, this PR improves the logic of shared datastore selection. With this PR, the datastores accessible to all the hosts in the vSphere cluster where the K8s cluster is deployed will be the potential candidates for volume provisioning. Datastores which are accessible to a subset of the hosts in the vSphere cluster will not be selected.
In a topology aware setup, the datastore selection can be illustrated with the following examples: 
 1. If the volume is requested on `zone1` which is applied on a vSphere Cluster, the vSphere CSI driver will select datastores accessible to **all** the hosts under this cluster if at least one K8s nodeVM is present in `zone1` availability zone (AZ). If an AZ doesn't have any K8s nodeVMs associated with it, volume provisioning will fail for this AZ. 
 2. If the volume is requested on `zone1` which spans over 2 clusters i.e Cluster1, Cluster2, the vSphere CSI driver will select datastores accessible to all the hosts in Cluster1 & Cluster2 combined.
 3. If the volume is requested on `zone2` which spans over a datacenter, the vSphere CSI driver will select datastores accessible to all the hosts under this datacenter (even if it is present on 
 4. If the volume is requested on `zone3` which is applied on a HostSystem, the vSphere CSI driver will select all datastores accessible to that host.
 5. If the volume is requested on `region1` which is applied on a datacenter and there are 2 zones (zone1, zone2) present under it, both representing a cluster. The vSphere CSI driver will choose any of the following datastores:
     i. accessible to all the hosts under zone1 OR
     ii. accessible to all the hosts under zone2 OR
    iii. accessible to all the hosts under zone1 & zone2 combined

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran Vanilla block volume & Multi-VC regression pipelines.

Logs for CreateVolume with immediate volume binding mode SC in a 2 level topology testbed:
```
2023-08-04T23:45:14.299Z	INFO	vanilla/controller.go:1794	CreateVolume: called with args {Name:pvc-88e1c707-7ced-4cd6-8ba8-eaeceba53335 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"failure-domain.beta.kubernetes.io/region" value:"region-domain-c12-208" > segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"zone-domain-c12-208" > > requisite:<segments:<key:"failure-domain.beta.kubernetes.io/region" value:"region-domain-c10-208" > segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"zone-domain-c10-208" > > requisite:<segments:<key:"failure-domain.beta.kubernetes.io/region" value:"region-domain-c8-208" > segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"zone-domain-c8-208" > > preferred:<segments:<key:"failure-domain.beta.kubernetes.io/region" value:"region-domain-c12-208" > segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"zone-domain-c12-208" > > preferred:<segments:<key:"failure-domain.beta.kubernetes.io/region" value:"region-domain-c8-208" > segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"zone-domain-c8-208" > > preferred:<segments:<key:"failure-domain.beta.kubernetes.io/region" value:"region-domain-c10-208" > segments:<key:"failure-domain.beta.kubernetes.io/zone" value:"zone-domain-c10-208" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.310Z	INFO	config/config.go:404	No Net Permissions given in Config. Using default permissions.	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.316Z	INFO	placementengine/placement.go:27	GetSharedDatastores called with policyID: "" , Topology Segment List: [map[failure-domain.beta.kubernetes.io/region:region-domain-c12-208 failure-domain.beta.kubernetes.io/zone:zone-domain-c12-208] map[failure-domain.beta.kubernetes.io/region:region-domain-c8-208 failure-domain.beta.kubernetes.io/zone:zone-domain-c8-208] map[failure-domain.beta.kubernetes.io/region:region-domain-c10-208 failure-domain.beta.kubernetes.io/zone:zone-domain-c10-208]]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.319Z	INFO	config/config.go:404	No Net Permissions given in Config. Using default permissions.	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.324Z	INFO	placementengine/placement.go:67	TopologySegments expanded as: [map[failure-domain.beta.kubernetes.io/region:region-domain-c12-208 failure-domain.beta.kubernetes.io/zone:zone-domain-c12-208]]	{"TraceId": ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.324Z	INFO	common/topology.go:148	Tag "zone-domain-c12-208" is applied on entities [{Type:HostSystem Value:host-78} {Type:HostSystem Value:host-66} {Type:HostSystem Value:host-72}]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.324Z	INFO	common/topology.go:148	Tag "region-domain-c12-208" is applied on entities [{Type:ClusterComputeResource Value:domain-c12}]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.375Z	INFO	placementengine/placement.go:86	Obtained list of shared datastores [Datastore: Datastore:datastore-116, datastore URL: ds:///vmfs/volumes/vsan:52f013d1fff22e08-a9903f31f721b95c/ Datastore: Datastore:datastore-98, datastore URL: ds:///vmfs/volumes/8ace86e5-87cc7b10/] for hosts [HostSystem:host-78 HostSystem:host-66 HostSystem:host-72]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.376Z	INFO	config/config.go:404	No Net Permissions given in Config. Using default permissions.	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.396Z	INFO	config/config.go:404	No Net Permissions given in Config. Using default permissions.	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.411Z	INFO	config/config.go:404	No Net Permissions given in Config. Using default permissions.	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.435Z	INFO	config/config.go:404	No Net Permissions given in Config. Using default permissions.	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.443Z	INFO	config/config.go:404	No Net Permissions given in Config. Using default permissions.	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.449Z	INFO	config/config.go:404	No Net Permissions given in Config. Using default permissions.	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.454Z	INFO	placementengine/placement.go:67	TopologySegments expanded as: [map[failure-domain.beta.kubernetes.io/region:region-domain-c8-208 failure-domain.beta.kubernetes.io/zone:zone-domain-c8-208]]	{"TraceId": ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.454Z	INFO	common/topology.go:148	Tag "region-domain-c8-208" is applied on entities [{Type:ClusterComputeResource Value:domain-c8}]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.454Z	INFO	common/topology.go:148	Tag "zone-domain-c8-208" is applied on entities [{Type:HostSystem Value:host-18} {Type:HostSystem Value:host-24} {Type:HostSystem Value:host-30} {Type:HostSystem Value:host-36} {Type:HostSystem Value:host-42}]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.527Z	INFO	placementengine/placement.go:86	Obtained list of shared datastores [Datastore: Datastore:datastore-115, datastore URL: ds:///vmfs/volumes/vsan:528979c71fcbbc1b-8fbd65dfdabd7121/ Datastore: Datastore:datastore-81, datastore URL: ds:///vmfs/volumes/1d8d3be9-d64976ad/] for hosts [HostSystem:host-18 HostSystem:host-24 HostSystem:host-30 HostSystem:host-36 HostSystem:host-42]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.528Z	INFO	config/config.go:404	No Net Permissions given in Config. Using default permissions.	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.532Z	INFO	config/config.go:404	No Net Permissions given in Config. Using default permissions.	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.536Z	INFO	placementengine/placement.go:67	TopologySegments expanded as: [map[failure-domain.beta.kubernetes.io/region:region-domain-c10-208 failure-domain.beta.kubernetes.io/zone:zone-domain-c10-208]]	{"TraceId": ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.536Z	INFO	common/topology.go:148	Tag "zone-domain-c10-208" is applied on entities [{Type:HostSystem Value:host-48} {Type:HostSystem Value:host-54} {Type:HostSystem Value:host-60}]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.536Z	INFO	common/topology.go:148	Tag "region-domain-c10-208" is applied on entities [{Type:ClusterComputeResource Value:domain-c10}]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.560Z	INFO	placementengine/placement.go:86	Obtained list of shared datastores [Datastore: Datastore:datastore-111, datastore URL: ds:///vmfs/volumes/vsan:52282eeeee9d6daa-f3e2688b023eb5e6/ Datastore: Datastore:datastore-95, datastore URL: ds:///vmfs/volumes/71bf661f-f5671e19/] for hosts [HostSystem:host-48 HostSystem:host-54 HostSystem:host-60]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.560Z	INFO	placementengine/placement.go:165	Shared compatible datastores being considered for volume provisioning on vCenter: ["Datastore: Datastore:datastore-116, datastore URL: ds:///vmfs/volumes/vsan:52f013d1fff22e08-a9903f31f721b95c/" "Datastore: Datastore:datastore-98, datastore URL: ds:///vmfs/volumes/8ace86e5-87cc7b10/" "Datastore: Datastore:datastore-115, datastore URL: ds:///vmfs/volumes/vsan:528979c71fcbbc1b-8fbd65dfdabd7121/" "Datastore: Datastore:datastore-81, datastore URL: ds:///vmfs/volumes/1d8d3be9-d64976ad/" "Datastore: Datastore:datastore-111, datastore URL: ds:///vmfs/volumes/vsan:52282eeeee9d6daa-f3e2688b023eb5e6/" "Datastore: Datastore:datastore-95, datastore URL: ds:///vmfs/volumes/71bf661f-f5671e19/"] are: 10.193.45.4	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.561Z	INFO	vsphere/utils.go:585	Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-116, datastore URL: ds:///vmfs/volumes/vsan:52f013d1fff22e08-a9903f31f721b95c/ Datastore: Datastore:datastore-98, datastore URL: ds:///vmfs/volumes/8ace86e5-87cc7b10/ Datastore: Datastore:datastore-115, datastore URL: ds:///vmfs/volumes/vsan:528979c71fcbbc1b-8fbd65dfdabd7121/ Datastore: Datastore:datastore-81, datastore URL: ds:///vmfs/volumes/1d8d3be9-d64976ad/ Datastore: Datastore:datastore-111, datastore URL: ds:///vmfs/volumes/vsan:52282eeeee9d6daa-f3e2688b023eb5e6/ Datastore: Datastore:datastore-95, datastore URL: ds:///vmfs/volumes/71bf661f-f5671e19/]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.563Z	INFO	config/config.go:404	No Net Permissions given in Config. Using default permissions.	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.829Z	INFO	volume/listview.go:120	AddTask called for Task:task-788	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:14.868Z	INFO	volume/listview.go:134	task Task:task-788 added to listView	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:41.964Z	INFO	volume/listview.go:148	task Task:task-788 removed from listView	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:41.964Z	INFO	volume/manager.go:409	CreateVolume: VolumeName: "pvc-88e1c707-7ced-4cd6-8ba8-eaeceba53335", opId: "8c65cf32"	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:41.970Z	INFO	volume/util.go:326	Volume created successfully. VolumeName: "pvc-88e1c707-7ced-4cd6-8ba8-eaeceba53335", volumeID: "bfafbb93-dfc3-4415-96f9-ef1fc650caa7"	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:41.996Z	INFO	vanilla/controller.go:1363	volume "bfafbb93-dfc3-4415-96f9-ef1fc650caa7" created in vCenter "10.193.45.4". Proceeding to calculate accessible topology for the volume	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:41.997Z	INFO	config/config.go:404	No Net Permissions given in Config. Using default permissions.	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:42.061Z	INFO	common/vsphereutil.go:1161	Nodes that have access to datastore "ds:///vmfs/volumes/vsan:528979c71fcbbc1b-8fbd65dfdabd7121/" are [VirtualMachine:vm-124 VirtualMachine:vm-127 VirtualMachine:vm-132 VirtualMachine:vm-123 VirtualMachine:vm-125 VirtualMachine:vm-126]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:42.090Z	INFO	placementengine/placement.go:301	Topology segments retrieved from nodes accessible to datastore "ds:///vmfs/volumes/vsan:528979c71fcbbc1b-8fbd65dfdabd7121/" are: [map[failure-domain.beta.kubernetes.io/region:region-domain-c8-208 failure-domain.beta.kubernetes.io/zone:zone-domain-c8-208]]	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
2023-08-04T23:45:42.090Z	INFO	vanilla/controller.go:1859	Volume created successfully. Volume Handle: "bfafbb93-dfc3-4415-96f9-ef1fc650caa7", PV Name: "pvc-88e1c707-7ced-4cd6-8ba8-eaeceba53335"	{"TraceId": "ef6d6712-8c72-4bae-aafe-9a309961e6fd"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
6. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix shared datastore selection for vanilla
```
