### PR TITLE
Add resource limits for vSphere CSI driver containers

### DIFF
--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -157,6 +157,12 @@ spec:
             - mountPath: /run/secrets/tls
               name: webhook-certs
               readOnly: true
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -159,6 +159,7 @@ spec:
               readOnly: true
           resources:
             limits:
+              cpu: 10m
               memory: 500Mi
             requests:
               cpu: 10m

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -262,6 +262,7 @@ spec:
               name: socket-dir
           resources:
             limits:
+              cpu: 10m
               memory: 500Mi
             requests:
               cpu: 10m
@@ -287,6 +288,7 @@ spec:
               name: socket-dir
           resources:
             limits:
+              cpu: 10m
               memory: 500Mi
             requests:
               cpu: 10m
@@ -345,6 +347,7 @@ spec:
             failureThreshold: 3
           resources:
             limits:
+              cpu: 50m
               memory: 500Mi
             requests:
               cpu: 10m
@@ -404,6 +407,7 @@ spec:
               readOnly: true
           resources:
             limits:
+              cpu: 50m
               memory: 500Mi
             requests:
               cpu: 10m
@@ -450,6 +454,7 @@ spec:
               name: socket-dir
           resources:
             limits:
+              cpu: 10m
               memory: 500Mi
             requests:
               cpu: 10m
@@ -512,6 +517,7 @@ spec:
             initialDelaySeconds: 3
           resources:
             limits:
+              cpu: 50m
               memory: 500Mi
             requests:
               cpu: 10m
@@ -580,6 +586,7 @@ spec:
             failureThreshold: 3
           resources:
             limits:
+              cpu: 50m
               memory: 500Mi
             requests:
               cpu: 10m
@@ -677,6 +684,7 @@ spec:
             initialDelaySeconds: 3
           resources:
             limits:
+              cpu: 50m
               memory: 500Mi
             requests:
               cpu: 10m
@@ -740,6 +748,7 @@ spec:
             failureThreshold: 3
           resources:
             limits:
+              cpu: 10m
               memory: 500Mi
             requests:
               cpu: 10m

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -260,6 +260,12 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
         - name: csi-resizer
           image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
           args:
@@ -279,6 +285,12 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
         - name: vsphere-csi-controller
           image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
           args:
@@ -331,6 +343,12 @@ spec:
             timeoutSeconds: 10
             periodSeconds: 180
             failureThreshold: 3
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
           args:
@@ -339,6 +357,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
         - name: vsphere-syncer
           image: gcr.io/cloud-provider-vsphere/csi/ci/syncer:latest
           args:
@@ -378,6 +402,12 @@ spec:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
               readOnly: true
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
         - name: csi-provisioner
           image: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
           args:
@@ -418,6 +448,12 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
       volumes:
         - name: vsphere-config-volume
           secret:
@@ -474,6 +510,12 @@ spec:
               - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
         - name: vsphere-csi-node
           image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
           args:
@@ -536,6 +578,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 5
             failureThreshold: 3
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
           args:
@@ -544,6 +592,12 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
       volumes:
         - name: registration-dir
           hostPath:
@@ -621,6 +675,12 @@ spec:
               - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
         - name: vsphere-csi-node
           image: gcr.io/cloud-provider-vsphere/csi/ci/driver:latest
           args:
@@ -678,6 +738,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 5
             failureThreshold: 3
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
           args:
@@ -686,6 +752,12 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
       volumes:
         - name: registration-dir
           hostPath:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add resource limits for vSphere CSI driver containers so that kube-scheduler and kubelet can schedule, reserve and limit the resources consumed by vSphere CSI driver. This also avoids memory leaks if there is an unexpected request timeout.

The numbers provided in the yamls seem to be working locally on dev clusters. The values will be validated against FVT & ST environments

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
[e2e pipeline result](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2545#issuecomment-1712154272)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add resource limits for vSphere CSI driver containers
```
