### PR TITLE
Update StoragePolicyUsage used capacity from Syncer's PV Delete informer event

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -2382,6 +2382,58 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 // Vanills k8s and supervisor cluster.
 func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *metadataSyncInformer) {
 	log := logger.GetLogger(ctx)
+	if isPodVMOnStretchSupervisorFSSEnabled {
+		volumeInfo, err := volumeInfoService.GetVolumeInfoForVolumeID(ctx, pv.Spec.CSI.VolumeHandle)
+		if err != nil {
+			log.Errorf("failed to fetch CnsVolumeInfo CR. Error: %+v", err)
+			return
+		}
+		restConfig, err := config.GetConfig()
+		if err != nil {
+			log.Errorf("failed to fetch kubernetes config. Error: %+v", err)
+			return
+		}
+		cnsOperatorClient, err := k8s.NewClientForGroup(ctx, restConfig, cnsoperatorv1alpha1.GroupName)
+		if err != nil {
+			log.Errorf("failed to create CNSOperator client. Error: %+v", err)
+			return
+		}
+
+		// Fetch StoragePolicyUsage instance for storageClass associated with the volume.
+		storagePolicyUsageInstanceName := volumeInfo.Spec.StorageClassName + "-" +
+			storagepolicyusagev1alpha1.NameSuffixForPVC
+		storagePolicyUsageCR := &storagepolicyusagev1alpha1.StoragePolicyUsage{}
+		err = cnsOperatorClient.Get(ctx, k8stypes.NamespacedName{
+			Namespace: volumeInfo.Spec.Namespace,
+			Name:      storagePolicyUsageInstanceName},
+			storagePolicyUsageCR)
+		if err != nil {
+			log.Errorf("failed to fetch %s instance with name %q from supervisor namespace %q. Error: %+v",
+				storagepolicyusagev1alpha1.CRDSingular, storagePolicyUsageInstanceName,
+				volumeInfo.Spec.Namespace, err)
+			return
+		}
+
+		// Decrease the used capacity in StoragePolicyUsage instance as we are deleting the volume.
+		patchedStoragePolicyUsageCR := storagePolicyUsageCR.DeepCopy()
+		patchedStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Used.Sub(*volumeInfo.Spec.Capacity)
+		err = PatchStoragePolicyUsage(ctx, cnsOperatorClient, storagePolicyUsageCR,
+			patchedStoragePolicyUsageCR)
+		if err != nil {
+			log.Errorf("updateStoragePolicyUsage failed. err: %v", err)
+			return
+		}
+		log.Infof("Successfully decreased the used capacity by %q Mb for StoragePolicyUsage: %q in namespace: %q",
+			volumeInfo.Spec.Capacity.ScaledValue(resource.Mega), storagePolicyUsageCR.Name, storagePolicyUsageCR.Namespace)
+	}
+	// Delete the CNSVolumeInfo instance for this volume.
+	if pv.Spec.CSI != nil && volumeInfoService != nil {
+		err := volumeInfoService.DeleteVolumeInfo(ctx, pv.Spec.CSI.VolumeHandle)
+		if err != nil {
+			log.Errorf("failed to delete cnsVolumeInfo CR for volume: %q. Error: %+v", pv.Spec.CSI.VolumeHandle, err)
+			return
+		}
+	}
 	if pv.Spec.ClaimRef != nil && pv.Status.Phase == v1.VolumeReleased &&
 		pv.Spec.PersistentVolumeReclaimPolicy == v1.PersistentVolumeReclaimDelete {
 		log.Debugf("PVDeleted: Volume deletion will be handled by Controller")

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -815,6 +815,8 @@ func getPatchData(oldObj, newObj interface{}) ([]byte, error) {
 	}
 	return patchBytes, nil
 }
+
+// PatchStoragePolicyUsage patches the StoragePolicyUsage CR based
 func PatchStoragePolicyUsage(ctx context.Context, cnsOperatorClient client.Client,
 	oldObj *storagepolicyusagev1alpha1.StoragePolicyUsage,
 	newObj *storagepolicyusagev1alpha1.StoragePolicyUsage) error {
@@ -841,6 +843,7 @@ func PatchStoragePolicyUsage(ctx context.Context, cnsOperatorClient client.Clien
 	return nil
 }
 
+// addResourceVersion sets the resource version for the patch obj
 func addResourceVersion(patchBytes []byte, resourceVersion string) ([]byte, error) {
 	var patchMap map[string]interface{}
 	err := json.Unmarshal(patchBytes, &patchMap)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Performing StoragePolicyUsage CR update in the CSI Driver does not bring down the used capacity to the correct value when concurrent DeleteVolumes are invoked. So, the PR is moving the CR update to Syncer's PVDeleted informer event and verified that the concurrent delete volume operations does bring down the used capacity.

See testing section below. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
kubectl get pvc -A
NAMESPACE     NAME                           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
chethan-dev   example-block-pvc-1            Bound    pvc-8c27bfd4-1af7-4df2-afb1-4e09fdc4a2b3   10Mi       RWO            test-zonal-policy   1m
...
...
chethan-dev   example-block-pvc-25            Bound    pvc-7913cccc-a2a1-4b13-9898-37c1b6c7a0fe   10Mi       RWO            test-zonal-policy   1m

kubectl get storagepolicyusage -n chethan-dev -o json 
            "spec": {
                "storageClassName": "test-zonal-policy",
                "storagePolicyId": "dff969da-17cb-4c77-9ada-58ff8c8d32fb"
            },
            "status": {
                "quotaUsage": {
                    "reserved": "0",
                    "used": "250Mi"
                }

kubectl delete pvc --all -n chethan-dev

kubectl get storagepolicyusage -n chethan-dev -o json 
            "spec": {
                "resourceApiGroup": "",
                "resourceExtensionName": "pvc-quota-webhook-extension",
                "resourceKind": "PersistentVolumeClaim",
                "storageClassName": "test-zonal-policy",
                "storagePolicyId": "dff969da-17cb-4c77-9ada-58ff8c8d32fb"
            },
            "status": {
                "quotaUsage": {
                    "reserved": "0",
                    "used": "0Mi"                 }
```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update StoragePolicyUsage used capacity from Syncer's PV Delete informer event
```
