### PR TITLE
Check for static volume accessibility in all AZs

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -131,6 +131,11 @@ func (cntrlTopology *mockControllerVolumeTopology) GetSharedDatastoresInTopology
 	return nil, logger.LogNewError(log, "GetSharedDatastoresInTopology is not yet implemented.")
 }
 
+// GetAZClustersMap returns the zone to clusterMorefs map from the azClustersMap.
+func (cntrlTopology *mockControllerVolumeTopology) GetAZClustersMap(ctx context.Context) map[string][]string {
+	return nil
+}
+
 // GetTopologyInfoFromNodes retrieves the topology information of the given list of node names.
 func (cntrlTopology *mockControllerVolumeTopology) GetTopologyInfoFromNodes(ctx context.Context,
 	reqParams interface{}) ([]map[string]string, error) {

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -497,6 +497,16 @@ func removeFromAZClusterMap(ctx context.Context, azName string) {
 	}
 }
 
+// GetAZClustersMap returns the zone to clusterMorefs map from the azClustersMap.
+func (volTopology *wcpControllerVolumeTopology) GetAZClustersMap(ctx context.Context) map[string][]string {
+	return azClustersMap
+}
+
+// GetAZClustersMap returns the zone to clusterMorefs map from the azClustersMap.
+func (volTopology *controllerVolumeTopology) GetAZClustersMap(ctx context.Context) map[string][]string {
+	return nil
+}
+
 // startTopologyCRInformer creates and starts an informer for CSINodeTopology custom resource.
 func startTopologyCRInformer(ctx context.Context, cfg *restclient.Config) (*cache.SharedIndexInformer, error) {
 	log := logger.GetLogger(ctx)

--- a/pkg/csi/service/common/commonco/types/types.go
+++ b/pkg/csi/service/common/commonco/types/types.go
@@ -100,6 +100,9 @@ type ControllerTopologyService interface {
 	// GetTopologyInfoFromNodes retrieves the topology information of the nodes after the datastore has been
 	// selected for volume provisioning.
 	GetTopologyInfoFromNodes(ctx context.Context, retrieveTopologyInfoParams interface{}) ([]map[string]string, error)
+
+	// GetAZClustersMap returns the zone to clusterMorefs map from the azClustersMap.
+	GetAZClustersMap(ctx context.Context) map[string][]string
 }
 
 // NodeTopologyService is an interface which exposes functionality related to


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
PR adds changes to verify if static volumes provisioned on a zonal datastore is accessible in one of the AZs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
cat static-pvc-2.yaml 
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: test-cns-static-volume-2
  namespace: chethan-dev
spec:
  volumeID: 4bd82bbf-1140-4534-8e2a-5b0855dfd380
  accessMode: ReadWriteOnce
  pvcName: static-pvc-test-2
```

```
kubectl describe pvc static-pvc-test-2 -n chethan-dev
Name:          static-pvc-test-2
Namespace:     chethan-dev
StorageClass:  test-zonal-policy
Status:        Bound
Volume:        static-pv-4bd82bbf-1140-4534-8e2a-5b0855dfd380
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Tue Dec 19 08:39:02 UTC 2023
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      10Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:        <none>
```

```
Name:              static-pv-4bd82bbf-1140-4534-8e2a-5b0855dfd380
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      test-zonal-policy
Status:            Bound
Claim:             chethan-dev/static-pvc-test-2
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          10Mi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.kubernetes.io/zone in [zone-2]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      4bd82bbf-1140-4534-8e2a-5b0855dfd380
    ReadOnly:          false
    VolumeAttributes:  <none>
Events:                <none>
```

```
kubectl describe cnsregistervolume.cns.vmware.com test-cns-static-volume-2 -n chethan-dev
Name:         test-cns-static-volume-2
Namespace:    chethan-dev
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsRegisterVolume
Metadata:
  Creation Timestamp:  2023-12-19T08:34:22Z
  Generation:          2
  Owner References:
    API Version:           v1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  PersistentVolumeClaim
    Name:                  static-pvc-test-2
    UID:                   a4522a74-3965-4656-8d16-56bff44f8f38
  Resource Version:        21200192
  UID:                     95e0ed12-00e6-4e83-aa77-4703b23f9514
Spec:
  Access Mode:  ReadWriteOnce
  Pvc Name:     static-pvc-test-2
  Volume ID:    4bd82bbf-1140-4534-8e2a-5b0855dfd380
Status:
  Registered:  true
Events:
  Type    Reason                      Age   From            Message
  ----    ------                      ----  ----            -------
  Normal  CnsRegisterVolumeSucceeded  7s    cns.vmware.com  Successfully registered the volume on namespace: chethan-dev
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Check for static volume accessibility in all AZs
```
