### PR TITLE
matching ginkgo version in run-e2e-test.sh to the one in go.mod

### DIFF
--- a/hack/run-e2e-test.sh
+++ b/hack/run-e2e-test.sh
@@ -20,8 +20,8 @@ set -o pipefail
 
 # Fetching ginkgo for running the test
 export GO111MODULE=on
-export ACK_GINKGO_DEPRECATIONS=2.8.3
-if ! (go mod vendor && go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.3)
+export ACK_GINKGO_DEPRECATIONS=2.11.0
+if ! (go mod vendor && go install github.com/onsi/ginkgo/v2/ginkgo@v2.11.0)
 then
     echo "go mod vendor or go install ginkgo error"
     exit 1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: matching ginkgo version in run-e2e-test.sh to the one in go.mod

**Testing done**:
we were getting this warning in the logs

```bash
sashrith@sashrithKWT4T vsphere-csi-driver % make test-e2e
hack/run-e2e-test.sh
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.8.3
  Mismatched package versions found:
    2.11.0 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.
```


after the fix
```bash
sashrith@sashrithKWT4T vsphere-csi-driver % make test-e2e
hack/run-e2e-test.sh
  W0226 12:44:43.755313   16485 test_context.go:478] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  Feb 26 12:44:43.755: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: CNS CSI Driver End-to-End Tests - /Users/sashrith/vsphere-csi-driver/tests/e2e
=============================================================================================
Random Seed: 1708931670

Will run 35 of 816 specs
```