### PR TITLE
Tag CSI images for 3.1.0 release

### DIFF
--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -134,7 +134,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.0-rc.5
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.0
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -280,7 +280,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.0-rc.5
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -340,7 +340,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.0-rc.5
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.0
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=30s"
@@ -475,7 +475,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.0-rc.5
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -622,7 +622,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.0-rc.5
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Tag CSI images for 3.1.0 release

**Testing done**:
CSI QE teams f have provided a Go for the 3.1.0 vSphere CSI Driver release

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Tag CSI images for 3.1.0 release
```
