### PR TITLE
Upgrade controller-gen to v0.14.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ export SYNCER_BIN_SRCS
 endif
 
 syncer_manifest: controller-gen
-	$(CONTROLLER_GEN) crd:trivialVersions=true paths=./pkg/apis/storagepool/... output:crd:dir=pkg/apis/storagepool/config
+	$(CONTROLLER_GEN) crd paths=./pkg/apis/storagepool/... output:crd:dir=pkg/apis/storagepool/config
 # find or download controller-gen
 # download controller-gen if necessary
 controller-gen:
@@ -133,7 +133,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/pkg/apis/storagepool/config/cns.vmware.com_storagepools.yaml
+++ b/pkg/apis/storagepool/config/cns.vmware.com_storagepools.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: storagepools.cns.vmware.com
 spec:
   group: cns.vmware.com
@@ -22,14 +20,19 @@ spec:
         description: StoragePool is the Schema for the storagepools API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -100,18 +103,12 @@ spec:
                     description: Message details of the encountered error
                     type: string
                   state:
-                    description: State indicates a single word description of the
-                      error state that has occurred on the StoragePool, "InMaintenance",
-                      "NotAccessible", etc.
+                    description: |-
+                      State indicates a single word description of the error state that has occurred on the StoragePool,
+                      "InMaintenance", "NotAccessible", etc.
                     type: string
                 type: object
             type: object
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Upgrade controller-gen to v0.14.0

make build is failing with 
```
(vsphere-csi-driver) $ make build
/Users/adkulkarni/go/bin/controller-gen crd:trivialVersions=true paths=./pkg/apis/storagepool/... output:crd:dir=pkg/apis/storagepool/config
Error: unable to parse option "crd:trivialVersions=true": [unknown argument "trivialVersions" (at <input>:1:16) extra arguments provided: "true" (at <input>:1:17)]
Usage:
  controller-gen [flags]
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Statefulset testing with parallel podManagementPolicy: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2789#issuecomment-1933126828

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Upgrade controller-gen to v0.14.0
```
