### PR TITLE
Cherry-pick : Update leader election lease arguments to reduce delay in syncer startup

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -343,9 +343,9 @@ spec:
           image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.0-rc.2
           args:
             - "--leader-election"
-            - "--leader-election-lease-duration=120s"
-            - "--leader-election-renew-deadline=60s"
-            - "--leader-election-retry-period=30s"
+            - "--leader-election-lease-duration=30s"
+            - "--leader-election-renew-deadline=20s"
+            - "--leader-election-retry-period=10s"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
           imagePullPolicy: "Always"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherrypick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2528 to release-3.1

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherrypick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2528 to release-3.1
```
