### PR TITLE
Use WCP FSS configmap in CSI driver for features dependent on WCP service

### DIFF
--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -467,7 +467,6 @@ data:
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
   "listview-tasks": "true"
-  "podvm-on-stretched-supervisor": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -467,7 +467,6 @@ data:
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
   "listview-tasks": "true"
-  "podvm-on-stretched-supervisor": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -467,7 +467,6 @@ data:
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
   "listview-tasks": "true"
-  "podvm-on-stretched-supervisor": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -467,7 +467,6 @@ data:
   "list-volumes": "true"
   "cnsmgr-suspend-create-volume": "true"
   "listview-tasks": "true"
-  "podvm-on-stretched-supervisor": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -341,6 +341,12 @@ const (
 	// CreateCSINodeAnnotation is the annotation applied by spherelet
 	// to convey to CSI driver to create a CSINode instance for each node.
 	CreateCSINodeAnnotation = "vmware-system/csi-create-csinode-object"
+
+	// KubeSystemNamespace is the namespace for system resources.
+	KubeSystemNamespace = "kube-system"
+
+	// WCPCapabilityConfigMapName is the name of the configmap where WCP component's FSS values are stored.
+	WCPCapabilityConfigMapName = "wcp-cluster-capabilities"
 )
 
 // Supported container orchestrators.
@@ -408,6 +414,11 @@ const (
 	ListViewPerf = "listview-tasks"
 	// TopologyAwareFileVolume enables provisioning of file volumes in a topology enabled environment
 	TopologyAwareFileVolume = "topology-aware-file-volume"
-	// PodVMOnStretchedSupervisor enables Pod Vm Support on stretched supervisor cluster
-	PodVMOnStretchedSupervisor = "podvm-on-stretched-supervisor"
+	// PodVMOnStretchedSupervisor is the WCP FSS which determines if PodVM
+	// support is available on stretched supervisor cluster.
+	PodVMOnStretchedSupervisor = "PodVM_On_Stretched_Supervisor_Supported"
 )
+
+var WCPFeatureStates = map[string]struct{}{
+	PodVMOnStretchedSupervisor: {},
+}

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -40,12 +40,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	storagepolicyusagev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha1"
-	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer"
 
 	clientConfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	apis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsregistervolumev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsregistervolume/v1alpha1"
+	storagepolicyusagev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha1"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
 	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
 	commonconfig "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -55,6 +54,7 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeinfo"
 	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer"
 )
 
 const (
@@ -62,19 +62,18 @@ const (
 	staticPvNamePrefix                       = "static-pv-"
 )
 
-// backOffDuration is a map of cnsregistervolume name's to the time after which
-// a request for this instance will be requeued.
-// Initialized to 1 second for new instances and for instances whose latest
-// reconcile operation succeeded.
-// If the reconcile fails, backoff is incremented exponentially.
 var (
+	// backOffDuration is a map of cnsregistervolume name's to the time after which
+	// a request for this instance will be requeued.
+	// Initialized to 1 second for new instances and for instances whose latest
+	// reconcile operation succeeded.
+	// If the reconcile fails, backoff is incremented exponentially.
 	backOffDuration         map[string]time.Duration
 	backOffDurationMapMutex = sync.Mutex{}
-)
 
-var topologyMgr commoncotypes.ControllerTopologyService
-var isPodVMOnStretchedSupervisorEnabled bool
-var clusterComputeResourceMoIds []string
+	topologyMgr                 commoncotypes.ControllerTopologyService
+	clusterComputeResourceMoIds []string
+)
 
 // Add creates a new CnsRegisterVolume Controller and adds it to the Manager,
 // ConfigurationInfo and VirtualCenterTypes. The Manager will set fields on
@@ -95,9 +94,7 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 				log.Errorf("failed to get clusterComputeResourceMoIds. err: %v", err)
 				return err
 			}
-			isPodVMOnStretchedSupervisorEnabled =
-				commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.PodVMOnStretchedSupervisor)
-			if isPodVMOnStretchedSupervisorEnabled {
+			if syncer.IsPodVMOnStretchSupervisorFSSEnabled {
 				topologyMgr, err = commonco.ContainerOrchestratorUtility.InitTopologyServiceInController(ctx)
 				if err != nil {
 					log.Errorf("failed to init topology manager. err: %v", err)
@@ -299,7 +296,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
 
-	if isPodVMOnStretchedSupervisorEnabled && len(clusterComputeResourceMoIds) > 1 {
+	if syncer.IsPodVMOnStretchSupervisorFSSEnabled && len(clusterComputeResourceMoIds) > 1 {
 		azClustersMap := topologyMgr.GetAZClustersMap(ctx)
 		isAccessible := isDatastoreAccessibleToAZClusters(ctx, vc, azClustersMap, volume.DatastoreUrl)
 		if !isAccessible {
@@ -339,7 +336,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
 
-	if isPodVMOnStretchedSupervisorEnabled && len(clusterComputeResourceMoIds) > 1 {
+	if syncer.IsPodVMOnStretchSupervisorFSSEnabled && len(clusterComputeResourceMoIds) > 1 {
 		// Calculate accessible topology for the provisioned volume.
 		datastoreAccessibleTopology, err := topologyMgr.GetTopologyInfoFromNodes(ctx,
 			commoncotypes.WCPRetrieveTopologyInfoParams{
@@ -382,7 +379,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 
 	// Get K8S storageclass name mapping the storagepolicy id with Immediate volume binding mode
 	storageClassName, err := getK8sStorageClassNameWithImmediateBindingModeForPolicy(ctx, k8sclient, r.client,
-		volume.StoragePolicyId, request.Namespace, isPodVMOnStretchedSupervisorEnabled)
+		volume.StoragePolicyId, request.Namespace, syncer.IsPodVMOnStretchSupervisorFSSEnabled)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to find K8S Storageclass mapping storagepolicyId: %s and assigned to namespace: %s",
 			volume.StoragePolicyId, request.Namespace)
@@ -496,7 +493,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 	isBound, err := isPVCBound(ctx, k8sclient, pvc, time.Duration(1*time.Minute))
 	if isBound {
 		log.Infof("PVC: %s is bound", instance.Spec.PvcName)
-		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.PodVMOnStretchedSupervisor) {
+		if syncer.IsPodVMOnStretchSupervisorFSSEnabled {
 			// Create CNSVolumeInfo CR for static pv
 			capacityInBytes := capacityInMb * common.MbInBytes
 			capacity := resource.NewQuantity(capacityInBytes, resource.BinarySI)

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -59,7 +59,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 	}
 	// Attempt to patch StoragePolicyUsage CRs
 	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
-		if metadataSyncer.coCommonInterface.IsFSSEnabled(ctx, common.PodVMOnStretchedSupervisor) {
+		if IsPodVMOnStretchSupervisorFSSEnabled {
 			storagePolicyUsageCRSync(ctx, metadataSyncer)
 		}
 	}
@@ -290,7 +290,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer, vc s
 	// Sync VolumeInfo CRs for the below conditions:
 	// Either it is a Vanilla k8s deployment with Multi-VC configuration or, it's a StretchSupervisor cluster
 	if isMultiVCenterFssEnabled && len(metadataSyncer.configInfo.Cfg.VirtualCenter) > 1 ||
-		(metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload && isPodVMOnStretchSupervisorFSSEnabled) {
+		(metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload && IsPodVMOnStretchSupervisorFSSEnabled) {
 		volumeInfoCRFullSync(ctx, metadataSyncer, vc)
 		cleanUpVolumeInfoCrDeletionMap(ctx, metadataSyncer, vc)
 	}
@@ -365,7 +365,7 @@ func volumeInfoCRFullSync(ctx context.Context, metadataSyncer *metadataSyncInfor
 
 	volumeIdTok8sPVMap := make(map[string]*v1.PersistentVolume)
 	scNameToPolicyIdMap := make(map[string]string)
-	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload && isPodVMOnStretchSupervisorFSSEnabled {
+	if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload && IsPodVMOnStretchSupervisorFSSEnabled {
 		// Create volumeIdTok8sPVMap map for easy lookup of PVs
 		for _, pv := range currentK8sPV {
 			if pv.Spec.CSI != nil {
@@ -414,7 +414,8 @@ func volumeInfoCRFullSync(ctx context.Context, metadataSyncer *metadataSyncInfor
 						"Error: %+v", vc, volumeID, err)
 					continue
 				}
-			} else if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload && isPodVMOnStretchSupervisorFSSEnabled {
+			} else if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
+				IsPodVMOnStretchSupervisorFSSEnabled {
 				pv := volumeIdTok8sPVMap[volumeID]
 				pvc, err := metadataSyncer.pvcLister.PersistentVolumeClaims(
 					pv.Spec.ClaimRef.Namespace).Get(pv.Spec.ClaimRef.Name)

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -90,11 +90,10 @@ var (
 	isMultiVCenterFssEnabled bool
 	// nodeMgr stores the manager to interact with nodeVMs.
 	nodeMgr node.Manager
-	// isPodVMOnStretchSupervisorFSSEnabled is true when PodVMOnStretchedSupervisor FSS is enabled.
-	isPodVMOnStretchSupervisorFSSEnabled bool
+	// IsPodVMOnStretchSupervisorFSSEnabled is true when PodVMOnStretchedSupervisor FSS is enabled.
+	IsPodVMOnStretchSupervisorFSSEnabled bool
 
-	// For core API resource ResourceAPIGroup will be set to "". PVC is part of the core API resources
-	// and ResourceAPIgroupPVC is set to "".
+	// ResourceAPIgroupPVC is an empty string as PVC belongs to the core resource group denoted by `""`.
 	ResourceAPIgroupPVC = ""
 )
 
@@ -230,9 +229,9 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 			}
 			clusterIDforVolumeMetadata = configInfo.Cfg.Global.SupervisorID
 		}
-		isPodVMOnStretchSupervisorFSSEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		IsPodVMOnStretchSupervisorFSSEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
 			common.PodVMOnStretchedSupervisor)
-		if isPodVMOnStretchSupervisorFSSEnabled {
+		if IsPodVMOnStretchSupervisorFSSEnabled {
 			// Start watching on nodes to create CSINodes, if not already present.
 			err = commonco.ContainerOrchestratorUtility.InitializeCSINodes(ctx)
 			if err != nil {
@@ -303,7 +302,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				}
 			}()
 		}
-		if isPodVMOnStretchSupervisorFSSEnabled {
+		if IsPodVMOnStretchSupervisorFSSEnabled {
 			log.Info("Loading CnsVolumeInfo Service to persist mapping for VolumeID to storage policy info")
 			volumeInfoService, err = cnsvolumeinfo.InitVolumeInfoService(ctx)
 			if err != nil {
@@ -730,7 +729,7 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 				}
 			}
 		}()
-		if isPodVMOnStretchSupervisorFSSEnabled {
+		if IsPodVMOnStretchSupervisorFSSEnabled {
 			log.Info("Syncing StoragePolicyUsage CRs with the kubernetes PVs that are in Bound state")
 			storagePolicyUsageCRSync(ctx, metadataSyncer)
 		}
@@ -2366,7 +2365,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 // Vanills k8s and supervisor cluster.
 func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *metadataSyncInformer) {
 	log := logger.GetLogger(ctx)
-	if isPodVMOnStretchSupervisorFSSEnabled {
+	if IsPodVMOnStretchSupervisorFSSEnabled {
 		volumeInfo, err := volumeInfoService.GetVolumeInfoForVolumeID(ctx, pv.Spec.CSI.VolumeHandle)
 		if err != nil {
 			log.Errorf("failed to fetch CnsVolumeInfo CR. Error: %+v", err)
@@ -2574,7 +2573,7 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 				}
 			}
 		} else if metadataSyncer.clusterFlavor == cnstypes.CnsClusterFlavorWorkload &&
-			isPodVMOnStretchSupervisorFSSEnabled {
+			IsPodVMOnStretchSupervisorFSSEnabled {
 			// Delete CNSVolumeInfo CR for the volume ID.
 			err = volumeInfoService.DeleteVolumeInfo(ctx, volumeHandle)
 			if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Use WCP FSS instead of CSI specific FSS when a CSI feature has dependency on WCP services.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested CreateVolume & DeleteVolume in stretched supervisor after removing FSS from csi-feature-states configmap:
```
{"level":"info","time":"2024-01-31T22:26:16.003851953Z","caller":"wcp/controller.go:905","msg":"CreateVolume: called with args {Name:pvc-04ddb25e-72c9-4b46-8fb2-27720f09b30f CapacityRange:required_bytes:104857600  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[StorageTopologyType:Zonal csi.storage.k8s.io/pv/name:pvc-04ddb25e-72c9-4b46-8fb2-27720f09b30f csi.storage.k8s.io/pvc/name:pvc1 csi.storage.k8s.io/pvc/namespace:shalini-ns csi.storage.k8s.io/sc/name:zonal-policy storagePolicyID:92b1f1d7-fd8b-4aec-aa6f-651d79dfa533] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:16.009240446Z","caller":"wcp/controller.go:487","msg":"Topology aware environment detected with requirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > ","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:16.010312361Z","caller":"k8sorchestrator/topology.go:1602","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-1] are [domain-c92]","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:16.105947896Z","caller":"vsphere/utils.go:454","msg":"Found shared datastores: [Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/] and vSAN Direct datastores: []","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:16.106569113Z","caller":"k8sorchestrator/topology.go:1602","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-2] are [domain-c101]","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:16.192915235Z","caller":"vsphere/utils.go:454","msg":"Found shared datastores: [Datastore: Datastore:datastore-154, datastore URL: ds:///vmfs/volumes/3e22e60a-2de98570-0000-000000000000/ Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/] and vSAN Direct datastores: []","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:16.193257196Z","caller":"k8sorchestrator/topology.go:1602","msg":"Clusters matching topology requirement map[topology.kubernetes.io/zone:zone-3] are [domain-c109]","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:16.265268241Z","caller":"vsphere/utils.go:454","msg":"Found shared datastores: [Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/] and vSAN Direct datastores: []","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:16.266440011Z","caller":"k8sorchestrator/topology.go:1574","msg":"Shared datastores [Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/ Datastore: Datastore:datastore-154, datastore URL: ds:///vmfs/volumes/3e22e60a-2de98570-0000-000000000000/ Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/ Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/] for topologyRequirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-2\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > ","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:16.270108022Z","caller":"vsphere/utils.go:590","msg":"Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/ Datastore: Datastore:datastore-154, datastore URL: ds:///vmfs/volumes/3e22e60a-2de98570-0000-000000000000/ Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/ Datastore: Datastore:datastore-89, datastore URL: ds:///vmfs/volumes/65b7ed9e-63370c58-dacc-0200ab0eecc9/]","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:17.028163941Z","caller":"volume/manager.go:534","msg":"QuotaInfo during CreateVolume call: {Reserved:100Mi StoragePolicyId:92b1f1d7-fd8b-4aec-aa6f-651d79dfa533 StorageClassName:zonal-policy Namespace:shalini-ns}","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:17.130426279Z","caller":"volume/listview.go:124","msg":"AddTask called for Task:task-636","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:17.151105466Z","caller":"volume/listview.go:159","msg":"task Task:task-636 added to listView","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:17.151320946Z","caller":"volume/listview.go:296","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-636 Task:Task:task-636 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc00055f6e0 QueueTime:2024-01-31 22:26:17.107259 +0000 UTC StartTime:2024-01-31 22:26:17.113227 +0000 UTC CompleteTime:<nil> EventChainId:28028 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:ca852500}}","TraceId":"bc467eae-9249-4372-bf46-c41ef8d4312b"}
{"level":"info","time":"2024-01-31T22:26:18.530264414Z","caller":"volume/listview.go:296","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-636 Task:Task:task-636 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:running Cancelled:false Cancelable:false Error:<nil> Result:<nil> Progress:0 ProgressDetails:[] Reason:0xc00055faf0 QueueTime:2024-01-31 22:26:17.107259 +0000 UTC StartTime:2024-01-31 22:26:17.113227 +0000 UTC CompleteTime:<nil> EventChainId:28028 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:ca852500}}","TraceId":"bc467eae-9249-4372-bf46-c41ef8d4312b"}
{"level":"info","time":"2024-01-31T22:26:18.554104761Z","caller":"volume/listview.go:296","msg":"processTaskUpdate for property change update: {DynamicData:{} Name:info Op:assign Val:{DynamicData:{} Key:task-636 Task:Task:task-636 Description:<nil> Name: DescriptionId:com.vmware.cns.tasks.createvolume Entity:Folder:group-d1 EntityName:Datacenters Locked:[] State:success Cancelled:false Cancelable:false Error:<nil> Result:{DynamicData:{} VolumeResults:[0xc000ac3ec0]} Progress:0 ProgressDetails:[] Reason:0xc000733800 QueueTime:2024-01-31 22:26:17.107259 +0000 UTC StartTime:2024-01-31 22:26:17.113227 +0000 UTC CompleteTime:2024-01-31 22:26:18.547205 +0000 UTC EventChainId:28028 ChangeTag: ParentTaskKey: RootTaskKey: ActivationId:ca852500}}","TraceId":"bc467eae-9249-4372-bf46-c41ef8d4312b"}
{"level":"info","time":"2024-01-31T22:26:18.560227066Z","caller":"volume/listview.go:178","msg":"task Task:task-636 removed from listView","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:18.560975158Z","caller":"volume/manager.go:445","msg":"CreateVolume: VolumeName: \"pvc-04ddb25e-72c9-4b46-8fb2-27720f09b30f\", opId: \"ca852500\"","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:18.563957838Z","caller":"volume/util.go:329","msg":"Volume created successfully. VolumeName: \"pvc-04ddb25e-72c9-4b46-8fb2-27720f09b30f\", volumeID: \"e08273d9-3ff8-4e73-ae9d-8a1babb03e54\"","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:18.564066862Z","caller":"volume/manager.go:595","msg":"Setting the reserved field for VolumeOperationDetails instance pvc-04ddb25e-72c9-4b46-8fb2-27720f09b30f to 0","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:18.686487703Z","caller":"k8sorchestrator/topology.go:1721","msg":"Topology of the provisioned volume detected as [map[topology.kubernetes.io/zone:zone-2]]","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:18.68734891Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:204","msg":"creating cnsvolumeinfo for volumeID: \"e08273d9-3ff8-4e73-ae9d-8a1babb03e54\", StoragePolicyID: \"92b1f1d7-fd8b-4aec-aa6f-651d79dfa533\", StorageClassName: \"zonal-policy\", vCenter: \"sc2-10-186-198-133.eng.vmware.com\", Capacity: {i:{value:104857600 scale:0} d:{Dec:<nil>} s: Format:BinarySI} in the namespace: \"vmware-system-csi\"","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:18.701420587Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:233","msg":"Successfully created CNSVolumeInfo CR for volumeID: \"e08273d9-3ff8-4e73-ae9d-8a1babb03e54\", StoragePolicyID: \"92b1f1d7-fd8b-4aec-aa6f-651d79dfa533\", StorageClassName: \"zonal-policy\", vCenter: \"sc2-10-186-198-133.eng.vmware.com\", Capacity: {i:{value:104857600 scale:0} d:{Dec:<nil>} s: Format:BinarySI} mapping in the namespace: \"vmware-system-csi\"","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
{"level":"info","time":"2024-01-31T22:26:18.701544722Z","caller":"wcp/controller.go:956","msg":"Volume created successfully. Volume Handle: \"e08273d9-3ff8-4e73-ae9d-8a1babb03e54\", PV Name: \"pvc-04ddb25e-72c9-4b46-8fb2-27720f09b30f\"","TraceId":"511ea4a8-e71a-4eb8-9e5f-a59c374ed325"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use WCP FSS configmap in CSI driver for features dependent on WCP service
```
