### PR TITLE
PodVM on stretched supervisor support: Bump up WCP provisioner

### DIFF
--- a/manifests/supervisorcluster/1.25/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.25/cns-csi.yaml
@@ -222,13 +222,12 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.2
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.4
           args:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--feature-gates=Topology=true"
-            - "--extra-create-metadata=false"
             - "--strict-topology"
             - "--leader-election"
             - "--enable-hostlocal-placement=true"
@@ -236,7 +235,6 @@ spec:
             - "--kube-api-burst=100"
             - "--default-fstype=ext4"
             - "--use-service-for-placement-engine=false"
-            - "--podvm-on-stretched-supervisor=false"
             - "--tkgs-ha=true"
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"

--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -222,13 +222,12 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.2
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.4
           args:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--feature-gates=Topology=true"
-            - "--extra-create-metadata=false"
             - "--strict-topology"
             - "--leader-election"
             - "--enable-hostlocal-placement=true"
@@ -237,7 +236,6 @@ spec:
             - "--default-fstype=ext4"
             - "--use-service-for-placement-engine=false"
             - "--tkgs-ha=true"
-            - "--podvm-on-stretched-supervisor=false"
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -222,13 +222,12 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.2
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.4
           args:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--feature-gates=Topology=true"
-            - "--extra-create-metadata=false"
             - "--strict-topology"
             - "--leader-election"
             - "--enable-hostlocal-placement=true"
@@ -237,7 +236,6 @@ spec:
             - "--default-fstype=ext4"
             - "--use-service-for-placement-engine=false"
             - "--tkgs-ha=true"
-            - "--podvm-on-stretched-supervisor=false"
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -222,13 +222,12 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.2
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.4
           args:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--feature-gates=Topology=true"
-            - "--extra-create-metadata=false"
             - "--strict-topology"
             - "--leader-election"
             - "--enable-hostlocal-placement=true"
@@ -237,7 +236,6 @@ spec:
             - "--default-fstype=ext4"
             - "--use-service-for-placement-engine=false"
             - "--tkgs-ha=true"
-            - "--podvm-on-stretched-supervisor=false"
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Bump up WCP provisioner. This points to the commit where provisioner looks at WCP cluster capabilities configmap to enable podVM on stretched supervisor support.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
NA

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
PodVM on stretched supervisor support: Bump up WCP provisioner
```
