### PR TITLE
Update resizer & snapshotter to latest release

### DIFF
--- a/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
+++ b/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
@@ -84,7 +84,7 @@ spec:
       serviceAccountName: snapshot-webhook
       containers:
         - name: snapshot-validation
-          image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.3.3 # change the image if you wish to use your own custom validation server image
+          image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v7.0.1 # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/run/secrets/tls/tls.crt', '--tls-private-key-file=/run/secrets/tls/tls.key']
           ports:

--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -50,7 +50,7 @@ if ! command -v kubectl > /dev/null; then
   exit 1
 fi
 
-qualified_version="v6.3.3"
+qualified_version="v7.0.1"
 volumesnapshotclasses_crd="volumesnapshotclasses.snapshot.storage.k8s.io"
 volumesnapshotcontents_crd="volumesnapshotcontents.snapshot.storage.k8s.io"
 volumesnapshots_crd="volumesnapshots.snapshot.storage.k8s.io"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -249,7 +249,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.9.3
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -391,7 +391,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.3
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
           args:
             - "--v=4"
             - "--kube-api-qps=100"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update resizer to [v1.10.0](https://github.com/kubernetes-csi/external-resizer/releases/tag/v1.10.0) & snapshotter to [v7.0.1](https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v7.0.1)

**Testing done**:
```
# kubectl get pods -n vmware-system-csi -o wide
NAME                                      READY   STATUS    RESTARTS        AGE     IP             NODE                         NOMINATED NODE   READINESS GATES
vsphere-csi-controller-55dff7ffdd-6tjsk   7/7     Running   0               4m15s   10.244.1.6     k8s-control-614-1703330373   <none>           <none>
vsphere-csi-controller-55dff7ffdd-gr996   7/7     Running   0               4m32s   10.244.2.7     k8s-control-759-1703330389   <none>           <none>
vsphere-csi-controller-55dff7ffdd-r5k9f   7/7     Running   0               4m50s   10.244.0.8     k8s-control-985-1703330351   <none>           <none>
```

```
[2024-02-01T22:24:34.562Z] [0mVolume Expansion Test [0m[1m[csi-block-vanilla] [csi-guest] [csi-supervisor] [csi-block-vanilla-parallelized] [csi-vcp-mig] Verify volume expansion can happen multiple times[0m [38;5;204m[p1, block, vanilla, wcp, core][0m
[2024-02-01T22:24:34.562Z] [38;5;243m/home/worker/workspace/csi-block-vanilla-precheckin/2633/vsphere-csi-driver/tests/e2e/vsphere_volume_expansion.go:271[0m
[2024-02-01T22:24:34.562Z]   [1mSTEP:[0m Creating a kubernetes client [38;5;243m@ 02/01/24 14:24:25.97[0m
[2024-02-01T22:24:34.562Z]   Feb  1 14:24:25.971: INFO: >>> kubeConfig: /home/worker/workspace/csi-block-vanilla-precheckin/2633/.kube/config
[2024-02-01T22:24:34.562Z]   [1mSTEP:[0m Building a namespace api object, basename volume-expansion [38;5;243m@ 02/01/24 14:24:25.973[0m
[2024-02-01T22:24:34.562Z]   Feb  1 14:24:26.031: INFO: Skipping waiting for service account
[2024-02-01T22:24:34.562Z]   Feb  1 14:24:26.033: INFO: Creating new VC session
[2024-02-01T22:24:34.563Z]   Feb  1 14:24:26.182: INFO: storage policy id: aa6d5a82-1c88-45da-85d3-3d74b91a5bad for storage policy name is: vSAN Default Storage Policy
[2024-02-01T22:24:34.563Z]   Feb  1 14:24:26.232: INFO: Condition Ready of node k8s-node-804-1703330491 is false, but Node is tainted by NodeController with [{node.kubernetes.io/unreachable  NoSchedule 2024-01-31 15:54:34 -0800 PST} {node.kubernetes.io/unreachable  NoExecute 2024-02-01 14:06:53 -0800 PST}]. Failure
[2024-02-01T22:24:34.563Z]   Feb  1 14:24:26.240: INFO: Looking for default datastore in DC: VSAN-DC
[2024-02-01T22:24:34.563Z]   Feb  1 14:24:26.265: INFO: Datstore found for DS URL:ds:///vmfs/volumes/vsan:527e701efc2bb0c8-670c10b6f0187fc5/
[2024-02-01T22:24:34.563Z]   [1mSTEP:[0m Invoking Test to verify Multiple Volume Expansions on the same volume [38;5;243m@ 02/01/24 14:24:26.265[0m
[2024-02-01T22:24:34.563Z]   [1mSTEP:[0m Creating Storage Class and PVC with allowVolumeExpansion = true [38;5;243m@ 02/01/24 14:24:26.265[0m
[2024-02-01T22:24:34.563Z]   [1mSTEP:[0m Creating StorageClass  with scParameters: map[csi.storage.k8s.io/fstype:ext4] and allowedTopologies: [] and ReclaimPolicy:  and allowVolumeExpansion: true [38;5;243m@ 02/01/24 14:24:26.265[0m
[2024-02-01T22:24:34.563Z]   [1mSTEP:[0m Creating PVC using the Storage Class sc-pgdcs with disk size  and labels: map[] accessMode:  [38;5;243m@ 02/01/24 14:24:26.283[0m
[2024-02-01T22:24:34.563Z]   Feb  1 14:24:26.303: INFO: PVC created: pvc-s9pbk in namespace: volume-expansion-5747
[2024-02-01T22:24:34.563Z]   [1mSTEP:[0m Waiting for all claims to be in bound state [38;5;243m@ 02/01/24 14:24:26.303[0m
[2024-02-01T22:24:34.563Z]   Feb  1 14:24:26.303: INFO: Waiting up to timeout=5m0s for PersistentVolumeClaims [pvc-s9pbk] to have phase Bound
[2024-02-01T22:24:34.563Z]   Feb  1 14:24:26.325: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:34.563Z]   Feb  1 14:24:28.334: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:34.563Z]   Feb  1 14:24:30.350: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:34.563Z]   Feb  1 14:24:32.359: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:34.563Z]   Feb  1 14:24:34.367: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:36.557Z]   Feb  1 14:24:36.380: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:38.538Z]   Feb  1 14:24:38.390: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:40.536Z]   Feb  1 14:24:40.398: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:42.521Z]   Feb  1 14:24:42.408: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:44.511Z]   Feb  1 14:24:44.418: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:46.489Z]   Feb  1 14:24:46.427: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:49.114Z]   Feb  1 14:24:48.561: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:51.100Z]   Feb  1 14:24:50.570: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:53.073Z]   Feb  1 14:24:52.580: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:57.379Z]   Feb  1 14:24:56.646: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:24:58.822Z]   Feb  1 14:24:58.658: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:00.831Z]   Feb  1 14:25:00.670: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:02.824Z]   Feb  1 14:25:02.684: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:04.820Z]   Feb  1 14:25:04.704: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:06.814Z]   Feb  1 14:25:06.722: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:08.812Z]   Feb  1 14:25:08.740: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:10.803Z]   Feb  1 14:25:10.757: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:12.782Z]   Feb  1 14:25:12.779: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:15.408Z]   Feb  1 14:25:14.791: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:16.851Z]   Feb  1 14:25:16.800: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:18.872Z]   Feb  1 14:25:18.816: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:20.867Z]   Feb  1 14:25:20.827: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:22.859Z]   Feb  1 14:25:22.839: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:24.856Z]   Feb  1 14:25:24.850: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:27.489Z]   Feb  1 14:25:26.862: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:28.926Z]   Feb  1 14:25:28.872: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:30.914Z]   Feb  1 14:25:30.882: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:33.541Z]   Feb  1 14:25:32.899: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:34.985Z]   Feb  1 14:25:34.910: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:36.970Z]   Feb  1 14:25:36.921: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:38.943Z]   Feb  1 14:25:38.930: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:41.011Z]   Feb  1 14:25:40.940: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:43.009Z]   Feb  1 14:25:42.951: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:45.002Z]   Feb  1 14:25:44.962: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:46.991Z]   Feb  1 14:25:46.974: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:49.630Z]   Feb  1 14:25:48.984: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:51.112Z]   Feb  1 14:25:51.011: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:55.435Z]   Feb  1 14:25:55.141: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:57.428Z]   Feb  1 14:25:57.150: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:25:59.418Z]   Feb  1 14:25:59.160: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:01.416Z]   Feb  1 14:26:01.169: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:03.421Z]   Feb  1 14:26:03.183: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:05.430Z]   Feb  1 14:26:05.195: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:07.438Z]   Feb  1 14:26:07.205: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:09.429Z]   Feb  1 14:26:09.217: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:11.425Z]   Feb  1 14:26:11.226: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:13.408Z]   Feb  1 14:26:13.236: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:15.391Z]   Feb  1 14:26:15.246: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:17.374Z]   Feb  1 14:26:17.256: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:19.366Z]   Feb  1 14:26:19.267: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:21.408Z]   Feb  1 14:26:21.279: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:23.397Z]   Feb  1 14:26:23.289: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:25.391Z]   Feb  1 14:26:25.298: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:27.385Z]   Feb  1 14:26:27.309: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:29.442Z]   Feb  1 14:26:29.319: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:34.922Z]   Feb  1 14:26:33.950: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:36.367Z]   Feb  1 14:26:35.961: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:38.366Z]   Feb  1 14:26:37.974: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:40.410Z]   Feb  1 14:26:39.984: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:42.385Z]   Feb  1 14:26:41.995: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:44.357Z]   Feb  1 14:26:44.008: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:46.339Z]   Feb  1 14:26:46.018: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:48.315Z]   Feb  1 14:26:48.030: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:50.300Z]   Feb  1 14:26:50.040: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:52.273Z]   Feb  1 14:26:52.054: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:54.259Z]   Feb  1 14:26:54.066: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:56.256Z]   Feb  1 14:26:56.079: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:26:58.254Z]   Feb  1 14:26:58.089: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:00.255Z]   Feb  1 14:27:00.100: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:02.240Z]   Feb  1 14:27:02.112: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:04.246Z]   Feb  1 14:27:04.125: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:06.218Z]   Feb  1 14:27:06.138: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:08.187Z]   Feb  1 14:27:08.148: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:10.235Z]   Feb  1 14:27:10.177: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:12.217Z]   Feb  1 14:27:12.190: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:14.843Z]   Feb  1 14:27:14.202: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:16.286Z]   Feb  1 14:27:16.216: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:18.265Z]   Feb  1 14:27:18.227: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:20.311Z]   Feb  1 14:27:20.241: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:22.293Z]   Feb  1 14:27:22.251: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:24.271Z]   Feb  1 14:27:24.267: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:26.908Z]   Feb  1 14:27:26.275: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:28.401Z]   Feb  1 14:27:28.284: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:31.024Z]   Feb  1 14:27:30.751: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:33.001Z]   Feb  1 14:27:32.762: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:34.988Z]   Feb  1 14:27:34.773: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:36.970Z]   Feb  1 14:27:36.790: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:38.963Z]   Feb  1 14:27:38.807: INFO: PersistentVolumeClaim pvc-s9pbk found but phase is Pending instead of Bound.
[2024-02-01T22:27:40.952Z]   Feb  1 14:27:40.817: INFO: PersistentVolumeClaim pvc-s9pbk found and phase=Bound (3m14.513599223s)
[2024-02-01T22:27:40.952Z]   [1mSTEP:[0m Expanding pvc 10 times [38;5;243m@ 02/01/24 14:27:40.833[0m
[2024-02-01T22:27:40.952Z]   [1mSTEP:[0m Expanding pvc to new size: {{3221225472 0} {<nil>}  BinarySI} [38;5;243m@ 02/01/24 14:27:40.833[0m
[2024-02-01T22:27:40.952Z]   [1mSTEP:[0m Expanding pvc to new size: {{4294967296 0} {<nil>}  BinarySI} [38;5;243m@ 02/01/24 14:27:40.881[0m
[2024-02-01T22:27:40.952Z]   Feb  1 14:27:40.921: INFO: Error updating pvc pvc-s9pbk with Operation cannot be fulfilled on persistentvolumeclaims "pvc-s9pbk": the object has been modified; please apply your changes to the latest version and try again
[2024-02-01T22:27:43.592Z]   [1mSTEP:[0m Expanding pvc to new size: {{5368709120 0} {<nil>}  BinarySI} [38;5;243m@ 02/01/24 14:27:42.96[0m
[2024-02-01T22:27:43.592Z]   [1mSTEP:[0m Expanding pvc to new size: {{6442450944 0} {<nil>}  BinarySI} [38;5;243m@ 02/01/24 14:27:43.006[0m
[2024-02-01T22:27:43.592Z]   [1mSTEP:[0m Expanding pvc to new size: {{7516192768 0} {<nil>}  BinarySI} [38;5;243m@ 02/01/24 14:27:43.043[0m
[2024-02-01T22:27:43.592Z]   [1mSTEP:[0m Expanding pvc to new size: {{8589934592 0} {<nil>}  BinarySI} [38;5;243m@ 02/01/24 14:27:43.09[0m
[2024-02-01T22:27:43.592Z]   [1mSTEP:[0m Expanding pvc to new size: {{9663676416 0} {<nil>}  BinarySI} [38;5;243m@ 02/01/24 14:27:43.132[0m
[2024-02-01T22:27:43.592Z]   [1mSTEP:[0m Expanding pvc to new size: {{10737418240 0} {<nil>}  BinarySI} [38;5;243m@ 02/01/24 14:27:43.177[0m
[2024-02-01T22:27:43.592Z]   Feb  1 14:27:43.221: INFO: Error updating pvc pvc-s9pbk with Operation cannot be fulfilled on persistentvolumeclaims "pvc-s9pbk": the object has been modified; please apply your changes to the latest version and try again
[2024-02-01T22:27:45.583Z]   [1mSTEP:[0m Expanding pvc to new size: {{11811160064 0} {<nil>}  BinarySI} [38;5;243m@ 02/01/24 14:27:45.253[0m
[2024-02-01T22:27:45.583Z]   Feb  1 14:27:45.306: INFO: Error updating pvc pvc-s9pbk with Operation cannot be fulfilled on persistentvolumeclaims "pvc-s9pbk": the object has been modified; please apply your changes to the latest version and try again
[2024-02-01T22:27:47.585Z]   [1mSTEP:[0m Expanding pvc to new size: {{12884901888 0} {<nil>}  BinarySI} [38;5;243m@ 02/01/24 14:27:47.428[0m
[2024-02-01T22:27:47.585Z]   [1mSTEP:[0m Waiting for controller resize to finish [38;5;243m@ 02/01/24 14:27:47.472[0m
[2024-02-01T22:27:51.917Z]   [1mSTEP:[0m Checking for conditions on pvc [38;5;243m@ 02/01/24 14:27:51.521[0m
[2024-02-01T22:27:51.917Z]   [1mSTEP:[0m Invoking QueryCNSVolumeWithResult with VolumeID: 93005ec1-e5f8-4b7d-8b57-68812bffcf5f [38;5;243m@ 02/01/24 14:27:51.528[0m
[2024-02-01T22:27:51.917Z]   [1mSTEP:[0m Verifying disk size requested in volume expansion is honored [38;5;243m@ 02/01/24 14:27:51.635[0m
[2024-02-01T22:27:51.917Z]   [1mSTEP:[0m Creating pod to attach PV to the node [38;5;243m@ 02/01/24 14:27:51.635[0m
[2024-02-01T22:27:51.917Z]   Feb  1 14:27:51.668: INFO: Waiting up to 5m0s for pod "pvc-tester-zp6n6" in namespace "volume-expansion-5747" to be "running"
[2024-02-01T22:27:51.917Z]   Feb  1 14:27:51.678: INFO: Pod "pvc-tester-zp6n6": Phase="Pending", Reason="", readiness=false. Elapsed: 10.201592ms
[2024-02-01T22:27:53.919Z]   Feb  1 14:27:53.689: INFO: Pod "pvc-tester-zp6n6": Phase="Pending", Reason="", readiness=false. Elapsed: 2.021586873s
[2024-02-01T22:27:55.916Z]   Feb  1 14:27:55.691: INFO: Pod "pvc-tester-zp6n6": Phase="Pending", Reason="", readiness=false. Elapsed: 4.023520688s
[2024-02-01T22:27:57.924Z]   Feb  1 14:27:57.688: INFO: Pod "pvc-tester-zp6n6": Phase="Pending", Reason="", readiness=false. Elapsed: 6.019921173s
[2024-02-01T22:27:59.933Z]   Feb  1 14:27:59.690: INFO: Pod "pvc-tester-zp6n6": Phase="Pending", Reason="", readiness=false. Elapsed: 8.022762502s
[2024-02-01T22:28:01.935Z]   Feb  1 14:28:01.691: INFO: Pod "pvc-tester-zp6n6": Phase="Running", Reason="", readiness=true. Elapsed: 10.023134337s
[2024-02-01T22:28:01.935Z]   Feb  1 14:28:01.691: INFO: Pod "pvc-tester-zp6n6" satisfied condition "running"
[2024-02-01T22:28:01.935Z]   [1mSTEP:[0m Verify volume: 93005ec1-e5f8-4b7d-8b57-68812bffcf5f is attached to the node: k8s-node-574-1703330404 [38;5;243m@ 02/01/24 14:28:01.702[0m
[2024-02-01T22:28:01.935Z]   [1mSTEP:[0m VM UUID is: 422605b2-579a-51be-0813-b811115e60e0 for node: k8s-node-574-1703330404 [38;5;243m@ 02/01/24 14:28:01.711[0m
[2024-02-01T22:28:01.935Z]   Feb  1 14:28:01.711: INFO: VMUUID : 422605b2-579a-51be-0813-b811115e60e0
[2024-02-01T22:28:01.935Z]   Feb  1 14:28:01.732: INFO: vmRef: VirtualMachine:vm-153 for the VM uuid: 422605b2-579a-51be-0813-b811115e60e0
[2024-02-01T22:28:01.935Z]   Feb  1 14:28:01.743: INFO: Found FCDID "93005ec1-e5f8-4b7d-8b57-68812bffcf5f" attached to VM "k8s1-worker1"
[2024-02-01T22:28:01.935Z]   Feb  1 14:28:01.743: INFO: Found the disk "93005ec1-e5f8-4b7d-8b57-68812bffcf5f" is attached to the VM with UUID: "422605b2-579a-51be-0813-b811115e60e0"
[2024-02-01T22:28:01.935Z]   [1mSTEP:[0m Verify the volume is accessible and filesystem type is as expected [38;5;243m@ 02/01/24 14:28:01.743[0m
[2024-02-01T22:28:01.935Z]   Feb  1 14:28:01.744: INFO: Running '/usr/bin/kubectl --kubeconfig=/home/worker/workspace/csi-block-vanilla-precheckin/2633/.kube/config --namespace=volume-expansion-5747 exec pvc-tester-zp6n6 --namespace=volume-expansion-5747 -- /bin/cat /mnt/volume1/fstype'
[2024-02-01T22:28:02.215Z]   Feb  1 14:28:02.198: INFO: stderr: ""
[2024-02-01T22:28:02.215Z]   Feb  1 14:28:02.198: INFO: stdout: "ext4\n"
[2024-02-01T22:28:02.215Z]   [1mSTEP:[0m Waiting for file system resize to finish [38;5;243m@ 02/01/24 14:28:02.198[0m
[2024-02-01T22:28:02.215Z]   [1mSTEP:[0m Verify filesystem size for mount point /mnt/volume1 [38;5;243m@ 02/01/24 14:28:02.208[0m
[2024-02-01T22:28:02.215Z]   Feb  1 14:28:02.208: INFO: ExecWithOptions {Command:[/bin/sh -c df -T -m | grep /mnt/volume1] Namespace:volume-expansion-5747 PodName:pvc-tester-zp6n6 ContainerName:write-pod Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false Quiet:false}
[2024-02-01T22:28:02.215Z]   Feb  1 14:28:02.208: INFO: >>> kubeConfig: /home/worker/workspace/csi-block-vanilla-precheckin/2633/.kube/config
[2024-02-01T22:28:02.215Z]   Feb  1 14:28:02.209: INFO: ExecWithOptions: Clientset creation
[2024-02-01T22:28:02.215Z]   Feb  1 14:28:02.209: INFO: ExecWithOptions: execute(POST https://10.193.0.183:6443/api/v1/namespaces/volume-expansion-5747/pods/pvc-tester-zp6n6/exec?command=%2Fbin%2Fsh&command=-c&command=df+-T+-m+%7C+grep+%2Fmnt%2Fvolume1&container=write-pod&container=write-pod&stderr=true&stdout=true)
[2024-02-01T22:28:02.498Z]   Feb  1 14:28:02.349: INFO: File system size after expansion : %!s(int64=11991)
[2024-02-01T22:28:02.498Z]   [1mSTEP:[0m File system resize finished successfully to 11991 [38;5;243m@ 02/01/24 14:28:02.349[0m
[2024-02-01T22:28:02.498Z]   [1mSTEP:[0m Deleting the pod pvc-tester-zp6n6 in namespace volume-expansion-5747 [38;5;243m@ 02/01/24 14:28:02.349[0m
[2024-02-01T22:28:02.498Z]   Feb  1 14:28:02.349: INFO: Deleting pod "pvc-tester-zp6n6" in namespace "volume-expansion-5747"
[2024-02-01T22:28:02.498Z]   Feb  1 14:28:02.373: INFO: Wait up to 5m0s for pod "pvc-tester-zp6n6" to be fully deleted
[2024-02-01T22:28:35.081Z]   [1mSTEP:[0m Verify volume is detached from the node [38;5;243m@ 02/01/24 14:28:34.431[0m
[2024-02-01T22:28:36.529Z]   [1mSTEP:[0m VM UUID is: 422605b2-579a-51be-0813-b811115e60e0 for node: k8s-node-574-1703330404 [38;5;243m@ 02/01/24 14:28:36.44[0m
[2024-02-01T22:28:36.529Z]   Feb  1 14:28:36.463: INFO: vmRef: VirtualMachine:vm-153 for the VM uuid: 422605b2-579a-51be-0813-b811115e60e0
[2024-02-01T22:28:36.529Z]   Feb  1 14:28:36.473: INFO: failed to find FCDID "93005ec1-e5f8-4b7d-8b57-68812bffcf5f" attached to VM "k8s1-worker1"
[2024-02-01T22:28:36.529Z]   Feb  1 14:28:36.473: INFO: Disk: 93005ec1-e5f8-4b7d-8b57-68812bffcf5f successfully detached
[2024-02-01T22:28:36.529Z]   [1mSTEP:[0m Deleting the pod [38;5;243m@ 02/01/24 14:28:36.474[0m
[2024-02-01T22:28:36.529Z]   Feb  1 14:28:36.474: INFO: Deleting pod "pvc-tester-zp6n6" in namespace "volume-expansion-5747"
[2024-02-01T22:28:36.529Z]   Feb  1 14:28:36.492: INFO: Deleting PersistentVolumeClaim "pvc-s9pbk"
[2024-02-01T22:28:39.217Z]   Feb  1 14:28:38.562: INFO: volume "93005ec1-e5f8-4b7d-8b57-68812bffcf5f" has successfully deleted
[2024-02-01T22:28:39.217Z]   Feb  1 14:28:38.562: INFO: Deleting PersistentVolumeClaim "pvc-s9pbk"
[2024-02-01T22:28:39.217Z]   [1mSTEP:[0m Destroying namespace "volume-expansion-5747" for this suite. [38;5;243m@ 02/01/24 14:28:38.585[0m
```

**Ran snapshot related basic e2e tests**: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2782#issuecomment-1944463568
 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update resizer to 1.10.0 & snapshotter to 7.0.0
```
