### PR TITLE
Podvm on stretched svc tests

### DIFF
--- a/tests/e2e/csi_snapshot_basic.go
+++ b/tests/e2e/csi_snapshot_basic.go
@@ -5695,12 +5695,17 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 	   Cleanup the snapshots, PVC and SC
 	*/
 
-	ginkgo.It("[tkg-snapshot] Verify Snapshot creation should fail on supervisor cluster", ginkgo.Label(p0,
+	ginkgo.It("[tkg-snapshot] [stretched-svc] Verify Snapshot creation should fail on supervisor cluster", ginkgo.Label(p0,
 		snapshot, tkg, newTest, negative), func() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
+		if stretchedSVC {
+			zonalPolicy := GetAndExpectStringEnvVar(envZonalStoragePolicyName)
+			scParameters[svStorageClassName] = zonalPolicy
+			storagePolicyName = zonalPolicy
+		}
 		storageclass, err := svcClient.StorageV1().StorageClasses().Get(ctx, storagePolicyName, metav1.GetOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -246,6 +246,9 @@ const (
 	vsphereClusterIdConfigMapName              = "vsphere-csi-cluster-id"
 	authAPI                                    = "https://console.cloud.vmware.com/csp/gateway/am/api/auth" +
 		"/api-tokens/authorize"
+	podVMOnStretchedSupervisor = "stretched-svc"
+	stretchedSVCTopologyLevels = 1
+	envZonalStoragePolicyName2 = "ZONAL2_STORAGECLASS"
 )
 
 /*
@@ -311,6 +314,7 @@ var (
 	wcpVsanDirectCluster bool
 	vcptocsi             bool
 	windowsEnv           bool
+	stretchedSVC         bool
 )
 
 // For busybox pod image
@@ -458,5 +462,11 @@ func setClusterFlavor(clusterFlavor cnstypes.CnsClusterFlavor) {
 	workerNode := os.Getenv("WORKER_TYPE")
 	if strings.TrimSpace(string(workerNode)) == "WINDOWS" {
 		windowsEnv = true
+	}
+
+	//Check if its stretched SVC testbed
+	testbedType := os.Getenv("STRETCHED_SVC")
+	if strings.TrimSpace(string(testbedType)) == "1" {
+		stretchedSVC = true
 	}
 }

--- a/tests/e2e/statefulsets.go
+++ b/tests/e2e/statefulsets.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
 	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
@@ -67,11 +68,17 @@ var _ = ginkgo.Describe("statefulset", func() {
 	f := framework.NewDefaultFramework("e2e-vsphere-statefulset")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var (
-		namespace         string
-		client            clientset.Interface
-		storagePolicyName string
-		scParameters      map[string]string
-		storageClassName  string
+		namespace            string
+		client               clientset.Interface
+		storagePolicyName    string
+		scParameters         map[string]string
+		storageClassName     string
+		zonalPolicy          string
+		zonalWffcPolicy      string
+		categories           []string
+		labels_ns            map[string]string
+		allowedTopologyHAMap map[string][]string
+		nodeList             *v1.NodeList
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -88,6 +95,33 @@ var _ = ginkgo.Describe("statefulset", func() {
 
 		scParameters = make(map[string]string)
 		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
+
+		if stretchedSVC {
+			zonalPolicy = GetAndExpectStringEnvVar(envZonalStoragePolicyName)
+			labels_ns = map[string]string{}
+			labels_ns[admissionapi.EnforceLevelLabel] = string(admissionapi.LevelPrivileged)
+			labels_ns["e2e-framework"] = f.BaseName
+
+			if zonalPolicy == "" {
+				ginkgo.Fail(envZonalStoragePolicyName + " env variable not set")
+			}
+			zonalWffcPolicy = GetAndExpectStringEnvVar(envZonalWffcStoragePolicyName)
+			if zonalWffcPolicy == "" {
+				ginkgo.Fail(envZonalWffcStoragePolicyName + " env variable not set")
+			}
+			framework.Logf("zonal policy: %s and zonal wffc policy: %s", zonalPolicy, zonalWffcPolicy)
+
+			topologyHaMap := GetAndExpectStringEnvVar(topologyHaMap)
+			_, categories = createTopologyMapLevel5(topologyHaMap, stretchedSVCTopologyLevels)
+			allowedTopologies := createAllowedTopolgies(topologyHaMap, stretchedSVCTopologyLevels)
+			allowedTopologyHAMap = createAllowedTopologiesMap(allowedTopologies)
+			framework.Logf("Topology map: %v, categories: %v", allowedTopologyHAMap, categories)
+		}
+
+		if stretchedSVC {
+			nodeList, err = fnodes.GetReadySchedulableNodes(client)
+			framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		}
 	})
 
 	ginkgo.AfterEach(func() {
@@ -106,7 +140,18 @@ var _ = ginkgo.Describe("statefulset", func() {
 		}
 	})
 
-	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized] Statefulset "+
+	/**
+	Statefulset testing with default podManagementPolicy
+	1. create appropriate storage class
+	2. create statefull set with 3 replica's with above created SC
+	3. scale down statefill set
+	4. scale up statefull set
+	5. Validate POD's are coming up on appropriate nodes
+	6. in case of stretched svc - validate PV node affinity
+	7. clean up the statefulset
+	*/
+
+	ginkgo.It("[csi-block-vanilla] [csi-supervisor] [csi-block-vanilla-parallelized] [stretched-svc] Statefulset "+
 		"testing with default podManagementPolicy", ginkgo.Label(p0, vanilla, block, wcp, core), func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -117,21 +162,24 @@ var _ = ginkgo.Describe("statefulset", func() {
 			scParameters = nil
 			storageClassName = "nginx-sc-default"
 		} else {
-			ginkgo.By("CNS_TEST: Running for WCP setup")
-			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
-			scParameters[scParamStoragePolicyID] = profileID
-			storageClassName = defaultNginxStorageClassName
-			// create resource quota
-			createResourceQuota(client, namespace, rqLimit, defaultNginxStorageClassName)
+			if !stretchedSVC {
+				ginkgo.By("CNS_TEST: Running for WCP setup")
+				profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+				scParameters[scParamStoragePolicyID] = profileID
+				createResourceQuota(client, namespace, rqLimit, defaultNginxStorageClassName)
+				storageClassName = defaultNginxStorageClassName
+			}
 		}
 
-		scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
-		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		defer func() {
-			err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+		if !stretchedSVC {
+			scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+			sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		}()
+			defer func() {
+				err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}()
+		}
 
 		ginkgo.By("Creating service")
 		service := CreateService(namespace, client)
@@ -142,6 +190,19 @@ var _ = ginkgo.Describe("statefulset", func() {
 		ginkgo.By("Creating statefulset")
 		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
 			Spec.StorageClassName = &storageClassName
+
+		if stretchedSVC {
+			scParameters[svStorageClassName] = zonalPolicy
+			storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+			if !apierrors.IsNotFound(err) {
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			storageClassName = storageclass.Name
+			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+				Spec.StorageClassName = &storageclass.Name
+
+		}
+
 		CreateStatefulSet(namespace, statefulset, client)
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
@@ -276,6 +337,9 @@ var _ = ginkgo.Describe("statefulset", func() {
 					err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
 						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					if stretchedSVC {
+						verifyAnnotationsAndNodeAffinityInSVC(allowedTopologyHAMap, pod, nodeList, pv)
+					}
 				}
 			}
 		}
@@ -288,6 +352,7 @@ var _ = ginkgo.Describe("statefulset", func() {
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
 			"Number of Pods in the statefulset should match with number of replicas")
 	})
+
 	/*
 		Test performs following operations
 
@@ -973,6 +1038,590 @@ var _ = ginkgo.Describe("statefulset", func() {
 		exitHostMM(ctx, hostInMM, mmTimeout)
 		enterMaintenanceMode = false
 
+	})
+
+	/**
+	Statefulset parallel podManagementPolicy wffc
+	1. create zonal storage class
+	2. create statefull set  with replica 3 using zonal-latebinding storage class
+	3. scale down statefull set
+	4. scale up statefull set
+	5. Verify node affinity on each PV
+	6. Verify statefull pods are coming up on appropriate nodes
+	7. clean up the data
+	*/
+
+	ginkgo.It("[stretched-svc] Statefulset parallel podManagementPolicy "+
+		"wffc", ginkgo.Label(p0, vanilla, block, wcp, core), func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass for Statefulset")
+
+		// decide which test setup is available to run
+		if vanillaCluster {
+			ginkgo.By("CNS_TEST: Running for vanilla k8s setup")
+			scParameters = nil
+			storageClassName = "nginx-sc-default"
+		} else {
+			if !stretchedSVC {
+				ginkgo.By("CNS_TEST: Running for WCP setup")
+				profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+				scParameters[scParamStoragePolicyID] = profileID
+				createResourceQuota(client, namespace, rqLimit, defaultNginxStorageClassName)
+				storageClassName = defaultNginxStorageClassName
+
+			}
+
+		}
+
+		if !stretchedSVC {
+			scSpec := getVSphereStorageClassSpec(storageClassName, scParameters, nil, "", "", false)
+			sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer func() {
+				err := client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}()
+
+		}
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Spec.StorageClassName = &storageClassName
+		if stretchedSVC {
+			scParameters[svStorageClassName] = zonalWffcPolicy
+			storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalWffcPolicy, metav1.GetOptions{})
+			if !apierrors.IsNotFound(err) {
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+			storageClassName = storageclass.Name
+			statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+				Spec.StorageClassName = &storageclass.Name
+			statefulset.Spec.PodManagementPolicy = apps.ParallelPodManagement
+
+		}
+
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		// Waiting for pods status to be Ready
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// Get the list of Volumes attached to Pods before scale down
+		var volumesBeforeScaleDown []string
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					volumesBeforeScaleDown = append(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)
+					// Verify the attached volume match the one in CNS cache
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas-1))
+		_, scaledownErr := fss.Scale(client, statefulset, replicas-1)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas-1)
+		ssPodsAfterScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas-1)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// After scale down, verify vSphere volumes are detached from deleted pods
+		ginkgo.By("Verify Volumes are detached from Nodes after Statefulsets is scaled down")
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			if err != nil {
+				gomega.Expect(apierrors.IsNotFound(err), gomega.BeTrue())
+				for _, volumespec := range sspod.Spec.Volumes {
+					if volumespec.PersistentVolumeClaim != nil {
+						pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+						if vanillaCluster {
+							isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(
+								client, pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+								fmt.Sprintf("Volume %q is not detached from the node %q",
+									pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+						} else {
+							annotations := sspod.Annotations
+							vmUUID, exists := annotations[vmUUIDLabel]
+							gomega.Expect(exists).To(gomega.BeTrue(),
+								fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+
+							ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s",
+								pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+							ctx, cancel := context.WithCancel(context.Background())
+							defer cancel()
+							_, err := e2eVSphere.getVMByUUIDWithWait(ctx, vmUUID, supervisorClusterOperationsTimeout)
+							gomega.Expect(err).To(gomega.HaveOccurred(),
+								fmt.Sprintf("PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM",
+									vmUUID, sspod.Spec.NodeName))
+						}
+					}
+				}
+			}
+		}
+
+		// After scale down, verify the attached volumes match those in CNS Cache
+		for _, sspod := range ssPodsAfterScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By(fmt.Sprintf("Scaling up statefulsets to number of Replica: %v", replicas))
+		_, scaleupErr := fss.Scale(client, statefulset, replicas)
+		gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+
+		ssPodsAfterScaleUp := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// After scale up, verify all vSphere volumes are attached to node VMs.
+		ginkgo.By("Verify all volumes are attached to Nodes after Statefulsets is scaled up")
+		for _, sspod := range ssPodsAfterScaleUp.Items {
+			err := fpod.WaitTimeoutForPodReadyInNamespace(client, sspod.Name, statefulset.Namespace, pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range pod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					ginkgo.By("Verify scale up operation should not introduced new volume")
+					gomega.Expect(contains(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)).To(gomega.BeTrue())
+					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+					var vmUUID string
+					var exists bool
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					if vanillaCluster {
+						vmUUID = getNodeUUID(ctx, client, sspod.Spec.NodeName)
+					} else {
+						annotations := pod.Annotations
+						vmUUID, exists = annotations[vmUUIDLabel]
+						gomega.Expect(exists).To(gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+						_, err := e2eVSphere.getVMByUUID(ctx, vmUUID)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+					isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Disk is not attached to the node")
+					gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached")
+					ginkgo.By("After scale up, verify the attached volumes match those in CNS Cache")
+					err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					if stretchedSVC {
+						verifyAnnotationsAndNodeAffinityInSVC(allowedTopologyHAMap, pod, nodeList, pv)
+					}
+
+				}
+			}
+		}
+		replicas = 0
+		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas))
+		_, scaledownErr = fss.Scale(client, statefulset, replicas)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		ssPodsAfterScaleDown = fss.GetPodList(client, statefulset)
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+	})
+
+	/**
+	Statefulset statefullset nodeAffinity
+	1. create zonal storage class
+	2. create statefull set  with replica 3 using zonal sc along with node affinity details
+	3. scale down statefull set
+	4. scale up statefull set
+	5. Verify node affinity on each PV
+	6. Verify statefull pods are coming up on appropriate nodes
+	7. clean up the data
+	*/
+
+	ginkgo.It("[stretched-svc] statefulset-nodeAffinity", ginkgo.Label(p0, wcp, core), func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass for Statefulset")
+
+		storageClassName = zonalPolicy
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Spec.StorageClassName = &storageClassName
+
+		scParameters[svStorageClassName] = zonalPolicy
+		storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		storageClassName = storageclass.Name
+
+		ginkgo.By("++++++Topology selector++++++++")
+		topologyHaMap := GetAndExpectStringEnvVar(topologyHaMap)
+
+		_, categories = createTopologyMapLevel5(topologyHaMap, stretchedSVCTopologyLevels)
+		allowedTopologies := createAllowedTopolgies(topologyHaMap, stretchedSVCTopologyLevels)
+		allowedTopologyHAMap = createAllowedTopologiesMap(allowedTopologies)
+		allowedTopologies = getTopologySelector(allowedTopologyHAMap, categories,
+			stretchedSVCTopologyLevels)
+		allowedTopologyHAMap = createAllowedTopologiesMap(allowedTopologies)
+
+		storageClassName = storageclass.Name
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Spec.StorageClassName = &storageclass.Name
+		statefulset.Spec.Template.Spec.Affinity = new(v1.Affinity)
+		statefulset.Spec.Template.Spec.Affinity.NodeAffinity = new(v1.NodeAffinity)
+		statefulset.Spec.Template.Spec.Affinity.NodeAffinity.
+			RequiredDuringSchedulingIgnoredDuringExecution = new(v1.NodeSelector)
+		statefulset.Spec.Template.Spec.Affinity.NodeAffinity.
+			RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = getNodeSelectorTerms(allowedTopologies)
+		*statefulset.Spec.Replicas = 3
+
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+		// Waiting for pods status to be Ready
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// Get the list of Volumes attached to Pods before scale down
+		var volumesBeforeScaleDown []string
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					volumesBeforeScaleDown = append(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)
+					// Verify the attached volume match the one in CNS cache
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas-1))
+		_, scaledownErr := fss.Scale(client, statefulset, replicas-1)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas-1)
+		ssPodsAfterScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas-1)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// After scale down, verify vSphere volumes are detached from deleted pods
+		ginkgo.By("Verify Volumes are detached from Nodes after Statefulsets is scaled down")
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			if err != nil {
+				gomega.Expect(apierrors.IsNotFound(err), gomega.BeTrue())
+				for _, volumespec := range sspod.Spec.Volumes {
+					if volumespec.PersistentVolumeClaim != nil {
+						pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+						if vanillaCluster {
+							isDiskDetached, err := e2eVSphere.waitForVolumeDetachedFromNode(
+								client, pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName)
+							gomega.Expect(err).NotTo(gomega.HaveOccurred())
+							gomega.Expect(isDiskDetached).To(gomega.BeTrue(),
+								fmt.Sprintf("Volume %q is not detached from the node %q",
+									pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+						} else {
+							annotations := sspod.Annotations
+							vmUUID, exists := annotations[vmUUIDLabel]
+							gomega.Expect(exists).To(gomega.BeTrue(),
+								fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+
+							ginkgo.By(fmt.Sprintf("Verify volume: %s is detached from PodVM with vmUUID: %s",
+								pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+							ctx, cancel := context.WithCancel(context.Background())
+							defer cancel()
+							_, err := e2eVSphere.getVMByUUIDWithWait(ctx, vmUUID, supervisorClusterOperationsTimeout)
+							gomega.Expect(err).To(gomega.HaveOccurred(),
+								fmt.Sprintf("PodVM with vmUUID: %s still exists. So volume: %s is not detached from the PodVM",
+									vmUUID, sspod.Spec.NodeName))
+						}
+					}
+				}
+			}
+		}
+
+		// After scale down, verify the attached volumes match those in CNS Cache
+		for _, sspod := range ssPodsAfterScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		ginkgo.By(fmt.Sprintf("Scaling up statefulsets to number of Replica: %v", replicas))
+		_, scaleupErr := fss.Scale(client, statefulset, replicas)
+		gomega.Expect(scaleupErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+
+		ssPodsAfterScaleUp := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsAfterScaleUp.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// After scale up, verify all vSphere volumes are attached to node VMs.
+		ginkgo.By("Verify all volumes are attached to Nodes after Statefulsets is scaled up")
+		for _, sspod := range ssPodsAfterScaleUp.Items {
+			err := fpod.WaitTimeoutForPodReadyInNamespace(client, sspod.Name, statefulset.Namespace, pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range pod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					ginkgo.By("Verify scale up operation should not introduced new volume")
+					gomega.Expect(contains(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)).To(gomega.BeTrue())
+					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+					var vmUUID string
+					var exists bool
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					if vanillaCluster {
+						vmUUID = getNodeUUID(ctx, client, sspod.Spec.NodeName)
+					} else {
+						annotations := pod.Annotations
+						vmUUID, exists = annotations[vmUUIDLabel]
+						gomega.Expect(exists).To(gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+						_, err := e2eVSphere.getVMByUUID(ctx, vmUUID)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+					isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Disk is not attached to the node")
+					gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached")
+					ginkgo.By("After scale up, verify the attached volumes match those in CNS Cache")
+					err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					if stretchedSVC {
+						verifyAnnotationsAndNodeAffinityInSVC(allowedTopologyHAMap, pod, nodeList, pv)
+					}
+
+				}
+			}
+		}
+		replicas = 0
+		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas))
+		_, scaledownErr = fss.Scale(client, statefulset, replicas)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		ssPodsAfterScaleDown = fss.GetPodList(client, statefulset)
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+	})
+
+	/**
+	statefulset pod-affinity
+	1. create zonal storage class
+	2. create statefull set  with replica 3 using zonal sc along with pod affinity details
+	3. Verify Pod's are coming up on appropriate nodes
+	4. Verify allowed topology details on PV
+	6. clean up the data
+	*/
+	ginkgo.It("[stretched-svc] statefulset-pod-Affinity", ginkgo.Label(p0, wcp, core), func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ginkgo.By("Creating StorageClass for Statefulset")
+
+		storageClassName = zonalPolicy
+
+		ginkgo.By("Creating service")
+		service := CreateService(namespace, client)
+		defer func() {
+			deleteService(namespace, client, service)
+		}()
+
+		statefulset := GetStatefulSetFromManifest(namespace)
+		ginkgo.By("Creating statefulset")
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Spec.StorageClassName = &storageClassName
+
+		scParameters[svStorageClassName] = zonalPolicy
+		storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		storageClassName = storageclass.Name
+
+		topologyHaMap := GetAndExpectStringEnvVar(topologyHaMap)
+
+		_, categories = createTopologyMapLevel5(topologyHaMap, stretchedSVCTopologyLevels)
+		allowedTopologies := createAllowedTopolgies(topologyHaMap, stretchedSVCTopologyLevels)
+		allowedTopologyHAMap = createAllowedTopologiesMap(allowedTopologies)
+		allowedTopologies = getTopologySelector(allowedTopologyHAMap, categories,
+			stretchedSVCTopologyLevels)
+		allowedTopologyHAMap = createAllowedTopologiesMap(allowedTopologies)
+
+		ginkgo.By("Creating statefulset with POD Anti affinity")
+		framework.Logf("allowedTopo: %v", allowedTopologies)
+		statefulset.Spec.PodManagementPolicy = apps.ParallelPodManagement
+		statefulset.Spec.VolumeClaimTemplates[len(statefulset.Spec.VolumeClaimTemplates)-1].
+			Spec.StorageClassName = &storageclass.Name
+		statefulset.Spec.Template.Spec.Affinity = new(v1.Affinity)
+		statefulset.Spec.Template.Spec.Affinity.NodeAffinity = new(v1.NodeAffinity)
+		statefulset.Spec.Template.Spec.Affinity.NodeAffinity.
+			RequiredDuringSchedulingIgnoredDuringExecution = new(v1.NodeSelector)
+		statefulset.Spec.Template.Spec.Affinity.NodeAffinity.
+			RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = getNodeSelectorTerms(allowedTopologies)
+
+		statefulset.Spec.Template.Spec.Affinity.PodAntiAffinity = new(v1.PodAntiAffinity)
+		statefulset.Spec.Template.Spec.Affinity.PodAntiAffinity.
+			RequiredDuringSchedulingIgnoredDuringExecution = getPodAffinityTerm(allowedTopologyHAMap)
+
+		*statefulset.Spec.Replicas = 3
+
+		CreateStatefulSet(namespace, statefulset, client)
+		replicas := *(statefulset.Spec.Replicas)
+
+		// Waiting for pods status to be Ready
+		fss.WaitForStatusReadyReplicas(client, statefulset, replicas)
+		gomega.Expect(fss.CheckMount(client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
+		ssPodsBeforeScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(ssPodsBeforeScaleDown.Items).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		gomega.Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
+
+		// Get the list of Volumes attached to Pods before scale down
+		var volumesBeforeScaleDown []string
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					volumesBeforeScaleDown = append(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)
+					// Verify the attached volume match the one in CNS cache
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		// After scale down, verify the attached volumes match those in CNS Cache
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+			}
+		}
+
+		// After scale up, verify all vSphere volumes are attached to node VMs.
+		ginkgo.By("Verify all volumes are attached to Nodes after Statefulsets is scaled up")
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			err := fpod.WaitTimeoutForPodReadyInNamespace(client, sspod.Name, statefulset.Namespace, pollTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pod, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, volumespec := range pod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					ginkgo.By("Verify scale up operation should not introduced new volume")
+					gomega.Expect(contains(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)).To(gomega.BeTrue())
+					ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
+						pv.Spec.CSI.VolumeHandle, sspod.Spec.NodeName))
+					var vmUUID string
+					var exists bool
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					if vanillaCluster {
+						vmUUID = getNodeUUID(ctx, client, sspod.Spec.NodeName)
+					} else {
+						annotations := pod.Annotations
+						vmUUID, exists = annotations[vmUUIDLabel]
+						gomega.Expect(exists).To(gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+						_, err := e2eVSphere.getVMByUUID(ctx, vmUUID)
+						gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					}
+					isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, pv.Spec.CSI.VolumeHandle, vmUUID)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Disk is not attached to the node")
+					gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Disk is not attached")
+					ginkgo.By("After scale up, verify the attached volumes match those in CNS Cache")
+					err = verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
+						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					if stretchedSVC {
+						verifyAnnotationsAndNodeAffinityInSVC(allowedTopologyHAMap, pod, nodeList, pv)
+					}
+
+				}
+			}
+		}
+		replicas = 0
+		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas))
+		_, scaledownErr := fss.Scale(client, statefulset, replicas)
+		gomega.Expect(scaledownErr).NotTo(gomega.HaveOccurred())
+		fss.WaitForStatusReplicas(client, statefulset, replicas)
+		ssPodsAfterScaleDown := fss.GetPodList(client, statefulset)
+		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(replicas)).To(gomega.BeTrue(),
+			"Number of Pods in the statefulset should match with number of replicas")
 	})
 
 })

--- a/tests/e2e/tkgs_ha_utils.go
+++ b/tests/e2e/tkgs_ha_utils.go
@@ -131,6 +131,20 @@ func verifyAnnotationsAndNodeAffinity(allowedTopologyHAMap map[string][]string,
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
+// verifyAnnotationsAndNodeAffinityInSVC verifies annotations on SVC PVC
+// and node affinities and pod location of volumes on correct zones
+func verifyAnnotationsAndNodeAffinityInSVC(allowedTopologyHAMap map[string][]string,
+	pod *v1.Pod, nodeList *v1.NodeList, pv *v1.PersistentVolume) {
+
+	framework.Logf("Verify  PV has has required  node affinity details")
+	_, err := verifyVolumeTopologyForLevel5(pv, allowedTopologyHAMap)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	framework.Logf("SVC PV: %s has required Pv node affinity details", pv.Name)
+
+	_, err = verifyPodLocationLevel5(pod, nodeList, allowedTopologyHAMap)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
 // verifyVolumeProvisioningWithServiceDown brings the service down and creates the statefulset and then brings up
 // the service and validates the volumes are bound and required annotations and node affinity are present
 func verifyVolumeProvisioningWithServiceDown(serviceName string, namespace string, client clientset.Interface,

--- a/tests/e2e/vsphere_volume_expansion.go
+++ b/tests/e2e/vsphere_volume_expansion.go
@@ -45,7 +45,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	fdep "k8s.io/kubernetes/test/e2e/framework/deployment"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
-	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
 	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
@@ -70,23 +69,22 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 		isVsanHealthServiceStopped bool
 		isSPSServiceStopped        bool
 	)
+
 	ginkgo.BeforeEach(func() {
 		client = f.ClientSet
 		namespace = getNamespaceToRunTests(f)
 		bootstrap()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		var err error
 
 		isVsanHealthServiceStopped = false
 		isSPSServiceStopped = false
 
-		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
-		profileID = e2eVSphere.GetSpbmPolicyID(storagePolicyName)
-
-		nodeList, err := fnodes.GetReadySchedulableNodes(f.ClientSet)
-		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
-		if !(len(nodeList.Items) > 0) {
-			framework.Failf("Unable to find ready and schedulable Node")
+		if !stretchedSVC {
+			storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
+			profileID = e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+			defaultDatastore = getDefaultDatastore(ctx)
 		}
 
 		if os.Getenv(envPandoraSyncWaitTime) != "" {
@@ -96,9 +94,6 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 			pandoraSyncWaitTime = defaultPandoraSyncWaitTime
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		defaultDatastore = getDefaultDatastore(ctx)
-		storagePolicyName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 
 		if guestCluster {
 			svcClient, svNamespace := getSvcClientAndNamespace()
@@ -2501,6 +2496,154 @@ var _ = ginkgo.Describe("Volume Expansion Test", func() {
 
 	})
 
+	/**
+	Offline and online volume expansion on stretched SVC
+	    1. Create zonal storage policy
+		2. Create PVC which uses the above sc.
+		3. Wait for PV to be provisioned.
+		4. Wait for PVC's status to become Bound and note down the size
+		5. Modify PVC's size to trigger offline volume expansion
+		6. verify the PVC status will change to "Resizing", but resize won't succeed until POD is created
+		9. Create POD
+		10. Verify PVC resize completes
+		11. Verify the resized PVC by doing CNS query
+		12. Modify PVC's size to trigger online volume expansion
+		12. Make sure data is intact on the PV mounted on the pod
+		13. After resize completes verify and Make sure file system has also increased
+		14. clean up the data
+	*/
+	ginkgo.It("[stretched-svc] offline and online volume "+
+		"expansion on stretched svc", ginkgo.Label(p1, block, newTest), func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		var pvclaims []*v1.PersistentVolumeClaim
+		//var zonalPolicy string
+		var categories []string
+		var allowedTopologyHAMap map[string][]string
+
+		scParameters := make(map[string]string)
+
+		topologyHaMap := GetAndExpectStringEnvVar(topologyHaMap)
+		_, categories = createTopologyMapLevel5(topologyHaMap, stretchedSVCTopologyLevels)
+		allowedTopologies := createAllowedTopolgies(topologyHaMap, stretchedSVCTopologyLevels)
+		allowedTopologyHAMap = createAllowedTopologiesMap(allowedTopologies)
+		framework.Logf("Topology map: %v, categories: %v", allowedTopologyHAMap, categories)
+
+		zonalPolicy := GetAndExpectStringEnvVar(envZonalStoragePolicyName)
+		scParameters[svStorageClassName] = zonalPolicy
+		storageclass, err := client.StorageV1().StorageClasses().Get(ctx, zonalPolicy, metav1.GetOptions{})
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		pvclaim, err := createPVC(client, namespace, nil, "", storageclass, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Expect claim to provision volume successfully")
+		pvclaims = append(pvclaims, pvclaim)
+		pv, err := fpv.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		volHandle := pv[0].Spec.CSI.VolumeHandle
+		gomega.Expect(volHandle).NotTo(gomega.BeEmpty())
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// Modify PVC spec to trigger volume expansion
+		// We expand the PVC while no pod is using it to ensure offline expansion
+		ginkgo.By("Expanding current pvc")
+		currentPvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
+		newSize := currentPvcSize.DeepCopy()
+		newSize.Add(resource.MustParse("1Gi"))
+		framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
+		pvclaim, err = expandPVCSize(pvclaim, newSize, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+
+		pvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
+		if pvcSize.Cmp(newSize) != 0 {
+			framework.Failf("error updating pvc size %q", pvclaim.Name)
+		}
+
+		ginkgo.By("Waiting for controller volume resize to finish")
+		err = waitForPvResizeForGivenPvc(pvclaim, client, totalResizeWaitPeriod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Checking for conditions on pvc")
+		pvclaim, err = waitForPVCToReachFileSystemResizePendingCondition(client, namespace, pvclaim.Name, pollTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
+		queryResult, err := e2eVSphere.queryCNSVolumeWithResult(volHandle)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if len(queryResult.Volumes) == 0 {
+			err = fmt.Errorf("queryCNSVolumeWithResult returned no volume")
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Verifying disk size requested in volume expansion is honored")
+		newSizeInMb := int64(3072)
+		if queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsBlockBackingDetails).CapacityInMb != newSizeInMb {
+			err = fmt.Errorf("got wrong disk size after volume expansion")
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Create a Pod to use this PVC, and verify volume has been attached
+		ginkgo.By("Creating pod to attach PV to the node")
+		pod, err := createPod(client, namespace, nil, []*v1.PersistentVolumeClaim{pvclaim}, false, execCommand)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer func() {
+			ginkgo.By("Deleting the pod")
+			err = fpod.DeletePodWithWait(client, pod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		var vmUUID string
+		var exists bool
+		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volHandle, pod.Spec.NodeName))
+
+		annotations := pod.Annotations
+		vmUUID, exists = annotations[vmUUIDLabel]
+		gomega.Expect(exists).To(gomega.BeTrue(), fmt.Sprintf("Pod doesn't have %s annotation", vmUUIDLabel))
+
+		framework.Logf("VMUUID : %s", vmUUID)
+		isDiskAttached, err := e2eVSphere.isVolumeAttachedToVM(client, volHandle, vmUUID)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
+
+		ginkgo.By("Verify the volume is accessible and filesystem type is as expected")
+		_, err = e2eoutput.LookForStringInPodExec(namespace, pod.Name,
+			[]string{"/bin/cat", "/mnt/volume1/fstype"}, "", time.Minute)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Waiting for file system resize to finish")
+		pvclaim, err = waitForFSResize(pvclaim, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pvcConditions := pvclaim.Status.Conditions
+		expectEqual(len(pvcConditions), 0, "pvc should not have conditions")
+
+		ginkgo.By("Verify filesystem size for mount point /mnt/volume1")
+		fsSize, err := getFSSizeMb(f, pod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		framework.Logf("File system size after expansion : %s, before expansion: %s", fsSize, diskSizeInMb)
+
+		// Filesystem size may be smaller than the size of the block volume
+		// so here we are checking if the new filesystem size is greater than
+		// the original volume size as the filesystem is formatted for the
+		// first time after pod creation
+		if fsSize < diskSizeInMb {
+			framework.Failf("error updating filesystem size for %q. Resulting filesystem size is %d", pvclaim.Name, fsSize)
+		}
+		ginkgo.By("File system resize finished successfully")
+
+		ginkgo.By("Increase PVC size and verify online volume resize")
+		increaseSizeOfPvcAttachedToPod(f, client, namespace, pvclaim, pod)
+
+	})
+
 })
 
 // increaseOnlineVolumeMultipleTimes this method increases the same volume
@@ -2817,7 +2960,7 @@ func increaseSizeOfPvcAttachedToPod(f *framework.Framework, client clientset.Int
 		ginkgo.By("Verify filesystem size for mount point /mnt/volume1")
 		fsSize, err = getFileSystemSizeForOsType(f, client, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		framework.Logf("File system size after expansion : %v", fsSize)
+		framework.Logf("File system size before expansion: %v, after expansion : %v", originalSizeInMb, fsSize)
 		// Filesystem size may be smaller than the size of the block volume
 		// so here we are checking if the new filesystem size is greater than
 		// the original volume size as the filesystem is formatted for the


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Yes 

**Special notes for your reviewer**:

**Release note**:
1. stateful set using immediate binding mode storage policy with default podmanagement policy
2. stateful set using WFFC storage policy parallel podmanagement policy
3. statefull set with node-affinity
4. stateful set pod affinity
5. offline and online volume expansion
6. static volume provisioning
7. VC reboot
8. create snapshot - validate error message 

Logs: https://gist.github.com/kavyashree-r/1104cb63b6892ce95b696d29a5566adf
