### PR TITLE
[PodVMOnStretchedSupervisor] CnsVolumeOperationRequest CR update handler

### DIFF
--- a/pkg/apis/cnsoperator/config/cns.vmware.com_storagepolicyusages.yaml
+++ b/pkg/apis/cnsoperator/config/cns.vmware.com_storagepolicyusages.yaml
@@ -107,5 +107,3 @@ spec:
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}

--- a/pkg/apis/cnsoperator/storagepolicy/v1alpha1/storagepolicyusage_types.go
+++ b/pkg/apis/cnsoperator/storagepolicy/v1alpha1/storagepolicyusage_types.go
@@ -7,6 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const CRDSingular = "storagepolicyusage"
+
 // StoragePolicyUsageSpec defines the desired state of StoragePolicyUsage
 type StoragePolicyUsageSpec struct {
 	// +kubebuilder:validation:Required

--- a/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/cnsvolumeoperationrequest.go
@@ -37,9 +37,15 @@ import (
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
 )
 
-// EnvCSINamespace represents the environment variable which
-// stores the namespace in which the CSI driver is running.
-const EnvCSINamespace = "CSI_NAMESPACE"
+const (
+	// CRDSingular represents the singular name of cnsvolumeoperationrequest CRD.
+	CRDSingular = "cnsvolumeoperationrequest"
+	// CRDPlural represents the plural name of cnsvolumeoperationrequest CRD.
+	CRDPlural = "cnsvolumeoperationrequests"
+	// EnvCSINamespace represents the environment variable which
+	// stores the namespace in which the CSI driver is running.
+	EnvCSINamespace = "CSI_NAMESPACE"
+)
 
 // VolumeOperationRequest is an interface that supports handling idempotency
 // in CSI volume manager. This interface persists operation details invoked

--- a/pkg/syncer/resize_reconciler.go
+++ b/pkg/syncer/resize_reconciler.go
@@ -24,9 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -302,25 +300,6 @@ func createPVCPatch(
 	}
 
 	return patchBytes, nil
-}
-
-func addResourceVersion(patchBytes []byte, resourceVersion string) ([]byte, error) {
-	var patchMap map[string]interface{}
-	err := json.Unmarshal(patchBytes, &patchMap)
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling patch: %v", err)
-	}
-	u := unstructured.Unstructured{Object: patchMap}
-	a, err := meta.Accessor(&u)
-	if err != nil {
-		return nil, fmt.Errorf("error creating accessor: %v", err)
-	}
-	a.SetResourceVersion(resourceVersion)
-	versionBytes, err := json.Marshal(patchMap)
-	if err != nil {
-		return nil, fmt.Errorf("error marshalling json patch: %v", err)
-	}
-	return versionBytes, nil
 }
 
 // mergeResizeConditionOnPVC updates pvc with requested resize conditions


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add CnsVolumeOperationRequest CR update handler to update reserved field in StorageQuotaUsage CR

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
kubectl  describe cnsvolumeinfoes.cns.vmware.com -n vmware-system-csi
```
Name:         e471afce-ca23-4ab2-9a8e-2b8cedc8d762
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CNSVolumeInfo
Metadata:
  Creation Timestamp:  2023-12-08T21:33:14Z
  Generation:          2
  Resource Version:    10638186
  UID:                 9425eefc-b5ab-46b8-91c9-13cd0ff781ac
Spec:
  Storage Class Name:  test-zonal-policy
  Storage Policy ID:   dff969da-17cb-4c77-9ada-58ff8c8d32fb
  V Center Server:     sc2-10-186-104-11.eng.vmware.com
  Volume ID:           e471afce-ca23-4ab2-9a8e-2b8cedc8d762
Events:                <none>
```

kubectl get storagepolicyusages -n chethan-dev   spusage-1 -o yaml
```
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2023-12-07T22:27:14Z"
  generation: 5
  name: spusage-1
  namespace: chethan-dev
  resourceVersion: "10676339"
  uid: 90b77689-cc2d-45f4-a2fc-261c4c1aec91
spec:
  resourceExtensionName: ""
  resourceKind: ""
  storageClassName: test-zonal-policy
  storagePolicyId: dff969da-17cb-4c77-9ada-58ff8c8d32fb
status:
  quotaUsage:
    reserved: "17"
    used: "1"
```

kubectl get cnsvolumeoperationrequests.cns.vmware.com -n vmware-system-csi   pvc-a1ef7a0b-13fa-4c2d-a104-7ea695953161 -o yaml

```
apiVersion: cns.vmware.com/v1alpha1
kind: CnsVolumeOperationRequest
metadata:
  creationTimestamp: "2023-12-08T21:33:13Z"
  generation: 13
  name: pvc-a1ef7a0b-13fa-4c2d-a104-7ea695953161
  namespace: vmware-system-csi
  resourceVersion: "10676235"
  uid: c1ef4d06-71bd-4b6f-8425-6107583e6368
spec:
  name: pvc-a1ef7a0b-13fa-4c2d-a104-7ea695953161
status:
  firstOperationDetails:
    opId: fa201381
    taskId: task-1894
    taskInvocationTimestamp: "2023-12-08T21:33:13Z"
    taskStatus: Success
  latestOperationDetails:
  - opId: fa201381
    taskId: task-1894
    taskInvocationTimestamp: "2023-12-08T21:33:13Z"
    taskStatus: Success
  quotaDetails:
    namespace: chethan-dev
    reserved: 10
    storageClassName: test-zonal-policy
    storagePolicyID: dff969da-17cb-4c77-9ada-58ff8c8d32fb
  volumeID: e471afce-ca23-4ab2-9a8e-2b8cedc8d762
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add CnsVolumeOperationRequest CR update handler
```
