### PR TITLE
vanilla: disallow disabling GA'ed features

### DIFF
--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -50,15 +50,6 @@ if ! command -v kubectl > /dev/null; then
   exit 1
 fi
 
-feature_state=$(kubectl get configmap internal-feature-states.csi.vsphere.vmware.com -n vmware-system-csi -o jsonpath='{.data.block-volume-snapshot}')
-if [ "$feature_state" = "true" ]
-then
-        echo -e "✅ Verified that block-volume-snapshot feature is enabled"
-else
-        echo -e "❌ ERROR: Please enable the block-volume-snapshot feature to proceed"
-        exit 1
-fi
-
 qualified_version="v6.3.3"
 volumesnapshotclasses_crd="volumesnapshotclasses.snapshot.storage.k8s.io"
 volumesnapshotcontents_crd="volumesnapshotcontents.snapshot.storage.k8s.io"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -148,20 +148,8 @@ roleRef:
 ---
 apiVersion: v1
 data:
-  "csi-migration": "true"
-  "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"
-  "async-query-volume": "true"
-  "block-volume-snapshot": "true"
-  "csi-windows-support": "true"
-  "list-volumes": "true"
   "pv-to-backingdiskobjectid-mapping": "false"
-  "cnsmgr-suspend-create-volume": "true"
-  "topology-preferential-datastores": "true"
-  "max-pvscsi-targets-per-vm": "true"
-  "multi-vcenter-csi-topology": "true"
-  "csi-internal-generated-cluster-id": "true"
-  "listview-tasks": "true"
   "topology-aware-file-volume": "false"
 kind: ConfigMap
 metadata:

--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator_test.go
@@ -196,40 +196,20 @@ func TestIsFSSEnabledInSV(t *testing.T) {
 
 // TestIsFSSEnabledInVanilla tests IsFSSEnabled in vanilla flavor - all scenarios
 func TestIsFSSEnabledInVanilla(t *testing.T) {
-	internalFSS := map[string]string{
-		"csi-migration": "true",
-		"volume-extend": "false",
-		"volume-health": "disabled",
-	}
 	internalFSSConfigMapInfo := FSSConfigMapInfo{
 		configMapName:      cnsconfig.DefaultInternalFSSConfigMapName,
 		configMapNamespace: cnsconfig.DefaultCSINamespace,
-		featureStates:      internalFSS,
 		featureStatesLock:  &sync.RWMutex{},
 	}
 	k8sOrchestrator := K8sOrchestrator{
-		clusterFlavor: cnstypes.CnsClusterFlavorVanilla,
-		internalFSS:   internalFSSConfigMapInfo,
-	}
-	// Should be enabled
-	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "csi-migration")
-	if !isEnabled {
-		t.Errorf("csi-migration feature state is disabled!")
-	}
-	// Should be disabled
-	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "volume-extend")
-	if isEnabled {
-		t.Errorf("volume-extend feature state is enabled!")
-	}
-	// Wrong value given
-	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "volume-health")
-	if isEnabled {
-		t.Errorf("volume-health feature state is enabled even when it was assigned a wrong value!")
+		clusterFlavor:      cnstypes.CnsClusterFlavorVanilla,
+		internalFSS:        internalFSSConfigMapInfo,
+		releasedVanillaFSS: getReleasedVanillaFSS(),
 	}
 	// Feature state missing
-	isEnabled = k8sOrchestrator.IsFSSEnabled(ctx, "online-volume-extend")
+	isEnabled := k8sOrchestrator.IsFSSEnabled(ctx, "unknown-performance-feature")
 	if isEnabled {
-		t.Errorf("Non existing feature state online-volume-extend is enabled!")
+		t.Errorf("Non existing feature state unknown-performance-feature is enabled!")
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Disabling GA'ed feature(s) is not ideal as those code paths are not validated. So, we want to disallow disabling such features. A simple way to do that is by hardcoding already enabled features in code while still allowing unreleased features to be enabled via the configmap. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2781#issuecomment-1922249221

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
vanilla: disallow disabling GA'ed features
```
