### PR TITLE
Optimize topology aware CreateVolume performance in WCP

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -396,14 +396,9 @@ func GetTagManager(ctx context.Context, vc *VirtualCenter) (*tags.Manager, error
 // managed datastores of given VC cluster.
 // The 1st output parameter will be shared datastores.
 // The 2nd output parameter will be vSAN-direct managed datastores.
-func GetCandidateDatastoresInCluster(ctx context.Context, vc *VirtualCenter, clusterID string) (
-	[]*DatastoreInfo, []*DatastoreInfo, error) {
+func GetCandidateDatastoresInCluster(ctx context.Context, vc *VirtualCenter, clusterID string,
+	includevSANDirectDatastores bool) ([]*DatastoreInfo, []*DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
-	// Get all vsan direct datastore urls in VC. Later, filter in this cluster.
-	allVsanDirectUrls, err := getVsanDirectDatastores(ctx, vc, clusterID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get vSAN Direct VMFS datastores. Err: %+v", err)
-	}
 
 	// Find datastores shared across all hosts in given cluster.
 	hosts, err := vc.GetHostsByCluster(ctx, clusterID)
@@ -413,6 +408,7 @@ func GetCandidateDatastoresInCluster(ctx context.Context, vc *VirtualCenter, clu
 	if len(hosts) == 0 {
 		return nil, nil, fmt.Errorf("empty List of hosts returned from VC")
 	}
+
 	sharedDatastores := make([]*DatastoreInfo, 0)
 	vsanDirectDatastores := make([]*DatastoreInfo, 0)
 	for index, host := range hosts {
@@ -420,9 +416,22 @@ func GetCandidateDatastoresInCluster(ctx context.Context, vc *VirtualCenter, clu
 		if err != nil {
 			return nil, nil, err
 		}
+		if len(accessibleDatastores) == 0 {
+			return nil, nil, logger.LogNewErrorf(log, "host %q does not have any accessible datastores.",
+				host.Name())
+		}
 		if index == 0 {
 			for _, accessibleDs := range accessibleDatastores {
-				if allVsanDirectUrls[accessibleDs.Info.Url] {
+				var dsType string
+				if includevSANDirectDatastores {
+					_, dsType, err = accessibleDs.GetDatastoreURLAndType(ctx)
+					if err != nil {
+						return nil, nil, logger.LogNewErrorf(log,
+							"Unable to find datastore type and URL for %q. Error: %+v",
+							accessibleDs.Reference().Value, err)
+					}
+				}
+				if dsType == vsanDType {
 					vsanDirectDatastores = append(vsanDirectDatastores, accessibleDs)
 				} else {
 					sharedDatastores = append(sharedDatastores, accessibleDs)
@@ -431,7 +440,16 @@ func GetCandidateDatastoresInCluster(ctx context.Context, vc *VirtualCenter, clu
 		} else {
 			var sharedAccessibleDatastores []*DatastoreInfo
 			for _, accessibleDs := range accessibleDatastores {
-				if allVsanDirectUrls[accessibleDs.Info.Url] {
+				var dsType string
+				if includevSANDirectDatastores {
+					_, dsType, err = accessibleDs.GetDatastoreURLAndType(ctx)
+					if err != nil {
+						return nil, nil, logger.LogNewErrorf(log,
+							"Unable to find datastore type and URL for %q. Error: %+v",
+							accessibleDs.Reference().Value, err)
+					}
+				}
+				if dsType == vsanDType {
 					vsanDirectDatastores = append(vsanDirectDatastores, accessibleDs)
 					continue
 				}
@@ -454,33 +472,6 @@ func GetCandidateDatastoresInCluster(ctx context.Context, vc *VirtualCenter, clu
 	log.Infof("Found shared datastores: %+v and vSAN Direct datastores: %+v", sharedDatastores,
 		vsanDirectDatastores)
 	return sharedDatastores, vsanDirectDatastores, nil
-}
-
-// getVsanDirectDatastores returns the datastore URLs of all the vSAN-Direct
-// managed datatores in the given VirtualCenter.
-func getVsanDirectDatastores(ctx context.Context, vc *VirtualCenter, clusterID string) (map[string]bool, error) {
-	log := logger.GetLogger(ctx)
-	var datastores = make(map[string]bool)
-
-	// Get all datastores in this cluster.
-	datastoreInfos, err := vc.GetDatastoresByCluster(ctx, clusterID)
-	if err != nil {
-		log.Warnf("Not able to fetch datastores in cluster %q. Err: %v", clusterID, err)
-		return nil, err
-	}
-
-	// Filter them by datastore type of vsanD.
-	for _, dsInfo := range datastoreInfos {
-		dsURL, dsType, err := dsInfo.GetDatastoreURLAndType(ctx)
-		if err != nil {
-			log.Errorf("Not able to find datastore type and url for %s. Err: %v", dsInfo.Reference().Value, err)
-			return nil, err
-		}
-		if dsType == vsanDType {
-			datastores[dsURL] = true
-		}
-	}
-	return datastores, nil
 }
 
 // GetDatastoreInfoByURL returns info of a datastore found in given cluster

--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -396,6 +396,7 @@ func GetTagManager(ctx context.Context, vc *VirtualCenter) (*tags.Manager, error
 // managed datastores of given VC cluster.
 // The 1st output parameter will be shared datastores.
 // The 2nd output parameter will be vSAN-direct managed datastores.
+// NOTE: The second output will be an empty list if `includevSANDirectDatastores` is set to false.
 func GetCandidateDatastoresInCluster(ctx context.Context, vc *VirtualCenter, clusterID string,
 	includevSANDirectDatastores bool) ([]*DatastoreInfo, []*DatastoreInfo, error) {
 	log := logger.GetLogger(ctx)
@@ -415,10 +416,6 @@ func GetCandidateDatastoresInCluster(ctx context.Context, vc *VirtualCenter, clu
 		accessibleDatastores, err := host.GetAllAccessibleDatastores(ctx)
 		if err != nil {
 			return nil, nil, err
-		}
-		if len(accessibleDatastores) == 0 {
-			return nil, nil, logger.LogNewErrorf(log, "host %q does not have any accessible datastores.",
-				host.Name())
 		}
 		if index == 0 {
 			for _, accessibleDs := range accessibleDatastores {

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -1553,7 +1553,7 @@ func (volTopology *wcpControllerVolumeTopology) GetSharedDatastoresInTopology(ct
 		// Call GetCandidateDatastores for each cluster moref. Ignore the vsanDirectDatastores for now.
 		if !isPodVMOnStretchedSupervisorEnabled {
 			// This code block assume we have 1 Cluster Per AZ
-			accessibleDs, _, err := cnsvsphere.GetCandidateDatastoresInCluster(ctx, params.Vc, clusterMorefs[0])
+			accessibleDs, _, err := cnsvsphere.GetCandidateDatastoresInCluster(ctx, params.Vc, clusterMorefs[0], false)
 			if err != nil {
 				return nil, logger.LogNewErrorf(log,
 					"failed to find candidate datastores to place volume in cluster %q. Error: %v",
@@ -1728,7 +1728,7 @@ func getSharedDatastoresInClusters(ctx context.Context, clusterMorefs []string,
 	log := logger.GetLogger(ctx)
 	var sharedDatastoresForclusterMorefs []*cnsvsphere.DatastoreInfo
 	for index, clusterMoref := range clusterMorefs {
-		accessibleDs, _, err := cnsvsphere.GetCandidateDatastoresInCluster(ctx, vc, clusterMoref)
+		accessibleDs, _, err := cnsvsphere.GetCandidateDatastoresInCluster(ctx, vc, clusterMoref, false)
 		if err != nil {
 			return nil, logger.LogNewErrorf(log,
 				"failed to find candidate datastores to place volume in cluster %q. Error: %v",

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -1536,10 +1536,11 @@ func (volTopology *wcpControllerVolumeTopology) GetSharedDatastoresInTopology(ct
 	log.Debugf("Using preferred topology")
 	for _, topology := range params.TopologyRequirement.GetPreferred() {
 		segments := topology.GetSegments()
+		zone := segments[v1.LabelTopologyZone]
 
 		// For each topology segments, fetch cluster morefs satisfying the condition.
 		log.Debugf("Getting list of cluster morefs for topology segments %+v", segments)
-		clusterMorefs, err := volTopology.getClustersMatchingTopologySegment(ctx, segments)
+		clusterMorefs, err := volTopology.getClustersMatchingTopologySegment(ctx, zone)
 		if err != nil {
 			return nil, logger.LogNewErrorf(log,
 				"failed to fetch clusters matching topology requirement. Error: %v", err)
@@ -1559,6 +1560,7 @@ func (volTopology *wcpControllerVolumeTopology) GetSharedDatastoresInTopology(ct
 					"failed to find candidate datastores to place volume in cluster %q. Error: %v",
 					clusterMorefs[0], err)
 			}
+			params.TopoSegToDatastoresMap[zone] = accessibleDs
 			sharedDatastores = append(sharedDatastores, accessibleDs...)
 		} else {
 			// This code block adds support for multiple vSphere Clusters Per AZ
@@ -1568,6 +1570,7 @@ func (volTopology *wcpControllerVolumeTopology) GetSharedDatastoresInTopology(ct
 				return nil, logger.LogNewErrorf(log, "failed to get shared datastores "+
 					"for clusters: %v, err: %v", clusterMorefs, err)
 			}
+			params.TopoSegToDatastoresMap[zone] = sharedDatastoresForclusterMorefs
 			sharedDatastores = append(sharedDatastores, sharedDatastoresForclusterMorefs...)
 		}
 	}
@@ -1578,28 +1581,26 @@ func (volTopology *wcpControllerVolumeTopology) GetSharedDatastoresInTopology(ct
 
 // getClustersMatchingTopologySegment fetches clusters matching the topology requirement provided by checking
 // the azClusterMap cache.
-func (volTopology *wcpControllerVolumeTopology) getClustersMatchingTopologySegment(ctx context.Context,
-	segments map[string]string) ([]string, error) {
+func (volTopology *wcpControllerVolumeTopology) getClustersMatchingTopologySegment(ctx context.Context, zone string) (
+	[]string, error) {
 	log := logger.GetLogger(ctx)
 	var matchingClusterMorefs []string
-	for _, zone := range segments {
-		if isPodVMOnStretchedSupervisorEnabled {
-			clusterMorefs, exists := azClustersMap[zone]
-			if !exists || len(clusterMorefs) == 0 {
-				return nil, logger.LogNewErrorf(log, "could not find the cluster MoIDs for zone %q in "+
-					"AvailabilityZone resources", zone)
-			}
-			matchingClusterMorefs = append(matchingClusterMorefs, clusterMorefs...)
-		} else {
-			clusterMoref, exists := azClusterMap[zone]
-			if !exists || clusterMoref == "" {
-				return nil, logger.LogNewErrorf(log, "could not find the cluster MoID for zone %q in "+
-					"AvailabilityZone resources", zone)
-			}
-			matchingClusterMorefs = append(matchingClusterMorefs, clusterMoref)
+	if isPodVMOnStretchedSupervisorEnabled {
+		clusterMorefs, exists := azClustersMap[zone]
+		if !exists || len(clusterMorefs) == 0 {
+			return nil, logger.LogNewErrorf(log, "could not find the cluster MoIDs for zone %q in "+
+				"AvailabilityZone resources", zone)
 		}
+		matchingClusterMorefs = append(matchingClusterMorefs, clusterMorefs...)
+	} else {
+		clusterMoref, exists := azClusterMap[zone]
+		if !exists || clusterMoref == "" {
+			return nil, logger.LogNewErrorf(log, "could not find the cluster MoID for zone %q in "+
+				"AvailabilityZone resources", zone)
+		}
+		matchingClusterMorefs = append(matchingClusterMorefs, clusterMoref)
 	}
-	log.Infof("Clusters matching topology requirement %+v are %+v", segments, matchingClusterMorefs)
+	log.Infof("Clusters matching topology requirement %q are %+v", zone, matchingClusterMorefs)
 	return matchingClusterMorefs, nil
 }
 
@@ -1660,34 +1661,7 @@ func (volTopology *wcpControllerVolumeTopology) GetTopologyInfoFromNodes(ctx con
 			var selectedSegments []map[string]string
 			for _, topology := range params.TopologyRequirement.GetPreferred() {
 				for label, value := range topology.GetSegments() {
-					var datastores []*cnsvsphere.DatastoreInfo
-					var err error
-					if isPodVMOnStretchedSupervisorEnabled {
-						clusterMorefs, exists := azClustersMap[value]
-						if !exists || len(clusterMorefs) == 0 {
-							return nil, logger.LogNewErrorf(log, "could not find the cluster MoIDs for zone %q in "+
-								"AvailabilityZone resources", value)
-						}
-						for _, clusterMoref := range clusterMorefs {
-							datastoresforClusterMoRef, err := params.Vc.GetDatastoresByCluster(ctx, clusterMoref)
-							if err != nil {
-								return nil, logger.LogNewErrorf(log,
-									"failed to fetch datastores associated with cluster %q", clusterMoref)
-							}
-							datastores = append(datastores, datastoresforClusterMoRef...)
-						}
-					} else {
-						clusterMoref, exists := azClusterMap[value]
-						if !exists || clusterMoref == "" {
-							return nil, logger.LogNewErrorf(log, "could not find the cluster MoID for zone %q in "+
-								"AvailabilityZone resources", value)
-						}
-						datastores, err = params.Vc.GetDatastoresByCluster(ctx, clusterMoref)
-						if err != nil {
-							return nil, logger.LogNewErrorf(log,
-								"failed to fetch datastores associated with cluster %q", clusterMoref)
-						}
-					}
+					datastores := params.TopoSegToDatastoresMap[value]
 					for _, ds := range datastores {
 						if ds.Info.Url == params.DatastoreURL {
 							selectedSegments = append(selectedSegments, map[string]string{label: value})

--- a/pkg/csi/service/common/commonco/types/types.go
+++ b/pkg/csi/service/common/commonco/types/types.go
@@ -56,6 +56,9 @@ type WCPTopologyFetchDSParams struct {
 	// Vc is the vcenter instance using which the potential
 	// datastores will be calculated.
 	Vc *cnsvsphere.VirtualCenter
+	// TopoSegToDatastoresMap stores the candidate datastores available in each
+	// topology segment given in the CreateVolume accessibility requirements.
+	TopoSegToDatastoresMap map[string][]*cnsvsphere.DatastoreInfo
 }
 
 // VanillaRetrieveTopologyInfoParams represents the params
@@ -88,6 +91,9 @@ type WCPRetrieveTopologyInfoParams struct {
 	// Vc is the vcenter instance using which the potential
 	// datastores will be calculated.
 	Vc *cnsvsphere.VirtualCenter
+	// TopoSegToDatastoresMap stores the candidate datastores available in each
+	// topology segment given in the CreateVolume accessibility requirements.
+	TopoSegToDatastoresMap map[string][]*cnsvsphere.DatastoreInfo
 }
 
 // ControllerTopologyService is an interface which exposes functionality

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -462,6 +462,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 	topologyRequirement = req.GetAccessibilityRequirements()
 	filterSuspendedDatastores := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsMgrSuspendCreateVolume)
 	isTKGSHAEnabled := commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
+	topoSegToDatastoresMap := make(map[string][]*cnsvsphere.DatastoreInfo)
 	if isTKGSHAEnabled {
 		// TKGS-HA feature is enabled
 		// Identify the topology keys in Accessibility requirements.
@@ -487,8 +488,9 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			log.Infof("Topology aware environment detected with requirement: %+v", topologyRequirement)
 			sharedDatastores, err = c.topologyMgr.GetSharedDatastoresInTopology(ctx,
 				commoncotypes.WCPTopologyFetchDSParams{
-					TopologyRequirement: topologyRequirement,
-					Vc:                  vc})
+					TopologyRequirement:    topologyRequirement,
+					Vc:                     vc,
+					TopoSegToDatastoresMap: topoSegToDatastoresMap})
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to find shared datastores for given topology requirement. Error: %v", err)
@@ -683,10 +685,11 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 			// Calculate accessible topology for the provisioned volume.
 			datastoreAccessibleTopology, err := c.topologyMgr.GetTopologyInfoFromNodes(ctx,
 				commoncotypes.WCPRetrieveTopologyInfoParams{
-					DatastoreURL:        selectedDatastore,
-					StorageTopologyType: storageTopologyType,
-					TopologyRequirement: topologyRequirement,
-					Vc:                  vc})
+					DatastoreURL:           selectedDatastore,
+					StorageTopologyType:    storageTopologyType,
+					TopologyRequirement:    topologyRequirement,
+					Vc:                     vc,
+					TopoSegToDatastoresMap: topoSegToDatastoresMap})
 			if err != nil {
 				// If the error is of InvalidTopologyProvisioningError type, it means we cannot
 				// recover from this error with a retry, so cleanup the volume created above.

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -205,7 +205,8 @@ func getControllerTest(t *testing.T) *controllerTest {
 }
 
 func getFakeDatastores(ctx context.Context, vc *cnsvsphere.VirtualCenter,
-	clusterID string) ([]*cnsvsphere.DatastoreInfo, []*cnsvsphere.DatastoreInfo, error) {
+	clusterID string, includevSANDirectDatastores bool) ([]*cnsvsphere.DatastoreInfo,
+	[]*cnsvsphere.DatastoreInfo, error) {
 	var sharedDatastoreURL string
 	if v := os.Getenv("VSPHERE_DATASTORE_URL"); v != "" {
 		sharedDatastoreURL = v

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/util.go
@@ -52,7 +52,7 @@ const (
 func isDatastoreAccessibleToCluster(ctx context.Context, vc *vsphere.VirtualCenter,
 	clusterID string, datastoreURL string) bool {
 	log := logger.GetLogger(ctx)
-	sharedDatastores, _, err := vsphere.GetCandidateDatastoresInCluster(ctx, vc, clusterID)
+	sharedDatastores, _, err := vsphere.GetCandidateDatastoresInCluster(ctx, vc, clusterID, false)
 	if err != nil {
 		log.Errorf("Failed to get candidate datastores for cluster: %s with err: %+v", clusterID, err)
 		return false
@@ -73,7 +73,7 @@ func isDatastoreAccessibleToAZClusters(ctx context.Context, vc *vsphere.VirtualC
 	log := logger.GetLogger(ctx)
 	for _, clusterIDs := range azClustersMap {
 		for _, clusterID := range clusterIDs {
-			sharedDatastores, _, err := vsphere.GetCandidateDatastoresInCluster(ctx, vc, clusterID)
+			sharedDatastores, _, err := vsphere.GetCandidateDatastoresInCluster(ctx, vc, clusterID, false)
 			if err != nil {
 				log.Warnf("Failed to get candidate datastores for cluster: %s with err: %+v", clusterID, err)
 				continue

--- a/pkg/syncer/storagepool/listener.go
+++ b/pkg/syncer/storagepool/listener.go
@@ -231,7 +231,8 @@ func ReconcileAllStoragePools(ctx context.Context, scWatchCntlr *StorageClassWat
 		return err
 	}
 	// Get datastores from VC.
-	sharedDatastores, vsanDirectDatastores, err := cnsvsphere.GetCandidateDatastoresInCluster(ctx, &vc, spCtl.clusterID)
+	sharedDatastores, vsanDirectDatastores, err := cnsvsphere.GetCandidateDatastoresInCluster(ctx, &vc,
+		spCtl.clusterID, true)
 	if err != nil {
 		log.Errorf("Failed to find datastores from VC. Err: %+v", err)
 		return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Optimize topology aware CreateVolume performance in WCP by reducing the number of VC calls made.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Ran CreateVolume in stretched supervisor:
```
{"level":"info","time":"2024-01-30T21:31:53.117380686Z","caller":"wcp/controller.go:910","msg":"CreateVolume: called with args {Name:pvc-a65ea039-b0a2-407e-baea-426c08b2a487 CapacityRange:required_bytes:104857600  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[StorageTopologyType:Zonal csi.storage.k8s.io/pv/name:pvc-a65ea039-b0a2-407e-baea-426c08b2a487 csi.storage.k8s.io/pvc/name:pvc1 csi.storage.k8s.io/pvc/namespace:shalini-ns csi.storage.k8s.io/sc/name:zonal-policy storagePolicyID:92b1f1d7-fd8b-4aec-aa6f-651d79dfa533] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.151957978Z","caller":"wcp/controller.go:489","msg":"Topology aware environment detected with requirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > ","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.153136836Z","caller":"k8sorchestrator/topology.go:1603","msg":"Clusters matching topology requirement \"zone-1\" are [domain-c92]","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.201344633Z","caller":"vsphere/utils.go:472","msg":"Found shared datastores: [Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/] and vSAN Direct datastores: []","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.201829818Z","caller":"k8sorchestrator/topology.go:1603","msg":"Clusters matching topology requirement \"zone-2\" are [domain-c101]","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.226180859Z","caller":"vsphere/utils.go:472","msg":"Found shared datastores: [Datastore: Datastore:datastore-154, datastore URL: ds:///vmfs/volumes/3e22e60a-2de98570-0000-000000000000/ Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/] and vSAN Direct datastores: []","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.22628719Z","caller":"k8sorchestrator/topology.go:1603","msg":"Clusters matching topology requirement \"zone-3\" are [domain-c109]","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.260974623Z","caller":"vsphere/utils.go:472","msg":"Found shared datastores: [Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/] and vSAN Direct datastores: []","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.261983561Z","caller":"k8sorchestrator/topology.go:1577","msg":"Shared datastores [Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/ Datastore: Datastore:datastore-154, datastore URL: ds:///vmfs/volumes/3e22e60a-2de98570-0000-000000000000/ Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/ Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/] for topologyRequirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > ","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.285834828Z","caller":"vsphere/utils.go:581","msg":"Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/ Datastore: Datastore:datastore-154, datastore URL: ds:///vmfs/volumes/3e22e60a-2de98570-0000-000000000000/ Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/ Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/]","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.382749496Z","caller":"volume/manager.go:534","msg":"QuotaInfo during CreateVolume call: {Reserved:100Mi StoragePolicyId:92b1f1d7-fd8b-4aec-aa6f-651d79dfa533 StorageClassName:zonal-policy Namespace:shalini-ns}","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.571329981Z","caller":"volume/listview.go:124","msg":"AddTask called for Task:task-540","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.599334626Z","caller":"volume/listview.go:159","msg":"task Task:task-540 added to listView","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:53.601355806Z","caller":"volume/listview.go:296","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-540 Task:Task:task-540 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc0011e8820 QueueTime:2024-01-30 21:31:53.531199 +0000 UTC StartTime:2024-01-30 21:31:53.54982 +0000 UTC CompleteTime:<nil> EventChainId:19174 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:ca84c4c6}}","TraceId":"225a5a7c-7abf-4f8c-a83f-79d3056f207f"}
{"level":"info","time":"2024-01-30T21:31:54.217381812Z","caller":"volume/listview.go:296","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-540 Task:Task:task-540 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc0010e2b10 QueueTime:2024-01-30 21:31:53.531199 +0000 UTC StartTime:2024-01-30 21:31:53.54982 +0000 UTC CompleteTime:<nil> EventChainId:19174 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:ca84c4c6}}","TraceId":"225a5a7c-7abf-4f8c-a83f-79d3056f207f"}
{"level":"info","time":"2024-01-30T21:31:54.38010327Z","caller":"volume/listview.go:296","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-540 Task:Task:task-540 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:success Cancelled:false Cancelable:false Error:<nil> Result:{DynamicData:{} VolumeResults:[0xc0012b0780]} Progress:0 ProgressDetails:[] Reason:0xc0011e8dd0 QueueTime:2024-01-30 21:31:53.531199 +0000 UTC StartTime:2024-01-30 21:31:53.54982 +0000 UTC CompleteTime:2024-01-30 21:31:54.371849 +0000 UTC EventChainId:19174 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:ca84c4c6}}","TraceId":"225a5a7c-7abf-4f8c-a83f-79d3056f207f"}
{"level":"info","time":"2024-01-30T21:31:54.387047433Z","caller":"volume/listview.go:178","msg":"task Task:task-540 removed from listView","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:54.387436386Z","caller":"volume/manager.go:445","msg":"CreateVolume: VolumeName: \"pvc-a65ea039-b0a2-407e-baea-426c08b2a487\", opId: \"ca84c4c6\"","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:54.39058032Z","caller":"volume/util.go:329","msg":"Volume created successfully. VolumeName: \"pvc-a65ea039-b0a2-407e-baea-426c08b2a487\", volumeID: \"ed36e30d-4547-42ad-8004-e67ae03809d9\"","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:54.391064658Z","caller":"volume/manager.go:595","msg":"Setting the reserved field for VolumeOperationDetails instance pvc-a65ea039-b0a2-407e-baea-426c08b2a487 to 0","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:54.41634985Z","caller":"k8sorchestrator/topology.go:1695","msg":"Topology of the provisioned volume detected as [map[topology.kubernetes.io/zone:zone-2]]","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:54.417072307Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:204","msg":"creating cnsvolumeinfo for volumeID: \"ed36e30d-4547-42ad-8004-e67ae03809d9\", StoragePolicyID: \"92b1f1d7-fd8b-4aec-aa6f-651d79dfa533\", StorageClassName: \"zonal-policy\", vCenter: \"sc2-10-186-198-133.eng.vmware.com\", Capacity: {i:{value:104857600 scale:0} d:{Dec:<nil>} s: Format:BinarySI} in the namespace: \"vmware-system-csi\"","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:54.444907982Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:233","msg":"Successfully created CNSVolumeInfo CR for volumeID: \"ed36e30d-4547-42ad-8004-e67ae03809d9\", StoragePolicyID: \"92b1f1d7-fd8b-4aec-aa6f-651d79dfa533\", StorageClassName: \"zonal-policy\", vCenter: \"sc2-10-186-198-133.eng.vmware.com\", Capacity: {i:{value:104857600 scale:0} d:{Dec:<nil>} s: Format:BinarySI} mapping in the namespace: \"vmware-system-csi\"","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
{"level":"info","time":"2024-01-30T21:31:54.444993545Z","caller":"wcp/controller.go:962","msg":"Volume created successfully. Volume Handle: \"ed36e30d-4547-42ad-8004-e67ae03809d9\", PV Name: \"pvc-a65ea039-b0a2-407e-baea-426c08b2a487\"","TraceId":"8a556375-5147-4111-bfd3-33dae2c22156"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Optimize topology aware CreateVolume performance in WCP
```
