### PR TITLE
Topology pvc timeout fix

### DIFF
--- a/tests/e2e/binding_modes_with_topology.go
+++ b/tests/e2e/binding_modes_with_topology.go
@@ -99,9 +99,9 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By("Expect claim status to be in Pending state")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+			"Failed to find the volume in pending state with err: ", err.Error())
 
 		ginkgo.By("Creating a pod")
 		pod, err = createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, "")
@@ -109,8 +109,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 
 		ginkgo.By("Expect claim to be in Bound state and provisioning volume passes")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume with err: "+err.Error())
 
 		pv = getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",

--- a/tests/e2e/config_secret.go
+++ b/tests/e2e/config_secret.go
@@ -337,9 +337,9 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Expect claim status to be in Pending state")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
-			pvclaim3.Namespace, pvclaim3.Name, framework.Poll, time.Minute)
+			pvclaim3.Namespace, pvclaim3.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+			"Failed to find the volume in pending state with err: ", err.Error())
 		defer func() {
 			ginkgo.By("Deleting the PVC")
 			err = fpv.DeletePersistentVolumeClaim(client, pvclaim3.Name, namespace)
@@ -692,9 +692,9 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Expect claim status to be in Pending state")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
-			pvclaim2.Namespace, pvclaim2.Name, framework.Poll, time.Minute)
+			pvclaim2.Namespace, pvclaim2.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+			"Failed to find the volume in pending state with err: ", err.Error())
 		defer func() {
 			ginkgo.By("Deleting the PVC")
 			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
@@ -813,9 +813,9 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Expect claim status to be in Pending state")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
-			pvclaim2.Namespace, pvclaim2.Name, framework.Poll, time.Minute)
+			pvclaim2.Namespace, pvclaim2.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+			"Failed to find the volume in pending state with err: "+err.Error())
 		defer func() {
 			ginkgo.By("Deleting the PVC")
 			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
@@ -931,9 +931,10 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Expect claim status to be in Pending state")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
-			pvclaim1.Namespace, pvclaim1.Name, framework.Poll, time.Minute)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+			pvclaim1.Namespace, pvclaim1.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to find the volume in pending state "+
+			"with err: "+err.Error())
+
 		defer func() {
 			ginkgo.By("Deleting the PVC")
 			err = fpv.DeletePersistentVolumeClaim(client, pvclaim1.Name, namespace)
@@ -1049,9 +1050,9 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Expect claim status to be in Pending state")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
-			pvclaim2.Namespace, pvclaim2.Name, framework.Poll, time.Minute)
+			pvclaim2.Namespace, pvclaim2.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+			"Failed to find the volume in pending state with err: "+err.Error())
 		defer func() {
 			ginkgo.By("Deleting the PVC")
 			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)
@@ -1258,9 +1259,9 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Expect claim status to be in Pending state")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
-			pvclaim1.Namespace, pvclaim1.Name, framework.Poll, time.Minute)
+			pvclaim1.Namespace, pvclaim1.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+			"Failed to find the volume in pending state with err: "+err.Error())
 		var pvclaims1 []*v1.PersistentVolumeClaim
 		pvclaims1 = append(pvclaims1, pvclaim1)
 		defer func() {
@@ -1401,9 +1402,8 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ginkgo.By("Expect claim status to be in Pending state")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
-			pvclaim2.Namespace, pvclaim2.Name, framework.Poll, time.Minute)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+			pvclaim2.Namespace, pvclaim2.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to find the volume in pending state with err: "+err.Error())
 		defer func() {
 			ginkgo.By("Deleting the PVC")
 			err = fpv.DeletePersistentVolumeClaim(client, pvclaim2.Name, namespace)

--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -2561,9 +2561,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 
 		ginkgo.By("Expect claim status to be in Pending state since sps service is down")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, client,
-			pvc.Namespace, pvc.Name, framework.Poll, time.Minute)
+			pvc.Namespace, pvc.Name, framework.Poll, framework.ClaimProvisionTimeout)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err))
+			fmt.Sprintf("Failed to find the volume in pending state with err: %v", err.Error()))
 
 		ginkgo.By("Bringup SPS service")
 		startVCServiceWait4VPs(ctx, vcAddress, spsServiceName, &isSPSServiceStopped)

--- a/tests/e2e/provision_with_multiple_zones.go
+++ b/tests/e2e/provision_with_multiple_zones.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -113,8 +112,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Topology-Aware-Provisioning-With
 		}()
 		ginkgo.By("Expect claim to pass provisioning volume")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err.Error()))
 
 		ginkgo.By("Verify if volume is provisioned in specified zone and region")
 		pv = getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -808,13 +808,11 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 			}
 		}()
 
-		// Expect PVC claim to fail as invalid topology label is given in Storage Class
 		ginkgo.By("Expect claim to fail as invalid topology label is specified in Storage Class")
-		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
-			pvc.Namespace, pvc.Name, framework.Poll, time.Minute/2)
-		gomega.Expect(err).To(gomega.HaveOccurred())
-		framework.Logf("Volume Provisioning Failed for PVC %s due to invalid topology "+
-			"label given in Storage Class", pvc.Name)
+		expectedErrMsg := "No compatible datastores found for accessibility requirements"
+		framework.Logf("Expected failure message: %+q", expectedErrMsg)
+		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvc.Name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
 	})
 
 	/*

--- a/tests/e2e/volume_provisioning_with_topology.go
+++ b/tests/e2e/volume_provisioning_with_topology.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -101,8 +100,8 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 
 		ginkgo.By("Expect claim to pass provisioning volume")
 		err = fpv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client,
-			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to provision volume with err: %v", err))
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to provision volume with err: "+err.Error())
 
 		ginkgo.By("Verify if volume is provisioned in specified zone and region")
 		pv := getPvFromClaim(client, pvclaim.Namespace, pvclaim.Name)


### PR DESCRIPTION

**What this PR does / why we need it:**
Topology pvc creation timeout fix, earlier default wait time for PVC creation was set to 1 min, making it uniform to 5 mins default wait time for pvc creation.

**Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #**
Topology pvc creation timeout fix, earlier default wait time for PVC creation was set to 1 min, making it uniform to 5 mins default wait time for pvc creation.

Testing done:
Yes, regression results uploaded
[test-e2e-logs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/12715373/test-e2e-logs.txt)

