### PR TITLE
Better RKE1 support for snapshot components.

### DIFF
--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -197,9 +197,6 @@ check_and_deploy_crds(){
 }
 
 find_control_plane_metadata(){
-	declare -g node_tolerations=""
-	declare -g node_tolerations=""
-
 	echo -e "Looking for control plane labels and taints..."
 	controller_labels=""
 	for label in "control-plane" "controlplane" "master"; do


### PR DESCRIPTION
Apparently I inadvertently deleted the branch this PR came from during my merge. This is an attempt to resurrect the now rebased https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2509 and on an actual branch, whoops.

- Allow specifying the kubernetes context when deploying.
- Allow specifying the namespace where the vmware components are located.
- Search for the control plane and pull necessary labels and taints from the actual nodes.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We user Rancher's RKE1 Kubernetes distribution which does some things differently from how this script
expects.

RKE1 uses "controlplane" and "etcd" labels and taints. It does not use "control-plane". Our RKE1 deployment has the "etcd" taint set to "NoExecute" rather than "NoSchedule". Pulling the taints off the nodes seems better than hardcoding them.

In addition, for some reason our CSI driver components are deployed in `kube-system` so we need to
be able to specify the namespace.

Finally, to make it a little easier to deploy to multiple clusters, the ability to specify the context helps us not
accidentally deploy to the wrong cluster.

**Testing done**:
It doesn't look like there are automated tests for this script. I would welcome some ideas about how to better
test it but unfortunately we only have one type of cluster available. I have tested this deployment in all 4 of our clusters.

```
❯ for context in operations academic ais-qaprod ais-devtest; do kubectl --context=${context} -n kube-system get pod -l app=snapshot-controller; kubectl --context=${context} -n kube-system get pod -l app=snapshot-validation; done
NAME                                  READY   STATUS    RESTARTS   AGE
snapshot-controller-ccb845689-7bjj8   1/1     Running   0          32m
snapshot-controller-ccb845689-qspch   1/1     Running   0          33m
NAME                                              READY   STATUS    RESTARTS   AGE
snapshot-validation-deployment-75b65785fb-2dsbh   1/1     Running   0          32m
snapshot-validation-deployment-75b65785fb-twjqr   1/1     Running   0          32m
snapshot-validation-deployment-75b65785fb-znckb   1/1     Running   0          32m
NAME                                  READY   STATUS    RESTARTS   AGE
snapshot-controller-ccb845689-5nsbf   1/1     Running   0          10m
snapshot-controller-ccb845689-bm2nn   1/1     Running   0          11m
NAME                                              READY   STATUS    RESTARTS   AGE
snapshot-validation-deployment-75b65785fb-lnq55   1/1     Running   0          10m
snapshot-validation-deployment-75b65785fb-pv6sh   1/1     Running   0          10m
snapshot-validation-deployment-75b65785fb-zbn5l   1/1     Running   0          10m
NAME                                  READY   STATUS    RESTARTS   AGE
snapshot-controller-ccb845689-5s4h9   1/1     Running   0          7m21s
snapshot-controller-ccb845689-6v84l   1/1     Running   0          7m41s
NAME                                              READY   STATUS    RESTARTS   AGE
snapshot-validation-deployment-75b65785fb-kl9bb   1/1     Running   0          6m52s
snapshot-validation-deployment-75b65785fb-qxvmb   1/1     Running   0          6m56s
snapshot-validation-deployment-75b65785fb-sczbt   1/1     Running   0          6m48s
NAME                                  READY   STATUS    RESTARTS   AGE
snapshot-controller-ccb845689-8hxlc   1/1     Running   0          15m
snapshot-controller-ccb845689-b6nch   1/1     Running   0          15m
NAME                                              READY   STATUS    RESTARTS   AGE
snapshot-validation-deployment-75b65785fb-b4z4j   1/1     Running   0          14m
snapshot-validation-deployment-75b65785fb-fs2nm   1/1     Running   0          14m
snapshot-validation-deployment-75b65785fb-r8j4m   1/1     Running   0          14m
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Expanded cluster support for snapshot component deployment
```
