### PR TITLE
Add PVC Namespace in CnsVolumeInfo & CnsVolumeOperationRequest API definitions

### DIFF
--- a/pkg/internalapis/cnsvolumeinfo/config/cns.vmware.com_cnsvolumeinfoes.yaml
+++ b/pkg/internalapis/cnsvolumeinfo/config/cns.vmware.com_cnsvolumeinfoes.yaml
@@ -43,6 +43,9 @@ spec:
                   description: VolumeID is the FCD ID obtained from creating volume
                     using CNS API.
                   type: string
+                namespace:
+                  description: Namespace of the PersistentVolumeClaim.
+                  type: string
                 storagePolicyID:
                   description: StoragePolicyID is the ID of the storage policy associated with the volume
                   type: string

--- a/pkg/internalapis/cnsvolumeinfo/v1alpha1/cnsvolumeinfo_types.go
+++ b/pkg/internalapis/cnsvolumeinfo/v1alpha1/cnsvolumeinfo_types.go
@@ -26,6 +26,9 @@ type CNSVolumeInfoSpec struct {
 	// VolumeID is the FCD ID obtained from creating volume using CNS API.
 	VolumeID string `json:"volumeID"`
 
+	// Namespace of the PersistentVolumeClaim.
+	Namespace string `json:"namespace,omitempty"`
+
 	// vCenterServer is the IP/FQDN of the vCenter host on which the CNS volume is accessible.
 	VCenterServer string `json:"vCenterServer"`
 

--- a/pkg/internalapis/cnsvolumeoperationrequest/config/cns.vmware.com_cnsvolumeoperationrequests.yaml
+++ b/pkg/internalapis/cnsvolumeoperationrequest/config/cns.vmware.com_cnsvolumeoperationrequests.yaml
@@ -79,6 +79,9 @@ spec:
                     description: StoragePolicyId is the ID associated with the storage
                       policy.
                     type: string
+                  namespace:
+                    description: Namespace of the PersistentVolumeClaim.
+                    type: string
                 type: object
               firstOperationDetails:
                 description: FirstOperationDetails stores the details of the first

--- a/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1/cnsvolumeoperationrequest_types.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1/cnsvolumeoperationrequest_types.go
@@ -53,7 +53,6 @@ type CnsVolumeOperationRequestStatus struct {
 	// on the volume. Should have a maximum of 10 entries.
 	LatestOperationDetails []OperationDetails `json:"latestOperationDetails,omitempty"`
 }
-
 type QuotaDetails struct {
 	// Reserved keeps a track of the quantity that should be reserved in
 	// storage quota during a create volume/snapshot operation.
@@ -63,6 +62,8 @@ type QuotaDetails struct {
 	StoragePolicyId string `json:"storagePolicyId,omitempty"`
 	// StorageClassName is the name of K8s storage class associated with the given storage policy.
 	StorageClassName string `json:"storageClassName,omitempty"`
+	// Namespace of the PersistentVolumeClaim.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // OperationDetails stores the details of the operation performed on a volume.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add PVC Namespace in CnsVolumeInfo & CnsVolumeOperationRequest API definitions


**Testing done**:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add PVC Namespace in CnsVolumeInfo & CnsVolumeOperationRequest API definitions
```
