### PR TITLE
Cherry-pick : Prevent node cache update during attach & detach (#2597)

### DIFF
--- a/pkg/common/cns-lib/node/manager_test.go
+++ b/pkg/common/cns-lib/node/manager_test.go
@@ -24,7 +24,7 @@ func TestDefaultManager_GetNodeByName(t *testing.T) {
 	k8sClient := k8sClientWithNodes(nodeName)
 	m.SetKubernetesClient(k8sClient)
 
-	vm, _ := m.GetNodeByName(context.TODO(), nodeName)
+	vm, _ := m.GetNodeVMByNameAndUpdateCache(context.TODO(), nodeName)
 	if vm != nil {
 		t.Errorf("Unexpected vm found:%v", vm)
 	}

--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -182,19 +182,19 @@ func (nodes *Nodes) csiNodeDelete(obj interface{}) {
 	}
 }
 
-// GetNodeByName returns VirtualMachine object for given nodeName.
+// GetNodeVMByNameAndUpdateCache returns VirtualMachine object for given nodeName.
 // This is called by ControllerPublishVolume and ControllerUnpublishVolume
 // to perform attach and detach operations.
-func (nodes *Nodes) GetNodeByName(ctx context.Context, nodeName string) (
+func (nodes *Nodes) GetNodeVMByNameAndUpdateCache(ctx context.Context, nodeName string) (
 	*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNodeByName(ctx, nodeName)
+	return nodes.cnsNodeManager.GetNodeVMByNameAndUpdateCache(ctx, nodeName)
 }
 
-// GetNodeByNameOrUUID returns VirtualMachine object for given nodeName
+// GetNodeVMByNameOrUUID returns VirtualMachine object for given nodeName
 // This function can be called either using nodeName or nodeUID.
-func (nodes *Nodes) GetNodeByNameOrUUID(
+func (nodes *Nodes) GetNodeVMByNameOrUUID(
 	ctx context.Context, nodeNameOrUUID string) (*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNodeByNameOrUUID(ctx, nodeNameOrUUID)
+	return nodes.cnsNodeManager.GetNodeVMByNameOrUUID(ctx, nodeNameOrUUID)
 }
 
 // GetNodeNameByUUID fetches the name of the node given the VM UUID.
@@ -203,11 +203,11 @@ func (nodes *Nodes) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (
 	return nodes.cnsNodeManager.GetNodeNameByUUID(ctx, nodeUUID)
 }
 
-// GetNodeByUuid returns VirtualMachine object for given nodeUuid.
+// GetNodeVMByUuid returns VirtualMachine object for given nodeUuid.
 // This is called by ControllerPublishVolume and ControllerUnpublishVolume
 // to perform attach and detach operations.
-func (nodes *Nodes) GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNode(ctx, nodeUuid, nil)
+func (nodes *Nodes) GetNodeVMByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
+	return nodes.cnsNodeManager.GetNodeVMByUuid(ctx, nodeUuid)
 }
 
 // GetAllNodes returns VirtualMachine objects for all registered nodes in cluster.

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -1252,10 +1252,10 @@ func (volTopology *controllerVolumeTopology) getTopologySegmentsWithMatchingNode
 			var nodeVM *cnsvsphere.VirtualMachine
 			if volTopology.isCSINodeIdFeatureEnabled &&
 				volTopology.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-				nodeVM, err = volTopology.nodeMgr.GetNode(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeUUID, nil)
 			} else {
-				nodeVM, err = volTopology.nodeMgr.GetNodeByName(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMByNameAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeID)
 			}
 			if err != nil {
@@ -1323,10 +1323,10 @@ func (volTopology *controllerVolumeTopology) getNodesMatchingTopologySegment(ctx
 			var nodeVM *cnsvsphere.VirtualMachine
 			if volTopology.isCSINodeIdFeatureEnabled &&
 				volTopology.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-				nodeVM, err = volTopology.nodeMgr.GetNode(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeUUID, nil)
 			} else {
-				nodeVM, err = volTopology.nodeMgr.GetNodeByName(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMByNameAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeID)
 			}
 			if err != nil {

--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -183,7 +183,7 @@ func getTopologySegmentsWithMatchingNodes(ctx context.Context, requestedSegments
 		}
 		// If there is a match, fetch the nodeVM object and add it to matchingNodeVMs.
 		if isMatch {
-			nodeVM, err := nodeMgr.GetNode(ctx, nodeTopologyInstance.Spec.NodeUUID, nil)
+			nodeVM, err := nodeMgr.GetNodeVMAndUpdateCache(ctx, nodeTopologyInstance.Spec.NodeUUID, nil)
 			if err != nil {
 				return nil, nil, logger.LogNewErrorf(log,
 					"failed to retrieve NodeVM %q. Error - %+v", nodeTopologyInstance.Spec.NodeID, err)

--- a/pkg/csi/service/common/topology.go
+++ b/pkg/csi/service/common/topology.go
@@ -241,7 +241,7 @@ func AddLabelsToTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopologyv1
 	log := logger.GetLogger(ctx)
 	// Get node manager instance.
 	nodeManager := node.GetManager(ctx)
-	nodeVM, err := nodeManager.GetNode(ctx, nodeTopoObj.Spec.NodeUUID, nil)
+	nodeVM, err := nodeManager.GetNodeVMAndUpdateCache(ctx, nodeTopoObj.Spec.NodeUUID, nil)
 	if err != nil {
 		log.Errorf("Node %q is not yet registered in the node manager. Error: %+v",
 			nodeTopoObj.Spec.NodeUUID, err)
@@ -267,7 +267,7 @@ func RemoveLabelsFromTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopol
 	log := logger.GetLogger(ctx)
 	// Get node manager instance.
 	nodeManager := node.GetManager(ctx)
-	nodeVM, err := nodeManager.GetNode(ctx, nodeTopoObj.Spec.NodeUUID, nil)
+	nodeVM, err := nodeManager.GetNodeVMAndUpdateCache(ctx, nodeTopoObj.Spec.NodeUUID, nil)
 	if err != nil {
 		log.Errorf("Node %q is not yet registered in the node manager. Error: %+v",
 			nodeTopoObj.Spec.NodeUUID, err)

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -60,10 +60,10 @@ import (
 type NodeManagerInterface interface {
 	Initialize(ctx context.Context, useNodeUuid bool) error
 	GetSharedDatastoresInK8SCluster(ctx context.Context) ([]*cnsvsphere.DatastoreInfo, error)
-	GetNodeByName(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
-	GetNodeByNameOrUUID(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
+	GetNodeVMByNameAndUpdateCache(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
+	GetNodeVMByNameOrUUID(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
 	GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error)
-	GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error)
+	GetNodeVMByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error)
 	GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachine, error)
 	GetAllNodesByVC(ctx context.Context, vcHost string) ([]*cnsvsphere.VirtualMachine, error)
 }
@@ -2116,14 +2116,14 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
 				// if node is not yet updated to run the release of the driver publishing Node VM UUID as Node ID
 				// look up Node by name
-				nodevm, err = c.nodeMgr.GetNodeByNameOrUUID(ctx, req.NodeId)
+				nodevm, err = c.nodeMgr.GetNodeVMByNameOrUUID(ctx, req.NodeId)
 				if err == node.ErrNodeNotFound {
 					log.Infof("Performing node VM lookup using node VM UUID: %q", req.NodeId)
-					nodevm, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
+					nodevm, err = c.nodeMgr.GetNodeVMByUuid(ctx, req.NodeId)
 				}
 
 			} else {
-				nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+				nodevm, err = c.nodeMgr.GetNodeVMByNameAndUpdateCache(ctx, req.NodeId)
 			}
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
@@ -2257,13 +2257,13 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
 			// if node is not yet updated to run the release of the driver publishing Node VM UUID as Node ID
 			// look up Node by name
-			nodevm, err = c.nodeMgr.GetNodeByNameOrUUID(ctx, req.NodeId)
+			nodevm, err = c.nodeMgr.GetNodeVMByNameOrUUID(ctx, req.NodeId)
 			if err == node.ErrNodeNotFound {
 				log.Infof("Performing node VM lookup using node VM UUID: %q", req.NodeId)
-				nodevm, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
+				nodevm, err = c.nodeMgr.GetNodeVMByUuid(ctx, req.NodeId)
 			}
 		} else {
-			nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+			nodevm, err = c.nodeMgr.GetNodeVMByNameAndUpdateCache(ctx, req.NodeId)
 		}
 		if err != nil {
 			if err == cnsvsphere.ErrVMNotFound {
@@ -2605,7 +2605,7 @@ func (c *controller) processQueryResultsListVolumes(ctx context.Context, startin
 			publishedNodeIds := commonco.ContainerOrchestratorUtility.GetNodesForVolumes(ctx, []string{fileVolID})
 			for volID, nodeName := range publishedNodeIds {
 				if volID == fileVolID && len(nodeName) != 0 {
-					nodeVMObj, err := c.nodeMgr.GetNodeByName(ctx, publishedNodeIds[fileVolID][0])
+					nodeVMObj, err := c.nodeMgr.GetNodeVMByNameAndUpdateCache(ctx, publishedNodeIds[fileVolID][0])
 					if err != nil {
 						log.Errorf("Failed to get node vm object from the node name, err:%v", err)
 						return entries, nextToken, volumeType, err

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -223,7 +223,8 @@ func (f *FakeNodeManager) GetSharedDatastoresInK8SCluster(ctx context.Context) (
 	}, nil
 }
 
-func (f *FakeNodeManager) GetNodeByName(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error) {
+func (f *FakeNodeManager) GetNodeVMByNameAndUpdateCache(ctx context.Context,
+	nodeName string) (*cnsvsphere.VirtualMachine, error) {
 	var vm *cnsvsphere.VirtualMachine
 	var t *testing.T
 	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
@@ -246,16 +247,16 @@ func (f *FakeNodeManager) GetNodeByName(ctx context.Context, nodeName string) (*
 	return vm, nil
 }
 
-func (f *FakeNodeManager) GetNodeByNameOrUUID(
+func (f *FakeNodeManager) GetNodeVMByNameOrUUID(
 	ctx context.Context, nodeNameOrUUID string) (*cnsvsphere.VirtualMachine, error) {
-	return f.GetNodeByName(ctx, nodeNameOrUUID)
+	return f.GetNodeVMByNameAndUpdateCache(ctx, nodeNameOrUUID)
 }
 
 func (f *FakeNodeManager) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error) {
 	return "", nil
 }
 
-func (f *FakeNodeManager) GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
+func (f *FakeNodeManager) GetNodeVMByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
 	var vm *cnsvsphere.VirtualMachine
 	var t *testing.T
 	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -275,13 +275,13 @@ func (r *ReconcileCSINodeTopology) reconcileForVanilla(ctx context.Context, requ
 	if r.useNodeUuid && clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		nodeID = instance.Spec.NodeUUID
 		if nodeID != "" {
-			nodeVM, err = nodeManager.GetNode(ctx, nodeID, nil)
+			nodeVM, err = nodeManager.GetNodeVMAndUpdateCache(ctx, nodeID, nil)
 		} else {
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
 	} else {
 		nodeID = instance.Spec.NodeID
-		nodeVM, err = nodeManager.GetNodeByName(ctx, nodeID)
+		nodeVM, err = nodeManager.GetNodeVMByNameAndUpdateCache(ctx, nodeID)
 	}
 	if err != nil {
 		if err == node.ErrNodeNotFound {

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -737,7 +737,7 @@ func startTopologyCRInformer(ctx context.Context, cfg *restclient.Config) error 
 // in the MetadataSyncer.topologyVCMap parameter.
 func addLabelsToTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopologyv1alpha1.CSINodeTopology) {
 	log := logger.GetLogger(ctx)
-	nodeVM, err := nodeMgr.GetNode(ctx, nodeTopoObj.Spec.NodeUUID, nil)
+	nodeVM, err := nodeMgr.GetNodeVMAndUpdateCache(ctx, nodeTopoObj.Spec.NodeUUID, nil)
 	if err != nil {
 		log.Errorf("Node %q is not yet registered in the node manager. Error: %+v",
 			nodeTopoObj.Spec.NodeUUID, err)
@@ -854,7 +854,7 @@ func topoCRDeleted(obj interface{}) {
 // instance in the MetadataSyncer.topologyVCMap parameter.
 func removeLabelsFromTopologyVCMap(ctx context.Context, nodeTopoObj csinodetopologyv1alpha1.CSINodeTopology) {
 	log := logger.GetLogger(ctx)
-	nodeVM, err := nodeMgr.GetNode(ctx, nodeTopoObj.Spec.NodeUUID, nil)
+	nodeVM, err := nodeMgr.GetNodeVMAndUpdateCache(ctx, nodeTopoObj.Spec.NodeUUID, nil)
 	if err != nil {
 		log.Errorf("Node %q is not yet registered in the node manager. Error: %+v",
 			nodeTopoObj.Spec.NodeUUID, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick #2597 to release-3.0

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Available on the original PR

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherry-pick (release-3.0) : Prevent node cache update during attach & detach (#2597)
```
