### PR TITLE
Return error for IsDiskAttached when vmDevices are empty

### DIFF
--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -57,6 +57,9 @@ func IsDiskAttached(ctx context.Context, vm *cnsvsphere.VirtualMachine, volumeID
 		log.Errorf("failed to get devices from vm: %s", vm.InventoryPath)
 		return "", err
 	}
+	if len(vmDevices) == 0 {
+		return "", logger.LogNewErrorf(log, "virtual devices list is empty for the vm: %s", vm.InventoryPath)
+	}
 	// Build a map of NVME Controller key : NVME controller name.
 	// This is needed to check if disk in contention is attached to a NVME
 	// controller. The virtual disk devices do not contain the controller type


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making changes in IsDiskAttached to check if vmDevices are empty when CSI makes a call to property collector.
There is a case during ESX host power off scenarios, where vmDevices is returned empty and CSI assumes disk is not attached and returns success for DetachVolume. This PR is addressing the issue by returning error and let DetachVolume be invoked again until vmDevices are not empty from the property collector 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Return error for IsDiskAttached when vmDevices are empty
```
