### PR TITLE
handle credential change during add/remove from listview

### DIFF
--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -123,6 +123,12 @@ func (l *ListViewImpl) AddTask(ctx context.Context, taskMoRef types.ManagedObjec
 	log := logger.GetLogger(ctx)
 	log.Infof("AddTask called for %+v", taskMoRef)
 
+	if err := l.isClientValid(); err != nil {
+		return fmt.Errorf("%w. task: %v, err: %v", ErrListViewTaskAddition, taskMoRef, err)
+	} else {
+		log.Debugf("connection to vc successful")
+	}
+
 	l.taskMap.Upsert(taskMoRef, TaskDetails{
 		Reference:        taskMoRef,
 		MarkedForRemoval: false,
@@ -159,6 +165,11 @@ func (l *ListViewImpl) RemoveTask(ctx context.Context, taskMoRef types.ManagedOb
 	log := logger.GetLogger(ctx)
 	if l.listView == nil {
 		return logger.LogNewErrorf(log, "failed to remove task from listView: listView not initialized")
+	}
+	if err := l.isClientValid(); err != nil {
+		return logger.LogNewErrorf(log, "failed to remove task %v from ListView. error: %+v", taskMoRef, err)
+	} else {
+		log.Debugf("connection to vc successful")
 	}
 	_, err := l.listView.Remove(l.ctx, []types.ManagedObjectReference{taskMoRef})
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

As part of the `ReloadConfiguration` process, `ListView` stores a reference to the new `VirtualCenter` instance created but doesn't create a new govmomi client from it immediately. This is to continue existing operations until we get a "Session is not authenticated error" on `WaitForUpdates()`. Once we get an error, a call to `isClientValid()` will end up creating a new govmomi client using the updated credentials. 

However, during Add() and Remove() ListView operations, we are not using the `isClientValid()` method. This change will add that check. So, after a ReloadConfiguration event, the next Add/Remove operation will end up creating a new govmomi client from the new `VirtualCenter` instance. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
wcp-precheckin -> https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2647#issuecomment-1816608556


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
wcp: handle credential change during add/remove from listview
```
