### PR TITLE
Upgrade sidecars to latest versions

### DIFF
--- a/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
+++ b/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
@@ -84,7 +84,7 @@ spec:
       serviceAccountName: snapshot-webhook
       containers:
         - name: snapshot-validation
-          image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.2.2 # change the image if you wish to use your own custom validation server image
+          image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.3.0 # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/run/secrets/tls/tls.crt', '--tls-private-key-file=/run/secrets/tls/tls.key']
           ports:

--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -59,7 +59,7 @@ else
         exit 1
 fi
 
-qualified_version="v6.2.2"
+qualified_version="v6.3.0"
 volumesnapshotclasses_crd="volumesnapshotclasses.snapshot.storage.k8s.io"
 volumesnapshotcontents_crd="volumesnapshotcontents.snapshot.storage.k8s.io"
 volumesnapshots_crd="volumesnapshots.snapshot.storage.k8s.io"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -332,7 +332,7 @@ spec:
             periodSeconds: 180
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -537,7 +537,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -679,7 +679,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -243,7 +243,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.4.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -261,7 +261,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.9.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -379,7 +379,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -452,7 +452,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -599,7 +599,7 @@ spec:
       serviceAccountName: vsphere-csi-node
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Upgrade sidecars to latest versions.
```
csi-attacher:v4.4.0
csi-resizer:v1.9.0
csi-provisioner:v3.6.0
csi-node-driver-registrar:v2.9.0
snapshotter:v6.3.0
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
[e2e pipeline result](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2555#issuecomment-1724754666)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Upgrade sidecars to latest versions
csi-attacher:v4.4.0
csi-resizer:v1.9.0
csi-provisioner:v3.6.0
csi-node-driver-registrar:v2.9.0
snapshotter:v6.3.0
```
