### PR TITLE
Cherry-pick : Return error for IsDiskAttached when vmDevices are empty (#2548)

### DIFF
--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -57,6 +57,9 @@ func IsDiskAttached(ctx context.Context, vm *cnsvsphere.VirtualMachine, volumeID
 		log.Errorf("failed to get devices from vm: %s", vm.InventoryPath)
 		return "", err
 	}
+	if len(vmDevices) == 0 {
+		return "", logger.LogNewErrorf(log, "virtual devices list is empty for the vm: %s", vm.InventoryPath)
+	}
 	// Build a map of NVME Controller key : NVME controller name.
 	// This is needed to check if disk in contention is attached to a NVME
 	// controller. The virtual disk devices do not contain the controller type


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry-pick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2548 to release-3.1

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherry-pick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2548 to release-3.1
```
