### PR TITLE
Fix volumeinfo service initialization for WCP flavor

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -304,6 +304,14 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			}()
 		}
 		if isPodVMOnStretchSupervisorFSSEnabled {
+			log.Info("Loading CnsVolumeInfo Service to persist mapping for VolumeID to storage policy info")
+			volumeInfoService, err = cnsvolumeinfo.InitVolumeInfoService(ctx)
+			if err != nil {
+				return logger.LogNewErrorf(log, "error initializing volumeInfoService. Error: %+v", err)
+			}
+			if volumeInfoService != nil {
+				log.Infof("Successfully initialized VolumeInfoService")
+			}
 			k8sConfig, err := k8s.GetKubeConfig(ctx)
 			if err != nil {
 				return logger.LogNewErrorf(log, "failed to get kubeconfig with error: %v", err)
@@ -371,23 +379,11 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				volumeInfoCrDeletionMap[vcconfig.Host] = make(map[string]bool)
 				volumeOperationsLock[vcconfig.Host] = &sync.Mutex{}
 			}
-			if clusterFlavor == cnstypes.CnsClusterFlavorVanilla {
-				// If it is a multi VC deployment, initialize volumeInfoService
-				if len(vcconfigs) > 1 && volumeInfoService == nil {
-					volumeInfoService, err = cnsvolumeinfo.InitVolumeInfoService(ctx)
-					if err != nil {
-						return logger.LogNewErrorf(log, "error initializing volumeInfoService. Error: %+v", err)
-					}
-				}
-			} else if clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
-				isPodVMOnStretchSupervisorFSSEnabled {
-				log.Info("Loading CnsVolumeInfo Service to persist mapping for VolumeID to storage policy info")
+			// If it is a multi VC deployment, initialize volumeInfoService
+			if len(vcconfigs) > 1 && volumeInfoService == nil {
 				volumeInfoService, err = cnsvolumeinfo.InitVolumeInfoService(ctx)
 				if err != nil {
 					return logger.LogNewErrorf(log, "error initializing volumeInfoService. Error: %+v", err)
-				}
-				if volumeInfoService != nil {
-					log.Infof("Successfully initialized VolumeInfoService")
 				}
 			}
 			// Add informer on CSINodeTopology instances and update metadataSyncer.topologyVCMap parameter.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR moves the volumeinfo service initialization for WCP flavor to the appropriate code block. The current initVolumeInfoService invocation does not get executed due to the Multi-VC FSS check which is only present in Vanilla k8s Flavor code block.

**Testing done**:
```
2023-12-21T15:44:18.454Z	INFO	wcp/controller.go:229	Loading CnsVolumeInfo Service to persist mapping for VolumeID to storage policy info	{"TraceId": "821f3fab-3103-4f88-a0b4-72a04b815dad"}
...
...
2023-12-21T15:44:18.496Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:106	Starting Informer for cnsvolumeinfo	{"TraceId": "821f3fab-3103-4f88-a0b4-72a04b815dad"}
2023-12-21T15:44:18.496Z	INFO	kubernetes/dynamicInformers.go:70	Created new dynamic informer factory for "vmware-system-csi" namespace	{"TraceId": "821f3fab-3103-4f88-a0b4-72a04b815dad"}
2023-12-21T15:44:18.496Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:119	volumeInfo service initialized	{"TraceId": "821f3fab-3103-4f88-a0b4-72a04b815dad"}
2023-12-21T15:44:18.496Z	INFO	wcp/controller.go:234	Successfully initialized VolumeInfoService	{"TraceId": "821f3fab-3103-4f88-a0b4-72a04b815dad"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix volumeinfo service initialization for WCP flavor
```
