### PR TITLE
Fix storageclass parameter name for storage policy ID in e2e testcases

### DIFF
--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -175,7 +175,7 @@ const (
 	resizerContainerName                      = "csi-resizer"
 	scParamDatastoreURL                       = "DatastoreURL"
 	scParamFsType                             = "csi.storage.k8s.io/fstype"
-	scParamStoragePolicyID                    = "StoragePolicyId"
+	scParamStoragePolicyID                    = "storagePolicyID"
 	scParamStoragePolicyName                  = "StoragePolicyName"
 	shortProvisionerTimeout                   = "10"
 	snapshotapigroup                          = "snapshot.storage.k8s.io"

--- a/tests/e2e/statefulsets.go
+++ b/tests/e2e/statefulsets.go
@@ -313,9 +313,9 @@ var _ = ginkgo.Describe("statefulset", func() {
 			scParameters = nil
 			storageClassName = "nginx-sc-parallel"
 		} else {
-			storageClassName = defaultNginxStorageClassName
+			storageClassName = GetAndExpectStringEnvVar(envStoragePolicyNameForSharedDatastores)
 			ginkgo.By("Running for WCP setup")
-			profileID := e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+			profileID := e2eVSphere.GetSpbmPolicyID(storageClassName)
 			scParameters[scParamStoragePolicyID] = profileID
 			// create resource quota
 			createResourceQuota(client, namespace, rqLimit, storageClassName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fixes the incorrect storageclass parameter name for storage policy ID in e2e testcases from "StoragePolicyId" to "storagePolicyID". Due to this incorrect parameter, wcp pre-checking pipeline was failing with recent changes for storage quota evalution enabled due to PodVMOnStretchedSupervisor FSS enabled by default.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
TBA

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix storageclass parameter name for storage policy ID in e2e testcases
```
