### PR TITLE
Add flag "--extra-create-metadata" to PVCSI csi-snapshotter sidecar to pass required parameters

### DIFF
--- a/manifests/guestcluster/1.24/pvcsi.yaml
+++ b/manifests/guestcluster/1.24/pvcsi.yaml
@@ -344,6 +344,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--extra-create-metadata"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/guestcluster/1.25/pvcsi.yaml
+++ b/manifests/guestcluster/1.25/pvcsi.yaml
@@ -356,6 +356,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--extra-create-metadata"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/guestcluster/1.26/pvcsi.yaml
+++ b/manifests/guestcluster/1.26/pvcsi.yaml
@@ -356,6 +356,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--extra-create-metadata"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/manifests/guestcluster/1.27/pvcsi.yaml
+++ b/manifests/guestcluster/1.27/pvcsi.yaml
@@ -356,6 +356,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--extra-create-metadata"
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
**What this PR does / why we need it**:
In PVCSI CSI controller deployment, csi-snapshotter sidecar was deployed without passing flag "--extra-create-metadata". As per documentation https://kubernetes-csi.github.io/docs/external-snapshotter.html#volumesnapshot-and-volumesnapshotcontent-parameters, this flag passes extra parameters in the CreateSnapshot() request such as
* csi.storage.k8s.io/volumesnapshot/name
* csi.storage.k8s.io/volumesnapshot/namespace

Currently these parameters are getting used in our code with "--extra-create-metadata" flag missing, with null value. 
In CreateSnapshot() call, after successfully creating snapshot at supervisor cluster, we add snapshotID as annotation using code below.

```
                volumeSnapshotName := req.Parameters[common.VolumeSnapshotNameKey]
		volumeSnapshotNamespace := req.Parameters[common.VolumeSnapshotNamespaceKey]

		log.Infof("Attempting to annotate volumesnapshot %s/%s with annotation %s:%s",
			volumeSnapshotNamespace, volumeSnapshotName, common.VolumeSnapshotInfoKey, snapshotID)
		annotated, err := commonco.ContainerOrchestratorUtility.AnnotateVolumeSnapshot(ctx, volumeSnapshotName,
			volumeSnapshotNamespace, map[string]string{common.VolumeSnapshotInfoKey: snapshotID})
		if err != nil || !annotated {
			log.Warnf("The snapshot: %s was created successfully, but failed to annotate volumesnapshot %s/%s"+
				"with annotation %s:%s. Error: %v", snapshotID, volumeSnapshotNamespace,
				volumeSnapshotName, common.VolumeSnapshotInfoKey, snapshotID, err)
		} 

```
However, volumeSnapshotName & volumeSnapshotNamespace evaluate to be null since parameters are not passed due to missing flag.
While adding annotation in AnnotateVolumeSnapshot() call, inside function updateVolumeSnapshotAnnotations(), we poll for 5 min to update the annotation, which never succeeds and hence CreateSnapshot() times out.
This causes VolumeSnapshot to be in NotReady state forever, without returning success.
To fix this, we need to provide the required flag to csi-snapshotter, which passes the parameters and annotates the VolumeSnapshot successfully.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested fix by adding the required flag to csi-snapshotter on the setup where the issue was observed and volume snapshot (that was in NotReady state for long time since its creation) got Ready successfully.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add flag "--extra-create-metadata" to PVCSI csi-snapshotter sidecar to pass required parameters
```
