### PR TITLE
Fix a bug in patching storage policy usage CR method invocation

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -927,7 +927,7 @@ func cnsvolumeoperationrequestCRAdded(obj interface{}) {
 			patchedStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Add(
 				*resource.NewQuantity(cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved.Value(),
 					cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved.Format))
-			err := patchStoragePolicyUsage(ctx, cnsOperatorClient, patchedStoragePolicyUsageCR,
+			err := patchStoragePolicyUsage(ctx, cnsOperatorClient, storagePolicyUsageCR,
 				patchedStoragePolicyUsageCR)
 			if err != nil {
 				log.Errorf("updateStoragePolicyUsage failed. err: %v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix a bug in patching storage policy usage CR method invocation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
kubectl create -f pvc-test.yaml -n chethan-dev
```

```
Every 2.0s: kubectl get storagepolicyusage -n chethan-dev -o yaml                                                           422a19a7d7be227cc3ddfafaa141dea3: Fri Dec 15 19:12:10 2023

apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2023-12-15T06:47:47Z"
    generation: 15
    name: test-policy-pvc-usage
    namespace: chethan-dev
    resourceVersion: "17375560"
    uid: 760e2e28-32ab-4534-a077-78b6514599c4
  spec:
    resourceApiGroup: ""
    resourceExtensionName: pvc-quota-webhook-extension
    resourceKind: PersistentVolumeClaim
    storageClassName: test-zonal-policy
    storagePolicyId: dff969da-17cb-4c77-9ada-58ff8c8d32fb
  status:
    quotaUsage:
      reserved: "10"
      used: "0"
kind: List
metadata:
  resourceVersion: ""
```

```
Every 2.0s: kubectl get storagepolicyusage -n chethan-dev -o yaml                                                           422a19a7d7be227cc3ddfafaa141dea3: Fri Dec 15 19:12:10 2023

apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2023-12-15T06:47:47Z"
    generation: 15
    name: test-policy-pvc-usage
    namespace: chethan-dev
    resourceVersion: "17375560"
    uid: 760e2e28-32ab-4534-a077-78b6514599c4
  spec:
    resourceApiGroup: ""
    resourceExtensionName: pvc-quota-webhook-extension
    resourceKind: PersistentVolumeClaim
    storageClassName: test-zonal-policy
    storagePolicyId: dff969da-17cb-4c77-9ada-58ff8c8d32fb
  status:
    quotaUsage:
      reserved: "0"
      used: "10"
kind: List
metadata:
  resourceVersion: ""
```
```
{"level":"info","time":"2023-12-15T19:06:13.30115351Z","caller":"syncer/metadatasyncer.go:876","msg":"currcnsvolumeoperationrequestObj: 10","TraceId":"aab64c92-52d3-4eee-bdbe-f9c999d0d232"}
{"level":"info","time":"2023-12-15T19:06:13.325516154Z","caller":"syncer/metadatasyncer.go:932","msg":"storagePolicyUsageCR: &{{StoragePolicyUsage cns.vmware.com/v1alpha1} {test-policy-pvc-usage  chethan-dev  760e2e28-32ab-4534-a077-78b6514599c4 17373401 13 2023-12-15 06:47:47 +0000 UTC <nil> <nil> map[] map[] [] [] [{kubectl-create Update cns.vmware.com/v1alpha1 2023-12-15 06:47:47 +0000 UTC FieldsV1 {\"f:spec\":{\".\":{},\"f:resourceApiGroup\":{},\"f:resourceExtensionName\":{},\"f:resourceKind\":{},\"f:storageClassName\":{},\"f:storagePolicyId\":{}}} } {vsphere-syncer Update cns.vmware.com/v1alpha1 2023-12-15 19:01:16 +0000 UTC FieldsV1 {\"f:status\":{\"f:quotaUsage\":{\"f:reserved\":{}}}} } {kubectl-edit Update cns.vmware.com/v1alpha1 2023-12-15 19:03:20 +0000 UTC FieldsV1 {\"f:status\":{\".\":{},\"f:quotaUsage\":{\".\":{},\"f:used\":{}}}} }]} {dff969da-17cb-4c77-9ada-58ff8c8d32fb test-zonal-policy 0xc000647d00 PersistentVolumeClaim pvc-quota-webhook-extension} {0xc000647d20}}","TraceId":"aab64c92-52d3-4eee-bdbe-f9c999d0d232"}
{"level":"info","time":"2023-12-15T19:06:13.345578863Z","caller":"syncer/metadatasyncer.go:943","msg":"cnsvolumeoperationrequestCRAdded: Successfully increased the reserved field by 10 for storagepolicyusage CR: \"test-policy-pvc-usage\"","TraceId":"aab64c92-52d3-4eee-bdbe-f9c999d0d232"}
{"level":"info","time":"2023-12-15T19:06:14.851669565Z","caller":"syncer/metadatasyncer.go:1056","msg":"oldcnsvolumeoperationrequestObj: 10","TraceId":"c98a3ccb-9507-4266-bcd4-5b3e5c24892e"}
{"level":"info","time":"2023-12-15T19:06:14.851785058Z","caller":"syncer/metadatasyncer.go:1057","msg":"newcnsvolumeoperationrequestObj: 0","TraceId":"c98a3ccb-9507-4266-bcd4-5b3e5c24892e"}
{"level":"info","time":"2023-12-15T19:06:14.879709903Z","caller":"syncer/metadatasyncer.go:1152","msg":"patchedStoragePolicyUsageCR: &{{StoragePolicyUsage cns.vmware.com/v1alpha1} {test-policy-pvc-usage  chethan-dev  760e2e28-32ab-4534-a077-78b6514599c4 17375539 14 2023-12-15 06:47:47 +0000 UTC <nil> <nil> map[] map[] [] [] [{kubectl-create Update cns.vmware.com/v1alpha1 2023-12-15 06:47:47 +0000 UTC FieldsV1 {\"f:spec\":{\".\":{},\"f:resourceApiGroup\":{},\"f:resourceExtensionName\":{},\"f:resourceKind\":{},\"f:storageClassName\":{},\"f:storagePolicyId\":{}}} } {kubectl-edit Update cns.vmware.com/v1alpha1 2023-12-15 19:03:20 +0000 UTC FieldsV1 {\"f:status\":{\".\":{},\"f:quotaUsage\":{\".\":{},\"f:used\":{}}}} } {vsphere-syncer Update cns.vmware.com/v1alpha1 2023-12-15 19:06:13 +0000 UTC FieldsV1 {\"f:status\":{\"f:quotaUsage\":{\"f:reserved\":{}}}} }]} {dff969da-17cb-4c77-9ada-58ff8c8d32fb test-zonal-policy 0xc001ebeda0 PersistentVolumeClaim pvc-quota-webhook-extension} {0xc001ebedb0}}","TraceId":"c98a3ccb-9507-4266-bcd4-5b3e5c24892e"}
{"level":"info","time":"2023-12-15T19:06:14.899673339Z","caller":"syncer/metadatasyncer.go:1164","msg":"cnsvolumeoperationrequestCRUpdated: Successfully decreased the reserved field by 10 for storagepolicyusage CR: \"test-policy-pvc-usage\" in namespace: \"chethan-dev\"","TraceId":"c98a3ccb-9507-4266-bcd4-5b3e5c24892e"}
{"level":"info","time":"2023-12-15T19:06:14.899769568Z","caller":"syncer/metadatasyncer.go:1168","msg":"cnsvolumeoperationrequestCRUpdated: Successfully increased the used field by 10 for storagepolicyusage CR: \"test-policy-pvc-usage\" in namespace: \"chethan-dev\"","TraceId":"c98a3ccb-9507-4266-bcd4-5b3e5c24892e"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix a bug in patching storage policy usage CR method invocation
```
