### PR TITLE
Bugfix: Error out ControllerExpandVolume when volume is not found during a resize operation

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -17,7 +17,6 @@ limitations under the License.
 package common
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -1020,9 +1019,8 @@ func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int
 	if len(queryResult.Volumes) > 0 {
 		currentSize = queryResult.Volumes[0].BackingObjectDetails.GetCnsBackingObjectDetails().CapacityInMb
 	} else {
-		msg := fmt.Sprintf("failed to find volume by querying volumeID: %q", volumeID)
-		log.Error(msg)
-		return false, err
+		// Error out as volume is not found during a resize operation.
+		return false, logger.LogNewErrorf(log, "failed to find volume by querying volumeID: %q", volumeID)
 	}
 
 	log.Infof("isExpansionRequired: Found current size of volumeID %q to be %d Mb. "+


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Cherry pick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2525 to release-3.1

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bugfix: Error out ControllerExpandVolume when volume is not found during a resize operation
```
