### PR TITLE
[PodVMOnStretchedSupervisor] Quota changes for CreateVolume

### DIFF
--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -552,7 +552,7 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volu
 		}
 		log.Debugf("vSphere CSI driver registering volume %q with create spec %+v",
 			volumeSpec.VolumePath, spew.Sdump(createSpec))
-		volumeInfo, _, err = (*volumeMigration.volumeManager).CreateVolume(ctx, createSpec)
+		volumeInfo, _, err = (*volumeMigration.volumeManager).CreateVolume(ctx, createSpec, nil)
 		if err != nil {
 			log.Warnf("failed to register volume %q with createSpec: %v. error: %+v",
 				volumeSpec.VolumePath, createSpec, err)

--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -56,9 +56,8 @@ type VanillaCreateBlockVolParamsForMultiVC struct {
 
 // CreateBlockVolumeUtil is the helper function to create CNS block volume.
 func CreateBlockVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor, manager *Manager,
-	spec *CreateVolumeSpec, sharedDatastores []*vsphere.DatastoreInfo,
-	filterSuspendedDatastores bool, useSupervisorId,
-	checkCompatibleDataStores bool) (*cnsvolume.CnsVolumeInfo, string, error) {
+	spec *CreateVolumeSpec, sharedDatastores []*vsphere.DatastoreInfo, filterSuspendedDatastores bool, useSupervisorId,
+	checkCompatibleDataStores bool, extraParams interface{}) (*cnsvolume.CnsVolumeInfo, string, error) {
 	log := logger.GetLogger(ctx)
 	vc, err := GetVCenter(ctx, manager)
 	if err != nil {
@@ -306,7 +305,7 @@ func CreateBlockVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluste
 	}
 
 	log.Debugf("vSphere CSI driver creating volume %s with create spec %+v", spec.Name, spew.Sdump(createSpec))
-	volumeInfo, faultType, err := manager.VolumeManager.CreateVolume(ctx, createSpec)
+	volumeInfo, faultType, err := manager.VolumeManager.CreateVolume(ctx, createSpec, extraParams)
 	if err != nil {
 		log.Errorf("failed to create disk %s with error %+v faultType %q", spec.Name, err, faultType)
 		return nil, faultType, err
@@ -444,7 +443,7 @@ func CreateBlockVolumeUtilForMultiVC(ctx context.Context, reqParams interface{})
 	}
 
 	log.Debugf("vSphere CSI driver creating volume %s with create spec %+v", params.Spec.Name, spew.Sdump(createSpec))
-	volumeInfo, faultType, err := params.VolumeManager.CreateVolume(ctx, createSpec)
+	volumeInfo, faultType, err := params.VolumeManager.CreateVolume(ctx, createSpec, nil)
 	if err != nil {
 		log.Errorf("failed to create disk %s on vCenter %q with error %+v faultType %q",
 			params.Spec.Name, params.Vcenter.Config.Host, err, faultType)
@@ -457,9 +456,8 @@ func CreateBlockVolumeUtilForMultiVC(ctx context.Context, reqParams interface{})
 // datastores.
 func CreateFileVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
 	vc *vsphere.VirtualCenter, volumeManager cnsvolume.Manager, cnsConfig *config.Config, spec *CreateVolumeSpec,
-	datastores []*vsphere.DatastoreInfo,
-	filterSuspendedDatastores bool, useSupervisorId,
-	checkCompatibleDataStores bool) (string, string, error) {
+	datastores []*vsphere.DatastoreInfo, filterSuspendedDatastores, useSupervisorId bool, extraParams interface{}) (
+	string, string, error) {
 	log := logger.GetLogger(ctx)
 	var err error
 	if spec.ScParams.StoragePolicyName != "" {
@@ -563,7 +561,7 @@ func CreateFileVolumeUtil(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 	}
 
 	log.Debugf("vSphere CSI driver creating volume %q with create spec %+v", spec.Name, spew.Sdump(createSpec))
-	volumeInfo, faultType, err := volumeManager.CreateVolume(ctx, createSpec)
+	volumeInfo, faultType, err := volumeManager.CreateVolume(ctx, createSpec, extraParams)
 	if err != nil {
 		log.Errorf("failed to create file volume %q with error %+v faultType %q", spec.Name, err, faultType)
 		return "", faultType, err

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -123,7 +123,7 @@ func (c *controller) Init(config *cnsconfig.Config, version string) error {
 		config.Global.CnsVolumeOperationRequestCleanupIntervalInMin,
 		func() bool {
 			return commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
-		})
+		}, false)
 	if err != nil {
 		log.Errorf("failed to initialize VolumeOperationRequestInterface with error: %v", err)
 		return err
@@ -784,7 +784,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		}
 		volumeInfo, faultType, err = common.CreateBlockVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
 			c.manager, &createVolumeSpec, sharedDatastores, filterSuspendedDatastores, false,
-			checkCompatibleDataStores)
+			checkCompatibleDataStores, nil)
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to create volume. Error: %+v", err)
@@ -1886,7 +1886,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 				}
 				volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
 					vc, c.managers.VolumeManagers[vcHost], c.managers.CnsConfig, &createVolumeSpec,
-					fsEnabledCandidateDatastores, filterSuspendedDatastores, false, checkCompatibleDataStores)
+					fsEnabledCandidateDatastores, filterSuspendedDatastores, false, nil)
 				if err != nil {
 					return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 						"failed to create volume. Error: %+v", err)
@@ -1946,7 +1946,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 			}
 			volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
 				vc, c.managers.VolumeManagers[vc.Config.Host], c.managers.CnsConfig, &createVolumeSpec,
-				filteredDatastores, filterSuspendedDatastores, false, checkCompatibleDataStores)
+				filteredDatastores, filterSuspendedDatastores, false, nil)
 			if err != nil {
 				return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to create volume. Error: %+v", err)
@@ -1959,7 +1959,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 			}
 			volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
 				vc, c.manager.VolumeManager, c.manager.CnsConfig, &createVolumeSpec,
-				filteredDatastores, filterSuspendedDatastores, false, checkCompatibleDataStores)
+				filteredDatastores, filterSuspendedDatastores, false, nil)
 			if err != nil {
 				return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to create volume. Error: %+v", err)

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -2143,7 +2143,7 @@ func TestDeleteBlockVolumeSnapshotWithManagedObjectNotFound(t *testing.T) {
 	taskID := "non-existent-task-id" // use a task id that must be non-existent
 	instanceName := "deletesnapshot-" + volID + "-" + snapshotID
 	operationInstance := cnsvolumeoperationrequest.CreateVolumeOperationRequestDetails(
-		instanceName, "", "", 0, metav1.Now(),
+		instanceName, "", "", 0, nil, metav1.Now(),
 		taskID, "", "", cnsvolumeoperationrequest.TaskInvocationStatusInProgress, "")
 	_ = ct.operationStore.StoreRequestDetails(ctx, operationInstance)
 
@@ -2274,7 +2274,7 @@ func TestCreateSnapshotWithManagedObjectNotFound(t *testing.T) {
 	taskID := "non-existent-task-id" // use a task id that must be non-existent
 	instanceName := snapshotName + "-" + volID
 	operationInstance := cnsvolumeoperationrequest.CreateVolumeOperationRequestDetails(
-		instanceName, volID, "", 0, metav1.Now(),
+		instanceName, volID, "", 0, nil, metav1.Now(),
 		taskID, "", "", cnsvolumeoperationrequest.TaskInvocationStatusInProgress, "")
 	_ = ct.operationStore.StoreRequestDetails(ctx, operationInstance)
 	// Attempt to create snapshot again, but the task-id is non-existent.

--- a/pkg/internalapis/cnsvolumeoperationrequest/util.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cnsvolumeoperationrequest
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cnsvolumeoprequestv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1"
@@ -43,7 +44,17 @@ type VolumeOperationRequestDetails struct {
 	VolumeID         string
 	SnapshotID       string
 	Capacity         int64
+	QuotaDetails     *QuotaDetails
 	OperationDetails *OperationDetails
+}
+
+// QuotaDetails stores information required to interact with the custom
+// storage policy quota CRs during create volume operations.
+type QuotaDetails struct {
+	Reserved         *resource.Quantity
+	StoragePolicyID  string
+	StorageClassName string
+	Namespace        string
 }
 
 // OperationDetails stores information about a particular operation.
@@ -59,13 +70,14 @@ type OperationDetails struct {
 // CreateVolumeOperationRequestDetails returns an object of type
 // VolumeOperationRequestDetails from the input parameters.
 func CreateVolumeOperationRequestDetails(name, volumeID, snapshotID string, capacity int64,
-	taskInvocationTimestamp metav1.Time, taskID, vCenterServer, opID,
+	quotaDetails *QuotaDetails, taskInvocationTimestamp metav1.Time, taskID, vCenterServer, opID,
 	taskStatus, error string) *VolumeOperationRequestDetails {
 	return &VolumeOperationRequestDetails{
-		Name:       name,
-		VolumeID:   volumeID,
-		SnapshotID: snapshotID,
-		Capacity:   capacity,
+		Name:         name,
+		VolumeID:     volumeID,
+		SnapshotID:   snapshotID,
+		Capacity:     capacity,
+		QuotaDetails: quotaDetails,
 		OperationDetails: &OperationDetails{
 			TaskInvocationTimestamp: taskInvocationTimestamp,
 			TaskID:                  taskID,

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
@@ -248,7 +249,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 	log.Infof("Creating CNS volume: %+v for CnsRegisterVolume request with name: %q on namespace: %q",
 		instance, instance.Name, instance.Namespace)
 	log.Debugf("CNS Volume create spec is: %+v", createSpec)
-	volInfo, _, err := r.volumeManager.CreateVolume(ctx, createSpec)
+	volInfo, _, err := r.volumeManager.CreateVolume(ctx, createSpec, nil)
 	if err != nil {
 		msg := "failed to create CNS volume"
 		log.Errorf(msg)

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -455,7 +455,7 @@ func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVo
 		if _, existsInK8s := currentK8sPVMap[volumeID]; existsInK8s {
 			log.Debugf("FullSync for VC %s: Calling CreateVolume for volume id: %q with createSpec %+v",
 				vc, volumeID, spew.Sdump(createSpec))
-			_, _, err := volManager.CreateVolume(ctx, &createSpec)
+			_, _, err := volManager.CreateVolume(ctx, &createSpec, nil)
 			if err != nil {
 				log.Warnf("FullSync for VC %s: Failed to create volume with the spec: %+v. "+
 					"Err: %+v", vc, spew.Sdump(createSpec), err)

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -305,7 +305,7 @@ func runTestMetadataSyncInformer(t *testing.T) {
 		},
 	}
 
-	volumeInfo, _, err := volumeManager.CreateVolume(ctx, &createSpec)
+	volumeInfo, _, err := volumeManager.CreateVolume(ctx, &createSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -657,7 +657,7 @@ func runTestFullSyncWorkflows(t *testing.T) {
 	cnsCreationMap = make(map[string]map[string]bool)
 	cnsCreationMap[csiConfig.Global.VCenterIP] = make(map[string]bool)
 
-	volumeInfo, _, err := volumeManager.CreateVolume(ctx, &createSpec)
+	volumeInfo, _, err := volumeManager.CreateVolume(ctx, &createSpec, nil)
 	if err != nil {
 		t.Errorf("failed to create volume. Error: %+v", err)
 		t.Fatal(err)

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -704,7 +704,7 @@ func createCnsVolume(ctx context.Context, pv *v1.PersistentVolume,
 	}
 	log.Debugf("vSphere CSI Driver is creating volume %q with create spec %+v",
 		pv.Name, spew.Sdump(createSpec))
-	_, _, err := cnsVolumeMgr.CreateVolume(ctx, createSpec)
+	_, _, err := cnsVolumeMgr.CreateVolume(ctx, createSpec, nil)
 	if err != nil {
 		log.Errorf("Failed to create disk %s with error %+v", pv.Name, err)
 		return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR introduces necessary changes to support custom Quota implementation during CreateVolume call.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran few block vanilla regression tests which were successful.

CreateVolume logs in a stretch supervisor setup:
```
2023-12-13T11:16:34.034Z	INFO	wcp/controller.go:893	CreateVolume: called with args {Name:pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[StorageTopologyType:Zonal csi.storage.k8s.io/pv/name:pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193 csi.storage.k8s.io/pvc/name:pvc1 csi.storage.k8s.io/pvc/namespace:test-shalini csi.storage.k8s.io/sc/name:zonal-policy storagePolicyID:ce20c289-73f2-448a-9b00-d30ddfd4d6f6] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.063Z	INFO	wcp/controller.go:486	Topology aware environment detected with requirement: requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > 	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.063Z	DEBUG	k8sorchestrator/topology.go:1519	Get shared datastores with topologyRequirement: requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > 	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.063Z	DEBUG	k8sorchestrator/topology.go:1531	Getting list of cluster morefs for topology segments map[topology.kubernetes.io/zone:zone-1]	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.063Z	INFO	k8sorchestrator/topology.go:1592	Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-1] are [domain-c113]	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.230Z	INFO	vsphere/utils.go:440	Found shared datastores: [Datastore: Datastore:datastore-109, datastore URL: ds:///vmfs/volumes/65720a25-7c5efaa2-f79f-0200aa619147/] and vSAN Direct datastores: []	{"TraceId": 56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.231Z	DEBUG	k8sorchestrator/topology.go:1531	Getting list of cluster morefs for topology segments map[topology.kubernetes.io/zone:zone-2]	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.231Z	INFO	k8sorchestrator/topology.go:1592	Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-2] are [domain-c124]	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.413Z	INFO	vsphere/utils.go:440	Found shared datastores: [Datastore: Datastore:datastore-109, datastore URL: ds:///vmfs/volumes/65720a25-7c5efaa2-f79f-0200aa619147/ Datastore: Datastore:datastore-452, datastore URL: ds:///vmfs/volumes/c89ee2c5-b1e131b7-0000-000000000000/] and vSAN Direct datastores: []	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.413Z	DEBUG	k8sorchestrator/topology.go:1531	Getting list of cluster morefs for topology segments map[topology.kubernetes.io/zone:zone-3]	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.413Z	INFO	k8sorchestrator/topology.go:1592	Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-3] are [domain-c133]	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.587Z	INFO	vsphere/utils.go:440	Found shared datastores: [Datastore: Datastore:datastore-109, datastore URL: ds:///vmfs/volumes/65720a25-7c5efaa2-f79f-0200aa619147/] and vSAN Direct datastores: []	{"TraceId": 56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.587Z	INFO	k8sorchestrator/topology.go:1564	Shared datastores [Datastore: Datastore:datastore-109, datastore URL: ds:///vmfs/volumes/65720a25-7c5efaa2-f79f-0200aa619147/ Datastore: Datastore:datastore-109, datastore URL: ds:///vmfs/volumes/65720a25-7c5efaa2-f79f-0200aa619147/ Datastore: Datastore:datastore-452, datastore URL: ds:///vmfs/volumes/c89ee2c5-b1e131b7-0000-000000000000/ Datastore: Datastore:datastore-109, datastore URL: ds:///vmfs/volumes/65720a25-7c5efaa2-f79f-0200aa619147/] for topologyRequirement: requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > 	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.603Z	INFO	vsphere/utils.go:553	Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-109, datastore URL: ds:///vmfs/volumes/65720a25-7c5efaa2-f79f-0200aa619147/ Datastore: Datastore:datastore-109, datastore URL: ds:///vmfs/volumes/65720a25-7c5efaa2-f79f-0200aa619147/ Datastore: Datastore:datastore-452, datastore URL: ds:///vmfs/volumes/c89ee2c5-b1e131b7-0000-000000000000/ Datastore: Datastore:datastore-109, datastore URL: ds:///vmfs/volumes/65720a25-7c5efaa2-f79f-0200aa619147/]	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.948Z	DEBUG	common/vsphereutil.go:307	vSphere CSI driver creating volume pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193 with create spec (*types.CnsVolumeCreateSpec)(0xc000f4ee00)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=4 cap=4) {
  (types.ManagedObjectReference) Datastore:datastore-109,
  (types.ManagedObjectReference) Datastore:datastore-109,
  (types.ManagedObjectReference) Datastore:datastore-452,
  (types.ManagedObjectReference) Datastore:datastore-109
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=56) "vSphereSupervisorID-34f2daa2-e3b8-4edc-8b62-eb92249f7452",
   VSphereUser: (string) (len=104) "wcp-storage-user-34f2daa2-e3b8-4edc-8b62-eb92249f7452-766bba82-298e-46b9-a50b-241164e96ff3@vsphere.local",
   ClusterFlavor: (string) (len=8) "WORKLOAD",
   ClusterDistribution: (string) (len=17) "SupervisorCluster"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=56) "vSphereSupervisorID-34f2daa2-e3b8-4edc-8b62-eb92249f7452",
    VSphereUser: (string) (len=104) "wcp-storage-user-34f2daa2-e3b8-4edc-8b62-eb92249f7452-766bba82-298e-46b9-a50b-241164e96ff3@vsphere.local",
    ClusterFlavor: (string) (len=8) "WORKLOAD",
    ClusterDistribution: (string) (len=17) "SupervisorCluster"
   }
  }
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc000f7a040)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 1024
  },
  BackingDiskId: (string) "",
  BackingDiskUrlPath: (string) "",
  BackingDiskObjectId: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) (len=1 cap=1) {
  (*types.VirtualMachineDefinedProfileSpec)(0xc000f7a080)({
   VirtualMachineProfileSpec: (types.VirtualMachineProfileSpec) {
    DynamicData: (types.DynamicData) {
    }
   },
   ProfileId: (string) (len=36) "ce20c289-73f2-448a-9b00-d30ddfd4d6f6",
   ReplicationSpec: (*types.ReplicationSpec)(<nil>),
   ProfileData: (*types.VirtualMachineProfileRawData)(<nil>),
   ProfileParams: ([]types.KeyValue) <nil>
  })
 },
 CreateSpec: (types.BaseCnsBaseCreateSpec) <nil>,
 VolumeSource: (types.BaseCnsVolumeSource) <nil>
})
	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.959Z	DEBUG	volume/util.go:204	Update VSphereUser from wcp-storage-user-34f2daa2-e3b8-4edc-8b62-eb92249f7452-766bba82-298e-46b9-a50b-241164e96ff3@vsphere.local to VSPHERE.LOCAL\wcp-storage-user-34f2daa2-e3b8-4edc-8b62-eb92249f7452-766bba82-298e-46b9-a50b-241164e96ff3	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.959Z	DEBUG	volume/manager.go:498	Received CreateVolume extraParams: &{StorageClassName:zonal-policy Namespace:test-shalini ClusterFlavor:WORKLOAD IsPodVMOnStretchSupervisorFSSEnabled:true}	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.960Z	INFO	volume/manager.go:519	QuotaInfo during CreateVolume call: &{Reserved:1024 StoragePolicyID:ce20c289-73f2-448a-9b00-d30ddfd4d6f6 StorageClassName:zonal-policy Namespace:test-shalini}	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:34.960Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:151	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}	
2023-12-13T11:16:35.125Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:196	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc000115680)({
 Name: (string) (len=40) "pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193",
 VolumeID: (string) "",
 SnapshotID: (string) "",
 Capacity: (int64) 0,
 QuotaDetails: (*cnsvolumeoperationrequest.QuotaDetails)(0xc000f7a880)({
  Reserved: (*resource.Quantity)(0xc000f7a840)(1024),
  StoragePolicyID: (string) (len=36) "ce20c289-73f2-448a-9b00-d30ddfd4d6f6",
  StorageClassName: (string) (len=12) "zonal-policy",
  Namespace: (string) (len=12) "test-shalini"
 }),
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc00041b180)({
  TaskInvocationTimestamp: (v1.Time) 2023-12-13 11:16:35.125096917 +0000 UTC m=+144.594152920,
  TaskID: (string) (len=9) "task-1097",
  VCenterServer: (string) "",
  OpID: (string) "",
  TaskStatus: (string) (len=10) "InProgress",
  Error: (string) ""
 })
})
	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:35.145Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:243	Created CnsVolumeOperationRequest instance vmware-system-csi/pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193 with latest information for task with ID: task-1097	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:35.145Z	INFO	volume/listview.go:124	AddTask called for Task:task-1097	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:35.165Z	INFO	volume/listview.go:159	task Task:task-1097 added to listView	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.019Z	INFO	volume/listview.go:178	task Task:task-1097 removed from listView	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.019Z	INFO	volume/manager.go:423	CreateVolume: VolumeName: "pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193", opId: "4ef3eb93"	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.019Z	DEBUG	volume/util.go:308	volumeCreateResult.PlacementResults :[{Datastore:datastore-452 []} {Datastore:datastore-109 [0xc0008a5ea0]}]	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.025Z	INFO	volume/util.go:329	Volume created successfully. VolumeName: "pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193", volumeID: "230dc5de-ae30-4de4-9a62-2de7b37ee183"	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.026Z	DEBUG	volume/util.go:331	CreateVolume volumeId {{} "230dc5de-ae30-4de4-9a62-2de7b37ee183"} is placed on datastore "ds:///vmfs/volumes/c89ee2c5-b1e131b7-0000-000000000000/"	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.026Z	INFO	volume/manager.go:583	Setting the reserved field for VolumeOperationDetails instance pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193 to 0	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.026Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:196	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc000204280)({
 Name: (string) (len=40) "pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193",
 VolumeID: (string) (len=36) "230dc5de-ae30-4de4-9a62-2de7b37ee183",
 SnapshotID: (string) "",
 Capacity: (int64) 0,
 QuotaDetails: (*cnsvolumeoperationrequest.QuotaDetails)(0xc000f7a880)({
  Reserved: (*resource.Quantity)(0xc000ada480)(0),
  StoragePolicyID: (string) (len=36) "ce20c289-73f2-448a-9b00-d30ddfd4d6f6",
  StorageClassName: (string) (len=12) "zonal-policy",
  Namespace: (string) (len=12) "test-shalini"
 }),
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc000342230)({
  TaskInvocationTimestamp: (v1.Time) 2023-12-13 11:16:35.125096917 +0000 UTC m=+144.594152920,
  TaskID: (string) (len=9) "task-1097",
  VCenterServer: (string) "",
  OpID: (string) (len=8) "4ef3eb93",
  TaskStatus: (string) (len=7) "Success",
  Error: (string) ""
 })
})
	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.042Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:319	Updated CnsVolumeOperationRequest instance vmware-system-csi/pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193 with latest information for task with ID: task-1097	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.042Z	DEBUG	volume/manager.go:859	internalCreateVolume: returns fault ""	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.203Z	INFO	k8sorchestrator/topology.go:1711	Topology of the provisioned volume detected as [map[topology.kubernetes.io/zone:zone-2]]	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.203Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:196	creating cnsvolumeinfo for volumeID: "230dc5de-ae30-4de4-9a62-2de7b37ee183", StoragePolicyID: "ce20c289-73f2-448a-9b00-d30ddfd4d6f6", StorageClassName: "zonal-policy", vCenter: "sc2-10-186-193-253.eng.vmware.com" in the namespace: "vmware-system-csi"	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.213Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:224	Successfully created CNSVolumeInfo CR for volumeID: "230dc5de-ae30-4de4-9a62-2de7b37ee183", StoragePolicyID: "ce20c289-73f2-448a-9b00-d30ddfd4d6f6", StorageClassName: "zonal-policy", vCenter: "sc2-10-186-193-253.eng.vmware.com" mapping in the namespace: "vmware-system-csi"	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.213Z	DEBUG	wcp/controller.go:933	createVolumeInternal: returns fault ""	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
2023-12-13T11:16:36.213Z	INFO	wcp/controller.go:945	Volume created successfully. Volume Handle: "230dc5de-ae30-4de4-9a62-2de7b37ee183", PV Name: "pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193"	{"TraceId": "56a17fde-3d0d-47a8-8b94-a03bd02f7ecb"}
```

$ kubectl -n vmware-system-csi get cnsvolumeoperationrequest pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193 -o yaml
```
apiVersion: cns.vmware.com/v1alpha1
kind: CnsVolumeOperationRequest
metadata:
  creationTimestamp: "2023-12-13T11:16:35Z"
  generation: 2
  name: pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193
  namespace: vmware-system-csi
  resourceVersion: "5926764"
  uid: 0e2c9bfe-cf73-47fd-ad7c-ed34944757d2
spec:
  name: pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193
status:
  firstOperationDetails:
    opId: 4ef3eb93
    taskId: task-1097
    taskInvocationTimestamp: "2023-12-13T11:16:35Z"
    taskStatus: Success
  latestOperationDetails:
  - opId: 4ef3eb93
    taskId: task-1097
    taskInvocationTimestamp: "2023-12-13T11:16:35Z"
    taskStatus: Success
  quotaDetails:
    namespace: test-shalini
    reserved: "0"
    storageClassName: zonal-policy
    storagePolicyId: ce20c289-73f2-448a-9b00-d30ddfd4d6f6
  volumeID: 230dc5de-ae30-4de4-9a62-2de7b37ee183
```

PVC:
```
Name:          pvc1
Namespace:     test-shalini
StorageClass:  zonal-policy
Status:        Bound
Volume:        pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Wed Dec 13 11:21:21 UTC 2023
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                 From                                                                                          Message
  ----    ------                 ----                ----                                                                                          -------
  Normal  ExternalProvisioning   18m (x10 over 20m)  persistentvolume-controller                                                                   waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  Provisioning           18m                 csi.vsphere.vmware.com_42318d622727bb68ab77d165df4cdf76_32c717ac-5d1e-418c-99a7-21a1349427cd  External provisioner is provisioning volume for claim "test-shalini/pvc1"
  Normal  ProvisioningSucceeded  18m                 csi.vsphere.vmware.com_42318d622727bb68ab77d165df4cdf76_32c717ac-5d1e-418c-99a7-21a1349427cd  Successfully provisioned volume pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193
```

PV:
```
Name:              pvc-0610912d-b490-4fe5-b6a5-2518e4a8f193
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      zonal-policy
Status:            Bound
Claim:             test-shalini/pvc1
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.kubernetes.io/zone in [zone-2]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      230dc5de-ae30-4de4-9a62-2de7b37ee183
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1702466051929-6164-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```

$ kubectl -n vmware-system-csi get cnsvolumeinfo 230dc5de-ae30-4de4-9a62-2de7b37ee183 -o yaml
```
apiVersion: cns.vmware.com/v1alpha1
kind: CNSVolumeInfo
metadata:
  creationTimestamp: "2023-12-13T11:16:36Z"
  generation: 1
  name: 230dc5de-ae30-4de4-9a62-2de7b37ee183
  namespace: vmware-system-csi
  resourceVersion: "5926766"
  uid: 25093ae9-0ecd-4032-b747-29bcaab9c246
spec:
  namespace: test-shalini
  storageClassName: zonal-policy
  storagePolicyID: ce20c289-73f2-448a-9b00-d30ddfd4d6f6
  vCenterServer: sc2-10-186-193-253.eng.vmware.com
  volumeID: 230dc5de-ae30-4de4-9a62-2de7b37ee183
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Quota changes for CreateVolume
```
