### PR TITLE
Cherry-pick : Prevent node cache update during attach & detach (#2597)

### DIFF
--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -52,13 +52,16 @@ type Manager interface {
 	// given its UUID. If datacenter is present, GetNode will search within this
 	// datacenter given its UUID. If not, it will search in all registered
 	// datacenters.
-	GetNode(ctx context.Context, nodeUUID string, dc *vsphere.Datacenter) (*vsphere.VirtualMachine, error)
-	// GetNodeByName refreshes and returns the VirtualMachine for a registered
+	GetNodeVMAndUpdateCache(ctx context.Context, nodeUUID string, dc *vsphere.Datacenter) (*vsphere.VirtualMachine, error)
+	// GetNodeVMByUuid returns the VirtualMachine for a registered node
+	// given its UUID.
+	GetNodeVMByUuid(ctx context.Context, nodeUUID string) (*vsphere.VirtualMachine, error)
+	// GetNodeVMByNameAndUpdateCache refreshes and returns the VirtualMachine for a registered
 	// node given its name.
-	GetNodeByName(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error)
-	// GetNodeByNameOrUUID refreshes and returns VirtualMachine for a registered node
+	GetNodeVMByNameAndUpdateCache(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error)
+	// GetNodeVMByNameOrUUID refreshes and returns VirtualMachine for a registered node
 	// using either its name or UUID.
-	GetNodeByNameOrUUID(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error)
+	GetNodeVMByNameOrUUID(ctx context.Context, nodeNameOrUuid string) (*vsphere.VirtualMachine, error)
 	// GetNodeNameByUUID fetches the name of the node given the VM UUID.
 	GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error)
 	// GetAllNodes refreshes and returns VirtualMachine for all registered
@@ -141,13 +144,14 @@ func (m *defaultManager) DiscoverNode(ctx context.Context, nodeUUID string) erro
 	return nil
 }
 
-// GetNodeByName refreshes and returns the VirtualMachine for a registered node
+// GetNodeVMByNameAndUpdateCache refreshes and returns the VirtualMachine for a registered node
 // given its name.
-func (m *defaultManager) GetNodeByName(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error) {
+func (m *defaultManager) GetNodeVMByNameAndUpdateCache(ctx context.Context,
+	nodeName string) (*vsphere.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
 	nodeUUID, found := m.nodeNameToUUID.Load(nodeName)
 	if found && nodeUUID != nil && nodeUUID.(string) != "" {
-		return m.GetNode(ctx, nodeUUID.(string), nil)
+		return m.GetNodeVMAndUpdateCache(ctx, nodeUUID.(string), nil)
 	}
 	log.Infof("Empty nodeUUID observed in cache for the node: %q", nodeName)
 	k8snodeUUID, err := k8s.GetNodeUUID(ctx, m.k8sClient, nodeName)
@@ -156,11 +160,11 @@ func (m *defaultManager) GetNodeByName(ctx context.Context, nodeName string) (*v
 		return nil, err
 	}
 	m.nodeNameToUUID.Store(nodeName, k8snodeUUID)
-	return m.GetNode(ctx, k8snodeUUID, nil)
+	return m.GetNodeVMAndUpdateCache(ctx, k8snodeUUID, nil)
 
 }
 
-func (m *defaultManager) GetNodeByNameOrUUID(
+func (m *defaultManager) GetNodeVMByNameOrUUID(
 	ctx context.Context, nodeNameOrUUID string) (*vsphere.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
 	nodeUUID, found := m.nodeNameToUUID.Load(nodeNameOrUUID)
@@ -169,7 +173,7 @@ func (m *defaultManager) GetNodeByNameOrUUID(
 		return nil, ErrNodeNotFound
 	}
 	if nodeUUID != nil && nodeUUID.(string) != "" {
-		return m.GetNode(ctx, nodeUUID.(string), nil)
+		return m.GetNodeVMAndUpdateCache(ctx, nodeUUID.(string), nil)
 	}
 	log.Infof("Empty nodeUUID observed in cache for the node: %q", nodeNameOrUUID)
 	k8snodeUUID, err := k8s.GetNodeUUID(ctx, m.k8sClient, nodeNameOrUUID)
@@ -177,7 +181,7 @@ func (m *defaultManager) GetNodeByNameOrUUID(
 		log.Errorf("failed to get node UUID from node: %q. Err: %v", nodeNameOrUUID, err)
 		return nil, err
 	}
-	return m.GetNode(ctx, k8snodeUUID, nil)
+	return m.GetNodeVMAndUpdateCache(ctx, k8snodeUUID, nil)
 }
 
 // GetNodeNameByUUID fetches the name of the node given the VM UUID.
@@ -210,7 +214,7 @@ func (m *defaultManager) GetK8sNode(ctx context.Context, nodename string) (*v1.N
 
 // GetNode refreshes and returns the VirtualMachine for a registered node
 // given its UUID.
-func (m *defaultManager) GetNode(ctx context.Context,
+func (m *defaultManager) GetNodeVMAndUpdateCache(ctx context.Context,
 	nodeUUID string, dc *vsphere.Datacenter) (*vsphere.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
 	vmInf, discovered := m.nodeVMs.Load(nodeUUID)
@@ -247,6 +251,27 @@ func (m *defaultManager) GetNode(ctx context.Context,
 	}
 
 	log.Debugf("VM %v was successfully renewed with nodeUUID %q", vm, nodeUUID)
+	return vm, nil
+}
+
+// GetNodeVMByUuid returns the VirtualMachine for a registered node
+// given its UUID. This is called by ControllerPublishVolume and
+// ControllerUnpublishVolume to perform attach and detach operations.
+func (m *defaultManager) GetNodeVMByUuid(ctx context.Context,
+	nodeUUID string) (*vsphere.VirtualMachine, error) {
+	log := logger.GetLogger(ctx)
+	vmInf, discovered := m.nodeVMs.Load(nodeUUID)
+	if !discovered {
+		log.Infof("Node VM not found with nodeUUID %s", nodeUUID)
+		vm, err := vsphere.GetVirtualMachineByUUID(ctx, nodeUUID, false)
+		if err != nil {
+			log.Errorf("Couldn't find VM instance with nodeUUID %s, failed to discover with err: %v", nodeUUID, err)
+			return nil, err
+		}
+		log.Infof("Node was successfully found with nodeUUID %s in vm %v", nodeUUID, vm)
+		return vm, nil
+	}
+	vm := vmInf.(*vsphere.VirtualMachine)
 	return vm, nil
 }
 

--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -122,19 +122,19 @@ func (nodes *Nodes) csiNodeDelete(obj interface{}) {
 	}
 }
 
-// GetNodeByName returns VirtualMachine object for given nodeName.
+// GetNodeVMByNameAndUpdateCache returns VirtualMachine object for given nodeName.
 // This is called by ControllerPublishVolume and ControllerUnpublishVolume
 // to perform attach and detach operations.
-func (nodes *Nodes) GetNodeByName(ctx context.Context, nodeName string) (
+func (nodes *Nodes) GetNodeVMByNameAndUpdateCache(ctx context.Context, nodeName string) (
 	*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNodeByName(ctx, nodeName)
+	return nodes.cnsNodeManager.GetNodeVMByNameAndUpdateCache(ctx, nodeName)
 }
 
-// GetNodeByNameOrUUID returns VirtualMachine object for given nodeName
+// GetNodeVMByNameOrUUID returns VirtualMachine object for given nodeName
 // This function can be called either using nodeName or nodeUID.
-func (nodes *Nodes) GetNodeByNameOrUUID(
+func (nodes *Nodes) GetNodeVMByNameOrUUID(
 	ctx context.Context, nodeNameOrUUID string) (*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNodeByNameOrUUID(ctx, nodeNameOrUUID)
+	return nodes.cnsNodeManager.GetNodeVMByNameOrUUID(ctx, nodeNameOrUUID)
 }
 
 // GetNodeNameByUUID fetches the name of the node given the VM UUID.
@@ -143,11 +143,11 @@ func (nodes *Nodes) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (
 	return nodes.cnsNodeManager.GetNodeNameByUUID(ctx, nodeUUID)
 }
 
-// GetNodeByUuid returns VirtualMachine object for given nodeUuid.
+// GetNodeVMByUuid returns VirtualMachine object for given nodeUuid.
 // This is called by ControllerPublishVolume and ControllerUnpublishVolume
 // to perform attach and detach operations.
-func (nodes *Nodes) GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNode(ctx, nodeUuid, nil)
+func (nodes *Nodes) GetNodeVMByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
+	return nodes.cnsNodeManager.GetNodeVMByUuid(ctx, nodeUuid)
 }
 
 // GetAllNodes returns VirtualMachine objects for all registered nodes in cluster.

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -1233,10 +1233,10 @@ func (volTopology *controllerVolumeTopology) getTopologySegmentsWithMatchingNode
 		if isMatch {
 			var nodeVM *cnsvsphere.VirtualMachine
 			if volTopology.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-				nodeVM, err = volTopology.nodeMgr.GetNode(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeUUID, nil)
 			} else {
-				nodeVM, err = volTopology.nodeMgr.GetNodeByName(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMByNameAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeID)
 			}
 			if err != nil {
@@ -1303,10 +1303,10 @@ func (volTopology *controllerVolumeTopology) getNodesMatchingTopologySegment(ctx
 		if isMatch {
 			var nodeVM *cnsvsphere.VirtualMachine
 			if volTopology.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-				nodeVM, err = volTopology.nodeMgr.GetNode(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeUUID, nil)
 			} else {
-				nodeVM, err = volTopology.nodeMgr.GetNodeByName(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMByNameAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeID)
 			}
 			if err != nil {

--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -216,7 +216,7 @@ func getExpandedTopologySegments(ctx context.Context, requestedSegments map[stri
 		// If there is a match, check if each compatible NodeVM belongs to the same VC. If not,
 		// error out as we do not support cross-zonal volume provisioning.
 		if isMatch {
-			nodeVM, err := nodeMgr.GetNode(ctx, nodeTopologyInstance.Spec.NodeUUID, nil)
+			nodeVM, err := nodeMgr.GetNodeVMAndUpdateCache(ctx, nodeTopologyInstance.Spec.NodeUUID, nil)
 			if err != nil {
 				return nil, logger.LogNewErrorf(log,
 					"failed to retrieve NodeVM %q. Error - %+v", nodeTopologyInstance.Spec.NodeID, err)

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -223,7 +223,8 @@ func (f *FakeNodeManager) GetSharedDatastoresInK8SCluster(ctx context.Context) (
 	}, nil
 }
 
-func (f *FakeNodeManager) GetNodeByName(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error) {
+func (f *FakeNodeManager) GetNodeVMByNameAndUpdateCache(ctx context.Context,
+	nodeName string) (*cnsvsphere.VirtualMachine, error) {
 	var vm *cnsvsphere.VirtualMachine
 	var t *testing.T
 	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
@@ -246,16 +247,16 @@ func (f *FakeNodeManager) GetNodeByName(ctx context.Context, nodeName string) (*
 	return vm, nil
 }
 
-func (f *FakeNodeManager) GetNodeByNameOrUUID(
+func (f *FakeNodeManager) GetNodeVMByNameOrUUID(
 	ctx context.Context, nodeNameOrUUID string) (*cnsvsphere.VirtualMachine, error) {
-	return f.GetNodeByName(ctx, nodeNameOrUUID)
+	return f.GetNodeVMByNameAndUpdateCache(ctx, nodeNameOrUUID)
 }
 
 func (f *FakeNodeManager) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error) {
 	return "", nil
 }
 
-func (f *FakeNodeManager) GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
+func (f *FakeNodeManager) GetNodeVMByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
 	var vm *cnsvsphere.VirtualMachine
 	var t *testing.T
 	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -272,13 +272,13 @@ func (r *ReconcileCSINodeTopology) reconcileForVanilla(ctx context.Context, requ
 	if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		nodeID = instance.Spec.NodeUUID
 		if nodeID != "" {
-			nodeVM, err = nodeManager.GetNode(ctx, nodeID, nil)
+			nodeVM, err = nodeManager.GetNodeVMAndUpdateCache(ctx, nodeID, nil)
 		} else {
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
 	} else {
 		nodeID = instance.Spec.NodeID
-		nodeVM, err = nodeManager.GetNodeByName(ctx, nodeID)
+		nodeVM, err = nodeManager.GetNodeVMByNameAndUpdateCache(ctx, nodeID)
 	}
 	if err != nil {
 		if err == node.ErrNodeNotFound {

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -738,7 +738,7 @@ func startTopologyCRInformer(ctx context.Context, cfg *restclient.Config) error 
 // in the MetadataSyncer.topologyVCMap parameter.
 func addLabelsToTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopologyv1alpha1.CSINodeTopology) {
 	log := logger.GetLogger(ctx)
-	nodeVM, err := nodeMgr.GetNode(ctx, nodeTopoObj.Spec.NodeUUID, nil)
+	nodeVM, err := nodeMgr.GetNodeVMAndUpdateCache(ctx, nodeTopoObj.Spec.NodeUUID, nil)
 	if err != nil {
 		log.Errorf("Node %q is not yet registered in the node manager. Error: %+v",
 			nodeTopoObj.Spec.NodeUUID, err)
@@ -855,7 +855,7 @@ func topoCRDeleted(obj interface{}) {
 // instance in the MetadataSyncer.topologyVCMap parameter.
 func removeLabelsFromTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopologyv1alpha1.CSINodeTopology) {
 	log := logger.GetLogger(ctx)
-	nodeVM, err := nodeMgr.GetNode(ctx, nodeTopoObj.Spec.NodeUUID, nil)
+	nodeVM, err := nodeMgr.GetNodeVMAndUpdateCache(ctx, nodeTopoObj.Spec.NodeUUID, nil)
 	if err != nil {
 		log.Errorf("Node %q is not yet registered in the node manager. Error: %+v",
 			nodeTopoObj.Spec.NodeUUID, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick #2597 to release-3.1

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Available on the original PR

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherry-pick (release-3.1) : Prevent node cache update during attach & detach (#2597)
```
