### PR TITLE
Add compute resource entity to consider a standalone host for volume provisioning

### DIFF
--- a/pkg/csi/service/common/topology.go
+++ b/pkg/csi/service/common/topology.go
@@ -279,6 +279,18 @@ func fetchHosts(ctx context.Context, entity mo.Reference, vCenter *cnsvsphere.Vi
 				entity.Reference(), err)
 		}
 		hosts = append(hosts, hostList...)
+	case "ComputeResource":
+		cr := object.NewComputeResource(vCenter.Client.Client, entity.Reference())
+		hostList, err := cr.Hosts(ctx)
+		if err != nil {
+			return nil, logger.LogNewErrorf(log,
+				"failed to retrieve host from stand alone host (Compute Resource) %+v. Error: %+v",
+				entity.Reference(), err)
+		}
+		for _, host := range hostList {
+			hosts = append(hosts,
+				&cnsvsphere.HostSystem{HostSystem: object.NewHostSystem(vCenter.Client.Client, host.Reference())})
+		}
 	case "HostSystem":
 		host := cnsvsphere.HostSystem{HostSystem: object.NewHostSystem(vCenter.Client.Client, entity.Reference())}
 		hosts = append(hosts, &host)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We don't consider ComputeResource (or a standalone host) as a valid entity while looking for candidate datastores in the fetchHosts method. Because of this, customer can no longer create a volume on a standalone host.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

We have a VC deployment having Datacenter as region-1 and a vSAN cluster as zone-1. There is also a standalone host under the same datacenter. There is no K8s node on the standalone host.


==============================
Test 1
==============================
Created a storageclass with region-1 in allowed topologies.

File volume:

ComputeResource entity is considered for getting hosts: 
```
2023-12-18T10:00:10.593Z	DEBUG	common/topology.go:149	Fetching hosts for entities [{Type:Datacenter Value:datacenter-3}]	{"TraceId": "fcd8206e-f6f8-457d-966e-1b4f34be6e6d"}
2023-12-18T10:00:10.593Z	INFO	common/topology.go:224	fetching hosts for entity: {Datacenter datacenter-3} on vCenter: "10.182.0.34"	{"TraceId": "fcd8206e-f6f8-457d-966e-1b4f34be6e6d"}
2023-12-18T10:00:10.601Z	INFO	common/topology.go:224	fetching hosts for entity: Folder:group-h5 on vCenter: "10.182.0.34"	{"TraceId": "fcd8206e-f6f8-457d-966e-1b4f34be6e6d"}
2023-12-18T10:00:10.622Z	INFO	common/topology.go:224	fetching hosts for entity: ComputeResource:domain-s3010 on vCenter: "10.182.0.34"	{"TraceId": "fcd8206e-f6f8-457d-966e-1b4f34be6e6d"}
2023-12-18T10:00:10.645Z	INFO	common/topology.go:224	fetching hosts for entity: ClusterComputeResource:domain-c8 on vCenter: "10.182.0.34"	{"TraceId": "fcd8206e-f6f8-457d-966e-1b4f34be6e6d"}
```

host-3009 - standalone is considered for volume provisioning
```
2023-12-18T10:00:10.652Z	INFO	common/topology.go:158	Hosts returned for topology category: "topology.csi.vmware.com/k8s-region" and tag: "region-1" are [HostSystem:host-3009 HostSystem:host-32 HostSystem:host-26 HostSystem:host-20 HostSystem:host-14]	{"TraceId": "fcd8206e-f6f8-457d-966e-1b4f34be6e6d"}
```

datastore-3012 - associated with standalone host is among the candidate datastores list
```
2023-12-18T10:00:10.723Z	INFO	vanilla/controller_helper.go:338	Obtained candidate datastores: [Datastore: Datastore:datastore-3012, datastore URL: ds:///vmfs/volumes/65786b67-29e6701a-dc80-020076dbeefa/ Datastore: Datastore:datastore-37, datastore URL: ds:///vmfs/volumes/f3acd86b-69b439d7/ Datastore: Datastore:datastore-39, datastore URL: ds:///vmfs/volumes/6575e04e-95c83545-c818-02006f1900fe/ Datastore: Datastore:datastore-40, datastore URL: ds:///vmfs/volumes/6575e050-17929bd7-a5f8-02006f1900fe/ Datastore: Datastore:datastore-46, datastore URL: ds:///vmfs/volumes/vsan:529cd93ed92045fc-15935cace2ca74e4/ Datastore: Datastore:datastore-43, datastore URL: ds:///vmfs/volumes/6575e04c-b843d4eb-7d32-02006f10aa24/ Datastore: Datastore:datastore-44, datastore URL: ds:///vmfs/volumes/6575e04e-574afb35-5bd1-02006f10aa24/ Datastore: Datastore:datastore-41, datastore URL: ds:///vmfs/volumes/6575e049-2d285b11-2093-02006f55a483/ Datastore: Datastore:datastore-42, datastore URL: ds:///vmfs/volumes/6575e04a-d0bd551d-2ba0-02006f55a483/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/6575e047-49dcdc2f-548a-02006f9d128b/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/6575e048-a887ea0b-37c1-02006f9d128b/]	{"TraceId": "fcd8206e-f6f8-457d-966e-1b4f34be6e6d"}
```

Block volume:

ComputeResource is considered as an entity:
```
2023-12-18T10:06:40.591Z	INFO	common/topology.go:224	fetching hosts for entity: {Datacenter datacenter-3} on vCenter: "10.182.0.34"	{"TraceId": "04116b83-22f5-4dba-90aa-7c6a14580e6c"}
2023-12-18T10:06:40.600Z	INFO	common/topology.go:224	fetching hosts for entity: Folder:group-h5 on vCenter: "10.182.0.34"	{"TraceId": "04116b83-22f5-4dba-90aa-7c6a14580e6c"}
2023-12-18T10:06:40.608Z	INFO	common/topology.go:224	fetching hosts for entity: ComputeResource:domain-s3010 on vCenter: "10.182.0.34"	{"TraceId": "04116b83-22f5-4dba-90aa-7c6a14580e6c"}
2023-12-18T10:06:40.619Z	INFO	common/topology.go:224	fetching hosts for entity: ClusterComputeResource:domain-c8 on vCenter: "10.182.0.34"	{"TraceId": "04116b83-22f5-4dba-90aa-7c6a14580e6c"}
2023-12-18T10:06:40.625Z	INFO	common/topology.go:224	fetching hosts for entity: {ClusterComputeResource domain-c8} on vCenter: "10.182.0.34"	{"TraceId": "04116b83-22f5-4dba-90aa-7c6a14580e6c"}
```

As for block volume, we expand the topology segment, we have different sets of hosts received for region-1 and zone-1. For region-1, we do have standalone host in the list - host-3009:

```
2023-12-18T10:06:40.624Z	INFO	common/topology.go:158	Hosts returned for topology category: "topology.csi.vmware.com/k8s-region" and tag: "region-1" are [HostSystem:host-3009 HostSystem:host-32 HostSystem:host-26 HostSystem:host-20 HostSystem:host-14]	{"TraceId": "04116b83-22f5-4dba-90aa-7c6a14580e6c"}
2023-12-18T10:06:40.630Z	INFO	common/topology.go:158	Hosts returned for topology category: "topology.csi.vmware.com/k8s-zone" and tag: "zone-1" are [HostSystem:host-32 HostSystem:host-26 HostSystem:host-20 HostSystem:host-14]	{"TraceId": "04116b83-22f5-4dba-90aa-7c6a14580e6c"}
```

After this we are taking common hosts among region-1 and zone-1 which does not have the standalone host:

```
2023-12-18T10:06:40.631Z	INFO	common/topology.go:162	common hosts: [HostSystem:host-32 HostSystem:host-26 HostSystem:host-20 HostSystem:host-14] for all segments: map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-1]	{"TraceId": "04116b83-22f5-4dba-90aa-7c6a14580e6c"}
```
==============================
Test 2
==============================
 Tag the standalone datastore as zone-2.

In SC provide allowed topology as region-1, zone-2.

File volume:

Standalone host is the only candidate datastore:
```
2023-12-18T10:16:17.662Z	INFO	vanilla/controller_helper.go:338	Obtained candidate datastores: [Datastore: Datastore:datastore-3012, datastore URL: ds:///vmfs/volumes/65786b67-29e6701a-dc80-020076dbeefa/]	{"TraceId": "a0b99751-8339-48c8-878c-1e629c321a64"}
```

Block volume:

For block volume provisioning failed as CSI refers to the node VMs on the cluster and it could not find any node VM with zone-2 which is the expected result:

```
2023-12-18T10:20:58.801Z	WARN	placementengine/placement.go:63	No nodes in the cluster matched the topology requirement: map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-2]	{"TraceId": "ef62d6be-a3fd-4774-bd87-a9eff44cc84b"}
2023-12-18T10:20:58.811Z	WARN	vanilla/controller.go:1302	No compatible datastores found for accessibility requirements [map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-2]] pertaining to vCenter "10.182.0.34"	{"TraceId": "ef62d6be-a3fd-4774-bd87-a9eff44cc84b"}
2023-12-18T10:20:58.811Z	ERROR	vanilla/controller.go:1414	failed to create volume. Errors encountered: [No compatible datastores found for accessibility requirements [map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-2]] pertaining to vCenter "10.182.0.34"]	{"TraceId": "ef62d6be-a3fd-4774-bd87-a9eff44cc84b"}
```


For the following tests I ma using the following deployment

Datacenter (region-1) having a vSAN cluster (zone-1) and a standalone host (zone-2)
In this case, the only difference is that, one of the k8s workers is also present on the standalone host.

==============================
Test 3
==============================

Block volume

Created an SC with allowedTopologies as region-1 & zone-2

Common host is the standalone host:
```
root@k8s-control-516-1702833685:~# kubectl logs vsphere-csi-controller-9dbd646f4-x2dxw -n vmware-system-csi -c vsphere-csi-controller | grep "common hosts:"
2023-12-19T12:03:00.693Z	DEBUG	common/topology.go:200	common hosts: [HostSystem:host-3009]	{"TraceId": "4d4748d2-4bba-4e84-bbd8-a8451657e1a7"}
2023-12-19T12:03:00.696Z	INFO	common/topology.go:162	common hosts: [HostSystem:host-3009] for all segments: map[topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-2]	{"TraceId":
"4d4748d2-4bba-4e84-bbd8-a8451657e1a7"}
```

Volume got provisioned on a shared datastore of the standalone host.





**Special notes for your reviewer**:

**Release note**:
With this change, if a topology domain consists of a standalone host, vSphere CSI driver will be able provision a volume on it.
