### PR TITLE
Update sidecar versions to latest releases

### DIFF
--- a/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
+++ b/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
@@ -84,7 +84,7 @@ spec:
       serviceAccountName: snapshot-webhook
       containers:
         - name: snapshot-validation
-          image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.3.1 # change the image if you wish to use your own custom validation server image
+          image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.3.2 # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/run/secrets/tls/tls.crt', '--tls-private-key-file=/run/secrets/tls/tls.key']
           ports:

--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -59,7 +59,7 @@ else
         exit 1
 fi
 
-qualified_version="v6.3.1"
+qualified_version="v6.3.2"
 volumesnapshotclasses_crd="volumesnapshotclasses.snapshot.storage.k8s.io"
 volumesnapshotcontents_crd="volumesnapshotcontents.snapshot.storage.k8s.io"
 volumesnapshots_crd="volumesnapshots.snapshot.storage.k8s.io"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -244,7 +244,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.4.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.4.2
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -262,7 +262,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.9.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -380,7 +380,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -402,7 +402,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.2
           args:
             - "--v=4"
             - "--kube-api-qps=100"
@@ -453,7 +453,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -600,7 +600,7 @@ spec:
       serviceAccountName: vsphere-csi-node
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update sidecar versions to latest releases
```
csi-provisioner: v3.6.2
csi-attacher: v4.4.2
csi-resizer: v1.9.2
csi-snapshotter: v.6.3.2
csi-node-driver-registrar: v2.9.1
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
The above sidecar releases addresses the CVE fixes:
```
Bump google.golang.org/grpc from v1.57.0 to v1.59.0 to fix CVE-2023-44487
Bump go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc from 0.41.0 to 0.46.0 to fix CVE-2023-47108
```

**Testing done**:
Volume Create, Delete, Attach, Detach test: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2676#issuecomment-1841470639
Volume Expansion test: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2676#issuecomment-1841506178
Volume Snapshot test: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2676#issuecomment-1841710473

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update sidecar versions to latest releases
```
