### PR TITLE
Update logging and comments for SPUsage CR informer, and add watch cnsvolumeoperation rbac rule

### DIFF
--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -71,7 +71,7 @@ rules:
     verbs: ["get"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeoperationrequests"]
-    verbs: ["create", "get", "list", "update", "delete"]
+    verbs: ["create", "get", "list", "update", "delete", "watch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["storagepolicyusages"]
     verbs: ["create", "get", "list", "patch", "delete"]

--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -71,7 +71,7 @@ rules:
     verbs: ["get"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeoperationrequests"]
-    verbs: ["create", "get", "list", "update", "delete"]
+    verbs: ["create", "get", "list", "update", "delete", "watch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["storagepolicyusages"]
     verbs: ["create", "get", "list", "patch", "delete"]

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -71,7 +71,7 @@ rules:
     verbs: ["get"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeoperationrequests"]
-    verbs: ["create", "get", "list", "update", "delete"]
+    verbs: ["create", "get", "list", "update", "delete", "watch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["storagepolicyusages"]
     verbs: ["create", "get", "list", "patch", "delete"]

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -71,7 +71,7 @@ rules:
     verbs: ["get"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeoperationrequests"]
-    verbs: ["create", "get", "list", "update", "delete"]
+    verbs: ["create", "get", "list", "update", "delete", "watch"]
   - apiGroups: ["cns.vmware.com"]
     resources: ["storagepolicyusages"]
     verbs: ["create", "get", "list", "patch", "delete"]

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -945,17 +945,19 @@ func cnsvolumeoperationrequestCRAdded(obj interface{}) {
 				log.Errorf("updateStoragePolicyUsage failed. err: %v", err)
 				return
 			}
-			log.Infof("cnsvolumeoperationrequestCRAdded: Successfully increased the reserved field by %v "+
+			log.Infof("cnsvolumeoperationrequestCRAdded: Successfully increased the reserved field by %v bytes "+
 				"for storagepolicyusage CR: %q", cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved.Value(),
 				patchedStoragePolicyUsageCR.Name)
 			return
 		} else {
+			// This is a case where, the storagePolicyUsage CR does not have Status field.
+			// The else{} block is usually executed for the 1st CreateVolume call after the
+			// podVMOnStretchedSupervisor FSS is enabled
 			var (
 				usedQty     resource.Quantity
 				reservedQty resource.Quantity
 			)
 			reservedQty = *cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved
-
 			patchedStoragePolicyUsageCR.Status = storagepolicyusagev1alpha1.StoragePolicyUsageStatus{
 				ResourceTypeLevelQuotaUsage: &storagepolicyusagev1alpha1.QuotaUsageDetails{
 					Reserved: &reservedQty,
@@ -968,7 +970,7 @@ func cnsvolumeoperationrequestCRAdded(obj interface{}) {
 				log.Errorf("updateStoragePolicyUsage failed. err: %v", err)
 				return
 			}
-			log.Infof("cnsvolumeoperationrequestCRAdded: Successfully increased the reserved field by %v "+
+			log.Infof("cnsvolumeoperationrequestCRAdded: Successfully increased the reserved field by %v bytes "+
 				"for storagepolicyusage CR: %q", cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved.Value(),
 				patchedStoragePolicyUsageCR.Name)
 			return
@@ -1047,7 +1049,7 @@ func cnsvolumeoperationrequestCRDeleted(obj interface{}) {
 			log.Errorf("updateStoragePolicyUsage failed. err: %v", err)
 			return
 		}
-		log.Infof("cnsvolumeoperationrequestCRDeleted: Successfully decreased the reserved field by %v "+
+		log.Infof("cnsvolumeoperationrequestCRDeleted: Successfully decreased the reserved field by %v bytes "+
 			"for storagepolicyusage CR: %q", cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved.Value(),
 			patchedStoragePolicyUsageCR.Name)
 	}
@@ -1150,7 +1152,7 @@ func cnsvolumeoperationrequestCRUpdated(oldObj interface{}, newObj interface{}) 
 					log.Errorf("updateStoragePolicyUsage failed. err: %v", err)
 					return
 				}
-				log.Infof("cnsvolumeoperationrequestCRUpdated: Successfully increased the reserved field by %v "+
+				log.Infof("cnsvolumeoperationrequestCRUpdated: Successfully increased the reserved field by %v bytes "+
 					"for storagepolicyusage CR: %q", newcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved.Value(),
 					patchedStoragePolicyUsageCR.Name)
 			}
@@ -1172,11 +1174,11 @@ func cnsvolumeoperationrequestCRUpdated(oldObj interface{}, newObj interface{}) 
 					patchedStoragePolicyUsageCR.Name, patchedStoragePolicyUsageCR.Namespace, err)
 				return
 			}
-			log.Infof("cnsvolumeoperationrequestCRUpdated: Successfully decreased the reserved field by %v "+
+			log.Infof("cnsvolumeoperationrequestCRUpdated: Successfully decreased the reserved field by %v bytes "+
 				"for storagepolicyusage CR: %q in namespace: %q",
 				oldcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved.Value(), patchedStoragePolicyUsageCR.Name,
 				patchedStoragePolicyUsageCR.Namespace)
-			log.Infof("cnsvolumeoperationrequestCRUpdated: Successfully increased the used field by %v "+
+			log.Infof("cnsvolumeoperationrequestCRUpdated: Successfully increased the used field by %v bytes "+
 				"for storagepolicyusage CR: %q in namespace: %q",
 				oldcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved.Value(), patchedStoragePolicyUsageCR.Name,
 				patchedStoragePolicyUsageCR.Namespace)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update logging and comments for SPUsage CR informer after the recent changes to value/format section of "Reserved" & "Used"  fields.

PR also adds watch cnsvolumeoperation rbac rule


**Testing done**:
Before:
```
	Successfully increased the used field by 1888000000 for storagepolicyusage CR: "test-zonal-policy-pvc-usage" in namespace: "chethan-dev"
```
After:
```
	Successfully increased the used field by 1888000000 bytes for storagepolicyusage CR: "test-zonal-policy-pvc-usage" in namespace: "chethan-dev"
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update logging and comments for SPUsage CR informer
```
