### PR TITLE
[CSI 3.0.3] Cross-port telemetry enhancements, CSI Migration bug fix related to AttachVolumes and also the nodes cache fix during attach/detach.

### DIFF
--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -192,7 +192,6 @@ func (m *defaultManager) GetNodeByNameOrUUID(
 		log.Errorf("failed to get node UUID from node: %q. Err: %v", nodeNameOrUUID, err)
 		return nil, err
 	}
-	m.nodeNameToUUID.Store(nodeNameOrUUID, k8snodeUUID)
 	return m.GetNode(ctx, k8snodeUUID, nil)
 }
 

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -294,3 +294,8 @@ func (c *FakeK8SOrchestrator) GetCSINodeTopologyInstanceByName(nodeName string) 
 	item interface{}, exists bool, err error) {
 	return nil, false, nil
 }
+
+// GetPVCNamespaceFromVolumeID retrieves the pv name from volumeID.
+func (c *FakeK8SOrchestrator) GetPVNameFromCSIVolumeID(volumeID string) (string, bool) {
+	return "", false
+}

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -81,6 +81,9 @@ type COCommonInterface interface {
 	GetCSINodeTopologyInstancesList() []interface{}
 	// GetCSINodeTopologyInstanceByName fetches the CSINodeTopology instance for a given node name in the cluster.
 	GetCSINodeTopologyInstanceByName(nodeName string) (item interface{}, exists bool, err error)
+	// GetPVNameFromCSIVolumeID retrieves the pv name from the volumeID.
+	// This method will not return pv name in case of in-tree migrated volumes
+	GetPVNameFromCSIVolumeID(volumeID string) (string, bool)
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -1544,3 +1544,8 @@ func (c *K8sOrchestrator) CreateConfigMap(ctx context.Context, name string, name
 
 	return nil
 }
+
+// GetPVNameFromCSIVolumeID retrieves the pv name from volumeID using volumeIDToNameMap.
+func (c *K8sOrchestrator) GetPVNameFromCSIVolumeID(volumeID string) (string, bool) {
+	return c.volumeIDToNameMap.get(volumeID)
+}

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1804,7 +1804,7 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 	createVolumeInternal := func() (
 		*csi.CreateVolumeResponse, string, error) {
 		log.Infof("CreateVolume: called with args %+v", *req)
-		//TODO: If the err is returned by invoking CNS API, then faultType should be
+		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
 		// If thr reqeust failed due to object not found, "csi.fault.NotFound" will be return.
@@ -1884,7 +1884,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 	deleteVolumeInternal := func() (
 		*csi.DeleteVolumeResponse, string, error) {
 		log.Infof("DeleteVolume: called with args: %+v", *req)
-		//TODO: If the err is returned by invoking CNS API, then faultType should be
+		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
 		// If thr reqeust failed due to object not found, "csi.fault.NotFound" will be return.
@@ -2024,7 +2024,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 	controllerPublishVolumeInternal := func() (
 		*csi.ControllerPublishVolumeResponse, string, error) {
 		log.Infof("ControllerPublishVolume: called with args %+v", *req)
-		//TODO: If the err is returned by invoking CNS API, then faultType should be
+		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
 		// If thr reqeust failed due to object not found, "csi.fault.NotFound" will be return.
@@ -2174,7 +2174,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		*csi.ControllerUnpublishVolumeResponse, string, error) {
 		var faultType string
 		log.Infof("ControllerUnpublishVolume: called with args %+v", *req)
-		//TODO: If the err is returned by invoking CNS API, then faultType should be
+		// TODO: If the err is returned by invoking CNS API, then faultType should be
 		// populated by the underlying layer.
 		// If the request failed due to validate the request, "csi.fault.InvalidArgument" will be return.
 		// If thr reqeust failed due to object not found, "csi.fault.NotFound" will be return.
@@ -2488,6 +2488,7 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 			querySelection := cnstypes.CnsQuerySelection{
 				Names: []string{
 					string(cnstypes.QuerySelectionNameTypeVolumeType),
+					string(cnstypes.QuerySelectionNameTypeVolumeName),
 				},
 			}
 			// For multi-VC configuration, query volumes from all vCenters
@@ -2636,9 +2637,17 @@ func (c *controller) processQueryResultsListVolumes(ctx context.Context, startin
 			nodeVMUUID, found := volumeIDToNodeUUIDMap[blockVolID]
 			if found {
 				volCounter += 1
-				//Populate csi.Volume info for the given volume
+				volumeId := blockVolID
+				migratedVolumePath, err := volumeMigrationService.GetVolumePathFromMigrationServiceCache(ctx, blockVolID)
+				if err != nil && err == common.ErrNotFound {
+					log.Debugf("volumeID: %v not found in migration service in-memory cache "+
+						"so it's not a migrated in-tree volume", blockVolID)
+				} else if migratedVolumePath != "" {
+					volumeId = migratedVolumePath
+				}
+				// Populate csi.Volume info for the given volume
 				blockVolumeInfo := &csi.Volume{
-					VolumeId: blockVolID,
+					VolumeId: volumeId,
 				}
 				// Getting published nodes
 				volStatus := &csi.ListVolumesResponse_VolumeStatus{
@@ -3199,7 +3208,7 @@ func queryAllVolumeSnapshotsForMultiVC(ctx context.Context, c *controller, token
 			CNSSnapshotsForListSnapshots = snapQueryEntries
 			CNSVolumeDetailsMap = cnsVolumeDetailsMap
 		} else {
-			//fetch snapshots
+			// fetch snapshots
 			snapQueryEntries, volumeDetails, err := getSnapshotsAndSourceVolumeDetails(ctx, vCenterManager,
 				c.manager.VolumeManager, c.manager.VcenterConfig.Host)
 			if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cross-port telemetry enhancements, CSI Migration bug fix related to AttachVolumes  and also the nodes cache fix during attach/detach.

The below pull requests are cherry-picked as part of this PR: 
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2546
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2404
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2558

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Running Vanilla k8s e2e pipeline

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cross-port telemetry enhancements and nodes cache fix during attach/detach.
```
