### PR TITLE
Validate vCenter username and crash CSI driver if username is not a fully qualified domain name

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -105,6 +106,11 @@ const (
 var (
 	// ErrUsernameMissing is returned when the provided username is empty.
 	ErrUsernameMissing = errors.New("username is missing")
+
+	// ErrInvalidUsername is returned when vCenter username provided in vSphere config
+	// secret is invalid. e.g. If username is not a fully qualified domain name, then
+	// it will be considered as invalid username.
+	ErrInvalidUsername = errors.New("username is invalid, make sure it is a fully qualified domain username")
 
 	// ErrPasswordMissing is returned when the provided password is empty.
 	ErrPasswordMissing = errors.New("password is missing")
@@ -303,6 +309,18 @@ func FromEnv(ctx context.Context, cfg *Config) error {
 	return nil
 }
 
+// Check if username is valid or not. If username is not a fully qualified domain name, then
+// we consider it as an invalid username.
+func isValidvCenterUsernameWithDomain(username string) bool {
+	// Regular expression to validate vCenter server username.
+	// Allowed username is in the format "userName@domainName" or "domainName\\userName".
+	// If domain name is not provided in username, then functions like HasUserPrivilegeOnEntities
+	// doesn't return any entity for given user and eventually volume creation fails.
+	regex := `^(?:[a-zA-Z0-9.-]+\\[a-zA-Z0-9._-]+|[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+)$`
+	match, _ := regexp.MatchString(regex, username)
+	return match
+}
+
 func validateConfig(ctx context.Context, cfg *Config) error {
 	log := logger.GetLogger(ctx)
 	// Fix default global values.
@@ -338,6 +356,15 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 				return ErrUsernameMissing
 			}
 		}
+
+		// vCenter server username provided in vSphere config secret should contain domain name,
+		// CSI driver will crash if username doesn't contain domain name.
+		if !isValidvCenterUsernameWithDomain(vcConfig.User) {
+			log.Errorf("username %v specified in vSphere config secret is invalid, "+
+				"make sure that username is a fully qualified domain name.", vcConfig.User)
+			return ErrInvalidUsername
+		}
+
 		if vcConfig.Password == "" {
 			vcConfig.Password = cfg.Global.Password
 			if vcConfig.Password == "" {

--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -35,7 +35,7 @@ func init() {
 	defer cancel()
 	idealVCConfig = map[string]*VirtualCenterConfig{
 		"1.1.1.1": {
-			User:         "Admin",
+			User:         "Administrator@vsphere.local",
 			Password:     "Password",
 			VCenterPort:  "443",
 			Datacenters:  "dc1",
@@ -156,6 +156,66 @@ func TestValidateConfigWithInvalidClusterId(t *testing.T) {
 	err := validateConfig(ctx, cfg)
 	if err == nil {
 		t.Errorf("Expected error due to invalid cluster id. Config given - %+v", *cfg)
+	}
+}
+
+func TestValidateConfigWithInvalidUsername(t *testing.T) {
+	vcConfigInvalidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			User:         "Administrator",
+			Password:     "Password",
+			VCenterPort:  "443",
+			Datacenters:  "dc1",
+			InsecureFlag: true,
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigInvalidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err == nil {
+		t.Errorf("Expected error due to invalid username. Config given - %+v", *cfg)
+	}
+}
+
+func TestValidateConfigWithValidUsername1(t *testing.T) {
+	vcConfigValidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			User:         "Administrator@vsphere.local",
+			Password:     "Password",
+			VCenterPort:  "443",
+			Datacenters:  "dc1",
+			InsecureFlag: true,
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigValidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err != nil {
+		t.Errorf("Unexpected error, as valid username is specified. Config given - %+v", *cfg)
+	}
+}
+
+func TestValidateConfigWithValidUsername2(t *testing.T) {
+	vcConfigValidUsername := map[string]*VirtualCenterConfig{
+		"1.1.1.1": {
+			User:         "vsphere.local\\Administrator",
+			Password:     "Password",
+			VCenterPort:  "443",
+			Datacenters:  "dc1",
+			InsecureFlag: true,
+		},
+	}
+	cfg := &Config{
+		VirtualCenter: vcConfigValidUsername,
+	}
+
+	err := validateConfig(ctx, cfg)
+	if err != nil {
+		t.Errorf("Unexpected error, as valid username is specified. Config given - %+v", *cfg)
 	}
 }
 

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -68,7 +68,7 @@ func configFromCustomizedSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool)
 
 	cfg.Global.VCenterIP = s.URL.Hostname()
 	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = "DC0"
 

--- a/pkg/csi/service/common/authmanager.go
+++ b/pkg/csi/service/common/authmanager.go
@@ -343,9 +343,14 @@ func getDatastoresWithBlockVolumePrivs(ctx context.Context, vc *cnsvsphere.Virtu
 		log.Errorf("auth manager: failed to check privilege %v on entities %v for user %s", privIds, entities, userName)
 		return nil, err
 	}
-	log.Debugf(
-		"auth manager: HasUserPrivilegeOnEntities returns %v, when checking privileges %v on entities %v for user %s",
-		result, privIds, entities, userName)
+	if len(result) == 0 {
+		log.Infof("auth manager: HasUserPrivilegeOnEntities returned empty result when checking privileges %v "+
+			"on entities %v for user %s and for vCenter %q", privIds, entities, userName, vc.Config.Host)
+	} else {
+		log.Debugf("auth manager: HasUserPrivilegeOnEntities returned %v when checking privileges %v on entities %v "+
+			"for user %s and for vCenter %q", result, privIds, entities, userName, vc.Config.Host)
+	}
+
 	for index, entityPriv := range result {
 		hasPriv := true
 		privAvails := entityPriv.PrivAvailability
@@ -361,6 +366,11 @@ func getDatastoresWithBlockVolumePrivs(ctx context.Context, vc *cnsvsphere.Virtu
 			log.Debugf("auth manager: datastore with URL %s and name %s has privileges and is added to dsURLToInfoMap",
 				dsInfos[index].Info.Name, dsURLs[index])
 		}
+	}
+	if len(result) != 0 && len(dsURLToInfoMap) == 0 {
+		log.Infof("auth manager: user %s on vCenter %q doesn't have privileges for any datastore. "+
+			"HasUserPrivilegeOnEntities returns %v, when checking privileges %v on entities %v."+
+			userName, vc.Config.Host, result, privIds, entities)
 	}
 	return dsURLToInfoMap, nil
 }
@@ -473,9 +483,14 @@ func getFSEnabledClustersWithPriv(ctx context.Context, vc *cnsvsphere.VirtualCen
 		log.Errorf("auth manager: failed to check privilege %v on entities %v for user %s", privIds, entities, userName)
 		return nil, err
 	}
-	log.Debugf(
-		"auth manager: HasUserPrivilegeOnEntities returns %v when checking privileges %v on entities %v for user %s",
-		result, privIds, entities, userName)
+	if len(result) == 0 {
+		log.Infof("auth manager: HasUserPrivilegeOnEntities returned empty result when checking privileges %v "+
+			"on entities %v for user %s and for vCenter %q", privIds, entities, userName, vc.Config.Host)
+	} else {
+		log.Debugf("auth manager: HasUserPrivilegeOnEntities returned %v when checking privileges %v on entities %v "+
+			"for user %s and for vCenter %q", result, privIds, entities, userName, vc.Config.Host)
+	}
+
 	clusterComputeResourceWithPriv := []*object.ClusterComputeResource{}
 	for _, entityPriv := range result {
 		hasPriv := true
@@ -492,7 +507,14 @@ func getFSEnabledClustersWithPriv(ctx context.Context, vc *cnsvsphere.VirtualCen
 				clusterComputeResourcesMap[entityPriv.Entity.Value])
 		}
 	}
-	log.Debugf("Clusters with priv: %s are : %+v", HostConfigStoragePriv, clusterComputeResourceWithPriv)
+	if len(result) != 0 && len(clusterComputeResourceWithPriv) == 0 {
+		log.Infof("auth manager: user %s on vCenter %q doesn't have privileges for any ClusterComputeResource. "+
+			"HasUserPrivilegeOnEntities returns %v, when checking privileges %v on entities %v."+
+			userName, vc.Config.Host, result, privIds, entities)
+	} else {
+		log.Debugf("Clusters with priv: %s and vCenter: %q are : %+v", HostConfigStoragePriv,
+			vc.Config.Host, clusterComputeResourceWithPriv)
+	}
 
 	// Get clusters which are vSAN and have vSAN FS enabled.
 	clusterComputeResourceWithPrivAndFS := []*object.ClusterComputeResource{}
@@ -508,14 +530,18 @@ func getFSEnabledClustersWithPriv(ctx context.Context, vc *cnsvsphere.VirtualCen
 			log.Infof("cluster: %+v is a non-vSAN cluster. Skipping this cluster", cluster)
 			continue
 		} else if config.FileServiceConfig == nil {
-			log.Debugf("VsanClusterGetConfig.FileServiceConfig is empty. Skipping this cluster: %+v with config: %+v",
-				cluster, config)
+			log.Infof("VsanClusterGetConfig.FileServiceConfig is empty. Skipping this cluster: %+v with "+
+				"vCenter: %q and with config: %+v", cluster, vc.Config.Host, config)
 			continue
 		}
 
-		log.Debugf("cluster: %+v has vSAN file services enabled: %t", cluster, config.FileServiceConfig.Enabled)
 		if config.FileServiceConfig.Enabled {
 			clusterComputeResourceWithPrivAndFS = append(clusterComputeResourceWithPrivAndFS, cluster)
+			log.Debugf("vSAN file service is enabled for cluster: %+v and vCenter: %q.",
+				cluster, vc.Config.Host)
+		} else {
+			log.Infof("vSAN file service is disabled for cluster: %+v and vCenter: %q.",
+				cluster, vc.Config.Host)
 		}
 	}
 

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -126,7 +126,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.
 
 	cfg.Global.VCenterIP = s.URL.Hostname()
 	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = "DC0"
 

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -99,7 +99,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.
 
 	cfg.Global.VCenterIP = s.URL.Hostname()
 	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = "DC0"
 

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -113,7 +113,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*cnsconf
 
 	cfg.Global.VCenterIP = s.URL.Hostname()
 	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = "DC0"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry picking changes from https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2490 and https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2595 to release-2.7 branch.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Will run e2e tests

**Special notes for your reviewer**:

**Release note**:
```release-note
Validate vCenter username and crash CSI driver if username is not a fully qualified domain name
```
