### PR TITLE
remove usage of deprecated API WaitForResult

### DIFF
--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -280,7 +280,7 @@ func (l *ListViewImpl) listenToTaskUpdates() {
 
 		log.Info("Starting listening for task updates...")
 		pc := property.DefaultCollector(l.govmomiClient.Client)
-		err := property.WaitForUpdates(l.waitForUpdatesContext, pc, filter, func(updates []types.ObjectUpdate) bool {
+		err := property.WaitForUpdatesEx(l.waitForUpdatesContext, pc, filter, func(updates []types.ObjectUpdate) bool {
 			log.Debugf("Got %d property collector update(s)", len(updates))
 			for _, update := range updates {
 				for _, prop := range update.ChangeSet {

--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -380,7 +380,7 @@ func (m *defaultManager) MonitorCreateVolumeTask(ctx context.Context,
 	if m.tasksListViewEnabled {
 		taskInfo, err = m.waitOnTask(ctx, task.Reference())
 	} else {
-		taskInfo, err = task.WaitForResult(ctx, nil)
+		taskInfo, err = task.WaitForResultEx(ctx, nil)
 	}
 	if err != nil {
 		if cnsvsphere.IsManagedObjectNotFound(err, task.Reference()) {

--- a/pkg/syncer/storagepool/listener.go
+++ b/pkg/syncer/storagepool/listener.go
@@ -119,7 +119,7 @@ func initListener(ctx context.Context, scWatchCntlr *StorageClassWatch,
 		for {
 			log.Infof("Starting property collector...")
 			p := property.DefaultCollector(spController.vc.Client.Client)
-			err := property.WaitForUpdates(ctx, p, filter, func(updates []types.ObjectUpdate) bool {
+			err := property.WaitForUpdatesEx(ctx, p, filter, func(updates []types.ObjectUpdate) bool {
 				ctx := logger.NewContextWithLogger(ctx)
 				log = logger.GetLogger(ctx)
 				log.Infof("Got %d property collector update(s)", len(updates))

--- a/pkg/syncer/storagepool/migrationController.go
+++ b/pkg/syncer/storagepool/migrationController.go
@@ -108,7 +108,7 @@ func (m *migrationController) relocateCNSVolume(ctx context.Context, volumeID st
 		}
 		return err
 	}
-	taskInfo, err := task.WaitForResult(ctx)
+	taskInfo, err := task.WaitForResultEx(ctx)
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/multi_vc_utils.go
+++ b/tests/e2e/multi_vc_utils.go
@@ -1159,7 +1159,7 @@ func (vs *multiVCvSphere) createFCDInMultiVC(ctx context.Context, fcdname string
 		return "", err
 	}
 	task := object.NewTask(vs.multiVcClient[clientIndex].Client, res.Returnval)
-	taskInfo, err := task.WaitForResult(ctx, nil)
+	taskInfo, err := task.WaitForResultEx(ctx, nil)
 	if err != nil {
 		return "", err
 	}
@@ -1180,7 +1180,7 @@ func (vs *multiVCvSphere) deleteFCDInMultiVc(ctx context.Context, fcdID string,
 		return err
 	}
 	task := object.NewTask(vs.multiVcClient[clientIndex].Client, res.Returnval)
-	_, err = task.WaitForResult(ctx, nil)
+	_, err = task.WaitForResultEx(ctx, nil)
 	if err != nil {
 		framework.Logf(err.Error())
 	}

--- a/tests/e2e/tkgs_ha_utils.go
+++ b/tests/e2e/tkgs_ha_utils.go
@@ -789,7 +789,7 @@ func enterHostIntoMM(ctx context.Context, host *object.HostSystem, mmModeType st
 	task, err := host.EnterMaintenanceMode(ctx, timeout, false, &hostMMSpec)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	_, err = task.WaitForResult(ctx, nil)
+	_, err = task.WaitForResultEx(ctx, nil)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	framework.Logf("Host: %v in in maintenance mode", host)
@@ -800,7 +800,7 @@ func exitHostMM(ctx context.Context, host *object.HostSystem, timeout int32) {
 	task, err := host.ExitMaintenanceMode(ctx, timeout)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	_, err = task.WaitForResult(ctx, nil)
+	_, err = task.WaitForResultEx(ctx, nil)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	framework.Logf("Host: %v exited from maintenance mode", host)

--- a/tests/e2e/vcp_to_csi_create_delete.go
+++ b/tests/e2e/vcp_to_csi_create_delete.go
@@ -865,7 +865,7 @@ func fileExistsOnSharedDatastore(ctx context.Context, volPath string) (bool, err
 	}
 	task, err := b.SearchDatastore(ctx, volPath, &spec)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	_, err = task.WaitForResult(ctx, nil)
+	_, err = task.WaitForResultEx(ctx, nil)
 	if err != nil {
 		if types.IsFileNotFound(err) {
 			return false, nil

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -525,7 +525,7 @@ func (vs *vSphere) createFCD(ctx context.Context, fcdname string,
 		return "", err
 	}
 	task := object.NewTask(vs.Client.Client, res.Returnval)
-	taskInfo, err := task.WaitForResult(ctx, nil)
+	taskInfo, err := task.WaitForResultEx(ctx, nil)
 	if err != nil {
 		return "", err
 	}
@@ -562,7 +562,7 @@ func (vs *vSphere) createFCDwithValidProfileID(ctx context.Context, fcdname stri
 		return "", err
 	}
 	task := object.NewTask(vs.Client.Client, res.Returnval)
-	taskInfo, err := task.WaitForResult(ctx, nil)
+	taskInfo, err := task.WaitForResultEx(ctx, nil)
 	if err != nil {
 		return "", err
 	}
@@ -582,7 +582,7 @@ func (vs *vSphere) deleteFCD(ctx context.Context, fcdID string, dsRef vim25types
 		return err
 	}
 	task := object.NewTask(vs.Client.Client, res.Returnval)
-	_, err = task.WaitForResult(ctx, nil)
+	_, err = task.WaitForResultEx(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -613,7 +613,7 @@ func (vs *vSphere) relocateFCD(ctx context.Context, fcdID string,
 		return err
 	}
 	task := object.NewTask(vs.Client.Client, res.Returnval)
-	_, err = task.WaitForResult(ctx, nil)
+	_, err = task.WaitForResultEx(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -1131,7 +1131,7 @@ func (vs *vSphere) cnsRelocateVolume(e2eVSphere vSphere, ctx context.Context, fc
 	}
 	task := object.NewTask(e2eVSphere.Client.Client, res.Returnval)
 	if waitForTaskTocomplete {
-		taskInfo, err := task.WaitForResult(ctx, nil)
+		taskInfo, err := task.WaitForResultEx(ctx, nil)
 		framework.Logf("taskInfo: %v", taskInfo)
 		framework.Logf("error: %v", err)
 		if err != nil {
@@ -1279,7 +1279,7 @@ func waitForCNSTaskToComplete(ctx context.Context, task *object.Task) *vim25type
 		pandoraSyncWaitTime = defaultPandoraSyncWaitTime
 	}
 
-	taskInfo, err := task.WaitForResult(ctx, nil)
+	taskInfo, err := task.WaitForResultEx(ctx, nil)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	taskResult, err := cns.GetTaskResult(ctx, taskInfo)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1301,7 +1301,7 @@ func (vs *vSphere) svmotionVM2DiffDs(ctx context.Context, vm *object.VirtualMach
 	framework.Logf("Starting relocation of vm %s to datastore %s", vmname, dsref.Value)
 	task, err := vm.Relocate(ctx, relocateSpec, vim25types.VirtualMachineMovePriorityHighPriority)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	_, err = task.WaitForResult(ctx)
+	_, err = task.WaitForResultEx(ctx)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	framework.Logf("Relocation of vm %s to datastore %s completed successfully", vmname, dsref.Value)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Linter check is failing after https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2821 


In this PR replacing usage of  `WaitForUpdates` API with new API `WaitForUpdatesEx`.


> property.WaitForUpdates is deprecated: Please consider using WaitForUpdatesEx instead, as it does not create a new property collector, instead it destroys the property filter after the expected update is received.  (SA1019)


Since this change is present in govmomi v0.36.1 v0.36.0 v0.35.0, it is essential to move to new API. 
Also we want to add support for sha256 thumbprint introduced in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2821 

@skogta I will close https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2824 if pre-checkin job passes with this change.


**Testing done**:
1. Executed `make check`
2. Verified creating statefulset with 1 replica with this change. and confirmed no issue observed in the logs in CSI controller and CSI syncer specifically for list-view API.

```
root@k8s-control-372-1710292600:~# kubectl get pods
NAME    READY   STATUS    RESTARTS   AGE
web-0   1/1     Running   0          4m25s
root@k8s-control-372-1710292600:~# kubectl get pvc
NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        VOLUMEATTRIBUTESCLASS   AGE
www-web-0   Bound    pvc-9594238f-700a-4669-a757-23caca16d1b7   1Gi        RWO            example-vanilla-rwo-filesystem-sc   <unset>                 4m28s
```

Running pre-checkin job is in progress



**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
remove usage of deprecated API WaitForResult
```
