### PR TITLE
Update csi-provisioner sidecar version for Supervisor cluster to latest v4.0.0-vmware.2

### DIFF
--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -222,7 +222,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -222,7 +222,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -222,7 +222,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -222,7 +222,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.1
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.2
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This MR updates csi-provisioner sidecar version on WCP to v4.0.0-vmware.2 to include latest changes with bug fixes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Updated the sidecar image on WCP setup and verified basic volume provisioning works fine

```
root@422b585f8999633b9072d53847c56171 [ ~ ]# kubectl edit deploy -n vmware-system-csi vsphere-csi-controller
...
      containers:
      - args:
      ...
        image: sabu-persistence-service-docker-local.artifactory.eng.vmware.com/pansea:csi-provisioner-v4.0.0_vmware.2
        imagePullPolicy: IfNotPresent
        name: csi-provisioner

root@422b585f8999633b9072d53847c56171 [ ~ ]# cat pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: example-raw-block-pvc
  namespace: svc-tkg-domain-c115
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 10Mi
  storageClassName: wcpglobal-storage-profile
  volumeMode: Block
  
root@422b585f8999633b9072d53847c56171 [ ~ ]# kubectl create -f pvc.yaml
persistentvolumeclaim/example-raw-block-pvc created

root@422b585f8999633b9072d53847c56171 [ ~ ]# kubectl get pvc -A
NAMESPACE             NAME                    STATUS        VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
svc-tkg-domain-c115   example-raw-block-pvc   Bound         pvc-b9ec9881-72d1-4a2b-887a-8f5352667334   10Mi       RWO            wcpglobal-storage-profile   11s
root@422b585f8999633b9072d53847c56171 [ ~ ]#
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update csi-provisioner sidecar version for Supervisor cluster to latest v4.0.0-vmware.2
```
