### PR TITLE
Storagepolicyusage CR sync during Syncer Init & Full Sync

### DIFF
--- a/pkg/internalapis/cnsvolumeinfo/cnsvolumeinfoservice.go
+++ b/pkg/internalapis/cnsvolumeinfo/cnsvolumeinfoservice.go
@@ -132,7 +132,7 @@ func (volumeInfo *volumeInfo) ListAllVolumeInfos() []interface{} {
 func (volumeInfo *volumeInfo) VolumeInfoCrExistsForVolume(ctx context.Context, volumeID string) (bool, error) {
 	log := logger.GetLogger(ctx)
 
-	volumeInfoCrName := getCnsColumeInfoCrName(ctx, volumeID)
+	volumeInfoCrName := getCnsVolumeInfoCrName(ctx, volumeID)
 	key := csiNamespace + "/" + volumeInfoCrName
 	_, found, err := volumeInfo.volumeInfoInformer.GetStore().GetByKey(key)
 	if err != nil {
@@ -149,7 +149,7 @@ func (volumeInfo *volumeInfo) VolumeInfoCrExistsForVolume(ctx context.Context, v
 func (volumeInfo *volumeInfo) GetvCenterForVolumeID(ctx context.Context, volumeID string) (string, error) {
 	log := logger.GetLogger(ctx)
 	// Since CNSVolumeInfo is namespaced CR, we need to prefix "namespace-name/" to obtain value from the store
-	volumeInfoCrName := getCnsColumeInfoCrName(ctx, volumeID)
+	volumeInfoCrName := getCnsVolumeInfoCrName(ctx, volumeID)
 	key := csiNamespace + "/" + volumeInfoCrName
 	info, found, err := volumeInfo.volumeInfoInformer.GetStore().GetByKey(key)
 	if err != nil || !found {
@@ -171,7 +171,7 @@ func (volumeInfo *volumeInfo) CreateVolumeInfo(ctx context.Context, volumeID str
 	log.Infof("creating cnsvolumeinfo for volumeID: %q and vCenter: %q mapping in the namespace: %q",
 		volumeID, vCenter, csiNamespace)
 
-	volumeInfoCrName := getCnsColumeInfoCrName(ctx, volumeID)
+	volumeInfoCrName := getCnsVolumeInfoCrName(ctx, volumeID)
 
 	cnsvolumeinfo := cnsvolumeinfov1alpha1.CNSVolumeInfo{
 		ObjectMeta: metav1.ObjectMeta{
@@ -205,7 +205,7 @@ func (volumeInfo *volumeInfo) CreateVolumeInfoWithPolicyInfo(ctx context.Context
 		"StorageClassName: %q, vCenter: %q, Capacity: %+v in the namespace: %q",
 		volumeID, storagePolicyId, storageClassName, vCenter, *capacity, csiNamespace)
 
-	volumeInfoCrName := getCnsColumeInfoCrName(ctx, volumeID)
+	volumeInfoCrName := getCnsVolumeInfoCrName(ctx, volumeID)
 
 	cnsvolumeinfo := cnsvolumeinfov1alpha1.CNSVolumeInfo{
 		ObjectMeta: metav1.ObjectMeta{
@@ -240,7 +240,7 @@ func (volumeInfo *volumeInfo) CreateVolumeInfoWithPolicyInfo(ctx context.Context
 func (volumeInfo *volumeInfo) DeleteVolumeInfo(ctx context.Context, volumeID string) error {
 	log := logger.GetLogger(ctx)
 
-	volumeInfoCrName := getCnsColumeInfoCrName(ctx, volumeID)
+	volumeInfoCrName := getCnsVolumeInfoCrName(ctx, volumeID)
 
 	object := cnsvolumeinfov1alpha1.CNSVolumeInfo{
 		ObjectMeta: metav1.ObjectMeta{
@@ -267,7 +267,7 @@ func (volumeInfo *volumeInfo) GetVolumeInfoForVolumeID(ctx context.Context, volu
 	*cnsvolumeinfov1alpha1.CNSVolumeInfo, error) {
 	log := logger.GetLogger(ctx)
 	// Since CNSVolumeInfo is namespaced CR, we need to prefix "namespace-name/" to obtain value from the store
-	volumeInfoCrName := getCnsColumeInfoCrName(ctx, volumeID)
+	volumeInfoCrName := getCnsVolumeInfoCrName(ctx, volumeID)
 	key := csiNamespace + "/" + volumeInfoCrName
 	info, found, err := volumeInfo.volumeInfoInformer.GetStore().GetByKey(key)
 	if err != nil || !found {
@@ -293,8 +293,8 @@ func (volumeInfo *volumeInfo) PatchVolumeInfo(ctx context.Context, volumeID stri
 	return volumeInfo.k8sClient.Patch(ctx, volumeInfoInstance, client.RawPatch(types.MergePatchType, patchBytes))
 }
 
-// getCnsColumeInfoCrName replaces "file:" with "file-" as K8s only allows alphanumeric and "-" in object name."
-func getCnsColumeInfoCrName(ctx context.Context, volumeID string) string {
+// getCnsVolumeInfoCrName replaces "file:" with "file-" as K8s only allows alphanumeric and "-" in object name."
+func getCnsVolumeInfoCrName(ctx context.Context, volumeID string) string {
 	log := logger.GetLogger(ctx)
 
 	if strings.HasPrefix(volumeID, FileVolumePrefix) {

--- a/pkg/internalapis/cnsvolumeinfo/v1alpha1/cnsvolumeinfo_types.go
+++ b/pkg/internalapis/cnsvolumeinfo/v1alpha1/cnsvolumeinfo_types.go
@@ -21,6 +21,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// CRDSingular represents the singular name of CNSVolumeInfo CRD.
+	CRDSingular = "cnsvolumeinfo"
+)
+
 // CNSVolumeInfoSpec defines the desired state of CNSVolumeInfo
 type CNSVolumeInfoSpec struct {
 

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -54,6 +54,12 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 			migrationFeatureStateForFullSync = true
 		}
 	}
+	// Attempt to patch StoragePolicyUsage CRs
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
+		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.PodVMOnStretchedSupervisor) {
+			storagePolicyUsageCRSync(ctx, metadataSyncer)
+		}
+	}
 	defer func() {
 		fullSyncStatus := prometheus.PrometheusPassStatus
 		if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adds a sync method for Storagepolicyusage CRs to be invoked during Syncer Init.
The same sync method is invoked in CSI full sync.

**Testing done**:
State of the cluster: 
25 PVCs with 10Mi each
```
kubectl get quota -n chethan-dev -o json
{
            "status": {
                "hard": {
                    "test-zonal-policy.storageclass.storage.k8s.io/requests.storage": "9223372036854775807"
                },
                "used": {
                    "test-zonal-policy.storageclass.storage.k8s.io/requests.storage": "250Mi"
                }
            }

```

StoragePolicyUsage Before:
```
{
    "apiVersion": "cns.vmware.com/v1alpha1",
    "kind": "StoragePolicyUsage",
    "metadata": {
        "annotations": {
            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cns.vmware.com/v1alpha1\",\"kind\":\"StoragePolicyUsage\",\"metadata\":{\"annotations\":{},\"name\":\"
test-zonal-policy-pvc-usage\",\"namespace\":\"chethan-dev\"},\"spec\":{\"resourceApiGroup\":\"\",\"resourceExtensionName\":\"pvc-quota-webhook-extension\",\"resourceKind\":\"PersistentV
olumeClaim\",\"storageClassName\":\"test-zonal-policy\",\"storagePolicyId\":\"dff969da-17cb-4c77-9ada-58ff8c8d32fb\"}}\n"
        },
        "creationTimestamp": "2023-12-22T19:38:08Z",
        "generation": 169,
        "name": "test-zonal-policy-pvc-usage",
        "namespace": "chethan-dev",
        "resourceVersion": "25365774",
        "uid": "a4b787ea-715e-4a98-b8a7-2cb4ebde7a83"
    },
    "spec": {
        "resourceApiGroup": "",
        "resourceExtensionName": "pvc-quota-webhook-extension",
        "resourceKind": "PersistentVolumeClaim",
        "storageClassName": "test-zonal-policy",
        "storagePolicyId": "dff969da-17cb-4c77-9ada-58ff8c8d32fb"
    },
    "status": {
        "quotaUsage": {
            "reserved": "0",
            "used": "220Mi"
        }
    }
}
```

Restarted the Syncer:

```
2023-12-23T05:17:20.524Z	INFO	syncer/metadatasyncer.go:3055	storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: "test-zonal-policy-pvc-usage" in namespace: "chethan-dev" field is not matching with the total capacity of all the k8s volumes in Bound state. Current: 220200960 . Expected: 251658240
2023-12-23T05:17:20.539Z	INFO	syncer/util.go:836	Patching the StoragePolicyUsageCR "test-zonal-policy-pvc-usage" on namespace: "chethan-dev"}
2023-12-23T05:17:20.539Z	INFO	syncer/metadatasyncer.go:3065	storagePolicyUsageCRSync: Successfully updated the used field from 220200960 to 251658240 for StoragepolicyUsage CR: "test-zonal-policy-pvc-usage" in namespace: "chethan-dev"

```

StoragePolicyUsage After:
```
{
    "apiVersion": "cns.vmware.com/v1alpha1",
    "kind": "StoragePolicyUsage",
    "metadata": {
        "annotations": {
            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cns.vmware.com/v1alpha1\",\"kind\":\"StoragePolicyUsage\",\"metadata\":{\"annotations\":{},\"name\":\"
test-zonal-policy-pvc-usage\",\"namespace\":\"chethan-dev\"},\"spec\":{\"resourceApiGroup\":\"\",\"resourceExtensionName\":\"pvc-quota-webhook-extension\",\"resourceKind\":\"PersistentV
olumeClaim\",\"storageClassName\":\"test-zonal-policy\",\"storagePolicyId\":\"dff969da-17cb-4c77-9ada-58ff8c8d32fb\"}}\n"
        },
        "creationTimestamp": "2023-12-22T19:38:08Z",
        "generation": 169,
        "name": "test-zonal-policy-pvc-usage",
        "namespace": "chethan-dev",
        "resourceVersion": "25365774",
        "uid": "a4b787ea-715e-4a98-b8a7-2cb4ebde7a83"
    },
    "spec": {
        "resourceApiGroup": "",
        "resourceExtensionName": "pvc-quota-webhook-extension",
        "resourceKind": "PersistentVolumeClaim",
        "storageClassName": "test-zonal-policy",
        "storagePolicyId": "dff969da-17cb-4c77-9ada-58ff8c8d32fb"
    },
    "status": {
        "quotaUsage": {
            "reserved": "0",
            "used": "250Mi"
        }
    }
}
```


Full sync test:
Have 15 PVCs in the cluster with 110Mi each:
```
kubectl get pvc -n storage-policy-test
NAME             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             AGE
example-pvc-10   Bound    pvc-e0f64f22-4c33-42de-8b7d-780c0fb2a96d   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-11   Bound    pvc-f766bfe2-52d6-40ec-bc86-efe14effd49b   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-12   Bound    pvc-7b05d732-2c7a-4f13-931c-6adf6c38f738   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-13   Bound    pvc-827a36c0-beb2-4370-99f9-80a13164afcb   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-14   Bound    pvc-9f276148-a795-4a2e-adcc-84b2e8e5c02f   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-15   Bound    pvc-c10d5b68-de1f-41f3-b6bc-35892879a86c   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-16   Bound    pvc-b4b12b71-0c3a-4d80-bf3b-711a63591bd1   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-2    Bound    pvc-ffd068e5-e620-4cd6-82c9-d79e0d17148d   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-3    Bound    pvc-bbe0746f-97a2-490f-9055-aedc18e3fcac   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-4    Bound    pvc-74d50572-71cf-4d5c-9896-8eed3bef2cc4   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-5    Bound    pvc-0561628b-b174-4a04-adcb-d4808445e0b3   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-6    Bound    pvc-6b39297a-dc08-416f-acee-11856e5bad47   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-7    Bound    pvc-ebbfd0d8-222e-480c-b0e2-e304ee0383c3   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-8    Bound    pvc-48116413-fb1d-4482-b769-8d5b0aab0f55   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
example-pvc-9    Bound    pvc-97321596-ef2c-477e-a6b3-cff4a5033f82   110Mi      RWO            wcp-profile-wkaoxja3iq   3h24m
```
Total used capacity: 1650Mi

Now, edit the SP usage to make it 0Mi

kubectl edit storagepolicyusage -n storage-policy-test wcp-profile-wkaoxja3iq-pvc-usage -o yaml
```
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2023-12-26T08:57:49Z"
  generation: 496
  name: wcp-profile-wkaoxja3iq-pvc-usage
  namespace: storage-policy-test
  resourceVersion: "2600128"
  uid: 8ed5cea1-6822-4dfe-8973-5606a05b23a4
spec:
  resourceApiGroup: ""
  resourceExtensionName: volume.cns.vsphere.vmware.com
  resourceKind: PersistentVolumeClaim
  storageClassName: wcp-profile-wkaoxja3iq
  storagePolicyId: c268ab52-ee7f-409b-b524-241ac2e5d2f9
status:
  quotaUsage:
    reserved: "0"
    used: 0Mi
```

Let the full sync invoke CR Sync method and then verify the SP usage CR. The total used capacity is fixed:

kubectl get storagepolicyusage -n storage-policy-test wcp-profile-wkaoxja3iq-pvc-usage -o yaml
```
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2023-12-26T08:57:49Z"
  generation: 511
  name: wcp-profile-wkaoxja3iq-pvc-usage
  namespace: storage-policy-test
  resourceVersion: "2600216"
  uid: 8ed5cea1-6822-4dfe-8973-5606a05b23a4
spec:
  resourceApiGroup: ""
  resourceExtensionName: volume.cns.vsphere.vmware.com
  resourceKind: PersistentVolumeClaim
  storageClassName: wcp-profile-wkaoxja3iq
  storagePolicyId: c268ab52-ee7f-409b-b524-241ac2e5d2f9
status:
  quotaUsage:
    reserved: "0"
    used: 1650Mi
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Storagepolicyusage CR sync during Syncer Init
```
