### PR TITLE
Verify Snapshot object existence before failing CnsVolumeOperation task for CreateSnapshot operation if corresponding CNS task has timed out and marked as error due to VC reboot/crash

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -99,6 +99,14 @@ func IsVimFaultNotFoundError(err error) bool {
 	return isNotFoundError
 }
 
+func IsVimFaultTimedOutError(err error) bool {
+	isTimedOutError := false
+	if soap.IsVimFault(err) {
+		_, isTimedOutError = soap.ToVimFault(err).(*types.Timedout)
+	}
+	return isTimedOutError
+}
+
 // IsCnsSnapshotNotFoundError checks if err is the CnsSnapshotNotFoundFault fault returned by CNS QuerySnapshots API
 func IsCnsSnapshotNotFoundError(err error) bool {
 	isCnsSnapshotNotFoundError := false


### PR DESCRIPTION
**What this PR does / why we need it**:
If vCenter goes down while the CNS task for snapshot creation is in progress, task status is not updated at CSI layer and corresponding CnsVolumeOperationRequest CR keeps the task status as in-progress, even if CNS has marked the task as error. Hence the operation is continuously retried at CSI layer and snapshot creation remains stuck.
It is possible that CNS task in the background has created snapshot object but CSI cannot claim it.
To fix this, we now check the error and taskinfo returned by waitOnTask() for the given snapshot creation CNS task. If the err indicates task timed out and taskinfo indicates status as error, instead of directly failing, we first check if requested snapshot object is already created at the CNS end. If yes, we return success, else for any other error, we mark corresponding task as failed in CnsVolumeOperationRequest CR.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran VC reboot parallel with snapshot creation testcase, that passed successfully.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Verify Snapshot object existence before failing CnsVolumeOperation task for CreateSnapshot operation if corresponding CNS task has timed out and marked as error due to VC reboot/crash.
```
