### PR TITLE
fix: return err instead of nil in ListVolumes

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1437,7 +1437,7 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 		prometheus.CsiControlOpsHistVec.WithLabelValues(volumeType, prometheus.PrometheusListVolumeOpType,
 			prometheus.PrometheusPassStatus, faultType).Observe(time.Since(start).Seconds())
 	}
-	return resp, nil
+	return resp, err
 }
 
 func (c *controller) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1634 returns `nil` instead of returning the actual `err` var in the `ListVolumes` method. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2497#issuecomment-1673904027

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix: return err instead of nil in ListVolumes
```
