### PR TITLE
Skip CnsVolumeOperationRequest CR added event that are received during container restart

### DIFF
--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -833,8 +833,8 @@ func PatchStoragePolicyUsage(ctx context.Context, cnsOperatorClient client.Clien
 	}
 	rawPatch := client.RawPatch(apitypes.MergePatchType, patch)
 	err = cnsOperatorClient.Patch(ctx, oldObj, rawPatch)
-	log.Infof("Patching the StoragePolicyUsageCR %q on namespace: %q with the data: %+v",
-		oldObj.Name, oldObj.Namespace, rawPatch)
+	log.Debugf("Patching the StoragePolicyUsageCR %q on namespace: %q with the quota usage data: %+v",
+		oldObj.Name, oldObj.Namespace, newObj.Status.ResourceTypeLevelQuotaUsage)
 	if err != nil {
 		log.Errorf("failed to patch StoragePolicyUsage instance: %q on namespace: %q. Error: %+v",
 			oldObj.Name, oldObj.Namespace, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR ensures we skip CnsVolumeOperationRequest CR added event that are received during container restart

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Had 4 PVCs in the WCP cluster:
```
kubectl get pvc -A
NAMESPACE              NAME            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                       AGE
storage-class-test-2   wcp-profile     Bound    pvc-7ae33f27-94e0-4d31-add4-68c538006d09   1Gi        RWO            test-storage-class-update-policy   2d22h
storage-policy-test    example-pvc-2   Bound    pvc-f9e9bc65-6974-4586-b1ee-ccc61ee95b9d   110Mi      RWO            wcp-profile-wkaoxja3iq             36m
storage-policy-test    example-pvc-3   Bound    pvc-884d22b5-a49e-4b7e-8e6d-8b6319625987   110Mi      RWO            wcp-profile-wkaoxja3iq             36m
storage-policy-test    example-pvc-4   Bound    pvc-7fb83868-7d05-4a9b-ab30-4f00c79caf59   110Mi      RWO            wcp-profile-wkaoxja3iq             36m
root@4216522683360f78652aa4c30ece5339 [ ~ ]# kubectl get cnsvolumeoperationrequests.cns.vmware.com -n vmware-system-csi
NAME                                       AGE
pvc-7ae33f27-94e0-4d31-add4-68c538006d09   2d22h
pvc-7fb83868-7d05-4a9b-ab30-4f00c79caf59   36m
pvc-884d22b5-a49e-4b7e-8e6d-8b6319625987   36m
pvc-f9e9bc65-6974-4586-b1ee-ccc61ee95b9d   36m
```

restarted the driver and verified the below logs:
```
2023-12-29T07:38:24.506Z	INFO	syncer/metadatasyncer.go:894	cnsvolumeoperationrequestCRAdded: Received a cnsvolumeoperationrequest CR added event for "pvc-7ae33f27-94e0-4d31-add4-68c538006d09", with the reserved capacity as zero(0). Skipping the informer event	{"TraceId": "2fbef7db-7e95-4381-b3aa-3c52735bea15"}
2023-12-29T07:38:24.508Z	INFO	syncer/metadatasyncer.go:894	cnsvolumeoperationrequestCRAdded: Received a cnsvolumeoperationrequest CR added event for "pvc-7fb83868-7d05-4a9b-ab30-4f00c79caf59", with the reserved capacity as zero(0). Skipping the informer event	{"TraceId": "97a4874f-d47e-4821-a49d-77f78a87820d"}
2023-12-29T07:38:24.508Z	INFO	syncer/metadatasyncer.go:894	cnsvolumeoperationrequestCRAdded: Received a cnsvolumeoperationrequest CR added event for "pvc-884d22b5-a49e-4b7e-8e6d-8b6319625987", with the reserved capacity as zero(0). Skipping the informer event	{"TraceId": "8b2ed7f4-6db0-4572-bb61-a364b56d1444"}
2023-12-29T07:38:24.508Z	INFO	syncer/metadatasyncer.go:894	cnsvolumeoperationrequestCRAdded: Received a cnsvolumeoperationrequest CR added event for "pvc-f9e9bc65-6974-4586-b1ee-ccc61ee95b9d", with the reserved capacity as zero(0). Skipping the informer event	{"TraceId": "d26eacd7-3261-4b12-8bad-131bc17a1385"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Skip CnsVolumeOperationRequest CR added event that are received during container restart
```
