### PR TITLE
New Test Cases for Resize of VCPtoCSI Migrated Volumes

### DIFF
--- a/tests/e2e/docs/vanilla_cluster_setup.md
+++ b/tests/e2e/docs/vanilla_cluster_setup.md
@@ -82,6 +82,8 @@ list of datastore URLs where you want to deploy file share volumes. Retrieve thi
     # SHARED_VSPHERE_DATASTORE_NAME and SHARED_VSPHERE_DATASTORE_URL should correspond to same shared datastore
     # To run e2e test for VCP to CSI migration, need to set the following env variable
     export GINKGO_FOCUS="csi-vcp-mig"
+    # To run volume resize testcases of VCP to CSI migrated Volumes
+    export VCPTOCSI="1"
 
     # For vsan stretched cluster tests
     export TESTBEDINFO_JSON="/path/to/nimbus_testbedinfo.json"

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -285,6 +285,7 @@ var (
 	guestCluster         bool
 	rwxAccessMode        bool
 	wcpVsanDirectCluster bool
+	vcptocsi             bool
 )
 
 // For busybox pod image
@@ -402,5 +403,11 @@ func setClusterFlavor(clusterFlavor cnstypes.CnsClusterFlavor) {
 	kind := os.Getenv("ACCESS_MODE")
 	if strings.TrimSpace(string(kind)) == "RWX" {
 		rwxAccessMode = true
+	}
+
+	// Check if the access mode is set for File volume setups
+	mode := os.Getenv("VCPTOCSI")
+	if strings.TrimSpace(string(mode)) == "1" {
+		vcptocsi = true
 	}
 }

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -405,7 +405,7 @@ func setClusterFlavor(clusterFlavor cnstypes.CnsClusterFlavor) {
 		rwxAccessMode = true
 	}
 
-	// Check if the access mode is set for File volume setups
+	// Check if its the vcptocsi tesbed
 	mode := os.Getenv("VCPTOCSI")
 	if strings.TrimSpace(string(mode)) == "1" {
 		vcptocsi = true

--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -798,7 +798,7 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 
 		ginkgo.By("create a pvc pvc1, wait for pvc bound to pv")
 		volHandle, pvc, pv, storageclass := createSCwithVolumeExpansionTrueAndDynamicPVC(
-			f, client, "", storagePolicyName, namespace, ext4FSType)
+			ctx, f, client, "", storagePolicyName, namespace, ext4FSType)
 		defer func() {
 			if !supervisorCluster {
 				err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))

--- a/tests/e2e/statefulsets.go
+++ b/tests/e2e/statefulsets.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -495,11 +496,14 @@ var _ = ginkgo.Describe("statefulset", func() {
 			10. scale down statefulset to 0
 			11. delete statefulset and all PVC's and SC's
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized] "+
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized] [csi-vcp-mig] "+
 		"Verify online volume expansion on statefulset", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var pvcSizeBeforeExpansion int64
+		var sc, scSpec *storagev1.StorageClass
+		var err error
+		var volHandle string
 		scParameters := make(map[string]string)
 		scParameters[scParamFsType] = ext4FSType
 
@@ -516,10 +520,14 @@ var _ = ginkgo.Describe("statefulset", func() {
 			// create resource quota
 			createResourceQuota(client, namespace, rqLimit, storageClassName)
 		}
-
-		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", true)
-		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		if !vcptocsi {
+			scSpec = getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", true)
+		} else {
+			scSpec = getVcpVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", true)
+		}
+		sc, err = client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		defer func() {
 			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -561,6 +569,20 @@ var _ = ginkgo.Describe("statefulset", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
 
+					if vcptocsi {
+						ginkgo.By("Verify annotations on PVCs created after migration")
+						waitForPvcMigAnnotations(ctx, client, pvclaimName, pvclaim.Namespace, false)
+						ginkgo.By("Verify annotations on PV created after migration")
+						waitForPvMigAnnotations(ctx, client, pv.Name, false)
+						vpath := getvSphereVolumePathFromClaim(ctx, client, namespace, pvclaimName)
+						crd, err := waitForCnsVSphereVolumeMigrationCrd(ctx, vpath)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+						volHandle = crd.Spec.VolumeID
+
+					} else {
+						volHandle = pv.Spec.CSI.VolumeHandle
+					}
+
 					ginkgo.By("Expanding current pvc")
 					sizeBeforeexpansion := pvclaim.Status.Capacity[v1.ResourceStorage]
 					pvcSizeBeforeExpansion, _ = sizeBeforeexpansion.AsInt64()
@@ -577,7 +599,7 @@ var _ = ginkgo.Describe("statefulset", func() {
 					_, err = waitForFSResize(pvclaim, client)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-					err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+					err = verifyVolumeMetadataInCNS(&e2eVSphere, volHandle,
 						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
@@ -622,6 +644,14 @@ var _ = ginkgo.Describe("statefulset", func() {
 						ctx, pvclaimName, metav1.GetOptions{})
 					gomega.Expect(pvclaim).NotTo(gomega.BeNil())
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+
+					if vcptocsi {
+						ginkgo.By("Verify annotations on PVCs created after migration")
+						waitForPvcMigAnnotations(ctx, client, pvclaimName, pvclaim.Namespace, false)
+						ginkgo.By("Verify annotations on PV created after migration")
+						waitForPvMigAnnotations(ctx, client, pv.Name, false)
+					}
 
 					sizeAfterExpansion := pvclaim.Status.Capacity[v1.ResourceStorage]
 					pvcSizeAfterExpansion, _ := sizeAfterExpansion.AsInt64()

--- a/tests/e2e/statefulsets.go
+++ b/tests/e2e/statefulsets.go
@@ -568,12 +568,15 @@ var _ = ginkgo.Describe("statefulset", func() {
 					gomega.Expect(pvclaim).NotTo(gomega.BeNil())
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
-
+					//Minimum Version of k8s Support for Resize migrated volume is k8s 1.26 and
+					//CSI by default migrates volume.Hence Manual Migration is not needed
 					if vcptocsi {
 						ginkgo.By("Verify annotations on PVCs created after migration")
-						waitForPvcMigAnnotations(ctx, client, pvclaimName, pvclaim.Namespace, false)
+						_, err := waitForPvcMigAnnotations(ctx, client, pvclaimName, pvclaim.Namespace, false)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						ginkgo.By("Verify annotations on PV created after migration")
-						waitForPvMigAnnotations(ctx, client, pv.Name, false)
+						_, err = waitForPvMigAnnotations(ctx, client, pv.Name, false)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						vpath := getvSphereVolumePathFromClaim(ctx, client, namespace, pvclaimName)
 						crd, err := waitForCnsVSphereVolumeMigrationCrd(ctx, vpath)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -648,9 +651,11 @@ var _ = ginkgo.Describe("statefulset", func() {
 
 					if vcptocsi {
 						ginkgo.By("Verify annotations on PVCs created after migration")
-						waitForPvcMigAnnotations(ctx, client, pvclaimName, pvclaim.Namespace, false)
+						_, err = waitForPvcMigAnnotations(ctx, client, pvclaimName, pvclaim.Namespace, false)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						ginkgo.By("Verify annotations on PV created after migration")
-						waitForPvMigAnnotations(ctx, client, pv.Name, false)
+						_, err = waitForPvMigAnnotations(ctx, client, pv.Name, false)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					}
 
 					sizeAfterExpansion := pvclaim.Status.Capacity[v1.ResourceStorage]

--- a/tests/e2e/vcp_to_csi_create_delete.go
+++ b/tests/e2e/vcp_to_csi_create_delete.go
@@ -560,9 +560,11 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 	//     FCD ID noted in step 8 and SC2.
 	// 13. Create PVC2 using PV2 and SC2.
 	// 14. Verify CNS entries for PVC2 and PV2.
-	// 15. Delete PVC2.
-	// 16. verify PVC2, PV2 and the cns volume(vmdk) get deleted.
-	// 17. Delete SC1 and SC2.
+	// 15. Create POD on PVC2
+	// 16. Increase PVC size and verify online volume resize
+	// 17. Delete PVC2 , POD.
+	// 18. verify PVC2, PV2 and the cns volume(vmdk) get deleted.
+	// 19. Delete SC1 and SC2.
 	ginkgo.It("Statically provision VMDK used by a PV provisioned by VCP using CSI", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -674,7 +676,7 @@ var _ = ginkgo.Describe("[csi-vcp-mig] VCP to CSI migration create/delete tests"
 			err := fpod.DeletePodWithWait(client, pod)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
-
+		//Online volume resize of migrated volume is supported on k8s1.26 onwards.
 		ginkgo.By("Increase PVC size and verify online volume resize")
 		increaseSizeOfPvcAttachedToPod(f, client, namespace, pvc2, pod)
 	})

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -2659,9 +2659,8 @@ func createSCwithVolumeExpansionTrueAndDynamicPVC(ctx context.Context, f *framew
 	client clientset.Interface, dsurl string, storagePolicyName string, namespace string,
 	fstype string) (string, *v1.PersistentVolumeClaim, *v1.PersistentVolume, *storagev1.StorageClass) {
 	scParameters := make(map[string]string)
-	scParameters[scParamFsType] = fstype
 	if vcptocsi {
-		scParameters[vcpScParamFstype] = "xfs"
+		scParameters[vcpScParamFstype] = fstype
 	} else {
 		scParameters[scParamFsType] = fstype
 	}
@@ -3327,7 +3326,7 @@ func invokeTestForInvalidVolumeExpansion(f *framework.Framework, client clientse
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	} else {
-		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "", true, "")
+		storageclass, pvclaim, err = createPVCAndStorageClass(client, namespace, nil, scParameters, "", nil, "", false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds new test cases required for Resize of VCP to CSI Migrated Volumes

**Testing done**:
yes

Special notes for your reviewer:
Lint Check
inamdarm@inamdarmAMD6M PVResize-vsphere-csi-driver % golangci-lint run --enable=lll
inamdarm@inamdarmAMD6M PVResize-vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/inamdarm/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/inamdarm/Documents/CSIREPO/PVResize-vsphere-csi-driver /Users/inamdarm/Documents/CSIREPO /Users/inamdarm/Documents /Users/inamdarm /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused] 
INFO [loader] Go packages loading at mode 575 (files|imports|name|compiled_files|deps|exports_file|types_sizes) took 1m38.175077742s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 191.896211ms 
INFO [linters context/goanalysis] analyzers took 7m36.969589533s with top 10 stages: buildir: 5m27.398283562s, nilness: 20.014015132s, printf: 13.296174177s, fact_deprecated: 12.675636724s, ctrlflow: 12.648492063s, typedness: 11.001586964s, fact_purity: 10.692612304s, SA5012: 9.071303717s, inspect: 4.357006865s, S1038: 2.841398967s 
INFO [runner] Issues before processing: 113, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_files: 113/113, skip_dirs: 113/113, identifier_marker: 24/24, path_prettifier: 113/113, autogenerated_exclude: 24/113, cgo: 113/113, exclude: 24/24, exclude-rules: 1/24, nolint: 0/1, filename_unadjuster: 113/113 
INFO [runner] processing took 17.645398ms with stages: nolint: 14.003388ms, autogenerated_exclude: 2.70967ms, path_prettifier: 421.687µs, identifier_marker: 322.939µs, skip_dirs: 104.781µs, exclude-rules: 63.115µs, cgo: 9.749µs, filename_unadjuster: 5.619µs, max_same_issues: 1.246µs, exclude: 540ns, uniq_by_line: 483ns, max_from_linter: 353ns, skip_files: 287ns, source_code: 271ns, diff: 270ns, sort_results: 223ns, path_shortener: 218ns, max_per_file_from_linter: 218ns, severity-rules: 207ns, path_prefixer: 134ns 
INFO [runner] linters took 45.48796075s with stages: goanalysis_metalinter: 45.470214449s 
INFO File cache stats: 315 entries of total size 6.4MiB 
INFO Memory: 1371 samples, avg is 615.8MB, max is 3059.9MB 
INFO Execution took 2m23.872825114s             