### PR TITLE
Support ListVolumes RPC call on Stretched Supervisor cluster

### DIFF
--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1392,16 +1392,6 @@ func (c *controller) ListVolumes(ctx context.Context, req *csi.ListVolumesReques
 	if !commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.ListVolumes) {
 		return nil, status.Error(codes.Unimplemented, "list volumes FSS disabled")
 	}
-	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
-		clusterComputeResourceMoIds, err = common.GetClusterComputeResourceMoIds(ctx)
-		if err != nil {
-			log.Errorf("failed to get clusterComputeResourceMoIds. err: %v", err)
-			return nil, status.Error(codes.Internal, "failed to get clusterComputeResourceMoIds")
-		}
-		if len(clusterComputeResourceMoIds) > 1 {
-			return nil, status.Error(codes.Unimplemented, "list volumes is not supported on Stretched Cluster")
-		}
-	}
 	controllerListVolumeInternal := func() (*csi.ListVolumesResponse, string, error) {
 		log.Debugf("ListVolumes called with args %+v, expectedStartingIndex %v", *req, expectedStartingIndex)
 		k8sVolumeIDs := commonco.ContainerOrchestratorUtility.GetAllVolumes()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds support for ListVolumes RPC call on Stretched Supervisor cluster in context of PodVM support on Stretched Supervisor cluster

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manually tested ListVolumes on Stretched Supervisor setup 

```
root@423177c942ad24ba5deedc018aa91d47 [ ~ ]# kubectl get pvc -A
NAMESPACE             NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             AGE
storage-policy-test   test-pvc   Bound    pvc-fc2b76d2-f0c1-4f74-beef-760f182e39ad   1Gi        RWO            wcp-profile-27mcopw6uv   7h3m

root@423177c942ad24ba5deedc018aa91d47 [ ~ ]# kubectl get pods -n storage-policy-test test-pod
NAME       READY   STATUS    RESTARTS   AGE
test-pod   1/1     Running   0          5m

root@423177c942ad24ba5deedc018aa91d47 [ ~ ]# kubectl get volumeattachments -n storage-policy-test
NAME                                                                   ATTACHER                 PV                                         NODE
                        ATTACHED   AGE
csi-84bfbc1dba76fd9282d14390f30bf63b6a3e06e789e92327a81b49b36cfc04b7   csi.vsphere.vmware.com   pvc-fc2b76d2-f0c1-4f74-beef-760f182e39ad   sc1-10-218-61-51.nimbus.eng.vmware.com   true       5m10s
```

CSI controller logs:

```
2024-01-23T13:40:34.824Z        DEBUG   wcp/controller.go:1396  ListVolumes called with args {MaxEntries:0 StartingToken: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}, expectedStartingIndex 0 {"TraceId": "691d1cbe-2540-48fe-be94-e45c3b2125a4"}
...
2024-01-23T13:40:35.688Z        DEBUG   wcp/controller.go:1467  ListVolumes: cnsVolumeIDs [83c5004d-4a37-4824-89c2-a1a0248e1f0b], startingIdx 0, queryLimit 1   {"TraceId": "691d1cbe-2540-48fe-be94-e45c3b2125a4"}
...
2024-01-23T13:40:35.738Z        DEBUG   wcp/controller.go:1488  ListVolumes: Response entries entries:<volume:<volume_id:"83c5004d-4a37-4824-89c2-a1a0248e1f0b" > status:<published_node_ids:"sc1-10-218-61-51.nimbus.eng.vmware.com" > >       {"TraceId": "691d1cbe-2540-48fe-be94-e45c3b2125a4"}
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support ListVolumes RPC call on Stretched Supervisor cluster
```
