### PR TITLE
Validate vCenter username and crash CSI driver if username is not a fully qualified domain name

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -106,6 +107,11 @@ const (
 var (
 	// ErrUsernameMissing is returned when the provided username is empty.
 	ErrUsernameMissing = errors.New("username is missing")
+
+	// ErrInvalidUsername is returned when vCenter username provided in vSphere config
+	// secret is invalid. e.g. If username is not a fully qualified domain name, then
+	// it will be considered as invalid username.
+	ErrInvalidUsername = errors.New("username is invalid, make sure it is a fully qualified domain username")
 
 	// ErrPasswordMissing is returned when the provided password is empty.
 	ErrPasswordMissing = errors.New("password is missing")
@@ -322,6 +328,18 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 	return nil
 }
 
+// Check if username is valid or not. If username is not a fully qualified domain name, then
+// we consider it as an invalid username.
+func isValidvCenterUsernameWithDomain(username string) bool {
+	// Regular expression to validate vCenter server username.
+	// Allowed username is in the format "userName@domainName" or "domainName\\userName".
+	// If domain name is not provided in username, then functions like HasUserPrivilegeOnEntities
+	// doesn't return any entity for given user and eventually volume creation fails.
+	regex := `^(?:[a-zA-Z0-9.-]+\\[a-zA-Z0-9._-]+|[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+)$`
+	match, _ := regexp.MatchString(regex, username)
+	return match
+}
+
 func validateConfig(ctx context.Context, cfg *Config) error {
 	log := logger.GetLogger(ctx)
 	// Fix default global values.
@@ -369,6 +387,15 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 				return ErrUsernameMissing
 			}
 		}
+
+		// vCenter server username provided in vSphere config secret should contain domain name,
+		// CSI driver will crash if username doesn't contain domain name.
+		if !isValidvCenterUsernameWithDomain(vcConfig.User) {
+			log.Errorf("username %v specified in vSphere config secret is invalid, "+
+				"make sure that username is a fully qualified domain name.", vcConfig.User)
+			return ErrInvalidUsername
+		}
+
 		if vcConfig.Password == "" {
 			vcConfig.Password = cfg.Global.Password
 			if vcConfig.Password == "" {

--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -35,7 +35,7 @@ func init() {
 	defer cancel()
 	idealVCConfig = map[string]*VirtualCenterConfig{
 		"1.1.1.1": {
-			User:         "Admin",
+			User:         "Administrator@vsphere.local",
 			Password:     "Password",
 			VCenterPort:  "443",
 			Datacenters:  "dc1",
@@ -156,6 +156,66 @@ func TestValidateConfigWithInvalidClusterId(t *testing.T) {
 	err := validateConfig(ctx, cfg)
 	if err == nil {
 		t.Errorf("Expected error due to invalid cluster id. Config given - %+v", *cfg)
+	}
+}
+
+func TestValidateConfigWithInvalidUsername(t *testing.T) {
+	vcConfigInvalidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			User:         "Administrator",
+			Password:     "Password",
+			VCenterPort:  "443",
+			Datacenters:  "dc1",
+			InsecureFlag: true,
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigInvalidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err == nil {
+		t.Errorf("Expected error due to invalid username. Config given - %+v", *cfg)
+	}
+}
+
+func TestValidateConfigWithValidUsername1(t *testing.T) {
+	vcConfigValidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			User:         "Administrator@vsphere.local",
+			Password:     "Password",
+			VCenterPort:  "443",
+			Datacenters:  "dc1",
+			InsecureFlag: true,
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigValidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err != nil {
+		t.Errorf("Unexpected error, as valid username is specified. Config given - %+v", *cfg)
+	}
+}
+
+func TestValidateConfigWithValidUsername2(t *testing.T) {
+	vcConfigValidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			User:         "vsphere.local\\Administrator",
+			Password:     "Password",
+			VCenterPort:  "443",
+			Datacenters:  "dc1",
+			InsecureFlag: true,
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigValidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err != nil {
+		t.Errorf("Unexpected error, as valid username is specified. Config given - %+v", *cfg)
 	}
 }
 

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -65,7 +65,7 @@ func configFromCustomizedSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool)
 
 	cfg.Global.VCenterIP = s.URL.Hostname()
 	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = "DC0"
 

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -126,7 +126,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.
 
 	cfg.Global.VCenterIP = s.URL.Hostname()
 	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = "DC0"
 

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -105,7 +105,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.
 
 	cfg.Global.VCenterIP = s.URL.Hostname()
 	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = "DC0"
 

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -114,7 +114,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*cnsconf
 
 	cfg.Global.VCenterIP = s.URL.Hostname()
 	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = "DC0"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
If username specified in vSphere config secret is invalid (e.g. username is not a fully qualified domain name), then crash CSI driver.
We are adding this change as part of RCCA of SR.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Updated username in vSphere config secret from "Administrator@vsphere.local" to "Administrator" and observed that CSI driver crashes with proper error message.

```
# kubectl get pods -n vmware-system-csi
NAME                   READY  STATUS       RESTARTS    AGE
vsphere-csi-controller-5bc9b6b8d8-229zf  6/7   CrashLoopBackOff  6 (29s ago)  6m31s
vsphere-csi-controller-5bc9b6b8d8-c4vgv  6/7   CrashLoopBackOff  6 (47s ago)  6m31s
vsphere-csi-controller-5bc9b6b8d8-tqds9  5/7   CrashLoopBackOff  11 (19s ago)  6m31s
vsphere-csi-node-6nstq          3/3   Running      8 (124m ago)  134m
vsphere-csi-node-7wd96          3/3   Running      0       119m
vsphere-csi-node-b4rkj          3/3   Running      1 (133m ago)  135m
vsphere-csi-node-cvhjq          3/3   Running      0       119m
vsphere-csi-node-jz2bt          3/3   Running      1 (133m ago)  134m
vsphere-csi-node-tlcfj          3/3   Running      1 (133m ago)  134m
```

CSI controller logs snippet:
```
2023-10-09T09:22:02.841Z    DEBUG  config/config.go:533  GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf  {“TraceId”: “1c125e82-ce16-4505-8dda-2de2c72b7025", “TraceId”: “ab81f35e-0b03-47da-92d7-fa3170ec5979"}
2023-10-09T09:22:02.843Z    DEBUG  config/config.go:377  Initializing vc server 10.212.28.75   {“TraceId”: “1c125e82-ce16-4505-8dda-2de2c72b7025", “TraceId”: “ab81f35e-0b03-47da-92d7-fa3170ec5979"}
2023-10-09T09:22:02.844Z    ERROR  config/config.go:394  Username Administrator specified in vSphere config secret is invalid. Please make sure that username contains domain name.   {“TraceId”: “1c125e82-ce16-4505-8dda-2de2c72b7025", “TraceId”: “ab81f35e-0b03-47da-92d7-fa3170ec5979"}
...
2023-10-09T09:22:02.844Z    ERROR  config/config.go:552  failed to parse config. Err: username is invalid, make sure that username contains domain name {“TraceId”: “1c125e82-ce16-4505-8dda-2de2c72b7025", “TraceId”: “ab81f35e-0b03-47da-92d7-fa3170ec5979"}
```

**Special notes for your reviewer**:

**Release note**:
```release-note
Validate vCenter username and crash CSI driver if username is not a fully qualified domain name.
```
