### PR TITLE
fix: handle expired session for listview

### DIFF
--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/vmware/govmomi"
@@ -42,10 +43,16 @@ type ListViewImpl struct {
 	// it's separate from the context set by CSI ops
 	// to the channel created by the caller to receive the task result
 	ctx context.Context
+	// waitForUpdatesContext and waitForUpdatesCancelFunc allows us to break out of the WaitForUpdates loop
+	// use case: session expiry
+	waitForUpdatesContext    context.Context
+	waitForUpdatesCancelFunc context.CancelFunc
 	// shouldStopListening: in case of regular CSI operation, even after receiving a batch of updates,
 	// we want to continue listening for subsequent updates.
 	// in case of unit tests, we need to stop listening for the test to complete execution
 	shouldStopListening bool
+	// this mutex is used while logging out expired VC session and creating a new one
+	mu sync.RWMutex
 }
 
 // TaskDetails is used to hold state for a task
@@ -63,6 +70,7 @@ type TaskResult struct {
 }
 
 var ErrListViewTaskAddition = errors.New("failure to add task to listview")
+var ErrSessionNotAuthenticated = errors.New("session is not authenticated")
 
 // NewListViewImpl creates a new listView object and starts a goroutine to listen to property collector task updates
 func NewListViewImpl(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter,
@@ -101,7 +109,7 @@ func (l *ListViewImpl) createListView(ctx context.Context, tasks []types.Managed
 func (l *ListViewImpl) SetVirtualCenter(ctx context.Context, virtualCenter *cnsvsphere.VirtualCenter) {
 	log := logger.GetLogger(ctx)
 	l.virtualCenter = virtualCenter
-	log.Debugf("New virtualCenter object stored for use by ListView")
+	log.Infof("updated VirtualCenter object reference in ListView")
 }
 
 func getListViewWaitFilter(listView *view.ListView) *property.WaitFilter {
@@ -123,7 +131,7 @@ func (l *ListViewImpl) AddTask(ctx context.Context, taskMoRef types.ManagedObjec
 	log := logger.GetLogger(ctx)
 	log.Infof("AddTask called for %+v", taskMoRef)
 
-	if err := l.isClientValid(); err != nil {
+	if err := l.isClientValid(false); err != nil {
 		return fmt.Errorf("%w. task: %v, err: %v", ErrListViewTaskAddition, taskMoRef, err)
 	} else {
 		log.Debugf("connection to vc successful")
@@ -135,6 +143,7 @@ func (l *ListViewImpl) AddTask(ctx context.Context, taskMoRef types.ManagedObjec
 		ResultCh:         ch,
 	})
 	log.Debugf("task %+v added to map", taskMoRef)
+	log.Infof("client is valid. trying to add task to listview object")
 
 	response, err := l.listView.Add(l.ctx, []types.ManagedObjectReference{taskMoRef})
 	if err != nil {
@@ -166,11 +175,12 @@ func (l *ListViewImpl) RemoveTask(ctx context.Context, taskMoRef types.ManagedOb
 	if l.listView == nil {
 		return logger.LogNewErrorf(log, "failed to remove task from listView: listView not initialized")
 	}
-	if err := l.isClientValid(); err != nil {
+	if err := l.isClientValid(false); err != nil {
 		return logger.LogNewErrorf(log, "failed to remove task %v from ListView. error: %+v", taskMoRef, err)
 	} else {
 		log.Debugf("connection to vc successful")
 	}
+	log.Infof("client is valid. trying to remove task from listview object")
 	_, err := l.listView.Remove(l.ctx, []types.ManagedObjectReference{taskMoRef})
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to remove task %v from ListView. error: %+v", taskMoRef, err)
@@ -181,8 +191,18 @@ func (l *ListViewImpl) RemoveTask(ctx context.Context, taskMoRef types.ManagedOb
 	return nil
 }
 
-func (l *ListViewImpl) isClientValid() error {
+// The re-connect param is set to false for calls from AddTask() and RemoveTask()
+// as we want the re-connection to happen via the call from listenToTaskUpdates() method
+// as it will also re-create the ListView object which is what we want to do.
+func (l *ListViewImpl) isClientValid(reconnect bool) error {
 	log := logger.GetLogger(l.ctx)
+	if !reconnect {
+		l.mu.RLock()
+		defer l.mu.RUnlock()
+	} else {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+	}
 	// If session hasn't expired, nothing to do.
 	sessionMgr := session.NewManager(l.govmomiClient.Client)
 	// SessionMgr.UserSession(ctx) retrieves and returns the SessionManager's
@@ -193,6 +213,15 @@ func (l *ListViewImpl) isClientValid() error {
 	} else if userSession != nil {
 		return nil
 	}
+
+	log.Infof("current session is either nil or not authenticated")
+
+	if !reconnect {
+		l.waitForUpdatesCancelFunc()
+		return ErrSessionNotAuthenticated
+	}
+
+	log.Infof("creating a new session...")
 
 	err := cnsvsphere.ReadVCConfigs(l.ctx, l.virtualCenter)
 	if err != nil {
@@ -210,6 +239,7 @@ func (l *ListViewImpl) isClientValid() error {
 	}
 	client.Timeout = noTimeout
 	l.govmomiClient = client
+	log.Infof("successfully created new VC session")
 	return nil
 }
 
@@ -221,12 +251,13 @@ func (l *ListViewImpl) isClientValid() error {
 func (l *ListViewImpl) listenToTaskUpdates() {
 	log := logger.GetLogger(l.ctx)
 	filter := getListViewWaitFilter(l.listView)
+	l.waitForUpdatesContext, l.waitForUpdatesCancelFunc = context.WithCancel(context.Background())
 	// we need to recreate the listView and the wait filter after any error from vc
 	// for the first iteration we already have the listView and filter initialized
 	recreateView := false
 	for {
 		// calling Connect at the beginning to ensure the current session is neither nil nor NotAuthenticated
-		if err := l.isClientValid(); err != nil {
+		if err := l.isClientValid(true); err != nil {
 			log.Errorf("failed to connect to vCenter. err: %v", err)
 			time.Sleep(waitForUpdatesRetry)
 			continue
@@ -243,12 +274,13 @@ func (l *ListViewImpl) listenToTaskUpdates() {
 			}
 
 			filter = getListViewWaitFilter(l.listView)
+			l.waitForUpdatesContext, l.waitForUpdatesCancelFunc = context.WithCancel(context.Background())
 			recreateView = false
 		}
 
 		log.Info("Starting listening for task updates...")
 		pc := property.DefaultCollector(l.govmomiClient.Client)
-		err := property.WaitForUpdates(l.ctx, pc, filter, func(updates []types.ObjectUpdate) bool {
+		err := property.WaitForUpdates(l.waitForUpdatesContext, pc, filter, func(updates []types.ObjectUpdate) bool {
 			log.Debugf("Got %d property collector update(s)", len(updates))
 			for _, update := range updates {
 				for _, prop := range update.ChangeSet {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/common/cns-lib/volume/listview.go#L90-L93 ListView object creation requires the govmomiClient
2. AddTask checks if session is valid before adding a task to the ListView. Checking if a session is valid requires the govmomiClient object. If not valid, it will go ahead and create a new client but won’t re-create the ListView object https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/pkg/common/cns-lib/volume/listview.go#L126
3. Next time when AddTask checks if session is valid, it will use the new govmomiClient and thus the session will be valid.
However, if no requests are made within a certain time period, the session associated with the ListView object will get unauthenticated. 
4. Post this, the isSessionValid still returns true but adding a new task to the ListView object will fail with ServerFault NotAuthenticated error. 

Solution: 
If AddTask or RemoveTask realize a session is no longer authenticated, we can logout the current session. This causes WaitForUpdates to stop listening. In its next iteration, it will end up creating a new govmomiClient from the new VC credentials and a ListView object with the new govmomiClient will be created. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

### perf

https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2788#issuecomment-1939361215

```
### wcp

Build #1289 (Feb 12, 2024, 4:11:51 PM)
adkulkarni
PR 2788
FAIL! -- 12 Passed | 1 Failed | 0 Pending | 803 Skipped --- FAIL: TestE2E (2499.94s) FAIL Ginkgo ran 1 suite in 42m41.422942767s Test Suite Failed make: Leaving directory `/home/worker/workspace/csi-wcp-precheckin/Results/1289/vsphere-csi-driver'

Build #1290 (Feb 12, 2024, 10:29:06 PM)
adkulkarni
PR 2788
Ran 1 of 816 Specs in 407.771 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 815 Skipped PASS Ginkgo ran 1 suite in 7m46.672761409s Test Suite Passed make: Leaving directory `/home/worker/workspace/csi-wcp-precheckin/Results/1290/vsphere-csi-driver'

### wcp vol-allocation

00:29:37  [ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
00:29:37  autogenerated by Ginkgo
00:29:37  [ReportAfterSuite] PASSED [0.047 seconds]
00:29:37  ------------------------------
00:29:37  
00:29:37  Ran 6 of 816 Specs in 1768.786 seconds
00:29:37  SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 810 Skipped
00:29:37  PASS

### vanilla

Build #2665 (Feb 12, 2024, 4:12:04 PM)
adkulkarni
PR 2788
------------------------------ Ran 1 of 816 Specs in 369.312 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 815 Skipped PASS Ginkgo ran 1 suite in 7m7.899706345s Test Suite Passed -- Ran 13 of 816 Specs in 6488.510 seconds FAIL! -- 12 Passed | 1 Failed | 0 Pending | 803 Skipped --- FAIL: TestE2E (6488.58s) FAIL Ginkgo ran 1 suite in 1h48m21.905849382s Test Suite Failed 

Build #2670 (Feb 12, 2024, 11:49:29 PM)
adkulkarni
PR 2788
------------------------------ Ran 1 of 816 Specs in 404.456 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 815 Skipped PASS Ginkgo ran 1 suite in 7m48.159704111s Test Suite Passed 

Build #2674 (Feb 13, 2024, 9:14:45 AM)
adkulkarni
PR 2788
Ran 50 of 816 Specs in 757.881 seconds FAIL! -- 48 Passed | 2 Failed | 0 Pending | 766 Skipped Ginkgo ran 1 suite in 14m15.037060389s Test Suite Failed

Build #2675 (Feb 13, 2024, 10:31:54 AM)
adkulkarni
PR 2788
------------------------------ Ran 2 of 816 Specs in 196.236 seconds SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 814 Skipped PASS Ginkgo ran 1 suite in 4m48.083539421s Test Suite Passed 

### vanilla vol-allocation

Build #337 (Feb 13, 2024, 8:17:33 AM)
adkulkarni
PR 2788
Ran 15 of 816 Specs in 6240.834 seconds FAIL! -- 11 Passed | 4 Failed | 0 Pending | 801 Skipped --- FAIL: TestE2E (6240.93s) FAIL Ginkgo ran 1 suite in 1h45m10.357923519s Test Suite Failed
VC ob-23264548
ESX ob-23264547
VC IP 10.187.108.47
K8S IP 10.187.110.127
Testbed password: OVVL-g9sBzdqB*5a

Build #338 (Feb 13, 2024, 10:35:17 AM)
adkulkarni
PR 2788
------------------------------ Ran 4 of 816 Specs in 1293.347 seconds SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 812 Skipped PASS Ginkgo ran 1 suite in 22m41.019705856s Test Suite Passed 
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix: handle expired session for listview
```
