### PR TITLE
Logging improvements for storage policy usage & quota related changes

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -539,8 +539,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 			// Patch an increase of "reserved" in storagePolicyUsageCR.
 			patchedStoragePolicyUsageCR := storagePolicyUsageCR.DeepCopy()
 			if storagePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage != nil {
-				patchedStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Add(
-					*resource.NewQuantity(capacity.Value(), capacity.Format))
+				patchedStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Add(*capacity)
 			} else {
 				var (
 					usedQty     resource.Quantity
@@ -578,8 +577,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 					currentStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Format))
 			// Increase the Used field for StoragePolicyUsageCR
 			finalStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Used.Add(
-				*resource.NewQuantity(currentStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Value(),
-					currentStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Format))
+				*currentStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved)
 			err = syncer.PatchStoragePolicyUsage(ctx, cnsOperatorClient, currentStoragePolicyUsageCR,
 				finalStoragePolicyUsageCR)
 			if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Addresses some logging improvements.
No need to create a new quantity every time during policyusage updates
Additional Nil pointer checks

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Before:
```
2024-01-04T16:35:37.432Z	INFO	syncer/metadatasyncer.go:2452	Successfully decreased the used capacity by 'в' Mb for StoragePolicyUsage: "0-wcp-test-storage-policyname-wkaoxja3iq-pvc-usage" in namespace: "storage-policy-test"	{"TraceId": "77dbf753-a21a-4dd7-9329-921d9435d258"}
```

After:
```
2024-01-04T18:46:54.092Z	INFO	syncer/metadatasyncer.go:2452	Successfully decreased the used capacity by 52614 Mb for StoragePolicyUsage: "0-wcp-test-storage-policyname-wkaoxja3iq-pvc-usage" in namespace: "storage-policy-test"	{"TraceId": "0e94a256-8e46-4d1e-8f3d-878814fde96f"}
```

Create PVCs
```
kubectl get pvc -n storage-policy-test 
NAME             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                               AGE
example-pvc-10   Bound    pvc-3df4feb5-db70-43f0-baa4-b707a8a9cb8c   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   85s
example-pvc-11   Bound    pvc-b38a4ef6-b666-4a60-982a-8143f7670c11   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   84s
example-pvc-12   Bound    pvc-a8e970ec-17f8-456d-866f-5968f215d4ed   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   83s
example-pvc-13   Bound    pvc-3f78b596-9bbb-4db0-9938-122ea6c4d498   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   81s
example-pvc-14   Bound    pvc-3b72017c-e8c0-4076-abdf-970eb3e3c224   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   80s
example-pvc-15   Bound    pvc-689801a9-1c8b-4013-b774-efd3025411f2   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   80s
example-pvc-16   Bound    pvc-1753b8bd-829e-4aeb-b4c6-2359c245e05a   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   79s
example-pvc-2    Bound    pvc-08a1ec16-c49b-4e7d-b6b3-042f08c468a1   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   95s
example-pvc-3    Bound    pvc-0cee18a6-9979-4d8e-8fc0-c0f406560ada   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   94s
example-pvc-4    Bound    pvc-c6d0d3c5-1e3d-4bfe-966a-c4f7a0141534   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   93s
example-pvc-5    Bound    pvc-a841e1e1-3658-4d14-bfde-a554a114e072   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   90s
example-pvc-6    Bound    pvc-638b2752-2beb-437d-8f12-8dae3871a7ee   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   89s
example-pvc-7    Bound    pvc-8e3154d3-e6b7-4e76-a145-20482f0c5aa8   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   88s
example-pvc-8    Bound    pvc-5f3e1840-8848-47a9-926a-a56e7d73b1c3   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   87s
example-pvc-9    Bound    pvc-24d66f79-366e-499f-b639-d0f69721c87d   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   86s
```


Verify SP Usage CR:
```
kubectl get storagepolicyusages.cns.vmware.com -n storage-policy-test 0-wcp-test-storage-policyname-wkaoxja3iq-pvc-usage -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-01-04T19:52:55Z"
  generation: 31
  name: 0-wcp-test-storage-policyname-wkaoxja3iq-pvc-usage
  namespace: storage-policy-test
  resourceVersion: "8985411"
  uid: 25b4bbaf-ccd1-4fe9-b3f4-49cbc66faa79
spec:
  resourceApiGroup: ""
  resourceExtensionName: volume.cns.vsphere.vmware.com
  resourceKind: PersistentVolumeClaim
  storageClassName: 0-wcp-test-storage-policyname-wkaoxja3iq
  storagePolicyId: 34ef0cc5-ddb9-4010-92a2-1a8dda347c53
status:
  quotaUsage:
    reserved: "0"
    used: 1650Mi
```
Verify Quota CRs:
```
kubectl get storagepolicyquota -n storage-policy-test 0-wcp-test-storage-policyname-wkaoxja3iq-storagepolicyquota -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyQuota
metadata:
  creationTimestamp: "2024-01-04T05:41:38Z"
  generation: 4
  name: 0-wcp-test-storage-policyname-wkaoxja3iq-storagepolicyquota
  namespace: storage-policy-test
  resourceVersion: "8985374"
  uid: a822dcd8-9ce2-44eb-80a3-3c79e0044e33
spec:
  limit: 50Gi
  storagePolicyId: 34ef0cc5-ddb9-4010-92a2-1a8dda347c53
status:
  extensions:
  - extensionName: volume.cns.vsphere.vmware.com
    extensionQuotaUsage:
    - scQuotaUsage:
        reserved: "0"
        used: "0"
      storageClassName: 0-wcp-test-storage-policyname-wkaoxja3iq-wffc
  - extensionName: volume.cns.vsphere.vmware.com
    extensionQuotaUsage:
    - scQuotaUsage:
        reserved: 3300Mi
        used: "0"
      storageClassName: 0-wcp-test-storage-policyname-wkaoxja3iq
  total:
  - scQuotaUsage:
      reserved: "0"
      used: "0"
    storageClassName: 0-wcp-test-storage-policyname-wkaoxja3iq-wffc
  - scQuotaUsage:
      reserved: 1650Mi
      used: "0"
    storageClassName: 0-wcp-test-storage-policyname-wkaoxja3iq
```

Delete all PVCs:
```
kubectl delete pvc --all -n storage-policy-test
persistentvolumeclaim "example-pvc-10" deleted
persistentvolumeclaim "example-pvc-11" deleted
persistentvolumeclaim "example-pvc-12" deleted
persistentvolumeclaim "example-pvc-13" deleted
persistentvolumeclaim "example-pvc-14" deleted
persistentvolumeclaim "example-pvc-15" deleted
persistentvolumeclaim "example-pvc-16" deleted
persistentvolumeclaim "example-pvc-2" deleted
persistentvolumeclaim "example-pvc-3" deleted
persistentvolumeclaim "example-pvc-4" deleted
persistentvolumeclaim "example-pvc-5" deleted
persistentvolumeclaim "example-pvc-6" deleted
persistentvolumeclaim "example-pvc-7" deleted
persistentvolumeclaim "example-pvc-8" deleted
persistentvolumeclaim "example-pvc-9" deleted
```

Verify CR has used = 0
```
kubectl get storagepolicyusages.cns.vmware.com -n storage-policy-test 0-wcp-test-storage-policyname-wkaoxja3iq-pvc-usage -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-01-04T19:52:55Z"
  generation: 46
  name: 0-wcp-test-storage-policyname-wkaoxja3iq-pvc-usage
  namespace: storage-policy-test
  resourceVersion: "8987334"
  uid: 25b4bbaf-ccd1-4fe9-b3f4-49cbc66faa79
spec:
  resourceApiGroup: ""
  resourceExtensionName: volume.cns.vsphere.vmware.com
  resourceKind: PersistentVolumeClaim
  storageClassName: 0-wcp-test-storage-policyname-wkaoxja3iq
  storagePolicyId: 34ef0cc5-ddb9-4010-92a2-1a8dda347c53
status:
  quotaUsage:
    reserved: "0"
    used: "0"

```

Create 2 PVCs & verify the SP Usage CR:
```
 kubectl get pvc -n storage-policy-test 
NAME            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                               AGE
example-pvc-2   Bound    pvc-093accf6-ba32-4fb9-8e4b-5852dacee5cf   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   8s
example-pvc-3   Bound    pvc-75c6f58b-5ab7-4b98-b526-fb395da97fd3   110Mi      RWO            0-wcp-test-storage-policyname-wkaoxja3iq   6s
root@4216522683360f78652aa4c30ece5339 [ ~ ]# kubectl get storagepolicyusages.cns.vmware.com -n storage-policy-test 0-wcp-test-storage-policyname-wkaoxja3iq-pvc-usage -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-01-04T19:52:55Z"
  generation: 50
  name: 0-wcp-test-storage-policyname-wkaoxja3iq-pvc-usage
  namespace: storage-policy-test
  resourceVersion: "8987987"
  uid: 25b4bbaf-ccd1-4fe9-b3f4-49cbc66faa79
spec:
  resourceApiGroup: ""
  resourceExtensionName: volume.cns.vsphere.vmware.com
  resourceKind: PersistentVolumeClaim
  storageClassName: 0-wcp-test-storage-policyname-wkaoxja3iq
  storagePolicyId: 34ef0cc5-ddb9-4010-92a2-1a8dda347c53
status:
  quotaUsage:
    reserved: "0"
    used: 220Mi

```
Expand PVC:

```
kubectl get pv -A
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                               STORAGECLASS                               REASON   AGE
pvc-093accf6-ba32-4fb9-8e4b-5852dacee5cf   220Mi      RWO            Delete           Bound    storage-policy-test/example-pvc-2   0-wcp-test-storage-policyname-wkaoxja3iq            54s
pvc-75c6f58b-5ab7-4b98-b526-fb395da97fd3   110Mi      RWO            Delete           Bound    storage-policy-test/example-pvc-3   0-wcp-test-storage-policyname-wkaoxja3iq            54s
```

```
kubectl get storagepolicyusages.cns.vmware.com -n storage-policy-test 0-wcp-test-storage-policyname-wkaoxja3iq-pvc-usage -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-01-04T19:52:55Z"
  generation: 52
  name: 0-wcp-test-storage-policyname-wkaoxja3iq-pvc-usage
  namespace: storage-policy-test
  resourceVersion: "8988525"
  uid: 25b4bbaf-ccd1-4fe9-b3f4-49cbc66faa79
spec:
  resourceApiGroup: ""
  resourceExtensionName: volume.cns.vsphere.vmware.com
  resourceKind: PersistentVolumeClaim
  storageClassName: 0-wcp-test-storage-policyname-wkaoxja3iq
  storagePolicyId: 34ef0cc5-ddb9-4010-92a2-1a8dda347c53
status:
  quotaUsage:
    reserved: "0"
    used: 330Mi
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Logging improvements for storage policy usage & quota related changes
```
