### PR TITLE
supervisor: re-read config before creating vc client

### DIFF
--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -164,6 +164,11 @@ func (l *ListViewImpl) isClientValid() error {
 	} else if userSession != nil {
 		return nil
 	}
+
+	err := cnsvsphere.ReadVCConfigs(l.ctx, l.virtualCenter)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to read VC config. err: %v", err)
+	}
 	// If session has expired, create a new instance.
 	useragent, err := config.GetSessionUserAgent(l.ctx)
 	if err != nil {

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -645,11 +645,17 @@ func (m *defaultManager) initListView() error {
 		}
 	}
 
+	err := cnsvsphere.ReadVCConfigs(ctx, m.virtualCenter)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to read VC config. err: %v", err)
+	}
+
 	useragent, err := config.GetSessionUserAgent(ctx)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to get useragent for vCenter session. error: %+v", err)
 	}
 	useragent = useragent + "-listview"
+
 	govmomiClient, err := m.virtualCenter.NewClient(ctx, useragent)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to create a separate govmomi client for listView. error: %+v", err)

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -129,6 +129,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		log.Errorf("failed to get VirtualCenterConfig. err=%v", err)
 		return err
 	}
+	vcenterconfig.ReloadVCConfigForNewClient = true
 	vcManager := cnsvsphere.GetVirtualCenterManager(ctx)
 	vcenter, err := vcManager.RegisterVirtualCenter(ctx, vcenterconfig)
 	if err != nil {
@@ -243,8 +244,8 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 							log.Infof("Successfully reloaded configuration from: %q", cfgPath)
 							break
 						}
-						log.Errorf("failed to reload configuration. will retry again in 5 seconds. err: %+v", reloadConfigErr)
-						time.Sleep(5 * time.Second)
+						log.Errorf("failed to reload configuration. will retry again in 60 seconds. err: %+v", reloadConfigErr)
+						time.Sleep(60 * time.Second)
 					}
 				}
 				// Handling create event for reconnecting to VC when ca file is
@@ -322,6 +323,7 @@ func (c *controller) ReloadConfiguration(reconnectToVCFromNewConfig bool) error 
 		return err
 	}
 	if newVCConfig != nil {
+		newVCConfig.ReloadVCConfigForNewClient = true
 		var vcenter *cnsvsphere.VirtualCenter
 		if c.manager.VcenterConfig.Host != newVCConfig.Host ||
 			c.manager.VcenterConfig.Username != newVCConfig.Username ||

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -248,6 +248,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		if err != nil {
 			return err
 		}
+		vCenter.Config.ReloadVCConfigForNewClient = true
 		metadataSyncer.host = vCenter.Config.Host
 
 		cnsDeletionMap[metadataSyncer.host] = make(map[string]bool)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Recently, we found CSI pods going into CLBO for cases like b2b upgrades and backup & restore in VC with multiple supervisors. 
Often, there's a delay in wcpsvc rotating the service account credentials in VC and updating the same in the `vsphere-config-secret`. In these cases, we've seen CSI attempting to create govmomi client with the same old credentials and failing repeatedly. In this loop, we don't end up reading the new credentials as we haven't processed an fsnotify event yet. 

This change will make sure we are reading the new config every time we attempt to create a new govmomi client. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
vpxd restart, backup & restore -> https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2489#issuecomment-1671856159

wcp-precheckin -> https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2489#issuecomment-1672187631

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
supervisor: re-read config before creating vc client
```
