### PR TITLE
GetDevMounts: eval symlinks found in mount table

### DIFF
--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -827,7 +827,14 @@ func (osUtils *OsUtils) GetDevMounts(ctx context.Context,
 		return devMnts, err
 	}
 	for _, m := range mnts {
-		if m.Device == sysDevice.RealDev || (m.Device == "devtmpfs" && m.Source == sysDevice.RealDev) {
+		// the device in the mount table may be a symlink
+		realDev, err := filepath.EvalSymlinks(m.Device)
+		if err != nil {
+			realDev = m.Device
+		}
+
+		if m.Device == sysDevice.RealDev || realDev == sysDevice.RealDev ||
+			(m.Device == "devtmpfs" && m.Source == sysDevice.RealDev) {
 			devMnts = append(devMnts, m)
 		}
 	}


### PR DESCRIPTION
Each Device object has a RealDev field showing the underlying device
path after resolving symlinks. GetDevMounts checks each device in the
mount table against the RealDev field and only returns mounts for that
device. However, the mount table may have symlinks, such as /dev/mapper
devices, and it should resolve those before comparing to RealDev.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This issue was reported on RHEL 8 / RHEL 9 nodes with multipath enabled.

```
touch /etc/multipath.conf && systemctl restart multipathd
```

Mounting CSI volumes then fails with:

`
  Warning  FailedMount             3s (x4 over 7s)  kubelet                  MountVolume.SetUp failed for volume "pvc-77d05006-3912-4ba1-b6ae-f19c5e766d37" : rpc error: code = FailedPrecondition desc = volume ID: "ff8a685e-d1fc-4f05-bea6-46ba15133a4f" does not appear staged to "/var/lib/kubelet/plugins/kubernetes.io/csi/csi.vsphere.vmware.com/219f1da44c39eb24d8c03677ee0907cedd00e9a8924a4dd288720a89704e19f7/globalmount"
`

PublishMountVol claims that the [volume is not staged](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/6648d0e70646701e3db73a532b5b5bb408ede49e/pkg/csi/service/osutils/linux_os_utils.go#L443-L446) because GetDevMounts did not find the device in the mount table.

`
2023-10-06T19:47:58.862Z        DEBUG   osutils/linux_os_utils.go:418   publishMountVol: device {FullPath:/dev/disk/by-id/wwn-0x6000c295f967d947c5528549554637c8 Name:wwn-0x6000c295f967d947c5528549554637c8 RealDev:/dev/dm-0}, device mounts []       {"TraceId": "e4cb48f6-dc34-4163-bc31-071b6db5c57d"}
`

RealDev shows as `/dev/dm-0` here, but the mount table shows `/dev/mapper/36000c295f967d947c5528549554637c8`:

```
sh-5.1# mount | grep csi
/dev/mapper/36000c295f967d947c5528549554637c8 on /var/lib/kubelet/plugins/kubernetes.io/csi/csi.vsphere.vmware.com/219f1da44c39eb24d8c03677ee0907cedd00e9a8924a4dd288720a89704e19f7/globalmount type ext4 (rw,relatime,seclabel)

sh-5.1# ls -l /dev/mapper/36000c295f967d947c5528549554637c8
lrwxrwxrwx. 1 root root 7 Oct  6 19:39 /dev/mapper/36000c295f967d947c5528549554637c8 -> ../dm-0
sh-5.1# ls -l /dev/disk/by-id/wwn-0x6000c295f967d947c5528549554637c8
lrwxrwxrwx. 1 root root 10 Oct  6 19:39 /dev/disk/by-id/wwn-0x6000c295f967d947c5528549554637c8 -> ../../dm-0
```

It points to the same underlying device (/dev/dm-0) though.

[RealDev is set in GetDevice](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/6648d0e70646701e3db73a532b5b5bb408ede49e/pkg/csi/service/osutils/linux_os_utils.go#L625-L645) _after_ evaluating symlinks, but [GetDevMounts compares RealDev](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/6648d0e70646701e3db73a532b5b5bb408ede49e/pkg/csi/service/osutils/linux_os_utils.go#L828) to the device in the mount table. The mount table may reference a symlink instead of the real device.

This PR allows GetDevMounts to resolve symlinks found in the mount table before comparing it to RealDev.

**Which issue this PR fixes**:


**Testing done**:

1) Reproduced this issue by enabling multipath on RHEL 9.2 hosts and creating a PVC & Pod using vSphere CSI driver
2) Updated CSI driver node daemonset to a build with this proposed fix
3) Recreated the failed pod, it attached and mounted the volume successfully

With the fix:

`
2023-10-06T20:52:18.859Z        DEBUG   osutils/linux_os_utils.go:418   publishMountVol: device {FullPath:/dev/disk/by-id/wwn-0x6000c295f967d947c5528549554637c8 Name:wwn-0x6000c295f967d947c5528549554637c8 RealDev:/dev/dm-0}, device mounts [{"/dev/mapper/36000c295f967d947c5528549554637c8" "/var/lib/kubelet/plugins/kubernetes.io/csi/csi.vsphere.vmware.com/219f1da44c39eb24d8c03677ee0907cedd00e9a8924a4dd288720a89704e19f7/globalmount" "/dev/mapper/36000c295f967d947c5528549554637c8" "ext4" ["rw" "relatime"]}]    {"TraceId": "8252d8a9-d77c-4b1f-87dc-a11122ff78d5"}
`

**Special notes for your reviewer**:

/cc @divyenpatel

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix FailedPrecondition error in NodePublishVolume when multipathd is enabled
```
