### PR TITLE
skip adding node to cache during attach or detach operation

### DIFF
--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -177,7 +177,6 @@ func (m *defaultManager) GetNodeByNameOrUUID(
 		log.Errorf("failed to get node UUID from node: %q. Err: %v", nodeNameOrUUID, err)
 		return nil, err
 	}
-	m.nodeNameToUUID.Store(nodeNameOrUUID, k8snodeUUID)
 	return m.GetNode(ctx, k8snodeUUID, nil)
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is to skip adding node to cache during attach or detach operation.

**Which issue this PR fixes**
When worker node is deleted, CSI driver gets informer event for node delete operation and CSI Driver remove node information from the cache.
In some cases we have observed that CSI gets duplicated detach volume call and during that call, Node information is getting added back to the cache. Later after system deleted the node vm from VC inventory, we do not update the cache and still keep the deleted node VM information in the cache. So driver thinks we have a valid node VM representing the stale information added during detach volume call so while creating volume driver fails with the error - `failed to get host system for VM  with err: ServerFaultCode: The object 'vim.VirtualMachine:vm-x' has already been deleted or has not been completely created`

**Testing done**:
TKGi team has validated this fix and post upgrade they are not seeing any issue with creating new volumes.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
skip adding node to cache during attach or detach operation
```
