### PR TITLE
vanilla: return volume path as part of ListVolumes response for migrated in-tree volumes

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -304,3 +304,8 @@ func (c *FakeK8SOrchestrator) GetCSINodeTopologyInstanceByName(nodeName string) 
 	item interface{}, exists bool, err error) {
 	return nil, false, nil
 }
+
+// GetPVCNamespaceFromVolumeID retrieves the pv name from volumeID.
+func (c *FakeK8SOrchestrator) GetPVNameFromCSIVolumeID(volumeID string) (string, bool) {
+	return "", false
+}

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -81,6 +81,9 @@ type COCommonInterface interface {
 	GetCSINodeTopologyInstancesList() []interface{}
 	// GetCSINodeTopologyInstanceByName fetches the CSINodeTopology instance for a given node name in the cluster.
 	GetCSINodeTopologyInstanceByName(nodeName string) (item interface{}, exists bool, err error)
+	// GetPVNameFromCSIVolumeID retrieves the pv name from the volumeID.
+	// This method will not return pv name in case of in-tree migrated volumes
+	GetPVNameFromCSIVolumeID(volumeID string) (string, bool)
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1544,3 +1544,8 @@ func (c *K8sOrchestrator) CreateConfigMap(ctx context.Context, name string, name
 
 	return nil
 }
+
+// GetPVNameFromCSIVolumeID retrieves the pv name from volumeID using volumeIDToNameMap.
+func (c *K8sOrchestrator) GetPVNameFromCSIVolumeID(volumeID string) (string, bool) {
+	return c.volumeIDToNameMap.get(volumeID)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
`ListVolumes` call returns `volumeID` to `nodeID` mapping even in case of migrated in-tree volumes. In case of migrated volumes, external-attacher will look for the initial `volumePath` in the ListVolumes response. Since vSphere CSI Driver's ListVolumes response doesn't emit the volumePath for migrated volumes, external-attacher continuously makes `AttachVolume` calls to CSI and the VC UI gets filled with AttachVolume tasks. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/2534

**Testing done**:
#### Manual
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2558#issuecomment-1726682191

#### block vanilla precheckin
```
Build #2441 (Sep 21, 2023, 7:20:34 PM)
adkulkarni
PR 2558
------------------------------ Ran 1 of 803 Specs in 368.841 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 802 Skipped PASS Ginkgo ran 1 suite in 18m43.833249849s Test Suite Passed -- ------------------------------ Ran 13 of 803 Specs in 6636.796 seconds SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 790 Skipped PASS Ginkgo ran 1 suite in 1h51m53.279468293s Test Suite Passed -- Ran 50 of 803 Specs in 4666.036 seconds FAIL! -- 49 Passed | 1 Failed | 0 Pending | 753 Skipped --- FAIL: TestE2E (4666.33s) FAIL Ginkgo ran 1 suite in 1h29m46.981350902s Test Suite Failed 

Build #2442 (Sep 21, 2023, 11:26:18 PM)
adkulkarni
PR 2558
------------------------------ Ran 1 of 803 Specs in 103.482 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 802 Skipped PASS Ginkgo ran 1 suite in 17m37.383719365s Test Suite Passed 
```

#### vcp to csi
```
Build #627 (Sep 22, 2023, 12:10:08 AM)
adkulkarni
PR 2558
Nimbus testbed password: KWAE0smy5QKw-*wd
------------------------------ Ran 20 of 803 Specs in 4391.390 seconds SUCCESS! -- 20 Passed | 0 Failed | 0 Pending | 783 Skipped PASS Ginkgo ran 1 suite in 1h14m45.85898182s Test Suite Passed 
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
vanilla: return volume path as part of ListVolumes response for migrated in-tree volumes
```
