### PR TITLE
fss for PodVMOnStretchedSupervisor

### DIFF
--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -457,6 +457,7 @@ data:
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
   "listview-tasks": "true"
+  "podvm-on-stretched-supervisor": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -457,6 +457,7 @@ data:
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
   "listview-tasks": "true"
+  "podvm-on-stretched-supervisor": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -457,6 +457,7 @@ data:
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
   "listview-tasks": "true"
+  "podvm-on-stretched-supervisor": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -392,6 +392,8 @@ const (
 	CSIInternalGeneratedClusterID = "csi-internal-generated-cluster-id"
 	// ListViewPerf uses govmomi ListView to wait for CNS tasks
 	ListViewPerf = "listview-tasks"
-	// TopologyAwareFileVolume enables provisioning of file volumes in a topology emabled environment
+	// TopologyAwareFileVolume enables provisioning of file volumes in a topology enabled environment
 	TopologyAwareFileVolume = "topology-aware-file-volume"
+	// PodVMOnStretchedSupervisor enables Pod Vm Support on stretched supervisor cluster
+	PodVMOnStretchedSupervisor = "podvm-on-stretched-supervisor"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fss for PodVMOnStretchedSupervisor

This FSS will be used to guard cns-csi supervisor CSI controller changes to  support Pod VM on stretched supervisor cluster.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add podvm-on-stretched-supervisor fss
```
