### PR TITLE
Bugfix for supporting folder type during volume provisioning in topology

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -401,7 +401,7 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 	}
 	if cfg.NetPermissions == nil {
 		// If no net permissions are given, assume default.
-		log.Info("No Net Permissions given in Config. Using default permissions.")
+		log.Debug("No Net Permissions given in Config. Using default permissions.")
 		if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 			cfg.NetPermissions = map[string]*NetPermissionConfig{"#": GetDefaultNetPermission()}
 		}

--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -24,8 +24,8 @@ func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
 	params := reqParams.(VanillaSharedDatastoresParams)
 	nodeMgr := node.GetManager(ctx)
 
-	log.Infof("GetSharedDatastores called with policyID: %q , Topology Segment List: %v",
-		params.StoragePolicyID, params.TopologySegmentsList)
+	log.Infof("GetSharedDatastores called for VC %q with policyID: %q , Topology Segment List: %v",
+		params.Vcenter.Config.Host, params.StoragePolicyID, params.TopologySegmentsList)
 	var sharedDatastores []*cnsvsphere.DatastoreInfo
 	// Iterate through each set of topology segments and find shared datastores for that segment.
 	/* For example, if the topology environment is as follows:
@@ -64,7 +64,7 @@ func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
 				reqSegment)
 			continue
 		}
-		log.Infof("TopologySegments expanded as: %+v", completeTopologySegments)
+		log.Infof("TopologySegment %+v expanded as: %+v", reqSegment, completeTopologySegments)
 		// For each segment in the complete topology segments hierarchy, get the matching hosts.
 		for _, segment := range completeTopologySegments {
 			hostMoRefs, err := common.GetHostsForSegment(ctx, segment, params.Vcenter)

--- a/pkg/csi/service/common/topology.go
+++ b/pkg/csi/service/common/topology.go
@@ -163,11 +163,11 @@ func GetHostsForSegment(ctx context.Context, topoSegment map[string]string, vCen
 				}
 				for _, childType := range folder.ChildType {
 					switch childType {
-					case "vim.Datacenter":
+					case "Datacenter":
 						entityPref = 2
-					case "vim.ComputeResource":
+					case "ComputeResource":
 						entityPref = 4
-					case "vim.Folder":
+					case "Folder":
 						continue
 					default:
 						return nil, logger.LogNewErrorf(log, "unrecognised childType for Folder %+v",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Volume provisioning workflow is broken if the topology discovery path has a Folder type in it. This PR fixes that issue.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested creating volumes on a 5 level topology testbed.

SC:
```
Name:                  sc-5xfzg
IsDefaultClass:        No
Annotations:           <none>
Provisioner:           csi.vsphere.vmware.com
Parameters:            <none>
AllowVolumeExpansion:  False
MountOptions:          <none>
ReclaimPolicy:         Delete
VolumeBindingMode:     Immediate
AllowedTopologies:     
  Term 0:              topology.csi.vmware.com/k8s-region in [region-1]
                       topology.csi.vmware.com/k8s-zone in [zone-1]
                       topology.csi.vmware.com/k8s-building in [building-1]
                       topology.csi.vmware.com/k8s-level in [level-1]
                       topology.csi.vmware.com/k8s-rack in [rack-1, rack-2, rack-3]
Events:                <none>
```

PVC:
```
Name:          rack3-pvc
Namespace:     default
StorageClass:  sc-79d2m
Status:        Bound
Volume:        pvc-33b6b325-4bc2-4175-a5b7-dd326d9005a8
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                  From                                                                                                 Message
  ----    ------                 ----                 ----                                                                                                 -------
  Normal  Provisioning           9m48s                csi.vsphere.vmware.com_vsphere-csi-controller-58cc87b78d-7k4qq_be439db7-ebca-4dda-8f9c-5b6325bf9e48  External provisioner is provisioning volume for claim "default/rack3-pvc"
  Normal  ExternalProvisioning   9m23s (x5 over 10m)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  ProvisioningSucceeded  9m15s                csi.vsphere.vmware.com_vsphere-csi-controller-58cc87b78d-7k4qq_be439db7-ebca-4dda-8f9c-5b6325bf9e48  Successfully provisioned volume pvc-33b6b325-4bc2-4175-a5b7-dd326d9005a8
```

PV:
```
Name:              pvc-33b6b325-4bc2-4175-a5b7-dd326d9005a8
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      sc-79d2m
Status:            Bound
Claim:             default/rack3-pvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.csi.vmware.com/k8s-region in [region-1]
                   topology.csi.vmware.com/k8s-zone in [zone-1]
                   topology.csi.vmware.com/k8s-building in [building-1]
                   topology.csi.vmware.com/k8s-level in [level-1]
                   topology.csi.vmware.com/k8s-rack in [rack-3]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      b9296c51-fa6e-4e2f-93ee-364590a0ee65
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1692207819221-8305-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```


SC 2:
```
Name:                  sc-79d2m
IsDefaultClass:        No
Annotations:           <none>
Provisioner:           csi.vsphere.vmware.com
Parameters:            storagepolicyname=vSAN Default Storage Policy
AllowVolumeExpansion:  False
MountOptions:          <none>
ReclaimPolicy:         Delete
VolumeBindingMode:     Immediate
AllowedTopologies:     
  Term 0:              topology.csi.vmware.com/k8s-region in [region-1]
                       topology.csi.vmware.com/k8s-zone in [zone-1]
                       topology.csi.vmware.com/k8s-building in [building-1]
                       topology.csi.vmware.com/k8s-level in [level-1]
                       topology.csi.vmware.com/k8s-rack in [rack-3]
Events:                <none>
```

PVC 2:
```
Name:          rack-pvc
Namespace:     default
StorageClass:  sc-5xfzg
Status:        Bound
Volume:        pvc-f7891cf3-cdc9-4a48-bf98-ae5feef21725
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                    From                                                                                                 Message
  ----    ------                 ----                   ----                                                                                                 -------
  Normal  Provisioning           5m34s                  csi.vsphere.vmware.com_vsphere-csi-controller-58cc87b78d-7k4qq_be439db7-ebca-4dda-8f9c-5b6325bf9e48  External provisioner is provisioning volume for claim "default/rack-pvc"
  Normal  ExternalProvisioning   5m34s (x2 over 5m34s)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  ProvisioningSucceeded  5m31s                  csi.vsphere.vmware.com_vsphere-csi-controller-58cc87b78d-7k4qq_be439db7-ebca-4dda-8f9c-5b6325bf9e48  Successfully provisioned volume pvc-f7891cf3-cdc9-4a48-bf98-ae5feef21725
```

PV 2:
```
Name:              pvc-f7891cf3-cdc9-4a48-bf98-ae5feef21725
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      sc-5xfzg
Status:            Bound
Claim:             default/rack-pvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.csi.vmware.com/k8s-building in [building-1]
                   topology.csi.vmware.com/k8s-level in [level-1]
                   topology.csi.vmware.com/k8s-rack in [rack-3]
                   topology.csi.vmware.com/k8s-region in [region-1]
                   topology.csi.vmware.com/k8s-zone in [zone-1]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      545f9866-7b42-4c84-9687-7c1cbce37876
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1692207819221-8305-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```


**Special notes for your reviewer**: NA

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bugfix for supporting folder type during volume provisioning in topology
```
