### PR TITLE
fss: move detach logic to csi

### DIFF
--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -421,8 +421,11 @@ const (
 	StorageQuotaM2 = "storage-quota-m2"
 	// VdppOnStretchedSupervisor enables support for vDPp workloads on stretched SV clusters
 	VdppOnStretchedSupervisor = "vdpp-on-stretched-supervisor"
+	// CSIDetachOnSupervisor enables CSI to detach the disk from the podvm in a supervisor environment
+	CSIDetachOnSupervisor = "CSI_Detach_Supported"
 )
 
 var WCPFeatureStates = map[string]struct{}{
 	PodVMOnStretchedSupervisor: {},
+	CSIDetachOnSupervisor:      {},
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

For cases of ungraceful shutdown of nodes in supervisor environment, we need a way for CSI to detach volumes when spherelet cannot perform the detach. 

This code is being guarded by a supervisor capability which is currently disabled. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Tests with capability disabled

```
Build #1455 (Jun 26, 2024, 7:40:41 PM)
adkulkarni
PR 2695
FAIL! -- 12 Passed | 1 Failed | 0 Pending | 864 Skipped --- FAIL: TestE2E (3114.08s) FAIL Ginkgo ran 1 suite in 53m21.484744816s Test Suite Failed make: Leaving directory `/home/worker/workspace/csi-wcp-precheckin@2/Results/1455/vsphere-csi-driver'
```

```
Build #1456 (Jun 26, 2024, 8:45:03 PM)
adkulkarni
PR 2695
Ran 1 of 877 Specs in 785.871 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 876 Skipped PASS Ginkgo ran 1 suite in 14m41.702529624s Test Suite Passed make: Leaving directory `/home/worker/workspace/csi-wcp-precheckin@2/Results/1456/vsphere-csi-driver'
```

Sanity test with capability enabled ->

```
root@4214c7c56fd01429bba83088f0498336 [ ~ ]# k -n kube-system get cm wcp-cluster-capabilities -o yaml | grep CSI
  CSI_Detach_Supported: "true"
  
  
root@4214c7c56fd01429bba83088f0498336 [ ~ ]# k create -f podpvc.yaml -n adi-ns
persistentvolumeclaim/aditya-pvc created
pod/aditya-pod created

root@4214c7c56fd01429bba83088f0498336 [ ~ ]# k -n adi-ns get po
NAME         READY   STATUS    RESTARTS   AGE
aditya-pod   1/1     Running   0          33s
root@4214c7c56fd01429bba83088f0498336 [ ~ ]# k -n adi-ns get pvc
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
aditya-pvc   Bound    pvc-3b4f13da-8f21-4e4c-baf8-0905c3117d85   1Gi        RWO            wcpglobal-storage-profile   <unset>                 35s

------

root@4214c7c56fd01429bba83088f0498336 [ ~ ]# k create -f sts.yaml -n adi-ns
service/nginx created
statefulset.apps/web created

root@4214c7c56fd01429bba83088f0498336 [ ~ ]# k -n adi-ns get sts
NAME   READY   AGE
web    1/1     117s

root@4214c7c56fd01429bba83088f0498336 [ ~ ]# k -n adi-ns scale sts web --replicas=10
statefulset.apps/web scaled

root@4214c7c56fd01429bba83088f0498336 [ ~ ]# k -n adi-ns get sts
NAME   READY   AGE
web    10/10   3m39s

root@4214c7c56fd01429bba83088f0498336 [ ~ ]# k -n adi-ns scale sts web --replicas=2
statefulset.apps/web scaled

root@4214c7c56fd01429bba83088f0498336 [ ~ ]# k -n adi-ns get sts
NAME   READY   AGE
web    2/2     6m6s

```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
