### PR TITLE
(do-not-merge) supervisor: allow setting higher bit RSA key size for custom certificates

### DIFF
--- a/manifests/supervisorcluster/1.23/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.23/cns-csi.yaml
@@ -335,7 +335,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - mountPath: /etc/vmware/wcp
@@ -383,7 +383,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
           imagePullPolicy: "IfNotPresent"
           ports:
            - containerPort: 2113

--- a/manifests/supervisorcluster/1.24/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.24/cns-csi.yaml
@@ -338,7 +338,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -390,7 +390,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "50"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2113

--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -346,7 +346,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -398,7 +398,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2113

--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -346,7 +346,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -398,7 +398,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2113

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -346,7 +346,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -398,7 +398,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2113

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -346,7 +346,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -398,7 +398,7 @@ spec:
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
             - name: GODEBUG
-              value: x509sha1=1
+              value: x509sha1=1,tlsmaxrsasize=16384
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2113


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Golang fixed a CVE in  go1.19.12, go1.20.7, go1.21.0-0 by restricting the RSA Key size transmitted during handshakes to <= 8192 bits. VC supports custom certificates with larger key size upto 16384. Services written in Golang and using the versions of Go that has the CVE fix is impacted when communicating with VC with custom server certificates with key size > 8192.

This MR is adding the support for RSA Key size up to 16384 bytes by setting it in tlsmaxrsasize environment variable.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

### supervisor

```
{"level":"error","time":"2024-01-26T19:47:47.494406854Z","caller":"wcp/controller.go:1426","msg":"Error while querying volumes from CNS Post \"https://sc2-10-186-193-76.eng.vmware.com:443/vsanHealth\": tls: server sent certificate containing RSA key larger than 8192 bits","TraceId":"7f9d818b-1a8a-4ef9-85fb-6f7f7112ebbd","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).ListVolumes.func1\n\t/build/mts/release/sb-70746926/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/csi/service/wcp/controller.go:1426\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).ListVolumes\n\t/build/mts/release/sb-70746926/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/csi/service/wcp/controller.go:1491\ngithub.com/container-storage-interface/spec/lib/go/csi._Controller_ListVolumes_Handler\n\t/build/mts/release/sb-70746926/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/github.com/container-storage-interface/spec@v1.9.0/lib/go/csi/csi.pb.go:6670\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/build/mts/release/sb-70746926/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/google.golang.org/grpc@v1.59.0/server.go:1343\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/build/mts/release/sb-70746926/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/google.golang.org/grpc@v1.59.0/server.go:1737\ngoogle.golang.org/grpc.(*Server).serveStreams.func1.1\n\t/build/mts/release/sb-70746926/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/google.golang.org/grpc@v1.59.0/server.go:986"}

root@421af6b11f36e6002a31350f55324f0f [ ~ ]# k -n vmware-system-csi get po
NAME                                      READY   STATUS             RESTARTS         AGE
vsphere-csi-controller-6f6cff77b6-br6zx   7/7     Running            23 (5h37m ago)   5h56m
vsphere-csi-controller-6f6cff77b6-qwf6x   6/7     CrashLoopBackOff   11 (67s ago)     5h56m
vsphere-csi-webhook-5c98f96bb8-2d55h      1/1     Running            0                5h56m
vsphere-csi-webhook-5c98f96bb8-mfbxd      1/1     Running            0                5h56m

root@421af6b11f36e6002a31350f55324f0f [ ~ ]# k -n vmware-system-csi edit deploy
deployment.apps/vsphere-csi-controller edited
deployment.apps/vsphere-csi-webhook skipped

root@421af6b11f36e6002a31350f55324f0f [ ~ ]# k -n vmware-system-csi get deploy -o yaml | grep sha1
            value: x509sha1=1,tlsmaxrsasize=16384
            value: x509sha1=1,tlsmaxrsasize=16384

root@421af6b11f36e6002a31350f55324f0f [ ~ ]# k -n vmware-system-csi get po
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-7874967794-6k5p8   7/7     Running   0          23s
vsphere-csi-controller-7874967794-8xq9n   7/7     Running   0          8s
vsphere-csi-webhook-5c98f96bb8-2d55h      1/1     Running   0          5h57m
vsphere-csi-webhook-5c98f96bb8-mfbxd      1/1     Running   0          5h57m

```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
 Allow setting higher bit RSA key size for customer certificates
```
