### PR TITLE
Changes to handle CnsSnapshotCreatedFault returned by CNS if snapshot creation is successful but post-processing failed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/golang/protobuf v1.5.3
-	github.com/google/uuid v1.3.1
+	github.com/google/uuid v1.4.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kubernetes-csi/csi-lib-utils v0.11.0
 	github.com/kubernetes-csi/csi-proxy/client v1.0.1
@@ -23,7 +23,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae
 	github.com/vmware-tanzu/vm-operator/api v1.8.2
-	github.com/vmware/govmomi v0.33.0
+	github.com/vmware/govmomi v0.34.2
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.17.0
 	golang.org/x/sync v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -358,8 +358,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
-github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
+github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.2.3 h1:yk9/cqRKtT9wXZSsRH9aurXEpJX+U6FLtpYTdC3R06k=
 github.com/googleapis/enterprise-certificate-proxy v0.2.3/go.mod h1:AwSRAtLfXpU5Nm3pW+v7rGDHp09LsPtGY9MduiEsR9k=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -638,8 +638,8 @@ github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae h1:
 github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20211202183846-992b48c128ae/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
 github.com/vmware-tanzu/vm-operator/api v1.8.2 h1:7cZHVusqAmAMFWvsiU7X5xontxdjasknI/sVfe0p0Z4=
 github.com/vmware-tanzu/vm-operator/api v1.8.2/go.mod h1:vauVboD3sQxP+pb28TnI9wfrj+0nH2zSEc9Q7AzWJ54=
-github.com/vmware/govmomi v0.33.0 h1:fCkDfgyNgAwmHAtEMgqlLIjBsSJqWPk0YYhuAdXBVrE=
-github.com/vmware/govmomi v0.33.0/go.mod h1:QuzWGiEMA/FYlu5JXKjytiORQoxv2hTHdS2lWnIqKMM=
+github.com/vmware/govmomi v0.34.2 h1:o6ydkTVITOkpQU6HAf6tP5GvHFCNJlNUNlMsvFK77X4=
+github.com/vmware/govmomi v0.34.2/go.mod h1:qWWT6n9mdCr/T9vySsoUqcI04sSEj4CqHXxtk/Y+Los=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -102,6 +102,17 @@ func IsVimFaultNotFoundError(err error) bool {
 	return isNotFoundError
 }
 
+// IsCnsSnapshotCreatedFaultError checks if err is the CnsSnapshotCreatedFault fault returned by
+// CNS CreateSnapshots API. This fault is returned by CNS in case snapshot creation is successful,
+// but post-processing failed (like update db failed).
+func IsCnsSnapshotCreatedFaultError(err error) bool {
+	isCnsSnapshotCreatedFaultError := false
+	if soap.IsVimFault(err) {
+		_, isCnsSnapshotCreatedFaultError = soap.ToVimFault(err).(cnstypes.CnsSnapshotCreatedFault)
+	}
+	return isCnsSnapshotCreatedFaultError
+}
+
 // IsCnsSnapshotNotFoundError checks if err is the CnsSnapshotNotFoundFault fault returned by CNS QuerySnapshots API
 func IsCnsSnapshotNotFoundError(err error) bool {
 	isCnsSnapshotNotFoundError := false

--- a/pkg/internalapis/cnsvolumeoperationrequest/util.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/util.go
@@ -33,6 +33,8 @@ const (
 	TaskInvocationStatusError = "Error"
 	// TaskInvocationStatusSuccess represents a task thats status is Success.
 	TaskInvocationStatusSuccess = "Success"
+	// TaskInvocationStatusPartiallyFailed represents a task thats status is PartiallyFailed.
+	TaskInvocationStatusPartiallyFailed = "PartiallyFailed"
 )
 
 // VolumeOperationRequestDetails stores details about a single operation

--- a/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1/cnsvolumeoperationrequest_types.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/v1alpha1/cnsvolumeoperationrequest_types.go
@@ -79,7 +79,7 @@ type OperationDetails struct {
 	// OpID stores the OpID for a task that was invoked on CNS for a volume.
 	OpID string `json:"opId,omitempty"`
 	// TaskStatus describes the current status of the task invoked on CNS.
-	// Valid strings are "In Progress", "Successful" and "Failed".
+	// Valid strings are "In Progress", "Successful", "PartiallyFailed" and "Failed".
 	TaskStatus string `json:"taskStatus,omitempty"`
 	// Error represents the error returned if the task fails on CNS.
 	// Defaults to empty string.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CNS returns CnsSnapshotCreatedFault when snapshot creation is successful, but post-processing failed (e.g. update db failed). CSI driver retries snapshot creation and if underlying problem persists, then it leads to creation of orphan snapshots. To prevent more orphaned snapshots from getting created when Kubernetes triggers retries for snapshot creation, we are using CnsVolumeOperationRequest to record that the snapshot is already created but post-processing failed, and therefore no need to call CNS again for the same request.

Changes overview:
- In CnsVolumeOperationRequest, added a new TaskStatus named "PatiallyFailed" to indicate a resource is created but post-processing failed.
- In CreateSnapshot, when the call to CNS create snapshot returns an error, checking if it is CnsSnapshotCreatedFault.
- If the error code is CnsSnapshotCreatedFault, set SnapshotID and set TaskStatus to PatiallyFailed in CnsVolumeOperationRequestStatus.
- If Kubernetes calls CreateSnapshot again during retries, CSI driver doesn't call CNS again by checking if SnapshotID is set and TaskStatus is PatiallyFailed. CSI driver returns an error message indicating that snapshot is already created but post-processing failed.

With these changes, we make sure that more orphan snapshots are not created in each retry.
User needs to manually delete orphan snapshot that gets created when CNS throws this fault.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran csi-block-vanilla-precheckin job. Failed TCs are not related to this fix.

```
Ran 1 of 809 Specs in 402.276 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 808 Skipped
PASS

Ran 14 of 809 Specs in 7782.521 seconds
FAIL! -- 8 Passed | 6 Failed | 0 Pending | 795 Skipped
--- FAIL: TestE2E (7782.65s)
```



Unit testing logs:
[Unit test logs CnsSnapshotCreatedFault.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/13752460/Unit.test.logs.CnsSnapshotCreatedFault.txt)


CnsSnapshotCreatedFault simulation:

Followed following steps to simulate the CnsSNapshotCreatedFault.
```
1. create a volume
2. set changeBlockTracking flag for this volume using mob UI
3. create snapshot s1
4. log in to esx host and remember s1's diskPath
5. create snapshot s2
6. delete the ctk file corresponding to s1 created from step 4
7. create snapshot s3, we should observe CnsSnapshotCreatedFault in cns
```

It will generate CnsSnapshotCreatedFault:
```
ERROR   volume/manager.go:2470  snapshot "snapshot-3064de21-2a47-42b6-8bde-8daecf38cc9b-8443eb58-c1b2-44af-b88c-90a5eb182f08" on volume "8443eb58-c1b2-44af-b88c-90a5eb182f08" got created, but post-processing failed. Fault: "(*types.LocalizedMethodFault)(0xc0009391e0)({\n DynamicData: (types.DynamicData) {\n },\n Fault: (types.CnsSnapshotCreatedFault) {\n  CnsFault: (types.CnsFault) {\n   BaseMethodFault: (types.BaseMethodFault) <nil>,\n   Reason: (string) (len=24) \"Snapshot already created\"\n  },\n  VolumeId: (types.CnsVolumeId) {\n   DynamicData: (types.DynamicData) {\n   },\n   Id: (string) (len=36) \"8443eb58-c1b2-44af-b88c-90a5eb182f08\"\n  },\n  SnapshotId: (types.CnsSnapshotId) {\n   DynamicData: (types.DynamicData) {\n   },\n   Id: (string) (len=36) \"\22af6013-ef75-4c6c-b25a-a9eed9b8a7d2"\n  },\n  Datastore: (types.ManagedObjectReference) Datastore:datastore-46\n },\n LocalizedMessage: (string) (len=141) \"Volume 8443eb58-c1b2-44af-b88c-90a5eb182f08 has created snapshot 22af6013-ef75-4c6c-b25a-a9eed9b8a7d2 on datastore vim.Datastore:datastore-46\"\n})\n", opID: "a4d9ac00"   {"TraceId": "de2799e2-e979-47fc-849c-6614d7a43c03"}
```

Once we get CnsSnapshotCreatedFault while creation of snapshot s3, CSI persists this task as PartiallyFailed. And in next attempt of snapshot creation, it will return appropriate error to user.

**Special notes for your reviewer**:

**Release note**:
```release-note
Changes to handle CnsSnapshotCreatedFault returned by CNS if snapshot creation is successful but post-processing failed
```
