### PR TITLE
increase k8s client qps and burst setting for CSI controller and syncer container 

### DIFF
--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -342,9 +342,9 @@ spec:
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
-              value: "50"
+              value: "200"
             - name: INCLUSTER_CLIENT_BURST
-              value: "50"
+              value: "200"
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
@@ -394,9 +394,9 @@ spec:
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
-              value: "50"
+              value: "200"
             - name: INCLUSTER_CLIENT_BURST
-              value: "50"
+              value: "200"
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"

--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -342,9 +342,9 @@ spec:
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
-              value: "50"
+              value: "200"
             - name: INCLUSTER_CLIENT_BURST
-              value: "50"
+              value: "200"
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
@@ -394,9 +394,9 @@ spec:
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
-              value: "50"
+              value: "200"
             - name: INCLUSTER_CLIENT_BURST
-              value: "50"
+              value: "200"
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -342,9 +342,9 @@ spec:
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
-              value: "50"
+              value: "200"
             - name: INCLUSTER_CLIENT_BURST
-              value: "50"
+              value: "200"
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
@@ -394,9 +394,9 @@ spec:
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
-              value: "50"
+              value: "200"
             - name: INCLUSTER_CLIENT_BURST
-              value: "50"
+              value: "200"
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -342,9 +342,9 @@ spec:
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
-              value: "50"
+              value: "200"
             - name: INCLUSTER_CLIENT_BURST
-              value: "50"
+              value: "200"
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
@@ -394,9 +394,9 @@ spec:
             - name: LOGGER_LEVEL
               value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
             - name: INCLUSTER_CLIENT_QPS
-              value: "50"
+              value: "200"
             - name: INCLUSTER_CLIENT_BURST
-              value: "50"
+              value: "200"
             - name: GODEBUG
               value: x509sha1=1
           imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Increase k8s client qps and burst setting for CSI controller and syncer container.

with k8s client QPS and burst set to 50, we are observing performance degradation in the CSI operations.
vSphere CSI Driver for WCP has been updated to get and update many k8s instances during CSI control operations which requires bumping these setting to 200.






**Testing done**:
With 50 QPS and burst config throughput for expand volumes = throughput = 6.998 ops/sec
With 100 QPS and burst config throughput for expand volumes = 11 ops/sec


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
increase k8s client qps and burst setting for CSI controller and syncer container 
```
