### PR TITLE
Webhook certs patch 1

### DIFF
--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -197,10 +197,13 @@ deploy_validation_webhook() {
 	DNS.3 = ${service}.${namespace}.svc
 EOF
 
-	openssl req -nodes -new -x509 -keyout "${tmpdir}"/ca.key -out "${tmpdir}"/ca.crt -subj "/CN=vSphere CSI Admission Controller Webhook CA"
+	# Default webhook server and ca certificate validity
+	validity=180
+ 
+	openssl req -nodes -new -x509 -keyout "${tmpdir}"/ca.key -days ${validity} -out "${tmpdir}"/ca.crt -subj "/CN=vSphere CSI Admission Controller Webhook CA"
 	openssl genrsa -out "${tmpdir}"/webhook-server-tls.key 2048
 	openssl req -new -key "${tmpdir}"/webhook-server-tls.key -subj "/CN=${service}.${namespace}.svc" -config "${tmpdir}"/server.conf \
-	| openssl x509 -req -CA "${tmpdir}"/ca.crt -CAkey "${tmpdir}"/ca.key -days 180 -CAcreateserial -out "${tmpdir}"/webhook-server-tls.crt -extensions v3_req -extfile "${tmpdir}"/server.conf
+	| openssl x509 -req -CA "${tmpdir}"/ca.crt -CAkey "${tmpdir}"/ca.key -days $((${validity}-1)) -CAcreateserial -out "${tmpdir}"/webhook-server-tls.crt -extensions v3_req -extfile "${tmpdir}"/server.conf
 	cat <<EOF >"${tmpdir}"/webhook.config
 	[WebHookConfig]
 	port = "8443"

--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -203,7 +203,7 @@ EOF
 	openssl req -nodes -new -x509 -keyout "${tmpdir}"/ca.key -days ${validity} -out "${tmpdir}"/ca.crt -subj "/CN=vSphere CSI Admission Controller Webhook CA"
 	openssl genrsa -out "${tmpdir}"/webhook-server-tls.key 2048
 	openssl req -new -key "${tmpdir}"/webhook-server-tls.key -subj "/CN=${service}.${namespace}.svc" -config "${tmpdir}"/server.conf \
-	| openssl x509 -req -CA "${tmpdir}"/ca.crt -CAkey "${tmpdir}"/ca.key -days $((${validity}-1)) -CAcreateserial -out "${tmpdir}"/webhook-server-tls.crt -extensions v3_req -extfile "${tmpdir}"/server.conf
+	| openssl x509 -req -CA "${tmpdir}"/ca.crt -CAkey "${tmpdir}"/ca.key -days $((validity-1)) -CAcreateserial -out "${tmpdir}"/webhook-server-tls.crt -extensions v3_req -extfile "${tmpdir}"/server.conf
 	cat <<EOF >"${tmpdir}"/webhook.config
 	[WebHookConfig]
 	port = "8443"

--- a/manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh
+++ b/manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh
@@ -84,7 +84,7 @@ validity=180
 openssl req -nodes -new -x509 -keyout "${tmpdir}"/ca.key -days ${validity} -out "${tmpdir}"/ca.crt -subj "/CN=vSphere CSI Admission Controller Webhook CA"
 openssl genrsa -out "${tmpdir}"/webhook-server-tls.key 2048
 openssl req -new -key "${tmpdir}"/webhook-server-tls.key -subj "/CN=${service}.${namespace}.svc" -config "${tmpdir}"/server.conf \
-  | openssl x509 -req -CA "${tmpdir}"/ca.crt -CAkey "${tmpdir}"/ca.key -days $((${validity}-1)) -CAcreateserial -out "${tmpdir}"/webhook-server-tls.crt -extensions v3_req -extfile "${tmpdir}"/server.conf
+  | openssl x509 -req -CA "${tmpdir}"/ca.crt -CAkey "${tmpdir}"/ca.key -days $((validity-1)) -CAcreateserial -out "${tmpdir}"/webhook-server-tls.crt -extensions v3_req -extfile "${tmpdir}"/server.conf
 
 cat <<eof >"${tmpdir}"/webhook.config
 [WebHookConfig]

--- a/manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh
+++ b/manifests/vanilla/deploy-vsphere-csi-validation-webhook.sh
@@ -77,11 +77,14 @@ DNS.2 = ${service}.${namespace}
 DNS.3 = ${service}.${namespace}.svc
 EOF
 
+# Default webhook server and ca certificate validity
+validity=180
+
 # Generate the CA cert and private key
-openssl req -nodes -new -x509 -keyout "${tmpdir}"/ca.key -out "${tmpdir}"/ca.crt -subj "/CN=vSphere CSI Admission Controller Webhook CA"
+openssl req -nodes -new -x509 -keyout "${tmpdir}"/ca.key -days ${validity} -out "${tmpdir}"/ca.crt -subj "/CN=vSphere CSI Admission Controller Webhook CA"
 openssl genrsa -out "${tmpdir}"/webhook-server-tls.key 2048
 openssl req -new -key "${tmpdir}"/webhook-server-tls.key -subj "/CN=${service}.${namespace}.svc" -config "${tmpdir}"/server.conf \
-  | openssl x509 -req -CA "${tmpdir}"/ca.crt -CAkey "${tmpdir}"/ca.key -days 180 -CAcreateserial -out "${tmpdir}"/webhook-server-tls.crt -extensions v3_req -extfile "${tmpdir}"/server.conf
+  | openssl x509 -req -CA "${tmpdir}"/ca.crt -CAkey "${tmpdir}"/ca.key -days $((${validity}-1)) -CAcreateserial -out "${tmpdir}"/webhook-server-tls.crt -extensions v3_req -extfile "${tmpdir}"/server.conf
 
 cat <<eof >"${tmpdir}"/webhook.config
 [WebHookConfig]


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2514/commits/636dc7307f1b21d82125547c65462466d4a52b50 unfortunately only did half the job. This is a extension to that pull to actually fix the problem with the very short lived default webhook certificate.

**Testing done**:
Verified certificate validity after re-deploying webhook with updated script.

**Special notes for your reviewer**:
This is only a workaround for the existing issue with the current openssl / bash script approach. Obviously this hole approach is unreliable and certificate management should be outsourced to certmanager instead. 
