### PR TITLE
fix RWM volume creation when topology-aware-file-volume fss is disabled

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1933,9 +1933,11 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 					vcTopologySegmentsMap)
 			}
 		}
+		// When FSS for topology-aware-file-volume is disabled and topologyRequirement is nil, below code is invoked
 		filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 		var fsEnabledClusterToDsInfoMap map[string][]*cnsvsphere.DatastoreInfo
 		if multivCenterCSITopologyEnabled {
+			vcHost = c.managers.CnsConfig.Global.VCenterIP
 			fsEnabledClusterToDsInfoMap = c.authMgrs[vcHost].GetFsEnabledClusterToDsMap(ctx)
 		} else {
 			fsEnabledClusterToDsInfoMap = c.authMgr.GetFsEnabledClusterToDsMap(ctx)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix RWM volume creation when topology-aware-file-volume fss is disabled

without this fix, RWM volume creation on single vCenter deployment with topology-aware-file-volume fss is disabled is not working. 

Volume Creations is failing with Panic

```
2023-12-28T17:35:22.218Z	DEBUG	vanilla/controller.go:1633	CreateVolume task details for file volume pvc-506a0fd1-cd55-4868-9789-43e107a9ff21 are not found.	{"TraceId": "94244149-89a1-4c55-98f0-9ef0d643f670"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1b4bd71]

goroutine 337 [running]:
sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common.(*AuthManager).GetFsEnabledClusterToDsMap(0x0, {0xc00034a120?, 0x0?})
 /build/pkg/csi/service/common/authmanager.go:137 +0x51
sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/vanilla.(*controller).createFileVolume(0xc000604000, {0x284e088?, 0xc000947440}, 0xc000616080)
 /build/pkg/csi/service/vanilla/controller.go:1939 +0x1748
sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/vanilla.(*controller).CreateVolume.func1()
 /build/pkg/csi/service/vanilla/controller.go:2058 +0x368
sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/vanilla.(*controller).CreateVolume(0xc000604000, {0x284e088, 0xc000946180}, 0xc000616080)
 /build/pkg/csi/service/vanilla/controller.go:2068 +0x1b4
github.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler({0x24345e0?, 0xc000604000}, {0x284e088, 0xc000946180}, 0xc000616000, 0x0)
 /go/pkg/mod/github.com/container-storage-interface/[spec@v1.9.0](mailto:spec@v1.9.0)/lib/go/csi/csi.pb.go:6580 +0x169
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0002d6000, {0x284e088, 0xc0009160c0}, {0x28554c0, 0xc000981520}, 0xc00003c5a0, 0xc000992930, 0x3b89620, 0x0)
 /go/pkg/mod/google.golang.org/[grpc@v1.59.0](mailto:grpc@v1.59.0)/server.go:1343 +0xe03
google.golang.org/grpc.(*Server).handleStream(0xc0002d6000, {0x28554c0, 0xc000981520}, 0xc00003c5a0)
 /go/pkg/mod/google.golang.org/[grpc@v1.59.0](mailto:grpc@v1.59.0)/server.go:1737 +0xc4c
google.golang.org/grpc.(*Server).serveStreams.func1.1()
 /go/pkg/mod/google.golang.org/[grpc@v1.59.0](mailto:grpc@v1.59.0)/server.go:986 +0x86
created by google.golang.org/grpc.(*Server).serveStreams.func1 in goroutine 328
 /go/pkg/mod/google.golang.org/[grpc@v1.59.0](mailto:grpc@v1.59.0)/server.go:997 +0x145
```

**Testing done**:
Verified RWM Creation with topology-aware-file-volume FSS disabled

```
2023-12-28T19:04:42.088Z	INFO	vanilla/controller.go:2007	CreateVolume: called with args {Name:pvc-506a0fd1-cd55-4868-9789-43e107a9ff21 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[storagepolicyname:vSAN Default Storage Policy] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.089Z	DEBUG	vsphere/utils.go:493	Checking if vCenter version is of vsan 67u3 release	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.089Z	DEBUG	vsphere/utils.go:499	vCenter version is :"8.0.0.3"	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.089Z	DEBUG	vanilla/controller.go:1600	Checking if vCenter task for file volume pvc-506a0fd1-cd55-4868-9789-43e107a9ff21 is already registered.	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.089Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:151	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-506a0fd1-cd55-4868-9789-43e107a9ff21	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.154Z	DEBUG	vanilla/controller.go:1633	CreateVolume task details for file volume pvc-506a0fd1-cd55-4868-9789-43e107a9ff21 are not found.	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.158Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.160Z	DEBUG	config/config.go:372	Initializing vc server 10.185.233.121	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.162Z	DEBUG	config/config.go:417	vc server 10.185.233.121 config: &{User:Administrator@vsphere.local Password:GSUP4gXvh-_Vx2as VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.162Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.310Z	INFO	vsphere/utils.go:553	Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-105, datastore URL: ds:///vmfs/volumes/vsan:522bcbde1c0b4b5f-8f5c4e308ff83cc3/]	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.311Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.311Z	DEBUG	config/config.go:372	Initializing vc server 10.185.233.121	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.311Z	DEBUG	config/config.go:417	vc server 10.185.233.121 config: &{User:Administrator@vsphere.local Password:GSUP4gXvh-_Vx2as VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.311Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.375Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.376Z	DEBUG	config/config.go:372	Initializing vc server 10.185.233.121	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.376Z	DEBUG	config/config.go:417	vc server 10.185.233.121 config: &{User:Administrator@vsphere.local Password:GSUP4gXvh-_Vx2as VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.376Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.390Z	DEBUG	volume/util.go:204	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:42.390Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:151	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-506a0fd1-cd55-4868-9789-43e107a9ff21	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:44.643Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:243	Created CnsVolumeOperationRequest instance vmware-system-csi/pvc-506a0fd1-cd55-4868-9789-43e107a9ff21 with latest information for task with ID: task-644	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:44.643Z	INFO	volume/listview.go:124	AddTask called for Task:task-644	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:44.655Z	DEBUG	volume/listview.go:129	connection to vc successful	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:44.657Z	DEBUG	volume/listview.go:137	task Task:task-644 added to map	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:04:44.665Z	INFO	volume/listview.go:159	task Task:task-644 added to listView	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:05:03.868Z	DEBUG	volume/listview.go:172	connection to vc successful	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:05:03.873Z	INFO	volume/listview.go:178	task Task:task-644 removed from listView	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:05:03.873Z	DEBUG	volume/listview.go:180	task Task:task-644 removed from map	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:05:03.873Z	INFO	volume/manager.go:439	CreateVolume: VolumeName: "pvc-506a0fd1-cd55-4868-9789-43e107a9ff21", opId: "6f1d31c1"	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:05:03.874Z	DEBUG	volume/util.go:308	volumeCreateResult.PlacementResults :[{Datastore:datastore-105 []}]	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:05:03.882Z	INFO	volume/util.go:329	Volume created successfully. VolumeName: "pvc-506a0fd1-cd55-4868-9789-43e107a9ff21", volumeID: "file:05ce7b0c-7576-4535-a126-a11e1bba4e9b"	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:05:03.882Z	DEBUG	volume/util.go:331	CreateVolume volumeId {{} "file:05ce7b0c-7576-4535-a126-a11e1bba4e9b"} is placed on datastore "ds:///vmfs/volumes/vsan:522bcbde1c0b4b5f-8f5c4e308ff83cc3/"	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:05:03.942Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:319	Updated CnsVolumeOperationRequest instance vmware-system-csi/pvc-506a0fd1-cd55-4868-9789-43e107a9ff21 with latest information for task with ID: task-644	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:05:03.942Z	DEBUG	volume/manager.go:869	internalCreateVolume: returns fault ""	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:05:03.943Z	DEBUG	vanilla/controller.go:2071	createVolumeInternal: returns fault ""	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}
2023-12-28T19:05:03.943Z	INFO	vanilla/controller.go:2082	Volume created successfully. Volume Handle: "file:05ce7b0c-7576-4535-a126-a11e1bba4e9b", PV Name: "pvc-506a0fd1-cd55-4868-9789-43e107a9ff21"	{"TraceId": "055494f6-3112-4d29-b246-de5a6ca68d7b"}

```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix RWM volume creation when topology-aware-file-volume fss is disabled
```
