### PR TITLE
Add StoragePolicyID and StorageClassName to CnsVolumeOperationRequestStatus

### DIFF
--- a/pkg/internalapis/cnsvolumeoperationrequest/config/cns.vmware.com_cnsvolumeoperationrequests.yaml
+++ b/pkg/internalapis/cnsvolumeoperationrequest/config/cns.vmware.com_cnsvolumeoperationrequests.yaml
@@ -54,19 +54,32 @@ spec:
                   ExtendVolume call for a volume.
                 format: int64
                 type: integer
-              reserved:
-                description: Storage quota quantity to be reserved for in-flight 
-                  create/expand volume operations.
-                anyOf:
-                - type: integer
-                - type: string
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
               errorCount:
                 description: ErrorCount is the number of times this operation failed
                   for this volume. Incremented by clients when new OperationDetails
                   are added with error set.
                 type: integer
+              quotaDetails:
+                description: StorageQuotaDetails stores the details required by the
+                  CSI driver and syncer to access the quota custom resources.
+                properties:
+                  reserved:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Reserved keeps a track of the quantity that should
+                      be reserved in storage quota during an in-flight create/expand volume operation.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  storageClassName:
+                    description: StorageClassName is the name of K8s storage class
+                      associated with the given storage policy.
+                    type: string
+                  storagePolicyId:
+                    description: StoragePolicyId is the ID associated with the storage
+                      policy.
+                    type: string
+                type: object
               firstOperationDetails:
                 description: FirstOperationDetails stores the details of the first
                   operation performed on the volume. For debugging purposes, clients

--- a/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1/cnsvolumeoperationrequest_types.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1/cnsvolumeoperationrequest_types.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -42,10 +41,10 @@ type CnsVolumeOperationRequestStatus struct {
 	// ErrorCount is the number of times this operation failed for this volume.
 	// Incremented by clients when new OperationDetails are added with error set.
 	ErrorCount int `json:"errorCount,omitempty"`
-	// Reserved keeps a track of the quantity that should be reserved in
-	// storage quota during a create/expand volume operation.
+	// StorageQuotaDetails stores the details required by the CSI driver and syncer to
+	// access the quota custom resources.
 	// +optional
-	Reserved *resource.Quantity `json:"reserved,omitempty"`
+	StorageQuotaDetails *QuotaDetails `json:"quotaDetails,omitempty"`
 	// FirstOperationDetails stores the details of the first operation performed on the volume.
 	// For debugging purposes, clients should ensure that this information is never overwritten.
 	// More recent operation details should be stored in the LatestOperationDetails field.
@@ -53,6 +52,17 @@ type CnsVolumeOperationRequestStatus struct {
 	// LatestOperationDetails stores the details of the latest operations performed
 	// on the volume. Should have a maximum of 10 entries.
 	LatestOperationDetails []OperationDetails `json:"latestOperationDetails,omitempty"`
+}
+
+type QuotaDetails struct {
+	// Reserved keeps a track of the quantity that should be reserved in
+	// storage quota during a create volume/snapshot operation.
+	// +optional
+	Reserved *resource.Quantity `json:"reserved,omitempty"`
+	// StoragePolicyId is the ID associated with the storage policy.
+	StoragePolicyId string `json:"storagePolicyId,omitempty"`
+	// StorageClassName is the name of K8s storage class associated with the given storage policy.
+	StorageClassName string `json:"storageClassName,omitempty"`
 }
 
 // OperationDetails stores the details of the operation performed on a volume.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR adds StoragePolicyID and StorageClassName to CnsVolumeOperationRequestStatus. This will help retrieve StoragePolicyUsage CR in CreateVolume workflow in WCP flavor.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran vanilla block pipeline with basic tests

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add StoragePolicyID and StorageClassName to CnsVolumeOperationRequestStatus
```
