### PR TITLE
Revert "Set owner reference for CNSVolumeInfo objects in PV informer …

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -633,7 +633,7 @@ func DeleteVolumeUtil(ctx context.Context, volManager cnsvolume.Manager, volumeI
 		log.Errorf("failed to delete disk %s, deleteDisk flag: %t with error %+v", volumeID, deleteDisk, err)
 		return faultType, err
 	}
-	log.Infof("Successfully deleted disk for volumeid: %s, deleteDisk flag: %t", volumeID, deleteDisk)
+	log.Debugf("Successfully deleted disk for volumeid: %s, deleteDisk flag: %t", volumeID, deleteDisk)
 	return "", nil
 }
 

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -18,7 +18,6 @@ package syncer
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -92,15 +91,16 @@ var (
 	nodeMgr node.Manager
 	// isPodVMOnStretchSupervisorFSSEnabled is true when PodVMOnStretchedSupervisor FSS is enabled.
 	isPodVMOnStretchSupervisorFSSEnabled bool
+
+	// For core API resource ResourceAPIGroup will be set to "". PVC is part of the core API resources
+	// and ResourceAPIgroupPVC is set to "".
+	ResourceAPIgroupPVC = ""
 )
 
 const (
 	ResourceKindPVC           = "PersistentVolumeClaim"
 	QuotaExtensionServiceName = "volume.cns.vsphere.vmware.com"
 	scParamStoragePolicyID    = "storagePolicyID"
-	// ResourceAPIgroupPVC is the API group PVCs belong to. PVC is part of the core API resources
-	// which are denoted as "".
-	ResourceAPIgroupPVC = ""
 )
 
 // newInformer returns uninitialized metadataSyncInformer.
@@ -510,9 +510,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 	}
 	err = metadataSyncer.k8sInformerManager.AddPVListener(
 		ctx,
-		func(obj interface{}) { // Add.
-			pvAdded(obj, metadataSyncer)
-		},
+		nil, // Add.
 		func(oldObj interface{}, newObj interface{}) { // Update.
 			pvUpdated(oldObj, newObj, metadataSyncer)
 		},
@@ -1721,73 +1719,6 @@ func pvcDeleted(obj interface{}, metadataSyncer *metadataSyncInformer) {
 	}
 }
 
-func pvAdded(obj interface{}, metadataSyncer *metadataSyncInformer) {
-	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload && isPodVMOnStretchSupervisorFSSEnabled {
-		ctx, log := logger.GetNewContextWithLogger()
-		// Add owner reference of PV to its corresponding CNSVolumeInfo instance, if it doesn't exist.
-		pv, ok := obj.(*v1.PersistentVolume)
-		if pv == nil || !ok {
-			log.Warnf("pvAdded: unrecognized object %+v", obj)
-			return
-		}
-		log.Debugf("pvAdded: PV object %+v", pv)
-		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != csitypes.Name {
-			log.Infof("PV %q is not a vSphere CSI volume. Skipping pvAdded functionality.", pv.Name)
-			return
-		}
-		if pv.Status.Phase != v1.VolumeBound {
-			log.Infof("PV %q not bound yet. Skipping to update owner reference "+
-				"on the corresponding CNSVolumeInfo object.", pv.Name)
-			return
-		}
-		err := setOwnerRefForCNSVolumeInfo(ctx, pv)
-		if err != nil {
-			log.Errorf("failed to set owner reference of PV %q on CNSVolumeInfo object %q. Error: %+v",
-				pv.Name, pv.Spec.CSI.VolumeHandle, err)
-			return
-		}
-	}
-}
-
-func setOwnerRefForCNSVolumeInfo(ctx context.Context, pv *v1.PersistentVolume) error {
-	log := logger.GetLogger(ctx)
-	volumeInfoObj, err := volumeInfoService.GetVolumeInfoForVolumeID(ctx, pv.Spec.CSI.VolumeHandle)
-	if err != nil {
-		return logger.LogNewErrorf(log, "failed to fetch CNSVolumeInfo object for volumeID: %q",
-			pv.Spec.CSI.VolumeHandle)
-	}
-	if len(volumeInfoObj.OwnerReferences) > 0 {
-		log.Infof("Owner reference already set for CNSVolumeInfo object %+v", volumeInfoObj)
-		return nil
-	}
-	patch := map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"ownerReferences": []map[string]interface{}{
-				{
-					"apiVersion": "v1",
-					"kind":       "PersistentVolume",
-					"name":       pv.Name,
-					"uid":        pv.UID,
-				},
-			},
-		},
-	}
-	log.Infof("Patching CNSVolumeInfo object %q with patch %+v", pv.Spec.CSI.VolumeHandle, patch)
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return logger.LogNewErrorf(log, "failed to create patch with owner reference of PV %q "+
-			"for CNSVolumeInfo object %q. Error: %+v", pv.Name, pv.Spec.CSI.VolumeHandle, err)
-	}
-	err = volumeInfoService.PatchVolumeInfo(ctx, pv.Spec.CSI.VolumeHandle, patchBytes)
-	if err != nil {
-		return logger.LogNewErrorf(log, "failed to patch CNSVolumeInfo object %q with owner "+
-			"reference of PV %q. Error: %+v", pv.Spec.CSI.VolumeHandle, pv.Name, err)
-	}
-	log.Infof("Successfully patched owner reference of PV %q on CNSVolumeInfo object %q",
-		pv.Name, pv.Spec.CSI.VolumeHandle)
-	return nil
-}
-
 // pvUpdated updates volume metadata on VC when volume labels on K8S cluster
 // have been updated.
 func pvUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer) {
@@ -1858,16 +1789,6 @@ func pvUpdated(oldObj, newObj interface{}, metadataSyncer *metadataSyncInformer)
 			log.Debugf("PVUpdated: PV is not a vSphere CSI Volume: %+v", newPv)
 			return
 		}
-		if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload && isPodVMOnStretchSupervisorFSSEnabled {
-			if newPv.Status.Phase == v1.VolumeBound {
-				err := setOwnerRefForCNSVolumeInfo(ctx, newPv)
-				if err != nil {
-					log.Errorf("failed to set owner reference of PV %q on CNSVolumeInfo object %q. Error: %+v",
-						newPv.Name, newPv.Spec.CSI.VolumeHandle, err)
-				}
-			}
-		}
-
 		// Return if labels are unchanged.
 		if (oldPv.Status.Phase == v1.VolumeAvailable || oldPv.Status.Phase == v1.VolumeBound) &&
 			reflect.DeepEqual(newPv.GetLabels(), oldPv.GetLabels()) {
@@ -2350,7 +2271,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 					log.Errorf("PVUpdated: Failed to get VC host and volume manager. "+
 						"Error occurred: %+v", err)
 
-					// Could not find vcHost mapping, attempt to create the volume on all VCs util successful
+					// Could not find vcHost mapping, attempt to create the volume on all VCs utill successful
 					vcHost, _, err = createVolumeOnMultiVc(ctx, oldPv, metadataSyncer,
 						volumeType, metadataList, volumeHandle)
 					if err == nil {
@@ -2503,6 +2424,14 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 		log.Infof("Successfully decreased the used capacity by %q Mb for StoragePolicyUsage: %q in namespace: %q",
 			volumeInfo.Spec.Capacity.ScaledValue(resource.Mega), storagePolicyUsageCR.Name, storagePolicyUsageCR.Namespace)
 	}
+	// Delete the CNSVolumeInfo instance for this volume.
+	if pv.Spec.CSI != nil && volumeInfoService != nil {
+		err := volumeInfoService.DeleteVolumeInfo(ctx, pv.Spec.CSI.VolumeHandle)
+		if err != nil {
+			log.Errorf("failed to delete cnsVolumeInfo CR for volume: %q. Error: %+v", pv.Spec.CSI.VolumeHandle, err)
+			return
+		}
+	}
 	if pv.Spec.ClaimRef != nil && pv.Status.Phase == v1.VolumeReleased &&
 		pv.Spec.PersistentVolumeReclaimPolicy == v1.PersistentVolumeReclaimDelete {
 		log.Debugf("PVDeleted: Volume deletion will be handled by Controller")
@@ -2648,6 +2577,14 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 					log.Errorf("failed to remove CNSVolumeInfo CR for volumeID %q. Error: %+v",
 						volumeHandle, err)
 				}
+			}
+		} else if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+			isPodVMOnStretchSupervisorFSSEnabled {
+			// Delete CNSVolumeInfo CR for the volume ID.
+			err = volumeInfoService.DeleteVolumeInfo(ctx, volumeHandle)
+			if err != nil {
+				log.Errorf("failed to remove CNSVolumeInfo CR for volumeID %q. Error: %+v",
+					volumeHandle, err)
 			}
 		}
 	}


### PR DESCRIPTION
…events (#2724)"

This reverts commit 4d898171971e56e44cf535172ba5cf9c4342145c.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
See comment here:
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2724#issuecomment-1868779202

We set owner reference on CNSVolumeInfo so that it will be deleted automatically when PV is deleted, but it turns out that that CNSVolumeInfo gets deleted too soon sometimes. As a result, we can't always retrieve information from it to update quota info when a PV is being deleted.

This revert also brought back the change that deletes CNSVolumeInfo after the syncer has done updating quota info when a PV is being deleted in csiPVDeleted().

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested concurrent create and delete. Note: Before starting the test, there was 806Mi in "used" from previous testing.
```
# kubectl get storagepolicyusage -n test-podvm-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2023-12-24T20:48:24Z"
    generation: 177
    name: zonal-policy-pvc-usage
    namespace: test-podvm-ns
    resourceVersion: "1114016"
    uid: b618bf42-fb51-4e79-8581-d374ea0053b6
  spec:
    resourceApiGroup: ""
    resourceExtensionName: volume.cns.vsphere.vmware.com
    resourceKind: PersistentVolumeClaim
    storageClassName: zonal-policy
    storagePolicyId: e6051d6c-4f32-4f7e-a753-f2d7d7902510
  status:
    quotaUsage:
      reserved: "0"
      used: 806Mi
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2023-12-24T20:48:24Z"
    generation: 1
    name: zonal-policy-wffc-pvc-usage
    namespace: test-podvm-ns
    resourceVersion: "197000"
    uid: 4ebd497c-71cf-466e-b04c-ccb33033dab3
  spec:
    resourceApiGroup: ""
    resourceExtensionName: volume.cns.vsphere.vmware.com
    resourceKind: PersistentVolumeClaim
    storageClassName: zonal-policy-wffc
    storagePolicyId: e6051d6c-4f32-4f7e-a753-f2d7d7902510
  status: {}
kind: List
metadata:
  resourceVersion: ""

# kubectl get storagepolicyquota -n test-podvm-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyQuota
  metadata:
    creationTimestamp: "2023-12-24T20:48:24Z"
    generation: 3
    name: zonal-policy-storagepolicyquota
    namespace: test-podvm-ns
    resourceVersion: "1114019"
    uid: 7c92d9f4-4996-4b0b-b6ac-473bd3b0bc9a
  spec:
    limit: 3Gi
    storagePolicyId: e6051d6c-4f32-4f7e-a753-f2d7d7902510
  status:
    extensions:
    - extensionName: volume.cns.vsphere.vmware.com
      extensionQuotaUsage:
      - scQuotaUsage:
          reserved: "0"
          used: 806Mi
        storageClassName: zonal-policy
    - extensionName: volume.cns.vsphere.vmware.com
      extensionQuotaUsage:
      - scQuotaUsage:
          reserved: "0"
          used: "0"
        storageClassName: zonal-policy-wffc
    total:
    - scQuotaUsage:
        reserved: "0"
        used: 806Mi
      storageClassName: zonal-policy
    - scQuotaUsage:
        reserved: "0"
        used: "0"
      storageClassName: zonal-policy-wffc
kind: List
metadata:
  resourceVersion: ""

# kubectl get storagequota -n test-podvm-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StorageQuota
  metadata:
    creationTimestamp: "2023-12-24T20:49:52Z"
    generation: 2
    name: total-quota
    namespace: test-podvm-ns
    resourceVersion: "1114020"
    uid: 5993da58-c931-4593-a351-fcfca06f933c
  spec:
    limit: 3Gi
  status:
    total:
    - policyQuotaUsage:
        reserved: "0"
        used: 806Mi
      storagePolicyId: e6051d6c-4f32-4f7e-a753-f2d7d7902510
kind: List
metadata:
  resourceVersion: ""

```

Created 10 PVCs of 100Mi each and observed that StoragePolicyUsage, StoragePolicyQuota, and StorageQuota CR statuses got updated properly. CNSVolumeInfo objects got created as well.
```
# kubectl create -f multiple-pvcs.yaml
persistentvolumeclaim/pvc1 created
persistentvolumeclaim/pvc2 created
persistentvolumeclaim/pvc3 created
persistentvolumeclaim/pvc4 created
persistentvolumeclaim/pvc5 created
persistentvolumeclaim/pvc6 created
persistentvolumeclaim/pvc7 created
persistentvolumeclaim/pvc8 created
persistentvolumeclaim/pvc9 created
persistentvolumeclaim/pvc10 created

# kubectl get pvc -n test-podvm-ns
NAME    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pvc1    Bound    pvc-284a10c8-8621-41eb-8359-fba8e537ffb0   100Mi      RWO            zonal-policy   12s
pvc10   Bound    pvc-73d7d0e1-12a7-48cd-be1c-c9355db5872e   100Mi      RWO            zonal-policy   11s
pvc2    Bound    pvc-6e2a591b-4ba9-4dc3-bca9-1e0c3663e082   100Mi      RWO            zonal-policy   11s
pvc3    Bound    pvc-a74c76d1-7aad-46ef-94ca-128896811838   100Mi      RWO            zonal-policy   11s
pvc4    Bound    pvc-1ca27f2c-f9d2-49f5-819a-890f1b1dad2a   100Mi      RWO            zonal-policy   11s
pvc5    Bound    pvc-27bc8dbc-9c10-4d72-a9bd-eda9efaf9026   100Mi      RWO            zonal-policy   11s
pvc6    Bound    pvc-9d5594bc-2ff0-404c-a332-758613f01098   100Mi      RWO            zonal-policy   11s
pvc7    Bound    pvc-d3a9dce9-d92b-429c-b35b-c5e7e905f159   100Mi      RWO            zonal-policy   11s
pvc8    Bound    pvc-9d6ccf08-2397-4775-b8c8-d1379466b7c9   100Mi      RWO            zonal-policy   11s
pvc9    Bound    pvc-e8cf3363-f6df-4371-b80b-04c3f30a0fb7   100Mi      RWO            zonal-policy   11s

# kubectl get cnsvolumeinfo -n vmware-system-csi -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CNSVolumeInfo
  metadata:
    creationTimestamp: "2023-12-25T20:54:15Z"
    generation: 1
    name: 14a88ea8-47b4-411b-b4fa-628f2f9138b5
    namespace: vmware-system-csi
    resourceVersion: "1226778"
    uid: 16443487-2846-402a-8b31-54fb7ff63771
  spec:
    capacity: 100Mi
    namespace: test-podvm-ns
    storageClassName: zonal-policy
    storagePolicyID: e6051d6c-4f32-4f7e-a753-f2d7d7902510
    vCenterServer: sc1-10-168-191-199.nimbus.eng.vmware.com
    volumeID: 14a88ea8-47b4-411b-b4fa-628f2f9138b5
- apiVersion: cns.vmware.com/v1alpha1
  kind: CNSVolumeInfo
  metadata:
    creationTimestamp: "2023-12-25T20:54:14Z"
    generation: 1
    name: 2d020b7b-9fa1-4131-b151-645929b8c6fb
    namespace: vmware-system-csi
    resourceVersion: "1226734"
    uid: ec91e9ae-a717-4c38-b23d-0218cfd5a40b
  spec:
    capacity: 100Mi
    namespace: test-podvm-ns
    storageClassName: zonal-policy
    storagePolicyID: e6051d6c-4f32-4f7e-a753-f2d7d7902510
    vCenterServer: sc1-10-168-191-199.nimbus.eng.vmware.com
    volumeID: 2d020b7b-9fa1-4131-b151-645929b8c6fb
- apiVersion: cns.vmware.com/v1alpha1
  kind: CNSVolumeInfo
  metadata:
    creationTimestamp: "2023-12-25T20:54:14Z"
    generation: 1
    name: 42b17ca1-7ad0-49b1-8b83-5f71f7ed4086
    namespace: vmware-system-csi
    resourceVersion: "1226740"
    uid: 854b6645-b020-489b-a0e1-d9dd1fed15b7
  spec:
    capacity: 100Mi
    namespace: test-podvm-ns
    storageClassName: zonal-policy
    storagePolicyID: e6051d6c-4f32-4f7e-a753-f2d7d7902510
    vCenterServer: sc1-10-168-191-199.nimbus.eng.vmware.com
    volumeID: 42b17ca1-7ad0-49b1-8b83-5f71f7ed4086
- apiVersion: cns.vmware.com/v1alpha1
  kind: CNSVolumeInfo
  metadata:
    creationTimestamp: "2023-12-25T20:54:15Z"
    generation: 1
    name: 7f84e988-f6fd-4403-8d23-3a86d2bf7bdd
    namespace: vmware-system-csi
    resourceVersion: "1226781"
    uid: a9e58e68-1af6-4a34-bd07-51bad863b1cf
  spec:
    capacity: 100Mi
    namespace: test-podvm-ns
    storageClassName: zonal-policy
    storagePolicyID: e6051d6c-4f32-4f7e-a753-f2d7d7902510
    vCenterServer: sc1-10-168-191-199.nimbus.eng.vmware.com
    volumeID: 7f84e988-f6fd-4403-8d23-3a86d2bf7bdd
- apiVersion: cns.vmware.com/v1alpha1
  kind: CNSVolumeInfo
  metadata:
    creationTimestamp: "2023-12-25T20:54:14Z"
    generation: 1
    name: 9c8b604b-bc53-4979-b148-c3c4bbb4f7ea
    namespace: vmware-system-csi
    resourceVersion: "1226742"
    uid: 9c1ca12e-0856-451f-a95b-a8aef30b3355
  spec:
    capacity: 100Mi
    namespace: test-podvm-ns
    storageClassName: zonal-policy
    storagePolicyID: e6051d6c-4f32-4f7e-a753-f2d7d7902510
    vCenterServer: sc1-10-168-191-199.nimbus.eng.vmware.com
    volumeID: 9c8b604b-bc53-4979-b148-c3c4bbb4f7ea
- apiVersion: cns.vmware.com/v1alpha1
  kind: CNSVolumeInfo
  metadata:
    creationTimestamp: "2023-12-25T20:54:14Z"
    generation: 1
    name: b130a8e9-95af-4be2-b2ac-c334bad4e4c8
    namespace: vmware-system-csi
    resourceVersion: "1226696"
    uid: 3dd8f667-c38e-40d9-abca-5d139d1189d2
  spec:
    capacity: 100Mi
    namespace: test-podvm-ns
    storageClassName: zonal-policy
    storagePolicyID: e6051d6c-4f32-4f7e-a753-f2d7d7902510
    vCenterServer: sc1-10-168-191-199.nimbus.eng.vmware.com
    volumeID: b130a8e9-95af-4be2-b2ac-c334bad4e4c8
- apiVersion: cns.vmware.com/v1alpha1
  kind: CNSVolumeInfo
  metadata:
    creationTimestamp: "2023-12-25T20:54:14Z"
    generation: 1
    name: badf147a-c062-423d-adb4-4fa15151184e
    namespace: vmware-system-csi
    resourceVersion: "1226750"
    uid: 6d1178dc-e32c-4aca-a430-2b7bab3e9b4c
  spec:
    capacity: 100Mi
    namespace: test-podvm-ns
    storageClassName: zonal-policy
    storagePolicyID: e6051d6c-4f32-4f7e-a753-f2d7d7902510
    vCenterServer: sc1-10-168-191-199.nimbus.eng.vmware.com
    volumeID: badf147a-c062-423d-adb4-4fa15151184e
- apiVersion: cns.vmware.com/v1alpha1
  kind: CNSVolumeInfo
  metadata:
    creationTimestamp: "2023-12-25T20:54:15Z"
    generation: 1
    name: c8c208d7-7f55-4295-94ab-4fc2e78f73f3
    namespace: vmware-system-csi
    resourceVersion: "1226794"
    uid: 4f2471a4-af47-41e4-adc6-92a1a6f14dcc
  spec:
    capacity: 100Mi
    namespace: test-podvm-ns
    storageClassName: zonal-policy
    storagePolicyID: e6051d6c-4f32-4f7e-a753-f2d7d7902510
    vCenterServer: sc1-10-168-191-199.nimbus.eng.vmware.com
    volumeID: c8c208d7-7f55-4295-94ab-4fc2e78f73f3
- apiVersion: cns.vmware.com/v1alpha1
  kind: CNSVolumeInfo
  metadata:
    creationTimestamp: "2023-12-25T20:54:14Z"
    generation: 1
    name: d9af125c-a7d6-4115-a557-22a06d223e4b
    namespace: vmware-system-csi
    resourceVersion: "1226715"
    uid: e2e1c8be-ebae-44f3-9120-e523247185f8
  spec:
    capacity: 100Mi
    namespace: test-podvm-ns
    storageClassName: zonal-policy
    storagePolicyID: e6051d6c-4f32-4f7e-a753-f2d7d7902510
    vCenterServer: sc1-10-168-191-199.nimbus.eng.vmware.com
    volumeID: d9af125c-a7d6-4115-a557-22a06d223e4b
- apiVersion: cns.vmware.com/v1alpha1
  kind: CNSVolumeInfo
  metadata:
    creationTimestamp: "2023-12-25T20:54:14Z"
    generation: 1
    name: dca6b9e8-db89-4929-b0e2-3bd018b7040c
    namespace: vmware-system-csi
    resourceVersion: "1226758"
    uid: bd080913-1f8c-4261-939a-9bd47520cb8d
  spec:
    capacity: 100Mi
    namespace: test-podvm-ns
    storageClassName: zonal-policy
    storagePolicyID: e6051d6c-4f32-4f7e-a753-f2d7d7902510
    vCenterServer: sc1-10-168-191-199.nimbus.eng.vmware.com
    volumeID: dca6b9e8-db89-4929-b0e2-3bd018b7040c
kind: List
metadata:
  resourceVersion: ""

# kubectl get StoragePolicyUsage -n test-podvm-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2023-12-24T20:48:24Z"
    generation: 230
    name: zonal-policy-pvc-usage
    namespace: test-podvm-ns
    resourceVersion: "1226787"
    uid: b618bf42-fb51-4e79-8581-d374ea0053b6
  spec:
    resourceApiGroup: ""
    resourceExtensionName: volume.cns.vsphere.vmware.com
    resourceKind: PersistentVolumeClaim
    storageClassName: zonal-policy
    storagePolicyId: e6051d6c-4f32-4f7e-a753-f2d7d7902510
  status:
    quotaUsage:
      reserved: "0"
      used: 1806Mi
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2023-12-24T20:48:24Z"
    generation: 1
    name: zonal-policy-wffc-pvc-usage
    namespace: test-podvm-ns
    resourceVersion: "197000"
    uid: 4ebd497c-71cf-466e-b04c-ccb33033dab3
  spec:
    resourceApiGroup: ""
    resourceExtensionName: volume.cns.vsphere.vmware.com
    resourceKind: PersistentVolumeClaim
    storageClassName: zonal-policy-wffc
    storagePolicyId: e6051d6c-4f32-4f7e-a753-f2d7d7902510
  status: {}
kind: List
metadata:
  resourceVersion: ""

# kubectl get StoragePolicyQuota -n test-podvm-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyQuota
  metadata:
    creationTimestamp: "2023-12-24T20:48:24Z"
    generation: 3
    name: zonal-policy-storagepolicyquota
    namespace: test-podvm-ns
    resourceVersion: "1226789"
    uid: 7c92d9f4-4996-4b0b-b6ac-473bd3b0bc9a
  spec:
    limit: 3Gi
    storagePolicyId: e6051d6c-4f32-4f7e-a753-f2d7d7902510
  status:
    extensions:
    - extensionName: volume.cns.vsphere.vmware.com
      extensionQuotaUsage:
      - scQuotaUsage:
          reserved: "0"
          used: 1806Mi
        storageClassName: zonal-policy
    - extensionName: volume.cns.vsphere.vmware.com
      extensionQuotaUsage:
      - scQuotaUsage:
          reserved: "0"
          used: "0"
        storageClassName: zonal-policy-wffc
    total:
    - scQuotaUsage:
        reserved: "0"
        used: 1806Mi
      storageClassName: zonal-policy
    - scQuotaUsage:
        reserved: "0"
        used: "0"
      storageClassName: zonal-policy-wffc
kind: List
metadata:
  resourceVersion: ""

# kubectl get StorageQuota -n test-podvm-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StorageQuota
  metadata:
    creationTimestamp: "2023-12-24T20:49:52Z"
    generation: 2
    name: total-quota
    namespace: test-podvm-ns
    resourceVersion: "1226791"
    uid: 5993da58-c931-4593-a351-fcfca06f933c
  spec:
    limit: 3Gi
  status:
    total:
    - policyQuotaUsage:
        reserved: "0"
        used: 1806Mi
      storagePolicyId: e6051d6c-4f32-4f7e-a753-f2d7d7902510
kind: List
metadata:
  resourceVersion: ""
```

Deleted all PVCs and observed quota CR statuses got updated properly. CNSVolumeInfo objects got deleted as well.
```
# kubectl delete -f multiple-pvcs.yaml
persistentvolumeclaim "pvc1" deleted
persistentvolumeclaim "pvc2" deleted
persistentvolumeclaim "pvc3" deleted
persistentvolumeclaim "pvc4" deleted
persistentvolumeclaim "pvc5" deleted
persistentvolumeclaim "pvc6" deleted
persistentvolumeclaim "pvc7" deleted
persistentvolumeclaim "pvc8" deleted
persistentvolumeclaim "pvc9" deleted
persistentvolumeclaim "pvc10" deleted

# kubectl get pv
No resources found

# kubectl get pvc -n test-podvm-ns
No resources found in test-podvm-ns namespace.

# kubectl get StoragePolicyUsage -n test-podvm-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2023-12-24T20:48:24Z"
    generation: 240
    name: zonal-policy-pvc-usage
    namespace: test-podvm-ns
    resourceVersion: "1229922"
    uid: b618bf42-fb51-4e79-8581-d374ea0053b6
  spec:
    resourceApiGroup: ""
    resourceExtensionName: volume.cns.vsphere.vmware.com
    resourceKind: PersistentVolumeClaim
    storageClassName: zonal-policy
    storagePolicyId: e6051d6c-4f32-4f7e-a753-f2d7d7902510
  status:
    quotaUsage:
      reserved: "0"
      used: 806Mi
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2023-12-24T20:48:24Z"
    generation: 1
    name: zonal-policy-wffc-pvc-usage
    namespace: test-podvm-ns
    resourceVersion: "197000"
    uid: 4ebd497c-71cf-466e-b04c-ccb33033dab3
  spec:
    resourceApiGroup: ""
    resourceExtensionName: volume.cns.vsphere.vmware.com
    resourceKind: PersistentVolumeClaim
    storageClassName: zonal-policy-wffc
    storagePolicyId: e6051d6c-4f32-4f7e-a753-f2d7d7902510
  status: {}
kind: List
metadata:
  resourceVersion: ""

# kubectl get StoragePolicyQuota -n test-podvm-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyQuota
  metadata:
    creationTimestamp: "2023-12-24T20:48:24Z"
    generation: 3
    name: zonal-policy-storagepolicyquota
    namespace: test-podvm-ns
    resourceVersion: "1229925"
    uid: 7c92d9f4-4996-4b0b-b6ac-473bd3b0bc9a
  spec:
    limit: 3Gi
    storagePolicyId: e6051d6c-4f32-4f7e-a753-f2d7d7902510
  status:
    extensions:
    - extensionName: volume.cns.vsphere.vmware.com
      extensionQuotaUsage:
      - scQuotaUsage:
          reserved: "0"
          used: 806Mi
        storageClassName: zonal-policy
    - extensionName: volume.cns.vsphere.vmware.com
      extensionQuotaUsage:
      - scQuotaUsage:
          reserved: "0"
          used: "0"
        storageClassName: zonal-policy-wffc
    total:
    - scQuotaUsage:
        reserved: "0"
        used: 806Mi
      storageClassName: zonal-policy
    - scQuotaUsage:
        reserved: "0"
        used: "0"
      storageClassName: zonal-policy-wffc
kind: List
metadata:
  resourceVersion: ""

# kubectl get StorageQuota -n test-podvm-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StorageQuota
  metadata:
    creationTimestamp: "2023-12-24T20:49:52Z"
    generation: 2
    name: total-quota
    namespace: test-podvm-ns
    resourceVersion: "1229927"
    uid: 5993da58-c931-4593-a351-fcfca06f933c
  spec:
    limit: 3Gi
  status:
    total:
    - policyQuotaUsage:
        reserved: "0"
        used: 806Mi
      storagePolicyId: e6051d6c-4f32-4f7e-a753-f2d7d7902510
kind: List
metadata:
  resourceVersion: ""

# kubectl get cnsvolumeinfo -n vmware-system-csi
No resources found in vmware-system-csi namespace.
```

**Special notes for your reviewer**:
TODO: Full sync should make sure CNSVolumeInfo is deleted if PV is already deleted.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove owner reference from CNSVolumeInfo objects.
```
