### PR TITLE
Add PV validation to webhook

### DIFF
--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -33,6 +33,10 @@ webhooks:
         resources:   ["storageclasses"]
       - apiGroups:   [""]
         apiVersions: ["v1", "v1beta1"]
+        operations:  ["CREATE"]
+        resources:   ["persistentvolumes"]
+      - apiGroups:   [""]
+        apiVersions: ["v1", "v1beta1"]
         operations:  ["UPDATE", "DELETE"]
         resources:   ["persistentvolumeclaims"]
         scope: "Namespaced"

--- a/pkg/syncer/admissionhandler/validatepv.go
+++ b/pkg/syncer/admissionhandler/validatepv.go
@@ -1,0 +1,85 @@
+package admissionhandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+)
+
+const (
+	// FileVolumeWithNodeAffinityError conveys the message that a file volume cannot have node affinity rules on it.
+	FileVolumeWithNodeAffinityError = "Invalid configuration. File volumes cannot have node affinity rules"
+)
+
+func validatePv(ctx context.Context, req *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+
+	log := logger.GetLogger(ctx)
+
+	if !featureGateTopologyAwareFileVolumeEnabled {
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
+	var (
+		allowed bool
+		result  *metav1.Status
+	)
+
+	switch req.Kind.Kind {
+	case "PersistentVolume":
+		pv := corev1.PersistentVolume{}
+		log.Debugf("JSON req.Object.Raw: %v", string(req.Object.Raw))
+		if err := json.Unmarshal(req.Object.Raw, &pv); err != nil {
+			log.Errorf("error deserializing PV: %v. skipping validation.", err)
+			allowed = false
+			result = &metav1.Status{
+				Message: fmt.Sprintf("Failed to serialize PV: %+V", err),
+			}
+			break
+		}
+
+		if !isFileVolume(pv.Spec.AccessModes) {
+			log.Debugf("Not a file volume. Skipping validation.")
+			allowed = true
+			break
+		}
+
+		allowed = true
+		if pv.Spec.NodeAffinity != nil {
+			allowed = false
+			result = &metav1.Status{
+				Message: FileVolumeWithNodeAffinityError,
+			}
+		}
+
+	default:
+		allowed = false
+		result = &metav1.Status{
+			Message: fmt.Sprintf("Can't validate resource kind: %q using validatePv function", req.Kind.Kind),
+		}
+		log.Errorf("Can't validate resource kind: %q using validatePv function", req.Kind.Kind)
+	}
+
+	// return AdmissionResponse result
+	return &admissionv1.AdmissionResponse{
+		Allowed: allowed,
+		Result:  result,
+	}
+
+}
+
+func isFileVolume(accessModes []corev1.PersistentVolumeAccessMode) bool {
+	for _, accessMode := range accessModes {
+		if accessMode == corev1.ReadWriteMany || accessMode == corev1.ReadOnlyMany {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Validate PV creation by making sure in RWX volumes, nodeAffinity rules are not provided.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
tested the following scenarios:

1. Dynamic file volume provisioning with FSS disabled - SUCCESS
2. Static file volume provisioning with no nodeaffinity rules - SUUCESS
3. Static file volume provisioning with nodeaffinity rules - failed

```
root@k8s-control-581-1704272376:~# kubectl apply -f staticpv.yaml 
Error from server: error when creating "staticpv.yaml": admission webhook "validation.csi.vsphere.vmware.com" denied the request: Invalid configuration. File volumes cannot have node affinity rules.


2024-01-04T07:44:42.915Z	DEBUG	admissionhandler/admissionhandler.go:282	admissionResponse: &AdmissionResponse{UID:,Allowed:false,Result:&v1.Status{ListMeta:ListMeta{SelfLink:,ResourceVersion:,Continue:,RemainingItemCount:nil,},Status:,Message:Invalid configuration. File volumes cannot have node affinity rules.,Reason:,Details:nil,Code:0,},Patch:nil,PatchType:nil,AuditAnnotations:map[string]string{},Warnings:[],}	{"TraceId": "9ddfc315-0878-471a-b38c-9dc27adb1ace"}
2024-01-04T07:44:42.915Z	DEBUG	admissionhandler/admissionhandler.go:299	Ready to write response	{"TraceId": "9ddfc315-0878-471a-b38c-9dc27adb1ace"}
```

4. Static ReadOnlyMany volume with nodeaffinity rules- failed.
5. Static block volume provisioning without nodeaffinty rules - SUCCESS
```
2024-01-04T07:51:52.553Z	DEBUG	admissionhandler/validatepv.go:44	Not a file volume. Skipping validation.	{"TraceId": "61877df9-e342-4e9a-a5ae-452e03c0d747"}
2024-01-04T07:51:52.554Z	DEBUG	admissionhandler/admissionhandler.go:282	admissionResponse: &AdmissionResponse{UID:,Allowed:true,Result:nil,Patch:nil,PatchType:nil,AuditAnnotations:map[string]string{},Warnings:[],}	{"TraceId": "61877df9-e342-4e9a-a5ae-452e03c0d747"}
2024-01-04T07:51:52.554Z	DEBUG	admissionhandler/admissionhandler.go:299	Ready to write response	{"TraceId": "61877df9-e342-4e9a-a5ae-452e03c0d747"}
```

6. Static block volume provisioning with nodeaffinity rules - SUCCESS
```
2024-01-04T07:55:30.431Z	DEBUG	admissionhandler/validatepv.go:44	Not a file volume. Skipping validation.	{"TraceId": "e4c87ba8-2fff-45d5-b6f9-9d1b08516df3"}
2024-01-04T07:55:30.431Z	DEBUG	admissionhandler/admissionhandler.go:282	admissionResponse: &AdmissionResponse{UID:,Allowed:true,Result:nil,Patch:nil,PatchType:nil,AuditAnnotations:map[string]string{},Warnings:[],}	{"TraceId": "e4c87ba8-2fff-45d5-b6f9-9d1b08516df3"}
2024-01-04T07:55:30.431Z	DEBUG	admissionhandler/admissionhandler.go:299	Ready to write response	{"TraceId": "e4c87ba8-2fff-45d5-b6f9-9d1b08516df3"}
```

7. Dynamic block volume provisioning - SUCCESS
```
2024-01-04T07:57:13.395Z	DEBUG	admissionhandler/validatepv.go:44	Not a file volume. Skipping validation.	{"TraceId": "50c423ad-70ad-4a29-ad86-af0c1d8637b1"}
2024-01-04T07:57:13.395Z	DEBUG	admissionhandler/admissionhandler.go:282	admissionResponse: &AdmissionResponse{UID:,Allowed:true,Result:nil,Patch:nil,PatchType:nil,AuditAnnotations:map[string]string{},Warnings:[],}	{"TraceId": "50c423ad-70ad-4a29-ad86-af0c1d8637b1"}
2024-01-04T07:57:13.395Z	DEBUG	admissionhandler/admissionhandler.go:299	Ready to write response	{"TraceId": "50c423ad-70ad-4a29-ad86-af0c1d8637b1"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
9. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
