### PR TITLE
[CSI 2.6.x] Cross-port telemetry enhancements and the nodes cache fix during attach/detach

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/prometheus"
@@ -29,6 +30,8 @@ import (
 
 	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
 	cnstypes "github.com/vmware/govmomi/cns/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/common/config"
 	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco"
@@ -175,6 +178,52 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 					os.Exit(1)
 				}
 			}()
+		}
+		if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
+			if configInfo.Cfg.Global.ClusterDistribution == "" {
+				config, err := rest.InClusterConfig()
+				if err != nil {
+					log.Errorf("failed to get InClusterConfig: %v", err)
+					os.Exit(1)
+				}
+				clientset, err := kubernetes.NewForConfig(config)
+				if err != nil {
+					log.Errorf("failed to create kubernetes client with err: %v", err)
+					os.Exit(1)
+				}
+
+				// Get the version info for the Kubernetes API server
+				versionInfo, err := clientset.Discovery().ServerVersion()
+				if err != nil {
+					log.Errorf("failed to fetch versionInfo with err: %v", err)
+					os.Exit(1)
+				}
+
+				// Extract the version string from the version info
+				version := versionInfo.GitVersion
+				var ClusterDistNameToServerVersion = map[string]string{
+					"gke":       "Anthos",
+					"racher":    "Rancher",
+					"rke":       "Rancher",
+					"docker":    "DockerEE",
+					"dockeree":  "DockerEE",
+					"openshift": "Openshift",
+					"wcp":       "Supervisor",
+					"vmware":    "TanzuKubernetesCluster",
+					"nativek8s": "VanillaK8S",
+				}
+				distributionUnknown := true
+				for distServerVersion, distName := range ClusterDistNameToServerVersion {
+					if strings.Contains(version, distServerVersion) {
+						configInfo.Cfg.Global.ClusterDistribution = distName
+						distributionUnknown = false
+						break
+					}
+				}
+				if distributionUnknown {
+					configInfo.Cfg.Global.ClusterDistribution = ClusterDistNameToServerVersion["nativek8s"]
+				}
+			}
 		}
 		go func() {
 			if err := manager.InitCnsOperator(ctx, clusterFlavor, configInfo, coInitParams); err != nil {

--- a/hack/check-staticcheck.sh
+++ b/hack/check-staticcheck.sh
@@ -19,14 +19,18 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+go version
+
 # Change directories to the parent directory of the one in which this
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-go install honnef.co/go/tools/cmd/staticcheck@2022.1.1
+go install honnef.co/go/tools/cmd/staticcheck@2023.1
+
+GOOS=linux "$(go env GOPATH)"/bin/staticcheck --version
 
 # shellcheck disable=SC2046
 # shellcheck disable=SC1083
-GOOS=linux $(go env GOPATH)/bin/staticcheck $(go list ./... | grep -v /vendor/)
+GOOS=linux "$(go env GOPATH)"/bin/staticcheck $(go list ./... | grep -v /vendor/)
 
 

--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -52,17 +52,20 @@ type Manager interface {
 	DiscoverNode(ctx context.Context, nodeUUID string) error
 	// GetK8sNode returns Kubernetes Node object for the given node name
 	GetK8sNode(ctx context.Context, nodename string) (*v1.Node, error)
-	// GetNode refreshes and returns the VirtualMachine for a registered node
+	// GetNodeVMAndUpdateCache refreshes and returns the VirtualMachine for a registered node
 	// given its UUID. If datacenter is present, GetNode will search within this
 	// datacenter given its UUID. If not, it will search in all registered
 	// datacenters.
-	GetNode(ctx context.Context, nodeUUID string, dc *vsphere.Datacenter) (*vsphere.VirtualMachine, error)
-	// GetNodeByName refreshes and returns the VirtualMachine for a registered
+	GetNodeVMAndUpdateCache(ctx context.Context, nodeUUID string, dc *vsphere.Datacenter) (*vsphere.VirtualMachine, error)
+	// GetNodeVMByUuid returns the VirtualMachine for a registered node
+	// given its UUID.
+	GetNodeVMByUuid(ctx context.Context, nodeUUID string) (*vsphere.VirtualMachine, error)
+	// GetNodeVMByNameAndUpdateCache refreshes and returns the VirtualMachine for a registered
 	// node given its name.
-	GetNodeByName(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error)
-	// GetNodeByNameReadOnly returns the VirtualMachine for a registered node
+	GetNodeVMByNameAndUpdateCache(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error)
+	// GetNodeVMByName returns the VirtualMachine for a registered node
 	// given its name without refreshing cache the nodes.
-	GetNodeByNameReadOnly(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error)
+	GetNodeVMByName(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error)
 	// GetNodeNameByUUID fetches the name of the node given the VM UUID.
 	GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error)
 	// GetAllNodes refreshes and returns VirtualMachine for all registered
@@ -151,9 +154,10 @@ func (m *defaultManager) DiscoverNode(ctx context.Context, nodeUUID string) erro
 	return nil
 }
 
-// GetNodeByName refreshes and returns the VirtualMachine for a registered node
+// GetNodeVMByNameAndUpdateCache refreshes and returns the VirtualMachine for a registered node
 // given its name.
-func (m *defaultManager) GetNodeByName(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error) {
+func (m *defaultManager) GetNodeVMByNameAndUpdateCache(ctx context.Context,
+	nodeName string) (*vsphere.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
 	nodeUUID, found := m.nodeNameToUUID.Load(nodeName)
 	if !found {
@@ -161,7 +165,7 @@ func (m *defaultManager) GetNodeByName(ctx context.Context, nodeName string) (*v
 		return nil, ErrNodeNotFound
 	}
 	if nodeUUID != nil && nodeUUID.(string) != "" {
-		return m.GetNode(ctx, nodeUUID.(string), nil)
+		return m.GetNodeVMAndUpdateCache(ctx, nodeUUID.(string), nil)
 	}
 	log.Infof("Empty nodeUUID observed in cache for the node: %q", nodeName)
 	k8snodeUUID, err := k8s.GetNodeUUID(ctx, m.k8sClient, nodeName,
@@ -171,13 +175,13 @@ func (m *defaultManager) GetNodeByName(ctx context.Context, nodeName string) (*v
 		return nil, err
 	}
 	m.nodeNameToUUID.Store(nodeName, k8snodeUUID)
-	return m.GetNode(ctx, k8snodeUUID, nil)
+	return m.GetNodeVMAndUpdateCache(ctx, k8snodeUUID, nil)
 
 }
 
-// GetNodeByNameReadOnly returns the VirtualMachine for a registered node
+// GetNodeVMByName returns the VirtualMachine for a registered node
 // given its name without refreshing cache the nodes.
-func (m *defaultManager) GetNodeByNameReadOnly(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error) {
+func (m *defaultManager) GetNodeVMByName(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
 	nodeUUID, found := m.nodeNameToUUID.Load(nodeName)
 	if !found {
@@ -185,7 +189,7 @@ func (m *defaultManager) GetNodeByNameReadOnly(ctx context.Context, nodeName str
 		return nil, ErrNodeNotFound
 	}
 	if nodeUUID != nil && nodeUUID.(string) != "" {
-		return m.GetNode(ctx, nodeUUID.(string), nil)
+		return m.GetNodeVMAndUpdateCache(ctx, nodeUUID.(string), nil)
 	}
 	log.Infof("Empty nodeUUID observed in cache for the node: %q", nodeName)
 	k8snodeUUID, err := k8s.GetNodeUUID(ctx, m.k8sClient, nodeName,
@@ -194,7 +198,7 @@ func (m *defaultManager) GetNodeByNameReadOnly(ctx context.Context, nodeName str
 		log.Errorf("failed to get node UUID from node: %q. Err: %v", nodeName, err)
 		return nil, err
 	}
-	return m.GetNode(ctx, k8snodeUUID, nil)
+	return m.GetNodeVMAndUpdateCache(ctx, k8snodeUUID, nil)
 
 }
 
@@ -226,9 +230,9 @@ func (m *defaultManager) GetK8sNode(ctx context.Context, nodename string) (*v1.N
 	return node, err
 }
 
-// GetNode refreshes and returns the VirtualMachine for a registered node
+// GetNodeVMAndUpdateCache refreshes and returns the VirtualMachine for a registered node
 // given its UUID.
-func (m *defaultManager) GetNode(ctx context.Context,
+func (m *defaultManager) GetNodeVMAndUpdateCache(ctx context.Context,
 	nodeUUID string, dc *vsphere.Datacenter) (*vsphere.VirtualMachine, error) {
 	log := logger.GetLogger(ctx)
 	vmInf, discovered := m.nodeVMs.Load(nodeUUID)
@@ -265,6 +269,27 @@ func (m *defaultManager) GetNode(ctx context.Context,
 	}
 
 	log.Debugf("VM %v was successfully renewed with nodeUUID %q", vm, nodeUUID)
+	return vm, nil
+}
+
+// GetNodeVMByUuid returns the VirtualMachine for a registered node
+// given its UUID. This is called by ControllerPublishVolume and
+// ControllerUnpublishVolume to perform attach and detach operations.
+func (m *defaultManager) GetNodeVMByUuid(ctx context.Context,
+	nodeUUID string) (*vsphere.VirtualMachine, error) {
+	log := logger.GetLogger(ctx)
+	vmInf, discovered := m.nodeVMs.Load(nodeUUID)
+	if !discovered {
+		log.Infof("Node VM not found with nodeUUID %s", nodeUUID)
+		vm, err := vsphere.GetVirtualMachineByUUID(ctx, nodeUUID, false)
+		if err != nil {
+			log.Errorf("Couldn't find VM instance with nodeUUID %s, failed to discover with err: %v", nodeUUID, err)
+			return nil, err
+		}
+		log.Infof("Node was successfully found with nodeUUID %s in vm %v", nodeUUID, vm)
+		return vm, nil
+	}
+	vm := vmInf.(*vsphere.VirtualMachine)
 	return vm, nil
 }
 

--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -192,6 +192,14 @@ func (nodes *Nodes) GetNodeByName(ctx context.Context, nodeName string) (
 	return nodes.cnsNodeManager.GetNodeByName(ctx, nodeName)
 }
 
+// GetNodeByNameReadOnly returns VirtualMachine object for given nodeName.
+// This is called by ControllerPublishVolume and ControllerUnpublishVolume
+// to perform attach and detach operations.
+func (nodes *Nodes) GetNodeByNameReadOnly(ctx context.Context, nodeName string) (
+	*cnsvsphere.VirtualMachine, error) {
+	return nodes.cnsNodeManager.GetNodeByNameReadOnly(ctx, nodeName)
+}
+
 // GetNodeNameByUUID fetches the name of the node given the VM UUID.
 func (nodes *Nodes) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (
 	string, error) {

--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -184,20 +184,20 @@ func (nodes *Nodes) csiNodeDelete(obj interface{}) {
 	}
 }
 
-// GetNodeByName returns VirtualMachine object for given nodeName.
+// GetNodeVMByNameAndUpdateCache returns VirtualMachine object for given nodeName.
 // This is called by ControllerPublishVolume and ControllerUnpublishVolume
 // to perform attach and detach operations.
-func (nodes *Nodes) GetNodeByName(ctx context.Context, nodeName string) (
+func (nodes *Nodes) GetNodeVMByNameAndUpdateCache(ctx context.Context, nodeName string) (
 	*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNodeByName(ctx, nodeName)
+	return nodes.cnsNodeManager.GetNodeVMByNameAndUpdateCache(ctx, nodeName)
 }
 
-// GetNodeByNameReadOnly returns VirtualMachine object for given nodeName.
+// GetNodeVMByName returns VirtualMachine object for given nodeName.
 // This is called by ControllerPublishVolume and ControllerUnpublishVolume
 // to perform attach and detach operations.
-func (nodes *Nodes) GetNodeByNameReadOnly(ctx context.Context, nodeName string) (
+func (nodes *Nodes) GetNodeVMByName(ctx context.Context, nodeName string) (
 	*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNodeByNameReadOnly(ctx, nodeName)
+	return nodes.cnsNodeManager.GetNodeVMByName(ctx, nodeName)
 }
 
 // GetNodeNameByUUID fetches the name of the node given the VM UUID.
@@ -206,11 +206,11 @@ func (nodes *Nodes) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (
 	return nodes.cnsNodeManager.GetNodeNameByUUID(ctx, nodeUUID)
 }
 
-// GetNodeByUuid returns VirtualMachine object for given nodeUuid.
+// GetNodeVMByUuid returns VirtualMachine object for given nodeUuid.
 // This is called by ControllerPublishVolume and ControllerUnpublishVolume
 // to perform attach and detach operations.
-func (nodes *Nodes) GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
-	return nodes.cnsNodeManager.GetNode(ctx, nodeUuid, nil)
+func (nodes *Nodes) GetNodeVMByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
+	return nodes.cnsNodeManager.GetNodeVMByUuid(ctx, nodeUuid)
 }
 
 // GetAllNodes returns VirtualMachine for all registered.

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -1113,10 +1113,10 @@ func (volTopology *controllerVolumeTopology) getTopologySegmentsWithMatchingNode
 			var nodeVM *cnsvsphere.VirtualMachine
 			if volTopology.isCSINodeIdFeatureEnabled &&
 				volTopology.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-				nodeVM, err = volTopology.nodeMgr.GetNode(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeUUID, nil)
 			} else {
-				nodeVM, err = volTopology.nodeMgr.GetNodeByName(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMByNameAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeID)
 			}
 			if err != nil {
@@ -1184,10 +1184,10 @@ func (volTopology *controllerVolumeTopology) getNodesMatchingTopologySegment(ctx
 			var nodeVM *cnsvsphere.VirtualMachine
 			if volTopology.isCSINodeIdFeatureEnabled &&
 				volTopology.clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-				nodeVM, err = volTopology.nodeMgr.GetNode(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeUUID, nil)
 			} else {
-				nodeVM, err = volTopology.nodeMgr.GetNodeByName(ctx,
+				nodeVM, err = volTopology.nodeMgr.GetNodeVMByNameAndUpdateCache(ctx,
 					nodeTopologyInstance.Spec.NodeID)
 			}
 			if err != nil {

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -59,6 +59,7 @@ type NodeManagerInterface interface {
 		tagManager *tags.Manager, zoneKey string, regionKey string) ([]*cnsvsphere.DatastoreInfo,
 		map[string][]map[string]string, error)
 	GetNodeByName(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
+	GetNodeByNameReadOnly(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
 	GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error)
 	GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error)
 	GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachine, error)
@@ -1111,14 +1112,14 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
 				// if node is not yet updated to run the release of the driver publishing Node VM UUID as Node ID
 				// look up Node by name
-				nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+				nodevm, err = c.nodeMgr.GetNodeByNameReadOnly(ctx, req.NodeId)
 				if err == node.ErrNodeNotFound {
 					log.Infof("Performing node VM lookup using node VM UUID: %q", req.NodeId)
 					nodevm, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
 				}
 
 			} else {
-				nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+				nodevm, err = c.nodeMgr.GetNodeByNameReadOnly(ctx, req.NodeId)
 			}
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
@@ -1242,13 +1243,13 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
 			// if node is not yet updated to run the release of the driver publishing Node VM UUID as Node ID
 			// look up Node by name
-			nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+			nodevm, err = c.nodeMgr.GetNodeByNameReadOnly(ctx, req.NodeId)
 			if err == node.ErrNodeNotFound {
 				log.Infof("Performing node VM lookup using node VM UUID: %q", req.NodeId)
 				nodevm, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
 			}
 		} else {
-			nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+			nodevm, err = c.nodeMgr.GetNodeByNameReadOnly(ctx, req.NodeId)
 		}
 		if err != nil {
 			if err == cnsvsphere.ErrVMNotFound {

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -223,7 +223,8 @@ func (f *FakeNodeManager) GetSharedDatastoresInK8SCluster(ctx context.Context) (
 	}, nil
 }
 
-func (f *FakeNodeManager) GetNodeByName(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error) {
+func (f *FakeNodeManager) GetNodeVMByNameAndUpdateCache(ctx context.Context,
+	nodeName string) (*cnsvsphere.VirtualMachine, error) {
 	var vm *cnsvsphere.VirtualMachine
 	var t *testing.T
 	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
@@ -246,7 +247,7 @@ func (f *FakeNodeManager) GetNodeByName(ctx context.Context, nodeName string) (*
 	return vm, nil
 }
 
-func (f *FakeNodeManager) GetNodeByNameReadOnly(ctx context.Context,
+func (f *FakeNodeManager) GetNodeVMByName(ctx context.Context,
 	nodeName string) (*cnsvsphere.VirtualMachine, error) {
 	var vm *cnsvsphere.VirtualMachine
 	var t *testing.T
@@ -274,7 +275,7 @@ func (f *FakeNodeManager) GetNodeNameByUUID(ctx context.Context, nodeUUID string
 	return "", nil
 }
 
-func (f *FakeNodeManager) GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
+func (f *FakeNodeManager) GetNodeVMByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error) {
 	var vm *cnsvsphere.VirtualMachine
 	var t *testing.T
 	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -275,13 +275,13 @@ func (r *ReconcileCSINodeTopology) reconcileForVanilla(ctx context.Context, requ
 	if r.useNodeUuid && clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
 		nodeID = instance.Spec.NodeUUID
 		if nodeID != "" {
-			nodeVM, err = nodeManager.GetNode(ctx, nodeID, nil)
+			nodeVM, err = nodeManager.GetNodeVMAndUpdateCache(ctx, nodeID, nil)
 		} else {
 			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
 	} else {
 		nodeID = instance.Spec.NodeID
-		nodeVM, err = nodeManager.GetNodeByName(ctx, nodeID)
+		nodeVM, err = nodeManager.GetNodeVMByNameAndUpdateCache(ctx, nodeID)
 	}
 	if err != nil {
 		if err == node.ErrNodeNotFound {

--- a/tests/e2e/gc_block_volume_expansion.go
+++ b/tests/e2e/gc_block_volume_expansion.go
@@ -195,7 +195,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		originalFsSize, err := getFSSizeMb(f, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		rand.Seed(time.Now().Unix())
+		rand.New(rand.NewSource(time.Now().Unix()))
 		testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
 		ginkgo.By(fmt.Sprintf("Creating a 512mb test data file %v", testdataFile))
 		op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),
@@ -1455,7 +1455,7 @@ var _ = ginkgo.Describe("[csi-guest] Volume Expansion Test", func() {
 		lastOutput := framework.RunKubectlOrDie(namespace, cmd...)
 		gomega.Expect(strings.Contains(lastOutput, ext4FSType)).NotTo(gomega.BeFalse())
 
-		rand.Seed(time.Now().Unix())
+		rand.New(rand.NewSource(time.Now().Unix()))
 		testdataFile := fmt.Sprintf("/tmp/testdata_%v_%v", time.Now().Unix(), rand.Intn(1000))
 		ginkgo.By(fmt.Sprintf("Creating a 512mb test data file %v", testdataFile))
 		op, err := exec.Command("dd", "if=/dev/urandom", fmt.Sprintf("of=%v", testdataFile),

--- a/tests/e2e/policy_driven_vol_allocation.go
+++ b/tests/e2e/policy_driven_vol_allocation.go
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("[vol-allocation] Policy driven volume space allocation 
 		pvclaims2d := [][]*v1.PersistentVolumeClaim{}
 		scs := []*storagev1.StorageClass{}
 
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		suffix := fmt.Sprintf("-%v-%v", time.Now().UnixNano(), rand.Intn(10000))
 		categoryName := "category" + suffix
 		tagName := "tag" + suffix

--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -2960,7 +2960,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		}()
 
 		ginkgo.By("Bring down a host in secondary site")
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		max, min := 3, 0
 		randomValue := rand.Intn(max-min) + min
 		host := fds.secondarySiteHosts[randomValue]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cross-port telemetry enhancements, CSI Migration bug fix related to AttachVolumes  and also the nodes cache fix during attach/detach.

The below pull requests are cherry-picked as part of this PR: 
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2546
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2404

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
kubectl get pods -n vmware-system-csi -o wide 
NAME                                      READY   STATUS    RESTARTS   AGE   IP              NODE                         NOMINATED NODE   READINESS GATES
vsphere-csi-controller-7768f66499-dw5q9   7/7     Running   0          38m   10.244.2.5      k8s-control-282-1698699174   <none>           <none>
vsphere-csi-node-79r7w                    3/3     Running   0          34m   10.193.44.166   k8s-node-188-1698699204      <none>           <none>
vsphere-csi-node-8p9nk                    3/3     Running   0          36m   10.193.35.249   k8s-control-385-1698699161   <none>           <none>
vsphere-csi-node-bhxpd                    3/3     Running   0          35m   10.193.33.248   k8s-node-223-1698699216      <none>           <none>
vsphere-csi-node-c9v8c                    3/3     Running   0          35m   10.193.54.14    k8s-control-282-1698699174   <none>           <none>
vsphere-csi-node-hmqpr                    3/3     Running   0          37m   10.193.62.253   k8s-control-269-1698699149   <none>           <none>
vsphere-csi-node-xlsh4                    3/3     Running   0          36m   10.193.55.254   k8s-node-439-1698699188      <none>           <none>

kubectl get sc,pvc -A
NAME                                                            PROVISIONER              RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
storageclass.storage.k8s.io/example-vanilla-rwo-filesystem-sc   csi.vsphere.vmware.com   Delete          Immediate           true                   5m

NAMESPACE   NAME                                            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
default     persistentvolumeclaim/example-vanilla-rwo-pvc   Bound    pvc-d4cf7654-8w4d-4487-8c3e-66ef47eb4113   1Gi        RWO            example-vanilla-rwo-filesystem-sc   2m
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cross-port telemetry enhancements and nodes cache fix during attach/detach.
```
