### PR TITLE
Add resource version to patch in DeleteVolume and add logs

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -633,7 +633,7 @@ func DeleteVolumeUtil(ctx context.Context, volManager cnsvolume.Manager, volumeI
 		log.Errorf("failed to delete disk %s, deleteDisk flag: %t with error %+v", volumeID, deleteDisk, err)
 		return faultType, err
 	}
-	log.Debugf("Successfully deleted disk for volumeid: %s, deleteDisk flag: %t", volumeID, deleteDisk)
+	log.Infof("Successfully deleted disk for volumeid: %s, deleteDisk flag: %t", volumeID, deleteDisk)
 	return "", nil
 }
 

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1056,6 +1056,9 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 
 				// Patch the StoragePolicyUsage instance.
 				patch := map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"resourceVersion": storagePolicyUsageInstance.ResourceVersion,
+					},
 					"status": map[string]interface{}{
 						"quotaUsage": map[string]interface{}{
 							"used": newUsedVal,
@@ -1067,6 +1070,8 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 						"failed to create patch for StoragePolicyUsage instance. Error: %+v", err)
 				}
+				log.Debugf("Patching StoragePolicyUsage instance %q in namespace %q with used as %+v",
+					storagePolicyUsageInstance.Name, storagePolicyUsageInstance.Namespace, newUsedVal)
 				err = cnsOperatorClient.Patch(ctx, storagePolicyUsageInstance,
 					client.RawPatch(apitypes.MergePatchType, patchBytes))
 				if err != nil {
@@ -1075,6 +1080,8 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 							"volume %q. Error: %+v", storagePolicyUsageInstance.Name, storagePolicyUsageInstance.Namespace,
 						req.VolumeId, err)
 				}
+				log.Infof("Patched StoragePolicyUsage instance %q in namespace %q with used as %+v",
+					storagePolicyUsageInstance.Name, storagePolicyUsageInstance.Namespace, newUsedVal)
 
 				// Delete the CNSVolumeInfo instance for this volume.
 				err = volumeInfoService.DeleteVolumeInfo(ctx, req.VolumeId)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Concurrent delete operations do not seem to be patching the StoragePolicyUsage instance properly. Adding a resourceVersion to the merge patch to see if it resolves the issue.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
TBD

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add resource version to patch in DeleteVolume and add logs
```
