### PR TITLE
Bugfix for Multi-VC: Avoid sending non-compatible datastores to CNS during CreateVolume

### DIFF
--- a/pkg/csi/service/common/placementengine/placement.go
+++ b/pkg/csi/service/common/placementengine/placement.go
@@ -118,6 +118,7 @@ func GetSharedDatastores(ctx context.Context, reqParams interface{}) (
 				if len(compatibleDatastores) == 0 {
 					log.Infof("No compatible shared datastores found for storage policy %q on vCenter: %q",
 						params.StoragePolicyID, params.Vcenter.Config.Host)
+					continue
 				} else {
 					log.Infof("Shared datastores compatible with storage policy %q are %+v for vCenter: %q",
 						params.StoragePolicyID, compatibleDatastores, params.Vcenter.Config.Host)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR resolves a bug where CSI might send non-compatible datastores to CNS. As CNS further filters the datastores on its end, we did not recognize this bug earlier.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
CreateVolume with Immediate volume binding mode on a multi-VC setup:
```
2024-01-31T23:30:25.304Z	INFO	vanilla/controller.go:1960	CreateVolume: called with args {Name:pvc-ab75d20b-5971-4b94-96d8-199d2e235019 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-2" > > requisite:<segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-1" > > requisite:<segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-4" > > requisite:<segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-3" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-3" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-4" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-1" > > preferred:<segments:<key:"topology.csi.vmware.com/k8s-zone" value:"zone-2" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.305Z	DEBUG	vanilla/controller.go:1087	Checking if vCenter task for volume pvc-ab75d20b-5971-4b94-96d8-199d2e235019 is already registered.	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.305Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:151	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-ab75d20b-5971-4b94-96d8-199d2e235019	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.324Z	DEBUG	vanilla/controller.go:1112	CreateVolume task details for block volume pvc-ab75d20b-5971-4b94-96d8-199d2e235019 are not found.	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.324Z	INFO	common/topology.go:392	Topology segment(s) map[topology.csi.vmware.com/k8s-zone:zone-3] belong to vCenter: "10.185.70.239"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.325Z	INFO	common/topology.go:392	Topology segment(s) map[topology.csi.vmware.com/k8s-zone:zone-4] belong to vCenter: "10.185.70.239"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.325Z	INFO	common/topology.go:392	Topology segment(s) map[topology.csi.vmware.com/k8s-zone:zone-1] belong to vCenter: "10.161.97.50"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.325Z	INFO	common/topology.go:392	Topology segment(s) map[topology.csi.vmware.com/k8s-zone:zone-2] belong to vCenter: "10.185.70.239"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.325Z	DEBUG	vanilla/controller.go:1225	Topology accessibility requirements per VC are map[10.161.97.50:[map[topology.csi.vmware.com/k8s-zone:zone-1]] 10.185.70.239:[map[topology.csi.vmware.com/k8s-zone:zone-3] map[topology.csi.vmware.com/k8s-zone:zone-4] map[topology.csi.vmware.com/k8s-zone:zone-2]]]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.326Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.327Z	DEBUG	config/config.go:372	Initializing vc server 10.161.97.50	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.328Z	DEBUG	config/config.go:417	vc server 10.161.97.50 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.328Z	DEBUG	config/config.go:372	Initializing vc server 10.185.70.239	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.328Z	DEBUG	config/config.go:417	vc server 10.185.70.239 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.328Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.337Z	INFO	placementengine/placement.go:27	GetSharedDatastores called for VC "10.185.70.239" with policyID: "" , Topology Segment List: [map[topology.csi.vmware.com/k8s-zone:zone-3] map[topology.csi.vmware.com/k8s-zone:zone-4] map[topology.csi.vmware.com/k8s-zone:zone-2]]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.339Z	DEBUG	placementengine/placement.go:211	Node "k8s-node-523-1706685332" with topology map[topology.csi.vmware.com/k8s-zone:zone-4] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-3" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.340Z	DEBUG	node/manager.go:246	Renewing virtual machine VirtualMachine:vm-42 [VirtualCenterHost: 10.185.70.239, UUID: 423237dc-6d90-df55-19b3-97706bfb84e5, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.185.70.239]] with nodeUUID "423237dc-6d90-df55-19b3-97706bfb84e5"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.340Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.341Z	DEBUG	config/config.go:372	Initializing vc server 10.161.97.50	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.341Z	DEBUG	config/config.go:417	vc server 10.161.97.50 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.341Z	DEBUG	config/config.go:372	Initializing vc server 10.185.70.239	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.341Z	DEBUG	config/config.go:417	vc server 10.185.70.239 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.341Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.348Z	DEBUG	node/manager.go:253	VM VirtualMachine:vm-42 [VirtualCenterHost: 10.185.70.239, UUID: 423237dc-6d90-df55-19b3-97706bfb84e5, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.70.239]] was successfully renewed with nodeUUID "423237dc-6d90-df55-19b3-97706bfb84e5"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.349Z	DEBUG	placementengine/placement.go:211	Node "k8s-node-793-1706684752" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-3" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.349Z	DEBUG	placementengine/placement.go:211	Node "k8s-control-325-1706684719" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-3" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.349Z	DEBUG	placementengine/placement.go:211	Node "k8s-control-646-1706684689" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-3" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.350Z	DEBUG	placementengine/placement.go:211	Node "k8s-control-780-1706684704" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-3" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.350Z	DEBUG	placementengine/placement.go:211	Node "k8s-node-190-1706685294" with topology map[topology.csi.vmware.com/k8s-zone:zone-2] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-3" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.350Z	DEBUG	placementengine/placement.go:211	Node "k8s-node-521-1706684738" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-3" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.350Z	INFO	placementengine/placement.go:67	TopologySegment map[topology.csi.vmware.com/k8s-zone:zone-3] expanded as: [map[topology.csi.vmware.com/k8s-zone:zone-3]]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.351Z	INFO	common/topology.go:148	Tag "zone-3" is applied on entities [{Type:HostSystem Value:host-20}]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.351Z	DEBUG	common/topology.go:149	Fetching hosts for entities [{Type:HostSystem Value:host-20}]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.351Z	INFO	common/topology.go:224	fetching hosts for entity: {HostSystem host-20} on vCenter: "10.185.70.239"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.351Z	INFO	common/topology.go:158	Hosts returned for topology category: "topology.csi.vmware.com/k8s-zone" and tag: "zone-3" are [HostSystem:host-20]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.352Z	INFO	common/topology.go:170	finding common hosts for hostlists: [[HostSystem:host-20]]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.352Z	DEBUG	common/topology.go:180	hostCount after setting count in the first slice : map[HostSystem:host-20:1]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.352Z	DEBUG	common/topology.go:190	hostCount after iterate through the remaining slices and updated hostCount map : map[HostSystem:host-20:1]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.352Z	DEBUG	common/topology.go:200	common hosts: [HostSystem:host-20]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.352Z	DEBUG	common/topology.go:215	commonHostSystem: [HostSystem:host-20]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.352Z	INFO	common/topology.go:162	common hosts: [HostSystem:host-20] for all segments: map[topology.csi.vmware.com/k8s-zone:zone-3]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.372Z	INFO	placementengine/placement.go:86	Obtained list of shared datastores [Datastore: Datastore:datastore-33, datastore URL: ds:///vmfs/volumes/65b9eb10-0a25955e-f3c3-0200181b80fa/ Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/65b9eb12-29aad97e-6e14-0200181b80fa/] for hosts [HostSystem:host-20]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.372Z	DEBUG	placementengine/placement.go:211	Node "k8s-control-646-1706684689" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-4" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.373Z	DEBUG	placementengine/placement.go:211	Node "k8s-control-780-1706684704" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-4" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.373Z	DEBUG	placementengine/placement.go:211	Node "k8s-node-190-1706685294" with topology map[topology.csi.vmware.com/k8s-zone:zone-2] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-4" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.373Z	DEBUG	placementengine/placement.go:211	Node "k8s-node-521-1706684738" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-4" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.374Z	DEBUG	node/manager.go:246	Renewing virtual machine VirtualMachine:vm-40 [VirtualCenterHost: 10.185.70.239, UUID: 423277ad-a93c-7015-ede1-cb4c14f0f8b4, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.185.70.239]] with nodeUUID "423277ad-a93c-7015-ede1-cb4c14f0f8b4"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.374Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.375Z	DEBUG	config/config.go:372	Initializing vc server 10.161.97.50	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.375Z	DEBUG	config/config.go:417	vc server 10.161.97.50 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.375Z	DEBUG	config/config.go:372	Initializing vc server 10.185.70.239	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.375Z	DEBUG	config/config.go:417	vc server 10.185.70.239 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.375Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.385Z	DEBUG	node/manager.go:253	VM VirtualMachine:vm-40 [VirtualCenterHost: 10.185.70.239, UUID: 423277ad-a93c-7015-ede1-cb4c14f0f8b4, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.70.239]] was successfully renewed with nodeUUID "423277ad-a93c-7015-ede1-cb4c14f0f8b4"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.386Z	DEBUG	placementengine/placement.go:211	Node "k8s-node-749-1706685313" with topology map[topology.csi.vmware.com/k8s-zone:zone-3] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-4" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.387Z	DEBUG	placementengine/placement.go:211	Node "k8s-node-793-1706684752" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-4" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.387Z	DEBUG	placementengine/placement.go:211	Node "k8s-control-325-1706684719" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-4" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.387Z	INFO	placementengine/placement.go:67	TopologySegment map[topology.csi.vmware.com/k8s-zone:zone-4] expanded as: [map[topology.csi.vmware.com/k8s-zone:zone-4]]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.387Z	INFO	common/topology.go:148	Tag "zone-4" is applied on entities [{Type:HostSystem Value:host-26}]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.388Z	DEBUG	common/topology.go:149	Fetching hosts for entities [{Type:HostSystem Value:host-26}]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.388Z	INFO	common/topology.go:224	fetching hosts for entity: {HostSystem host-26} on vCenter: "10.185.70.239"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.388Z	INFO	common/topology.go:158	Hosts returned for topology category: "topology.csi.vmware.com/k8s-zone" and tag: "zone-4" are [HostSystem:host-26]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.388Z	INFO	common/topology.go:170	finding common hosts for hostlists: [[HostSystem:host-26]]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.388Z	DEBUG	common/topology.go:180	hostCount after setting count in the first slice : map[HostSystem:host-26:1]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.388Z	DEBUG	common/topology.go:190	hostCount after iterate through the remaining slices and updated hostCount map : map[HostSystem:host-26:1]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.388Z	DEBUG	common/topology.go:200	common hosts: [HostSystem:host-26]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.388Z	DEBUG	common/topology.go:215	commonHostSystem: [HostSystem:host-26]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.389Z	INFO	common/topology.go:162	common hosts: [HostSystem:host-26] for all segments: map[topology.csi.vmware.com/k8s-zone:zone-4]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.402Z	INFO	placementengine/placement.go:86	Obtained list of shared datastores [Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/65b9eb13-459ae81b-430b-0200180b8354/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/65b9eb16-5ae57b09-9b05-0200180b8354/] for hosts [HostSystem:host-26]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.402Z	DEBUG	placementengine/placement.go:211	Node "k8s-node-523-1706685332" with topology map[topology.csi.vmware.com/k8s-zone:zone-4] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-2" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.402Z	DEBUG	placementengine/placement.go:211	Node "k8s-node-749-1706685313" with topology map[topology.csi.vmware.com/k8s-zone:zone-3] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-2" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.403Z	DEBUG	placementengine/placement.go:211	Node "k8s-node-793-1706684752" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-2" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.403Z	DEBUG	placementengine/placement.go:211	Node "k8s-control-325-1706684719" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-2" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.403Z	DEBUG	placementengine/placement.go:211	Node "k8s-control-646-1706684689" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-2" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.403Z	DEBUG	placementengine/placement.go:211	Node "k8s-control-780-1706684704" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-2" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.403Z	DEBUG	node/manager.go:246	Renewing virtual machine VirtualMachine:vm-41 [VirtualCenterHost: 10.185.70.239, UUID: 42329467-62c7-8d89-5f7e-1323bdc0ce5e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3 @ /VSAN-DC, VirtualCenterHost: 10.185.70.239]] with nodeUUID "42329467-62c7-8d89-5f7e-1323bdc0ce5e"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.403Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.404Z	DEBUG	config/config.go:372	Initializing vc server 10.185.70.239	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.404Z	DEBUG	config/config.go:417	vc server 10.185.70.239 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.405Z	DEBUG	config/config.go:372	Initializing vc server 10.161.97.50	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.405Z	DEBUG	config/config.go:417	vc server 10.161.97.50 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.405Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.411Z	DEBUG	node/manager.go:253	VM VirtualMachine:vm-41 [VirtualCenterHost: 10.185.70.239, UUID: 42329467-62c7-8d89-5f7e-1323bdc0ce5e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.70.239]] was successfully renewed with nodeUUID "42329467-62c7-8d89-5f7e-1323bdc0ce5e"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.411Z	DEBUG	placementengine/placement.go:211	Node "k8s-node-521-1706684738" with topology map[topology.csi.vmware.com/k8s-zone:zone-1] did not match the topology requirement - "topology.csi.vmware.com/k8s-zone": "zone-2" 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.411Z	INFO	placementengine/placement.go:67	TopologySegment map[topology.csi.vmware.com/k8s-zone:zone-2] expanded as: [map[topology.csi.vmware.com/k8s-zone:zone-2]]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.411Z	INFO	common/topology.go:148	Tag "zone-2" is applied on entities [{Type:HostSystem Value:host-14}]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.411Z	DEBUG	common/topology.go:149	Fetching hosts for entities [{Type:HostSystem Value:host-14}]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.412Z	INFO	common/topology.go:224	fetching hosts for entity: {HostSystem host-14} on vCenter: "10.185.70.239"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.412Z	INFO	common/topology.go:158	Hosts returned for topology category: "topology.csi.vmware.com/k8s-zone" and tag: "zone-2" are [HostSystem:host-14]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.412Z	INFO	common/topology.go:170	finding common hosts for hostlists: [[HostSystem:host-14]]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.412Z	DEBUG	common/topology.go:180	hostCount after setting count in the first slice : map[HostSystem:host-14:1]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.412Z	DEBUG	common/topology.go:190	hostCount after iterate through the remaining slices and updated hostCount map : map[HostSystem:host-14:1]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.412Z	DEBUG	common/topology.go:200	common hosts: [HostSystem:host-14]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.412Z	DEBUG	common/topology.go:215	commonHostSystem: [HostSystem:host-14]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.412Z	INFO	common/topology.go:162	common hosts: [HostSystem:host-14] for all segments: map[topology.csi.vmware.com/k8s-zone:zone-2]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.425Z	INFO	placementengine/placement.go:86	Obtained list of shared datastores [Datastore: Datastore:datastore-30, datastore URL: ds:///vmfs/volumes/65b9eb0b-b58f52e3-043f-020018345fb7/ Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/65b9eb0d-a9c47401-87e0-020018345fb7/] for hosts [HostSystem:host-14]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.425Z	INFO	placementengine/placement.go:170	Shared compatible datastores being considered for volume provisioning on vCenter: "10.185.70.239" are: [Datastore: Datastore:datastore-33, datastore URL: ds:///vmfs/volumes/65b9eb10-0a25955e-f3c3-0200181b80fa/ Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/65b9eb12-29aad97e-6e14-0200181b80fa/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/65b9eb13-459ae81b-430b-0200180b8354/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/65b9eb16-5ae57b09-9b05-0200180b8354/ Datastore: Datastore:datastore-30, datastore URL: ds:///vmfs/volumes/65b9eb0b-b58f52e3-043f-020018345fb7/ Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/65b9eb0d-a9c47401-87e0-020018345fb7/]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.426Z	DEBUG	vanilla/controller.go:499	filterDatastores: dsMap map[ds:///vmfs/volumes/65b9eb0b-b58f52e3-043f-020018345fb7/:Datastore: Datastore:datastore-30, datastore URL: ds:///vmfs/volumes/65b9eb0b-b58f52e3-043f-020018345fb7/ ds:///vmfs/volumes/65b9eb0d-a9c47401-87e0-020018345fb7/:Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/65b9eb0d-a9c47401-87e0-020018345fb7/ ds:///vmfs/volumes/65b9eb10-0a25955e-f3c3-0200181b80fa/:Datastore: Datastore:datastore-33, datastore URL: ds:///vmfs/volumes/65b9eb10-0a25955e-f3c3-0200181b80fa/ ds:///vmfs/volumes/65b9eb12-29aad97e-6e14-0200181b80fa/:Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/65b9eb12-29aad97e-6e14-0200181b80fa/ ds:///vmfs/volumes/65b9eb13-459ae81b-430b-0200180b8354/:Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/65b9eb13-459ae81b-430b-0200180b8354/ ds:///vmfs/volumes/65b9eb16-5ae57b09-9b05-0200180b8354/:Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/65b9eb16-5ae57b09-9b05-0200180b8354/] sharedDatastores [Datastore: Datastore:datastore-33, datastore URL: ds:///vmfs/volumes/65b9eb10-0a25955e-f3c3-0200181b80fa/ Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/65b9eb12-29aad97e-6e14-0200181b80fa/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/65b9eb13-459ae81b-430b-0200180b8354/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/65b9eb16-5ae57b09-9b05-0200180b8354/ Datastore: Datastore:datastore-30, datastore URL: ds:///vmfs/volumes/65b9eb0b-b58f52e3-043f-020018345fb7/ Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/65b9eb0d-a9c47401-87e0-020018345fb7/]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.426Z	DEBUG	vanilla/controller.go:508	filterDatastores: filteredDatastores [Datastore: Datastore:datastore-33, datastore URL: ds:///vmfs/volumes/65b9eb10-0a25955e-f3c3-0200181b80fa/ Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/65b9eb12-29aad97e-6e14-0200181b80fa/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/65b9eb13-459ae81b-430b-0200180b8354/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/65b9eb16-5ae57b09-9b05-0200180b8354/ Datastore: Datastore:datastore-30, datastore URL: ds:///vmfs/volumes/65b9eb0b-b58f52e3-043f-020018345fb7/ Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/65b9eb0d-a9c47401-87e0-020018345fb7/]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.427Z	INFO	vsphere/utils.go:590	Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-33, datastore URL: ds:///vmfs/volumes/65b9eb10-0a25955e-f3c3-0200181b80fa/ Datastore: Datastore:datastore-34, datastore URL: ds:///vmfs/volumes/65b9eb12-29aad97e-6e14-0200181b80fa/ Datastore: Datastore:datastore-35, datastore URL: ds:///vmfs/volumes/65b9eb13-459ae81b-430b-0200180b8354/ Datastore: Datastore:datastore-36, datastore URL: ds:///vmfs/volumes/65b9eb16-5ae57b09-9b05-0200180b8354/ Datastore: Datastore:datastore-30, datastore URL: ds:///vmfs/volumes/65b9eb0b-b58f52e3-043f-020018345fb7/ Datastore: Datastore:datastore-31, datastore URL: ds:///vmfs/volumes/65b9eb0d-a9c47401-87e0-020018345fb7/]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.428Z	DEBUG	common/vsphereutil.go:445	vSphere CSI driver creating volume pvc-ab75d20b-5971-4b94-96d8-199d2e235019 with create spec (*types.CnsVolumeCreateSpec)(0xc00049da00)({
 DynamicData: (types.DynamicData) {
 },
 Name: (string) (len=40) "pvc-ab75d20b-5971-4b94-96d8-199d2e235019",
 VolumeType: (string) (len=5) "BLOCK",
 Datastores: ([]types.ManagedObjectReference) (len=6 cap=8) {
  (types.ManagedObjectReference) Datastore:datastore-33,
  (types.ManagedObjectReference) Datastore:datastore-34,
  (types.ManagedObjectReference) Datastore:datastore-35,
  (types.ManagedObjectReference) Datastore:datastore-36,
  (types.ManagedObjectReference) Datastore:datastore-30,
  (types.ManagedObjectReference) Datastore:datastore-31
 },
 Metadata: (types.CnsVolumeMetadata) {
  DynamicData: (types.DynamicData) {
  },
  ContainerCluster: (types.CnsContainerCluster) {
   DynamicData: (types.DynamicData) {
   },
   ClusterType: (string) (len=10) "KUBERNETES",
   ClusterId: (string) (len=36) "a20c951e-365a-4fba-80f7-a4910f95209b",
   VSphereUser: (string) (len=27) "Administrator@vsphere.local",
   ClusterFlavor: (string) (len=7) "VANILLA",
   ClusterDistribution: (string) (len=11) "CSI-Vanilla"
  },
  EntityMetadata: ([]types.BaseCnsEntityMetadata) <nil>,
  ContainerClusterArray: ([]types.CnsContainerCluster) (len=1 cap=1) {
   (types.CnsContainerCluster) {
    DynamicData: (types.DynamicData) {
    },
    ClusterType: (string) (len=10) "KUBERNETES",
    ClusterId: (string) (len=36) "a20c951e-365a-4fba-80f7-a4910f95209b",
    VSphereUser: (string) (len=27) "Administrator@vsphere.local",
    ClusterFlavor: (string) (len=7) "VANILLA",
    ClusterDistribution: (string) (len=11) "CSI-Vanilla"
   }
  }
 },
 BackingObjectDetails: (*types.CnsBlockBackingDetails)(0xc0006c8f80)({
  CnsBackingObjectDetails: (types.CnsBackingObjectDetails) {
   DynamicData: (types.DynamicData) {
   },
   CapacityInMb: (int64) 1024
  },
  BackingDiskId: (string) "",
  BackingDiskUrlPath: (string) "",
  BackingDiskObjectId: (string) ""
 }),
 Profile: ([]types.BaseVirtualMachineProfileSpec) <nil>,
 CreateSpec: (types.BaseCnsBaseCreateSpec) <nil>,
 VolumeSource: (types.BaseCnsVolumeSource) <nil>
})
	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.429Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.430Z	DEBUG	config/config.go:372	Initializing vc server 10.161.97.50	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.430Z	DEBUG	config/config.go:417	vc server 10.161.97.50 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.430Z	DEBUG	config/config.go:372	Initializing vc server 10.185.70.239	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.430Z	DEBUG	config/config.go:417	vc server 10.185.70.239 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.430Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.442Z	DEBUG	volume/util.go:204	Update VSphereUser from Administrator@vsphere.local to VSPHERE.LOCAL\Administrator	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.442Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:151	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-ab75d20b-5971-4b94-96d8-199d2e235019	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.450Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:196	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc000244a50)({
 Name: (string) (len=40) "pvc-ab75d20b-5971-4b94-96d8-199d2e235019",
 VolumeID: (string) "",
 SnapshotID: (string) "",
 Capacity: (int64) 0,
 QuotaDetails: (*cnsvolumeoperationrequest.QuotaDetails)(<nil>),
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc0004b81c0)({
  TaskInvocationTimestamp: (v1.Time) 2024-01-31 23:30:25.450318557 +0000 UTC m=+129.325404303,
  TaskID: (string) "",
  VCenterServer: (string) (len=13) "10.185.70.239",
  OpID: (string) "",
  TaskStatus: (string) (len=10) "InProgress",
  Error: (string) ""
 })
})
	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.505Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:243	Created CnsVolumeOperationRequest instance vmware-system-csi/pvc-ab75d20b-5971-4b94-96d8-199d2e235019 with latest information for task with ID: 	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.645Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:196	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc000321680)({
 Name: (string) (len=40) "pvc-ab75d20b-5971-4b94-96d8-199d2e235019",
 VolumeID: (string) "",
 SnapshotID: (string) "",
 Capacity: (int64) 0,
 QuotaDetails: (*cnsvolumeoperationrequest.QuotaDetails)(<nil>),
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc0004aad90)({
  TaskInvocationTimestamp: (v1.Time) 2024-01-31 23:30:25.645489579 +0000 UTC m=+129.520575287,
  TaskID: (string) (len=9) "task-3186",
  VCenterServer: (string) (len=13) "10.185.70.239",
  OpID: (string) "",
  TaskStatus: (string) (len=10) "InProgress",
  Error: (string) ""
 })
})
	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.681Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:319	Updated CnsVolumeOperationRequest instance vmware-system-csi/pvc-ab75d20b-5971-4b94-96d8-199d2e235019 with latest information for task with ID: task-3186	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.681Z	INFO	volume/listview.go:124	AddTask called for Task:task-3186	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.688Z	DEBUG	volume/listview.go:129	connection to vc successful	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.688Z	DEBUG	volume/listview.go:137	task Task:task-3186 added to map	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.700Z	INFO	volume/listview.go:159	task Task:task-3186 added to listView	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:25.701Z	DEBUG	volume/listview.go:252	Got 1 property collector update(s)	{"TraceId": "685e43d3-df85-49ec-99fb-facaaac76076"}
2024-01-31T23:30:25.701Z	DEBUG	volume/listview.go:255	Got update for object Task:task-3186 properties {{} info assign {{} task-3186 Task:task-3186 <nil>  com.vmware.cns.tasks.createvolume Folder:group-d1 Datacenters [] running false false <nil> <nil> 0 [] 0xc000afd690 2024-01-31 23:30:25.700121 +0000 UTC 2024-01-31 23:30:25.719133 +0000 UTC <nil> 10782    e1f3f331}}	{"TraceId": "685e43d3-df85-49ec-99fb-facaaac76076"}
2024-01-31T23:30:25.702Z	INFO	volume/listview.go:296	processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-3186 Task:Task:task-3186 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc000afd690 QueueTime:2024-01-31 23:30:25.700121 +0000 UTC StartTime:2024-01-31 23:30:25.719133 +0000 UTC CompleteTime:<nil> EventChainId:10782 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:e1f3f331}}	{"TraceId": "685e43d3-df85-49ec-99fb-facaaac76076"}
2024-01-31T23:30:26.962Z	DEBUG	volume/listview.go:252	Got 1 property collector update(s)	{"TraceId": "685e43d3-df85-49ec-99fb-facaaac76076"}
2024-01-31T23:30:26.962Z	DEBUG	volume/listview.go:255	Got update for object Task:task-3186 properties {{} info assign {{} task-3186 Task:task-3186 <nil>  com.vmware.cns.tasks.createvolume Folder:group-d1 Datacenters [] running false false <nil> <nil> 0 [] 0xc000afd870 2024-01-31 23:30:25.700121 +0000 UTC 2024-01-31 23:30:25.719133 +0000 UTC <nil> 10782    e1f3f331}}	{"TraceId": "685e43d3-df85-49ec-99fb-facaaac76076"}
2024-01-31T23:30:26.963Z	INFO	volume/listview.go:296	processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-3186 Task:Task:task-3186 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc000afd870 QueueTime:2024-01-31 23:30:25.700121 +0000 UTC StartTime:2024-01-31 23:30:25.719133 +0000 UTC CompleteTime:<nil> EventChainId:10782 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:e1f3f331}}	{"TraceId": "685e43d3-df85-49ec-99fb-facaaac76076"}
2024-01-31T23:30:26.999Z	DEBUG	volume/listview.go:252	Got 1 property collector update(s)	{"TraceId": "685e43d3-df85-49ec-99fb-facaaac76076"}
2024-01-31T23:30:26.999Z	DEBUG	volume/listview.go:255	Got update for object Task:task-3186 properties {{} info assign {{} task-3186 Task:task-3186 <nil>  com.vmware.cns.tasks.createvolume Folder:group-d1 Datacenters [] success false false <nil> {{} [0xc000c9f9c0]} 0 [] 0xc0006253c0 2024-01-31 23:30:25.700121 +0000 UTC 2024-01-31 23:30:25.719133 +0000 UTC 2024-01-31 23:30:27.065251 +0000 UTC 10782    e1f3f331}}	{"TraceId": "685e43d3-df85-49ec-99fb-facaaac76076"}
2024-01-31T23:30:26.999Z	INFO	volume/listview.go:296	processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-3186 Task:Task:task-3186 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:success Cancelled:false Cancelable:false Error:<nil> Result:{DynamicData:{} VolumeResults:[0xc000c9f9c0]} Progress:0 ProgressDetails:[] Reason:0xc0006253c0 QueueTime:2024-01-31 23:30:25.700121 +0000 UTC StartTime:2024-01-31 23:30:25.719133 +0000 UTC CompleteTime:2024-01-31 23:30:27.065251 +0000 UTC EventChainId:10782 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:e1f3f331}}	{"TraceId": "685e43d3-df85-49ec-99fb-facaaac76076"}
2024-01-31T23:30:27.006Z	DEBUG	volume/listview.go:172	connection to vc successful	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.012Z	INFO	volume/listview.go:178	task Task:task-3186 removed from listView	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.012Z	DEBUG	volume/listview.go:180	task Task:task-3186 removed from map	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.012Z	INFO	volume/manager.go:445	CreateVolume: VolumeName: "pvc-ab75d20b-5971-4b94-96d8-199d2e235019", opId: "e1f3f331"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.013Z	DEBUG	volume/listview.go:252	Got 1 property collector update(s)	{"TraceId": "685e43d3-df85-49ec-99fb-facaaac76076"}
2024-01-31T23:30:27.013Z	DEBUG	volume/util.go:308	volumeCreateResult.PlacementResults :[{Datastore:datastore-31 [0xc000061460]} {Datastore:datastore-30 []} {Datastore:datastore-36 [0xc000061740]} {Datastore:datastore-35 [0xc000061900]} {Datastore:datastore-34 [0xc000061aa0]} {Datastore:datastore-33 [0xc000061c40]}]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.023Z	INFO	volume/util.go:329	Volume created successfully. VolumeName: "pvc-ab75d20b-5971-4b94-96d8-199d2e235019", volumeID: "044f8927-e36e-49cc-bed5-5114de6c994c"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.023Z	DEBUG	volume/util.go:331	CreateVolume volumeId {{} "044f8927-e36e-49cc-bed5-5114de6c994c"} is placed on datastore "ds:///vmfs/volumes/65b9eb0b-b58f52e3-043f-020018345fb7/"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.024Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:196	Storing CnsVolumeOperationRequest instance with spec (*cnsvolumeoperationrequest.VolumeOperationRequestDetails)(0xc0000a98b0)({
 Name: (string) (len=40) "pvc-ab75d20b-5971-4b94-96d8-199d2e235019",
 VolumeID: (string) (len=36) "044f8927-e36e-49cc-bed5-5114de6c994c",
 SnapshotID: (string) "",
 Capacity: (int64) 0,
 QuotaDetails: (*cnsvolumeoperationrequest.QuotaDetails)(<nil>),
 OperationDetails: (*cnsvolumeoperationrequest.OperationDetails)(0xc0001aaf50)({
  TaskInvocationTimestamp: (v1.Time) 2024-01-31 23:30:25.645489579 +0000 UTC m=+129.520575287,
  TaskID: (string) (len=9) "task-3186",
  VCenterServer: (string) (len=13) "10.185.70.239",
  OpID: (string) (len=8) "e1f3f331",
  TaskStatus: (string) (len=7) "Success",
  Error: (string) ""
 })
})
	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.051Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:319	Updated CnsVolumeOperationRequest instance vmware-system-csi/pvc-ab75d20b-5971-4b94-96d8-199d2e235019 with latest information for task with ID: task-3186	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.051Z	DEBUG	volume/manager.go:884	internalCreateVolume: returns fault ""	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.052Z	INFO	vanilla/controller.go:1343	volume "044f8927-e36e-49cc-bed5-5114de6c994c" created in vCenter "10.185.70.239". Proceeding to calculate accessible topology for the volume	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.052Z	DEBUG	node/manager.go:392	Renewing VM VirtualMachine:vm-41 [VirtualCenterHost: 10.185.70.239, UUID: 42329467-62c7-8d89-5f7e-1323bdc0ce5e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.70.239]] with new connection: nodeUUID 42329467-62c7-8d89-5f7e-1323bdc0ce5e	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.052Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.052Z	DEBUG	config/config.go:372	Initializing vc server 10.161.97.50	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.052Z	DEBUG	config/config.go:417	vc server 10.161.97.50 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.052Z	DEBUG	config/config.go:372	Initializing vc server 10.185.70.239	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.052Z	DEBUG	config/config.go:417	vc server 10.185.70.239 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.052Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.060Z	DEBUG	node/manager.go:402	Updated VM VirtualMachine:vm-41 [VirtualCenterHost: 10.185.70.239, UUID: 42329467-62c7-8d89-5f7e-1323bdc0ce5e, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.70.239]] for node with nodeUUID 42329467-62c7-8d89-5f7e-1323bdc0ce5e	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.062Z	DEBUG	node/manager.go:389	Renewing VM VirtualMachine:vm-40 [VirtualCenterHost: 10.185.70.239, UUID: 423277ad-a93c-7015-ede1-cb4c14f0f8b4, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.70.239]], no new connection needed: nodeUUID 423277ad-a93c-7015-ede1-cb4c14f0f8b4	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.062Z	DEBUG	node/manager.go:402	Updated VM VirtualMachine:vm-40 [VirtualCenterHost: 10.185.70.239, UUID: 423277ad-a93c-7015-ede1-cb4c14f0f8b4, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.70.239]] for node with nodeUUID 423277ad-a93c-7015-ede1-cb4c14f0f8b4	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.062Z	DEBUG	node/manager.go:389	Renewing VM VirtualMachine:vm-42 [VirtualCenterHost: 10.185.70.239, UUID: 423237dc-6d90-df55-19b3-97706bfb84e5, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.70.239]], no new connection needed: nodeUUID 423237dc-6d90-df55-19b3-97706bfb84e5	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.062Z	DEBUG	node/manager.go:402	Updated VM VirtualMachine:vm-42 [VirtualCenterHost: 10.185.70.239, UUID: 423237dc-6d90-df55-19b3-97706bfb84e5, Datacenter: Datacenter [Datacenter: Datacenter:datacenter-3, VirtualCenterHost: 10.185.70.239]] for node with nodeUUID 423237dc-6d90-df55-19b3-97706bfb84e5	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.062Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/cloud/csi-vsphere.conf	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.064Z	DEBUG	config/config.go:372	Initializing vc server 10.161.97.50	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.065Z	DEBUG	config/config.go:417	vc server 10.161.97.50 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.065Z	DEBUG	config/config.go:372	Initializing vc server 10.185.70.239	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.065Z	DEBUG	config/config.go:417	vc server 10.185.70.239 config: &{User:Administrator@vsphere.local Password:UOHN_nC8dg7_Doep VCenterPort:443 InsecureFlag:true Datacenters:VSAN-DC TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.065Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.116Z	DEBUG	vsphere/datacenter.go:75	Found datastore MoRef Datastore:datastore-30 for datastoreURL: "ds:///vmfs/volumes/65b9eb0b-b58f52e3-043f-020018345fb7/" in datacenter: "/VSAN-DC" on vCenter: "10.185.70.239"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.127Z	INFO	common/vsphereutil.go:1157	Nodes that have access to datastore "ds:///vmfs/volumes/65b9eb0b-b58f52e3-043f-020018345fb7/" are [VirtualMachine:vm-41]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.136Z	DEBUG	node/manager.go:194	Retrieved node name "k8s-node-190-1706685294" for node UUID "42329467-62c7-8d89-5f7e-1323bdc0ce5e"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.136Z	INFO	placementengine/placement.go:353	Topology segments retrieved from nodes accessible to datastore "ds:///vmfs/volumes/65b9eb0b-b58f52e3-043f-020018345fb7/" are: [map[topology.csi.vmware.com/k8s-zone:zone-2]]	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.136Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:171	creating cnsvolumeinfo for volumeID: "044f8927-e36e-49cc-bed5-5114de6c994c" and vCenter: "10.185.70.239" mapping in the namespace: "vmware-system-csi"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.157Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:195	Successfully created CNSVolumeInfo CR for volumeID: "044f8927-e36e-49cc-bed5-5114de6c994c" and vCenter: "10.185.70.239" mapping in the namespace: "vmware-system-csi"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.157Z	DEBUG	vanilla/controller.go:2024	createVolumeInternal: returns fault ""	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
2024-01-31T23:30:27.157Z	INFO	vanilla/controller.go:2035	Volume created successfully. Volume Handle: "044f8927-e36e-49cc-bed5-5114de6c994c", PV Name: "pvc-ab75d20b-5971-4b94-96d8-199d2e235019"	{"TraceId": "b4c18316-7fb9-4d37-8caf-344ffb8db025"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bugfix for Multi-VC: Avoid sending non-compatible datastores to CNS during CreateVolume
```
