### PR TITLE
Initialize volume locks in driver init

### DIFF
--- a/pkg/csi/service/driver.go
+++ b/pkg/csi/service/driver.go
@@ -81,7 +81,9 @@ func init() {
 
 // NewDriver returns a new Driver.
 func NewDriver() Driver {
-	return &vsphereCSIDriver{}
+	return &vsphereCSIDriver{
+		volumeLocks: node.NewVolumeLocks(),
+	}
 }
 
 func (driver *vsphereCSIDriver) GetController() csi.ControllerServer {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Initialize volume locks in driver init

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Initialize volume locks in driver init
```
