### PR TITLE
Validate vCenter username and crash CSI driver if username is not a fully qualified domain name

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -106,6 +107,11 @@ const (
 var (
 	// ErrUsernameMissing is returned when the provided username is empty.
 	ErrUsernameMissing = errors.New("username is missing")
+
+	// ErrInvalidUsername is returned when vCenter username provided in vSphere config
+	// secret is invalid. e.g. If username is not a fully qualified domain name, then
+	// it will be considered as invalid username.
+	ErrInvalidUsername = errors.New("username is invalid, make sure it is a fully qualified domain username")
 
 	// ErrPasswordMissing is returned when the provided password is empty.
 	ErrPasswordMissing = errors.New("password is missing")
@@ -322,6 +328,18 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 	return nil
 }
 
+// Check if username is valid or not. If username is not a fully qualified domain name, then
+// we consider it as an invalid username.
+func isValidvCenterUsernameWithDomain(username string) bool {
+	// Regular expression to validate vCenter server username.
+	// Allowed username is in the format "userName@domainName" or "domainName\\userName".
+	// If domain name is not provided in username, then functions like HasUserPrivilegeOnEntities
+	// doesn't return any entity for given user and eventually volume creation fails.
+	regex := `^(?:[a-zA-Z0-9.-]+\\[a-zA-Z0-9._-]+|[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+)$`
+	match, _ := regexp.MatchString(regex, username)
+	return match
+}
+
 func validateConfig(ctx context.Context, cfg *Config) error {
 	log := logger.GetLogger(ctx)
 	// Fix default global values.
@@ -369,6 +387,15 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 				return ErrUsernameMissing
 			}
 		}
+
+		// vCenter server username provided in vSphere config secret should contain domain name,
+		// CSI driver will crash if username doesn't contain domain name.
+		if !isValidvCenterUsernameWithDomain(vcConfig.User) {
+			log.Errorf("username %v specified in vSphere config secret is invalid, "+
+				"make sure that username is a fully qualified domain name.", vcConfig.User)
+			return ErrInvalidUsername
+		}
+
 		if vcConfig.Password == "" {
 			vcConfig.Password = cfg.Global.Password
 			if vcConfig.Password == "" {

--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -35,7 +35,7 @@ func init() {
 	defer cancel()
 	idealVCConfig = map[string]*VirtualCenterConfig{
 		"1.1.1.1": {
-			User:         "Admin",
+			User:         "Administrator@vsphere.local",
 			Password:     "Password",
 			VCenterPort:  "443",
 			Datacenters:  "dc1",
@@ -156,6 +156,66 @@ func TestValidateConfigWithInvalidClusterId(t *testing.T) {
 	err := validateConfig(ctx, cfg)
 	if err == nil {
 		t.Errorf("Expected error due to invalid cluster id. Config given - %+v", *cfg)
+	}
+}
+
+func TestValidateConfigWithInvalidUsername(t *testing.T) {
+	vcConfigInvalidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			User:         "Administrator",
+			Password:     "Password",
+			VCenterPort:  "443",
+			Datacenters:  "dc1",
+			InsecureFlag: true,
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigInvalidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err == nil {
+		t.Errorf("Expected error due to invalid username. Config given - %+v", *cfg)
+	}
+}
+
+func TestValidateConfigWithValidUsername1(t *testing.T) {
+	vcConfigValidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			User:         "Administrator@vsphere.local",
+			Password:     "Password",
+			VCenterPort:  "443",
+			Datacenters:  "dc1",
+			InsecureFlag: true,
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigValidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err != nil {
+		t.Errorf("Unexpected error, as valid username is specified. Config given - %+v", *cfg)
+	}
+}
+
+func TestValidateConfigWithValidUsername2(t *testing.T) {
+	vcConfigValidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			User:         "vsphere.local\\Administrator",
+			Password:     "Password",
+			VCenterPort:  "443",
+			Datacenters:  "dc1",
+			InsecureFlag: true,
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigValidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err != nil {
+		t.Errorf("Unexpected error, as valid username is specified. Config given - %+v", *cfg)
 	}
 }
 

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -65,7 +65,7 @@ func configFromCustomizedSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool)
 
 	cfg.Global.VCenterIP = s.URL.Hostname()
 	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = "DC0"
 

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -126,7 +126,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.
 
 	cfg.Global.VCenterIP = s.URL.Hostname()
 	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = "DC0"
 

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -105,7 +105,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.
 
 	cfg.Global.VCenterIP = s.URL.Hostname()
 	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = "DC0"
 

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -114,7 +114,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*cnsconf
 
 	cfg.Global.VCenterIP = s.URL.Hostname()
 	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = "DC0"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry picking changes from https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2595 to release-3.1 branch.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran e2e tests :
```
Ran 1 of 788 Specs in 406.053 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 787 Skipped
PASS

------------------------------

Ran 13 of 788 Specs in 5708.856 seconds
SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 775 Skipped
PASS

------------------------------

Ran 53 of 788 Specs in 1314.854 seconds
FAIL! -- 29 Passed | 24 Failed | 0 Pending | 735 Skipped
```
 
**Special notes for your reviewer**:

**Release note**:
```release-note
Validate vCenter username and crash CSI driver if username is not a fully qualified domain name
```
