### PR TITLE
Decrease reserved in CNSVolumeOperationRequest when we receive a final error for an ongoing task

### DIFF
--- a/pkg/internalapis/cnsvolumeoperationrequest/util.go
+++ b/pkg/internalapis/cnsvolumeoperationrequest/util.go
@@ -103,3 +103,13 @@ func convertToCnsVolumeOperationRequestDetails(
 		Error:                   details.Error,
 	}
 }
+
+func UpdateReservedInQuotaDetails(reserved *resource.Quantity, originalQuotaDetails *QuotaDetails) *QuotaDetails {
+	updatedQuota := QuotaDetails{
+		Reserved:         reserved,
+		StoragePolicyId:  originalQuotaDetails.StoragePolicyId,
+		StorageClassName: originalQuotaDetails.StorageClassName,
+		Namespace:        originalQuotaDetails.Namespace,
+	}
+	return &updatedQuota
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR makes sure the reserved field is decreased in CNSVolumeOperationRequest CR when a CNS task for Create/Expand volume errors out. This will ensure that the next re-try operation has enough quota bandwidth to pass the webhook validation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested file volume creation in stretched supervisor testbed which is expected to fail to test the code in this PR.
Logs:
```
2024-01-05T01:07:06.631Z	INFO	wcp/controller.go:908	CreateVolume: called with args {Name:pvc-58465383-a8cf-45d1-a6fd-ee84382f3695 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[StorageTopologyType:Zonal csi.storage.k8s.io/pv/name:pvc-58465383-a8cf-45d1-a6fd-ee84382f3695 csi.storage.k8s.io/pvc/name:file-pvc csi.storage.k8s.io/pvc/namespace:test-quota csi.storage.k8s.io/sc/name:zonal-policy storagePolicyID:58855202-9df7-4714-be46-e6430e577fbc] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > requisite:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-3" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-1" > > preferred:<segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
2024-01-05T01:07:06.633Z	INFO	wcp/controller.go:802	Ignoring TopologyRequirement for file volume	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
2024-01-05T01:07:06.677Z	DEBUG	volume/manager.go:524	Received CreateVolume extraParams: &{VolSizeBytes:1073741824 StorageClassName:zonal-policy Namespace:test-quota ClusterFlavor:WORKLOAD IsPodVMOnStretchSupervisorFSSEnabled:true}	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
2024-01-05T01:07:06.677Z	INFO	volume/manager.go:539	QuotaInfo during CreateVolume call: {Reserved:1Gi StoragePolicyId:58855202-9df7-4714-be46-e6430e577fbc StorageClassName:zonal-policy Namespace:test-quota}	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
2024-01-05T01:07:06.677Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:151	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-58465383-a8cf-45d1-a6fd-ee84382f3695	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
2024-01-05T01:07:06.691Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:196	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc0001c20a0)({
 Name: (string) (len=40) "pvc-58465383-a8cf-45d1-a6fd-ee84382f3695",
 VolumeID: (string) "",
 SnapshotID: (string) "",
 Capacity: (int64) 0,
 QuotaDetails: (*cnsvolumeoperationrequest.QuotaDetails)(0xc0006c0680)({
  Reserved: (*resource.Quantity)(0xc0006c0700)(1Gi),
  StoragePolicyId: (string) (len=36) "58855202-9df7-4714-be46-e6430e577fbc",
  StorageClassName: (string) (len=12) "zonal-policy",
  Namespace: (string) (len=10) "test-quota"
 }),
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc000278690)({
  TaskInvocationTimestamp: (v1.Time) 2024-01-05 01:07:06.691311368 +0000 UTC m=+134.642811510,
  TaskID: (string) "",
  VCenterServer: (string) "",
  OpID: (string) "",
  TaskStatus: (string) (len=10) "InProgress",
  Error: (string) ""
 })
})
	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
2024-01-05T01:07:06.722Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:243	Created CnsVolumeOperationRequest instance vmware-system-csi/pvc-58465383-a8cf-45d1-a6fd-ee84382f3695 with latest information for task with ID: 	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
2024-01-05T01:07:06.735Z	ERROR	volume/util.go:241	CNS CreateVolume failed from vCenter "sc2-10-185-231-170.eng.vmware.com" with err: ServerFaultCode: A specified parameter was not correct: createSpecs.datastores	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
2024-01-05T01:07:06.736Z	ERROR	volume/manager.go:633	failed to create volume with error: ServerFaultCode: A specified parameter was not correct: createSpecs.datastores	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
2024-01-05T01:07:06.736Z	INFO	volume/util.go:350	Extract vimfault type: +types.InvalidArgument. SoapFault Info: +&{{http://schemas.xmlsoap.org/soap/envelope/ Fault} ServerFaultCode A specified parameter was not correct: createSpecs.datastores {{{{<nil> []}} createSpecs.datastores}}} from err +ServerFaultCode: A specified parameter was not correct: createSpecs.datastores	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
2024-01-05T01:07:06.737Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:196	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc000190c30)({
 Name: (string) (len=40) "pvc-58465383-a8cf-45d1-a6fd-ee84382f3695",
 VolumeID: (string) "",
 SnapshotID: (string) "",
 Capacity: (int64) 0,
 QuotaDetails: (*cnsvolumeoperationrequest.QuotaDetails)(0xc0006c0680)({
  Reserved: (*resource.Quantity)(0xc001113d80)(0),
  StoragePolicyId: (string) (len=36) "58855202-9df7-4714-be46-e6430e577fbc",
  StorageClassName: (string) (len=12) "zonal-policy",
  Namespace: (string) (len=10) "test-quota"
 }),
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc000454a80)({
  TaskInvocationTimestamp: (v1.Time) 2024-01-05 01:07:06.691311368 +0000 UTC m=+134.642811510,
  TaskID: (string) "",
  VCenterServer: (string) "",
  OpID: (string) "",
  TaskStatus: (string) (len=5) "Error",
  Error: (string) (len=78) "ServerFaultCode: A specified parameter was not correct: createSpecs.datastores"
 })
})
	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
2024-01-05T01:07:06.765Z	ERROR	common/vsphereutil.go:566	failed to create file volume "pvc-58465383-a8cf-45d1-a6fd-ee84382f3695" with error ServerFaultCode: A specified parameter was not correct: createSpecs.datastores faultType "vim.fault.InvalidArgument"	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
2024-01-05T01:07:06.765Z	ERROR	wcp/controller.go:876	failed to create volume. Error: ServerFaultCode: A specified parameter was not correct: createSpecs.datastores	{"TraceId": "9114da5d-d747-49eb-9ddd-a6c84385b7ca"}
```
The logs clearly show that the CreateFileVolumeUtil function received the actual requested size of PVC as 1Gi but as the request failed, we stored 0 under Reserved field instead.

CNSVolumeOperationRequest instance:
```
Name:         pvc-34c26865-ba14-4a5d-a48e-2fcc7cf3cc7b
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsVolumeOperationRequest
Metadata:
  Creation Timestamp:  2024-01-05T02:31:34Z
  Generation:          14
  Resource Version:    654460
  UID:                 2fb1bbec-4bb2-434a-979d-ecde60e41dcd
Spec:
  Name:  pvc-34c26865-ba14-4a5d-a48e-2fcc7cf3cc7b
Status:
  First Operation Details:
    Error:                      ServerFaultCode: A specified parameter was not correct: createSpecs.datastores
    Task Id:                    
    Task Invocation Timestamp:  2024-01-05T02:31:34Z
    Task Status:                Error
  Latest Operation Details:
    Error:                      ServerFaultCode: A specified parameter was not correct: createSpecs.datastores
    Task Id:                    
    Task Invocation Timestamp:  2024-01-05T02:31:34Z
    Task Status:                Error
    Error:                      ServerFaultCode: A specified parameter was not correct: createSpecs.datastores
    Task Id:                    
    Task Invocation Timestamp:  2024-01-05T02:31:35Z
    Task Status:                Error
    Error:                      ServerFaultCode: A specified parameter was not correct: createSpecs.datastores
    Task Id:                    
    Task Invocation Timestamp:  2024-01-05T02:31:37Z
    Task Status:                Error
    Error:                      ServerFaultCode: A specified parameter was not correct: createSpecs.datastores
    Task Id:                    
    Task Invocation Timestamp:  2024-01-05T02:31:41Z
    Task Status:                Error
    Error:                      ServerFaultCode: A specified parameter was not correct: createSpecs.datastores
    Task Id:                    
    Task Invocation Timestamp:  2024-01-05T02:31:49Z
    Task Status:                Error
    Error:                      ServerFaultCode: A specified parameter was not correct: createSpecs.datastores
    Task Id:                    
    Task Invocation Timestamp:  2024-01-05T02:32:05Z
    Task Status:                Error
    Error:                      ServerFaultCode: A specified parameter was not correct: createSpecs.datastores
    Task Id:                    
    Task Invocation Timestamp:  2024-01-05T02:32:09Z
    Task Status:                Error
  Quota Details:
    Namespace:           final-test
    Reserved:            0
    Storage Class Name:  zonal-policy
    Storage Policy Id:   58855202-9df7-4714-be46-e6430e577fbc
Events:                  <none>
```

Verified that syncer does not update used field when task errors out. The reserved and used fields in StorageQuota, StoragePolicyQuota and StoragePolicyUsage are consistent.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Decrease reserved in CNSVolumeOperationRequest when we receive a final error for an ongoing task
```
