### PR TITLE
Match topology key in example yaml files with the vSphere CSI official docs

### DIFF
--- a/example/vanilla-k8s-RWO-filesystem-volumes/example-sc-WaitForFirstConsumer-restricted.yaml
+++ b/example/vanilla-k8s-RWO-filesystem-volumes/example-sc-WaitForFirstConsumer-restricted.yaml
@@ -9,10 +9,10 @@ parameters:
   storagepolicyname: "vSAN Default Storage Policy"  # Optional Parameter
 allowedTopologies:
   - matchLabelExpressions:
-      - key: topology.kubernetes.io/zone
+      - key: topology.csi.vmware.com/k8s-zone
         values:
           - us-west-CA
           - us-west-WA
-      - key: topology.kubernetes.io/region
+      - key: topology.csi.vmware.com/k8s-region
         values:
           - us-west

--- a/example/vanilla-k8s-RWO-filesystem-volumes/example-sc-multiple-zones.yaml
+++ b/example/vanilla-k8s-RWO-filesystem-volumes/example-sc-multiple-zones.yaml
@@ -8,10 +8,10 @@ parameters:
   storagepolicyname: "vSAN Default Storage Policy"  # Optional Parameter
 allowedTopologies:
   - matchLabelExpressions:
-      - key: topology.kubernetes.io/zone
+      - key: topology.csi.vmware.com/k8s-zone
         values:
           - us-west-WA
           - us-west-CA
-      - key: topology.kubernetes.io/region
+      - key: topology.csi.vmware.com/k8s-region
         values:
           - us-west

--- a/example/vanilla-k8s-RWO-filesystem-volumes/example-sc-single-zone.yaml
+++ b/example/vanilla-k8s-RWO-filesystem-volumes/example-sc-single-zone.yaml
@@ -8,9 +8,9 @@ parameters:
   storagepolicyname: "vSAN Default Storage Policy"  # Optional Parameter
 allowedTopologies:
   - matchLabelExpressions:
-      - key: topology.kubernetes.io/zone
+      - key: topology.csi.vmware.com/k8s-zone
         values:
           - us-west-CA
-      - key: topology.kubernetes.io/region
+      - key: topology.csi.vmware.com/k8s-region
         values:
           - us-west


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making sure there is no mismatch in topology key in example yaml files when compared with the vSphere CSI official docs here https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-162E7582-723B-4A0F-A937-3ACE82EAFD31.html

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Match topology key in example yaml files with the vSphere CSI official docs
```
