### PR TITLE
Upgrade sidecars to latest releases

### DIFF
--- a/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
+++ b/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
@@ -84,7 +84,7 @@ spec:
       serviceAccountName: snapshot-webhook
       containers:
         - name: snapshot-validation
-          image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.3.2 # change the image if you wish to use your own custom validation server image
+          image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.3.3 # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/run/secrets/tls/tls.crt', '--tls-private-key-file=/run/secrets/tls/tls.key']
           ports:

--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -59,7 +59,7 @@ else
         exit 1
 fi
 
-qualified_version="v6.3.2"
+qualified_version="v6.3.3"
 volumesnapshotclasses_crd="volumesnapshotclasses.snapshot.storage.k8s.io"
 volumesnapshotcontents_crd="volumesnapshotcontents.snapshot.storage.k8s.io"
 volumesnapshots_crd="volumesnapshots.snapshot.storage.k8s.io"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -244,7 +244,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.4.2
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -262,7 +262,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.9.3
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -333,7 +333,7 @@ spec:
             periodSeconds: 180
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -380,7 +380,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -402,7 +402,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.2
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.3
           args:
             - "--v=4"
             - "--kube-api-qps=100"
@@ -453,7 +453,7 @@ spec:
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -538,7 +538,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -600,7 +600,7 @@ spec:
       serviceAccountName: vsphere-csi-node
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -680,7 +680,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Upgrade sidecars to latest releases

csi provisioner: https://github.com/kubernetes-csi/external-provisioner/releases/tag/v4.0.0
csi attacher: https://github.com/kubernetes-csi/external-attacher/releases/tag/v4.5.0
csi resizer: https://github.com/kubernetes-csi/external-resizer/releases/tag/v1.9.3
csi snapshotter: https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v6.3.3
csi livenessprobe: https://github.com/kubernetes-csi/livenessprobe/releases/tag/v2.12.0
csi node driver registrar: https://github.com/kubernetes-csi/node-driver-registrar/releases/tag/v2.10.0

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2757

**Testing done**:
Executed basic volume operation test and it ran successfully
```
12:39:17  Data Persistence [csi-block-vanilla] [csi-supervisor] [csi-guest] [csi-block-vanilla-parallelized] Should create and delete pod with the same volume source and data [p0, block, vanilla, wcp, tkg, core]
12:39:17  /home/worker/workspace/csi-block-vanilla-precheckin/2615/vsphere-csi-driver/tests/e2e/data_persistence.go:121
12:39:17    STEP: Creating a kubernetes client @ 01/23/24 12:39:15.513
12:39:17    Jan 23 12:39:15.513: INFO: >>> kubeConfig: /home/worker/workspace/csi-block-vanilla-precheckin/2615/.kube/config
12:39:17    STEP: Building a namespace api object, basename e2e-data-persistence @ 01/23/24 12:39:15.514
12:39:17    Jan 23 12:39:15.566: INFO: Skipping waiting for service account
12:39:17    Jan 23 12:39:15.586: INFO: Creating new VC session
12:39:17    STEP: Creating Storage Class and PVC @ 01/23/24 12:39:15.65
12:39:17    STEP: CNS_TEST: Running for vanilla k8s setup @ 01/23/24 12:39:15.65
12:39:17    STEP: Creating StorageClass  with scParameters: map[] and allowedTopologies: [] and ReclaimPolicy:  and allowVolumeExpansion: false @ 01/23/24 12:39:15.65
12:39:17    STEP: Creating PVC using the Storage Class sc-qxddb with disk size  and labels: map[] accessMode:  @ 01/23/24 12:39:15.743
12:39:17    Jan 23 12:39:15.776: INFO: PVC created: pvc-q2kdr in namespace: e2e-data-persistence-9233
12:39:17    STEP: Waiting for claim pvc-q2kdr to be in bound phase @ 01/23/24 12:39:15.776
12:39:17    Jan 23 12:39:15.776: INFO: Waiting up to timeout=5m0s for PersistentVolumeClaims [pvc-q2kdr] to have phase Bound
12:39:17    Jan 23 12:39:15.784: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:18    Jan 23 12:39:17.793: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:19    Jan 23 12:39:19.803: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:21    Jan 23 12:39:21.813: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:23    Jan 23 12:39:23.823: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:25    Jan 23 12:39:25.831: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:28    Jan 23 12:39:27.841: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:29    Jan 23 12:39:29.850: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:32    Jan 23 12:39:31.861: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:33    Jan 23 12:39:33.871: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:35    Jan 23 12:39:35.881: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:37    Jan 23 12:39:37.891: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:39    Jan 23 12:39:39.900: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:42    Jan 23 12:39:41.911: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:43    Jan 23 12:39:43.921: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:46    Jan 23 12:39:45.929: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:47    Jan 23 12:39:47.939: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:50    Jan 23 12:39:49.951: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:52    Jan 23 12:39:51.960: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:53    Jan 23 12:39:53.971: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:56    Jan 23 12:39:55.981: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:39:58    Jan 23 12:39:57.992: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:40:00    Jan 23 12:40:00.004: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:40:02    Jan 23 12:40:02.018: INFO: PersistentVolumeClaim pvc-q2kdr found but phase is Pending instead of Bound.
12:40:04    Jan 23 12:40:04.030: INFO: PersistentVolumeClaim pvc-q2kdr found and phase=Bound (48.254133371s)
12:40:04    STEP: Creating pod @ 01/23/24 12:40:04.047
12:40:04    Jan 23 12:40:04.084: INFO: Waiting up to 5m0s for pod "pvc-tester-snfns" in namespace "e2e-data-persistence-9233" to be "running"
12:40:04    Jan 23 12:40:04.096: INFO: Pod "pvc-tester-snfns": Phase="Pending", Reason="", readiness=false. Elapsed: 12.104006ms
12:40:06    Jan 23 12:40:06.109: INFO: Pod "pvc-tester-snfns": Phase="Pending", Reason="", readiness=false. Elapsed: 2.025400091s
12:40:08    Jan 23 12:40:08.107: INFO: Pod "pvc-tester-snfns": Phase="Pending", Reason="", readiness=false. Elapsed: 4.023443449s
12:40:10    Jan 23 12:40:10.108: INFO: Pod "pvc-tester-snfns": Phase="Pending", Reason="", readiness=false. Elapsed: 6.023578372s
12:40:12    Jan 23 12:40:12.105: INFO: Pod "pvc-tester-snfns": Phase="Pending", Reason="", readiness=false. Elapsed: 8.021482678s
12:40:14    Jan 23 12:40:14.107: INFO: Pod "pvc-tester-snfns": Phase="Pending", Reason="", readiness=false. Elapsed: 10.022862574s
12:40:16    Jan 23 12:40:16.107: INFO: Pod "pvc-tester-snfns": Phase="Pending", Reason="", readiness=false. Elapsed: 12.022977806s
12:40:18    Jan 23 12:40:18.111: INFO: Pod "pvc-tester-snfns": Phase="Running", Reason="", readiness=true. Elapsed: 14.027334747s
12:40:18    Jan 23 12:40:18.111: INFO: Pod "pvc-tester-snfns" satisfied condition "running"
12:40:18    STEP: Verify volume: 329946f0-a669-40b7-a7c9-a1df6ef22b9d is attached to the node: k8s-node-617-1705921241 @ 01/23/24 12:40:18.121
12:40:18    STEP: VM UUID is: 420ae6f8-9346-49d1-a3c5-1bad3dc8f905 for node: k8s-node-617-1705921241 @ 01/23/24 12:40:18.136
12:40:18    Jan 23 12:40:18.154: INFO: vmRef: VirtualMachine:vm-53 for the VM uuid: 420ae6f8-9346-49d1-a3c5-1bad3dc8f905
12:40:18    Jan 23 12:40:18.162: INFO: Found FCDID "329946f0-a669-40b7-a7c9-a1df6ef22b9d" attached to VM "k8s-worker2"
12:40:18    Jan 23 12:40:18.162: INFO: Found the disk "329946f0-a669-40b7-a7c9-a1df6ef22b9d" is attached to the VM with UUID: "420ae6f8-9346-49d1-a3c5-1bad3dc8f905"
12:40:18    STEP: Creating an empty file on the volume mounted on: pvc-tester-snfns @ 01/23/24 12:40:18.163
12:40:18    Jan 23 12:40:18.163: INFO: Running '/usr/bin/kubectl --kubeconfig=/home/worker/workspace/csi-block-vanilla-precheckin/2615/.kube/config --namespace=e2e-data-persistence-9233 exec pvc-tester-snfns -- /bin/sh -c touch /mnt/volume1/e2e-data-persistence-9233_file_A.txt'
12:40:18    Jan 23 12:40:18.524: INFO: stderr: ""
12:40:18    Jan 23 12:40:18.524: INFO: stdout: ""
12:40:18    STEP: Verify files exist on volume mounted on: pvc-tester-snfns @ 01/23/24 12:40:18.525
12:40:18    Jan 23 12:40:18.525: INFO: Running '/usr/bin/kubectl --kubeconfig=/home/worker/workspace/csi-block-vanilla-precheckin/2615/.kube/config --namespace=e2e-data-persistence-9233 exec --namespace=e2e-data-persistence-9233 pvc-tester-snfns -- /bin/ls /mnt/volume1/e2e-data-persistence-9233_file_A.txt'
12:40:18    Jan 23 12:40:18.721: INFO: stderr: ""
12:40:18    Jan 23 12:40:18.721: INFO: stdout: "/mnt/volume1/e2e-data-persistence-9233_file_A.txt\n"
12:40:18    STEP: Deleting the pod @ 01/23/24 12:40:18.722
12:40:18    Jan 23 12:40:18.722: INFO: Deleting pod "pvc-tester-snfns" in namespace "e2e-data-persistence-9233"
12:40:18    Jan 23 12:40:18.750: INFO: Wait up to 5m0s for pod "pvc-tester-snfns" to be fully deleted
12:40:20    STEP: Verify volume is detached from the node @ 01/23/24 12:40:20.772
12:40:22    STEP: VM UUID is: 420ae6f8-9346-49d1-a3c5-1bad3dc8f905 for node: k8s-node-617-1705921241 @ 01/23/24 12:40:22.782
12:40:22    Jan 23 12:40:22.796: INFO: vmRef: VirtualMachine:vm-53 for the VM uuid: 420ae6f8-9346-49d1-a3c5-1bad3dc8f905
12:40:22    Jan 23 12:40:22.803: INFO: Found FCDID "329946f0-a669-40b7-a7c9-a1df6ef22b9d" attached to VM "k8s-worker2"
12:40:22    Jan 23 12:40:22.803: INFO: Found the disk "329946f0-a669-40b7-a7c9-a1df6ef22b9d" is attached to the VM with UUID: "420ae6f8-9346-49d1-a3c5-1bad3dc8f905"
12:40:22    Jan 23 12:40:22.803: INFO: Waiting for disk: "329946f0-a669-40b7-a7c9-a1df6ef22b9d" to be detached from the node :"k8s-node-617-1705921241"
12:40:24    STEP: VM UUID is: 420ae6f8-9346-49d1-a3c5-1bad3dc8f905 for node: k8s-node-617-1705921241 @ 01/23/24 12:40:24.781
12:40:24    Jan 23 12:40:24.795: INFO: vmRef: VirtualMachine:vm-53 for the VM uuid: 420ae6f8-9346-49d1-a3c5-1bad3dc8f905
12:40:24    Jan 23 12:40:24.801: INFO: failed to find FCDID "329946f0-a669-40b7-a7c9-a1df6ef22b9d" attached to VM "k8s-worker2"
12:40:24    Jan 23 12:40:24.801: INFO: Disk: 329946f0-a669-40b7-a7c9-a1df6ef22b9d successfully detached
12:40:24    STEP: Creating a new pod using the same volume @ 01/23/24 12:40:24.801
12:40:25    Jan 23 12:40:24.822: INFO: Waiting up to 5m0s for pod "pvc-tester-tkkpr" in namespace "e2e-data-persistence-9233" to be "running"
12:40:25    Jan 23 12:40:24.832: INFO: Pod "pvc-tester-tkkpr": Phase="Pending", Reason="", readiness=false. Elapsed: 10.610595ms
12:40:27    Jan 23 12:40:26.843: INFO: Pod "pvc-tester-tkkpr": Phase="Pending", Reason="", readiness=false. Elapsed: 2.021227039s
12:40:29    Jan 23 12:40:28.844: INFO: Pod "pvc-tester-tkkpr": Phase="Pending", Reason="", readiness=false. Elapsed: 4.022053278s
12:40:30    Jan 23 12:40:30.843: INFO: Pod "pvc-tester-tkkpr": Phase="Pending", Reason="", readiness=false. Elapsed: 6.020771647s
12:40:32    Jan 23 12:40:32.844: INFO: Pod "pvc-tester-tkkpr": Phase="Running", Reason="", readiness=true. Elapsed: 8.022103652s
12:40:32    Jan 23 12:40:32.844: INFO: Pod "pvc-tester-tkkpr" satisfied condition "running"
12:40:32    STEP: Verify volume: 329946f0-a669-40b7-a7c9-a1df6ef22b9d is attached to the node: k8s-node-982-1705921252 @ 01/23/24 12:40:32.853
12:40:32    STEP: VM UUID is: 420a4918-1a5b-edc2-86d2-2451d916cde0 for node: k8s-node-982-1705921252 @ 01/23/24 12:40:32.865
12:40:32    Jan 23 12:40:32.879: INFO: vmRef: VirtualMachine:vm-50 for the VM uuid: 420a4918-1a5b-edc2-86d2-2451d916cde0
12:40:32    Jan 23 12:40:32.885: INFO: Found FCDID "329946f0-a669-40b7-a7c9-a1df6ef22b9d" attached to VM "k8s-worker3"
12:40:32    Jan 23 12:40:32.885: INFO: Found the disk "329946f0-a669-40b7-a7c9-a1df6ef22b9d" is attached to the VM with UUID: "420a4918-1a5b-edc2-86d2-2451d916cde0"
12:40:32    STEP: Creating a second empty file on the same volume mounted on: pvc-tester-tkkpr @ 01/23/24 12:40:32.885
12:40:32    Jan 23 12:40:32.885: INFO: Running '/usr/bin/kubectl --kubeconfig=/home/worker/workspace/csi-block-vanilla-precheckin/2615/.kube/config --namespace=e2e-data-persistence-9233 exec pvc-tester-tkkpr -- /bin/sh -c touch /mnt/volume1/e2e-data-persistence-9233_file_B.txt'
12:40:33    Jan 23 12:40:33.137: INFO: stderr: ""
12:40:33    Jan 23 12:40:33.137: INFO: stdout: ""
12:40:33    STEP: Verify files exist on volume mounted on: pvc-tester-tkkpr @ 01/23/24 12:40:33.137
12:40:33    Jan 23 12:40:33.138: INFO: Running '/usr/bin/kubectl --kubeconfig=/home/worker/workspace/csi-block-vanilla-precheckin/2615/.kube/config --namespace=e2e-data-persistence-9233 exec --namespace=e2e-data-persistence-9233 pvc-tester-tkkpr -- /bin/ls /mnt/volume1/e2e-data-persistence-9233_file_A.txt'
12:40:33    Jan 23 12:40:33.343: INFO: stderr: ""
12:40:33    Jan 23 12:40:33.343: INFO: stdout: "/mnt/volume1/e2e-data-persistence-9233_file_A.txt\n"
12:40:33    Jan 23 12:40:33.343: INFO: Running '/usr/bin/kubectl --kubeconfig=/home/worker/workspace/csi-block-vanilla-precheckin/2615/.kube/config --namespace=e2e-data-persistence-9233 exec --namespace=e2e-data-persistence-9233 pvc-tester-tkkpr -- /bin/ls /mnt/volume1/e2e-data-persistence-9233_file_B.txt'
12:40:33    Jan 23 12:40:33.548: INFO: stderr: ""
12:40:33    Jan 23 12:40:33.548: INFO: stdout: "/mnt/volume1/e2e-data-persistence-9233_file_B.txt\n"
12:40:33    STEP: Deleting the pod @ 01/23/24 12:40:33.548
12:40:33    Jan 23 12:40:33.548: INFO: Deleting pod "pvc-tester-tkkpr" in namespace "e2e-data-persistence-9233"
12:40:33    Jan 23 12:40:33.572: INFO: Wait up to 5m0s for pod "pvc-tester-tkkpr" to be fully deleted
12:40:38    STEP: Verify volume is detached from the node @ 01/23/24 12:40:37.595
12:40:39    STEP: VM UUID is: 420a4918-1a5b-edc2-86d2-2451d916cde0 for node: k8s-node-982-1705921252 @ 01/23/24 12:40:39.605
12:40:39    Jan 23 12:40:39.623: INFO: vmRef: VirtualMachine:vm-50 for the VM uuid: 420a4918-1a5b-edc2-86d2-2451d916cde0
12:40:39    Jan 23 12:40:39.630: INFO: Found FCDID "329946f0-a669-40b7-a7c9-a1df6ef22b9d" attached to VM "k8s-worker3"
12:40:39    Jan 23 12:40:39.630: INFO: Found the disk "329946f0-a669-40b7-a7c9-a1df6ef22b9d" is attached to the VM with UUID: "420a4918-1a5b-edc2-86d2-2451d916cde0"
12:40:39    Jan 23 12:40:39.630: INFO: Waiting for disk: "329946f0-a669-40b7-a7c9-a1df6ef22b9d" to be detached from the node :"k8s-node-982-1705921252"
12:40:41    STEP: VM UUID is: 420a4918-1a5b-edc2-86d2-2451d916cde0 for node: k8s-node-982-1705921252 @ 01/23/24 12:40:41.604
12:40:41    Jan 23 12:40:41.619: INFO: vmRef: VirtualMachine:vm-50 for the VM uuid: 420a4918-1a5b-edc2-86d2-2451d916cde0
12:40:41    Jan 23 12:40:41.626: INFO: failed to find FCDID "329946f0-a669-40b7-a7c9-a1df6ef22b9d" attached to VM "k8s-worker3"
12:40:41    Jan 23 12:40:41.626: INFO: Disk: 329946f0-a669-40b7-a7c9-a1df6ef22b9d successfully detached
12:40:41    Jan 23 12:40:41.626: INFO: Deleting PersistentVolumeClaim "pvc-q2kdr"
12:40:43    Jan 23 12:40:43.679: INFO: volume "329946f0-a669-40b7-a7c9-a1df6ef22b9d" has successfully deleted
12:40:43    STEP: Destroying namespace "e2e-data-persistence-9233" for this suite. @ 01/23/24 12:40:43.696
12:40:43  • [88.201 seconds]
12:40:43  ------------------------------
12:40:43  SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
12:40:43  ------------------------------
12:40:43  [ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
12:40:43  autogenerated by Ginkgo
12:40:43  [ReportAfterSuite] PASSED [0.061 seconds]
12:40:43  ------------------------------
12:40:43  
12:40:43  Ran 1 of 816 Specs in 88.228 seconds
12:40:43  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 815 Skipped
12:40:43  PASS
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Upgrade sidecars to latest releases
```
