### PR TITLE
[PodVMOnStretchedSupervisor] Store StoragePolicyInfo in CnsVolumeInfo CR

### DIFF
--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -90,6 +90,9 @@ rules:
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update", "patch" ]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvolumeinfoes"]
+    verbs: ["create", "get", "list", "watch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -90,6 +90,9 @@ rules:
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update", "patch" ]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvolumeinfoes"]
+    verbs: ["create", "get", "list", "watch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -90,6 +90,9 @@ rules:
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update", "patch" ]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvolumeinfoes"]
+    verbs: ["create", "get", "list", "watch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -90,6 +90,9 @@ rules:
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update", "patch" ]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvolumeinfoes"]
+    verbs: ["create", "get", "list", "watch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/internalapis/cnsvolumeinfo/config/cns.vmware.com_cnsvolumeinfoes.yaml
+++ b/pkg/internalapis/cnsvolumeinfo/config/cns.vmware.com_cnsvolumeinfoes.yaml
@@ -43,6 +43,12 @@ spec:
                   description: VolumeID is the FCD ID obtained from creating volume
                     using CNS API.
                   type: string
+                storagePolicyID:
+                  description: StoragePolicyID is the ID of the storage policy associated with the volume
+                  type: string
+                storageClassName:
+                  description: StorageClassName is the name of the storage class associated with the volume
+                  type: string
               required:
                 - vCenterServer
                 - volumeID

--- a/pkg/internalapis/cnsvolumeinfo/v1alpha1/cnsvolumeinfo_types.go
+++ b/pkg/internalapis/cnsvolumeinfo/v1alpha1/cnsvolumeinfo_types.go
@@ -28,6 +28,12 @@ type CNSVolumeInfoSpec struct {
 
 	// vCenterServer is the IP/FQDN of the vCenter host on which the CNS volume is accessible.
 	VCenterServer string `json:"vCenterServer"`
+
+	// ID of the storage policy
+	StoragePolicyID string `json:"storagePolicyID,omitempty"`
+
+	// Name of the storage class
+	StorageClassName string `json:"storageClassName,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -707,7 +707,6 @@ func createCnsVolume(ctx context.Context, pv *v1.PersistentVolume,
 	} else {
 		log.Infof("vSphere CSI Driver has successfully marked volume: %q as the container volume.",
 			pv.Spec.CSI.VolumeHandle)
-
 		if isMultiVCenterFssEnabled && len(metadataSyncer.configInfo.Cfg.VirtualCenter) > 1 {
 			// Create CNSVolumeInfo CR for the volume ID.
 			err = volumeInfoService.CreateVolumeInfo(ctx, pv.Spec.CSI.VolumeHandle, vcHost)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is making changes in WCP controller to store StoragePolicyInfo in CnsVolumeInfo CR. The StoragePolicyInfo is later needed in determining the StoragePolicyUsage CR for updating reserved & usage fields.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran a basic e2e test to verify Volume Create, Delete, Attach, Detach : https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2674#issuecomment-1843609392

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Store StoragePolicyInfo in CnsVolumeInfo CR
```
