### PR TITLE
Bump up Go to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/vsphere-csi-driver/v3
 
-go 1.20
+go 1.21
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.3.1

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -57,7 +57,7 @@ BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 # CUSTOM_REPO_FOR_GOLANG can be used to pass custom repository for golang builder image.
 # Please ensure it ends with a '/'.
 # Example: CUSTOM_REPO_FOR_GOLANG=<docker-registry>/dockerhub-proxy-cache/library/
-GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.20
+GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.21
 
 ARCH=amd64
 OSVERSION=1809

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -17,7 +17,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.20
+ARG GOLANG_IMAGE=golang:1.21
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.20
+ARG GOLANG_IMAGE=golang:1.21
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.20
+ARG GOLANG_IMAGE=golang:1.21
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest

--- a/images/windows/driver/Dockerfile
+++ b/images/windows/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.20
+ARG GOLANG_IMAGE=golang:1.21
 ARG OSVERSION
 ARG ARCH=amd64
 

--- a/tests/e2e/docs/supervisor_cluster_setup.md
+++ b/tests/e2e/docs/supervisor_cluster_setup.md
@@ -128,7 +128,7 @@ datacenters should be comma separated if deployed on multi-datacenters
 
 ## Requirements
 
-Go version: 1.20
+Go version: 1.21
 
 Export the go binary in your PATH to run end-to-end tests
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Bump up Go to 1.21

**Testing done**:
[Basic e2e test](https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2635#issuecomment-1796995790)

Steps performed in the test: 

1. Creates a SC
2. Creates a PVC
3. Creates a Pod
4. Writes some data
5. Deletes the Pod
6. Creates another Pod using the same PVC
7. Verifies if the old data is persisted
8. Deletes the Pod
9. Deletes the PVC 
10. Deletes the SC


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
7. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump up Go to 1.21
```
