### PR TITLE
[PodVMOnStretchedSupervisor] Store pvc namespace & storage class name in CnsVolumeInfo CR

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -81,6 +81,9 @@ const (
 	// AttributePvcNamespace represents the namespace of the PVC
 	AttributePvcNamespace = "csi.storage.k8s.io/pvc/namespace"
 
+	// AttributeStorageClassName represents name of the Storage Class.
+	AttributeStorageClassName = "csi.storage.k8s.io/sc/name"
+
 	// HostMoidAnnotationKey represents the Node annotation key that has the value
 	// of VC's ESX host moid of this node.
 	HostMoidAnnotationKey = "vmware-system-esxi-node-moid"

--- a/pkg/csi/service/wcp/controller_helper.go
+++ b/pkg/csi/service/wcp/controller_helper.go
@@ -60,6 +60,7 @@ func validateCreateBlockReqParam(paramName, value string) bool {
 		paramName == common.AttributePvName ||
 		paramName == common.AttributePvcName ||
 		paramName == common.AttributePvcNamespace ||
+		paramName == common.AttributeStorageClassName ||
 		(paramName == common.AttributeHostLocal && strings.EqualFold(value, "true"))
 }
 
@@ -77,7 +78,8 @@ func validateCreateFileReqParam(paramName, value string) bool {
 		paramName == common.AttributeFsType ||
 		paramName == common.AttributePvName ||
 		paramName == common.AttributePvcName ||
-		paramName == common.AttributePvcNamespace
+		paramName == common.AttributePvcNamespace ||
+		paramName == common.AttributeStorageClassName
 }
 
 // ValidateCreateVolumeRequest is the helper function to validate

--- a/pkg/internalapis/cnsvolumeinfo/cnsvolumeinfoservice.go
+++ b/pkg/internalapis/cnsvolumeinfo/cnsvolumeinfoservice.go
@@ -54,9 +54,9 @@ type VolumeInfoService interface {
 	CreateVolumeInfo(ctx context.Context, volumeID string, vCenter string) error
 
 	// CreateVolumeInfoWithPolicyInfo creates VolumeInfo CR to persist VolumeID,
-	// storage policy info and  vCenter details
-	CreateVolumeInfoWithPolicyInfo(ctx context.Context, volumeID string, storagePolicyId string,
-		storageClassName string, vCenter string) error
+	// pvcnamespace, storage policy info and  vCenter details
+	CreateVolumeInfoWithPolicyInfo(ctx context.Context, volumeID, pvcnamespace, storagePolicyId,
+		storageClassName, vCenter string) error
 
 	// DeleteVolumeInfo deletes VolumeInfo CR for the given VolumeID
 	DeleteVolumeInfo(ctx context.Context, volumeID string) error
@@ -190,8 +190,8 @@ func (volumeInfo *volumeInfo) CreateVolumeInfo(ctx context.Context, volumeID str
 }
 
 // CreateVolumeInfoWithPolicyInfo creates VolumeInfo CR to persist VolumeID to Storage policy mapping
-func (volumeInfo *volumeInfo) CreateVolumeInfoWithPolicyInfo(ctx context.Context,
-	volumeID string, storagePolicyId string, storageClassName string, vCenter string) error {
+func (volumeInfo *volumeInfo) CreateVolumeInfoWithPolicyInfo(ctx context.Context, volumeID string,
+	namespace, storagePolicyId, storageClassName, vCenter string) error {
 	log := logger.GetLogger(ctx)
 	log.Infof("creating cnsvolumeinfo for volumeID: %q, StoragePolicyID: %q, "+
 		"StorageClassName: %q, vCenter: %q in the namespace: %q",
@@ -206,6 +206,7 @@ func (volumeInfo *volumeInfo) CreateVolumeInfoWithPolicyInfo(ctx context.Context
 		},
 		Spec: cnsvolumeinfov1alpha1.CNSVolumeInfoSpec{
 			VolumeID:         volumeID,
+			Namespace:        namespace,
 			VCenterServer:    vCenter,
 			StoragePolicyID:  storagePolicyId,
 			StorageClassName: storageClassName,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Store pvc namespace & storage class name in CnsVolumeInfo CR

**Testing done**:
```
kubectl describe cnsvolumeinfoes.cns.vmware.com d1f6674e-5900-4901-87aa-355665ddb30a -n vmware-system-csi   

Name:         d1f6674e-5900-4901-87aa-355665ddb30a
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CNSVolumeInfo
Metadata:
  Creation Timestamp:  2023-12-09T00:09:16Z
  Generation:          1
  Resource Version:    10406550
  UID:                 79a5a6df-1a6a-4d6a-adee-208817e29fec
Spec:
  Namespace:          chethan-dev
  Storage Class Name: test-zonal-policy
  Storage Policy ID:  dff969da-17cb-4c77-9ada-58ff8c8d32fb
  V Center Server:    sc2-10-186-104-11.eng.vmware.com
  Volume ID:          d1f6674e-5900-4901-87aa-355665ddb30a
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Store pvc namespace in CnsVolumeInfo CR
```
