### PR TITLE
Use GetAccessibilityRequirementsByVC method for single VC deployments

### DIFF
--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1715,33 +1715,21 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 			}
 		}
 
-		var multivCenterTopologyDeployment bool
 		if len(c.managers.VcenterConfigs) > 1 {
-			multivCenterTopologyDeployment = true
-		}
-		vcTopologySegmentsMap := make(map[string][]map[string]string)
-		if multivCenterTopologyDeployment {
 			if topologyRequirement == nil {
 				return nil, csifault.CSIInvalidArgumentFault, logger.LogNewErrorCode(log, codes.InvalidArgument,
 					"accessibility requirements cannot be nil for a multi-VC environment")
 			}
-			// Get the accessibility requirements according to the VC they belong to.
+		}
+		vcTopologySegmentsMap := make(map[string][]map[string]string)
+		if topologyRequirement != nil {
+			// Get accessibility requirements.
 			vcTopologySegmentsMap, err = common.GetAccessibilityRequirementsByVC(ctx, topologyRequirement)
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to get accessibility requirements by VC. Error: %+v", err)
 			}
 			log.Debugf("Topology accessibility requirements per VC are %+v", vcTopologySegmentsMap)
-		} else {
-			if topologyRequirement != nil {
-				// Get accessibility requirements.
-				for _, topology := range topologyRequirement.Preferred {
-					vcTopologySegmentsMap[c.managers.CnsConfig.Global.VCenterIP] = append(
-						vcTopologySegmentsMap[c.managers.CnsConfig.Global.VCenterIP],
-						topology.GetSegments())
-				}
-				log.Debugf("Topology accessibility requirements per VC are %+v", vcTopologySegmentsMap)
-			}
 		}
 		var createVolumeSpec = common.CreateVolumeSpec{
 			CapacityMB: volSizeMB,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently for single VC deployments, we do not check if a given topology requested by user correct or not. By using the method GetAccessibilityRequirementsByVC, we can use make sure only valid topology requirements are provided by the user.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Single VC testbed
1. On a single VC testbed, create a volume with invalid allowedTopology in storageclass having rack-1 and rack-4(invalid)

```
                  Message
  ----     ------                ----              ----                                                                                                -------
  Normal   ExternalProvisioning  4s (x2 over 12s)  persistentvolume-controller                                                                         Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal   Provisioning          3s (x4 over 12s)  csi.vsphere.vmware.com_vsphere-csi-controller-8f76cdc94-r568m_64606d95-594d-4316-9f35-f747a38854e9  External provisioner is provisioning volume for claim "default/example-vanilla-block-pvc"
  Warning  ProvisioningFailed    2s (x4 over 11s)  csi.vsphere.vmware.com_vsphere-csi-controller-8f76cdc94-r568m_64606d95-594d-4316-9f35-f747a38854e9  failed to provision volume with StorageClass "example-vanilla-block-sc": rpc error: code = Internal desc = failed to get accessibility requirements by VC. Error: failed to fetch vCenter associated with topology segments: map[topology.csi.vmware.com/k8s-building:building-1 topology.csi.vmware.com/k8s-level:level-1 topology.csi.vmware.com/k8s-rack:rack-4 topology.csi.vmware.com/k8s-region:region-1 topology.csi.vmware.com/k8s-zone:zone-1] , err: Topology label "topology.csi.vmware.com/k8s-rack:rack-4" not found in tag to vCenter mapping.
```
2. Gave correct allowedTopology -  volume provisioning went through correctly.


Multi VC testbed

1. Create a volume with invalid allowedTopology in storageclass having zone-1 and zone-4(invalid)

```
  Type     Reason                Age                From                                                                                                 Message
  ----     ------                ----               ----                                                                                                 -------
  Normal   Provisioning          20s (x6 over 59s)  csi.vsphere.vmware.com_vsphere-csi-controller-74bd74b877-m9mkd_db190142-36e1-48a8-b66c-130d05258a3d  External provisioner is provisioning volume for claim "default/sktest2"
  Warning  ProvisioningFailed    19s (x6 over 57s)  csi.vsphere.vmware.com_vsphere-csi-controller-74bd74b877-m9mkd_db190142-36e1-48a8-b66c-130d05258a3d  failed to provision volume with StorageClass "test-sc-vc3-6": rpc error: code = Internal desc = failed to get accessibility requirements by VC. Error: failed to fetch vCenter associated with topology segments: map[topology.csi.vmware.com/k8s-zone:zone-4] , err: Topology label "topology.csi.vmware.com/k8s-zone:zone-4" not found in tag to vCenter mapping.
  Normal   ExternalProvisioning  0s (x5 over 59s)   persistentvolume-controller                                                                          Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
```

2. Gave valid allowedTopology in SC - volume provisioning went through successfully.


**Special notes for your reviewer**:

**Release note**:
```
Fail file volume provisioning if invalid topology is provided.
```
