### PR TITLE
Update csi-provisioner sidecar version for Supervisor cluster to v4.0.0-vmware.3

### DIFF
--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -222,7 +222,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.2
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.3
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -222,7 +222,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.2
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.3
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -222,7 +222,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.2
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.3
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -222,7 +222,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: csi-provisioner
-          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.2
+          image: localhost:5000/vmware/csi-provisioner/csi-provisioner:v4.0.0_vmware.3
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Update WCP provisioner sidecar image to v4.0.0-vmware.3 to utilize the latest bugfixes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before the change:
```
root@4222a8872719cfb262e23bf28fc38bc1 [ ~ ]# k describe persistentvolumeclaim/vmsvc-vm-pvc-new -n c2-vmsvc-ns
Name:          vmsvc-vm-pvc-new
Namespace:     c2-vmsvc-ns
StorageClass:  vsan-default-storage-policy
Status:        Pending
Volume:
Labels:        app=app-template-new
Annotations:   volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:
Access Modes:
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason                Age                From                                                                                          Message
  ----     ------                ----               ----                                                                                          -------
  Normal   Provisioning          11s (x5 over 26s)  csi.vsphere.vmware.com_4222a7807fc063b8d4cf0a2a259fb35d_30cbeb68-b958-424c-9dfc-0f8234307e55  External provisioner is provisioning volume for claim "c2-vmsvc-ns/vmsvc-vm-pvc-new"
  Warning  ProvisioningFailed    11s (x5 over 26s)  csi.vsphere.vmware.com_4222a7807fc063b8d4cf0a2a259fb35d_30cbeb68-b958-424c-9dfc-0f8234307e55  failed to provision volume with StorageClass "vsan-default-storage-policy": error generating accessibility requirements: no available topology found
  Normal   ExternalProvisioning  4s (x3 over 26s)   persistentvolume-controller  
```

After the change:
```
kdsc pvc -n c2-vmsvc-ns   vmsvc-vm-pvc-new  
Name:          vmsvc-vm-pvc-new
Namespace:     c2-vmsvc-ns
StorageClass:  vsan-default-storage-policy
Status:        Bound
Volume:        pvc-9223eef1-20a3-4d04-bc50-37818d20fe16
Labels:        app=app-template-new
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      10Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                     From                                                                                          Message
  ----    ------                 ----                    ----                                                                                          -------
  Normal  Provisioning           7m48s (x250 over 15h)   csi.vsphere.vmware.com_4222a7807fc063b8d4cf0a2a259fb35d_30cbeb68-b958-424c-9dfc-0f8234307e55  External provisioner is provisioning volume for claim "c2-vmsvc-ns/vmsvc-vm-pvc-new"
  Normal  ExternalProvisioning   5m12s (x3643 over 15h)  persistentvolume-controller                                                                   waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  Provisioning           29s                     csi.vsphere.vmware.com_4222a7807fc063b8d4cf0a2a259fb35d_c71e09f0-6413-48e0-910e-b85c065bc8bd  External provisioner is provisioning volume for claim "c2-vmsvc-ns/vmsvc-vm-pvc-new"
  Normal  ProvisioningSucceeded  16s                     csi.vsphere.vmware.com_4222a7807fc063b8d4cf0a2a259fb35d_c71e09f0-6413-48e0-910e-b85c065bc8bd  Successfully provisioned volume pvc-9223eef1-20a3-4d04-bc50-37818d20fe16
```
```
Name:            pvc-9223eef1-20a3-4d04-bc50-37818d20fe16
Labels:          <none>
Annotations:     pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                 volume.kubernetes.io/provisioner-deletion-secret-name: 
                 volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    vsan-default-storage-policy
Status:          Bound
Claim:           c2-vmsvc-ns/vmsvc-vm-pvc-new
Reclaim Policy:  Delete
Access Modes:    RWO
VolumeMode:      Filesystem
Capacity:        10Mi
Node Affinity:   <none>
Message:         
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      98270db8-b2b4-43e9-8a92-bd0f7bc4489e
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1712176304573-5861-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update csi-provisioner sidecar version for Supervisor cluster to v4.0.0-vmware.3
```
