### PR TITLE
fix panic in getVMByInstanceUUIDInDatacenter func

### DIFF
--- a/pkg/common/cns-lib/vsphere/virtualmachine.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine.go
@@ -36,6 +36,7 @@ var (
 	ErrVMNotFound = errors.New("virtual machine wasn't found")
 	// ErrNoSharedDatastoresFound is raised when no shared datastores are found among the given NodeVMs.
 	ErrNoSharedDatastoresFound = errors.New("no shared datastores found among given NodeVMs")
+	ErrInvalidVC               = errors.New("invalid VC Object")
 )
 
 // VirtualMachine holds details of a virtual machine instance.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix panic in getVMByInstanceUUIDInDatacenter func.

When `ControllerUnpublishVolume` and `ReloadConfiguration` called at the same time, vCenter object cached in the ControllerUnpublishVolume loop garbage collected by `ReloadConfiguration` call, causing Driver crash.

```
2024-02-18T07:53:45.374776642Z stderr F E0218 07:53:45.374372       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
2024-02-18T07:53:45.374836287Z stderr F goroutine 110256 [running]:
2024-02-18T07:53:45.374849302Z stderr F k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2212260?, 0x3eb5c20})
2024-02-18T07:53:45.374860248Z stderr F 	/build/mts/release/bora-23242524/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/k8s.io/[apimachinery@v0.26.10](mailto:apimachinery@v0.26.10)/pkg/util/runtime/runtime.go:75 +0x85
2024-02-18T07:53:45.374872806Z stderr F k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x0?})
2024-02-18T07:53:45.374897499Z stderr F 	/build/mts/release/bora-23242524/cayman_vsphere_csi_driver/vsphere_csi_driver/go/pkg/mod/k8s.io/[apimachinery@v0.26.10](mailto:apimachinery@v0.26.10)/pkg/util/runtime/runtime.go:49 +0x6b
2024-02-18T07:53:45.374910761Z stderr F panic({0x2212260?, 0x3eb5c20?})
2024-02-18T07:53:45.374922238Z stderr F 	/build/mts/release/bora-23242524/compcache/cayman_go/ob-22907722/linux64/src/runtime/panic.go:914 +0x21f
2024-02-18T07:53:45.374931801Z stderr F sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.getVMByInstanceUUIDInDatacenter({0x2a78d00, 0xc005ebdbc0}, 0xc0002f2200, {0xc000000a20, 0xf}, {0xc003946450, 0x24})
2024-02-18T07:53:45.374941639Z stderr F 	/build/mts/release/bora-23242524/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/csi/service/wcp/controller_helper.go:397 +0x6b
2024-02-18T07:53:45.374951277Z stderr F sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).ControllerUnpublishVolume.func1.1()
2024-02-18T07:53:45.374960557Z stderr F 	/build/mts/release/bora-23242524/cayman_vsphere_csi_driver/vsphere_csi_driver/src/pkg/csi/service/wcp/controller.go:1296 +0x77
```

Pre-chekin tests executed - https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2804#issuecomment-1958530650 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix panic in getVMByInstanceUUIDInDatacenter func
```
