### PR TITLE
Replace policy usage CR List method with CR Get method

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -913,40 +913,21 @@ func cnsvolumeoperationrequestCRAdded(obj interface{}) {
 			log.Errorf("cnsvolumeoperationrequestCRAdded: Failed to create CnsOperator client. Err: %+v", err)
 			return
 		}
-		namespace := cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Namespace
-		storagePolicyUsageList := &storagepolicyusagev1alpha1.StoragePolicyUsageList{}
-		err = cnsOperatorClient.List(ctx, storagePolicyUsageList, client.InNamespace(namespace))
-		if err != nil {
-			log.Errorf("failed to list %s CR from supervisor namespace %q. Error: %+v",
-				storagepolicyusagev1alpha1.CRDSingular, namespace, err)
-			return
-		}
-		foundStoragePolicyUsageCR := false
+		// Fetch StoragePolicyUsage instance for storageClass associated with the volume.
+		storagePolicyUsageInstanceName := cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StorageClassName + "-" +
+			storagepolicyusagev1alpha1.NameSuffixForPVC
 		storagePolicyUsageCR := &storagepolicyusagev1alpha1.StoragePolicyUsage{}
-		patchedStoragePolicyUsageCR := &storagepolicyusagev1alpha1.StoragePolicyUsage{}
-		if len(storagePolicyUsageList.Items) > 0 {
-			for _, item := range storagePolicyUsageList.Items {
-				policyId := cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StoragePolicyId
-				scName := cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StorageClassName
-				if item.Spec.StoragePolicyId == policyId && item.Spec.StorageClassName == scName {
-					log.Debugf("cnsvolumeoperationrequestCRAdded: Found storagePolicyUsage CR with matching "+
-						"storagePolicyId: %q & storageClassName: %q in namespace: %q", policyId, scName,
-						namespace)
-					storagePolicyUsageCR = item.DeepCopy()
-					foundStoragePolicyUsageCR = true
-					break
-				}
-			}
-		}
-		if !foundStoragePolicyUsageCR {
-			log.Errorf("unable to find matching %q CR with PolicyId: %q & PolicyName: %q from "+
-				"supervisor namespace %q", storagepolicyusagev1alpha1.CRDSingular,
-				cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StoragePolicyId,
-				cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StorageClassName,
-				namespace)
+		err = cnsOperatorClient.Get(ctx, k8stypes.NamespacedName{
+			Namespace: cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Namespace,
+			Name:      storagePolicyUsageInstanceName},
+			storagePolicyUsageCR)
+		if err != nil {
+			log.Errorf("failed to fetch %s instance with name %q from supervisor namespace %q. Error: %+v",
+				storagepolicyusagev1alpha1.CRDSingular, storagePolicyUsageInstanceName,
+				cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Namespace, err)
 			return
 		}
-		patchedStoragePolicyUsageCR = storagePolicyUsageCR.DeepCopy()
+		patchedStoragePolicyUsageCR := storagePolicyUsageCR.DeepCopy()
 		if storagePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage != nil &&
 			storagePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved != nil {
 			// If StoragePolicyUsage CR has Status.QuotaUsage fields not nil update StoragePolicyUsage reserved field
@@ -1016,40 +997,21 @@ func cnsvolumeoperationrequestCRDeleted(obj interface{}) {
 			log.Errorf("Failed to create CnsOperator client. Err: %+v", err)
 			return
 		}
-		namespace := cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Namespace
-		storagePolicyUsageList := &storagepolicyusagev1alpha1.StoragePolicyUsageList{}
-		err = cnsOperatorClient.List(ctx, storagePolicyUsageList, client.InNamespace(namespace))
-		if err != nil {
-			log.Errorf("failed to list %s CR from supervisor namespace %q. Error: %+v",
-				storagepolicyusagev1alpha1.CRDSingular, namespace, err)
-			return
-		}
-		foundStoragePolicyUsageCR := false
+		// Fetch StoragePolicyUsage instance for storageClass associated with the volume.
+		storagePolicyUsageInstanceName := cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StorageClassName + "-" +
+			storagepolicyusagev1alpha1.NameSuffixForPVC
 		storagePolicyUsageCR := &storagepolicyusagev1alpha1.StoragePolicyUsage{}
-		patchedStoragePolicyUsageCR := &storagepolicyusagev1alpha1.StoragePolicyUsage{}
-		if len(storagePolicyUsageList.Items) > 0 {
-			for _, item := range storagePolicyUsageList.Items {
-				policyId := cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StoragePolicyId
-				scName := cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StorageClassName
-				if item.Spec.StoragePolicyId == policyId && item.Spec.StorageClassName == scName {
-					log.Debugf("cnsvolumeoperationrequestCRDeleted: Found storagePolicyUsage CR with matching "+
-						"storagePolicyId: %q & storageClassName: %q in namespace: %q", policyId, scName,
-						namespace)
-					storagePolicyUsageCR = item.DeepCopy()
-					foundStoragePolicyUsageCR = true
-					break
-				}
-			}
-		}
-		if !foundStoragePolicyUsageCR {
-			log.Errorf("unable to find matching %q CR with PolicyId: %q & PolicyName: %q from "+
-				"supervisor namespace %q", storagepolicyusagev1alpha1.CRDSingular,
-				cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StoragePolicyId,
-				cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StorageClassName,
-				namespace)
+		err = cnsOperatorClient.Get(ctx, k8stypes.NamespacedName{
+			Namespace: cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Namespace,
+			Name:      storagePolicyUsageInstanceName},
+			storagePolicyUsageCR)
+		if err != nil {
+			log.Errorf("failed to fetch %s instance with name %q from supervisor namespace %q. Error: %+v",
+				storagepolicyusagev1alpha1.CRDSingular, storagePolicyUsageInstanceName,
+				cnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Namespace, err)
 			return
 		}
-		patchedStoragePolicyUsageCR = storagePolicyUsageCR.DeepCopy()
+		patchedStoragePolicyUsageCR := storagePolicyUsageCR.DeepCopy()
 		// This is a case where CnsVolumeOperationRequest is cleaned up due to CreateVolume failure.
 		// Hence, the "reserved" field in StoragePolicyUsage needs to be decreased based on the
 		// deleted CnsVolumeOperationRequest object's "reserved" field.
@@ -1112,41 +1074,21 @@ func cnsvolumeoperationrequestCRUpdated(oldObj interface{}, newObj interface{}) 
 			log.Errorf("Failed to create CnsOperator client. Err: %+v", err)
 			return
 		}
-		namespace := newcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Namespace
-		storagePolicyUsageList := &storagepolicyusagev1alpha1.StoragePolicyUsageList{}
-		err = cnsOperatorClient.List(ctx, storagePolicyUsageList, client.InNamespace(namespace))
-		if err != nil {
-			log.Errorf("failed to list %s CR from supervisor namespace %q. Error: %+v",
-				storagepolicyusagev1alpha1.CRDSingular, namespace, err)
-			return
-		}
-		foundStoragePolicyUsageCR := false
+		// Fetch StoragePolicyUsage instance for storageClass associated with the volume.
+		storagePolicyUsageInstanceName := newcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StorageClassName + "-" +
+			storagepolicyusagev1alpha1.NameSuffixForPVC
 		storagePolicyUsageCR := &storagepolicyusagev1alpha1.StoragePolicyUsage{}
-		patchedStoragePolicyUsageCR := &storagepolicyusagev1alpha1.StoragePolicyUsage{}
-		if len(storagePolicyUsageList.Items) > 0 {
-			for _, item := range storagePolicyUsageList.Items {
-				policyId := newcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StoragePolicyId
-				scName := newcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StorageClassName
-				if item.Spec.StoragePolicyId == policyId && item.Spec.StorageClassName == scName {
-					log.Debugf("cnsvolumeoperationrequestCRUpdated: Found storagePolicyUsage CR with matching "+
-						"storagePolicyId: %q & storageClassName: %q in namespace: %q", policyId, scName,
-						namespace)
-					storagePolicyUsageCR = item.DeepCopy()
-
-					foundStoragePolicyUsageCR = true
-					break
-				}
-			}
-		}
-		if !foundStoragePolicyUsageCR {
-			log.Errorf("unable to find matching %q CR with PolicyId: %q & PolicyName: %q from "+
-				"supervisor namespace %q", storagepolicyusagev1alpha1.CRDSingular,
-				newcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StoragePolicyId,
-				newcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.StorageClassName,
-				namespace)
+		err = cnsOperatorClient.Get(ctx, k8stypes.NamespacedName{
+			Namespace: newcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Namespace,
+			Name:      storagePolicyUsageInstanceName},
+			storagePolicyUsageCR)
+		if err != nil {
+			log.Errorf("failed to fetch %s instance with name %q from supervisor namespace %q. Error: %+v",
+				storagepolicyusagev1alpha1.CRDSingular, storagePolicyUsageInstanceName,
+				newcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Namespace, err)
 			return
 		}
-		patchedStoragePolicyUsageCR = storagePolicyUsageCR.DeepCopy()
+		patchedStoragePolicyUsageCR := storagePolicyUsageCR.DeepCopy()
 		if newcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved.Value() >
 			oldcnsvolumeoperationrequestObj.Status.StorageQuotaDetails.Reserved.Value() {
 			// This is a case where CSI Driver container increases the value of "reserved" field in


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Replace policy usage CR List method with CR Get method

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2707

**Testing done**:
StoragePolicyUsage Cr before:
```
kubectl get storagepolicyusage -n liping-test-ns-1 -o yaml test-zonal-policy-pvc-usage
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-01-10T21:30:03Z"
  generation: 3
  name: test-zonal-policy-pvc-usage
  namespace: liping-test-ns-1
  resourceVersion: "746205"
  uid: 6291a68f-d2d6-42ac-81e8-9cb8c7e6e76e
spec:
  resourceApiGroup: ""
  resourceExtensionName: volume.cns.vsphere.vmware.com
  resourceKind: PersistentVolumeClaim
  storageClassName: test-zonal-policy
  storagePolicyId: ef09d27b-d7ea-44e9-a4f6-5fd5c521b80d
status:
  quotaUsage:
    reserved: "0"
    used: 1Gi

```

Created 2 volumes with 50 Mi each:
```
kubectl get pvc -A
NAMESPACE          NAME                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
liping-test-ns-1   example-rwo-pvc     Bound    pvc-794e915c-2241-43da-a67f-49b89619f463   50Mi       RWO            test-zonal-policy   44s
liping-test-ns-1   example-rwo-pvc-1   Bound    pvc-f6a5246c-ed8f-415c-a6fd-8b7a79296644   50Mi       RWO            test-zonal-policy   3s
```
Verified the CR updates accordingly:
```
kubectl get storagepolicyusage -n liping-test-ns-1 -o yaml test-zonal-policy-pvc-usage
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-01-10T21:30:03Z"
  generation: 7
  name: test-zonal-policy-pvc-usage
  namespace: liping-test-ns-1
  resourceVersion: "9038168"
  uid: 6291a68f-d2d6-42ac-81e8-9cb8c7e6e76e
spec:
  resourceApiGroup: ""
  resourceExtensionName: volume.cns.vsphere.vmware.com
  resourceKind: PersistentVolumeClaim
  storageClassName: test-zonal-policy
  storagePolicyId: ef09d27b-d7ea-44e9-a4f6-5fd5c521b80d
status:
  quotaUsage:
    reserved: "0"
    used: 1124Mi
```

Verify CnsVolumeOperationCR Delete event:

Deleted the 2 PVCs:
```
kubectl delete pvc example-rwo-pvc example-rwo-pvc-1  -n liping-test-ns-1
persistentvolumeclaim "example-rwo-pvc" deleted
persistentvolumeclaim "example-rwo-pvc-1" deleted
```

Verified the SP Usage CR is updated successfully:
```
root@42153e5e2564277de2bd96ec7f82667b [ ~ ]# kubectl get storagepolicyusage -n liping-test-ns-1 -o yaml test-zonal-policy-pvc-usage
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-01-10T21:30:03Z"
  generation: 9
  name: test-zonal-policy-pvc-usage
  namespace: liping-test-ns-1
  resourceVersion: "9045566"
  uid: 6291a68f-d2d6-42ac-81e8-9cb8c7e6e76e
spec:
  resourceApiGroup: ""
  resourceExtensionName: volume.cns.vsphere.vmware.com
  resourceKind: PersistentVolumeClaim
  storageClassName: test-zonal-policy
  storagePolicyId: ef09d27b-d7ea-44e9-a4f6-5fd5c521b80d
status:
  quotaUsage:
    reserved: "0"
    used: 1Gi
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Replace policy usage CR List method with CR Get method
```
