### PR TITLE
Allow volume metadata cleanup of file volumes in multi vc deployments

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -2465,17 +2465,17 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 	if IsMultiAttachAllowed(pv) {
 		// If PV is file share volume.
 
-		// If it is a multi VC setup, then skip this volume as we do not support file share volumes
-		// on a multi VC deployment
-		if isMultiVCenterFssEnabled && len(metadataSyncer.configInfo.Cfg.VirtualCenter) > 1 {
+		// If TopologyAwareFileVolume FSS is false and it is a multi VC setup, then skip this volume
+		if isMultiVCenterFssEnabled && len(metadataSyncer.configInfo.Cfg.VirtualCenter) > 1 &&
+			!metadataSyncer.coCommonInterface.IsFSSEnabled(ctx,
+				common.TopologyAwareFileVolume) {
 			log.Debugf("PVDeleted: %q is a vSphere volume claim in namespace %q."+
 				"File share volumes are not supported in a multi VC setup."+
 				"Skipping deletion of PV metadata.", pv.Name, pv.Namespace)
 			return
 		}
 
-		// Setting volumeHandle as empty as there is only 1 VC so volumeID does not matter.
-		vcHost, cnsVolumeMgr, err := getVcHostAndVolumeManagerForVolumeID(ctx, metadataSyncer, "")
+		vcHost, cnsVolumeMgr, err := getVcHostAndVolumeManagerForVolumeID(ctx, metadataSyncer, pv.Spec.CSI.VolumeHandle)
 		if err != nil {
 			log.Errorf("PVDeleted: Failed to get VC host and volume manager for single VC setup. "+
 				"Error occoured: %+v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Allows volume metadata cleanup of file volumes in multi vc deployments. In the current workflow of PVDeleted() method, there is a check which skips volumemetadata cleanup for RWM volumes on multi-vc. This needs to be handled using a FSS check and the PR is addressing the same

**Testing done**:
Not needed as it is trivial

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Allow volume metadata cleanup of file volumes in multi vc deployments
```
