### PR TITLE
Supervisor: upgrade sidecars provisioner, resizer, snapshotter, attacher and livenessprobe

### DIFF
--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -222,7 +222,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -257,7 +257,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v4.3.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.5.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -281,7 +281,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.8.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.10.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -359,7 +359,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.10.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.12.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
           volumeMounts:
@@ -413,7 +413,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: csi-snapshotter
-          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.2
+          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.5
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -222,7 +222,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -257,7 +257,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v4.3.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.5.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -281,7 +281,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.8.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.10.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -359,7 +359,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.10.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.12.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
           volumeMounts:
@@ -413,7 +413,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: csi-snapshotter
-          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.2
+          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.5
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -222,7 +222,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -257,7 +257,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v4.3.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.5.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -281,7 +281,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.8.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.10.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -359,7 +359,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.10.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.12.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
           volumeMounts:
@@ -413,7 +413,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: csi-snapshotter
-          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.2
+          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.5
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -222,7 +222,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v3.4.0_vmware.4
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -257,7 +257,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: localhost:5000/vmware.io/csi-attacher:v4.3.0_vmware.1
+          image: localhost:5000/vmware.io/csi-attacher:v4.5.0_vmware.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -281,7 +281,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-resizer
-          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.8.0_vmware.1
+          image: localhost:5000/vmware/kubernetes-csi_external-resizer/kubernetes-csi_external-resizer:v1.10.0_vmware.1
           imagePullPolicy: IfNotPresent
           args:
             - --v=4
@@ -359,7 +359,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: liveness-probe
-          image: localhost:5000/vmware.io/csi-livenessprobe:v2.10.0_vmware.1
+          image: localhost:5000/vmware.io/csi-livenessprobe:v2.12.0_vmware.1
           args:
             - "--csi-address=/csi/csi.sock"
           volumeMounts:
@@ -413,7 +413,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: csi-snapshotter
-          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.2
+          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.5
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Upgrading sidecars as part of 80u3 upgrade.

**Testing done**:
Ran WCP precheckin pipeline. All test cases have passed except 2 which QE team has confirmed are seen very frequently and require a fix their side.

See build number 1317 for 1.28 results, 1318 for 1.26 and 1319 for 1.27

**Release note**:
```
Upgrade CSI sidecars - provisioner, resizer, snapshotter, attacher and livenessprobe
```
