### PR TITLE
Change reserved field to the difference between new volume size current volume capacity

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1882,6 +1882,7 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 					StorageClassName:                     cnsVolumeInfo.Spec.StorageClassName,
 					StoragePolicyID:                      cnsVolumeInfo.Spec.StoragePolicyID,
 					Namespace:                            cnsVolumeInfo.Spec.Namespace,
+					Capacity:                             cnsVolumeInfo.Spec.Capacity,
 					ClusterFlavor:                        cnstypes.CnsClusterFlavorWorkload,
 					IsPodVMOnStretchSupervisorFSSEnabled: isPodVMOnStretchSupervisorFSSEnabled,
 				})


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Change reserved field to the difference between new volume size current volume capacity
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
1. create a pvc with 1Gi
2. extend the pvc from 1Gi to 2Gi, check the cnsvolumeoperationrequest CR, the "spec.QuotaDetails.Reserved" is set to the correct value 1Gi
```
2023-12-19T23:56:56.128Z	INFO	volume/manager.go:1726	Calling CnsClient.ExtendVolume: VolumeID ["b11df38b-ebef-46d3-9a51-6a24110c288a"] Size [2048] cnsExtendSpecList [[]types.CnsVolumeExtendSpec{types.CnsVolumeExtendSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:"b11df38b-ebef-46d3-9a51-6a24110c288a"}, CapacityInMb:2048}}]	{"TraceId": "1b2fa0a5-149c-4d76-97e5-d00772a5bc25"}
2023-12-19T23:56:56.158Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:196	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc000252c80)({
 Name: (string) (len=43) "expand-b11df38b-ebef-46d3-9a51-6a24110c288a",
 VolumeID: (string) "",
 SnapshotID: (string) "",
 Capacity: (int64) 2048,
 QuotaDetails: (*cnsvolumeoperationrequest.QuotaDetails)(0xc000e99340)({
  Reserved: (*resource.Quantity)(0xc000e99300)(1Gi),
  StoragePolicyId: (string) (len=36) "dff969da-17cb-4c77-9ada-58ff8c8d32fb",
  StorageClassName: (string) (len=17) "test-zonal-policy",
  Namespace: (string) (len=11) "chethan-dev"
 }),
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc000484310)({
  TaskInvocationTimestamp: (v1.Time) 2023-12-19 23:56:56.157065096 +0000 UTC m=+166.692114871,
  TaskID: (string) (len=9) "task-8491",
  VCenterServer: (string) "",
  OpID: (string) "",
  TaskStatus: (string) (len=10) "InProgress",
  Error: (string) ""
 })
})
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
```
