### PR TITLE
tag v3.1.2-rc.1 images

### DIFF
--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -134,7 +134,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.2-rc.1
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -280,7 +280,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.2-rc.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -340,7 +340,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.2-rc.1
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=30s"
@@ -475,7 +475,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.2-rc.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -622,7 +622,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.2-rc.1
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
tag v3.1.2-rc.1 images

this tag contains following new changes on top of v3.1.1

1. https://github.com/kubernetes-sigs/vsphere-csi-driver/commit/21e43034dc4355fcfbbf8953e9e36e5a11d607ce - Bump govmomi to 0.32.0 to address CLBO for CSI Driver in TKGm deployments with `thumbprint` in vsphere-config-secret when vCenter is specified using IP address and not FQDN.


3. https://github.com/kubernetes-sigs/vsphere-csi-driver/commit/751b80141ea10e9d7d1ece877aa0d60fb70c2549 - Validation for vCenter username in the vSphere config secret to ensure username along with FQDN is used.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
tag v3.1.2-rc.1 images
```
