### PR TITLE
Bump up provisioner version to v3.4.0_vmware.2 for pod vm on stretch supervisor support

### DIFF
--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -219,7 +219,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -219,7 +219,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -219,7 +219,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -219,7 +219,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Bump up provisioner version for pod vm on stretch supervisor support

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Not needed. The testing will be done during consumption of CSI in CSP 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump up provisioner version to v3.4.0_vmware.2 for pod vm on stretch supervisor support
```
