### PR TITLE
Add more logs when creating CnsRegisterVolume CRD.

### DIFF
--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -149,15 +149,20 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 				stretchedSupervisor = true
 			}
 		}
+		if stretchedSupervisor {
+			log.Info("Observed stretchedSupervisor setup")
+		}
 		if !stretchedSupervisor ||
 			(stretchedSupervisor && commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.PodVMOnStretchedSupervisor)) {
 			// Create CnsRegisterVolume CRD from manifest.
+			log.Infof("Creating %q CRD", cnsoperatorv1alpha1.CnsRegisterVolumePlural)
 			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, cnsoperatorconfig.EmbedCnsRegisterVolumeCRFile,
 				cnsoperatorconfig.EmbedCnsRegisterVolumeCRFileName)
 			if err != nil {
 				log.Errorf("Failed to create %q CRD. Err: %+v", cnsoperatorv1alpha1.CnsRegisterVolumePlural, err)
 				return err
 			}
+			log.Infof("%q CRD is created successfully", cnsoperatorv1alpha1.CnsRegisterVolumePlural)
 		}
 
 		if !stretchedSupervisor {
@@ -182,8 +187,10 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			}
 		}
 
-		if !stretchedSupervisor {
+		if !stretchedSupervisor ||
+			(stretchedSupervisor && commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.PodVMOnStretchedSupervisor)) {
 			// Clean up routine to cleanup successful CnsRegisterVolume instances.
+			log.Info("Starting go routine to cleanup successful CnsRegisterVolume instances.")
 			err = watcher(ctx, cnsOperator)
 			if err != nil {
 				log.Error("Failed to watch on config file for changes to CnsRegisterVolumesCleanupIntervalInMin. Error: %+v",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This MR is to add logs when creating CnsRegisterVolume on stretchedSupervisor. 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Build the image with this change, and deployed in a stretchedSupervisor with FSS "PodVMOnStretchedSupervisor" enabled.
See the following new logs in the vsphere-syncer log, and syncer container does not crash.
```
2023-12-08T19:54:38.438Z        INFO    manager/init.go:153     Observed stretchedSupervisor setup
2023-12-08T19:54:38.438Z        INFO    manager/init.go:158     Creating "cnsregistervolumes" CRD
2023-12-08T19:54:43.535Z        INFO    manager/init.go:165     "cnsregistervolumes" CRD is created successfully
2023-12-08T19:54:43.535Z        INFO    manager/init.go:193     Starting go routine to cleanup successful CnsRegisterVolume instances.
```
After that, check the CnsRegisterVolume crd in the cluster, and found it has been created successfully.

```
root@4231210120e3d6174c015e702d87dbb9 [ ~ ]# kubectl get crd --all-namespaces | grep "register"
cnsregistervolumes.cns.vmware.com                                2023-12-08T19:54:38Z
```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
Add more logs when creating CnsRegisterVolume CRD
```
