### PR TITLE
Remove fail fast mechanism during compatible datastore computation in case of multiple topology segments

### DIFF
--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -116,11 +116,13 @@ func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
 					}
 				}
 				if len(compatibleDatastores) == 0 {
-					return nil, logger.LogNewErrorf(log,
-						"No compatible shared datastores found for storage policy %q on vCenter: %q",
+					log.Infof("No compatible shared datastores found for storage policy %q on vCenter: %q",
 						params.StoragePolicyID, params.Vcenter.Config.Host)
+				} else {
+					log.Infof("Shared datastores compatible with storage policy %q are %+v for vCenter: %q",
+						params.StoragePolicyID, compatibleDatastores, params.Vcenter.Config.Host)
+					sharedDatastoresInTopologySegment = compatibleDatastores
 				}
-				sharedDatastoresInTopologySegment = compatibleDatastores
 			}
 
 			// 3. Filter the shared datastores with preferential datastores, if any.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR avoids fail fast mechanism during compatible datastore computation in case of multiple topology segments.
While filtering shared datastores compatible with a given storage policy, we iterate over topology segments and find the shared datastores, which we are filtering against the storage policy. If we do not find any policy compatible datastore, we fail with error "No compatible shared datastores found for storage policy ".

If no compatible datastore for the storage policy is found for any topology segment, we should continue to find datastore for next topology segment, instead of failing immediately

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2542#issuecomment-1709421322
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2542#issuecomment-1709422062


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Avoid fail fast during compatible datastore computation in case of multiple topology segments
```
