### PR TITLE
Set FS enabled datastore list to compatible datastore list

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1866,12 +1866,12 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 							compatibleDatastores = append(compatibleDatastores, ds)
 						}
 					}
+					fsEnabledCandidateDatastores = compatibleDatastores
 					if len(compatibleDatastores) == 0 {
 						log.Errorf("No compatible datastores found for storage policy %q on VC %s",
 							scParams.StoragePolicyName, vcHost)
 						continue
 					}
-					fsEnabledCandidateDatastores = compatibleDatastores
 				}
 				log.Infof("fsEnabledCandidateDatastores %v", fsEnabledCandidateDatastores)
 				filterSuspendedDatastores := false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
FS enabled datastore list continue to have all datastores if storagepolicy does not match.
So set the FS enabled datastore list to compatible datastore list before continuing.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes bug no. 3323879

**Testing done**:
Created a SC having allowed topology as rack-2 where as provided storagepolicy the one tagged with rack-1.

Volume provisioning failed with such a storageclass.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
