### PR TITLE
supervisor: handle pnid change for listview

### DIFF
--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -160,7 +160,6 @@ func (l *ListViewImpl) isClientValid() error {
 	// authenticated or timed out.
 	if userSession, err := sessionMgr.UserSession(l.ctx); err != nil {
 		log.Errorf("failed to obtain user session with err: %v", err)
-		return err
 	} else if userSession != nil {
 		return nil
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Primary Network Identifier (PNID) change is a core workflow (https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vcenter-configuration/GUID-F46DBE63-F04E-42A1-B940-63A8F5B86ACF.html) that was broken due to a bug in the listview code. 
With the new vCenter config, the call to `sessionMgr.UserSession()` errored out as the older VC IP is no longer valid. 
At this point, listView struct already has the new VC object stored with the `ReloadConfiguration` workflow but since we simply return the above error, we get stuck in a loop. 

This is a one-liner change where if we are unable to obtain the current user session, it's best to go forward with creating a new govmomi client. This client will get created with the latest VC object we have which should have the new VC IP config. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

pnid change test -> https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2505#issuecomment-1685141411

wcp-precheckin -> https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2505#issuecomment-1685149374 and 

```
Build #1068 (Aug 20, 2023, 10:33:04 PM)
adkulkarni
PR 2505
Ran 1 of 788 Specs in 101.021 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 787 Skipped PASS Ginkgo ran 1 suite in 2m37.539668789s Test Suite Passed make: Leaving directory `/home/worker/workspace/csi-wcp-precheckin/Results/1068/vsphere-csi-driver' 
```

wcp all tests, wcp thick thin, vanilla thick thin -> https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2505#issuecomment-1687183026

block vanilla precheckin -> https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2505#issuecomment-1687500930

block vanilla config secret -> https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2505#issuecomment-1688958659

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
supervisor: handle pnid change for listview
```
