### PR TITLE
Multi VC - Do not error out when list of candidate datastores is zero. Check other VCs also.

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1867,8 +1867,9 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 						}
 					}
 					if len(compatibleDatastores) == 0 {
-						return nil, csifault.CSIInternalFault, logger.LogNewErrorf(log, "No compatible datastores found "+
-							"for storage policy %q", scParams.StoragePolicyName)
+						log.Errorf("No compatible datastores found for storage policy %q on VC %s",
+							scParams.StoragePolicyName, vcHost)
+						continue
 					}
 					fsEnabledCandidateDatastores = compatibleDatastores
 				}
@@ -1879,8 +1880,9 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 
 				if len(fsEnabledCandidateDatastores) == 0 {
 					// when len(filteredDatastore)==0, it means vsan file service is not enabled on any vsan cluster
-					return nil, csifault.CSIVSanFileServiceDisabledFault, logger.LogNewErrorCode(log, codes.FailedPrecondition,
-						"no datastores found to create file volume, vsan file service may be disabled")
+					log.Errorf("No datastores found to create file volume on VC %s, vsan file service may be disabled",
+						vcHost)
+					continue
 				}
 				var vc *cnsvsphere.VirtualCenter
 				if !multivCenterTopologyDeployment {

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -2817,8 +2817,11 @@ func (c *controller) processQueryResultsListVolumes(ctx context.Context, startin
 			// If this is multi-VC configuration, then
 			// skip processing query results for file volumes
 			if multivCenterCSITopologyEnabled && len(c.managers.VcenterConfigs) > 1 {
-				log.Debugf("Skipping processing for file volume %v in multi-VC configuration", cnsVolumes[i].Name)
-				continue
+				isTopologyAwareFileVolumeEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TopologyAwareFileVolume)
+				if !isTopologyAwareFileVolumeEnabled {
+					log.Debugf("Skipping processing for file volume %v in multi-VC configuration", cnsVolumes[i].Name)
+					continue
+				}
 			}
 
 			volumeType = prometheus.PrometheusFileVolumeType

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -2819,7 +2819,8 @@ func (c *controller) processQueryResultsListVolumes(ctx context.Context, startin
 			// If this is multi-VC configuration, then
 			// skip processing query results for file volumes
 			if multivCenterCSITopologyEnabled && len(c.managers.VcenterConfigs) > 1 {
-				isTopologyAwareFileVolumeEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TopologyAwareFileVolume)
+				isTopologyAwareFileVolumeEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+					common.TopologyAwareFileVolume)
 				if !isTopologyAwareFileVolumeEnabled {
 					log.Debugf("Skipping processing for file volume %v in multi-VC configuration", cnsVolumes[i].Name)
 					continue


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Right now we are erroring out when list of datastores is empty for a given VC. We should instead move onto the next VC.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
