### PR TITLE
Do not return success when CNS DeleteVolume returns NotFound fault

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -1171,12 +1171,6 @@ func (m *defaultManager) deleteVolume(ctx context.Context, volumeID string, dele
 	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
 	if volumeOperationRes.Fault != nil {
 		faultType = ExtractFaultTypeFromVolumeResponseResult(ctx, volumeOperationRes)
-		// If volume is not found on host, but is present in CNS DB, we will get vim.fault.NotFound fault.
-		// Send back success as the volume is already deleted.
-		if IsNotFoundFault(ctx, faultType) {
-			log.Infof("DeleteVolume: VolumeID %q, not found, thus returning success", volumeID)
-			return "", nil
-		}
 		return faultType, logger.LogNewErrorf(log, "failed to delete volume: %q, fault: %q, opID: %q",
 			volumeID, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 	}
@@ -1336,14 +1330,6 @@ func (m *defaultManager) deleteVolumeWithImprovedIdempotency(ctx context.Context
 	volumeOperationRes := taskResult.GetCnsVolumeOperationResult()
 	if volumeOperationRes.Fault != nil {
 		faultType = ExtractFaultTypeFromVolumeResponseResult(ctx, volumeOperationRes)
-
-		// If volume is not found on host, but is present in CNS DB, we will get vim.fault.NotFound fault.
-		// In such a case, send back success as the volume is already deleted.
-		if IsNotFoundFault(ctx, faultType) {
-			log.Infof("DeleteVolume: VolumeID %q, not found, thus returning success", volumeID)
-			return "", nil
-		}
-
 		msg := fmt.Sprintf("failed to delete volume: %q, fault: %q, opID: %q",
 			volumeID, spew.Sdump(volumeOperationRes.Fault), taskInfo.ActivationId)
 		volumeOperationDetails = createRequestDetails(instanceName, "", "", 0,

--- a/pkg/common/cns-lib/volume/util.go
+++ b/pkg/common/cns-lib/volume/util.go
@@ -549,11 +549,3 @@ func queryCreatedSnapshotByName(ctx context.Context, m *defaultManager, volumeID
 	}
 	return nil, false
 }
-
-// IsNotFoundFault returns true if a given faultType value is vim.fault.NotFound
-func IsNotFoundFault(ctx context.Context, faultType string) bool {
-	log := logger.GetLogger(ctx)
-	log.Infof("Checking fault type: %q is vim.fault.NotFound", faultType)
-	return faultType == "vim.fault.NotFound"
-
-}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Reverting this change: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2316
It would be incorrect return SUCCESS when CNS Delete Volume returns NotFound fault as they return this fault not only when the source disk is not found but also when the DB is not updated.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
1. Created a block volume and removed its VMDK file from the host. The proceeded to delete its PVC. The PV failed to get deleted with NotFound fault:

```
csi.vsphere.vmware.com_vsphere-csi-controller-5985944c9c-mnqdd_cbfa1f82-f61c-492e-9b33-9acdcbbbabd7  (combined from similar events): rpc error: code = Internal desc = failed to delete volume: "0d9ebd50-9bbf-4d4c-992d-fa007ff3f34d". Error: failed to delete volume: "0d9ebd50-9bbf-4d4c-992d-fa007ff3f34d", fault: "(*types.LocalizedMethodFault)(0xc000d47540)({\n DynamicData: (types.DynamicData) {\n },\n Fault: (*types.NotFound)(0xc000d47560)({\n  VimFault: (types.VimFault) {\n   MethodFault: (types.MethodFault) {\n    FaultCause: (*types.LocalizedMethodFault)(<nil>),\n    FaultMessage: ([]types.LocalizableMessage) <nil>\n   }\n  }\n }),\n LocalizedMessage: (string) (len=50) \"The object or item referred to could not be found.\"\n})\n", opID: "ae7aca80"
```
2. Create a PV and then deleted PVC. Observed that the PV also got deleted, as expected.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
