### PR TITLE
Ginkgo labels assignment to topology testcases

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -267,12 +267,11 @@ const (
 	wcp                 = "wcp"
 	tkg                 = "tkg"
 	vanilla             = "vanilla"
-	topology            = "topology"
 	preferential        = "preferential"
 	vsphereConfigSecret = "vsphereConfigSecret"
 	snapshot            = "snapshot"
 	stable              = "stable"
-	newTests            = "newTests"
+	newTest             = "newTest"
 	multiVc             = "multiVc"
 	block               = "block"
 	file                = "file"
@@ -291,6 +290,7 @@ const (
 	semiAutomated       = "semiAutomated"
 	level2              = "level2"
 	level5              = "level5"
+	negative            = "negative"
 )
 
 // The following variables are required to know cluster type to run common e2e

--- a/tests/e2e/invalid_topology_values.go
+++ b/tests/e2e/invalid_topology_values.go
@@ -75,10 +75,13 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		4. Delete PVC
 		5. Delete SC
 	*/
-	ginkgo.It("Verify provisioning fails with region and zone having no nodes specified in the storage class", func() {
+	ginkgo.It("Verify provisioning fails with region and zone having no nodes specified "+
+		"in the storage class", ginkgo.Label(p1, block, vanilla, level2, stable, negative), func() {
+
 		var cancel context.CancelFunc
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		topologyWithNoNodes := NonExistingRegion + ":" + NonExistingZone
 		_, _, allowedTopologies = topologyParameterForStorageClass(topologyWithNoNodes)
 		storageclass, pvclaim, err = createPVCAndStorageClass(client,
@@ -112,7 +115,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		4. Delete PVC
 		5. Delete SC
 	*/
-	ginkgo.It("Verify provisioning fails with non existing region specified in the storage class", func() {
+	ginkgo.It("Verify provisioning fails with non existing region specified in "+
+		"the storage class", ginkgo.Label(p1, block, vanilla, level2, stable, negative), func() {
+
 		// Topology value = <NonExistingRegion>:<zone-with-shared-datastore>
 		var cancel context.CancelFunc
 		ctx, cancel := context.WithCancel(context.Background())
@@ -153,7 +158,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		4. Delete PVC
 		5. Delete SC
 	*/
-	ginkgo.It("Verify provisioning fails with valid region and non existing zone specified in the storage class", func() {
+	ginkgo.It("Verify provisioning fails with valid region and non existing zone specified "+
+		"in the storage class", ginkgo.Label(p1, block, vanilla, level2, stable, negative), func() {
+
 		var cancel context.CancelFunc
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/multi_vc.go
+++ b/tests/e2e/multi_vc.go
@@ -202,10 +202,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	*/
 
 	ginkgo.It("Workload creation on a multivc environment with sts specified with node affinity "+
-		"and SC with no allowed topology", func() {
+		"and SC with no allowed topology", ginkgo.Label(p0, block, vanilla, multiVc,
+		newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		parallelPodPolicy = true
 		nodeAffinityToSet = true
 		stsReplicas = 3
@@ -281,7 +282,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	*/
 
 	ginkgo.It("Workload creation when all allowed topology specified in SC on a "+
-		"multivc environment", func() {
+		"multivc environment", ginkgo.Label(p0, block, vanilla, multiVc, newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -341,7 +343,9 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		7. Clean up the data
 	*/
 
-	ginkgo.It("Workload creation when specific storage policy of any single VC is given in SC", func() {
+	ginkgo.It("Workload creation when specific storage policy of any single VC is "+
+		"given in SC", ginkgo.Label(p0, block, vanilla, multiVc, newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -406,7 +410,9 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	7. Clean up the data
 	*/
 
-	ginkgo.It("Workload creation when storage policy available in multivc setup is given in SC", func() {
+	ginkgo.It("Workload creation when storage policy available in multivc setup"+
+		"is given in SC", ginkgo.Label(p0, block, vanilla, multiVc, newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -498,7 +504,9 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	*/
 
 	ginkgo.It("Workload creation on a multivc environment with sts specified with pod affinity "+
-		"and SC with no allowed topology", func() {
+		"and SC with no allowed topology", ginkgo.Label(p0, block, vanilla, multiVc,
+		newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -551,7 +559,9 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	10. Clean up the data
 	*/
 
-	ginkgo.It("Deploy workload with allowed topology and datastore url on a multivc environment", func() {
+	ginkgo.It("Deploy workload with allowed topology and datastore url on a multivc environment", ginkgo.Label(p0,
+		block, vanilla, multiVc, newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -615,7 +625,9 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	*/
 
 	ginkgo.It("Deploy workload with allowed topology details in SC specific "+
-		"to VC1 with Immediate Binding", func() {
+		"to VC1 with Immediate Binding", ginkgo.Label(p0, block, vanilla, multiVc,
+		newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -680,10 +692,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	*/
 
 	ginkgo.It("Deploy workload with allowed topology details in SC specific to VC2 with WFC "+
-		"binding mode and with default pod management policy", func() {
+		"binding mode and with default pod management policy", ginkgo.Label(p1, block, vanilla, multiVc,
+		newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		stsReplicas = 3
 		scaleDownReplicaCount = 2
 		scaleUpReplicaCount = 5
@@ -747,10 +760,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	*/
 
 	ginkgo.It("Deploy workload with allowed topology details in SC specific to VC3 with "+
-		"parallel pod management policy", func() {
+		"parallel pod management policy", ginkgo.Label(p1, block, vanilla, multiVc,
+		newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		stsReplicas = 3
 		parallelPodPolicy = true
 		scaleDownReplicaCount = 1
@@ -819,10 +833,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		7. Clean up the data
 	*/
 
-	ginkgo.It("Deploy workload with default SC parameters with WaitForFirstConsumer", func() {
+	ginkgo.It("Deploy workload with default SC parameters with WaitForFirstConsumer", ginkgo.Label(p0,
+		block, vanilla, multiVc, newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		stsReplicas = 5
 		pvcCount := 5
 		var podList []*v1.Pod
@@ -953,7 +968,9 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	7. Clean up the data
 	*/
 
-	ginkgo.It("Create SC with single allowed topology label on a multivc environment", func() {
+	ginkgo.It("Create SC with single allowed topology label on a multivc environment", ginkgo.Label(p1,
+		block, vanilla, multiVc, newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -1009,10 +1026,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	3. Perform cleanup
 	*/
 
-	ginkgo.It("PVC creation failure when wrong storage policy name is specified in SC", func() {
+	ginkgo.It("PVC creation failure when wrong storage policy name is specified in SC", ginkgo.Label(p2,
+		block, vanilla, multiVc, newTest, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		storagePolicyName := "shared-ds-polic"
 		scParameters[scParamStoragePolicyName] = storagePolicyName
 
@@ -1043,10 +1061,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		2. PVC should not go to bound, appropriate error should be shown
 	*/
 
-	ginkgo.It("Deploy workload with allowed topology of VC1 and datastore url of VC2", func() {
+	ginkgo.It("Deploy workload with allowed topology of VC1 and datastore url of VC2", ginkgo.Label(p2,
+		block, vanilla, multiVc, newTest, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		topValStartIndex = 0
 		topValEndIndex = 1
 		scParameters[scParamDatastoreURL] = datastoreURLVC2
@@ -1088,10 +1107,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		7. Clear data
 	*/
 
-	ginkgo.It("Create storage policy in multivc and later delete storage policy from one of the VC", func() {
+	ginkgo.It("Create storage policy in multivc and later delete storage policy from "+
+		"one of the VC", ginkgo.Label(p2, block, vanilla, multiVc, newTest, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		topValStartIndex = 1
 		topValEndIndex = 2
 		stsReplicas = 3
@@ -1158,10 +1178,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		6. Clean up the data
 	*/
 
-	ginkgo.It("Create Deployment pod using SC with allowed topology set to specific VC", func() {
+	ginkgo.It("Create Deployment pod using SC with allowed topology set to specific VC", ginkgo.Label(p1,
+		block, vanilla, multiVc, newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		topValStartIndex = 2
 		topValEndIndex = 3
 		var lables = make(map[string]string)
@@ -1228,10 +1249,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		2. Create PVC, Pvc should not reach bound state. It should throuw error
 	*/
 
-	ginkgo.It("Create SC with invalid allowed topology details", func() {
+	ginkgo.It("Create SC with invalid allowed topology details", ginkgo.Label(p2, block,
+		vanilla, multiVc, newTest, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		topValStartIndex = 1
 		topValEndIndex = 1
 
@@ -1282,10 +1304,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 			9. Clean up the data
 	*/
 
-	ginkgo.It("Offline and online volume expansion on a multivc setup", func() {
+	ginkgo.It("Offline and online volume expansion on a multivc setup", ginkgo.Label(p1, block,
+		vanilla, multiVc, newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		var pvclaims []*v1.PersistentVolumeClaim
 
 		ginkgo.By("Create StorageClass")
@@ -1370,10 +1393,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 			9. Perform Cleanup
 	*/
 
-	ginkgo.It("Create workload and reboot one of the VC", func() {
+	ginkgo.It("Create workload and reboot one of the VC", ginkgo.Label(p2, block,
+		vanilla, multiVc, newTest, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		stsReplicas = 5
 		sts_count := 3
 		parallelStatefulSetCreation = true
@@ -1457,10 +1481,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	    6. Clean up the data
 	*/
 
-	ginkgo.It("Storage policy is present in VC1 and VC1 is under reboot", func() {
+	ginkgo.It("Storage policy is present in VC1 and VC1 is under reboot", ginkgo.Label(p1, block,
+		vanilla, multiVc, newTest, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		stsReplicas = 3
 		scParameters[scParamStoragePolicyName] = storagePolicyInVc1
 		parallelStatefulSetCreation = true
@@ -1564,10 +1589,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	    15. Clean up the data
 	*/
 
-	ginkgo.It("Create workloads when VSAN-health is down on VC1", func() {
+	ginkgo.It("Create workloads when VSAN-health is down on VC1", ginkgo.Label(p1, block,
+		vanilla, multiVc, newTest, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		stsReplicas = 5
 		pvcCount := 3
 		scaleDownReplicaCount = 1
@@ -1739,7 +1765,9 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	12. Clean up the data
 	*/
 
-	ginkgo.It("Create workloads with storage policy given in SC and when sps service is down", func() {
+	ginkgo.It("Create workloads with storage policy given in SC and when sps service is down", ginkgo.Label(p1,
+		block, vanilla, multiVc, newTest, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -1857,7 +1885,9 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		6. Clean up data
 	*/
 
-	ginkgo.It("Verify static provisioning and node affinity details on PV in a multivc setup", func() {
+	ginkgo.It("Verify static provisioning and node affinity details on PV in a multivc setup", ginkgo.Label(p2,
+		block, vanilla, multiVc, newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -1971,10 +2001,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 	7. Clean up the data
 	*/
 
-	ginkgo.It("Validate Listvolume response when volume is deleted from CNS in a multivc", func() {
+	ginkgo.It("Validate Listvolume response when volume is deleted from CNS "+
+		"in a multivc", ginkgo.Label(p1, block, vanilla, multiVc, newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		curtime := time.Now().Unix()
 		randomValue := rand.Int()
 		val := strconv.FormatInt(int64(randomValue), 10)

--- a/tests/e2e/multi_vc_config_secret.go
+++ b/tests/e2e/multi_vc_config_secret.go
@@ -219,10 +219,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 	*/
 
 	ginkgo.It("Change vCenter password on one of the multi-vc setup and update the same "+
-		"in csi vsphere conf", func() {
+		"in csi vsphere conf", ginkgo.Label(p1, vsphereConfigSecret, block, vanilla,
+		multiVc, newTest, flaky), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		clientIndex := 0
 		stsReplicas = 3
 		scaleUpReplicaCount = 5
@@ -323,7 +324,9 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 	Observe the system behaviour , Expectation is CSI pod's should show CLBO or should show error
 	*/
 
-	ginkgo.It("Copy same vCenter details twice in csi vsphere conf in a multi-vc setup", func() {
+	ginkgo.It("Copy same vCenter details twice in csi vsphere conf in a multi-vc setup", ginkgo.Label(p2,
+		vsphereConfigSecret, block, vanilla, multiVc, newTest, flaky), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -435,10 +438,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 	*/
 
 	ginkgo.It("Use VC-hostname instead of VC-IP for one VC and try to switch the same during"+
-		"a workload vcreation in a multivc setup", func() {
+		"a workload vcreation in a multivc setup", ginkgo.Label(p1,
+		vsphereConfigSecret, block, vanilla, multiVc, newTest, flaky), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		stsReplicas = 10
 		scaleUpReplicaCount = 5
 		scaleDownReplicaCount = 2
@@ -548,10 +552,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 	*/
 
 	ginkgo.It("Install CSI driver on different namespace and restart CSI-controller and node daemon sets"+
-		"in between the statefulset creation", func() {
+		"in between the statefulset creation", ginkgo.Label(p2,
+		vsphereConfigSecret, block, vanilla, multiVc, newTest, flaky), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		stsReplicas = 5
 		sts_count := 3
 		ignoreLabels := make(map[string]string)
@@ -717,10 +722,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 	    8. Clean up the data
 	*/
 
-	ginkgo.It("Keep different passwords on each VC and check Statefulset creation and reboot VC", func() {
+	ginkgo.It("Keep different passwords on each VC and check Statefulset creation and reboot VC", ginkgo.Label(p2,
+		vsphereConfigSecret, block, vanilla, multiVc, newTest, flaky, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		stsReplicas = 3
 		scaleUpReplicaCount = 5
 		scaleDownReplicaCount = 2
@@ -898,10 +904,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 	*/
 
 	ginkgo.It("Change VC in the UI but not on the vsphere secret and verify "+
-		"volume creation workflow on a multivc setup", func() {
+		"volume creation workflow on a multivc setup", ginkgo.Label(p2,
+		vsphereConfigSecret, block, vanilla, multiVc, newTest, flaky), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		clientIndex := 0
 
 		ginkgo.By("Changing password on the vCenter VC1 host")
@@ -965,10 +972,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 	vsphere-secret is fixed
 	*/
 
-	ginkgo.It("Add any wrong entry in vsphere conf and verify csi pods behaviour", func() {
+	ginkgo.It("Add any wrong entry in vsphere conf and verify csi pods behaviour", ginkgo.Label(p2,
+		vsphereConfigSecret, block, vanilla, multiVc, newTest, flaky), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		wrongPortNoVC1 := "337"
 
 		// read original vsphere config secret
@@ -1055,5 +1063,4 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvclaim.Name)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
 	})
-
 })

--- a/tests/e2e/multi_vc_multi_replica.go
+++ b/tests/e2e/multi_vc_multi_replica.go
@@ -135,10 +135,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-replica] Multi-VC-Replica", func() {
 	*/
 
 	ginkgo.It("Verify behaviour when CSI-Provisioner, CSI-Attacher, Vsphere-Syncer is "+
-		"deleted repeatedly during workload creation in multivc", func() {
+		"deleted repeatedly during workload creation in multivc", ginkgo.Label(p1,
+		block, vanilla, multiVc, newTest), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		sts_count := 3
 		statefulSetReplicaCount = 5
 

--- a/tests/e2e/multi_vc_operation_storm.go
+++ b/tests/e2e/multi_vc_operation_storm.go
@@ -186,11 +186,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-operation-storm] Multi-VC-Operation-Storm
 	*/
 
 	ginkgo.It("Create statefulset pods in scale and in between bring down datatsore, esxi hosts "+
-		"and kill containers", func() {
+		"and kill containers", ginkgo.Label(p1, block, vanilla, multiVc, newTest, flaky,
+		disruptive), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		sts_count := 5
 		statefulSetReplicaCount = 10
 		noOfHostToBringDown := 1

--- a/tests/e2e/multi_vc_preferential_topology.go
+++ b/tests/e2e/multi_vc_preferential_topology.go
@@ -204,10 +204,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-preferential-topology] Multi-VC-Preferent
 	    9. The volumes should get provision on the datastores which has the preference
 	    10. Clear the data
 	*/
-	ginkgo.It("Tag one datastore as preferred each in VC1 and VC2 and verify it is honored", func() {
+	ginkgo.It("Tag one datastore as preferred each in VC1 and VC2 and verify it is honored", ginkgo.Label(p0,
+		block, vanilla, multiVc, newTest, preferential), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		parallelStatefulSetCreation = true
 		preferredDatastoreChosen = 1
 		preferredDatastorePaths = nil
@@ -362,7 +363,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-preferential-topology] Multi-VC-Preferent
 	*/
 
 	ginkgo.It("Create SC with storage policy available in VC1 and VC2 and set the "+
-		"preference in VC1 datastore only", func() {
+		"preference in VC1 datastore only", ginkgo.Label(p0, block, vanilla, multiVc, newTest,
+		preferential), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -508,10 +510,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-preferential-topology] Multi-VC-Preferent
 	18. Remove datastore preference tags as part of cleanup.
 	*/
 
-	ginkgo.It("Assign preferred datatsore to any one VC and verify create restore snapshot", func() {
+	ginkgo.It("Assign preferred datatsore to any one VC and verify create restore snapshot", ginkgo.Label(p0,
+		block, vanilla, multiVc, newTest, snapshot, preferential), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		preferredDatastoreChosen = 1
 		preferredDatastorePaths = nil
 		var dsUrls []string
@@ -654,10 +657,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-preferential-topology] Multi-VC-Preferent
 	*/
 
 	ginkgo.It("Assign preferred datatsore to any one VC and verify create restore snapshot "+
-		"and later change datastore preference", func() {
+		"and later change datastore preference", ginkgo.Label(p1, block, vanilla, multiVc,
+		newTest, snapshot, negative, preferential), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		preferredDatastoreChosen = 1
 		preferredDatastorePaths = nil
 		var dsUrls []string

--- a/tests/e2e/multi_vc_site_down.go
+++ b/tests/e2e/multi_vc_site_down.go
@@ -169,10 +169,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology-sitedown] Multi-VC-SiteDown", fu
 	9. Clean up the data
 	*/
 
-	ginkgo.It("Bring down few esx on VC2 availability zones in a multi-vc setup", func() {
+	ginkgo.It("Bring down few esx on VC2 availability zones in a multi-vc setup", ginkgo.Label(p1,
+		block, vanilla, multiVc, newTest, flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		sts_count := 3
 		statefulSetReplicaCount = 5
 		noOfHostToBringDown := 1
@@ -317,10 +318,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology-sitedown] Multi-VC-SiteDown", fu
 	    13. Clean up the data
 	*/
 
-	ginkgo.It("Bring down few esx on VC1 availability zones in a multi-vc setup", func() {
+	ginkgo.It("Bring down few esx on VC1 availability zones in a multi-vc setup", ginkgo.Label(p1,
+		block, vanilla, multiVc, newTest, flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		statefulSetReplicaCount = 10
 		scParameters[scParamStoragePolicyName] = storagePolicyInVc1Vc2
 		topValStartIndex = 0
@@ -420,10 +422,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology-sitedown] Multi-VC-SiteDown", fu
 	    9. Clean up the data
 	*/
 
-	ginkgo.It("Bring down full site VC2 in a multi setup", func() {
+	ginkgo.It("Bring down full site VC2 in a multi setup", ginkgo.Label(p1,
+		block, vanilla, multiVc, newTest, flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		statefulSetReplicaCount = 5
 		topValStartIndex = 0
 		topValEndIndex = 2
@@ -558,10 +561,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology-sitedown] Multi-VC-SiteDown", fu
 	    9. Clean up the data
 	*/
 
-	ginkgo.It("Bring down full site VC1 in a multi setup", func() {
+	ginkgo.It("Bring down full site VC1 in a multi setup", ginkgo.Label(p1,
+		block, vanilla, multiVc, newTest, flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		statefulSetReplicaCount = 5
 		topValStartIndex = 0
 		topValEndIndex = 2
@@ -696,10 +700,11 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology-sitedown] Multi-VC-SiteDown", fu
 	    8. Clean up the data
 	*/
 
-	ginkgo.It("TestBring down datastores in a multi vc setup", func() {
+	ginkgo.It("Bring down datastores in a multi vc setup", ginkgo.Label(p2,
+		block, vanilla, multiVc, newTest, flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		statefulSetReplicaCount = 10
 		parallelPodPolicy = true
 		clientIndex := 1

--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -233,8 +233,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			18. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
 			19. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Tag single preferred datastore each in rack-1 and rack-2 "+
-		"and verify it is honored", ginkgo.Label(p0, topology, preferential, block, vanilla, level5), func() {
+	ginkgo.It("Tag single preferred datastore each in rack-1 and rack-2 and verify it is "+
+		"honored", ginkgo.Label(p0, block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -404,7 +405,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			16. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
 			17. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Tag multiple preferred datastores in rack-3 and verify it is honored", func() {
+	ginkgo.It("Tag multiple preferred datastores in rack-3 and verify it is honored", ginkgo.Label(p0,
+		block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -527,7 +530,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			18. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
 			19. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Tag multiple preferred datastores in rack-2 and verify it is honored", func() {
+	ginkgo.It("Tag multiple preferred datastores in rack-2 and verify it is honored", ginkgo.Label(p0,
+		block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 2
@@ -649,7 +654,8 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			10. Remove datastore preference tags as part of cleanup.
 	*/
 	ginkgo.It("Assign preferred tag to shared datastore which is accessible across all racks "+
-		"and verify it is honored", func() {
+		"and verify it is honored", ginkgo.Label(p0, block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -740,7 +746,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			10. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
 			11. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Assign multiple preferred tags to shared datastore with single allowed topology set", func() {
+	ginkgo.It("Assign multiple preferred tags to shared datastore with single allowed topology set", ginkgo.Label(p0,
+		block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -838,7 +846,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			12. Remove datastore preference tags as part of cleanup.
 	*/
 	ginkgo.It("Assign multiple tags to preferred shared datastore which is shared across all "+
-		"racks with multiple allowed topologies", func() {
+		"racks with multiple allowed topologies", ginkgo.Label(p0, block, vanilla, level5, preferential,
+		stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -932,7 +942,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			10. Remove datastore preference tags as part of cleanup.
 	*/
 	ginkgo.It("Assign single tag to preferred shared datastore which is shared across all "+
-		"racks with multiple allowed topologies", func() {
+		"racks with multiple allowed topologies", ginkgo.Label(p0, block, vanilla, level5, preferential,
+		stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -1027,7 +1039,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			16. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
 			17. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Change datatsore preferences in rack-1 and verify it is honored", func() {
+	ginkgo.It("Change datatsore preferences in rack-1 and verify it is honored", ginkgo.Label(p0,
+		block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -1197,7 +1211,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			21. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
 			22. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Change datatsore preferences in rack-3 and verify it is honored", func() {
+	ginkgo.It("Change datatsore preferences in rack-3 and verify it is honored", ginkgo.Label(p0,
+		block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -1394,7 +1410,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		26. Remove datastore preference tags as part of cleanup.
 	*/
 	ginkgo.It("Change datastore preference multiple times and perform scaleup and scaleDown "+
-		"operation on StatefulSet", func() {
+		"operation on StatefulSet", ginkgo.Label(p0,
+		block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -1586,7 +1604,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		26. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
 		27. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Tag single datastore from each rack when no allowed topologies are set in the SC", func() {
+	ginkgo.It("Tag single datastore from each rack when no allowed topologies are set in the SC", ginkgo.Label(p1,
+		block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -1742,7 +1762,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		11. Perform cleanup. Delete StatefulSet, PVC, PV and SC.
 		12. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Tag multiple datastore and provide specific datastore url in SC", func() {
+	ginkgo.It("Tag multiple datastore and provide specific datastore url in SC", ginkgo.Label(p0,
+		block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 2
@@ -1840,7 +1862,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		7. Remove datastore preference tags as part of cleanup.
 	*/
 	ginkgo.It("Tag multiple preferred datastore and create pvc which is greater than the "+
-		"size of datastore capacity provided in storage policy", func() {
+		"size of datastore capacity provided in storage policy", ginkgo.Label(p2,
+		block, vanilla, level5, preferential, stable, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -1909,7 +1933,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		10. Perform cleanup. Delete Pod, PVC and PV, SC.
 		11. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Tag preferred datastore and provide storage policy in SC", func() {
+	ginkgo.It("Tag preferred datastore and provide storage policy in SC", ginkgo.Label(p0,
+		block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -2025,7 +2051,10 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		14. Perform cleanup. Delete StatefulSet, PVC and PV, SC.
 		15. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("When all racks are specfied in allowed topology with preferred tag assign to each rack datastore", func() {
+	ginkgo.It("When all racks are specfied in allowed topology with preferred tag assign to "+
+		"each rack datastore", ginkgo.Label(p1,
+		block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -2160,7 +2189,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		5. Perform cleanup. Delete PVC and SC.
 		6. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Assign tag rack-1 to datastores which is accessible only on rack-2", func() {
+	ginkgo.It("Assign tag rack-1 to datastores which is accessible only on rack-2", ginkgo.Label(p2,
+		block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 2
@@ -2273,7 +2304,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		10. Perform cleanup. Delete Pod, PVC and PV, SC.
 		11. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Assign vSan default storage policy and give preference to other datatsores", func() {
+	ginkgo.It("Assign vSan default storage policy and give preference to other datatsores", ginkgo.Label(p1,
+		block, vanilla, level5, preferential, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -2383,7 +2416,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		5. Perform cleanup. Delete PVC and SC.
 		6. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Assign invalid storage policy and give preference to the datatsore specific to rack-1", func() {
+	ginkgo.It("Assign invalid storage policy and give preference to the datatsore specific "+
+		"to rack-1", ginkgo.Label(p2, block, vanilla, level5, preferential, stable, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -2450,7 +2485,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		15. Perform cleanup. Delete Pod,PVC and SC.
 		16. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Volume provisioning on preferred datatsore when sps service is down", func() {
+	ginkgo.It("Volume provisioning on preferred datatsore when sps service is down", ginkgo.Label(p1,
+		block, vanilla, level5, preferential, stable, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 2

--- a/tests/e2e/preferential_topology_disruptive.go
+++ b/tests/e2e/preferential_topology_disruptive.go
@@ -233,7 +233,9 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 			25. Make sure K8s cluster  is healthy
 			26. Perform cleanup. Delete StatefulSet, PVC and PV, SC.
 	*/
-	ginkgo.It("Bring down partial site when multiple preferred datatsores are tagged", func() {
+	ginkgo.It("Bring down partial site when multiple preferred datatsores are tagged", ginkgo.Label(p1,
+		block, vanilla, level5, preferential, stable, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -494,7 +496,9 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 	*/
 
 	ginkgo.It("Multiple preferred datatstores are tagged in rack-2 where one preferred datatsore "+
-		"moved to inaccessible or in power off state", func() {
+		"moved to inaccessible or in power off state", ginkgo.Label(p1,
+		block, vanilla, level5, preferential, stable, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -717,7 +721,9 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 	*/
 
 	ginkgo.It("Multiple preferred datastores are tagged in rack-1 where one of the preferred datastore "+
-		"is moved to maintenance mode", func() {
+		"is moved to maintenance mode", ginkgo.Label(p1,
+		block, vanilla, level5, preferential, stable, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -950,7 +956,9 @@ var _ = ginkgo.Describe("[Disruptive-Preferential-Topology] Preferential-Topolog
 	*/
 
 	ginkgo.It("Multiple preferred datatstores are tagged in rack-2 where one preferred datatsore "+
-		"moved to suspended state", func() {
+		"moved to suspended state", ginkgo.Label(p1, block, vanilla, level5, preferential,
+		stable, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1

--- a/tests/e2e/preferential_topology_snapshot.go
+++ b/tests/e2e/preferential_topology_snapshot.go
@@ -235,7 +235,9 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		13.Remove datastore preference tags as part of cleanup.
 	*/
 
-	ginkgo.It("Create restore snapshot of pvc using single datastore preference", func() {
+	ginkgo.It("Create restore snapshot of pvc using single datastore preference", ginkgo.Label(p0,
+		block, vanilla, level5, preferential, stable, snapshot), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var pvclaim *v1.PersistentVolumeClaim
@@ -363,7 +365,9 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		11. Remove datastore preference tags as part of cleanup.
 	*/
 
-	ginkgo.It("Create restore snapshot of pvc when datastore preference gets changed", func() {
+	ginkgo.It("Create restore snapshot of pvc when datastore preference gets changed", ginkgo.Label(p1,
+		block, vanilla, level5, preferential, stable, snapshot, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var pvclaim *v1.PersistentVolumeClaim
@@ -515,7 +519,9 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 	*/
 
 	ginkgo.It("Create restore snapshot of pvc when multiple preferred datastores are tagged "+
-		"and datastore preference is changed", func() {
+		"and datastore preference is changed", ginkgo.Label(p0,
+		block, vanilla, level5, preferential, stable, snapshot), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1
@@ -922,7 +928,9 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		19. Perform Cleanup. Delete StatefulSet, PVC,PV
 		20. Remove datastore preference tags as part of cleanup.
 	*/
-	ginkgo.It("Tag preferred datatsore and verify snapshot workflow for statefulset", func() {
+	ginkgo.It("Tag preferred datatsore and verify snapshot workflow for statefulset", ginkgo.Label(p0,
+		block, vanilla, level5, preferential, stable, snapshot), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		preferredDatastoreChosen = 1

--- a/tests/e2e/provision_with_multiple_zones.go
+++ b/tests/e2e/provision_with_multiple_zones.go
@@ -98,9 +98,12 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		8. Delete PVC
 		9. Delete Storage Class
 	*/
-	ginkgo.It("Verify provisioning with multiple zones and with only one zone associated with shared datastore", func() {
+	ginkgo.It("Verify provisioning with multiple zones and with only one zone associated with "+
+		"shared datastore", ginkgo.Label(p0, block, vanilla, level2, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		storageclass, pvclaim, err = createPVCAndStorageClass(client,
 			namespace, nil, nil, "", allowedTopologies, "", false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -180,9 +183,11 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		7. Delete POD,PVC,PV
 	*/
 	ginkgo.It("Provisioning volume using storage policy with multiple zone and region "+
-		"details in the allowed topology", func() {
+		"details in the allowed topology", ginkgo.Label(p0, block, vanilla, level2, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		// Took Region1, Zone1 of Cluster1 and Region2, Zone2 of Cluster2
 		topologyLabelsCluster1 := GetAndExpectStringEnvVar(envRegionZoneWithSharedDS)
 		topologyLabelsCluster2 := GetAndExpectStringEnvVar(envRegionZoneWithNoSharedDS)

--- a/tests/e2e/statefulset_with_topology.go
+++ b/tests/e2e/statefulset_with_topology.go
@@ -74,9 +74,12 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		8. Delete PVC
 		9. Delete SC
 	*/
-	ginkgo.It("Verify if stateful set is scheduled on a node within the topology after deleting the pod", func() {
+	ginkgo.It("Verify if stateful set is scheduled on a node within the topology "+
+		"after deleting the pod", ginkgo.Label(p0, block, vanilla, level2, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		ginkgo.By("Creating StorageClass for Statefulset")
 		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "", "", false)
 		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
@@ -144,9 +147,12 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		7. Delete statefulset
 		8. Delete PVC and SC
 	*/
-	ginkgo.It("Storage policy with single zone and region details in the allowed topology", func() {
+	ginkgo.It("Storage policy with single zone and region details in "+
+		"the allowed topology", ginkgo.Label(p0, block, vanilla, level2, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		// Creating StorageClass with topology details
 		ginkgo.By("Creating StorageClass for Statefulset")
 		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, allowedTopologies, "", "", false)

--- a/tests/e2e/topology_aware_node_poweroff.go
+++ b/tests/e2e/topology_aware_node_poweroff.go
@@ -75,7 +75,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 	// 10. Delete Stateful set and wait for disk to be detached.
 	// 11. Delete PVC.
 	// 12. Delete SC.
-	ginkgo.It("Verify if stateful set is scheduled on a node within the topology after node power off", func() {
+	ginkgo.It("Verify if stateful set is scheduled on a node within the topology "+
+		"after node power off", ginkgo.Label(p1, block, vanilla, level2, stable, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		// Preparing allowedTopologies using topologies with shared and non shared datastores
@@ -208,7 +210,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 	// 10. Delete PVC.
 	// 11. Delete SC.
 	ginkgo.It("Verify if stateful set do not get scheduled on other zone "+
-		"after powering off the only node in current zone", func() {
+		"after powering off the only node in current zone", ginkgo.Label(p1, block, vanilla, level2,
+		stable, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		topologyValue := GetAndExpectStringEnvVar(envTopologyWithOnlyOneNode)
@@ -322,5 +326,4 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 			}
 		}
 	})
-
 })

--- a/tests/e2e/topology_multi_replica.go
+++ b/tests/e2e/topology_multi_replica.go
@@ -214,7 +214,9 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			19. Verify StatefulSet Pod's, PVC's are deleted successfully.
 		*/
 
-		ginkgo.It("Volume provisioning when CSI Provisioner is deleted during statefulset creation", func() {
+		ginkgo.It("Volume provisioning when CSI Provisioner is deleted during statefulset "+
+			"creation", ginkgo.Label(p1, block, vanilla, level5, stable), func() {
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			container_name = "csi-provisioner"
@@ -414,7 +416,9 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			15. Delete Statefulsets and Delete PVCs.
 		*/
 
-		ginkgo.It("Volume provisioning when CSI Attacher is deleted during statefulset creation", func() {
+		ginkgo.It("Volume provisioning when CSI Attacher is deleted during statefulset "+
+			"creation", ginkgo.Label(p1, block, vanilla, level5, stable), func() {
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			container_name = "csi-attacher"
@@ -596,7 +600,9 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			18. Delete Statefulsets and Delete PVCs.
 		*/
 
-		ginkgo.It("Volume provisioning when node daemonset restarts during statefulset creation", func() {
+		ginkgo.It("Volume provisioning when node daemonset restarts during statefulset "+
+			"creation", ginkgo.Label(p1, block, vanilla, level5, stable), func() {
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			container_name = "csi-attacher"
@@ -767,7 +773,9 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 		*/
 
 		ginkgo.It("Verify behaviour when CSI-resizer deleted and VSAN-Health "+
-			"is down during online Volume expansion", func() {
+			"is down during online Volume expansion", ginkgo.Label(p1, block, vanilla, level5,
+			stable), func() {
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			container_name = "csi-resizer"
@@ -968,7 +976,9 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			and filesystem for the volume on the pod should also be expanded.
 			8. Delete Pod, PVC and SC
 		*/
-		ginkgo.It("Verify the behaviour when CSI-resizer deleted during offline volume expansion", func() {
+		ginkgo.It("Verify the behaviour when CSI-resizer deleted during offline "+
+			"volume expansion", ginkgo.Label(p1, block, vanilla, level5, stable), func() {
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			container_name = "csi-resizer"
@@ -1176,7 +1186,9 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			10. Delete deployments and Delete PVCs.
 		*/
 
-		ginkgo.It("Verify behaviour when CSI Attacher is deleted during deployments pod creation", func() {
+		ginkgo.It("Verify behaviour when CSI Attacher is deleted during deployments pod "+
+			"creation", ginkgo.Label(p1, block, vanilla, level5, stable), func() {
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			container_name = "csi-attacher"
@@ -1317,7 +1329,9 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			16. Delete Statefulsets and Delete PVCs.
 		*/
 
-		ginkgo.It("Volume provisioning when sps service is down during statefulset creation", func() {
+		ginkgo.It("Volume provisioning when sps service is down during statefulset "+
+			"creation", ginkgo.Label(p1, block, vanilla, level5, stable), func() {
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			container_name = "csi-provisioner"
@@ -1508,7 +1522,9 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			9. Delete POD's, PVC's and SC.
 		*/
 
-		ginkgo.It("Verify dynamic provisioning with Thick policy when CSI-provisioner goes down", func() {
+		ginkgo.It("Verify dynamic provisioning with Thick policy when CSI-provisioner "+
+			"goes down", ginkgo.Label(p1, block, vanilla, level5, stable), func() {
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			container_name = "csi-provisioner"
@@ -1684,7 +1700,9 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			15. Delete POD, PVC and SC
 		*/
 
-		ginkgo.It("Password rotation during multiple pvc creations", func() {
+		ginkgo.It("Password rotation during multiple pvc creations", ginkgo.Label(p2, block, vanilla,
+			level5, stable, negative), func() {
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			container_name = "csi-provisioner"
@@ -1921,7 +1939,9 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			15. Expect all volume metadata, PVC metadata, Pod metadata should be present on the CNS.
 			16. Delete the POD's , PVC's and PV's
 		*/
-		ginkgo.It("Verify behaviour when CSI syncer is deleted and check fullsync", func() {
+		ginkgo.It("Verify behaviour when CSI syncer is deleted and check "+
+			"fullsync", ginkgo.Label(p1, block, vanilla, level5, stable), func() {
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			container_name = "vsphere-syncer"
@@ -2202,7 +2222,9 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 		   11. Verify CNS metadata for PVC's and PV's , Make sure label entries should got removed
 		*/
 
-		ginkgo.It("Verify Label update when syncer container goes down", func() {
+		ginkgo.It("Verify Label update when syncer container goes down", ginkgo.Label(p1, block, vanilla,
+			level5, stable), func() {
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			container_name = "vsphere-syncer"

--- a/tests/e2e/topology_new_node_with_different_labels.go
+++ b/tests/e2e/topology_new_node_with_different_labels.go
@@ -70,7 +70,9 @@ var _ = ginkgo.Describe("[csi-topology-for-new-node] Topology-Provisioning-For-N
 		from all the categories mentioned under `topology-categories`
 	*/
 
-	ginkgo.It("Verify volume provisioning when storage class created with different tag and category", func() {
+	ginkgo.It("Verify volume provisioning when storage class created with "+
+		"different tag and category", ginkgo.Label(p1, block, vanilla, level2, stable), func() {
+
 		var cancel context.CancelFunc
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -126,7 +128,9 @@ var _ = ginkgo.Describe("[csi-topology-for-new-node] Topology-Provisioning-For-N
 		8. Delete POD, PVC,SC
 	*/
 
-	ginkgo.It("Verify volume provisioning when storage class created with different tag under a known category", func() {
+	ginkgo.It("Verify volume provisioning when storage class created with "+
+		"different tag under a known category", ginkgo.Label(p1, block, vanilla, level2, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		StoragePolicyName := GetAndExpectStringEnvVar(envStoragePolicyNameForNonSharedDatastores)

--- a/tests/e2e/topology_operation_strom_cases.go
+++ b/tests/e2e/topology_operation_strom_cases.go
@@ -146,7 +146,9 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 	*/
 
 	ginkgo.It("Volume provisioning when multiple statefulsets creation is in "+
-		"progress and in between zones hosts are down", func() {
+		"progress and in between zones hosts are down", ginkgo.Label(p1, block,
+		vanilla, level5, flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		sts_count = 3
@@ -416,7 +418,9 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 	*/
 
 	ginkgo.It("Volume provisioning when multiple statefulsets creation in progress and in "+
-		"between zones hosts and container nodes are down", func() {
+		"between zones hosts and container nodes are down", ginkgo.Label(p1, block,
+		vanilla, level5, flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		sts_count = 3

--- a/tests/e2e/topology_site_down_cases.go
+++ b/tests/e2e/topology_site_down_cases.go
@@ -133,7 +133,9 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		20. Delete above created STS, PVC's and SC
 	*/
 
-	ginkgo.It("Volume provisioning when partial sites zone1 and zone2 hosts are down", func() {
+	ginkgo.It("Volume provisioning when partial sites zone1 and zone2 hosts are down", ginkgo.Label(p1,
+		block, vanilla, level5, flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		sts_count = 3
@@ -341,7 +343,9 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		20. Delete above created STS, PVC's and SC
 	*/
 
-	ginkgo.It("Volume provisioning when partial sites zone2 and zone3 hosts are down", func() {
+	ginkgo.It("Volume provisioning when partial sites zone2 and zone3 hosts are "+
+		"down", ginkgo.Label(p1, block, vanilla, level5, flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		sts_count = 3
@@ -541,7 +545,9 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		20. Delete above created STS, PVC's and SC
 	*/
 
-	ginkgo.It("Volume provisioning when partial sites zone1 zone2 and zone3 hosts are down", func() {
+	ginkgo.It("Volume provisioning when partial sites zone1 zone2 and zone3 hosts "+
+		"are down", ginkgo.Label(p1, block, vanilla, level5, flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		sts_count = 3
@@ -736,7 +742,9 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		20. Delete above created STS, PVC's and SC
 	*/
 
-	ginkgo.It("Volume provisioning when zone2 hosts are down", func() {
+	ginkgo.It("Volume provisioning when zone2 hosts are down", ginkgo.Label(p1, block, vanilla, level5,
+		flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		sts_count = 3
@@ -931,7 +939,9 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 			20. Delete above created STS, PVC's and SC
 	*/
 
-	ginkgo.It("Volume provisioning when zone3 hosts are down", func() {
+	ginkgo.It("Volume provisioning when zone3 hosts are down", ginkgo.Label(p1, block, vanilla,
+		level5, flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		sts_count = 3
@@ -1124,7 +1134,9 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		18. Delete above created STS, PVC's and SC
 	*/
 
-	ginkgo.It("Volume provisioning when zone2 is completely down", func() {
+	ginkgo.It("Volume provisioning when zone2 is completely down", ginkgo.Label(p1, block,
+		vanilla, level5, flaky, disruptive), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		sts_count = 3

--- a/tests/e2e/topology_snapshot.go
+++ b/tests/e2e/topology_snapshot.go
@@ -134,10 +134,11 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 	   9. Describe PV-2 and verify node affinity details, and verify POD should come up on same node as mentioned in PV2
 	   10. Perform Cleanup. Delete Snapshot, Pod, PVC, SC, volume-snapshot and VolumeSnapshot class.
 	*/
-	ginkgo.It("On a topology enabled testbed , create snapshot on dynamic PVC", func() {
+	ginkgo.It("On a topology enabled testbed , create snapshot on dynamic PVC", ginkgo.Label(p0,
+		block, vanilla, level5, snapshot, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-
 		var storageclass *storagev1.StorageClass
 		var pvclaim *v1.PersistentVolumeClaim
 		var err error
@@ -321,7 +322,9 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		8. Verify the node affinity details of all PV's and validate POD is up on appropriate node
 		9. Cleanup the sts and the snapshot  PVC's
 	*/
-	ginkgo.It("Topology Snapshot workflow for statefulset", func() {
+	ginkgo.It("Topology Snapshot workflow for statefulset", ginkgo.Label(p0,
+		block, vanilla, level5, snapshot, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var err error

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -154,10 +154,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 	*/
 
 	ginkgo.It("Provisioning volume when no topology details specified in storage class "+
-		"and using default pod management policy for statefulset", ginkgo.Label(p0, topology, block,
-		vanilla, level5), func() {
+		"and using default pod management policy for statefulset", ginkgo.Label(p0, block,
+		vanilla, level5, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		// Creating StorageClass when no topology details are specified using WFC Binding mode
 		ginkgo.By("Creating StorageClass for Statefulset")
 		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil, "",
@@ -228,9 +230,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 	*/
 
 	ginkgo.It("Provisioning volume when no topology details specified in storage class "+
-		"and using parallel pod management policy for statefulset", func() {
+		"and using parallel pod management policy for statefulset", ginkgo.Label(p0, block,
+		vanilla, level5, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		// Creating StorageClass when no topology details are specified using WFC Binding mode
 		ginkgo.By("Creating StorageClass for Statefulset")
 		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, nil, nil, "",
@@ -316,9 +321,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 	*/
 
 	ginkgo.It("Provisioning volume when storage class specified with WFC Binding mode "+
-		"with allowed topologies and using parallel pod management policy for statefulset", func() {
+		"with allowed topologies and using parallel pod management policy for statefulset", ginkgo.Label(p1,
+		block, vanilla, level5, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		/* Get allowed topologies for Storage Class
 		(region1 > zone1 > building1 > level1 > rack > rack3) */
 		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
@@ -411,9 +419,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 	*/
 
 	ginkgo.It("Provisioning volume when storage class specified with Immediate BindingMode "+
-		"with higher level allowed topologies and using default pod management policy for statefulset", func() {
+		"with higher level allowed topologies and using default pod management policy "+
+		"for statefulset", ginkgo.Label(p0, block, vanilla, level5, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		// Get allowed topologies for Storage Class (region1 > zone1 > building1)
 		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories, 3)
 
@@ -509,9 +520,11 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 
 	ginkgo.It("Provisioning volume when storage class specified with Immediate Bindingmode "+
 		"shared datastore url between multiple topology labels and using parallel pod management "+
-		"policy for statefulset", func() {
+		"policy for statefulset", ginkgo.Label(p1, block, vanilla, level5, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		sharedDataStoreUrlBetweenClusters := GetAndExpectStringEnvVar(datstoreSharedBetweenClusters)
 
 		/* Get allowed topologies for Storage Class
@@ -609,7 +622,9 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 	   8. Delete PVC and SC
 	*/
 	ginkgo.It("Provisioning volume when storage class specified with "+
-		"Immediate BindingMode with multiple allowed topologies and using DeploymentSet pod", func() {
+		"Immediate BindingMode with multiple allowed topologies and using DeploymentSet "+
+		"pod", ginkgo.Label(p1, block, vanilla, level5, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var lables = make(map[string]string)
@@ -694,9 +709,11 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 
 	ginkgo.It("Provisioning volume when storage class specified with multiple labels "+
 		"without specifying datastore url and using default pod management policy "+
-		"for statefulset", ginkgo.Label(p2, topology, block, vanilla, level5), func() {
+		"for statefulset", ginkgo.Label(p2, block, vanilla, level5, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		// Get allowed topologies for Storage Class rack > (rack1,rack2,rack3)
 		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
 			topologyLength)[4:]
@@ -759,9 +776,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		4. Delete PVC and SC.
 	*/
 
-	ginkgo.It("Verify volume provisioning when storage class specified with invalid topology label", func() {
+	ginkgo.It("Verify volume provisioning when storage class specified with invalid "+
+		"topology label", ginkgo.Label(p2, block, vanilla, level5, stable, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		// Get allowed topologies for Storage Class
 		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
 			topologyLength)
@@ -809,7 +829,9 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 	*/
 
 	ginkgo.It("Verify volume provisioning when storage class specified with Immediate "+
-		"BindingMode and pvc specified with ReadWriteMany access mode", func() {
+		"BindingMode and pvc specified with "+
+		"ReadWriteMany access mode", ginkgo.Label(p2, block, vanilla, level5, stable, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		// Get allowed topologies for Storage Class for all 5 levels
@@ -861,9 +883,11 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 	*/
 
 	ginkgo.It("Verify volume provisioning when storage class specified with one level "+
-		"topology along with datstore url", func() {
+		"topology along with datstore url", ginkgo.Label(p2, block, vanilla, level5, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		// Get allowed topologies for Storage Class (rack > rack2)
 		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
 			topologyLength, leafNode, leafNodeTag1)[4:]
@@ -951,9 +975,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		5. Delete POD, PVC and SC
 	*/
 	ginkgo.It("Verify volume provisioning when storage class specified with single "+
-		"level topology without datstore url", func() {
+		"level topology without datstore url", ginkgo.Label(p1, block, vanilla, level5,
+		stable, negative), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		// Get allowed topologies for Storage Class (rack > rack1)
 		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
 			topologyLength, leafNode, leafNodeTag0)[4:]
@@ -1038,9 +1065,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		the storage class.
 		9. Delete POD, PVC, PV and SC.
 	*/
-	ginkgo.It("Verify static volume provisioning with FCD and storage class with allowed topologies", func() {
+	ginkgo.It("Verify static volume provisioning with FCD and storage class with allowed "+
+		"topologies", ginkgo.Label(p1, block, vanilla, level5, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		/* Get allowed topologies for Storage Class
 		region1 > zone1 > building1 > level1 > rack > rack2 */
 		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
@@ -1177,9 +1207,12 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 
 	*/
 	ginkgo.It("Verify static volume provisioning with FCD and storage class specified "+
-		"with datastore url and set of allowed topologies", func() {
+		"with datastore url and set of allowed "+
+		"topologies", ginkgo.Label(p1, block, vanilla, level5, stable), func() {
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		/* Get allowed topologies for Storage Class
 		zone1 > building1 > level1 > rack > rack1/rack2/rack3 */
 		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,

--- a/tests/e2e/volume_provisioning_with_topology.go
+++ b/tests/e2e/volume_provisioning_with_topology.go
@@ -166,7 +166,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 		8. Delete PVC
 		9. Delete Storage Class
 	*/
-	ginkgo.It("Verify provisioning with valid topology specified in Storage Class passes", func() {
+	ginkgo.It("Verify provisioning with valid topology specified in Storage "+
+		"Class passes", ginkgo.Label(p0, block, vanilla, level2, stable), func() {
 		verifyBasicTopologyBasedVolumeProvisioning(f, client, namespace, nil, allowedTopologies)
 		testCleanUpUtil()
 	})
@@ -191,7 +192,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 	// 8. Delete PVC.
 	// 9. Delete Storage Class.
 	ginkgo.It("Verify provisioning with valid topology and accessible shared datastore "+
-		"specified in Storage Class passes", func() {
+		"specified in Storage Class passes", ginkgo.Label(p0, block, vanilla, level2, stable), func() {
+
 		sharedDatastoreURL := GetAndExpectStringEnvVar(envSharedDatastoreURL)
 		scParameters := make(map[string]string)
 		scParameters[scParamDatastoreURL] = sharedDatastoreURL
@@ -219,7 +221,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 	// 8. Delete PVC.
 	// 9. Delete Storage Class.
 	ginkgo.It("Verify dynamic volume provisioning works when allowed topology and "+
-		"storage policy is specified in the storageclass", func() {
+		"storage policy is specified in the storageclass", ginkgo.Label(p0, block, vanilla, level2,
+		stable), func() {
+
 		storagePolicyNameForSharedDatastores := GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 		scParameters := make(map[string]string)
 		scParameters[scParamStoragePolicyName] = storagePolicyNameForSharedDatastores
@@ -237,7 +241,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 	// 3. Verify PVC creation fails with “Not Accessible” error.
 	// 4. Delete PVC.
 	ginkgo.It("Verify provisioning volume with valid zone and region fails "+
-		"when an inaccessible non-shared datastore url is specified in Storage Class", func() {
+		"when an inaccessible non-shared datastore url is specified "+
+		"in Storage Class", ginkgo.Label(p0, block, vanilla, level2, stable), func() {
+
 		nonSharedDatastoreURLInZone := GetAndExpectStringEnvVar(envInaccessibleZoneDatastoreURL)
 		scParameters := make(map[string]string)
 		scParameters[scParamDatastoreURL] = nonSharedDatastoreURLInZone
@@ -257,7 +263,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 	// 3. Verify PVC creation fails with “Not Accessible” error.
 	// 4. Delete PVC.
 	ginkgo.It("Verify provisioning volume with valid zone and region fails "+
-		"when storage policy from different zone is specified in Storage Class", func() {
+		"when storage policy from different zone is specified "+
+		"in Storage Class", ginkgo.Label(p0, block, vanilla, level2, stable), func() {
+
 		storagePolicyNameFromOtherZone := GetAndExpectStringEnvVar(envStoragePolicyNameFromInaccessibleZone)
 		scParameters := make(map[string]string)
 		scParameters[scParamStoragePolicyName] = storagePolicyNameFromOtherZone
@@ -279,7 +287,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 		6. Delete PVC
 		7. Delete Storage Class
 	*/
-	ginkgo.It("Verify provisioning with no topology specified in Storage Class passes", func() {
+	ginkgo.It("Verify provisioning with no topology specified in "+
+		"Storage Class passes", ginkgo.Label(p0, block, vanilla, level2, stable), func() {
 		verifyBasicTopologyBasedVolumeProvisioning(f, client, namespace, nil, nil)
 		testCleanUpUtil()
 	})


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR holds code changes for assigning ginkgo labels to tectcase specific to its type. The code in this PR will distinguish which testcases are P0/P1 or P2 and belongs to which flavour.

**Testing done:**
Yes
[test-e2e-logs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/12672199/test-e2e-logs.txt)

Special notes for your reviewer:

**Make Check:**
sipriya@sipriyaSMD6M vsphere-csi-driver % golangci-lint run --enable=lll
sipriya@sipriyaSMD6M vsphere-csi-driver % make golangci-lint
hack/check-golangci-lint.sh
golangci/golangci-lint info checking GitHub for tag 'v1.49.0'
golangci/golangci-lint info found version: 1.49.0 for v1.49.0/darwin/amd64
golangci/golangci-lint info installed /Users/sipriya/go/bin/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/sipriya/adding-labels/vsphere-csi-driver /Users/sipriya/adding-labels /Users/sipriya /Users /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 9 linters: [errcheck gosimple govet ineffassign lll misspell staticcheck typecheck unused]
INFO [loader] Go packages loading at mode 575 (compiled_files|exports_file|imports|deps|files|name|types_sizes) took 1m17.315425624s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 160.730237ms