### PR TITLE
Create CSINodes in WCP cluster when appropriate annotation is present

### DIFF
--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -26,7 +26,7 @@ rules:
     verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "create"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]

--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -305,7 +305,12 @@ func (c *FakeK8SOrchestrator) GetCSINodeTopologyInstanceByName(nodeName string) 
 	return nil, false, nil
 }
 
-// GetPVCNamespaceFromVolumeID retrieves the pv name from volumeID.
+// GetPVNameFromCSIVolumeID retrieves the pv name from volumeID.
 func (c *FakeK8SOrchestrator) GetPVNameFromCSIVolumeID(volumeID string) (string, bool) {
 	return "", false
+}
+
+// InitializeCSINodes creates CSINode instances for each K8s node with the appropriate topology keys.
+func (c *FakeK8SOrchestrator) InitializeCSINodes(ctx context.Context) error {
+	return nil
 }

--- a/pkg/csi/service/common/commonco/coagnostic.go
+++ b/pkg/csi/service/common/commonco/coagnostic.go
@@ -38,14 +38,14 @@ var ContainerOrchestratorUtility COCommonInterface
 // COCommonInterface provides functionality to define container orchestrator
 // related implementation to read resources/objects.
 type COCommonInterface interface {
-	// Check if feature state switch is enabled for the given feature indicated
+	// IsFSSEnabled checks if feature state switch is enabled for the given feature indicated
 	// by featureName.
 	IsFSSEnabled(ctx context.Context, featureName string) bool
-	// Check if the passed volume can be fake attached.
+	// IsFakeAttachAllowed checks if the passed volume can be fake attached.
 	IsFakeAttachAllowed(ctx context.Context, volumeID string, volumeManager cnsvolume.Manager) (bool, error)
-	// Mark the volume as fake attached.
+	// MarkFakeAttached marks the volume as fake attached.
 	MarkFakeAttached(ctx context.Context, volumeID string) error
-	// Check if the volume was fake attached, and unmark it as not fake attached.
+	// ClearFakeAttached checks if the volume was fake attached, and unmark it as not fake attached.
 	ClearFakeAttached(ctx context.Context, volumeID string) error
 	// InitTopologyServiceInController initializes the necessary resources
 	// required for topology related functionality in the controller.
@@ -84,6 +84,8 @@ type COCommonInterface interface {
 	// GetPVNameFromCSIVolumeID retrieves the pv name from the volumeID.
 	// This method will not return pv name in case of in-tree migrated volumes
 	GetPVNameFromCSIVolumeID(volumeID string) (string, bool)
+	// InitializeCSINodes creates CSINode instances for each K8s node with the appropriate topology keys.
+	InitializeCSINodes(ctx context.Context) error
 }
 
 // GetContainerOrchestratorInterface returns orchestrator object for a given

--- a/pkg/csi/service/common/commonco/k8sorchestrator/wcp_node.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/wcp_node.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sorchestrator
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+var clusterComputeResourceMoIds []string
+
+// InitializeCSINodes listens on node Add events to create CSINode instance for each K8s node object.
+func (c *K8sOrchestrator) InitializeCSINodes(ctx context.Context) error {
+	log := logger.GetLogger(ctx)
+	var err error
+	clusterComputeResourceMoIds, err = common.GetClusterComputeResourceMoIds(ctx)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to get clusterComputeResourceMoIds. Error: %v", err)
+	}
+	err = c.informerManager.AddNodeListener(
+		ctx,
+		func(obj interface{}) { // Add.
+			c.createCSINode(obj)
+		},
+		nil,
+		nil)
+	if err != nil {
+		return logger.LogNewErrorf(log, "failed to listen on nodes. Error: %+v", err)
+	}
+	log.Infof("Started informer to listen on nodes and create corresponding CSINodes")
+	return nil
+}
+
+// createCSINode creates CSINode instances for each K8s node object.
+func (c *K8sOrchestrator) createCSINode(obj interface{}) {
+	ctx, log := logger.GetNewContextWithLogger()
+	node, ok := obj.(*corev1.Node)
+	if node == nil || !ok {
+		log.Warnf("createCSINode: unrecognized object %+v found", obj)
+		return
+	}
+
+	// Check if CreateCSINodeAnnotation is present on the node. Spherelet adds this annotation on
+	// the node to communicate to CSI driver to create CSINode instance for each node.
+	csiNodeAnnotation, exists := node.ObjectMeta.Annotations[common.CreateCSINodeAnnotation]
+	if val, _ := strconv.ParseBool(csiNodeAnnotation); !exists || !val {
+		log.Infof("createCSINode: %s annotation exists: %t with value: %t on the node %s",
+			common.CreateCSINodeAnnotation, exists, val, node.Name)
+		return
+	}
+
+	var topologyKeysList []string
+	if len(clusterComputeResourceMoIds) > 1 {
+		// Publish zone and host standard topology keys for stretch supervisor.
+		topologyKeysList = append(topologyKeysList, corev1.LabelTopologyZone, corev1.LabelHostname)
+	} else {
+		topologyKeysList = append(topologyKeysList, corev1.LabelHostname)
+	}
+	// NOTE: As this is a WCP node, we can safely assume that only vSphere CSI driver will be run on it.
+	// If spherelet is not creating the CSINodes, we will create them and ignore the error if it is already present.
+	csiNodeSpec := &storagev1.CSINode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: string(node.Name),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Node",
+					Name:       node.Name,
+					UID:        node.UID,
+				},
+			},
+		},
+		Spec: storagev1.CSINodeSpec{
+			Drivers: []storagev1.CSINodeDriver{
+				{
+					Name:         common.VSphereCSIDriverName,
+					NodeID:       node.Name,
+					TopologyKeys: topologyKeysList,
+				},
+			},
+		},
+	}
+	csinode, err := c.k8sClient.StorageV1().CSINodes().Create(ctx, csiNodeSpec, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			log.Warnf("CSINode object for node %q already exists.", node.Name)
+			return
+		}
+		log.Errorf("failed to create CSINode object %+v. Error: %v", csiNodeSpec, err)
+		os.Exit(1)
+	}
+	log.Infof("Created CSINode object %+v for node %q", csinode, node.Name)
+}

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -225,7 +225,7 @@ const (
 	// supposed to provision a volume for this PVC.
 	AnnStorageProvisioner = "volume.kubernetes.io/storage-provisioner"
 
-	// vSphereCSIDriverName vSphere CSI driver name
+	// VSphereCSIDriverName vSphere CSI driver name
 	VSphereCSIDriverName = "csi.vsphere.vmware.com"
 
 	// AnnDynamicallyProvisioned annotation is added to a PV that has been
@@ -325,6 +325,10 @@ const (
 
 	// VolumeSnapshotKind represents the VolumeSnapshot Kind name
 	VolumeSnapshotKind = "VolumeSnapshot"
+
+	// CreateCSINodeAnnotation is the annotation applied by spherelet
+	// to convey to CSI driver to create a CSINode instance for each node.
+	CreateCSINodeAnnotation = "vmware-system/csi-create-csinode-object"
 )
 
 // Supported container orchestrators.

--- a/pkg/kubernetes/informers.go
+++ b/pkg/kubernetes/informers.go
@@ -27,6 +27,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/sample-controller/pkg/signals"
+
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
 

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -213,6 +213,13 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			}
 			clusterIDforVolumeMetadata = configInfo.Cfg.Global.SupervisorID
 		}
+		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.PodVMOnStretchedSupervisor) {
+			// Start watching on nodes to create CSINodes, if not already present.
+			err = commonco.ContainerOrchestratorUtility.InitializeCSINodes(ctx)
+			if err != nil {
+				return logger.LogNewErrorf(log, "failed to initialize CSINodes creation. Error: %+v", err)
+			}
+		}
 	}
 
 	// Initialize cnsDeletionMap used by Full Sync.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Moving forward, vSphere CSI driver will take the onus to create CSINodes in WCP environments. This PR introduces the code required to do so.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Node which has annotation:
```
2023-11-03T23:29:53.958Z	INFO	k8sorchestrator/wcp_node.go:115	Created CSINode object &CSINode{ObjectMeta:{4235332d674c74cdae21f35d09bf55dd    0e75c344-0a65-42c2-a897-81f0dd45a44f 608847 0 2023-11-03 23:29:53 +0000 UTC <nil> <nil> map[] map[] [{v1 Node 4235332d674c74cdae21f35d09bf55dd 2ac06129-8bf1-43a2-a60a-01866f844bbc <nil> <nil>}] [] [{vsphere-syncer Update storage.k8s.io/v1 2023-11-03 23:29:53 +0000 UTC FieldsV1 {"f:metadata":{"f:ownerReferences":{".":{},"k:{\"uid\":\"2ac06129-8bf1-43a2-a60a-01866f844bbc\"}":{}}},"f:spec":{"f:drivers":{"k:{\"name\":\"csi.vsphere.vmware.com\"}":{".":{},"f:name":{},"f:nodeID":{},"f:topologyKeys":{}}}}} }]},Spec:CSINodeSpec{Drivers:[]CSINodeDriver{CSINodeDriver{Name:csi.vsphere.vmware.com,NodeID:4235332d674c74cdae21f35d09bf55dd,TopologyKeys:[topology.kubernetes.io/zone kubernetes.io/hostname],Allocatable:nil,},},},} for node "4235332d674c74cdae21f35d09bf55dd"	{"TraceId": "55dbb4a9-7943-4bda-83a3-df08efb858d5"}
2023-11-03T23:29:53.972Z	INFO	k8sorchestrator/wcp_node.go:115	Created CSINode object &CSINode{ObjectMeta:{4235764255cb7eba851b29ed4ad406e6    d21b966b-e549-4b29-8f69-e8cb5234b4da 608848 0 2023-11-03 23:29:53 +0000 UTC <nil> <nil> map[] map[] [{v1 Node 4235764255cb7eba851b29ed4ad406e6 d5976ce3-4182-4fd2-be7b-ab778f6e4313 <nil> <nil>}] [] [{vsphere-syncer Update storage.k8s.io/v1 2023-11-03 23:29:53 +0000 UTC FieldsV1 {"f:metadata":{"f:ownerReferences":{".":{},"k:{\"uid\":\"d5976ce3-4182-4fd2-be7b-ab778f6e4313\"}":{}}},"f:spec":{"f:drivers":{"k:{\"name\":\"csi.vsphere.vmware.com\"}":{".":{},"f:name":{},"f:nodeID":{},"f:topologyKeys":{}}}}} }]},Spec:CSINodeSpec{Drivers:[]CSINodeDriver{CSINodeDriver{Name:csi.vsphere.vmware.com,NodeID:4235764255cb7eba851b29ed4ad406e6,TopologyKeys:[topology.kubernetes.io/zone kubernetes.io/hostname],Allocatable:nil,},},},} for node "4235764255cb7eba851b29ed4ad406e6"	{"TraceId": "a4d126c0-a146-46b4-8370-006bc631d63e"}
```

CSINodes:
```
Name:               4235332d674c74cdae21f35d09bf55dd
Labels:             <none>
Annotations:        <none>
CreationTimestamp:  Fri, 03 Nov 2023 23:29:53 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:        4235332d674c74cdae21f35d09bf55dd
      Topology Keys:  [topology.kubernetes.io/zone kubernetes.io/hostname]
Events:               <none>


Name:               4235764255cb7eba851b29ed4ad406e6
Labels:             <none>
Annotations:        <none>
CreationTimestamp:  Fri, 03 Nov 2023 23:29:53 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:        4235764255cb7eba851b29ed4ad406e6
      Topology Keys:  [topology.kubernetes.io/zone kubernetes.io/hostname]
Events:               <none>
```

Node which doesn't have annotation:
```
2023-11-03T23:29:53.974Z	INFO	k8sorchestrator/wcp_node.go:70	createCSINode: vmware-system/csi-create-csinode-object annotation exists: false with value: false on the node 4235c21f95122e55c3ee60eb49644dae	{"TraceId": "0aefa1fd-afd8-48bc-90c6-e5d1c0bc9172"}
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Create CSINodes in WCP cluster when appropriate annotation is present
```
