### PR TITLE
Prevent node cache update during attach & detach

### DIFF
--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -147,7 +147,7 @@ func (nodes *Nodes) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (
 // This is called by ControllerPublishVolume and ControllerUnpublishVolume
 // to perform attach and detach operations.
 func (nodes *Nodes) GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNode(ctx, nodeUuid, nil)
+	return nodes.cnsNodeManager.GetNodeVM(ctx, nodeUuid)
 }
 
 // GetAllNodes returns VirtualMachine objects for all registered nodes in cluster.

--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -122,19 +122,19 @@ func (nodes *Nodes) csiNodeDelete(obj interface{}) {
 	}
 }
 
-// GetNodeByName returns VirtualMachine object for given nodeName.
+// GetNodeVMByNameAndUpdateCache returns VirtualMachine object for given nodeName.
 // This is called by ControllerPublishVolume and ControllerUnpublishVolume
 // to perform attach and detach operations.
-func (nodes *Nodes) GetNodeByName(ctx context.Context, nodeName string) (
+func (nodes *Nodes) GetNodeVMByNameAndUpdateCache(ctx context.Context, nodeName string) (
 	*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNodeByName(ctx, nodeName)
+	return nodes.cnsNodeManager.GetNodeVMByNameAndUpdateCache(ctx, nodeName)
 }
 
-// GetNodeByNameOrUUID returns VirtualMachine object for given nodeName
+// GetNodeVMByNameOrUUID returns VirtualMachine object for given nodeName
 // This function can be called either using nodeName or nodeUID.
-func (nodes *Nodes) GetNodeByNameOrUUID(
+func (nodes *Nodes) GetNodeVMByNameOrUUID(
 	ctx context.Context, nodeNameOrUUID string) (*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNodeByNameOrUUID(ctx, nodeNameOrUUID)
+	return nodes.cnsNodeManager.GetNodeVMByNameOrUUID(ctx, nodeNameOrUUID)
 }
 
 // GetNodeNameByUUID fetches the name of the node given the VM UUID.
@@ -143,11 +143,11 @@ func (nodes *Nodes) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (
 	return nodes.cnsNodeManager.GetNodeNameByUUID(ctx, nodeUUID)
 }
 
-// GetNodeByUuid returns VirtualMachine object for given nodeUuid.
+// GetNodeVMByUuid returns VirtualMachine object for given nodeUuid.
 // This is called by ControllerPublishVolume and ControllerUnpublishVolume
 // to perform attach and detach operations.
-func (nodes *Nodes) GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNodeVM(ctx, nodeUuid)
+func (nodes *Nodes) GetNodeVMByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
+	return nodes.cnsNodeManager.GetNodeVMByUuid(ctx, nodeUuid)
 }
 
 // GetAllNodes returns VirtualMachine objects for all registered nodes in cluster.

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -1233,10 +1233,10 @@ func (volTopology *controllerVolumeTopology) getTopologySegmentsWithMatchingNode
 		if isMatch {
 			var nodeVM *cnsvsphere.VirtualMachine
 			if volTopology.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-				nodeVM, err = volTopology.nodeMgr.GetNode(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeUUID, nil)
 			} else {
-				nodeVM, err = volTopology.nodeMgr.GetNodeByName(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMByNameAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeID)
 			}
 			if err != nil {
@@ -1303,10 +1303,10 @@ func (volTopology *controllerVolumeTopology) getNodesMatchingTopologySegment(ctx
 		if isMatch {
 			var nodeVM *cnsvsphere.VirtualMachine
 			if volTopology.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-				nodeVM, err = volTopology.nodeMgr.GetNode(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeUUID, nil)
 			} else {
-				nodeVM, err = volTopology.nodeMgr.GetNodeByName(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMByNameAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeID)
 			}
 			if err != nil {

--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -216,7 +216,7 @@ func getExpandedTopologySegments(ctx context.Context, requestedSegments map[stri
 		// If there is a match, check if each compatible NodeVM belongs to the same VC. If not,
 		// error out as we do not support cross-zonal volume provisioning.
 		if isMatch {
-			nodeVM, err := nodeMgr.GetNode(ctx, nodeTopologyInstance.Spec.NodeUUID, nil)
+			nodeVM, err := nodeMgr.GetNodeVMAndUpdateCache(ctx, nodeTopologyInstance.Spec.NodeUUID, nil)
 			if err != nil {
 				return nil, logger.LogNewErrorf(log,
 					"failed to retrieve NodeVM %q. Error - %+v", nodeTopologyInstance.Spec.NodeID, err)

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -223,7 +223,8 @@ func (f *FakeNodeManager) GetSharedDatastoresInK8SCluster(ctx context.Context) (
 	}, nil
 }
 
-func (f *FakeNodeManager) GetNodeByName(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error) {
+func (f *FakeNodeManager) GetNodeVMByNameAndUpdateCache(ctx context.Context,
+	nodeName string) (*cnsvsphere.VirtualMachine, error) {
 	var vm *cnsvsphere.VirtualMachine
 	var t *testing.T
 	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
@@ -246,16 +247,16 @@ func (f *FakeNodeManager) GetNodeByName(ctx context.Context, nodeName string) (*
 	return vm, nil
 }
 
-func (f *FakeNodeManager) GetNodeByNameOrUUID(
+func (f *FakeNodeManager) GetNodeVMByNameOrUUID(
 	ctx context.Context, nodeNameOrUUID string) (*cnsvsphere.VirtualMachine, error) {
-	return f.GetNodeByName(ctx, nodeNameOrUUID)
+	return f.GetNodeVMByNameAndUpdateCache(ctx, nodeNameOrUUID)
 }
 
 func (f *FakeNodeManager) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error) {
 	return "", nil
 }
 
-func (f *FakeNodeManager) GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
+func (f *FakeNodeManager) GetNodeVMByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
 	var vm *cnsvsphere.VirtualMachine
 	var t *testing.T
 	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -272,13 +272,13 @@ func (r *ReconcileCSINodeTopology) reconcileForVanilla(ctx context.Context, requ
 	if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		nodeID = instance.Spec.NodeUUID
 		if nodeID != "" {
-			nodeVM, err = nodeManager.GetNode(ctx, nodeID, nil)
+			nodeVM, err = nodeManager.GetNodeVMAndUpdateCache(ctx, nodeID, nil)
 		} else {
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
 	} else {
 		nodeID = instance.Spec.NodeID
-		nodeVM, err = nodeManager.GetNodeByName(ctx, nodeID)
+		nodeVM, err = nodeManager.GetNodeVMByNameAndUpdateCache(ctx, nodeID)
 	}
 	if err != nil {
 		if err == node.ErrNodeNotFound {

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -741,7 +741,7 @@ func startTopologyCRInformer(ctx context.Context, cfg *restclient.Config) error 
 // in the MetadataSyncer.topologyVCMap parameter.
 func addLabelsToTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopologyv1alpha1.CSINodeTopology) {
 	log := logger.GetLogger(ctx)
-	nodeVM, err := nodeMgr.GetNode(ctx, nodeTopoObj.Spec.NodeUUID, nil)
+	nodeVM, err := nodeMgr.GetNodeVMAndUpdateCache(ctx, nodeTopoObj.Spec.NodeUUID, nil)
 	if err != nil {
 		log.Errorf("Node %q is not yet registered in the node manager. Error: %+v",
 			nodeTopoObj.Spec.NodeUUID, err)
@@ -858,7 +858,7 @@ func topoCRDeleted(obj interface{}) {
 // instance in the MetadataSyncer.topologyVCMap parameter.
 func removeLabelsFromTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopologyv1alpha1.CSINodeTopology) {
 	log := logger.GetLogger(ctx)
-	nodeVM, err := nodeMgr.GetNode(ctx, nodeTopoObj.Spec.NodeUUID, nil)
+	nodeVM, err := nodeMgr.GetNodeVMAndUpdateCache(ctx, nodeTopoObj.Spec.NodeUUID, nil)
 	if err != nil {
 		log.Errorf("Node %q is not yet registered in the node manager. Error: %+v",
 			nodeTopoObj.Spec.NodeUUID, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We have observed that CSI Attach/Detach operations are updating the node cache with nodevms found in VC inventory. These updates happen due to node discovery calls that are made in the attach/detach code path. However, node cache should be updated only when there is a nodeAdd/nodeUpdate/nodeDelete handler method invoked. Hence we need a read-only type of getter methods that fetch node vm info from VC. 

**Testing done**:
Before:
```

1. Create a statefulset  with 3 replica
2. Identify Node on which Pod is scheduled.
3. Delete Node API server object on which Pod is scheduled. 
4. Delete the Pod. Detach should get invoked. and Pod will be up and running on another node.
5. Delete Node VM from VC inventory for which API server object is deleted.(Just delete the nodevm completely, not by doing power off)
6. Create new PVC. PVC creation is successfull, But observed the below error in the logs   

> {"level":"info","time":"2023-10-09T09:49:31.744558031Z","caller":"vanilla/controller.go:2168","msg":"ControllerUnpublishVolume: called with args {VolumeId:7ae13763-85a3-4ffe-ab3a-ab973b02efa3 NodeId:42061da2-b876-b1f4-a5a0-80f6f8f6b1dc Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"21df3376-4356-4a02-b9fe-4f9e57abd198"}
> {"level":"error","time":"2023-10-09T09:49:31.764562915Z","caller":"node/manager.go:168","msg":"Node not found with nodeName 42061da2-b876-b1f4-a5a0-80f6f8f6b1dc","TraceId":"21df3376-4356-4a02-b9fe-4f9e57abd198" ...
> {"level":"info","time":"2023-10-09T09:49:31.764925155Z","caller":"vanilla/controller.go:2253","msg":"Performing node VM > lookup using node VM UUID: \"42061da2-b876-b1f4-a5a0-80f6f8f6b1dc\"","TraceId":"21df3376-4356-4a02-b9fe-4f9e57abd198"}
> {"level":"info","time":"2023-10-09T09:49:31.765035872Z","caller":"node/manager.go:218","msg":"Node hasn't been discovered yet with nodeUUID 42061da2-b876-b1f4-a5a0-80f6f8f6b1dc","TraceId":"21df3376-4356-4a02-b9fe-4f9e57abd198"}
> {"level":"info","time":"2023-10-09T09:49:31.765414168Z","caller":"vsphere/virtualmachine.go:159","msg":"Initiating asynchronous datacenter listing with uuid 42061da2-b876-b1f4-a5a0-80f6f8f6b1dc","TraceId":"21df3376-4356-4a02-b9fe-4f9e57abd198"}
> {"level":"info","time":"2023-10-09T09:49:31.781038296Z","caller":"vsphere/datacenter.go:154","msg":"Publishing datacenter Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.63.215]","TraceId":"21df3376-4356-4a02-b9fe-4f9e57abd198"}
> {"level":"info","time":"2023-10-09T09:49:31.790447133Z","caller":"vsphere/virtualmachine.go:210","msg":"Found VM VirtualMachine:vm-53 [VirtualCenterHost: 10.186.63.215, UUID: 42061da2-b876-b1f4-a5a0-80f6f8f6b1dc, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.63.215]] given uuid 42061da2-b876-b1f4-a5a0-80f6f8f6b1dc on DC Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.63.215]","TraceId":"21df3376-4356-4a02-b9fe-4f9e57abd198"}
> {"level":"info","time":"2023-10-09T09:49:31.790570052Z","caller":"vsphere/virtualmachine.go:221","msg":"Returning VM VirtualMachine:vm-53 [VirtualCenterHost: 10.186.63.215, UUID: 42061da2-b876-b1f4-a5a0-80f6f8f6b1dc, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.186.63.215]] for UUID 42061da2-b876-b1f4-a5a0-80f6f8f6b1dc","TraceId":"21df3376-4356-4a02-b9fe-4f9e57abd198"}
> {"level":"info","time":"2023-10-09T09:49:31.790625263Z","caller":"node/manager.go:140","msg":"Successfully discovered node with nodeUUID 42061da2-b876-b1f4-a5a0-80f6f8f6b1dc in vm VirtualMachine:vm-53...
> {"level":"info","time":"2023-10-09T09:49:31.790751516Z","caller":"node/manager.go:237","msg":"Node was successfully discovered with nodeUUID 42061da2-b876-b1f4-a5a0-80f6f8f6b1dc in vm VirtualMachine:vm-53...

See https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/csi/service/vanilla/controller.go#L2254.
```

After the fix:

To be added

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Prevent node cache during attach & detach
```
