### PR TITLE
Assigning ginkgo_Labels to wcp and ListVolume tests

### DIFF
--- a/tests/e2e/csi_static_provisioning_basic.go
+++ b/tests/e2e/csi_static_provisioning_basic.go
@@ -284,7 +284,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 9. Verify volume is detached from the node.
 	// 10. Delete PVC.
 	// 11. Verify PV is deleted automatically.
-	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Verify basic static provisioning workflow", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Verify basic static provisioning"+
+		"workflow", ginkgo.Label(p0, block, vanilla, core), func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -393,7 +394,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 10. Delete PVC.
 	// 11. Verify PV is deleted automatically.
 	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Verify basic static provisioning workflow "+
-		"with XFS filesystem", func() {
+		"with XFS filesystem", ginkgo.Label(p1, block, vanilla, core), func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -511,8 +512,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 7. Wait for the volume entry to be created in CNS.
 	// 8. Delete PV2.
 	// 9. Wait for PV2 to be deleted, and also entry is deleted from CNS.
-	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
-		"Verify static provisioning workflow using same PV name twice", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Verify static provisioning workflow using"+
+		"same PV name twice", ginkgo.Label(p2, block, vanilla, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -588,7 +589,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 12. Delete the PVC in GC.
 	// 13. Verifying if PVC and PV also deleted in the SV cluster.
 	// 14. Verify volume is deleted on CNS.
-	ginkgo.It("[csi-guest] Static provisioning workflow in guest cluster", func() {
+	ginkgo.It("[csi-guest] Static provisioning workflow in guest"+
+		"cluster", ginkgo.Label(p1, block, tkg), func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -688,7 +690,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 6. Delete the PVC in GC.
 	// 7. Verifying if PVC and PV also deleted in the SV cluster.
 	// 8. Verify volume is deleted on CNS.
-	ginkgo.It("[csi-guest] Static provisioning workflow II in guest cluster", func() {
+	ginkgo.It("[csi-guest] Static provisioning workflow II in guest"+
+		"cluster", ginkgo.Label(p1, block, tkg), func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -776,7 +779,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 9. Verify PV is deleted automatically.
 	// 10. Verify Volume id deleted automatically.
 	// 11. Verify CRD deleted automatically.
-	ginkgo.It("[csi-supervisor] Verify static provisioning workflow on SVC - import CNS volume", func() {
+	ginkgo.It("[csi-supervisor] Verify static provisioning workflow on SVC - import"+
+		"CNS volume", ginkgo.Label(p0, block, wcp), func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -860,7 +864,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 9. Verify PV is deleted automatically.
 	// 10. Verify Volume id deleted automatically.
 	// 11. Verify CRD deleted automatically.
-	ginkgo.It("[csi-supervisor] Verify static provisioning workflow on SVC import FCD", func() {
+	ginkgo.It("[csi-supervisor] Verify static provisioning workflow on SVC import"+
+		"FCD", ginkgo.Label(p0, block, wcp), func() {
 
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -948,9 +953,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 12. Verify PV is deleted automatically.
 	// 13. Verify Volume id deleted automatically.
 	// 14. Verify CRD deleted automatically.
-	ginkgo.It("[csi-supervisor] Verify static provisioning workflow on svc - "+
-		"when there is no resourcequota available", func() {
-
+	ginkgo.It("[csi-supervisor] Verify static provisioning workflow on svc - when there is no"+
+		"resourcequota available", ginkgo.Label(p1, block, wcp), func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1035,7 +1039,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 5. Create CNS register volume with above created FCD, AccessMode as "ReadOnlyMany".
 	// 6. verify  the error message.
 	// 7. Delete Resource quota.
-	ginkgo.It("[csi-supervisor] Verify static provisioning when AccessMode is ReadWriteMany or ReadOnlyMany", func() {
+	ginkgo.It("[csi-supervisor] Verify static provisioning when AccessMode is ReadWriteMany or"+
+		"ReadOnlyMany", ginkgo.Label(p1, block, wcp), func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1091,7 +1096,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 8. Verify PV is deleted automatically.
 	// 9. Verify Volume id deleted automatically.
 	// 10. Verify CRD deleted automatically.
-	ginkgo.It("[csi-supervisor] Verify static provisioning workflow - when DuplicateFCD is used", func() {
+	ginkgo.It("[csi-supervisor] Verify static provisioning workflow - when"+
+		"DuplicateFCD is used", ginkgo.Label(p2, block, wcp), func() {
 
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1193,7 +1199,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 10. Verify PV is deleted automatically.
 	// 11. Verify Volume id deleted automatically.
 	// 12. Verify CRD deleted automatically.
-	ginkgo.It("[csi-supervisor] Verify static provisioning workflow - when DuplicatePVC name is used", func() {
+	ginkgo.It("[csi-supervisor] Verify static provisioning workflow - when"+
+		"DuplicatePVC name is used", ginkgo.Label(p2, block, wcp), func() {
 
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1293,7 +1300,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 9. PV and CRD gets auto deleted.
 	// 10. Delete Resource quota.
 	ginkgo.It("[csi-supervisor] Verifies static provisioning workflow on supervisor cluster - "+
-		"When vsanhealthService is down", func() {
+		"When vsanhealthService is down", ginkgo.Label(p2, block, wcp), func() {
 
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1374,7 +1381,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 8. Delete PVC.
 	// 9. PV and CRD gets auto deleted.
 	// 10. Delete Resource quota.
-	ginkgo.It("[csi-supervisor] Verifies static provisioning workflow on SVC - When SPS service is down", func() {
+	ginkgo.It("[csi-supervisor] Verifies static provisioning workflow on SVC - When"+
+		"SPS service is down", ginkgo.Label(p2, block, wcp), func() {
 
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1448,7 +1456,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 3. Create CNS register volume with above created FCD.
 	// 4. Verify the error message.
 	// 5. Delete Resource quota.
-	ginkgo.It("[csi-supervisor] Verify static provisioning workflow SVC - On non shared datastore", func() {
+	ginkgo.It("[csi-supervisor] Verify static provisioning workflow SVC - On"+
+		"non shared datastore", ginkgo.Label(p2, block, wcp), func() {
 
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1521,7 +1530,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 2. Create Resource quota.
 	// 3. Create CNS register volume with above created FCD.
 	// 4. Verify the error message.
-	ginkgo.It("[csi-supervisor] Verify creating static provisioning workflow when FCD with no storage policy", func() {
+	ginkgo.It("[csi-supervisor] Verify creating static provisioning workflow when FCD"+
+		"with no storage policy", ginkgo.Label(p2, block, wcp, negative), func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1581,7 +1591,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 3. Create FCD with the above created storage policy.
 	// 4. Import the volume created in step 3 to namespace created in step 1.
 	ginkgo.It("[csi-supervisor] static provisioning workflow - "+
-		"when tried to import volume with a storage policy that doesn't belong to the namespace", func() {
+		"when tried to import volume with a storage policy that"+
+		"doesn't belong to the namespace", ginkgo.Label(p2, block, wcp, negative), func() {
 
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1728,7 +1739,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 7. Wait for PV , PVC to get bound.
 	// 8. Create POD, verify the status.
 	// 9. Delete all the above created PV, PVC and resource quota.
-	ginkgo.It("[csi-guest] static volume provisioning on guest cluster", func() {
+	ginkgo.It("[csi-guest] static volume provisioning on guest"+
+		"cluster", ginkgo.Label(p0, block, tkg), func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1861,7 +1873,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 8. Verify that PV's got deleted (This ensures that all PVC, CNS register
 	//    volumes and POD's are deleted).
 	ginkgo.It("[csi-supervisor] Perform static and dynamic provisioning together, "+
-		"Create Pod and delete Namespace", func() {
+		"Create Pod and delete Namespace", ginkgo.Label(p0, block, wcp), func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1956,8 +1968,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 2. Create Resource quota.
 	// 3. Create CNS register volume with above created VMDK.
 	// 4. verify PV, PVC got created , check the bidirectional reference.
-	ginkgo.It("[csi-supervisor] Verify static provisioning - import VMDK", func() {
-
+	ginkgo.It("[csi-supervisor] Verify static provisioning - import"+
+		"VMDK", ginkgo.Label(p1, block, wcp), func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2039,7 +2051,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 	// 3. Create CNS register volume with above created VMDK and FCDID.
 	// 4. Verify the error message "VolumeID and DiskURLPath cannot be specified
 	//    together".
-	ginkgo.It("[csi-supervisor] Specify VolumeID and DiskURL together and verify the error message", func() {
+	ginkgo.It("[csi-supervisor] Specify VolumeID and DiskURL together and"+
+		"verify the error message", ginkgo.Label(p2, block, wcp, negative), func() {
 
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
@@ -2109,7 +2122,8 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		7.Verify Volume is deleted.
 		8.Delete FCD.
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] Full sync to deregister/delete volume", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] Full sync to deregister/delete"+
+		"volume", ginkgo.Label(p0, block, wcp, vanilla, core), func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2262,7 +2276,7 @@ var _ = ginkgo.Describe("Basic Static Provisioning", func() {
 		6.Wait for Volume to be deleted on CNS
 	*/
 	ginkgo.It("[csi-block-vanilla] [csi-supervisor] VMDK is deleted from datastore "+
-		"but CNS volume is still present", func() {
+		"but CNS volume is still present", ginkgo.Label(p1, block, wcp, vanilla, core), func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/data_persistence.go
+++ b/tests/e2e/data_persistence.go
@@ -118,8 +118,8 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 		}
 	})
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] "+
-		"Should create and delete pod with the same volume source and data", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] Should create and delete"+
+		"pod with the same volume source and data", ginkgo.Label(p0, block, vanilla, wcp, tkg, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var sc *storagev1.StorageClass
@@ -303,8 +303,8 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 	// 10. Delete pod.
 	// 11. Wait for volume to be detached.
 	// 12. Delete PVC and SC.
-	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
-		"Dynamic volume provisioning data persistence test with XFS filesystem", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Dynamic volume provisioning data persistence"+
+		"test with XFS filesystem", ginkgo.Label(p0, block, vanilla, wcp, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var sc *storagev1.StorageClass
@@ -436,7 +436,8 @@ var _ = ginkgo.Describe("Data Persistence", func() {
 	// 14. Verify Volume id deleted automatically.
 	// 15. Verify CRD deleted automatically.
 	// 16. Delete resource quota.
-	ginkgo.It("[csi-supervisor] Data Persistence in case of Static Volume Provisioning on SVC", func() {
+	ginkgo.It("[csi-supervisor] Data Persistence in case of Static Volume Provisioning on"+
+		"SVC", ginkgo.Label(p0, block, wcp), func() {
 		var pvc *v1.PersistentVolumeClaim
 		var err error
 		var vmUUID string

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -293,6 +293,7 @@ const (
 	level2              = "level2"
 	level5              = "level5"
 	negative            = "negative"
+	listVolume          = "listVolume"
 )
 
 // The following variables are required to know cluster type to run common e2e

--- a/tests/e2e/file_volume_statefulsets.go
+++ b/tests/e2e/file_volume_statefulsets.go
@@ -89,7 +89,8 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		8. Delete all PVCs from the tests namespace.
 		9. Delete the storage class.
 	*/
-	ginkgo.It("Statefulset with file volume testing with default podManagementPolicy", func() {
+	ginkgo.It("Statefulset with file volume testing with default"+
+		"podManagementPolicy", ginkgo.Label(p0, file, vanilla, core), func() {
 		curtime := time.Now().Unix()
 		randomValue := rand.Int()
 		val := strconv.FormatInt(int64(randomValue), 10)
@@ -252,7 +253,8 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		8. Delete all PVCs from the tests namespace.
 		9. Delete the storage class.
 	*/
-	ginkgo.It("Statefulset with file volume testing with parallel podManagementPolicy", func() {
+	ginkgo.It("Statefulset with file volume testing with parallel"+
+		"podManagementPolicy", ginkgo.Label(p0, file, vanilla, core), func() {
 		curtime := time.Now().Unix()
 		randomValue := rand.Int()
 		val := strconv.FormatInt(int64(randomValue), 10)
@@ -414,7 +416,8 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		7. Delete all PVCs from the tests namespace.
 		8. Delete the storage class.
 	*/
-	ginkgo.It("Statefulset with file volume testing scale-up first and scale-down", func() {
+	ginkgo.It("Statefulset with file volume testing scale-up first and"+
+		"scale-down", ginkgo.Label(p0, file, vanilla, core), func() {
 		curtime := time.Now().Unix()
 		randomValue := rand.Int()
 		val := strconv.FormatInt(int64(randomValue), 10)
@@ -529,7 +532,8 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 	   9. Delete all PVCs from the tests namespace.
 	   10. Delete the storage class.
 	*/
-	ginkgo.It("Statefulset with file volume testing with CSI daemonset restart", func() {
+	ginkgo.It("Statefulset with file volume testing with CSI daemonset"+
+		"restart", ginkgo.Label(p1, file, vanilla, core), func() {
 		curtime := time.Now().Unix()
 		randomValue := rand.Int()
 		val := strconv.FormatInt(int64(randomValue), 10)
@@ -719,7 +723,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 	  10. Increase the CSI driver  replica to 3
 
 	*/
-	ginkgo.It("List-volumeResponseFor-fileVolumes", func() {
+	ginkgo.It("List-volumeResponseFor-fileVolumes", ginkgo.Label(p1, listVolume, file, vanilla, core), func() {
 		curtime := time.Now().Unix()
 		randomValue := rand.Int()
 		val := strconv.FormatInt(int64(randomValue), 10)

--- a/tests/e2e/fullsync_test_for_block_volume.go
+++ b/tests/e2e/fullsync_test_for_block_volume.go
@@ -140,8 +140,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		}
 	})
 
-	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-serialized] "+
-		"Verify CNS volume is created after full sync when pv entry is present", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-serialized] Verify CNS volume is created after"+
+		"full sync when pv entry is present", ginkgo.Label(p0, block, vanilla, core), func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -216,8 +216,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 
 	})
 
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-block-vanilla-serialized] "+
-		"Verify labels are created in CNS after updating pvc and/or pv with new labels", func() {
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-block-vanilla-serialized] Verify labels are created in CNS after"+
+		"updating pvc and/or pv with new labels", ginkgo.Label(p0, block, vanilla, wcp, core), func() {
 		ginkgo.By("Invoking test to verify labels creation")
 		var sc *storagev1.StorageClass
 		var pvc *v1.PersistentVolumeClaim
@@ -304,8 +304,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 
 	})
 
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-block-vanilla-serialized] "+
-		"Verify CNS volume is deleted after full sync when pv entry is delete", func() {
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-block-vanilla-serialized] Verify CNS volume is"+
+		"deleted after full sync when pv entry is delete", ginkgo.Label(p0, block, vanilla, wcp, core), func() {
 		ginkgo.By("Invoking test to verify CNS volume creation")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -408,8 +408,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 	// 9. verify that pvc labels for pvclaim[2] has been updated.
 	// 10. verify that pv labels for pvs[3] has been updated.
 	// 11. cleanup to remove pvs and pvcliams.
-	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-serialized] "+
-		"Verify Multiple PVCs are deleted/updated after full sync", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-serialized] Verify Multiple PVCs are"+
+		"deleted/updated after full sync", ginkgo.Label(p0, block, vanilla, core), func() {
 		sc, err := createStorageClass(client, nil, nil, v1.PersistentVolumeReclaimRetain, "", false, "")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ctx, cancel := context.WithCancel(context.Background())
@@ -520,8 +520,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		}
 	})
 
-	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-serialized] "+
-		"Verify PVC metadata is created in CNS after PVC is created in k8s", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-serialized] Verify PVC metadata is created in CNS"+
+		"after PVC is created in k8s", ginkgo.Label(p0, block, vanilla, core), func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -597,8 +597,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-serialized] "+
-		"Verify PVC metadata is deleted in CNS after PVC is deleted in k8s", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-serialized] Verify PVC metadata is deleted in CNS after"+
+		"PVC is deleted in k8s", ginkgo.Label(p0, block, vanilla, core), func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -690,8 +690,8 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 
 	})
 
-	ginkgo.It("[csi-block-vanilla-destructive] "+
-		"Scale down driver deployment to zero replica and verify PV metadata is created in CNS", func() {
+	ginkgo.It("[csi-block-vanilla-destructive] Scale down driver deployment to zero replica and verify"+
+		"PV metadata is created in CNS", ginkgo.Label(p1, block, vanilla, disruptive, core), func() {
 		var err error
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -788,9 +788,9 @@ var _ bool = ginkgo.Describe("full-sync-test", func() {
 			8.	delete pod2
 			9.	delete pvc1
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-serialized] "+
-		"Attach volume to a new pod when CNS is down and verify volume metadata in CNS post full sync", func() {
-
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-serialized] Attach volume"+
+		"to a new pod when CNS is down and verify volume metadata in CNS post full"+
+		"sync", ginkgo.Label(p1, block, vanilla, wcp, tkg, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var err error

--- a/tests/e2e/labelupdates.go
+++ b/tests/e2e/labelupdates.go
@@ -124,7 +124,8 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelize
 		}
 	})
 
-	ginkgo.It("[csi-supervisor] verify labels are created in CNS after updating pvc and/or pv with new labels", func() {
+	ginkgo.It("[csi-supervisor] verify labels are created in CNS after updating pvc"+
+		"and/or pv with new labels", ginkgo.Label(p1, block, vanilla, wcp, core), func() {
 		ginkgo.By("Invoking test to verify labels creation")
 		var sc *storagev1.StorageClass
 		var pvc *v1.PersistentVolumeClaim
@@ -195,7 +196,8 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelize
 
 	})
 
-	ginkgo.It("[csi-supervisor] verify labels are removed in CNS after removing them from pvc and/or pv", func() {
+	ginkgo.It("[csi-supervisor] verify labels are removed in CNS after removing them from pvc and/or"+
+		"pv", ginkgo.Label(p0, block, vanilla, wcp, core), func() {
 		ginkgo.By("Invoking test to verify labels deletion")
 		labels := make(map[string]string)
 		labels[labelKey] = labelValue
@@ -282,8 +284,8 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelize
 
 	})
 
-	ginkgo.It("[csi-supervisor] verify podname label is created/deleted "+
-		"when pod with cns volume is created/deleted.", func() {
+	ginkgo.It("[csi-supervisor] verify podname label is created/deleted when pod with cns volume is"+
+		"created/deleted.", ginkgo.Label(p0, block, vanilla, wcp, core), func() {
 		ginkgo.By("Invoking test to verify pod name label updates")
 		var sc *storagev1.StorageClass
 		var pvc *v1.PersistentVolumeClaim
@@ -395,7 +397,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelize
 	*/
 
 	ginkgo.It("[csi-block-vanilla] Verify PVC name is removed from PV entry on CNS after PVC is deleted "+
-		"when Reclaim Policy is set to retain.", func() {
+		"when Reclaim Policy is set to retain.", ginkgo.Label(p0, block, vanilla, core), func() {
 
 		var err error
 
@@ -526,7 +528,7 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelize
 		13. Delete SC
 	*/
 
-	ginkgo.It("Verify label updates on statically provisioned volume.", func() {
+	ginkgo.It("Verify label updates on statically provisioned volume.", ginkgo.Label(p0, block, vanilla, core), func() {
 		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -659,7 +661,8 @@ var _ bool = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelize
 		10. Delete PVCs
 		11. Delete SC
 	*/
-	ginkgo.It("[csi-supervisor] Verify label updates on PVC and PV attached to a stateful set.", func() {
+	ginkgo.It("[csi-supervisor] Verify label updates on PVC and PV attached to a stateful"+
+		"set.", ginkgo.Label(p0, block, vanilla, wcp, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		// decide which test setup is available to run

--- a/tests/e2e/statefulsets.go
+++ b/tests/e2e/statefulsets.go
@@ -103,8 +103,8 @@ var _ = ginkgo.Describe("statefulset", func() {
 		}
 	})
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized]"+
-		"Statefulset testing with default podManagementPolicy", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized] Statefulset"+
+		"testing with default podManagementPolicy", ginkgo.Label(p0, vanilla, block, wcp, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -299,8 +299,8 @@ var _ = ginkgo.Describe("statefulset", func() {
 		8. Delete all PVCs from the tests namespace.
 		9. Delete the storage class.
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized]"+
-		"Statefulset testing with parallel podManagementPolicy", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized] Statefulset"+
+		"testing with parallel podManagementPolicy", ginkgo.Label(p0, vanilla, block, wcp, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -496,8 +496,8 @@ var _ = ginkgo.Describe("statefulset", func() {
 			10. scale down statefulset to 0
 			11. delete statefulset and all PVC's and SC's
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized] [csi-vcp-mig] "+
-		"Verify online volume expansion on statefulset", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify online volume"+
+		"expansion on statefulset", ginkgo.Label(p0, vanilla, block, wcp, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var pvcSizeBeforeExpansion int64
@@ -700,7 +700,8 @@ var _ = ginkgo.Describe("statefulset", func() {
 	  12. Inncrease the CSI driver  replica to 3
 
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] ListVolumeResponse Validation", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] ListVolumeResponse"+
+		"Validation", ginkgo.Label(p1, listVolume, block, vanilla, wcp, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var svcMasterPswd string

--- a/tests/e2e/vc_reboot_volume_lifecycle.go
+++ b/tests/e2e/vc_reboot_volume_lifecycle.go
@@ -87,8 +87,8 @@ var _ bool = ginkgo.Describe("Verify volume life_cycle operations works fine aft
 		9. Delete PVC, PV and Storage Class
 	*/
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-serialized] "+
-		"verify volume operations on VC works fine after vc reboots", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-serialized] verify volume"+
+		"operations on VC works fine after vc reboots", ginkgo.Label(p1, block, wcp, vanilla, tkg, core), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/volume_health_test.go
+++ b/tests/e2e/volume_health_test.go
@@ -132,7 +132,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	//    7.	Verify PV entry is deleted from CNS.
 	//    8.	Delete the SC.
 
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation added on the pvc is accessible", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation added on the pvc is"+
+		"accessible", ginkgo.Label(p0, block, wcp, tkg), func() {
 
 		var storageclass *storagev1.StorageClass
 		var pvclaim *v1.PersistentVolumeClaim
@@ -239,8 +240,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 5.	Delete PVC.
 	// 7.	Delete the SC.
 
-	ginkgo.It("[csi-supervisor] [csi-guest] "+
-		"Verify health annotation is not added on the pvc which is on pending state", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is not added on the pvc which is on"+
+		"pending state", ginkgo.Label(p1, block, wcp, tkg), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		nonShareadstoragePolicyName := GetAndExpectStringEnvVar(envStoragePolicyNameForNonSharedDatastores)
@@ -304,8 +305,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 9. Verify PV entry is deleted from CNS.
 	// 10. Delete the SC.
 
-	ginkgo.It("[csi-supervisor] [csi-guest] "+
-		"Verify health annotation is updated from unknown status to accessible", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is updated"+
+		"from unknown status to accessible", ginkgo.Label(p0, block, wcp, tkg), func() {
 		var storageclass *storagev1.StorageClass
 		var pvclaim *v1.PersistentVolumeClaim
 		var err error
@@ -447,8 +448,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 10. Verify PV entry is deleted from CNS.
 	// 11. Delete the SC.
 
-	ginkgo.It("[csi-supervisor] [csi-guest] "+
-		"Verify health annotation is not updated to unknown status from accessible", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is not updated to unknown"+
+		"status from accessible", ginkgo.Label(p1, block, wcp, tkg), func() {
 		var storageclass *storagev1.StorageClass
 		var pvclaim *v1.PersistentVolumeClaim
 		var err error
@@ -590,7 +591,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 9. Verify PV entry is deleted from CNS.
 	// 10. Delete the SC.
 
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is not updated when SPS is down", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is not updated when SPS is"+
+		"down", ginkgo.Label(p2, block, wcp, tkg), func() {
 		var storageclass *storagev1.StorageClass
 		var pvclaim *v1.PersistentVolumeClaim
 		var err error
@@ -723,7 +725,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 7. Verify health annotation is added on the PVC is accessible.
 	// 8. Delete PVC, SC
 
-	ginkgo.It("[csi-supervisor] Verify changing the annotated values on the PVC to random value", func() {
+	ginkgo.It("[csi-supervisor] Verify changing the annotated values on the PVC to random"+
+		"value", ginkgo.Label(p2, block, wcp), func() {
 		var storageclass *storagev1.StorageClass
 		var pvclaim *v1.PersistentVolumeClaim
 		var err error
@@ -837,7 +840,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 7. Delete PVC from the tests namespace.
 	// 8. Delete the storage class.
 
-	ginkgo.It("[csi-supervisor] Verify Volume health on Statefulset", func() {
+	ginkgo.It("[csi-supervisor] Verify Volume health on"+
+		"Statefulset", ginkgo.Label(p0, block, wcp), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -922,7 +926,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 6. Verify PV entry is deleted from CNS.
 	// 7. Delete the SC.
 
-	ginkgo.It("[csi-supervisor] Verify health annotaiton is not added on the PV ", func() {
+	ginkgo.It("[csi-supervisor] Verify health annotaiton is not added on the"+
+		"PV", ginkgo.Label(p1, block, wcp), func() {
 		var storageclass *storagev1.StorageClass
 		var pvclaim *v1.PersistentVolumeClaim
 		var err error
@@ -1004,7 +1009,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	//    annotation - it should not allowed to update the PVC annotation value
 	// 7. Verify health annotation is added on the PVC is accessible.
 	// 8. Delete PVC, SC
-	ginkgo.It("[csi-supervisor] Verify removing the health annotation on the PVC", func() {
+	ginkgo.It("[csi-supervisor] Verify removing the health annotation on the"+
+		"PVC", ginkgo.Label(p1, block, wcp), func() {
 		var storageclass *storagev1.StorageClass
 		var pvclaim *v1.PersistentVolumeClaim
 		var err error
@@ -1099,7 +1105,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 7. Delete PVC from the tests namespace.
 	// 8. Delete the storage class.
 
-	ginkgo.It("[csi-guest] In Guest Cluster Verify Volume health on Statefulset", func() {
+	ginkgo.It("[csi-guest] In Guest Cluster Verify Volume health on"+
+		"Statefulset", ginkgo.Label(p0, block, tkg), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Creating StorageClass for Statefulset")
@@ -1195,7 +1202,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 11. Verify PV entry is deleted from CNS.
 	// 12. Delete the SC.
 
-	ginkgo.It("[csi-guest] Verify Volume health when GC CSI is down", func() {
+	ginkgo.It("[csi-guest] Verify Volume health when GC CSI is down", ginkgo.Label(p1, block, tkg), func() {
 
 		var sc *storagev1.StorageClass
 		var pvc *v1.PersistentVolumeClaim
@@ -1327,7 +1334,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 6. Delete PVC.
 	// 7. Delete Storage class.
 
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify Volume health after password rotation", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] Verify Volume health after password"+
+		"rotation", ginkgo.Label(p2, block, wcp, tkg), func() {
 		var sc *storagev1.StorageClass
 		var pvc *v1.PersistentVolumeClaim
 		var err error
@@ -1447,7 +1455,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// Verify PV entry is deleted from CNS.
 	// Delete the SC.
 
-	ginkgo.It("[csi-supervisor] Verify Volume health when SVC CSI is down", func() {
+	ginkgo.It("[csi-supervisor] Verify Volume health when SVC CSI is"+
+		"down", ginkgo.Label(p1, block, wcp, tkg), func() {
 		var sc *storagev1.StorageClass
 		var err error
 		var isControllerUP = true
@@ -1589,8 +1598,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 10.Verify PV entry is deleted from CNS.
 	// 11.Delete the SC.
 
-	ginkgo.It("[csi-supervisor] [csi-guest] "+
-		"Verify health annotation added on the pvc is changed from accessible to inaccessible", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation added on the pvc is"+
+		"changed from accessible to inaccessible", ginkgo.Label(p1, block, wcp, tkg), func() {
 		var storageclass *storagev1.StorageClass
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
@@ -1759,7 +1768,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 9. validate that volume health on PVC changes from inaccessible to
 	//    accessible after default time interval.
 
-	ginkgo.It("[csi-supervisor] Verify health status of pvc after bringing SV API server down", func() {
+	ginkgo.It("[csi-supervisor] Verify health status of pvc after bringing SV API server"+
+		"down", ginkgo.Label(p2, block, wcp), func() {
 		var storageclass *storagev1.StorageClass
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
@@ -1874,8 +1884,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// Verify PV entry is deleted from CNS.
 	// Delete the SC.
 
-	ginkgo.It("[csi-supervisor] [csi-guest] "+
-		"Verify health annotation is updated from unknown status to inaccessible", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is updated from"+
+		"unknown status to inaccessible", ginkgo.Label(p1, block, wcp, tkg), func() {
 		var storageclass *storagev1.StorageClass
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
@@ -2049,7 +2059,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 12. Delete GC PVC.
 	// 13. Verify PV entry is deleted from CNS.
 	// 14. Delete the SC.
-	ginkgo.It("[csi-guest] Verify Inaccesssible Volume health when GC CSI is down", func() {
+	ginkgo.It("[csi-guest] Verify Inaccesssible Volume health when GC CSI is"+
+		"down", ginkgo.Label(p2, block, tkg), func() {
 		var sc *storagev1.StorageClass
 		var err error
 		var isControllerUP = true
@@ -2194,7 +2205,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// Delete PVC from the tests namespace.
 	// Delete the storage class.
 
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify Volume health Inaccessible on Statefulset", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] Verify Volume health Inaccessible on"+
+		"Statefulset", ginkgo.Label(p2, block, wcp, tkg), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var statusFlag bool = false
@@ -2426,8 +2438,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// Verify PV entry is deleted from CNS.
 	// Delete the SC.
 
-	ginkgo.It("[csi-supervisor] [csi-guest] "+
-		"Verify health annotation is not updated to unknown status from inaccessible", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] Verify health annotation is not updated"+
+		"to unknown status from inaccessible", ginkgo.Label(p2, block, wcp, tkg), func() {
 		var storageclass *storagev1.StorageClass
 		var err error
 		var pvclaims []*v1.PersistentVolumeClaim
@@ -2594,7 +2606,7 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// Delete the SC.
 
 	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Verify pvc is not annotated "+
-		"with health status in vanilla setup", func() {
+		"with health status in vanilla setup", ginkgo.Label(p1, block, vanilla, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ginkgo.By("Invoking Test volume health status")
@@ -2658,7 +2670,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// Verify PV entry is deleted from CNS.
 	// Delete the SC.
 
-	ginkgo.It("[csi-file-vanilla] File Vanilla Verify pvc is not annotated with health status", func() {
+	ginkgo.It("[csi-file-vanilla] File Vanilla Verify pvc is not annotated with health"+
+		"status", ginkgo.Label(p1, file, vanilla, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		scParameters := make(map[string]string)
@@ -2732,8 +2745,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	//    7. Verify PV entry is deleted from CNS.
 	//    8. Delete the SC.
 
-	ginkgo.It("[csi-supervisor] [csi-guest] Verify health timestamp annotation is added on the pvc", func() {
-
+	ginkgo.It("[csi-supervisor] [csi-guest] Verify health timestamp annotation is added on the"+
+		"pvc", ginkgo.Label(p1, block, wcp, tkg), func() {
 		var storageclass *storagev1.StorageClass
 		var err error
 		var svcPVCName string
@@ -2832,7 +2845,8 @@ var _ = ginkgo.Describe("Volume health check", func() {
 	// 10. Delete the PVC.
 	// 11. Delete the storage class.
 
-	ginkgo.It("[csi-supervisor] [csi-guest] If pod pvc becomes inaccessible restart pod and check pod status", func() {
+	ginkgo.It("[csi-supervisor] [csi-guest] If pod pvc becomes inaccessible restart pod and"+
+		"check pod status", ginkgo.Label(p2, block, wcp, tkg), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var statusFlag bool = false

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -152,8 +152,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 9. Delete pod and Wait for Volume Disk to be detached from the Node.
 	// 10. Delete PVC, PV and Storage Class.
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] [csi-vcp-mig]"+
-		"Verify volume expansion with no filesystem before expansion", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify"+
+		"volume expansion with no filesystem before expansion", ginkgo.Label(p0, block, vanilla, wcp, tkg, core), func() {
 		invokeTestForVolumeExpansion(f, client, namespace, "", storagePolicyName, profileID)
 	})
 
@@ -176,8 +176,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 12. Delete pod and Wait for Volume Disk to be detached from the Node.
 	// 13. Delete PVC, PV and Storage Class.
 
-	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized] [csi-vcp-mig] "+
-		"Verify volume expansion with initial filesystem before expansion", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify volume expansion"+
+		"with initial filesystem before expansion", ginkgo.Label(p0, block, vanilla, tkg, core), func() {
 		invokeTestForVolumeExpansionWithFilesystem(f, client, namespace, ext4FSType, "", storagePolicyName, profileID)
 	})
 
@@ -198,8 +198,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 12. Delete pod and Wait for Volume Disk to be detached from the Node.
 	// 13. Delete PVC, PV and Storage Class.
 
-	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized] "+
-		"Verify offline volume expansion workflow with xfs filesystem", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized] Verify offline volume expansion workflow"+
+		"with xfs filesystem", ginkgo.Label(p0, block, vanilla, tkg, core), func() {
 		invokeTestForVolumeExpansionWithFilesystem(f, client, namespace, xfsFSType, xfsFSType, storagePolicyName, profileID)
 	})
 
@@ -214,8 +214,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 5. Modify PVC's size to trigger offline volume expansion.
 	// 6. Verify if the PVC expansion fails.
 
-	ginkgo.It("[csi-block-vanilla] [csi-guest]  [csi-block-vanilla-parallelized] [csi-vcp-mig] "+
-		"Verify volume expansion not allowed", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-guest]  [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify volume"+
+		"expansion not allowed", ginkgo.Label(p2, block, vanilla, tkg, core), func() {
 		invokeTestForInvalidVolumeExpansion(f, client, namespace, storagePolicyName, profileID)
 	})
 
@@ -230,8 +230,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 5. Modify PVC's size to a smaller size.
 	// 6. Verify if the PVC expansion fails.
 
-	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-supervisor]  [csi-block-vanilla-parallelized] [csi-vcp-mig] "+
-		"Verify volume shrinking not allowed", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-supervisor]  [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify"+
+		"volume shrinking not allowed", ginkgo.Label(p1, block, vanilla, wcp, tkg, core), func() {
 		invokeTestForInvalidVolumeShrink(f, client, namespace, storagePolicyName, profileID)
 	})
 
@@ -248,8 +248,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 7. Delete PVC.
 	// 8. Verify PV is deleted automatically.
 
-	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
-		"Verify volume expansion is not supported for PVC using vSAN-Default-Storage-Policy", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Verify volume expansion is not supported for PVC"+
+		"using vSAN-Default-Storage-Policy", ginkgo.Label(p0, block, vanilla, core), func() {
 		invokeTestForInvalidVolumeExpansionStaticProvision(f, client, namespace, storagePolicyName, profileID)
 	})
 
@@ -268,8 +268,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 9. Delete pod and Wait for Volume Disk to be detached from the Node.
 	// 10. Delete PVC, PV and Storage Class.
 
-	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-supervisor] [csi-block-vanilla-parallelized] [csi-vcp-mig] "+
-		"Verify volume expansion can happen multiple times", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-guest] [csi-supervisor] [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify"+
+		"volume expansion can happen multiple times", ginkgo.Label(p1, block, vanilla, wcp, core), func() {
 		invokeTestForExpandVolumeMultipleTimes(f, client, namespace, "", storagePolicyName, profileID)
 	})
 
@@ -282,7 +282,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 4. Wait for PVC's status to become Bound.
 	// 5. Modify PVC's size to a bigger size.
 	// 6. Verify if the PVC expansion fails.
-	ginkgo.It("[csi-file-vanilla] Verify file volume expansion is not supported", func() {
+	ginkgo.It("[csi-file-vanilla] Verify file volume expansion is not"+
+		"supported", ginkgo.Label(p1, file, vanilla, core), func() {
 		invokeTestForUnsupportedFileVolumeExpansion(f, client, namespace, storagePolicyName, profileID)
 	})
 
@@ -301,8 +302,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		10.  Make sure file system has increased
 
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor]  [csi-block-vanilla-parallelized] [csi-vcp-mig] "+
-		"Verify online volume expansion on dynamic volume", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor]  [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify online"+
+		"volume expansion on dynamic volume", ginkgo.Label(p0, block, vanilla, wcp, core), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -375,8 +376,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		9. Make sure data is intact on the PV mounted on the pod
 		10. Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] [csi-vcp-mig] "+
-		"Verify online volume expansion workflow with xfs filesystem", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify online volume expansion"+
+		"workflow with xfs filesystem", ginkgo.Label(p1, block, vanilla, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var storageclass *storagev1.StorageClass
@@ -435,8 +436,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 	// 9. Make sure data is intact on the PV mounted on the pod.
 	// 10. Make sure file system has increased.
 
-	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] "+
-		"Verify online volume expansion on static volume", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-block-vanilla-parallelized] Verify online volume"+
+		"expansion on static volume", ginkgo.Label(p1, block, vanilla, core), func() {
 		ginkgo.By("Invoking Test for Volume Expansion on statically created PVC ")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -484,8 +485,9 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		6. Modify PVC to be a smaller size.
 		7. Verify that the PVC size does not change because volume shrinking is not supported.
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized][csi-vcp-mig]"+
-		"Verify online volume expansion shrinking volume not allowed", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized][csi-vcp-mig] Verify"+
+		"online volume expansion shrinking volume not"+
+		"allowed", ginkgo.Label(p1, block, vanilla, wcp, tkg, core), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -560,8 +562,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			8. Verify the PVC Size should increased by 10Gi
 			9. Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] [csi-vcp-mig]"+
-		"Verify online volume expansion multiple times on the same PVC", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify"+
+		"volume expansion multiple times on the same PVC", ginkgo.Label(p0, block, vanilla, wcp, tkg, core), func() {
 
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
@@ -629,9 +631,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		11. Make sure file system has increased
 	*/
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-serialized] [csi-vcp-mig]"+
-		"Verify online volume expansion when VSAN-health is down", func() {
-
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-serialized] [csi-vcp-mig] Verify"+
+		"online volume expansion when VSAN-health is down", ginkgo.Label(p1, block, vanilla, wcp, tkg, core), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -757,8 +758,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		10. Make sure data is intact on the PV mounted on the pod
 		11. Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-serialized] "+
-		"Verify online volume expansion when SPS-Service is down", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-serialized] Verify online volume"+
+		"expansion when SPS-Service is down", ginkgo.Label(p1, block, vanilla, wcp, tkg, core), func() {
 
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
@@ -886,8 +887,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		10. Make sure file system has increased
 	*/
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized] [csi-vcp-mig] "+
-		"Verify online volume expansion by updating PVC with different sizes concurrently", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify online volume"+
+		"expansion by updating PVC with different sizes concurrently", ginkgo.Label(p1, block, vanilla, wcp, core), func() {
 
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1011,8 +1012,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		9. Make sure data is intact on the PV mounted on the pod
 		10.  Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] "+
-		"Volume expansion on shared VVOL datastore", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] Volume expansion"+
+		"on shared VVOL datastore", ginkgo.Label(p0, block, vanilla, wcp, tkg, core), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1101,8 +1102,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		9. Make sure data is intact on the PV mounted on the pod
 		10.  Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] [csi-vcp-mig] "+
-		"Volume expansion on shared NFS datastore", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] [csi-vcp-mig] Volume"+
+		"expansion on shared NFS datastore", ginkgo.Label(p0, block, vanilla, wcp, tkg, core), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1197,8 +1198,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		9. Make sure data is intact on the PV mounted on the pod
 		10.  Make sure file system has increased
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized][csi-vcp-mig] "+
-		"Volume expansion on shared VMFS datastore", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized][csi-vcp-mig] Volume"+
+		"expansion on shared VMFS datastore", ginkgo.Label(p0, block, vanilla, wcp, tkg, core), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1299,7 +1300,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			13. Verify File system has increased
 			14. Delete POD, PVC, PV, CNSregisterVolume and SC
 	*/
-	ginkgo.It("[csi-supervisor] Offline and Online volume resize on statically created volume", func() {
+	ginkgo.It("[csi-supervisor] Offline and Online volume resize on statically"+
+		"created volume", ginkgo.Label(p0, block, wcp), func() {
 		var err error
 		var fsSize int64
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1472,7 +1474,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			13.  Make sure file system has increased
 
 	*/
-	ginkgo.It("[csi-supervisor] Verify offline and online volume expansion when there is no quota available", func() {
+	ginkgo.It("[csi-supervisor] Verify offline and online volume expansion when there is no quota"+
+		"available", ginkgo.Label(p1, block, wcp), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1566,7 +1569,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		10. Make sure data is intact on the PV mounted on the pod
 		11. Make sure file system has increased
 	*/
-	ginkgo.It("[csi-supervisor] Verify Offline volume expansion when SPS-Service is down ", func() {
+	ginkgo.It("[csi-supervisor] Verify Offline volume expansion when SPS-Service is"+
+		"down", ginkgo.Label(p1, block, wcp), func() {
 
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1717,7 +1721,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		11. Make sure file system has increased
 	*/
 
-	ginkgo.It("[csi-supervisor] Verify Offline volume expansion when VSAN-health is down", func() {
+	ginkgo.It("[csi-supervisor] Verify Offline volume expansion when VSAN-health is"+
+		"down", ginkgo.Label(p1, block, wcp), func() {
 
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
@@ -1866,8 +1871,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		11.  Make sure file system has increased
 
 	*/
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized][csi-vcp-mig] "+
-		"Verify online volume expansion when POD is deleted and re-created", func() {
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized][csi-vcp-mig] Verify"+
+		"online volume expansion when POD is deleted and re-created", ginkgo.Label(p1, block, wcp), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1994,8 +1999,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		7. Delete Pod and PVC
 		8. Verify there should not be any PVC entry in CNS
 	*/
-	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized] [csi-vcp-mig]  "+
-		"Verify online volume expansion when PVC is deleted", func() {
+	ginkgo.It("[csi-supervisor] [csi-block-vanilla] [csi-guest] [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify"+
+		"online volume expansion when PVC is deleted", ginkgo.Label(p1, vanilla, block, wcp, tkg, core), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2111,7 +2116,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		9. Make sure data is intact on the PV mounted on the pod
 		10.Make sure file system has increased
 	*/
-	ginkgo.It("[csi-supervisor] Verify online volume expansion when CSI Pod is down", func() {
+	ginkgo.It("[csi-supervisor] Verify online volume expansion when CSI Pod is"+
+		"down", ginkgo.Label(p1, block, wcp), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2234,7 +2240,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		13. Make sure file system has increased
 	*/
 	//TODO: Need to add test case for Vanilla
-	ginkgo.It("[csi-supervisor] Verify Offline volume expansion when CSI Pod is down", func() {
+	ginkgo.It("[csi-supervisor] Verify Offline volume expansion when CSI Pod is"+
+		"down", ginkgo.Label(p1, block, wcp), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2336,7 +2343,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		4. Wait for PVC's status to become Bound and note down the size
 		5. Verify there should not be any PVC entry in CNS
 	*/
-	ginkgo.It("[csi-supervisor] Verify offline volume expansion when PVC is deleted", func() {
+	ginkgo.It("[csi-supervisor] Verify offline volume expansion when PVC is"+
+		"deleted", ginkgo.Label(p1, block, wcp), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 
 		thickProvPolicy := os.Getenv(envStoragePolicyNameWithThickProvision)
@@ -2416,8 +2424,8 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		11. Scale down deployment set to 0 replicas and delete all pods, PVC and SC
 
 	*/
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] [csi-vcp-mig] "+
-		"Verify online volume expansion on deployment", func() {
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify"+
+		"online volume expansion on deployment", ginkgo.Label(p0, vanilla, block, wcp, tkg), func() {
 		ginkgo.By("Invoking Test for Volume Expansion")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tests/e2e/vsphere_volume_fsgroup.go
+++ b/tests/e2e/vsphere_volume_fsgroup.go
@@ -87,7 +87,8 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-file-vanilla] [csi-guest] [csi
 	})
 
 	// Test for Pod creation works when SecurityContext has FSGroup
-	ginkgo.It("Verify Pod Creation works when SecurityContext has FSGroup", func() {
+	ginkgo.It("Verify Pod Creation works when SecurityContext has"+
+		"FSGroup", ginkgo.Label(p0, vanilla, block, wcp, tkg, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 


### PR DESCRIPTION
**What this PR does / why we need it**:  This PR sets ginkgo_Labels

**Special notes for your reviewer**:
This PR sets ginkgo_Labels to below test cases
1. stateful set 
2. Volume health
3. Static provisioning
4. Online and offline volume expansion
5. Data persistance 
6. Full sync 
7. Label update
8. VC reboot 
9. List volume 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
10. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
