### PR TITLE
fix GetHostsForSegment to return correct list of hosts for all segments

### DIFF
--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -175,7 +175,6 @@ func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
 func getExpandedTopologySegments(ctx context.Context, requestedSegments map[string]string,
 	nodeMgr node.Manager) ([]map[string]string, error) {
 	log := logger.GetLogger(ctx)
-
 	var (
 		vcHost                   string
 		completeTopologySegments []map[string]string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 fix GetHostsForSegment to return correct list of hosts for all segments.

When we have multiple tags assigned for the same entity `GetHostsForSegment` does not return right set of common hosts among topology segments.


**Testing done**:
```bash
{"level":"info","time":"2023-09-06T06:24:04.253049943Z","caller":"vanilla/controller.go:1794","msg":"CreateVolume: called with args {Name:pvc-8580a7a2-f25f-4283-aa44-476abb9e2fe7 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:\"topology.csi.vmware.com/k8s-region\" value:\"region-1\" > segments:<key:\"topology.csi.vmware.com/k8s-zone\" value:\"zone-w4-hs2-k0504\" > > requisite:<segments:<key:\"topology.csi.vmware.com/k8s-region\" value:\"region-1\" > segments:<key:\"topology.csi.vmware.com/k8s-zone\" value:\"zone-w4-hs2-k0505\" > > requisite:<segments:<key:\"topology.csi.vmware.com/k8s-region\" value:\"region-1\" > segments:<key:\"topology.csi.vmware.com/k8s-zone\" value:\"zone-w4-hs2-k0506\" > > preferred:<segments:<key:\"topology.csi.vmware.com/k8s-region\" value:\"region-1\" > segments:<key:\"topology.csi.vmware.com/k8s-zone\" value:\"zone-w4-hs2-k0504\" > > preferred:<segments:<key:\"topology.csi.vmware.com/k8s-region\" value:\"region-1\" > segments:<key:\"topology.csi.vmware.com/k8s-zone\" value:\"zone-w4-hs2-k0505\" > > preferred:<segments:<key:\"topology.csi.vmware.com/k8s-region\" value:\"region-1\" > segments:<key:\"topology.csi.vmware.com/k8s-zone\" value:\"zone-w4-hs2-k0506\" > >  XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.283449519Z","caller":"placementengine/placement.go:27","msg":"GetSharedDatastores called for VC \"10.202.40.68\" with policyID: \"\" , Topology Segment List: [map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0504] map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0505] map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0506]]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.290316148Z","caller":"placementengine/placement.go:67","msg":"TopologySegment map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0504] expanded as: [map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0504]]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.290357164Z","caller":"common/topology.go:147","msg":"Tag \"region-1\" is applied on entities [{Type:HostSystem Value:host-12} {Type:HostSystem Value:host-29} {Type:HostSystem Value:host-21}]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.290406259Z","caller":"common/topology.go:157","msg":"Hosts returned for topology category: \"topology.csi.vmware.com/k8s-region\" and tag: \"region-1\" are [HostSystem:host-12 HostSystem:host-29 HostSystem:host-21]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.290419245Z","caller":"common/topology.go:147","msg":"Tag \"zone-w4-hs2-k0504\" is applied on entities [{Type:HostSystem Value:host-12}]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.290425415Z","caller":"common/topology.go:157","msg":"Hosts returned for topology category: \"topology.csi.vmware.com/k8s-zone\" and tag: \"zone-w4-hs2-k0504\" are [HostSystem:host-12]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.290439269Z","caller":"common/topology.go:168","msg":"finding common hosts for hostlists: [[HostSystem:host-12 HostSystem:host-29 HostSystem:host-21] [HostSystem:host-12]]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.290453963Z","caller":"common/topology.go:178","msg":"hostCount: map[HostSystem:host-12:1 HostSystem:host-21:1 HostSystem:host-29:1]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.290463292Z","caller":"common/topology.go:188","msg":"hostCount: map[HostSystem:host-12:2 HostSystem:host-21:1 HostSystem:host-29:1]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.290468069Z","caller":"common/topology.go:198","msg":"common hosts: [HostSystem:host-12]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.290474567Z","caller":"common/topology.go:213","msg":"commonHostSystem: [HostSystem:host-12]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.290480896Z","caller":"common/topology.go:161","msg":"common hosts: [HostSystem:host-12] for all segments: map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0504]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.306068903Z","caller":"placementengine/placement.go:86","msg":"Obtained list of shared datastores [Datastore: Datastore:datastore-13, datastore URL: ds:///vmfs/volumes/5e84acd3-b3333d0c-9346-34800d8dc156/ Datastore: Datastore:datastore-14, datastore URL: ds:///vmfs/volumes/60281d6b-ed35be22-ee8a-34800d8dc156/ Datastore: Datastore:datastore-15, datastore URL: ds:///vmfs/volumes/60281d98-9a958ee2-a943-34800d8dc156/ Datastore: Datastore:datastore-16, datastore URL: ds:///vmfs/volumes/60288ecc-6f6b5994-d652-34800d8dc156/ Datastore: Datastore:datastore-17, datastore URL: ds:///vmfs/volumes/647ed91b-79d7c728-c6bd-34800d8dc156/] for hosts [HostSystem:host-12]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.466993855Z","caller":"placementengine/placement.go:67","msg":"TopologySegment map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0505] expanded as: [map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0505]]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.467018132Z","caller":"common/topology.go:147","msg":"Tag \"region-1\" is applied on entities [{Type:HostSystem Value:host-12} {Type:HostSystem Value:host-29} {Type:HostSystem Value:host-21}]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.467037287Z","caller":"common/topology.go:157","msg":"Hosts returned for topology category: \"topology.csi.vmware.com/k8s-region\" and tag: \"region-1\" are [HostSystem:host-12 HostSystem:host-29 HostSystem:host-21]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.467046438Z","caller":"common/topology.go:147","msg":"Tag \"zone-w4-hs2-k0505\" is applied on entities [{Type:HostSystem Value:host-21}]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.467054535Z","caller":"common/topology.go:157","msg":"Hosts returned for topology category: \"topology.csi.vmware.com/k8s-zone\" and tag: \"zone-w4-hs2-k0505\" are [HostSystem:host-21]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.467063701Z","caller":"common/topology.go:168","msg":"finding common hosts for hostlists: [[HostSystem:host-12 HostSystem:host-29 HostSystem:host-21] [HostSystem:host-21]]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.46707321Z","caller":"common/topology.go:178","msg":"hostCount: map[HostSystem:host-12:1 HostSystem:host-21:1 HostSystem:host-29:1]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.467081391Z","caller":"common/topology.go:188","msg":"hostCount: map[HostSystem:host-12:1 HostSystem:host-21:2 HostSystem:host-29:1]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.467087812Z","caller":"common/topology.go:198","msg":"common hosts: [HostSystem:host-21]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.467099735Z","caller":"common/topology.go:213","msg":"commonHostSystem: [HostSystem:host-21]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.467107745Z","caller":"common/topology.go:161","msg":"common hosts: [HostSystem:host-21] for all segments: map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0505]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.480910078Z","caller":"placementengine/placement.go:86","msg":"Obtained list of shared datastores [Datastore: Datastore:datastore-22, datastore URL: ds:///vmfs/volumes/5e84ace7-3c35e00c-1767-34800d8db36a/ Datastore: Datastore:datastore-23, datastore URL: ds:///vmfs/volumes/60281dd7-5cff2b14-80cf-34800d8db36a/ Datastore: Datastore:datastore-24, datastore URL: ds:///vmfs/volumes/60281e0b-3d542b54-492a-34800d8db36a/ Datastore: Datastore:datastore-25, datastore URL: ds:///vmfs/volumes/60288f14-4482effc-bfd4-34800d8db36a/ Datastore: Datastore:datastore-26, datastore URL: ds:///vmfs/volumes/647ed931-46c3fc30-1315-34800d8db36a/] for hosts [HostSystem:host-21]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.664835097Z","caller":"placementengine/placement.go:67","msg":"TopologySegment map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0506] expanded as: [map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0506]]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.664854186Z","caller":"common/topology.go:147","msg":"Tag \"region-1\" is applied on entities [{Type:HostSystem Value:host-12} {Type:HostSystem Value:host-29} {Type:HostSystem Value:host-21}]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.664866831Z","caller":"common/topology.go:157","msg":"Hosts returned for topology category: \"topology.csi.vmware.com/k8s-region\" and tag: \"region-1\" are [HostSystem:host-12 HostSystem:host-29 HostSystem:host-21]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.664873705Z","caller":"common/topology.go:147","msg":"Tag \"zone-w4-hs2-k0506\" is applied on entities [{Type:HostSystem Value:host-29}]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.664880197Z","caller":"common/topology.go:157","msg":"Hosts returned for topology category: \"topology.csi.vmware.com/k8s-zone\" and tag: \"zone-w4-hs2-k0506\" are [HostSystem:host-29]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.664887491Z","caller":"common/topology.go:168","msg":"finding common hosts for hostlists: [[HostSystem:host-12 HostSystem:host-29 HostSystem:host-21] [HostSystem:host-29]]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.664895167Z","caller":"common/topology.go:178","msg":"hostCount: map[HostSystem:host-12:1 HostSystem:host-21:1 HostSystem:host-29:1]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.664901344Z","caller":"common/topology.go:188","msg":"hostCount: map[HostSystem:host-12:1 HostSystem:host-21:1 HostSystem:host-29:2]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.664906055Z","caller":"common/topology.go:198","msg":"common hosts: [HostSystem:host-29]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.664911469Z","caller":"common/topology.go:213","msg":"commonHostSystem: [HostSystem:host-29]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.664917562Z","caller":"common/topology.go:161","msg":"common hosts: [HostSystem:host-29] for all segments: map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0506]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.674454673Z","caller":"placementengine/placement.go:86","msg":"Obtained list of shared datastores [Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/5e84aceb-9aedad48-a9ca-34800d8db3c4/ Datastore: Datastore:datastore-32, datastore URL: ds:///vmfs/volumes/60281e4c-3422ab7a-6837-34800d8db3c4/ Datastore: Datastore:datastore-33, datastore URL: ds:///vmfs/volumes/60281e62-f586157a-3288-34800d8db3c4/ Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/60288f52-a1c6591a-ef70-34800d8db3c4/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/647ed962-bc9983a4-c0e9-34800d8db3c4/] for hosts [HostSystem:host-29]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.674491068Z","caller":"placementengine/placement.go:167","msg":"Shared compatible datastores being considered for volume provisioning on vCenter: \"10.202.40.68\" are: [Datastore: Datastore:datastore-13, datastore URL: ds:///vmfs/volumes/5e84acd3-b3333d0c-9346-34800d8dc156/ Datastore: Datastore:datastore-14, datastore URL: ds:///vmfs/volumes/60281d6b-ed35be22-ee8a-34800d8dc156/ Datastore: Datastore:datastore-15, datastore URL: ds:///vmfs/volumes/60281d98-9a958ee2-a943-34800d8dc156/ Datastore: Datastore:datastore-16, datastore URL: ds:///vmfs/volumes/60288ecc-6f6b5994-d652-34800d8dc156/ Datastore: Datastore:datastore-17, datastore URL: ds:///vmfs/volumes/647ed91b-79d7c728-c6bd-34800d8dc156/ Datastore: Datastore:datastore-22, datastore URL: ds:///vmfs/volumes/5e84ace7-3c35e00c-1767-34800d8db36a/ Datastore: Datastore:datastore-23, datastore URL: ds:///vmfs/volumes/60281dd7-5cff2b14-80cf-34800d8db36a/ Datastore: Datastore:datastore-24, datastore URL: ds:///vmfs/volumes/60281e0b-3d542b54-492a-34800d8db36a/ Datastore: Datastore:datastore-25, datastore URL: ds:///vmfs/volumes/60288f14-4482effc-bfd4-34800d8db36a/ Datastore: Datastore:datastore-26, datastore URL: ds:///vmfs/volumes/647ed931-46c3fc30-1315-34800d8db36a/ Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/5e84aceb-9aedad48-a9ca-34800d8db3c4/ Datastore: Datastore:datastore-32, datastore URL: ds:///vmfs/volumes/60281e4c-3422ab7a-6837-34800d8db3c4/ Datastore: Datastore:datastore-33, datastore URL: ds:///vmfs/volumes/60281e62-f586157a-3288-34800d8db3c4/ Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/60288f52-a1c6591a-ef70-34800d8db3c4/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/647ed962-bc9983a4-c0e9-34800d8db3c4/]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:04.674542059Z","caller":"vsphere/utils.go:585","msg":"Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-13, datastore URL: ds:///vmfs/volumes/5e84acd3-b3333d0c-9346-34800d8dc156/ Datastore: Datastore:datastore-14, datastore URL: ds:///vmfs/volumes/60281d6b-ed35be22-ee8a-34800d8dc156/ Datastore: Datastore:datastore-15, datastore URL: ds:///vmfs/volumes/60281d98-9a958ee2-a943-34800d8dc156/ Datastore: Datastore:datastore-16, datastore URL: ds:///vmfs/volumes/60288ecc-6f6b5994-d652-34800d8dc156/ Datastore: Datastore:datastore-17, datastore URL: ds:///vmfs/volumes/647ed91b-79d7c728-c6bd-34800d8dc156/ Datastore: Datastore:datastore-22, datastore URL: ds:///vmfs/volumes/5e84ace7-3c35e00c-1767-34800d8db36a/ Datastore: Datastore:datastore-23, datastore URL: ds:///vmfs/volumes/60281dd7-5cff2b14-80cf-34800d8db36a/ Datastore: Datastore:datastore-24, datastore URL: ds:///vmfs/volumes/60281e0b-3d542b54-492a-34800d8db36a/ Datastore: Datastore:datastore-25, datastore URL: ds:///vmfs/volumes/60288f14-4482effc-bfd4-34800d8db36a/ Datastore: Datastore:datastore-26, datastore URL: ds:///vmfs/volumes/647ed931-46c3fc30-1315-34800d8db36a/ Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/5e84aceb-9aedad48-a9ca-34800d8db3c4/ Datastore: Datastore:datastore-32, datastore URL: ds:///vmfs/volumes/60281e4c-3422ab7a-6837-34800d8db3c4/ Datastore: Datastore:datastore-33, datastore URL: ds:///vmfs/volumes/60281e62-f586157a-3288-34800d8db3c4/ Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/60288f52-a1c6591a-ef70-34800d8db3c4/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/647ed962-bc9983a4-c0e9-34800d8db3c4/]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:05.26151406Z","caller":"volume/listview.go:120","msg":"AddTask called for Task:task-67473","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:05.270037192Z","caller":"volume/listview.go:134","msg":"task Task:task-67473 added to listView","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:05.681890649Z","caller":"volume/listview.go:148","msg":"task Task:task-67473 removed from listView","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:05.681953819Z","caller":"volume/manager.go:409","msg":"CreateVolume: VolumeName: \"pvc-8580a7a2-f25f-4283-aa44-476abb9e2fe7\", opId: \"2fb55e5f\"","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:05.684874869Z","caller":"volume/util.go:326","msg":"Volume created successfully. VolumeName: \"pvc-8580a7a2-f25f-4283-aa44-476abb9e2fe7\", volumeID: \"b290f335-ef40-4871-816b-b7b502e8be9e\"","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:05.695081188Z","caller":"vanilla/controller.go:1363","msg":"volume \"b290f335-ef40-4871-816b-b7b502e8be9e\" created in vCenter \"10.202.40.68\". Proceeding to calculate accessible topology for the volume","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:05.741169958Z","caller":"common/vsphereutil.go:1159","msg":"Nodes that have access to datastore \"ds:///vmfs/volumes/60281e0b-3d542b54-492a-34800d8db36a/\" are [VirtualMachine:vm-102 VirtualMachine:vm-101]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:05.751766016Z","caller":"placementengine/placement.go:303","msg":"Topology segments retrieved from nodes accessible to datastore \"ds:///vmfs/volumes/60281e0b-3d542b54-492a-34800d8db36a/\" are: [map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-w4-hs2-k0505]]","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}
{"level":"info","time":"2023-09-06T06:24:05.751819479Z","caller":"vanilla/controller.go:1859","msg":"Volume created successfully. Volume Handle: \"b290f335-ef40-4871-816b-b7b502e8be9e\", PV Name: \"pvc-8580a7a2-f25f-4283-aa44-476abb9e2fe7\"","TraceId":"cd6b8463-06b0-4b39-9a26-8b5e0b0a8ea2"}

```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
 fix GetHostsForSegment to return correct list of hosts for all segments
```
