### PR TITLE
[E2E-Test-Fix]: Fixing NotAuthenticated issue in tests

### DIFF
--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -6058,9 +6058,10 @@ func triggerFullSync(ctx context.Context, client clientset.Interface,
 	updateTriggerFullSyncCrd(ctx, cnsOperatorClient, *crd)
 	err = waitForFullSyncToFinish(client, ctx, cnsOperatorClient)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Full sync did not finish in given time")
-	crd = getTriggerFullSyncCrd(ctx, client, cnsOperatorClient)
+	crd_updated := getTriggerFullSyncCrd(ctx, client, cnsOperatorClient)
 	framework.Logf("INFO: full sync crd details: %v", crd)
-	updateTriggerFullSyncCrd(ctx, cnsOperatorClient, *crd)
+
+	updateTriggerFullSyncCrd(ctx, cnsOperatorClient, *crd_updated)
 	err = waitForFullSyncToFinish(client, ctx, cnsOperatorClient)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Full sync did not finish in given time")
 }

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -784,6 +784,7 @@ func (vs *vSphere) getVsanClusterResource(ctx context.Context, forceRefresh ...b
 
 // getAllHostsIP reads cluster, gets hosts in it and returns IP array
 func getAllHostsIP(ctx context.Context, forceRefresh ...bool) []string {
+	bootstrap()
 	var result []string
 	refresh := false
 	if len(forceRefresh) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

Test: create volume snapshot when hostd goes down

Before Fix:
fault: <*types.NotAuthenticated | 0xc00095a9b0>{

After Fix:
14:58:42  Ran 2 of 816 Specs in 2086.849 seconds
14:58:42  SUCCESS! -- 2 Passed | 0 Failed

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NA

**Testing done**:
YES

https://container-dp.svc.eng.vmware.com/job/csi-block-vanilla-precheckin/2691/
https://container-dp.svc.eng.vmware.com/job/csi-block-vanilla-precheckin/2690/
https://container-dp.svc.eng.vmware.com/job/csi-block-vanilla-precheckin/2689/
https://container-dp.svc.eng.vmware.com/job/csi-block-vanilla-precheckin/2688/
https://container-dp.svc.eng.vmware.com/job/csi-block-vanilla-precheckin/2683/

**Special notes for your reviewer**:
NA

**Release note**:
NA