### PR TITLE
Update leader election lease arguments to reduce delay in syncer startup

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -343,9 +343,9 @@ spec:
           image: gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest
           args:
             - "--leader-election"
-            - "--leader-election-lease-duration=120s"
-            - "--leader-election-renew-deadline=60s"
-            - "--leader-election-retry-period=30s"
+            - "--leader-election-lease-duration=30s"
+            - "--leader-election-renew-deadline=20s"
+            - "--leader-election-retry-period=10s"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is updating the leader election lease arguments to reduce delay in syncer startup. Due to the large interval values in Syncer container args, it is causing delay in the container start up and hence delay in registration of CRs. 

The default values for these args are as follows:
```
--leader-election-lease-duration <duration>: Duration, in seconds, that non-leader candidates will wait to force acquire leadership. Defaults to 15 seconds.

--leader-election-renew-deadline <duration>: Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds.

--leader-election-retry-period <duration>: Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.
```
We are not removing it completely to remain consistent with other sidecar container args.
We are setting them to 30s, 20s and 10s to make sure Syncer does not restart too often during leader election and does not cause too much delay during container startup

**Testing done**:
```
root@k8s-control-862-1693412862:~# kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-5fbc964d99-fjb6l   7/7     Running   0          77s
vsphere-csi-controller-5fbc964d99-k8zcb   7/7     Running   0          77s
vsphere-csi-controller-5fbc964d99-xlzb5   7/7     Running   0          77s
vsphere-csi-node-2klp6                    3/3     Running   0          77s
vsphere-csi-node-2nkqw                    3/3     Running   0          76s
vsphere-csi-node-dp58l                    3/3     Running   0          76s
vsphere-csi-node-f8c5n                    3/3     Running   0          76s
vsphere-csi-node-jw2k7                    3/3     Running   0          77s
vsphere-csi-node-rl482                    3/3     Running   0          77s


root@k8s-control-862-1693412862:~# kubectl logs vsphere-csi-controller-5fbc964d99-k8zcb  -n vmware-system-csi -c vsphere-syncer
{"level":"info","time":"2023-08-31T22:01:53.425271563Z","caller":"logger/logger.go:41","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2023-08-31T22:01:53.426574765Z","caller":"syncer/main.go:92","msg":"Version : v3.1.0-rc.2","TraceId":"f82df8b4-2c1b-411b-abac-7d03004e26af"}
{"level":"info","time":"2023-08-31T22:01:53.4270116Z","caller":"syncer/main.go:130","msg":"Starting container with operation mode: METADATA_SYNC","TraceId":"f82df8b4-2c1b-411b-abac-7d03004e26af"}
{"level":"info","time":"2023-08-31T22:01:53.427354985Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config","TraceId":"f82df8b4-2c1b-411b-abac-7d03004e26af"}
{"level":"info","time":"2023-08-31T22:01:53.427953003Z","caller":"kubernetes/kubernetes.go:382","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"f82df8b4-2c1b-411b-abac-7d03004e26af"}
I0831 22:01:53.431609       1 leaderelection.go:248] attempting to acquire leader lease vmware-system-csi/vsphere-syncer...
{"level":"info","time":"2023-08-31T22:01:53.434107017Z","caller":"syncer/main.go:164","msg":"Starting the http server to expose Prometheus metrics..","TraceId":"f82df8b4-2c1b-411b-abac-7d03004e26af"}
root@k8s-control-862-1693412862:~# kubectl logs vsphere-csi-controller-5fbc964d99-fjb6l  -n vmware-system-csi -c vsphere-syncer
{"level":"info","time":"2023-08-31T22:01:55.712831501Z","caller":"logger/logger.go:41","msg":"Setting default log level to :\"PRODUCTION\""}
{"level":"info","time":"2023-08-31T22:01:55.713567338Z","caller":"syncer/main.go:92","msg":"Version : v3.1.0-rc.2","TraceId":"14c12c5e-110a-43a9-bdf5-b472933562a7"}
{"level":"info","time":"2023-08-31T22:01:55.714670685Z","caller":"syncer/main.go:130","msg":"Starting container with operation mode: METADATA_SYNC","TraceId":"14c12c5e-110a-43a9-bdf5-b472933562a7"}
{"level":"info","time":"2023-08-31T22:01:55.715501268Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config","TraceId":"14c12c5e-110a-43a9-bdf5-b472933562a7"}
{"level":"info","time":"2023-08-31T22:01:55.716414859Z","caller":"kubernetes/kubernetes.go:382","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"14c12c5e-110a-43a9-bdf5-b472933562a7"}
{"level":"info","time":"2023-08-31T22:01:55.718583154Z","caller":"syncer/main.go:164","msg":"Starting the http server to expose Prometheus metrics..","TraceId":"14c12c5e-110a-43a9-bdf5-b472933562a7"}
I0831 22:01:55.729480       1 leaderelection.go:248] attempting to acquire leader lease vmware-system-csi/vsphere-syncer...
I0831 22:02:31.519874       1 leaderelection.go:258] successfully acquired lease vmware-system-csi/vsphere-syncer
{"level":"info","time":"2023-08-31T22:02:31.522498335Z","caller":"k8sorchestrator/k8sorchestrator.go:251","msg":"Initializing k8sOrchestratorInstance","TraceId":"8c068736-ba9f-48e0-8d18-87d370b1443d"}
{"level":"info","time":"2023-08-31T22:02:31.529772174Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config","TraceId":"8c068736-ba9f-48e0-8d18-87d370b1443d"}
{"level":"info","time":"2023-08-31T22:02:31.53069678Z","caller":"kubernetes/kubernetes.go:382","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"8c068736-ba9f-48e0-8d18-87d370b1443d"}
{"level":"info","time":"2023-08-31T22:02:31.531254906Z","caller":"kubernetes/kubernetes.go:85","msg":"k8s client using in-cluster config","TraceId":"8c068736-ba9f-48e0-8d18-87d370b1443d"}
{"level":"info","time":"2023-08-31T22:02:31.531628682Z","caller":"kubernetes/kubernetes.go:382","msg":"Setting client QPS to 100.000000 and Burst to 100.","TraceId":"8c068736-ba9f-48e0-8d18-87d370b1443d"}
{"level":"info","time":"2023-08-31T22:02:31.534543865Z","caller":"kubernetes/informers.go:85","msg":"Created new informer factory for in-cluster client","TraceId":"8c068736-ba9f-48e0-8d18-87d370b1443d"}

```
CRs are created & patched immediately.
```
 kubectl get csinodetopologies.cns.vmware.com
NAME                         AGE
k8s-control-570-1693412915   3m6s
k8s-control-692-1693412889   3m7s
k8s-control-862-1693412862   3m6s
k8s-node-102-1693412997      3m9s
k8s-node-524-1693412969      3m7s
k8s-node-802-1693412942      3m9s
```

No crash observed in Node Daemon Set either.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update leader election lease arguments to reduce delay in syncer startup
```
