### PR TITLE
vanilla: add guard for uninitialized volumeMigrationService in case of multi-vc

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -2644,12 +2644,16 @@ func (c *controller) processQueryResultsListVolumes(ctx context.Context, startin
 			if found {
 				volCounter += 1
 				volumeId := blockVolID
-				migratedVolumePath, err := volumeMigrationService.GetVolumePathFromMigrationServiceCache(ctx, blockVolID)
-				if err != nil && err == common.ErrNotFound {
-					log.Debugf("volumeID: %v not found in migration service in-memory cache "+
-						"so it's not a migrated in-tree volume", blockVolID)
-				} else if migratedVolumePath != "" {
-					volumeId = migratedVolumePath
+				// this check is required as volumeMigrationService is not initialized
+				// when multi-vc is enabled and there is more than 1 vc
+				if volumeMigrationService != nil {
+					migratedVolumePath, err := volumeMigrationService.GetVolumePathFromMigrationServiceCache(ctx, blockVolID)
+					if err != nil && err == common.ErrNotFound {
+						log.Debugf("volumeID: %v not found in migration service in-memory cache "+
+							"so it's not a migrated in-tree volume", blockVolID)
+					} else if migratedVolumePath != "" {
+						volumeId = migratedVolumePath
+					}
 				}
 				// Populate csi.Volume info for the given volume
 				blockVolumeInfo := &csi.Volume{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

`volumeMigrationService` is not initialized (https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/v3.1.0/pkg/csi/service/vanilla/controller.go#L350-L371) when multi-vc fss is enabled and there is more than 1 vCenter. 
So, we need to guard the usage of this object with a `nil` check. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual -> https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2582#issuecomment-1747696450

Pipeline -> In progress

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add guard for uninitialized volumeMigrationService in case of multi-vc
```
