### PR TITLE
Allow volume snapshot creation from supervisor directly.

### DIFF
--- a/pkg/syncer/admissionhandler/admissionhandler.go
+++ b/pkg/syncer/admissionhandler/admissionhandler.go
@@ -60,6 +60,7 @@ var (
 	featureGateTKGSHaEnabled                  bool
 	featureGateVolumeHealthEnabled            bool
 	featureGateTopologyAwareFileVolumeEnabled bool
+	featureGateStorageQuotaM2Enabled          bool
 )
 
 // watchConfigChange watches on the webhook configuration directory for changes
@@ -142,6 +143,7 @@ func StartWebhookServer(ctx context.Context) error {
 		featureGateTKGSHaEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA)
 		featureGateVolumeHealthEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.VolumeHealth)
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)
+		featureGateStorageQuotaM2Enabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.StorageQuotaM2)
 		startCNSCSIWebhookManager(ctx)
 	} else if clusterFlavor == cnstypes.CnsClusterFlavorGuest {
 		featureGateBlockVolumeSnapshotEnabled = containerOrchestratorUtility.IsFSSEnabled(ctx, common.BlockVolumeSnapshot)

--- a/pkg/syncer/admissionhandler/validatesnapshotoperation.go
+++ b/pkg/syncer/admissionhandler/validatesnapshotoperation.go
@@ -36,6 +36,12 @@ func validateSnapshotOperationSupervisorRequest(ctx context.Context, request adm
 	}
 
 	if request.Operation == admissionv1.Create {
+		// NOTE: Change to allow snapshot creation from supervisor directly with StorageQuotaM2 FSS enabled
+		//        is temporary & will be reverted before release
+		if featureGateStorageQuotaM2Enabled {
+			log.Debugf("validateSnapshotOperationSupervisorRequest Allow %v since StorageQuotaM2 FSS enabled", request)
+			return admission.Allowed("")
+		}
 		if _, annotationFound := newVS.Annotations[common.SupervisorVolumeSnapshotAnnotationKey]; !annotationFound {
 			return admission.Denied(SnapshotOperationNotAllowed)
 		}


### PR DESCRIPTION
NOTE: This is temporary change and will be reverted after storage quota support for snapshots FSS enabled.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR allows snapshot creation from supervisor by removing webhook check temporarily for ease of testing.
NOTE: This is temporary change and will be reverted after storage quota support for snapshots FSS enabled.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Before fix: 

```
root@420bc997e27955b098ab2b5241b87781 [ ~ ]# kubectl create -f snap.yaml -n svc-velero-domain-c52
Error from server (Snapshot creation initiated directly from the Supervisor cluster is not supported. Please initiate snapshot creation from the Guest cluster.): error when creating "snap.yaml": admission webhook "validation.csi.vsphere.vmware.com" denied the request: Snapshot creation initiated directly from the Supervisor cluster is not supported. Please initiate snapshot creation from the Guest cluster.
root@420bc997e27955b098ab2b5241b87781 [ ~ ]#
```

After fix with manually enabling StorageQuotaM2 FSS and restarting webhook pods:
```
root@420bc997e27955b098ab2b5241b87781 [ ~ ]# kubectl get configmaps -n vmware-system-csi csi-feature-states -o yaml
apiVersion: v1
data:
  async-query-volume: "true"
  block-volume-snapshot: "true"
  cnsmgr-suspend-create-volume: "true"
  csi-sv-feature-states-replication: "true"
  fake-attach: "true"
  file-volume: "true"
  improved-csi-idempotency: "true"
  list-volumes: "true"
  listview-tasks: "true"
  online-volume-extend: "true"
  sibling-replica-bound-pvc-check: "true"
  storage-quota-m2: "true"                         <<< changed manually
  tkgs-ha: "true"
  trigger-csi-fullsync: "false"
  volume-extend: "true"
  volume-health: "true"
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"async-query-volume":"true","block-volume-snapshot":"true","cnsmgr-suspend-create-volume":"true","csi-sv-feature-states-replication":"true","fake-attach":"true","file-volume":"true","improved-csi-idempotency":"true","list-volumes":"true","listview-tasks":"true","online-volume-extend":"true","sibling-replica-bound-pvc-check":"true","tkgs-ha":"true","trigger-csi-fullsync":"false","volume-extend":"true","volume-health":"true"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"csi-feature-states","namespace":"vmware-system-csi"}}
  creationTimestamp: "2024-04-11T08:44:52Z"
  name: csi-feature-states
  namespace: vmware-system-csi
  resourceVersion: "12389353"
  uid: 3bc08c5b-c04e-49ae-abe5-b4042f7d9ea2
root@420bc997e27955b098ab2b5241b87781 [ ~ ]#

root@420bc997e27955b098ab2b5241b87781 [ ~ ]# kubectl get pods -n vmware-system-csi
NAME                                    READY   STATUS             RESTARTS     AGE
vsphere-csi-controller-79bf77c5-qdpxx   7/7     Running            0            3m8s
vsphere-csi-controller-79bf77c5-qqnmp   7/7     Running            0            3m17s
vsphere-csi-webhook-5d4c4b9c8b-8rjpz    0/1     CrashLoopBackOff   1 (3s ago)   5s
vsphere-csi-webhook-5d4c4b9c8b-wj9mb    1/1     Running            0            5s          <<< restarted to fetch latest FSS value
root@420bc997e27955b098ab2b5241b87781 [ ~ ]#

root@420bc997e27955b098ab2b5241b87781 [ ~ ]# kubectl create -f snap.yaml -n svc-velero-domain-c52
volumesnapshot.snapshot.storage.k8s.io/example-raw-block-snapshot created
root@420bc997e27955b098ab2b5241b87781 [ ~ ]#
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Allow volume snapshot creation from supervisor directly.
```
