### PR TITLE
Create storagePolicyUsage CR for Pending PVCs

### DIFF
--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -92,6 +92,29 @@ func getBoundPVs(ctx context.Context, metadataSyncer *metadataSyncInformer) ([]*
 	return boundPVs, nil
 }
 
+// getPVCsInPendingState is a helper function for fetching PVCs not in Bound state.
+func getPVCsInPendingState(ctx context.Context, metadataSyncer *metadataSyncInformer) ([]*v1.PersistentVolumeClaim,
+	error) {
+	log := logger.GetLogger(ctx)
+	var pendingPVCs []*v1.PersistentVolumeClaim
+	// Get all PVCs from kubernetes.
+	allPVCs, err := metadataSyncer.pvcLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	for _, pvc := range allPVCs {
+		if pvc.ObjectMeta.Annotations[common.AnnStorageProvisioner] == csitypes.Name {
+			log.Debugf("getPVCsInPendingState: pvc %s in namespace %s is in state %v",
+				pvc.Name, pvc.Namespace, pvc.Status.Phase)
+			if pvc.Status.Phase == v1.ClaimPending {
+				pendingPVCs = append(pendingPVCs, pvc)
+			}
+		}
+	}
+	log.Infof("getPVCsInPendingState: pendingPVCs %v", pendingPVCs)
+	return pendingPVCs, nil
+}
+
 // fullSyncGetInlineMigratedVolumesInfo is a helper function for retrieving
 // inline PV information from Pods.
 func fullSyncGetInlineMigratedVolumesInfo(ctx context.Context,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Create storagePolicyUsage CR for Pending PVCs

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-7 in namespace storage-policy-test is in state Pending
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-raw-block-pvc-2 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-3 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-5 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-10 in namespace storage-policy-test is in state Pending
2024-01-03T20:08:27.613Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-11 in namespace storage-policy-test is in state Pending
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-11 in namespace storage-policy-test is in state Pending
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-8 in namespace storage-policy-test is in state Pending
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-9 in namespace storage-policy-test is in state Pending
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-4 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-6 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-raw-block-pvc-1 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-12 in namespace storage-policy-test is in state Pending
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-2 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-3 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-5 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-10 in namespace storage-policy-test is in state Pending
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-9 in namespace storage-policy-test is in state Pending
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-8 in namespace storage-policy-test is in state Pending
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-2 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-4 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-6 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-raw-block-pvc-1 in namespace storage-policy-test is in state Bound
2024-01-03T20:08:27.614Z	DEBUG	syncer/util.go:107	getPVCsInPendingState: pvc example-pvc-12 in namespace storage-policy-test is in state Pending
2024-01-03T20:08:27.614Z	INFO	syncer/util.go:114	getPVCsInPendingState: pendingPVCs [&PersistentVolumeClaim{ObjectMeta:{example-pvc-7  storage-policy-test  1a34d3b2-5461-41e0-99dc-f6fa0f0bffb8 8046366 0 2024-01-03 20:08:00 +0000 UTC <nil> <nil> map[] map[volume.beta.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com volume.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com] [] [kubernetes.io/pvc-protection] [{kube-controller-manager Update v1 2024-01-03 20:08:00 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{".":{},"f:volume.beta.kubernetes.io/storage-provisioner":{},"f:volume.kubernetes.io/storage-provisioner":{}}}} } {kubectl-create Update v1 2024-01-03 20:08:00 +0000 UTC FieldsV1 {"f:spec":{"f:accessModes":{},"f:resources":{"f:requests":{".":{},"f:storage":{}}},"f:storageClassName":{},"f:volumeMode":{}}} }]},Spec:PersistentVolumeClaimSpec{AccessModes:[ReadWriteOnce],Resources:ResourceRequirements{Limits:ResourceList{},Requests:ResourceList{storage: {{115343360 0} {<nil>} 110Mi BinarySI},},Claims:[]ResourceClaim{},},VolumeName:,Selector:nil,StorageClassName:*wcp-profile-wkaoxja3iq,VolumeMode:*Filesystem,DataSource:nil,DataSourceRef:nil,},Status:PersistentVolumeClaimStatus{Phase:Pending,AccessModes:[],Capacity:ResourceList{},Conditions:[]PersistentVolumeClaimCondition{},AllocatedResources:ResourceList{},ResizeStatus:nil,},} &PersistentVolumeClaim{ObjectMeta:{example-pvc-10  storage-policy-test  45de3531-6ddc-47ce-a130-1750446bc46f 8046408 0 2024-01-03 20:08:02 +0000 UTC <nil> <nil> map[] map[volume.beta.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com volume.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com] [] [kubernetes.io/pvc-protection] [{kube-controller-manager Update v1 2024-01-03 20:08:02 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{".":{},"f:volume.beta.kubernetes.io/storage-provisioner":{},"f:volume.kubernetes.io/storage-provisioner":{}}}} } {kubectl-create Update v1 2024-01-03 20:08:02 +0000 UTC FieldsV1 {"f:spec":{"f:accessModes":{},"f:resources":{"f:requests":{".":{},"f:storage":{}}},"f:storageClassName":{},"f:volumeMode":{}}} }]},Spec:PersistentVolumeClaimSpec{AccessModes:[ReadWriteOnce],Resources:ResourceRequirements{Limits:ResourceList{},Requests:ResourceList{storage: {{115343360 0} {<nil>} 110Mi BinarySI},},Claims:[]ResourceClaim{},},VolumeName:,Selector:nil,StorageClassName:*wcp-profile-wkaoxja3iq,VolumeMode:*Filesystem,DataSource:nil,DataSourceRef:nil,},Status:PersistentVolumeClaimStatus{Phase:Pending,AccessModes:[],Capacity:ResourceList{},Conditions:[]PersistentVolumeClaimCondition{},AllocatedResources:ResourceList{},ResizeStatus:nil,},} &PersistentVolumeClaim{ObjectMeta:{example-pvc-11  storage-policy-test  db3c510a-52d9-42c5-a8a1-d0bb8f5bb5e9 8046420 0 2024-01-03 20:08:03 +0000 UTC <nil> <nil> map[] map[volume.beta.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com volume.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com] [] [kubernetes.io/pvc-protection] [{kube-controller-manager Update v1 2024-01-03 20:08:03 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{".":{},"f:volume.beta.kubernetes.io/storage-provisioner":{},"f:volume.kubernetes.io/storage-provisioner":{}}}} } {kubectl-create Update v1 2024-01-03 20:08:03 +0000 UTC FieldsV1 {"f:spec":{"f:accessModes":{},"f:resources":{"f:requests":{".":{},"f:storage":{}}},"f:storageClassName":{},"f:volumeMode":{}}} }]},Spec:PersistentVolumeClaimSpec{AccessModes:[ReadWriteOnce],Resources:ResourceRequirements{Limits:ResourceList{},Requests:ResourceList{storage: {{115343360 0} {<nil>} 110Mi BinarySI},},Claims:[]ResourceClaim{},},VolumeName:,Selector:nil,StorageClassName:*wcp-profile-wkaoxja3iq,VolumeMode:*Filesystem,DataSource:nil,DataSourceRef:nil,},Status:PersistentVolumeClaimStatus{Phase:Pending,AccessModes:[],Capacity:ResourceList{},Conditions:[]PersistentVolumeClaimCondition{},AllocatedResources:ResourceList{},ResizeStatus:nil,},} &PersistentVolumeClaim{ObjectMeta:{example-pvc-8  storage-policy-test  c5c23ab1-7e61-4674-b3e8-4b2a96262a3c 8046379 0 2024-01-03 20:08:01 +0000 UTC <nil> <nil> map[] map[volume.beta.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com volume.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com] [] [kubernetes.io/pvc-protection] [{kube-controller-manager Update v1 2024-01-03 20:08:01 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{".":{},"f:volume.beta.kubernetes.io/storage-provisioner":{},"f:volume.kubernetes.io/storage-provisioner":{}}}} } {kubectl-create Update v1 2024-01-03 20:08:01 +0000 UTC FieldsV1 {"f:spec":{"f:accessModes":{},"f:resources":{"f:requests":{".":{},"f:storage":{}}},"f:storageClassName":{},"f:volumeMode":{}}} }]},Spec:PersistentVolumeClaimSpec{AccessModes:[ReadWriteOnce],Resources:ResourceRequirements{Limits:ResourceList{},Requests:ResourceList{storage: {{115343360 0} {<nil>} 110Mi BinarySI},},Claims:[]ResourceClaim{},},VolumeName:,Selector:nil,StorageClassName:*wcp-profile-wkaoxja3iq,VolumeMode:*Filesystem,DataSource:nil,DataSourceRef:nil,},Status:PersistentVolumeClaimStatus{Phase:Pending,AccessModes:[],Capacity:ResourceList{},Conditions:[]PersistentVolumeClaimCondition{},AllocatedResources:ResourceList{},ResizeStatus:nil,},} &PersistentVolumeClaim{ObjectMeta:{example-pvc-9  storage-policy-test  bb3a4c74-0ee9-495e-8378-6539ed6e80be 8046391 0 2024-01-03 20:08:02 +0000 UTC <nil> <nil> map[] map[volume.beta.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com volume.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com] [] [kubernetes.io/pvc-protection] [{kube-controller-manager Update v1 2024-01-03 20:08:02 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{".":{},"f:volume.beta.kubernetes.io/storage-provisioner":{},"f:volume.kubernetes.io/storage-provisioner":{}}}} } {kubectl-create Update v1 2024-01-03 20:08:02 +0000 UTC FieldsV1 {"f:spec":{"f:accessModes":{},"f:resources":{"f:requests":{".":{},"f:storage":{}}},"f:storageClassName":{},"f:volumeMode":{}}} }]},Spec:PersistentVolumeClaimSpec{AccessModes:[ReadWriteOnce],Resources:ResourceRequirements{Limits:ResourceList{},Requests:ResourceList{storage: {{115343360 0} {<nil>} 110Mi BinarySI},},Claims:[]ResourceClaim{},},VolumeName:,Selector:nil,StorageClassName:*wcp-profile-wkaoxja3iq,VolumeMode:*Filesystem,DataSource:nil,DataSourceRef:nil,},Status:PersistentVolumeClaimStatus{Phase:Pending,AccessModes:[],Capacity:ResourceList{},Conditions:[]PersistentVolumeClaimCondition{},AllocatedResources:ResourceList{},ResizeStatus:nil,},} &PersistentVolumeClaim{ObjectMeta:{example-pvc-12  storage-policy-test  660f925e-3c8f-49f8-9249-851a73e55100 8046429 0 2024-01-03 20:08:04 +0000 UTC <nil> <nil> map[] map[volume.beta.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com volume.kubernetes.io/storage-provisioner:csi.vsphere.vmware.com] [] [kubernetes.io/pvc-protection] [{kube-controller-manager Update v1 2024-01-03 20:08:04 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{".":{},"f:volume.beta.kubernetes.io/storage-provisioner":{},"f:volume.kubernetes.io/storage-provisioner":{}}}} } {kubectl-create Update v1 2024-01-03 20:08:04 +0000 UTC FieldsV1 {"f:spec":{"f:accessModes":{},"f:resources":{"f:requests":{".":{},"f:storage":{}}},"f:storageClassName":{},"f:volumeMode":{}}} }]},Spec:PersistentVolumeClaimSpec{AccessModes:[ReadWriteOnce],Resources:ResourceRequirements{Limits:ResourceList{},Requests:ResourceList{storage: {{115343360 0} {<nil>} 110Mi BinarySI},},Claims:[]ResourceClaim{},},VolumeName:,Selector:nil,StorageClassName:*wcp-profile-wkaoxja3iq,VolumeMode:*Filesystem,DataSource:nil,DataSourceRef:nil,},Status:PersistentVolumeClaimStatus{Phase:Pending,AccessModes:[],Capacity:ResourceList{},Conditions:[]PersistentVolumeClaimCondition{},AllocatedResources:ResourceList{},ResizeStatus:nil,},}]
2024-01-03T20:08:27.705Z	INFO	syncer/metadatasyncer.go:3043	storagePolicyUsageCRSync: Successfully created the storagePolicyUsage CR "wcp-profile-wkaoxja3iq-pvc-usage" in namespace "storage-policy-test"
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Create storagePolicyUsage CR for Pending PVCs
```
