### PR TITLE
RWX topology HCI and No-HCI Mesh  testcases automation

### DIFF
--- a/tests/e2e/config_change_test.go
+++ b/tests/e2e/config_change_test.go
@@ -104,8 +104,7 @@ var _ bool = ginkgo.Describe("[csi-supervisor] config-change-test", func() {
 		username := vsphereCfg.Global.User
 		currentPassword := vsphereCfg.Global.Password
 		newPassword := e2eTestPassword
-		err = invokeVCenterChangePassword(ctx, username, nimbusGeneratedVcPwd, newPassword, vcAddress,
-			false, clientIndex)
+		err = invokeVCenterChangePassword(ctx, username, nimbusGeneratedVcPwd, newPassword, vcAddress, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Modifying the password in the secret")
@@ -120,7 +119,7 @@ var _ bool = ginkgo.Describe("[csi-supervisor] config-change-test", func() {
 
 		defer func() {
 			ginkgo.By("Reverting the password change")
-			err = invokeVCenterChangePassword(ctx, username, nimbusGeneratedVcPwd, currentPassword, vcAddress, false,
+			err = invokeVCenterChangePassword(ctx, username, nimbusGeneratedVcPwd, currentPassword, vcAddress,
 				clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/tests/e2e/config_secret.go
+++ b/tests/e2e/config_secret.go
@@ -106,12 +106,12 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 
 		ginkgo.By("Delete roles, permissions for testuser1 if already exist")
 		deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser1,
-			configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+			configSecretUser1Alias, propagateVal,
 			dataCenters, clusters, hosts, vms, datastores)
 
 		ginkgo.By("Delete roles, permissions for testuser2 if already exist")
 		deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
-			configSecretTestUser1Password, configSecretUser2Alias, propagateVal,
+			configSecretUser2Alias, propagateVal,
 			dataCenters, clusters, hosts, vms, datastores)
 
 		csiNamespace = GetAndExpectStringEnvVar(envCSINamespace)
@@ -162,7 +162,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser1,
-				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+				configSecretUser1Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -173,7 +173,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
-				configSecretTestUser1Password, configSecretUser2Alias, propagateVal,
+				configSecretUser2Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -263,7 +263,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser1,
-				testUser1NewPassword, configSecretUser1Alias, propagateVal,
+				configSecretUser1Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -274,7 +274,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
-				configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+				configSecretUser2Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -418,7 +418,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser1,
-				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+				configSecretUser1Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -429,7 +429,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
-				configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+				configSecretUser2Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -515,7 +515,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser1,
-				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+				configSecretUser1Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -526,7 +526,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
-				configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+				configSecretUser2Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -632,7 +632,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser1,
-				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+				configSecretUser1Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -643,7 +643,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
-				configSecretTestUser1Password, configSecretUser2Alias, propagateVal,
+				configSecretUser2Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -760,18 +760,18 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser1,
-				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+				configSecretUser1Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
 		ginkgo.By("Create testuser2 and assign limited roles and privileges to testuser2")
 		createTestUserAndAssignLimitedRolesAndPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
 			configSecretTestUser1Password, configSecretUser2Alias, propagateVal,
-			dataCenters, clusters, hosts, vms, datastores)
+			clusters, hosts)
 		defer func() {
 			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
-				configSecretTestUser1Password, configSecretUser2Alias, propagateVal,
+				configSecretUser2Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -877,22 +877,22 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		ginkgo.By("Create testuser1 and assign limited roles and privileges to testuser1")
 		createTestUserAndAssignLimitedRolesAndPrivileges(masterIp, sshClientConfig, configSecretTestUser1,
 			configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
-			dataCenters, clusters, hosts, vms, datastores)
+			clusters, hosts)
 		defer func() {
 			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser1,
-				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+				configSecretUser1Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
 		ginkgo.By("Create testuser2 and assign limited roles and privileges to testuser2")
 		createTestUserAndAssignLimitedRolesAndPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
 			configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
-			dataCenters, clusters, hosts, vms, datastores)
+			clusters, hosts)
 		defer func() {
 			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
-				configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+				configSecretUser2Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -995,7 +995,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser1,
-				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+				configSecretUser1Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -1006,7 +1006,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
-				configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+				configSecretUser2Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -1119,7 +1119,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser1,
-				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+				configSecretUser1Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -1130,7 +1130,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
-				configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+				configSecretUser2Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -1247,7 +1247,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser1 and remove roles and privileges assigned to testuser1")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser1,
-				configSecretTestUser1Password, configSecretUser1Alias, propagateVal,
+				configSecretUser1Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 
@@ -1258,7 +1258,7 @@ var _ = ginkgo.Describe("Config-Secret", func() {
 		defer func() {
 			ginkgo.By("Delete testuser2 and remove roles and privileges assigned to testuser2")
 			deleteTestUserAndRemoveRolesPrivileges(masterIp, sshClientConfig, configSecretTestUser2,
-				configSecretTestUser2Password, configSecretUser2Alias, propagateVal,
+				configSecretUser2Alias, propagateVal,
 				dataCenters, clusters, hosts, vms, datastores)
 		}()
 

--- a/tests/e2e/config_secret_utils.go
+++ b/tests/e2e/config_secret_utils.go
@@ -115,7 +115,7 @@ func deleteUserPermissions(masterIp string, sshClientConfig *ssh.ClientConfig,
 	}
 
 	for i := 0; i < len(dataCenter); i++ {
-		err = deleteDataStoreLevelPermission(masterIp, sshClientConfig, testUser, dataCenter[i].InventoryPath, datastores)
+		err = deleteDataStoreLevelPermission(masterIp, sshClientConfig, testUser, datastores)
 		if err != nil {
 			if strings.Contains(err.Error(), "The object or item referred to could not be found") {
 				framework.Logf("No datastore level permissions exist for a testuser")
@@ -205,7 +205,7 @@ func deleteClusterLevelPermission(masterIp string, sshClientConfig *ssh.ClientCo
 
 // deleteDataStoreLevelPermission method is used to delete datastore level permissions from a test user
 func deleteDataStoreLevelPermission(masterIp string, sshClientConfig *ssh.ClientConfig,
-	testUser string, dataCenter string, datastores []string) error {
+	testUser string, datastores []string) error {
 	for i := 0; i < len(datastores); i++ {
 		deleteDataStoreLevelPermissions := govcLoginCmd() + "govc permissions.remove -principal " +
 			testUser + " '" + datastores[i] + "'"
@@ -518,7 +518,7 @@ func setClusterLevelPermission(masterIp string, sshClientConfig *ssh.ClientConfi
 
 // setDataStoreLevelPermission is used to set datastore level permissions for test user
 func setDataStoreLevelPermission(masterIp string, sshClientConfig *ssh.ClientConfig, testUserAlias string,
-	testUser string, dataCenter string, datastores []string, propagateVal string, datastoreRole string) error {
+	testUser string, datastores []string, propagateVal string, datastoreRole string) error {
 	for i := 0; i < len(datastores); i++ {
 		setPermissionForDataStore := govcLoginCmd() + "govc permissions.set -principal " +
 			testUserAlias + " " + "-propagate=" + propagateVal + " -role " + datastoreRole + "-" + testUser + " '" +
@@ -634,7 +634,7 @@ func createTestUserAndAssignRolesPrivileges(masterIp string, sshClientConfig *ss
 			framework.Logf("Assign datastores level permissions")
 			for i := 0; i < len(dataCenters); i++ {
 				err := setDataStoreLevelPermission(masterIp, sshClientConfig, configSecretTestUserAlias, configSecretTestUser,
-					dataCenters[i].InventoryPath, datastores, propagateVal, key)
+					datastores, propagateVal, key)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "couldn't execute command on host: %v , error: %s",
 					masterIp, err)
 			}
@@ -668,7 +668,7 @@ deleteTestUserAndRemoveRolesPrivileges method is used to delete test user and to
 roles and privileges to test user
 */
 func deleteTestUserAndRemoveRolesPrivileges(masterIp string, sshClientConfig *ssh.ClientConfig,
-	configSecretTestUser string, configSecretTestUserPassword string, configSecretTestUserAlias string,
+	configSecretTestUser string, configSecretTestUserAlias string,
 	propagateVal string, dataCenters []*object.Datacenter, clusters []string, hosts []string,
 	vms []string, datastores []string) {
 	framework.Logf("Delete users roles and permissions")
@@ -771,8 +771,8 @@ and privilege access to the test user.
 func createTestUserAndAssignLimitedRolesAndPrivileges(masterIp string, sshClientConfig *ssh.ClientConfig,
 	configSecretTestUser string,
 	configSecretTestUserPassword string, configSecretTestUserAlias string, propagateVal string,
-	dataCenters []*object.Datacenter, clusters []string, hosts []string,
-	vms []string, datastores []string) {
+	clusters []string, hosts []string,
+) {
 	roleMap := userRoleMap()
 
 	framework.Logf("Create TestUser")

--- a/tests/e2e/csi_snapshot_basic.go
+++ b/tests/e2e/csi_snapshot_basic.go
@@ -251,7 +251,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -381,7 +381,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Creating volume snapshot content by snapshotHandle %s", snapshothandle))
@@ -517,7 +517,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		}()
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		snapshotHandle := volHandle + "+" + snapshotId
@@ -687,7 +687,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ns, err := framework.CreateTestingNS(ctx, f.BaseName, client, labels_ns)
@@ -871,7 +871,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Deleting volume snapshot 1 " + snapshot1.Name)
@@ -887,7 +887,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify snapshot entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify volume snapshot content is not deleted")
@@ -1018,7 +1018,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("Creating volume snapshot content by snapshotHandle %s", snapshothandle))
@@ -1208,7 +1208,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		snapshotId3 := strings.Split(snapshothandle3, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle2, snapshotId3, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle2, snapshotId3)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Deleted volume snapshot is created above")
@@ -1240,7 +1240,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		snapshotContentCreated = false
 
 		ginkgo.By("Verify snapshot entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -1368,7 +1368,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -1520,7 +1520,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -1697,7 +1697,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 
 		if guestCluster {
 			framework.Logf("Get volume snapshot handle from Supervisor Cluster")
-			staticSnapshotId, _, svcVolumeSnapshotName, err = getSnapshotHandleFromSupervisorCluster(ctx, volumeSnapshotClass,
+			staticSnapshotId, _, svcVolumeSnapshotName, err = getSnapshotHandleFromSupervisorCluster(ctx,
 				*snapshotContent.Status.SnapshotHandle)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			framework.Logf("svcVolumeSnapshotName: %s", svcVolumeSnapshotName)
@@ -1749,7 +1749,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		} else if guestCluster {
 			framework.Logf("Delete VolumeSnapshotContent from Guest Cluster explicitly")
-			err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, newNamespaceName, pandoraSyncWaitTime)
+			err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -1861,7 +1861,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			snapshotContentCreated = false
 
 			ginkgo.By("Verify snapshot entry is deleted from CNS")
-			err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
+			err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		} else if guestCluster {
 			framework.Logf("Deleting volume snapshot 2: %s", volumeSnapshot2.Name)
@@ -1934,7 +1934,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -2049,7 +2049,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -2130,7 +2130,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -2359,12 +2359,12 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			snapshotId1 = strings.Split(snapshothandle1, "+")[1]
 
 			ginkgo.By("Query CNS and check the volume snapshot entry")
-			err = verifySnapshotIsCreatedInCNS(volHandle1, snapshotId1, false)
+			err = verifySnapshotIsCreatedInCNS(volHandle1, snapshotId1)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		} else if guestCluster {
 			snapshothandle1 := *snapshotContent1.Status.SnapshotHandle
-			snapshotId1, _, _, err = getSnapshotHandleFromSupervisorCluster(ctx, volumeSnapshotClass,
+			snapshotId1, _, _, err = getSnapshotHandleFromSupervisorCluster(ctx,
 				snapshothandle1)
 		}
 
@@ -2411,12 +2411,12 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			snapshotId2 = strings.Split(snapshothandle2, "+")[1]
 
 			ginkgo.By("Query CNS and check the volume snapshot entry")
-			err = verifySnapshotIsCreatedInCNS(volHandle2, snapshotId2, false)
+			err = verifySnapshotIsCreatedInCNS(volHandle2, snapshotId2)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		} else if guestCluster {
 			snapshothandle2 := *snapshotContent2.Status.SnapshotHandle
-			snapshotId2, _, _, err = getSnapshotHandleFromSupervisorCluster(ctx, volumeSnapshotClass,
+			snapshotId2, _, _, err = getSnapshotHandleFromSupervisorCluster(ctx,
 				snapshothandle2)
 		}
 
@@ -2528,7 +2528,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 
 		if !guestCluster {
 			ginkgo.By("Verify snapshot 1 entry is deleted from CNS")
-			err = verifySnapshotIsDeletedInCNS(volHandle1, snapshotId1, false)
+			err = verifySnapshotIsDeletedInCNS(volHandle1, snapshotId1)
 			if err != nil {
 				if !apierrors.IsNotFound(err) {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2536,7 +2536,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			}
 
 			ginkgo.By("Verify snapshot 2 entry is deleted from CNS")
-			err = verifySnapshotIsDeletedInCNS(volHandle2, snapshotId2, false)
+			err = verifySnapshotIsDeletedInCNS(volHandle2, snapshotId2)
 			if err != nil {
 				if !apierrors.IsNotFound(err) {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2611,7 +2611,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -2717,7 +2717,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -2835,7 +2835,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		}()
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		snapshotHandle := volHandle + "+" + snapshotId
@@ -2994,7 +2994,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		}()
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		snapshotHandle := volHandle + "+" + snapshotId
@@ -3155,7 +3155,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -3326,7 +3326,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			pvclaim, volHandle, newDiskSize, true)
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -3520,7 +3520,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			pvclaim, volHandle, newDiskSize, true)
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -3710,7 +3710,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Identify the host on which the PV resides")
@@ -4090,7 +4090,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Fetching the username and password of the current vcenter session from secret")
@@ -4107,8 +4107,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		originalPassword := vsphereCfg.Global.Password
 		newPassword := e2eTestPassword
 		ginkgo.By(fmt.Sprintf("Original password %s, new password %s", originalPassword, newPassword))
-		err = invokeVCenterChangePassword(ctx, username, nimbusGeneratedVcPwd, newPassword, vcAddress,
-			false, clientIndex)
+		err = invokeVCenterChangePassword(ctx, username, nimbusGeneratedVcPwd, newPassword, vcAddress, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		originalVCPasswordChanged := true
 
@@ -4116,7 +4115,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			if originalVCPasswordChanged {
 				ginkgo.By("Reverting the password change")
 				err = invokeVCenterChangePassword(ctx, username, nimbusGeneratedVcPwd, originalPassword,
-					vcAddress, false, clientIndex)
+					vcAddress, clientIndex)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
@@ -4188,12 +4187,12 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		snapshotId3 := strings.Split(snapshothandle3, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId3, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId3)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Reverting the password change")
 		err = invokeVCenterChangePassword(ctx, username, nimbusGeneratedVcPwd, originalPassword,
-			vcAddress, false, clientIndex)
+			vcAddress, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		originalVCPasswordChanged = false
 
@@ -4405,13 +4404,12 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			volumeSnapshotContents = append(volumeSnapshotContents, snapshotContent)
 
 			framework.Logf("Get volume snapshot ID from snapshot handle")
-			snapshotId, err := getVolumeSnapshotIdFromSnapshotHandle(ctx, snapshotContent, volumeSnapshotClass,
-				volHandle)
+			snapshotId, err := getVolumeSnapshotIdFromSnapshotHandle(ctx, snapshotContent)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			framework.Logf("snapshot Id: %s", snapshotId)
 
 			ginkgo.By("Query CNS and check the volume snapshot entry")
-			err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+			err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -4476,8 +4474,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 
 		for i := 0; i < snapshotOpsScale; i++ {
 			framework.Logf("Get volume snapshot ID from snapshot handle")
-			snapshotId, err := getVolumeSnapshotIdFromSnapshotHandle(ctx, volumeSnapshotContents[i], volumeSnapshotClass,
-				volHandle)
+			snapshotId, err := getVolumeSnapshotIdFromSnapshotHandle(ctx, volumeSnapshotContents[i])
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			volumeSnapshot, err := snapc.SnapshotV1().VolumeSnapshots(namespace).Get(ctx,
@@ -4589,7 +4586,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			snapshotId := strings.Split(snapshothandle, "+")[1]
 
 			ginkgo.By("Query CNS and check the volume snapshot entry")
-			err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+			err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -4684,7 +4681,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			snapshotId := strings.Split(snapshothandle, "+")[1]
 
 			ginkgo.By("Query CNS and check the volume snapshot entry")
-			err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+			err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -4816,7 +4813,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		}
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -5141,14 +5138,14 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			}
 
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
 
 		framework.Logf("Get volume snapshot handle from Supervisor Cluster")
 		snapshotId, _, svcVolumeSnapshotName, err := getSnapshotHandleFromSupervisorCluster(ctx,
-			volumeSnapshotClass, *snapshotContent.Status.SnapshotHandle)
+			*snapshotContent.Status.SnapshotHandle)
 
 		ginkgo.By("Create pre-provisioned snapshot")
 		_, staticSnapshot, staticSnapshotContentCreated,
@@ -5253,7 +5250,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -5290,7 +5287,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		}()
 
 		framework.Logf("Get volume snapshot handle from Supervisor Cluster")
-		_, _, svcVolumeSnapshotName, err := getSnapshotHandleFromSupervisorCluster(ctx, volumeSnapshotClass,
+		_, _, svcVolumeSnapshotName, err := getSnapshotHandleFromSupervisorCluster(ctx,
 			*snapshotContent.Status.SnapshotHandle)
 
 		ginkgo.By("Create pre-provisioned snapshot in Guest Cluster")
@@ -5445,7 +5442,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -5462,7 +5459,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 
 		framework.Logf("Get volume snapshot handle from Supervisor Cluster")
 		staticSnapshotId, _, svcVolumeSnapshotName, err := getSnapshotHandleFromSupervisorCluster(ctx,
-			volumeSnapshotClass, *snapshotContent.Status.SnapshotHandle)
+			*snapshotContent.Status.SnapshotHandle)
 
 		ginkgo.By("Create pre-provisioned snapshot")
 		_, staticSnapshot, staticSnapshotContentCreated,
@@ -5579,7 +5576,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -5595,7 +5592,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		}()
 
 		framework.Logf("Get volume snapshot handle from Supervisor Cluster")
-		snapshotId, _, svcVolumeSnapshotName, err := getSnapshotHandleFromSupervisorCluster(ctx, volumeSnapshotClass,
+		snapshotId, _, svcVolumeSnapshotName, err := getSnapshotHandleFromSupervisorCluster(ctx,
 			*snapshotContent.Status.SnapshotHandle)
 
 		ginkgo.By("Create Pre-provisioned snapshot in Guest Cluster")
@@ -5608,7 +5605,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		deleteVolumeSnapshotWithPandoraWait(ctx, snapc, namespace, volumeSnapshot.Name, pandoraSyncWaitTime)
 
 		framework.Logf("Delete VolumeSnapshotContent from Guest Cluster explicitly")
-		err = deleteVolumeSnapshotContent(ctx, updatedSnapshotContent, snapc, namespace, pandoraSyncWaitTime)
+		err = deleteVolumeSnapshotContent(ctx, updatedSnapshotContent, snapc, pandoraSyncWaitTime)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Creating static VolumeSnapshotContent in Guest Cluster using "+
@@ -5879,7 +5876,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 				framework.Logf("Deleting volume snapshot content")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = deleteVolumeSnapshotContent(ctx, snapshotContentFromRestoreVol,
-					snapc, namespace, pandoraSyncWaitTime)
+					snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -5980,7 +5977,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		defer func() {
 			if snapshotContentCreated {
 				framework.Logf("Deleting volume snapshot content")
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -6226,7 +6223,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		defer func() {
 			if snapshotContentCreated {
 				framework.Logf("Deleting volume snapshot content")
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -6420,7 +6417,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -6496,7 +6493,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated1 {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent1, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent1, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -6866,7 +6863,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		}()
 
 		framework.Logf("Get volume snapshot handle from Supervisor Cluster")
-		_, _, svcVolumeSnapshotName, err := getSnapshotHandleFromSupervisorCluster(ctx, volumeSnapshotClass,
+		_, _, svcVolumeSnapshotName, err := getSnapshotHandleFromSupervisorCluster(ctx,
 			*snapshotContent.Status.SnapshotHandle)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -7257,21 +7254,19 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			volumeSnapshotContents = append(volumeSnapshotContents, snapshotContent)
 
 			framework.Logf("Get volume snapshot ID from snapshot handle")
-			snapshotId, err := getVolumeSnapshotIdFromSnapshotHandle(ctx, snapshotContent, volumeSnapshotClass,
-				volHandle)
+			snapshotId, err := getVolumeSnapshotIdFromSnapshotHandle(ctx, snapshotContent)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			framework.Logf("snapshot Id: %s", snapshotId)
 
 			ginkgo.By("Query CNS and check the volume snapshot entry")
-			err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+			err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		}
 
 		for i := 0; i < 33; i++ {
 			framework.Logf("Get volume snapshot ID from snapshot handle")
-			snapshotId, err := getVolumeSnapshotIdFromSnapshotHandle(ctx, volumeSnapshotContents[i], volumeSnapshotClass,
-				volHandle)
+			snapshotId, err := getVolumeSnapshotIdFromSnapshotHandle(ctx, volumeSnapshotContents[i])
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ginkgo.By("Deleted volume snapshot is created above")
 			framework.Logf("VolumeSnapshot Name to be deleted: %s", volumeSnapshots[i].Name)
@@ -7283,7 +7278,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Verify snapshot entry is deleted from CNS")
-			err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
+			err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 	})
@@ -7362,7 +7357,7 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 			}
 
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace1.Name, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
@@ -7403,14 +7398,14 @@ var _ = ginkgo.Describe("Volume Snapshot Basic Test", func() {
 		ginkgo.By("Create pre-provisioned on GC2")
 		framework.Logf("Get volume snapshot handle from Supervisor Cluster")
 		snapshotId, _, svcVolumeSnapshotName, err := getSnapshotHandleFromSupervisorCluster(ctx,
-			volumeSnapshotClass, *snapshotContent.Status.SnapshotHandle)
+			*snapshotContent.Status.SnapshotHandle)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Delete dynamic volume snapshot created in GC1")
 		deleteVolumeSnapshotWithPandoraWait(ctx, snapc, namespace, volumeSnapshot.Name, pandoraSyncWaitTime)
 
 		framework.Logf("Delete VolumeSnapshotContent from GC1 explicitly")
-		err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+		err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf(fmt.Sprintf("Creating static VolumeSnapshotContent in GC2 using "+

--- a/tests/e2e/e2e_common.go
+++ b/tests/e2e/e2e_common.go
@@ -313,6 +313,7 @@ var (
 	vcptocsi             bool
 	windowsEnv           bool
 	multipleSvc          bool
+	multivc              bool
 )
 
 // For busybox pod image
@@ -425,6 +426,14 @@ var (
 	roleCnsHostConfigStorageAndCnsVm    = "CNS-HOST-CONFIG-STORAGE-AND-CNS-VM"
 )
 
+// For rwx
+var (
+	envVsanDsStoragePolicyCluster1 = "VSAN_DATASTORE_CLUSTER1_STORAGE_POLICY"
+	envVsanDsStoragePolicyCluster3 = "VSAN_DATASTORE_CLUSTER3_STORAGE_POLICY"
+	envNonVsanDsUrl                = "NON_VSAN_DATASTOREURL"
+	envVsanDsUrlCluster3           = "VSAN_DATASTOREURL_CLUSTER3"
+)
+
 // GetAndExpectStringEnvVar parses a string from env variable.
 func GetAndExpectStringEnvVar(varName string) string {
 	varValue := os.Getenv(varName)
@@ -480,5 +489,11 @@ func setClusterFlavor(clusterFlavor cnstypes.CnsClusterFlavor) {
 	svcType := os.Getenv("SUPERVISOR_TYPE")
 	if strings.TrimSpace(string(svcType)) == "MULTI_SVC" {
 		multipleSvc = true
+	}
+
+	//Check if it is multivc env
+	topologyType := os.Getenv("TOPOLOGY_TYPE")
+	if strings.TrimSpace(string(topologyType)) == "MULTI_VC" {
+		multivc = true
 	}
 }

--- a/tests/e2e/file_volume_statefulsets.go
+++ b/tests/e2e/file_volume_statefulsets.go
@@ -766,7 +766,7 @@ var _ = ginkgo.Describe("[csi-file-vanilla] File Volume statefulset", func() {
 		}()
 		ginkgo.By("Creating statefulset with replica 3")
 		statefulset, _, volumesBeforeScaleUp := createStsDeployment(ctx, client, namespace, sc, false,
-			false, 0, "", v1.ReadWriteMany, false)
+			false, 0, "", v1.ReadWriteMany)
 		replicas := *(statefulset.Spec.Replicas)
 
 		//List volume responses will show up in the interval of every 1 minute.

--- a/tests/e2e/hci_mesh_rwx_singlevc_topology.go
+++ b/tests/e2e/hci_mesh_rwx_singlevc_topology.go
@@ -1,0 +1,320 @@
+/*
+	Copyright 2024 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = ginkgo.Describe("[hci-mesh-rwx-topology] Hci-Mesh-Topology-SingleVc", func() {
+	f := framework.NewDefaultFramework("rwx-topology")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		client                  clientset.Interface
+		namespace               string
+		bindingModeWffc         storagev1.VolumeBindingMode
+		bindingModeImm          storagev1.VolumeBindingMode
+		topologyAffinityDetails map[string][]string
+		topologyCategories      []string
+		leafNode                int
+		leafNodeTag2            int
+		topologyLength          int
+		scParameters            map[string]string
+		accessmode              v1.PersistentVolumeAccessMode
+		labelsMap               map[string]string
+		replica                 int32
+		createPvcItr            int
+		createDepItr            int
+		pvclaim                 *v1.PersistentVolumeClaim
+		pv                      *v1.PersistentVolume
+	)
+
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// connecting to vc
+		bootstrap()
+
+		// fetch list of k8s nodes
+		nodeList, err := fnodes.GetReadySchedulableNodes(ctx, f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		//global variables
+		scParameters = make(map[string]string)
+		labelsMap = make(map[string]string)
+		accessmode = v1.ReadWriteMany
+		bindingModeWffc = storagev1.VolumeBindingWaitForFirstConsumer
+		//bindingModeImm = storagev1.VolumeBindingImmediate
+
+		//read topology map
+		topologyLength, leafNode, _, _, leafNodeTag2 = 5, 4, 0, 1, 2
+		topologyMap := GetAndExpectStringEnvVar(topologyMap)
+		topologyAffinityDetails, topologyCategories = createTopologyMapLevel5(topologyMap,
+			topologyLength)
+
+		//setting map values
+		labelsMap["app"] = "test"
+		scParameters[scParamFsType] = nfs4FSType
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ginkgo.By("Perform cleanup if any resource left in the setup before starting a new test")
+
+		// perfrom cleanup of old stale entries of storage class if left in the setup
+		storageClassList, err := client.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(storageClassList.Items) != 0 {
+			for _, sc := range storageClassList.Items {
+				gomega.Expect(client.StorageV1().StorageClasses().Delete(ctx, sc.Name,
+					*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		// perfrom cleanup of old stale entries of statefulset if left in the setup
+		statefulsets, err := client.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(statefulsets.Items) != 0 {
+			for _, sts := range statefulsets.Items {
+				gomega.Expect(client.AppsV1().StatefulSets(namespace).Delete(ctx, sts.Name,
+					*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		// perfrom cleanup of old stale entries of nginx service if left in the setup
+		err = client.CoreV1().Services(namespace).Delete(ctx, servicename, *metav1.NewDeleteOptions(0))
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		// perfrom cleanup of old stale entries of pvc if left in the setup
+		pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(pvcs.Items) != 0 {
+			for _, pvc := range pvcs.Items {
+				gomega.Expect(client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name,
+					*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		// perfrom cleanup of old stale entries of any deployment entry if left in the setup
+		depList, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(depList.Items) != 0 {
+			for _, dep := range depList.Items {
+				err := client.AppsV1().Deployments(namespace).Delete(ctx, dep.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		// perfrom cleanup of old stale entries of pv if left in the setup
+		pvs, err := client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(pvs.Items) != 0 {
+			for _, pv := range pvs.Items {
+				gomega.Expect(client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name,
+					*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+			}
+		}
+	})
+
+	/*
+		TESTCASE-1
+		Deployment scale up/down
+		SC with WFFC with no Topology
+
+		Steps:
+		1. Create storage class with bindingMode set to WFFC. Do not define any allowed topologies.
+		2. Create 4 PVCs with RWX access mode.
+		3. Create 4 deployments with 3 replicas using the above SC.
+		4. Wait for PVC to be created and reach the Bound state, and for the Pods to be created and reach a running state.
+		5. Since the SC doesn't specify a specific topology, volume provisioning and Pod placement will occur
+		in any available availability zones (AZs).
+		6. Perform scaleup/scaledown operation on deployment
+		7. Perform cleanup by deleting deployment, PVCs and SC
+	*/
+
+	ginkgo.It("Multiple deployment pods with scaling operation "+
+		"attached to rwx pvcs", ginkgo.Label(p0, file, vanilla, level5, level2, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// variable declaration
+		var depl []*appsv1.Deployment
+
+		// pvc and deployment pod count
+		replica = 3
+		createPvcItr = 4
+		createDepItr = 4
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, nil, bindingModeWffc, false, accessmode,
+			"", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		defer func() {
+			for i := 0; i < len(pvclaims); i++ {
+				pv = getPvFromClaim(client, pvclaims[i].Namespace, pvclaims[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaims[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Create Deployments")
+		for i := 0; i < len(pvclaims); i++ {
+			deploymentList, _, err := createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, false, labelsMap,
+				pvclaims[i], nil, execRWXCommandPod, nginxImage, false, nil, createDepItr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			depl = append(depl, deploymentList...)
+		}
+		defer func() {
+			framework.Logf("Delete deployment set")
+			for i := 0; i < len(depl); i++ {
+				err := client.AppsV1().Deployments(namespace).Delete(ctx, depl[i].Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		_, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scale up deployment1 pods to 5 replicas")
+		replica = 5
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica,
+			true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, depl[0], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scale down deployment2 pods to 2 replica")
+		replica = 2
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica,
+			true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, depl[1], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/*
+		TESTCASE-2
+		PVCs with RWX accessmode and SC with Immediate mode with topology set to
+		region-1 > zone-1 > building-1 > level-1 > rack-3
+
+		Steps:
+		1. Create a StorageClass with bindingMode set to Immediate. and specify allowed
+		topologies for the SC, such as region-1 > zone-1 > building-1 > level-1 > rack-3
+		2. Create few PVCs with RWX accessmode.
+		3. Wait for the PVCs to be created and reach the Bound state.
+		4. Attach 3 pods to each PVC and wait for them to come to running state.
+		5. Volume provisioning should happen on the specified availability zone,
+		while pods can come up on any accessibility zone.
+		6. Perform cleanup by deleting Pods, PVCs and SC
+	*/
+
+	ginkgo.It("Multiple standalone pods attached to a multiple rwx "+
+		"pvcs", ginkgo.Label(p0, file, vanilla, level5, level2, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// standalone pod and pvc count
+		noPodsToDeploy := 3
+		createPvcItr = 3
+
+		//variable declaration
+		var podList []*v1.Pod
+		var err error
+
+		// Create allowed topologies for Storage Class: region1 > zone1 > building1 > level1 > rack > rack3
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag2)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with allowed "+
+			"topology set to AZ3", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap, scParameters,
+			diskSize, allowedTopologyForSC, bindingModeImm, false, accessmode, "", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		defer func() {
+			for i := 0; i < len(pvclaims); i++ {
+				pv = getPvFromClaim(client, pvclaims[i].Namespace, pvclaims[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaims[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		_, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Create 3 standalone Pods using the same PVC with different read/write permissions")
+		for i := 0; i < len(pvclaims); i++ {
+			podList, err = createStandalonePodsForRWXVolume(client, ctx, namespace, nil, pvclaims[i], false, execRWXCommandPod,
+				noPodsToDeploy)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err := fpod.DeletePodWithWait(ctx, client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify volume placement, should match with the allowed topology specified")
+		_, _, datastoreUrlsRack3, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isCorrectPlacement := e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle, datastoreUrlsRack3)
+		gomega.Expect(isCorrectPlacement).To(gomega.BeTrue(), fmt.Sprintf("Volume provisioning has happened on the wrong "+
+			"datastore. Expected 'true', got '%v'", isCorrectPlacement))
+	})
+})

--- a/tests/e2e/multi_svc_test.go
+++ b/tests/e2e/multi_svc_test.go
@@ -269,8 +269,8 @@ var _ = ginkgo.Describe("[csi-multi-svc] Multi-SVC", func() {
 
 				ginkgo.By("Create StatefulSet with 3 replicas with parallel pod management")
 				service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace,
-					true, 3, false, nil, 0,
-					false, false, false, "", "", nil, false)
+					true, 3, false, nil,
+					false, false, false, "", nil, false)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				defer func() {
 					fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -280,13 +280,13 @@ var _ = ginkgo.Describe("[csi-multi-svc] Multi-SVC", func() {
 				framework.Logf("Scale up sts replica count to 5")
 				scaleUpReplicaCount = 5
 				err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, scaleUpReplicaCount,
-					true, false)
+					true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				framework.Logf("Scale down sts replica count to 1")
 				scaleDownReplicaCount = 1
 				err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, scaleDownReplicaCount,
-					true, false)
+					true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			}
@@ -335,7 +335,7 @@ var _ = ginkgo.Describe("[csi-multi-svc] Multi-SVC", func() {
 
 				ginkgo.By("Create StatefulSet with 3 replicas with parallel pod management")
 				service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace,
-					true, 3, false, nil, 0, false, false, false, "", "", nil, false)
+					true, 3, false, nil, false, false, false, "", nil, false)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				defer func() {
 					fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -351,13 +351,13 @@ var _ = ginkgo.Describe("[csi-multi-svc] Multi-SVC", func() {
 				framework.Logf("Scale up sts replica count to 5")
 				scaleUpReplicaCount = 5
 				err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, scaleUpReplicaCount,
-					true, false)
+					true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				framework.Logf("Scale down sts replica count to 1")
 				scaleDownReplicaCount = 1
 				err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, scaleDownReplicaCount,
-					true, false)
+					true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// Create a Pvc and attach a pod to it
@@ -745,8 +745,8 @@ var _ = ginkgo.Describe("[csi-multi-svc] Multi-SVC", func() {
 
 			ginkgo.By("Create StatefulSet with 3 replica with parallel pod management")
 			service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace,
-				true, 3, false, nil, 0,
-				false, false, false, "", "", nil, false)
+				true, 3, false, nil,
+				false, false, false, "", nil, false)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer func() {
 				fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -756,13 +756,13 @@ var _ = ginkgo.Describe("[csi-multi-svc] Multi-SVC", func() {
 			framework.Logf("Scale up sts replica count to 5")
 			scaleUpReplicaCount = 5
 			err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, scaleUpReplicaCount,
-				true, false)
+				true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			framework.Logf("Scale down sts replica count to 1")
 			scaleDownReplicaCount = 1
 			err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, scaleDownReplicaCount,
-				true, false)
+				true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 

--- a/tests/e2e/multi_vc.go
+++ b/tests/e2e/multi_vc.go
@@ -52,7 +52,6 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		namespace                   string
 		allowedTopologies           []v1.TopologySelectorLabelRequirement
 		bindingMode                 storagev1.VolumeBindingMode
-		allowedTopologyLen          int
 		nodeAffinityToSet           bool
 		parallelStatefulSetCreation bool
 		stsReplicas                 int32
@@ -217,14 +216,12 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 			/* here in 2-VC setup statefulset node affinity is taken as k8s-zone -> zone-1,zone-2,zone-3
 			i.e VC1 allowed topology and VC2 partial allowed topology
 			*/
-			allowedTopologyLen = 3
 			topValStartIndex = 0
 			topValEndIndex = 3
 		} else if multiVCSetupType == "multi-3vc-setup" {
 			/* here in 3-VC setup, statefulset node affinity is taken as  k8s-zone -> zone-3
 			i.e only VC3 allowed topology
 			*/
-			allowedTopologyLen = 1
 			topValStartIndex = 2
 			topValEndIndex = 3
 		}
@@ -245,8 +242,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace,
-			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen,
-			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies,
+			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -310,8 +307,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
-			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
-			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			stsReplicas, nodeAffinityToSet, allowedTopologies, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -376,8 +373,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
-			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
-			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			stsReplicas, nodeAffinityToSet, allowedTopologies, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -474,7 +471,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulSets[i],
-				namespace, allowedTopologies, parallelStatefulSetCreation, true)
+				namespace, allowedTopologies, parallelStatefulSetCreation)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -527,8 +524,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
-			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
-			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			stsReplicas, nodeAffinityToSet, allowedTopologies, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -592,8 +589,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
-			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
-			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			stsReplicas, nodeAffinityToSet, allowedTopologies, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -657,8 +654,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
-			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
-			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			stsReplicas, nodeAffinityToSet, allowedTopologies, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -727,8 +724,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
-			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
-			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			stsReplicas, nodeAffinityToSet, allowedTopologies, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -798,8 +795,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
-			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
-			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			stsReplicas, nodeAffinityToSet, allowedTopologies, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -865,8 +862,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace,
-			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen,
-			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies,
+			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			deleteAllStsAndPodsPVCsInNamespace(ctx, client, namespace)
@@ -904,7 +901,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 			ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 				pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 			vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
-			isDiskAttached, err := multiVCe2eVSphere.verifyVolumeIsAttachedToVMInMultiVC(client,
+			isDiskAttached, err := multiVCe2eVSphere.verifyVolumeIsAttachedToVMInMultiVC(
 				pv.Spec.CSI.VolumeHandle, vmUUID)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
@@ -940,7 +937,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(podList); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, podList[i],
-				namespace, allowedTopologies, true)
+				namespace, allowedTopologies)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -1001,8 +998,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
-			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
-			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			stsReplicas, nodeAffinityToSet, allowedTopologies, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -1153,8 +1150,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, _, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
-			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
-			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			stsReplicas, nodeAffinityToSet, allowedTopologies, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -1238,7 +1235,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		ginkgo.By("Verify PV node affinity and that the PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5(ctx, client, deployment,
-			namespace, allowedTopologies, false, true)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -1353,7 +1350,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		}
 
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s", volHandle, nodeName))
-		isDiskAttached, err := multiVCe2eVSphere.verifyVolumeIsAttachedToVMInMultiVC(client, volHandle, vmUUID)
+		isDiskAttached, err := multiVCe2eVSphere.verifyVolumeIsAttachedToVMInMultiVC(volHandle, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached to the node")
 		defer func() {
@@ -1370,13 +1367,13 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		}()
 
 		ginkgo.By("Perform online volume expansion on PVC")
-		err = performOnlineVolumeExpansin(f, client, pvclaim, namespace, pod)
+		err = performOnlineVolumeExpansion(f, client, pvclaim, pod)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod,
-			namespace, allowedTopologies, true)
+			namespace, allowedTopologies)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -1460,7 +1457,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulSets[i],
-				namespace, allowedTopologies, parallelStatefulSetCreation, true)
+				namespace, allowedTopologies, parallelStatefulSetCreation)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -1557,7 +1554,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulSets[i],
-				namespace, allowedTopologies, parallelStatefulSetCreation, true)
+				namespace, allowedTopologies, parallelStatefulSetCreation)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -1735,7 +1732,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulSets[i],
-				namespace, allowedTopologies, parallelStatefulSetCreation, true)
+				namespace, allowedTopologies, parallelStatefulSetCreation)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -1805,8 +1802,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, parallelPodPolicy,
-			stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen, podAntiAffinityToSet,
-			parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			stsReplicas, nodeAffinityToSet, allowedTopologies, podAntiAffinityToSet,
+			parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			deleteAllStsAndPodsPVCsInNamespace(ctx, client, namespace)
@@ -1815,7 +1812,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, parallelStatefulSetCreation, true)
+			namespace, allowedTopologies, parallelStatefulSetCreation)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Bring down SPS service")
@@ -1858,7 +1855,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulSets[i],
-				namespace, allowedTopologies, parallelStatefulSetCreation, true)
+				namespace, allowedTopologies, parallelStatefulSetCreation)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -1959,7 +1956,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		ginkgo.By(fmt.Sprintf("Verify volume: %s is attached to the node: %s",
 			pv.Spec.CSI.VolumeHandle, pod.Spec.NodeName))
 		vmUUID := getNodeUUID(ctx, client, pod.Spec.NodeName)
-		isDiskAttached, err := multiVCe2eVSphere.verifyVolumeIsAttachedToVMInMultiVC(client,
+		isDiskAttached, err := multiVCe2eVSphere.verifyVolumeIsAttachedToVMInMultiVC(
 			pv.Spec.CSI.VolumeHandle, vmUUID)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(isDiskAttached).To(gomega.BeTrue(), "Volume is not attached")
@@ -1986,7 +1983,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 
 		ginkgo.By("Verify pv and pod node affinity")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod,
-			namespace, allowedTopologies, true)
+			namespace, allowedTopologies)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -2048,15 +2045,15 @@ var _ = ginkgo.Describe("[csi-multi-vc-topology] Multi-VC", func() {
 		}()
 		ginkgo.By("Creating statefulset with replica 3 and a deployment")
 		statefulset, deployment, volumesBeforeScaleUp := createStsDeployment(ctx, client, namespace, sc, true,
-			false, 0, "", "", true)
+			false, 0, "", "")
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, parallelStatefulSetCreation, true)
+			namespace, allowedTopologies, parallelStatefulSetCreation)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		err = verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5(ctx, client, deployment, namespace,
-			allowedTopologies, true, true)
+			allowedTopologies, true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		//List volume responses will show up in the interval of every 1 minute.

--- a/tests/e2e/multi_vc_config_secret.go
+++ b/tests/e2e/multi_vc_config_secret.go
@@ -53,7 +53,6 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 		allowedTopologies           []v1.TopologySelectorLabelRequirement
 		scaleUpReplicaCount         int32
 		scaleDownReplicaCount       int32
-		allowedTopologyLen          int
 		nodeAffinityToSet           bool
 		parallelStatefulSetCreation bool
 		stsReplicas                 int32
@@ -163,7 +162,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 			originalPassword := strings.Split(vCenterPassword, ",")[0]
 			newPassword := e2eTestPassword
 			ginkgo.By("Reverting the password change")
-			err = invokeVCenterChangePassword(ctx, username, newPassword, originalPassword, vcAddress, true,
+			err = invokeVCenterChangePassword(ctx, username, newPassword, originalPassword, vcAddress,
 				clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
@@ -175,7 +174,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 			originalPassword3 := strings.Split(vCenterPassword, ",")[2]
 			newPassword3 := "Admin!23"
 			ginkgo.By("Reverting the password change")
-			err = invokeVCenterChangePassword(ctx, username3, newPassword3, originalPassword3, vcAddress3, true,
+			err = invokeVCenterChangePassword(ctx, username3, newPassword3, originalPassword3, vcAddress3,
 				clientIndex2)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			originalVC3PasswordChanged = false
@@ -252,7 +251,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 		ginkgo.By(fmt.Sprintf("Original password %s, new password %s", originalPassword, newPassword))
 
 		ginkgo.By("Changing password on the vCenter VC1 host")
-		err = invokeVCenterChangePassword(ctx, username, originalPassword, newPassword, vcAddress, true, clientIndex)
+		err = invokeVCenterChangePassword(ctx, username, originalPassword, newPassword, vcAddress, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		originalVC1PasswordChanged = true
 
@@ -269,7 +268,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 		defer func() {
 			if originalVC1PasswordChanged {
 				ginkgo.By("Reverting the password change")
-				err = invokeVCenterChangePassword(ctx, username, newPassword, originalPassword, vcAddress, true,
+				err = invokeVCenterChangePassword(ctx, username, newPassword, originalPassword, vcAddress,
 					clientIndex)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				originalVC1PasswordChanged = false
@@ -302,8 +301,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace,
-			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen,
-			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies,
+			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -505,8 +504,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace,
-			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen,
-			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies,
+			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			deleteService(namespace, client, service)
@@ -650,7 +649,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, parallelStatefulSetCreation, true)
+				statefulSets[i], namespace, allowedTopologies, parallelStatefulSetCreation)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -758,7 +757,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 
 		ginkgo.By("Changing password on the vCenter VC1 host")
 		clientIndex0 := 0
-		err = invokeVCenterChangePassword(ctx, username1, originalPassword1, newPassword1, vcAddress1, true, clientIndex0)
+		err = invokeVCenterChangePassword(ctx, username1, originalPassword1, newPassword1, vcAddress1, clientIndex0)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		originalVC1PasswordChanged = true
 
@@ -771,7 +770,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 
 			ginkgo.By("Changing password on the vCenter VC3 host")
 			clientIndex2 = 2
-			err = invokeVCenterChangePassword(ctx, username3, originalPassword3, newPassword3, vcAddress3, true, clientIndex2)
+			err = invokeVCenterChangePassword(ctx, username3, originalPassword3, newPassword3, vcAddress3, clientIndex2)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			originalVC3PasswordChanged = true
 
@@ -794,7 +793,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 		defer func() {
 			if originalVC1PasswordChanged {
 				ginkgo.By("Reverting the password change")
-				err = invokeVCenterChangePassword(ctx, username1, newPassword1, originalPassword1, vcAddress1, true,
+				err = invokeVCenterChangePassword(ctx, username1, newPassword1, originalPassword1, vcAddress1,
 					clientIndex0)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				originalVC1PasswordChanged = false
@@ -803,7 +802,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 			if multiVCSetupType == "multi-3vc-setup" {
 				if originalVC3PasswordChanged {
 					ginkgo.By("Reverting the password change")
-					err = invokeVCenterChangePassword(ctx, username3, newPassword3, originalPassword3, vcAddress3, true,
+					err = invokeVCenterChangePassword(ctx, username3, newPassword3, originalPassword3, vcAddress3,
 						clientIndex2)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					originalVC3PasswordChanged = false
@@ -837,8 +836,8 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 
 		ginkgo.By("Create StatefulSet and verify pv affinity and pod affinity details")
 		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace,
-			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies, allowedTopologyLen,
-			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", "", nil, verifyTopologyAffinity)
+			parallelPodPolicy, stsReplicas, nodeAffinityToSet, allowedTopologies,
+			podAntiAffinityToSet, parallelStatefulSetCreation, false, "", nil, verifyTopologyAffinity)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			fss.DeleteAllStatefulSets(ctx, client, namespace)
@@ -859,14 +858,14 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
 
 		ginkgo.By("Reverting the password change on VC1")
-		err = invokeVCenterChangePassword(ctx, username1, newPassword1, originalPassword1, vcAddress1, true,
+		err = invokeVCenterChangePassword(ctx, username1, newPassword1, originalPassword1, vcAddress1,
 			clientIndex0)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		originalVC1PasswordChanged = false
 
 		if multiVCSetupType == "multi-3vc-setup" {
 			ginkgo.By("Reverting the password change on VC3")
-			err = invokeVCenterChangePassword(ctx, username3, newPassword3, originalPassword3, vcAddress3, true,
+			err = invokeVCenterChangePassword(ctx, username3, newPassword3, originalPassword3, vcAddress3,
 				clientIndex2)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			originalVC3PasswordChanged = false
@@ -924,13 +923,13 @@ var _ = ginkgo.Describe("[csi-multi-vc-config-secret] Multi-VC-Config-Secret", f
 		originalPassword := strings.Split(vsphereCfg.Global.Password, ",")[0]
 		newPassword := e2eTestPassword
 		ginkgo.By(fmt.Sprintf("Original password %s, new password %s", originalPassword, newPassword))
-		err = invokeVCenterChangePassword(ctx, username, originalPassword, newPassword, vcAddress, true, clientIndex)
+		err = invokeVCenterChangePassword(ctx, username, originalPassword, newPassword, vcAddress, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		originalVC1PasswordChanged = true
 		defer func() {
 			if originalVC1PasswordChanged {
 				ginkgo.By("Reverting the password change")
-				err = invokeVCenterChangePassword(ctx, username, newPassword, originalPassword, vcAddress, true,
+				err = invokeVCenterChangePassword(ctx, username, newPassword, originalPassword, vcAddress,
 					clientIndex)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				originalVC1PasswordChanged = false

--- a/tests/e2e/multi_vc_connection.go
+++ b/tests/e2e/multi_vc_connection.go
@@ -63,10 +63,26 @@ newClientForMultiVC creates a new client for vSphere connection on a multivc env
 */
 func newClientForMultiVC(ctx context.Context, vs *multiVCvSphere) []*govmomi.Client {
 	var clients []*govmomi.Client
-	configUser := strings.Split(vs.multivcConfig.Global.User, ",")
-	configPwd := strings.Split(vs.multivcConfig.Global.Password, ",")
-	configvCenterHostname := strings.Split(vs.multivcConfig.Global.VCenterHostname, ",")
-	configvCenterPort := strings.Split(vs.multivcConfig.Global.VCenterPort, ",")
+	configUser := []string{multiVCe2eVSphere.multivcConfig.Global.User}
+	configPwd := []string{multiVCe2eVSphere.multivcConfig.Global.Password}
+	configvCenterHostname := []string{multiVCe2eVSphere.multivcConfig.Global.VCenterHostname}
+	configvCenterPort := []string{multiVCe2eVSphere.multivcConfig.Global.VCenterPort}
+
+	if strings.Contains(multiVCe2eVSphere.multivcConfig.Global.User, ",") {
+		configUser = strings.Split(multiVCe2eVSphere.multivcConfig.Global.User, ",")
+	}
+
+	if strings.Contains(multiVCe2eVSphere.multivcConfig.Global.Password, ",") {
+		configPwd = strings.Split(multiVCe2eVSphere.multivcConfig.Global.Password, ",")
+	}
+
+	if strings.Contains(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",") {
+		configvCenterHostname = strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+	}
+
+	if strings.Contains(multiVCe2eVSphere.multivcConfig.Global.VCenterPort, ",") {
+		configvCenterPort = strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterPort, ",")
+	}
 	for i := 0; i < len(configvCenterHostname); i++ {
 		framework.Logf("https://%s:%s/sdk", configvCenterHostname[i], configvCenterPort[i])
 		url, err := neturl.Parse(fmt.Sprintf("https://%s:%s/sdk",

--- a/tests/e2e/multi_vc_multi_replica.go
+++ b/tests/e2e/multi_vc_multi_replica.go
@@ -214,7 +214,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-replica] Multi-VC-Replica", func() {
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, parallelStatefulSetCreation, true)
+				statefulSets[i], namespace, allowedTopologies, parallelStatefulSetCreation)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 

--- a/tests/e2e/multi_vc_operation_storm.go
+++ b/tests/e2e/multi_vc_operation_storm.go
@@ -135,7 +135,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-operation-storm] Multi-VC-Operation-Storm
 		// fetching list of datastores available in different VCs
 		ClusterdatastoreListVC1, ClusterdatastoreListVC2,
 			ClusterdatastoreListVC3, err = getDatastoresListFromMultiVCs(masterIp, sshClientConfig,
-			clusterComputeResource[0], true)
+			clusterComputeResource[0])
 		ClusterdatastoreListVC = append(ClusterdatastoreListVC, ClusterdatastoreListVC1,
 			ClusterdatastoreListVC2, ClusterdatastoreListVC3)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -295,7 +295,7 @@ var _ = ginkgo.Describe("[csi-multi-vc-operation-storm] Multi-VC-Operation-Storm
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, parallelStatefulSetCreation, true)
+				statefulSets[i], namespace, allowedTopologies, parallelStatefulSetCreation)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -368,21 +368,21 @@ var _ = ginkgo.Describe("[csi-multi-vc-operation-storm] Multi-VC-Operation-Storm
 
 		framework.Logf("Fetch worker vms sitting on VC-3")
 		vMsToMigrate, err := fetchWorkerNodeVms(masterIp, sshClientConfig, dataCenters, workerInitialAlias[0],
-			true, 2)
+			2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Move all the vms to destination datastore")
-		isMigrateSuccess, err := migrateVmsFromDatastore(masterIp, sshClientConfig, destDsName, vMsToMigrate, true, 2)
+		isMigrateSuccess, err := migrateVmsFromDatastore(masterIp, sshClientConfig, destDsName, vMsToMigrate, 2)
 		gomega.Expect(isMigrateSuccess).To(gomega.BeTrue(), "Migration of vms failed")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Put datastore in maintenance mode on VC-3")
-		err = preferredDatastoreInMaintenanceMode(masterIp, sshClientConfig, dataCenters, soureDsName, true, 2)
+		err = preferredDatastoreInMaintenanceMode(masterIp, sshClientConfig, dataCenters, soureDsName, 2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		isDatastoreInMaintenanceMode = true
 		defer func() {
 			if isDatastoreInMaintenanceMode {
-				err = exitDatastoreFromMaintenanceMode(masterIp, sshClientConfig, dataCenters, soureDsName, true, 2)
+				err = exitDatastoreFromMaintenanceMode(masterIp, sshClientConfig, soureDsName, 2)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				isDatastoreInMaintenanceMode = false
 			}

--- a/tests/e2e/no_hc_mesh_rwx_multivc_topology.go
+++ b/tests/e2e/no_hc_mesh_rwx_multivc_topology.go
@@ -1,0 +1,1517 @@
+/*
+	Copyright 2023 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"golang.org/x/crypto/ssh"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fdep "k8s.io/kubernetes/test/e2e/framework/deployment"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = ginkgo.Describe("[no-hci-mesh-topology-multivc] No-Hci-Mesh-Topology-MultiVc", func() {
+	f := framework.NewDefaultFramework("rwx-topology")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		client    clientset.Interface
+		namespace string
+
+		allowedTopologies          []v1.TopologySelectorLabelRequirement
+		topValStartIndex           int
+		topValEndIndex             int
+		topkeyStartIndex           int
+		scParameters               map[string]string
+		bindingModeWffc            storagev1.VolumeBindingMode
+		bindingModeImm             storagev1.VolumeBindingMode
+		accessmode                 v1.PersistentVolumeAccessMode
+		labelsMap                  map[string]string
+		replica                    int32
+		createPvcItr               int
+		createDepItr               int
+		pvs                        []*v1.PersistentVolume
+		pvclaim                    *v1.PersistentVolumeClaim
+		pv                         *v1.PersistentVolume
+		sshClientConfig            *ssh.ClientConfig
+		nimbusGeneratedK8sVmPwd    string
+		allMasterIps               []string
+		masterIp                   string
+		isStorageProfileDeleted    bool
+		storagePolicyToDelete      string
+		isVsanHealthServiceStopped bool
+		isSPSServiceStopped        bool
+		err                        error
+	)
+
+	ginkgo.BeforeEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+
+		// connecting to multiple VCs
+		multiVCbootstrap()
+
+		// fetch list f k8s nodes
+		nodeList, err := fnodes.GetReadySchedulableNodes(ctx, f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		//global variables
+		scParameters = make(map[string]string)
+		labelsMap = make(map[string]string)
+		accessmode = v1.ReadWriteMany
+		bindingModeWffc = storagev1.VolumeBindingWaitForFirstConsumer
+		bindingModeImm = storagev1.VolumeBindingImmediate
+
+		// read topology map
+		topologyMap := GetAndExpectStringEnvVar(topologyMap)
+		allowedTopologies = createAllowedTopolgies(topologyMap, topologyLength)
+
+		//setting map values
+		labelsMap["app"] = "test"
+		scParameters[scParamFsType] = nfs4FSType
+
+		// ssh connection to master vm
+		sshClientConfig = &ssh.ClientConfig{
+			User: "root",
+			Auth: []ssh.AuthMethod{
+				ssh.Password(nimbusGeneratedK8sVmPwd),
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+
+		// fetching k8s master ip
+		allMasterIps = getK8sMasterIPs(ctx, client)
+		masterIp = allMasterIps[0]
+
+		// nimbus export variable
+		nimbusGeneratedK8sVmPwd = GetAndExpectStringEnvVar(nimbusK8sVmPwd)
+		storagePolicyToDelete = GetAndExpectStringEnvVar(envStoragePolicyNameToDeleteLater)
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ginkgo.By("Perform cleanup if any resource left in the setup before starting a new test")
+
+		// perfrom cleanup of old stale entries of storage class if left in the setup
+		storageClassList, err := client.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(storageClassList.Items) != 0 {
+			for _, sc := range storageClassList.Items {
+				gomega.Expect(client.StorageV1().StorageClasses().Delete(ctx, sc.Name,
+					*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		// perfrom cleanup of old stale entries of statefulset if left in the setup
+		statefulsets, err := client.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(statefulsets.Items) != 0 {
+			for _, sts := range statefulsets.Items {
+				gomega.Expect(client.AppsV1().StatefulSets(namespace).Delete(ctx, sts.Name,
+					*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		// perfrom cleanup of old stale entries of nginx service if left in the setup
+		err = client.CoreV1().Services(namespace).Delete(ctx, servicename, *metav1.NewDeleteOptions(0))
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		// perfrom cleanup of old stale entries of pvc if left in the setup
+		pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(pvcs.Items) != 0 {
+			for _, pvc := range pvcs.Items {
+				gomega.Expect(client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name,
+					*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		// perfrom cleanup of old stale entries of any deployment entry if left in the setup
+		depList, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(depList.Items) != 0 {
+			for _, dep := range depList.Items {
+				err := client.AppsV1().Deployments(namespace).Delete(ctx, dep.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		// perfrom cleanup of old stale entries of pv if left in the setup
+		pvs, err := client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(pvs.Items) != 0 {
+			for _, pv := range pvs.Items {
+				gomega.Expect(client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name,
+					*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		if isVsanHealthServiceStopped {
+			vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+			vcAddress := vCenterHostname[0] + ":" + sshdPort
+			framework.Logf("Bringing vsanhealth up before terminating the test")
+			startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
+		}
+
+		if isSPSServiceStopped {
+			vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+			vcAddress := vCenterHostname[0] + ":" + sshdPort
+			framework.Logf("Bringing sps up before terminating the test")
+			startVCServiceWait4VPs(ctx, vcAddress, spsServiceName, &isSPSServiceStopped)
+			isSPSServiceStopped = false
+		}
+
+		if isStorageProfileDeleted {
+			clientIndex := 0
+			err = createStorageProfile(masterIp, sshClientConfig, storagePolicyToDelete, clientIndex)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	})
+
+	/* TESTCASE-1
+	Deployment Pods and Standalone Pods creation with different SC. Perform Scaleup of Deployment Pods
+	SC1 → WFC Binding Mode with default values
+	SC2 → Immediate Binding Mode with all allowed topologies i.e. zone-1 > zone-2 > zone-3
+
+		Steps:
+	    1. Create SC1 with default values so that all AZ's should be considered for volume provisioning.
+	    2. Create PVC with "RWX" access mode using SC created in step #1.
+	    3. Wait for PVC to reach Bound state
+	    4. Create deployment Pod with replica count 3 and specify Node selector terms.
+	    5. Volumes should get distributed across all AZs.
+	    6. Pods should be running on the appropriate nodes as mentioned in Deployment node selector terms.
+	    7. Create SC2 with Immediate Binding mode and with all levels of allowed topology set considering all 3 VC's.
+	    8. Create PVC with "RWX" access mode using SC created in step #8.
+	    9. Verify PVC should reach to Bound state.
+	    10. Create 3 Pods with different access mode and attach it to PVC created in step #9.
+	    11. Verify Pods should reach to Running state.
+	    12. Try reading/writing onto the volume from different Pods.
+	    13. Perform scale up of deployment Pods to replica count 5. Verify Scaling operation should go smooth.
+		14. Perform scale-down operation on deployment pods. Decrease the replica count to 1.
+		15. Verify scale down operation went smooth.
+	    16. Perform cleanup by deleting deployment Pods, PVCs and the StorageClass (SC)
+	*/
+
+	ginkgo.It("Deployment pods and standalone pods creation with rwx pvcs "+
+		"with different allowed topology given in SCs", ginkgo.Label(p0, file, vanilla, multiVc, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// variable declaration
+		var pvs1, pvs2 []*v1.PersistentVolume
+		var pvclaim1, pvclaim2 *v1.PersistentVolumeClaim
+		var pv1, pv2 *v1.PersistentVolume
+
+		// deployment pod and pvc count
+		replica = 3
+		createPvcItr = 1
+		createDepItr = 1
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with "+
+			"no allowed topology specified", accessmode, nfs4FSType))
+		storageclass1, pvclaims1, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, nil, bindingModeWffc, false, accessmode, "", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass1.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim1.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv1.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Set node selector term for deployment pods so that all pods " +
+			"should get created on one single AZ i.e. VC-1(zone-1)")
+		/* here in 3-VC setup, deployment pod node affinity is taken as  k8s-zone -> zone-1
+		i.e only VC1 allowed topology
+		*/
+		topValStartIndex = 0
+		topValEndIndex = 1
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+		nodeSelectorTerms, err := getNodeSelectorMapForDeploymentPods(allowedTopologies)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// taking pvclaims1 0th index because we are creating only single RWX PVC in this case
+		pvclaim1 = pvclaims1[0]
+
+		ginkgo.By("Create Deployment with replica count 3")
+		deploymentList, _, err := createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, false, labelsMap,
+			pvclaim1, nodeSelectorTerms, execRWXCommandPod, nginxImage, false, nil, createDepItr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			framework.Logf("Delete deployment set")
+			err := client.AppsV1().Deployments(namespace).Delete(ctx, deploymentList[0].Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs1, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims1, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// taking pv1 0th index because we are creating only single RWX PVC in this case
+		pv1 = pvs1[0]
+
+		// standalone pod and pvc count
+		noPodsToDeploy := 3
+		createPvcItr = 1
+
+		// here considering all 3 VCs so start index is set to 0 and endIndex will be set to 3rd VC value
+		topValStartIndex = 0
+		topValEndIndex = 3
+
+		ginkgo.By("Set allowed topology to all 3 VCs")
+		allowedTopologyForSC := setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with allowed "+
+			"topology set to all topology levels", accessmode, nfs4FSType))
+		storageclass2, pvclaims2, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, allowedTopologyForSC, bindingModeImm, false, accessmode, "", nil, 1, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass2.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim2.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv2.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs2, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims2, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// taking pvclaims2 0th index because we are creating only single RWX PVC in this case
+		pvclaim2 = pvclaims2[0]
+		pv2 = pvs2[0]
+
+		ginkgo.By("Create 3 standalone Pods using the same PVC with different read/write permissions")
+		podList, err := createStandalonePodsForRWXVolume(client, ctx, namespace, nil, pvclaim2, false,
+			execRWXCommandPod, noPodsToDeploy)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err := fpod.DeletePodWithWait(ctx, client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+		ginkgo.By("Scale up deployment to 6 replica")
+		replica = 6
+		/* here createDepItr value is set to 0, because we are performing scaleup operation
+		and not creating any new deployment */
+		_, pods, err := createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, true,
+			labelsMap, pvclaim1, nodeSelectorTerms, execRWXCommandPod, nginxImage, true, deploymentList[0], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify deployment pods are scheduled on a specified node selector terms")
+		err = verifyDeploymentPodNodeAffinity(ctx, client, namespace, allowedTopologies, pods)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scale down deployment to 1 replica")
+		replica = 1
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, true, labelsMap,
+			pvclaim1, nodeSelectorTerms, execRWXCommandPod, nginxImage, true, deploymentList[0], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/* TESTCASE-2
+		StatefulSet Workload with default Pod Management and Scale-Up/Scale-Down Operations
+		SC → Storage Policy (VC-1) with specific allowed topology i.e. k8s-zone:zone-1 and with WFC Binding mode
+
+		Steps:
+	    1. Create SC with storage policy name (tagged with vSAN ds) available in single VC (VC-1)
+	    2. Create StatefulSet with 3 replicas using default Pod management policy
+		3. Allow time for PVCs and Pods to reach Bound and Running states, respectively.
+		4. Volume provisioning should happen on the AZ as specified in the SC.
+		5. Pod placement can happen in any available availability zones (AZs)
+		6. Verify CNS metadata for PVC and Pod.
+		7. Scale-up/Scale-down the statefulset. Verify scaling operation went successful.
+		8. Volume provisioning should happen on the AZ as specified in the SC but Pod placement can
+		occur in any availability zones
+		(AZs) during the scale-up operation.
+		9. Perform cleanup by deleting StatefulSets, PVCs, and the StorageClass (SC)
+	*/
+
+	ginkgo.It("Statefulset creation with rwx pvcs having storage "+
+		"policy defined only in AZ1", ginkgo.Label(p0, file, vanilla, multiVc, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		//storage policy read of cluster-1(rack-1)
+		storagePolicyName := GetAndExpectStringEnvVar(envStoragePolicyNameVC1)
+		scParameters["storagepolicyname"] = storagePolicyName
+
+		// sts pod replica count
+		stsReplicas := 3
+		scaleUpReplicaCount := 5
+		scaleDownReplicaCount := 1
+
+		// here considering VC-1 so start index is set to 0 and endIndex will be set to 1
+		topValStartIndex = 0
+		topValEndIndex = 1
+
+		ginkgo.By("Set allowed topology to VC-1")
+		allowedTopologyForSC := setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with"+
+			"allowed topology specified to VC-1 (zone-1) and with WFFC binding mode", accessmode, nfs4FSType))
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, allowedTopologyForSC, "",
+			bindingModeWffc, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet with replica count 3 with RWX PVC access mode")
+		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, false,
+			int32(stsReplicas), false, allowedTopologyForSC, false, false, false, accessmode, sc, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			fss.DeleteAllStatefulSets(ctx, client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		/*Storage policy of vc-1 is passed in storage class creation, so fetching the list of datastores
+		which is available in VC-1, volume provision should happen on VC-1 vSAN FS compatible datastore */
+		datastoreUrlsRack1, _, _, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Verify volume placement, should match with the allowed topology specified")
+		err = volumePlacementVerificationForSts(ctx, client, statefulset, namespace, datastoreUrlsRack1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets")
+		err = performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, int32(scaleUpReplicaCount),
+			int32(scaleDownReplicaCount), statefulset, false, namespace, allowedTopologyForSC, true, true, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify new volume placement, should match with the allowed topology specified")
+		err = volumePlacementVerificationForSts(ctx, client, statefulset, namespace, datastoreUrlsRack1)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/* TESTCASE-3
+	PVC and multiple Pods creation → Same Policy is available in two VCs
+	SC → Same Storage Policy Name (VC-1 and VC-2) with specific allowed topology i.e.
+	k8s-zone:zone-1,zone-2 and with Immediate Binding mode
+
+	Steps:
+	1. Create SC with Storage policy name available in VC1 and VC2 and allowed topology set to
+	k8s-zone:zone-1,zone-2 and with Immediate Binding mode
+	2. Create PVC with "RWX" access mode using SC created in step #1.
+	3. Create Deployment Pods with replica count 2 using PVC created in step #2.
+	4. Allow time for PVCs and Pods to reach Bound and Running states, respectively.
+	5. PVC should get created on the AZ as given in the SC.
+	6. Pod placement can happen on any AZ.
+	7. Verify CNS metadata for PVC and Pod.
+	8. Perform Scale up of deployment Pod replica to count 5
+	9. Verify scaling operation should go successful.
+	10. Perform scale down of deployment Pod to count 1.
+	11. Verify scaling down operation went smooth.
+	12. Perform cleanup by deleting Deployment, PVCs, and the SC
+	*/
+
+	ginkgo.It("Multiple pods creation with single rwx pvcs created "+
+		"with storage policy available ", ginkgo.Label(p0, file, vanilla, multiVc, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// deployment pod and pvc count
+		replica = 2
+		createPvcItr = 1
+		createDepItr = 1
+
+		storagePolicyInVc1Vc2 := GetAndExpectStringEnvVar(envStoragePolicyNameInVC1VC2)
+		scParameters[scParamStoragePolicyName] = storagePolicyInVc1Vc2
+
+		/*
+			We are considering storage policy of VC1 and VC2 and the allowed
+			topology is k8s-zone -> zone-1, zone-2 i.e VC1 and VC2 allowed topologies.
+		*/
+		topValStartIndex = 0
+		topValEndIndex = 2
+
+		ginkgo.By("Set allowed topology to VC-1 and VC-2")
+		allowedTopologyForSC := setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with "+
+			"no allowed topology specified", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, allowedTopologyForSC, bindingModeImm, false, accessmode, "", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, storagePolicyInVc1Vc2, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// taking pvclaims and pv 0th index because we are creating only single RWX PVC in this case
+		pvclaim = pvclaims[0]
+		pv = pvs[0]
+
+		// volume placement should happen either on VC-1 or VC-2
+		ginkgo.By("Verify volume placement, should match with the allowed topology specified")
+		datastoreUrlsRack1, datastoreUrlsRack2, _, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var datastoreUrlsVc1Vc2 []string
+		datastoreUrlsVc1Vc2 = append(datastoreUrlsVc1Vc2, datastoreUrlsRack1...)
+		datastoreUrlsVc1Vc2 = append(datastoreUrlsVc1Vc2, datastoreUrlsRack2...)
+		isCorrectPlacement := multiVCe2eVSphere.verifyPreferredDatastoreMatchInMultiVC(pv.Spec.CSI.VolumeHandle,
+			datastoreUrlsVc1Vc2)
+		gomega.Expect(isCorrectPlacement).To(gomega.BeTrue(), fmt.Sprintf("Volume provisioning has happened on the wrong "+
+			"datastore. Expected 'true', got '%v'", isCorrectPlacement))
+
+		ginkgo.By("Create Deployment with replica count 2")
+		deploymentList, _, err := createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, false, labelsMap,
+			pvclaim, nil, execRWXCommandPod, nginxImage, false, nil, createDepItr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			framework.Logf("Delete deployment set")
+			err := client.AppsV1().Deployments(namespace).Delete(ctx, deploymentList[0].Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Scale up deployment to 5 replica")
+		replica = 5
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, true, labelsMap,
+			pvclaim, nil, execRWXCommandPod, nginxImage, true, deploymentList[0], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scale down deployment to 1 replica")
+		replica = 1
+		_, pods, err := createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, true,
+			labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, deploymentList[0], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify volume metadata for deployment pod, pvc and pv")
+		err = waitAndVerifyCnsVolumeMetadata(ctx, pv.Spec.CSI.VolumeHandle, pvclaim, pv, &pods.Items[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/* TESTCASE-4
+	Standalone Pods creation with allowed topology details in SC specific to VC-2
+	SC → specific allowed topology i.e. k8s-zone:zone-2 and datastore url of VC-2 with WFC Binding mode
+
+	Steps:
+	1. Create SC with allowed topology of VC-2 and use datastore url from same VC with WFC Binding mode.
+	2. Create PVC with "RWX" access mode using SC created in step #1.
+	3. Verify PVC should reach to Bound state and it should be created on the AZ as given in the SC.
+	4. PVC should get created on the given AZ of SC.
+	5. Create 3 standalone pods using PVC created in step #2.
+	6. Wait for Pods to reach running ready state.
+	7. Pods should get created on any VC or any AZ.
+	8. Try reading/writing data into the volume.
+	9. Perform cleanup by deleting deployment Pods, PVC and SC
+	*/
+
+	ginkgo.It("Multiple standalone pods attached to single rwx pvc with datastore url"+
+		"tagged to Az2 in SC", ginkgo.Label(p0, file, vanilla, multiVc, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// pods and pvc count
+		noPodsToDeploy := 3
+		createPvcItr = 1
+
+		// vSAN FS compatible datastore of VC-2
+		dsUrl := GetAndExpectStringEnvVar(envSharedDatastoreURLVC2)
+		scParameters["datastoreurl"] = dsUrl
+
+		/*
+			We are considering allowed topology of VC-2 i.e.
+			k8s-zone -> zone-2 and datastore url of VC-2
+		*/
+		topValStartIndex = 1
+		topValEndIndex = 2
+
+		ginkgo.By("Set allowed topology to VC-2")
+		allowedTopologyForSC := setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with "+
+			"allowed topology set to VC-2 AZ ", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, allowedTopologyForSC, bindingModeWffc, false, accessmode, "", nil,
+			createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// taking pvclaims 0th index because we are creating only single RWX PVC in this case
+		pvclaim = pvclaims[0]
+
+		ginkgo.By("Create 3 standalone Pods using the same PVC with different read/write permissions")
+		podList, err := createStandalonePodsForRWXVolume(client, ctx, namespace, nil, pvclaim, false, execRWXCommandPod,
+			noPodsToDeploy)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err := fpod.DeletePodWithWait(ctx, client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", dsUrl)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// taking pvs 0th index because we are creating only single RWX PVC in this case
+		pv = pvs[0]
+
+		// volume placement should happen either on VC-2
+		ginkgo.By("Verify volume placement, should match with the allowed topology specified")
+		_, datastoreUrlsRack2, _, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isCorrectPlacement := multiVCe2eVSphere.verifyPreferredDatastoreMatchInMultiVC(pv.Spec.CSI.VolumeHandle,
+			datastoreUrlsRack2)
+		gomega.Expect(isCorrectPlacement).To(gomega.BeTrue(), fmt.Sprintf("Volume provisioning has happened on the wrong "+
+			"datastore. Expected 'true', got '%v'", isCorrectPlacement))
+	})
+
+	/* TESTCASE-5
+	Deploy Statefulset workload with allowed topology details in SC specific to VC-1 and VC-3
+	SC → specific allowed topology like K8s-zone: zone-1 and zone-3 and with Immediate Binding mode
+
+		Steps//
+	    1. Create SC with allowedTopology details set to VC-1 and VC-3 availability Zone i.e. zone-1 and zone-3
+	    2. Create Statefulset with replica  count 3
+	    3. Wait for PVC to reach bound state and POD to reach Running state
+	    4. Volume provision should happen on the AZ as specified in the SC.
+	    5. Pods should get created on any AZ i.e. across all 3 VCs
+	    6. Scale-up the statefuset replica count to 7.
+	    7. Verify scaling operation went smooth and new volumes should get created on the VC-1 and VC-2 AZ.
+		8. Newly created Pods should get created across any of the AZs.
+		9. Perform Scale down operation. Reduce the replica count from 7 to 2.
+		10. Verify scale down operation went smooth.
+	    11. Perform cleanup by deleting StatefulSets, PVCs, and the StorageClass (SC)
+	*/
+
+	ginkgo.It("Scaling operations involving statefulSet pods with multiple replicas, "+
+		"each connected to rwx pvcs with allowed topology specified is "+
+		"of AZ-1 and AZ-3", ginkgo.Label(p0, file, vanilla, multiVc, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// pod replica count
+		stsReplicas := 3
+		scaleUpReplicaCount := 7
+		scaleDownReplicaCount := 2
+
+		/*
+			We are considering allowed topology of VC-1 and VC-3 i.e.
+			k8s-zone -> zone-1 and zone-3
+		*/
+		topValStartIndex = 0
+		topValEndIndex = 3
+
+		ginkgo.By("Setting allowed topology to vc-1 and vc-3")
+		allowedTopologyForSC := setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+		// fetching vc-1 and vc-3 AZ
+		value1 := allowedTopologyForSC[0].Values[0]
+		value3 := allowedTopologyForSC[0].Values[2]
+		// Set the values back into allowedTopologyForSC
+		allowedTopologyForSC[0].Values = []string{value1, value3}
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with no "+
+			"allowed topology specified and with WFFC binding mode", accessmode, nfs4FSType))
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, allowedTopologyForSC,
+			"", bindingModeImm, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet with replica count 3 with RWX PVC access mode")
+		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, true,
+			int32(stsReplicas), false, allowedTopologyForSC, false, false, false, accessmode, sc, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			fss.DeleteAllStatefulSets(ctx, client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Verify volume placement, should match with the allowed topology specified")
+		datastoreUrlsRack1, _, datastoreUrlsRack3, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var datastoreUrls []string
+		datastoreUrls = append(datastoreUrls, datastoreUrlsRack1...)
+		datastoreUrls = append(datastoreUrls, datastoreUrlsRack3...)
+		err = volumePlacementVerificationForSts(ctx, client, statefulset, namespace, datastoreUrls)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets")
+		err = performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, int32(scaleUpReplicaCount),
+			int32(scaleDownReplicaCount), statefulset, false, namespace, allowedTopologyForSC, true, true, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/* TESTCASE-6
+		Deploy workload with allowed topology details in SC specific to vc1 and vc2 but
+		storage policy is passed from vc1 (vSAN DS) and datastore url vc2 both passed
+
+		Steps:
+	    1. Create SC with allowedTopology details set to AZs i.e. zone1, zone2
+		Also pass storage policy tagged to vSAN DS from vc1 and datastore url tagged to vSAN DS from vc2 with
+		Immediate Binding mode.
+	    2. Create PVC using the SC created above.
+	    3. PVC creation should fail with an appropriate error message i.e. no compatible datastore found
+	    4. Perform cleanup by deleting SC and PVC
+	*/
+
+	ginkgo.It("Deploy workload with allowed topology of vc1 and "+
+		"vc2, tag storage policy of vc1 and datastore url of vc2", ginkgo.Label(p2, file, vanilla, multiVc,
+		newTest, negative), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		/* set allowed topology of vc1 and vc2*/
+		topValStartIndex = 0
+		topValEndIndex = 2
+		datastoreUrl := GetAndExpectStringEnvVar(envSharedDatastoreURLVC2)
+		storagePolicyName := GetAndExpectStringEnvVar(envStoragePolicyNameVC1)
+		scParameters[scParamDatastoreURL] = datastoreUrl
+		scParameters[scParamStoragePolicyName] = storagePolicyName
+		expectedErrMsg := "not found in candidate list for volume provisioning"
+
+		ginkgo.By("Set specific allowed topology")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		storageclass, pvclaim, err := createPVCAndStorageClass(ctx, client,
+			namespace, nil, scParameters, diskSize, allowedTopologies, bindingModeImm, false, accessmode)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Expect claim to fail provisioning volume since no valid datastore is specified in the storage class")
+		err = fpv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute/2)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		ginkgo.By(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
+		isFailureFound := checkEventsforError(client, namespace,
+			metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvclaim.Name)}, expectedErrMsg)
+		gomega.Expect(isFailureFound).To(gomega.BeTrue(), "Unable to verify pvc create failure")
+	})
+
+	/* TESTCASE-7
+		Create storage policy in vc1 and vc2 and create storage class with the same policy
+		and  delete Storage policy in vc1 .Expected pvc to go to vc2
+
+		Steps//
+	    1. Create Storage policy with same name which is present in both vc1 and vc2
+	    2. Create Storage Class with allowed topology specify to vc1 and vc2 and specify storage policy created in step #1.
+		3. Delete storage policy from VC1
+	    4. Create few PVCs (2 to 3 PVCs) with "RWX" access mode using SC created in step #1
+	    5. Create Deployment Pods with replica count 2 and Standalone Pods using PVC created in step #3.
+	    6. Verify PVC should reach Bound state and Pods should reach Running state.
+	    7. Volume provisioning can happen on the AZ as specified in the SC i.e. it
+		should provision volume on VC2 AZ as VC-1 storage policy is deleted
+	    8. Pod placement can happen on any AZ.
+	    9. Perform Scaleup operation on deployment Pods. Increase the replica count from 2 to 4.
+	    10. Perform cleanup by deleting Pods, PVC and SC.
+	*/
+
+	ginkgo.It("Same storage policy is available in vc1 and vc2 and later delete storage policy from "+
+		"one of the VC", ginkgo.Label(p1, file, vanilla, multiVc, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		/* set allowed topology of vc1 and vc2*/
+		topValStartIndex = 0
+		topValEndIndex = 2
+		clientIndex := 0
+
+		// pods and pvc count
+		noPodsToDeploy := 3
+		createPvcItr = 3
+		createDepItr = 1
+		replica = 2
+
+		// variable declaration
+		var depl []*appsv1.Deployment
+		var podList []*v1.Pod
+		var err error
+
+		// storage policy which is common in both vc1 and vc2
+		scParameters[scParamStoragePolicyName] = storagePolicyToDelete
+
+		ginkgo.By("Set allowed topology specific to vc1 and vc2")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex,
+			topValStartIndex, topValEndIndex)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with "+
+			"no allowed topology specified", accessmode, nfs4FSType))
+		storageclass, _, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, allowedTopologies, bindingModeImm, false, accessmode, "", nil, createPvcItr, false, true)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Delete Storage Policy created in VC1")
+		err = deleteStorageProfile(masterIp, sshClientConfig, storagePolicyToDelete, clientIndex)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isStorageProfileDeleted = true
+		defer func() {
+			if isStorageProfileDeleted {
+				err = createStorageProfile(masterIp, sshClientConfig, storagePolicyToDelete, clientIndex)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				isStorageProfileDeleted = false
+			}
+		}()
+
+		ginkgo.By("Creating multiple pvcs with rwx access mode")
+		_, pvclaims, err = createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, allowedTopologies, bindingModeImm, false, accessmode,
+			"", storageclass, createPvcItr, true, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			for i := 0; i < len(pvclaims); i++ {
+				pv = getPvFromClaim(client, pvclaims[i].Namespace, pvclaims[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaims[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Create Deployments and standalone pods")
+		for i := 0; i < len(pvclaims); i++ {
+			deploymentList, _, err := createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, false, labelsMap,
+				pvclaims[i], nil, execRWXCommandPod, nginxImage, false, nil, createDepItr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			depl = append(depl, deploymentList...)
+
+			// Create 3 standalone pods and attach it to 3rd rwx pvc
+			if i == 2 {
+				ginkgo.By("Create 3 standalone Pods using the same PVC with different read/write permissions")
+				podList, err = createStandalonePodsForRWXVolume(client, ctx, namespace, nil, pvclaims[i], false, execRWXCommandPod,
+					noPodsToDeploy)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err := fpod.DeletePodWithWait(ctx, client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		defer func() {
+			framework.Logf("Delete deployment set")
+			for i := 0; i < len(depl); i++ {
+				err := client.AppsV1().Deployments(namespace).Delete(ctx, depl[i].Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		// volume placement should happen on VC-2
+		ginkgo.By("Verify volume placement, should match with the allowed topology specified")
+		_, datastoreUrlsRack2, _, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for i := 0; i < len(pvclaims); i++ {
+			pv = getPvFromClaim(client, pvclaims[i].Namespace, pvclaims[i].Name)
+			isCorrectPlacement := multiVCe2eVSphere.verifyPreferredDatastoreMatchInMultiVC(pv.Spec.CSI.VolumeHandle,
+				datastoreUrlsRack2)
+			gomega.Expect(isCorrectPlacement).To(gomega.BeTrue(), fmt.Sprintf("Volume provisioning has happened on the wrong "+
+				"datastore. Expected 'true', got '%v'", isCorrectPlacement))
+		}
+
+		ginkgo.By("Scale up deployment to 4 replica")
+		replica = 4
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica,
+			true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, depl[0], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	})
+
+	/* TESTCASE-9
+	   	Storage policy is present in VC1 and VC1 is under reboot
+	   	SC → specific allowed topology i.e. k8s-zone:zone-1 with
+		immediate Binding mode and with Storage Policy (vSAN DS of VC-1)
+
+	   	Steps//
+		1. Create a StorageClass (SC) tagged to vSAN datastore of VC-1.
+		2. Create a deployment with a replica count of 3 and a size of 2Gi, using the previously created StorageClass.
+		3. Initiate a reboot of VC-1 while deployment pod creation is in progress.
+		4. Confirm that volume creation is in a "Pending" state while VC-1 is rebooting.
+		5. Wait for VC-1 to be fully operational.
+		6. Ensure that, upon VC-1 recovery, all volumes come up on the worker nodes within VC-1.
+		7. Confirm that volume provisioning occurs exclusively on VC-1.
+		8. Pod placement can happen on any AZ.
+		9. Perform cleanup by deleting Pods, PVCs and SC
+	*/
+
+	ginkgo.It("Creating statefulset with rwx pvcs with storage policy "+
+		"tagged to vc1 datastore and vc1 is under reboot", ginkgo.Label(p1, file, vanilla,
+		multiVc, disruptive), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// storage policy of vc1
+		storagePolicyInVc1 := GetAndExpectStringEnvVar(envStoragePolicyNameVC1)
+		scParameters[scParamStoragePolicyName] = storagePolicyInVc1
+
+		// count of pvc and deployment pod
+		replica := 3
+		createPvcItr := 1
+		// here, we are considering the allowed topology of VC1 i.e. k8s-zone -> zone-1
+		topValStartIndex = 0
+		topValEndIndex = 1
+
+		ginkgo.By("Set specific allowed topology of vc1")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with "+
+			"no allowed topology specified", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, allowedTopologies, bindingModeImm, false, accessmode, "", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// taking pvclaims and pvs 0th index because we are creating only single RWX PVC in this case
+		pvclaim = pvclaims[0]
+		pv = pvs[0]
+
+		ginkgo.By("Create deployment")
+		deployment, err := createDeployment(ctx, client, int32(replica), labelsMap, nil, namespace,
+			[]*v1.PersistentVolumeClaim{pvclaim}, execRWXCommandPod, false, nginxImage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Rebooting VC1")
+		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+		vcAddress := vCenterHostname[0] + ":" + sshdPort
+		framework.Logf("vcAddress - %s ", vcAddress)
+		err = invokeVCenterReboot(ctx, vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = waitForHostToBeUp(vCenterHostname[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.By("Done with reboot")
+
+		essentialServices := []string{spsServiceName, vsanhealthServiceName, vpxdServiceName}
+		checkVcenterServicesRunning(ctx, vcAddress, essentialServices)
+
+		//After reboot
+		multiVCbootstrap()
+
+		ginkgo.By("Verify deployment pods should be in running ready state post vc reboot")
+		pods, err := fdep.GetPodsForDeployment(ctx, client, deployment)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		pod := pods.Items[0]
+		err = fpod.WaitForPodNameRunningInNamespace(ctx, client, pod.Name, namespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			framework.Logf("Delete deployment set")
+			err := client.AppsV1().Deployments(namespace).Delete(ctx, deployment.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume placement, should match with the allowed topology specified")
+		datastoreUrlsVc1, _, _, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		isCorrectPlacement := multiVCe2eVSphere.verifyPreferredDatastoreMatchInMultiVC(pv.Spec.CSI.VolumeHandle,
+			datastoreUrlsVc1)
+		gomega.Expect(isCorrectPlacement).To(gomega.BeTrue(), fmt.Sprintf("Volume provisioning has happened on the "+
+			"wrong datastore. Expected 'true', got '%v'", isCorrectPlacement))
+
+		ginkgo.By("Scale up deployment pods to 5 replicas")
+		replica = 5
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, int32(replica),
+			true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, deployment, 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scale down deployment pods to 1 replica")
+		replica = 1
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, int32(replica),
+			true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, deployment, 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/* TESTCASE-10
+	VSAN-health down on VC1
+	SC → default values with Immediate Binding mode
+
+	Steps:
+	1. Create SC with default values so all the AZ's should be considered for volume provisioning
+	2. Create few dynamic PVCs and add labels to PVCs and PVs.
+	3. Verify pvc should reach to bound state
+	4. Bring down the VSAN-health on VC-1
+	5. Create new PVCs, add labels to the new pvcs when vsan health is down on vc1
+	6. New pvc should be stuck in a pending state
+	7. Create deployment Pods for the PVC created in step #2 with replica count 1.
+	8. Deployment pods should be stuck in ContainerCreating state due to vsan health cns query will fail
+	9. Update the label on PV and PVC created in step #2
+	10. Bring up the vSAN-health on vc1
+	11. Wait for 2 full sync cycle
+	12. Verify deployment Pods should come back to running state.
+	13. Verify that the pvcs which were created when service is down, evetually should reach to Bound state
+	14. Verify that the labels gets updated in CNS.
+	15. Perform scaleup operation on deployment pods by increasing the replica count to 5.
+	16. Perform scaledown operation on dep3 by decreasing the replica count to 2.
+	17. Perform cleanup by deleting pods,pvc and sc
+	*/
+
+	ginkgo.It("Podcreation and lables update when "+
+		"vsan health is down", ginkgo.Label(p1, file, vanilla, multiVc, newTest, disruptive), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// variable declaration
+		var depl []*appsv1.Deployment
+		var fullSyncWaitTime int
+
+		// pvc and deployment pod count
+		replica = 1
+		createPvcItr = 4
+		createDepItr = 1
+
+		// Read full-sync value.
+		if os.Getenv(envFullSyncWaitTime) != "" {
+			fullSyncWaitTime, err = strconv.Atoi(os.Getenv(envFullSyncWaitTime))
+			framework.Logf("Full-Sync interval time value is = %v", fullSyncWaitTime)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, nil, bindingModeImm, false, accessmode,
+			"", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		defer func() {
+			for i := 0; i < len(pvclaims); i++ {
+				pv = getPvFromClaim(client, pvclaims[i].Namespace, pvclaims[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaims[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Bring down Vsan-health service on VC1")
+		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+		vcAddress := vCenterHostname[0] + ":" + sshdPort
+		framework.Logf("vcAddress - %s ", vcAddress)
+		err = invokeVCenterServiceControl(ctx, stopOperation, vsanhealthServiceName, vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isVsanHealthServiceStopped = true
+		defer func() {
+			if isVsanHealthServiceStopped {
+				framework.Logf("Bringing vsanhealth up before terminating the test")
+				startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
+			}
+		}()
+
+		ginkgo.By("Creating new pvcs when vsan health is down, it should be stuck in a pending state")
+		createPvcItr = 3
+		_, pvclaimsNew, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, nil, bindingModeImm, false, accessmode,
+			"", storageclass, createPvcItr, true, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			for i := 0; i < len(pvclaimsNew); i++ {
+				pv = getPvFromClaim(client, pvclaimsNew[i].Namespace, pvclaimsNew[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaimsNew[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Create Deployment pod with replica count 1 for each rwx pvc")
+		for i := 0; i < len(pvclaims); i++ {
+			deploymentSpec := getDeploymentSpec(ctx, client, int32(replica), labelsMap, nil, namespace,
+				pvclaims, execRWXCommandPod, false, nginxImage)
+			deployment, err := client.AppsV1().Deployments(namespace).Create(ctx, deploymentSpec, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			depl = append(depl, deployment)
+		}
+
+		labelKey := "volIdNew"
+		labelValue := "pvcVolumeNew"
+		labels := make(map[string]string)
+		labels[labelKey] = labelValue
+
+		ginkgo.By("Updating labels for PVC and PV")
+		for i := 0; i < len(pvclaims); i++ {
+			pv := getPvFromClaim(client, pvclaims[i].Namespace, pvclaims[i].Name)
+			framework.Logf("Updating labels %+v for pvc %s in namespace %s", labels, pvclaims[i].Name,
+				pvclaims[i].Namespace)
+			pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvclaims[i].Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pvc.Labels = labels
+			_, err = client.CoreV1().PersistentVolumeClaims(namespace).Update(ctx, pvc, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			framework.Logf("Updating labels %+v for pv %s", labels, pv.Name)
+			pv.Labels = labels
+			_, err = client.CoreV1().PersistentVolumes().Update(ctx, pv, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By(fmt.Sprintln("Starting vsan-health on the vCenter host"))
+		startVCServiceWait4VPs(ctx, vcAddress, vsanhealthServiceName, &isVsanHealthServiceStopped)
+
+		ginkgo.By(fmt.Sprintf("Sleeping for %v seconds to allow full sync finish", fullSyncWaitTime))
+		time.Sleep(time.Duration(fullSyncWaitTime) * time.Second)
+
+		ginkgo.By("Verify deployment pods should be in running ready state post vsan health service up")
+		for i := 0; i < len(depl); i++ {
+			pods, err := fdep.GetPodsForDeployment(ctx, client, depl[i])
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pod := pods.Items[0]
+			err = fpod.WaitForPodNameRunningInNamespace(ctx, client, pod.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		defer func() {
+			framework.Logf("Delete deployment set")
+			for i := 0; i < len(depl); i++ {
+				err := client.AppsV1().Deployments(namespace).Delete(ctx, depl[i].Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Waiting for labels to be updated for PVC and PV")
+		for i := 0; i < len(pvclaims); i++ {
+			pv := getPvFromClaim(client, pvclaims[i].Namespace, pvclaims[i].Name)
+
+			framework.Logf("Waiting for labels %+v to be updated for pvc %s in namespace %s",
+				labels, pvclaims[i].Name, pvclaims[i].Namespace)
+			err = multiVCe2eVSphere.waitForLabelsToBeUpdatedInMultiVC(pv.Spec.CSI.VolumeHandle, labels,
+				string(cnstypes.CnsKubernetesEntityTypePVC), pvclaims[i].Name, pvclaims[i].Namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			framework.Logf("Waiting for labels %+v to be updated for pv %s", labels, pv.Name)
+			err = multiVCe2eVSphere.waitForLabelsToBeUpdatedInMultiVC(pv.Spec.CSI.VolumeHandle, labels,
+				string(cnstypes.CnsKubernetesEntityTypePV), pv.Name, pv.Namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By("Scale up deployments to replica count 5")
+		for i := 0; i < len(depl); i++ {
+			replica = 5
+			_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, int32(replica),
+				true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, depl[i], 0)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By("Scale down deployment3 pods to 2 replica")
+		replica = 2
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica,
+			true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, depl[2], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/* TESTCASE-11
+	sps service down
+	SC → all allowed topologies specified with Immediate Binding mode
+
+	Steps:
+	1. Create SC with all allowed topology values specified so all the AZ's should be considered for volume provisioning
+	2. Create few dynamic PVCs and add labels to PVCs and PVs.
+	3. Verify pvc should reach to bound state
+	4. Bring down the sps-service on vc1
+	5. Create deployment Pods for the PVC created in step #2 with replica count 1.
+	8. Deployment pods should be stuck in ContainerCreating state due to sps service down
+	10. Bring up the sps service on vc1
+	12. Verify deployment Pods should come back to running state.
+	15. Perform scaleup operation on deployment pods by increasing the replica count to 3.
+	16. Perform scaledown operation on dep3 by decreasing the replica count to 2.
+	17. Perform cleanup by deleting pods,pvc and sc
+	*/
+
+	ginkgo.It("RWX pvcs creation and in between sps "+
+		"service is down on any AZ", ginkgo.Label(p1, file, vanilla, multiVc, newTest, disruptive), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// variable declaration
+		var depl []*appsv1.Deployment
+
+		// pvc and deployment pod count
+		replica = 1
+		createPvcItr = 4
+		createDepItr = 4
+
+		// here, we are considering the allowed topology of all AZs
+		topValStartIndex = 0
+		topValEndIndex = 3
+
+		ginkgo.By("Set specific allowed topology of vc1")
+		allowedTopologies = setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, allowedTopologies, bindingModeImm, false, accessmode,
+			"", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		defer func() {
+			for i := 0; i < len(pvclaims); i++ {
+				pv = getPvFromClaim(client, pvclaims[i].Namespace, pvclaims[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaims[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Bring down SPS service")
+		vCenterHostname := strings.Split(multiVCe2eVSphere.multivcConfig.Global.VCenterHostname, ",")
+		vcAddress := vCenterHostname[0] + ":" + sshdPort
+		framework.Logf("vcAddress - %s ", vcAddress)
+		err = invokeVCenterServiceControl(ctx, stopOperation, spsServiceName, vcAddress)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isSPSServiceStopped = true
+		err = waitVCenterServiceToBeInState(ctx, spsServiceName, vcAddress, svcStoppedMessage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			if isSPSServiceStopped {
+				framework.Logf("Bringing sps up before terminating the test")
+				startVCServiceWait4VPs(ctx, vcAddress, spsServiceName, &isSPSServiceStopped)
+				isSPSServiceStopped = false
+			}
+		}()
+
+		ginkgo.By("Create Deployment pod with replica count 1 for each rwx pvc")
+		for i := 0; i < len(pvclaims); i++ {
+			deploymentSpec := getDeploymentSpec(ctx, client, int32(replica), labelsMap, nil, namespace,
+				pvclaims, execRWXCommandPod, false, nginxImage)
+			deployment, err := client.AppsV1().Deployments(namespace).Create(ctx, deploymentSpec, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			depl = append(depl, deployment)
+		}
+
+		ginkgo.By("Bringup SPS service")
+		startVCServiceWait4VPs(ctx, vcAddress, spsServiceName, &isSPSServiceStopped)
+
+		ginkgo.By("Verify deployment pods should be in running ready state post sps service up")
+		for i := 0; i < len(depl); i++ {
+			pods, err := fdep.GetPodsForDeployment(ctx, client, depl[i])
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			pod := pods.Items[0]
+			err = fpod.WaitForPodNameRunningInNamespace(ctx, client, pod.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		defer func() {
+			framework.Logf("Delete deployment set")
+			for i := 0; i < len(depl); i++ {
+				err := client.AppsV1().Deployments(namespace).Delete(ctx, depl[i].Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Scale up deployments to replica count 3")
+		for i := 0; i < len(depl); i++ {
+			replica = 3
+			_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, int32(replica),
+				true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, depl[i], 0)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By("Scale down deployment3 pods to 2 replica")
+		replica = 2
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica,
+			true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, depl[2], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+	/*
+		TESTCASE-13
+		When vSAN FS is enabled in all 3 VCs
+		SC → all allowed topology specified and Immediate Binding mode
+
+		1. Create Storage Class with all allowed topology specified and with Immediate Binding mode.
+		2. Create StatefulSet with 3 replicas using Parallel Pod management policy and with RWX access
+		mode and specify node selector term only to vc1 AZ
+		3. Wait for Pod and PVC to reach running ready state.
+		4. Volume provisioning can happen on any AZ but statefulset pod placement should happen only on vc1 AZ.
+		5. Create few RWX pvcs.
+		6. Wait for PVCs to reach Bound state.
+		7. Volume provisoning can happen on any AZ since all allowed topologies are specified.
+		8. Create 3 deployment pods each connected to rwx pvc with replica count 1.
+		9. Specify node selector term to vc2 AZ so that all deployment pods should get created only on vc2 AZ.
+		10. Create standalone pod and attached it to the 4th rwx pvc.
+		11. Specify node selector term for standalone pod to be vc2 and vc3 AZ.
+		12. Verify pod should reach to ready running sttae.
+		13. Verify pod should get created on the specified node selector term AZ.
+		14. Perform scaleup operation on statefulset pods. Increase the replica count to 5.
+		15. Verify newly created statefulset pods to get created on specified node selector term AZ.
+		16. Perform scaleup operation on any one deployment pods. Increase the replica count to 3.
+		17. Verify scaling operation went smooth and newly created pods should get created on the specified node selector.
+		18. Perform cleanup by deleting StatefulSet, Pods, PVCs and SC.
+	*/
+
+	ginkgo.It("Different types of pods creation attached to rwx pvcs "+
+		"involving scaling operation", ginkgo.Label(p0, file, vanilla, multiVc, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// variable declaration
+		var depl []*appsv1.Deployment
+		var pods *v1.PodList
+		var podList []*v1.Pod
+
+		// pvc and deployment pod count
+		replica = 1
+		stsReplicas := 3
+		createPvcItr = 4
+		createDepItr = 3
+		noPodsToDeploy := 3
+
+		// here, we are considering the allowed topology of all AZs
+		topValStartIndex = 0
+		topValEndIndex = 3
+
+		ginkgo.By("Set all allowed topology of all VCs for storage class creation")
+		allowedTopologiesForSC := setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, allowedTopologiesForSC, bindingModeImm, false, accessmode,
+			"nginx-sc", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			for i := 0; i < len(pvclaims); i++ {
+				pv = getPvFromClaim(client, pvclaims[i].Namespace, pvclaims[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaims[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = multiVCe2eVSphere.waitForCNSVolumeToBeDeletedInMultiVC(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// here, we are considering allowed topology of vc1(zone-1) for statefulset pod node selector terms
+		topValStartIndex = 0
+		topValEndIndex = 1
+
+		ginkgo.By("Setting node affinity for statefulset pods to be created in vc1 AZ")
+		allowedTopologiesForSts := setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+
+		ginkgo.By("Create StatefulSet with replica count 3 with RWX PVC access mode")
+		service, _, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, true,
+			int32(stsReplicas), true, allowedTopologiesForSts, false, false, false, accessmode, storageclass, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			fss.DeleteAllStatefulSets(ctx, client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Set node selector term for deployment pods so that all pods " +
+			"should get created on one single AZ i.e. vc2(zone-2)")
+		/* here in 3-VC setup, deployment pod node affinity is taken as  k8s-zone -> zone-2
+		i.e only VC2 allowed topology
+		*/
+		topValStartIndex = 2
+		topValEndIndex = 3
+		allowedTopologiesForDep := setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+		nodeSelectorTermsForDep, err := getNodeSelectorMapForDeploymentPods(allowedTopologiesForDep)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Set node selector term for standlone pods so that all pods should get " +
+			"created on one single AZ i.e. cluster-3(rack-3)")
+		/*
+			We are considering allowed topology of VC-1 and VC-3 i.e.
+			k8s-zone -> zone-1 and zone-3
+		*/
+		topValStartIndex = 0
+		topValEndIndex = 3
+
+		ginkgo.By("Setting allowed topology to vc-1 and vc-3")
+		allowedTopologiesForStandalonePod := setSpecificAllowedTopology(allowedTopologies, topkeyStartIndex, topValStartIndex,
+			topValEndIndex)
+		nodeSelectorTermsForPods, err := getNodeSelectorMapForDeploymentPods(allowedTopologiesForStandalonePod)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Create Deployments")
+		for i := 0; i < len(pvclaims); i++ {
+			if i != 3 {
+				var deployment []*appsv1.Deployment
+				deployment, pods, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, false, labelsMap,
+					pvclaims[i], nodeSelectorTermsForDep, execRWXCommandPod, nginxImage, false, nil, createDepItr)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				depl = append(depl, deployment...)
+			} else {
+				ginkgo.By("Create 3 standalone Pods using the same PVC with different read/write permissions")
+				podList, err = createStandalonePodsForRWXVolume(client, ctx, namespace, nodeSelectorTermsForPods,
+					pvclaims[i], false, execRWXCommandPod, noPodsToDeploy)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+		defer func() {
+			framework.Logf("Delete deployment set")
+			for i := 0; i < len(depl); i++ {
+				err := client.AppsV1().Deployments(namespace).Delete(ctx, depl[i].Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err := fpod.DeletePodWithWait(ctx, client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify deployment pods are scheduled on a specified node selector terms")
+		err = verifyDeploymentPodNodeAffinity(ctx, client, namespace, allowedTopologiesForDep, pods)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify standalone pods are scheduled on a selected node selector terms")
+		for i := 0; i < len(podList); i++ {
+			err = verifyStandalonePodAffinity(ctx, client, podList[i], allowedTopologies)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		ginkgo.By("Scale up deployment1 pods to 5 replicas")
+		replica = 3
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica,
+			true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, depl[0], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scale down deployment2 pods to 2 replica")
+		replica = 2
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica,
+			true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, depl[1], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})

--- a/tests/e2e/no_hci_mesh_rwx_singlevc_topology.go
+++ b/tests/e2e/no_hci_mesh_rwx_singlevc_topology.go
@@ -1,0 +1,1255 @@
+/*
+	Copyright 2024 The Kubernetes Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+	fss "k8s.io/kubernetes/test/e2e/framework/statefulset"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = ginkgo.Describe("[no-hci-mesh-topology-singlevc] No-Hci-Mesh-Topology-SingleVc", func() {
+	f := framework.NewDefaultFramework("rwx-topology")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	var (
+		client                  clientset.Interface
+		namespace               string
+		bindingModeWffc         storagev1.VolumeBindingMode
+		bindingModeImm          storagev1.VolumeBindingMode
+		topologyAffinityDetails map[string][]string
+		topologyCategories      []string
+		leafNode                int
+		leafNodeTag0            int
+		leafNodeTag1            int
+		leafNodeTag2            int
+		topologyLength          int
+		scParameters            map[string]string
+		accessmode              v1.PersistentVolumeAccessMode
+		labelsMap               map[string]string
+		replica                 int32
+		createPvcItr            int
+		createDepItr            int
+		pvs                     []*v1.PersistentVolume
+		pvclaim                 *v1.PersistentVolumeClaim
+		pv                      *v1.PersistentVolume
+	)
+
+	ginkgo.BeforeEach(func() {
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// connecting to vc
+		bootstrap()
+
+		// fetch list of k8s nodes
+		nodeList, err := fnodes.GetReadySchedulableNodes(ctx, f.ClientSet)
+		framework.ExpectNoError(err, "Unable to find ready and schedulable Node")
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+
+		//global variables
+		scParameters = make(map[string]string)
+		labelsMap = make(map[string]string)
+		accessmode = v1.ReadWriteMany
+		bindingModeWffc = storagev1.VolumeBindingWaitForFirstConsumer
+		bindingModeImm = storagev1.VolumeBindingImmediate
+
+		// read topology map
+		topologyLength, leafNode, leafNodeTag0, leafNodeTag1, leafNodeTag2 = 5, 4, 0, 1, 2
+		topologyMap := GetAndExpectStringEnvVar(topologyMap)
+		topologyAffinityDetails, topologyCategories = createTopologyMapLevel5(topologyMap,
+			topologyLength)
+
+		//setting map values
+		labelsMap["app"] = "test"
+		scParameters[scParamFsType] = nfs4FSType
+	})
+
+	ginkgo.AfterEach(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ginkgo.By("Perform cleanup if any resource left in the setup before starting a new test")
+
+		// perfrom cleanup of old stale entries of storage class if left in the setup
+		storageClassList, err := client.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(storageClassList.Items) != 0 {
+			for _, sc := range storageClassList.Items {
+				gomega.Expect(client.StorageV1().StorageClasses().Delete(ctx, sc.Name,
+					*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		// perfrom cleanup of old stale entries of statefulset if left in the setup
+		statefulsets, err := client.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(statefulsets.Items) != 0 {
+			for _, sts := range statefulsets.Items {
+				gomega.Expect(client.AppsV1().StatefulSets(namespace).Delete(ctx, sts.Name,
+					*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		// perfrom cleanup of old stale entries of nginx service if left in the setup
+		err = client.CoreV1().Services(namespace).Delete(ctx, servicename, *metav1.NewDeleteOptions(0))
+		if !apierrors.IsNotFound(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		// perfrom cleanup of old stale entries of pvc if left in the setup
+		pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(pvcs.Items) != 0 {
+			for _, pvc := range pvcs.Items {
+				gomega.Expect(client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name,
+					*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		// perfrom cleanup of old stale entries of any deployment entry if left in the setup
+		depList, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(depList.Items) != 0 {
+			for _, dep := range depList.Items {
+				err := client.AppsV1().Deployments(namespace).Delete(ctx, dep.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}
+
+		// perfrom cleanup of old stale entries of pv if left in the setup
+		pvs, err := client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if len(pvs.Items) != 0 {
+			for _, pv := range pvs.Items {
+				gomega.Expect(client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name,
+					*metav1.NewDeleteOptions(0))).NotTo(gomega.HaveOccurred())
+			}
+		}
+	})
+
+	/*
+		TESTCASE-1
+		Deployment Pods with multiple replicas attached to single RWX PVC
+
+		Steps:
+		1. Create a StorageClass with BindingMode set to Immediate with no allowed topologies
+		specified and with fsType as "nfs4"
+		2. Create one PVC with "RWX" access mode.
+		3. Wait for PVC to reach Bound state.
+		4. Create deployment Pods with replica count 3 and attach it to above PVC.
+		5. Wait for deployment Pods to reach Running state.
+		6. As the SC lacks a specific topology, volume provisioning and Pod placement can occur in any AZ.
+		7. Perform cleanup by deleting Pods, PVCs, and the SC.
+	*/
+
+	ginkgo.It("Deployment pods with multiple replicas attached to a "+
+		"single rwx pvc", ginkgo.Label(p0, file, vanilla, level5, level2, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// deployment pod and pvc count
+		replica = 3
+		createPvcItr = 1
+		createDepItr = 1
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with "+
+			"no allowed topology specified", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, nil, bindingModeImm, false, accessmode, "", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// taking pvclaims and pvs 0th index because we are creating only single RWX PVC in this case
+		pvclaim = pvclaims[0]
+		pv = pvs[0]
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create Deployment")
+		deploymentList, _, err := createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, false, labelsMap,
+			pvclaim, nil, execRWXCommandPod, nginxImage, false, nil, createDepItr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			framework.Logf("Delete deployment set")
+			err := client.AppsV1().Deployments(namespace).Delete(ctx, deploymentList[0].Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+	})
+
+	/*
+		TESTCASE-2
+		StatefulSet Pods with multiple replicas attached to multiple RWX PVCs with scaling operation
+
+		Steps:
+		1. Create a StorageClass with BindingMode set to WFFC with no allowed topologies specified and with fsType as "nfs4"
+		2. Use the SC to deploy a StatefulSet with 3 replicas, ReadWriteMany access mode, and Parallel pod management policy.
+		Allow time for PVCs and Pods to reach Bound and Running states, respectively.
+		3. Increase StatefulSet replica count to 5. Verify scaling operation.
+		4. Decrease replica count to 1. Verify smooth scaling operation.
+		5. As the SC lacks a specific topology, volume provisioning and Pod placement will occur in any available
+		availability zones (AZs) for new Pod and PVC.
+		6. Perform cleanup by deleting Pods, PVCs, and the SC.
+	*/
+
+	ginkgo.It("Scaling operations involving statefulSet pods with multiple replicas, "+
+		"each connected to rwx pvcs", ginkgo.Label(p0, file, vanilla, level5, level2, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// pod replica count
+		stsReplicas := 3
+		scaleUpReplicaCount := 5
+		scaleDownReplicaCount := 1
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with no "+
+			"allowed topology specified and with WFFC binding mode", accessmode, nfs4FSType))
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters, nil, "", bindingModeWffc, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet with replica count 3 with RWX PVC access mode")
+		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, true,
+			int32(stsReplicas), false, nil, false, false, false, accessmode, sc, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			fss.DeleteAllStatefulSets(ctx, client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets")
+		err = performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, int32(scaleUpReplicaCount),
+			int32(scaleDownReplicaCount), statefulset, false, namespace, nil, true, true, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/*
+		TESTCASE-3
+		Multiple standalone pods are connected to a single RWX PVC, with each pod configured to
+		have distinct read/write access permissions
+		SC → WFC Binding Mode with allowed topology specified i.e. region-1 > zone-1 > building-1 > level-1 > rack-3
+
+		Steps:
+		1. Create a Storage Class with BindingMode set to WFC and allowed topologies set to
+		   region-1 > zone-1 > building-1 > level-1 > rack-3
+		2. Create RWX PVC using the SC created above.
+		3. Wait for PVC to reach Bound state.
+		4. Volume provisioning should happen on the datastore of the allowed topology as given in the SC.
+		5. Create 3 standalone Pods using the PVC created in step #2.
+		6. For Pod1 and Pod2 set read/write access and try reading/writing data into the volume.
+		For the 3rd Pod set readOnly mode to true and verify that any write operation by Pod3 onto the volume
+		should fail with an appropriate error message.
+		7. Wait for Pods to reach Running Ready state.
+		8. Pods can be created on any AZ.
+		9. Perform cleanup by deleting Pod,PVC and SC.
+
+	*/
+
+	ginkgo.It("Multiple standalone pods attached to a single rwx "+
+		"pvc", ginkgo.Label(p0, file, vanilla, level5, level2, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// standalone pod and pvc count
+		noPodsToDeploy := 3
+		createPvcItr = 1
+
+		// Create allowed topologies for Storage Class: region1 > zone1 > building1 > level1 > rack > rack3
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag2)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with allowed "+
+			"topology set to cluster-3", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap, scParameters,
+			diskSize, allowedTopologyForSC, bindingModeWffc, false, accessmode, "", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		// taking pvclaims 0th index because we are creating only single RWX PVC in this case
+		pvclaim = pvclaims[0]
+
+		ginkgo.By("Create 3 standalone Pods using the same PVC with different read/write permissions")
+		podList, err := createStandalonePodsForRWXVolume(client, ctx, namespace, nil, pvclaim, false, execRWXCommandPod,
+			noPodsToDeploy)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err := fpod.DeletePodWithWait(ctx, client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// taking pvs 0th index because we are creating only single RWX PVC in this case
+		pv = pvs[0]
+
+		ginkgo.By("Verify volume placement, should match with the allowed topology specified")
+		_, _, datastoreUrlsRack3, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isCorrectPlacement := e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle, datastoreUrlsRack3)
+		gomega.Expect(isCorrectPlacement).To(gomega.BeTrue(), fmt.Sprintf("Volume provisioning has happened on the wrong "+
+			"datastore. Expected 'true', got '%v'", isCorrectPlacement))
+	})
+
+	/*
+		TESTCASE-4
+		Deployment Pods with multiple replicas attached to single RWX PVC with vSAN storage policy of rack-1
+		defined in SC along with top level allowed topology
+		SC → Immediate Binding Mode with allowed topology specified as region-1 > zone-1 > building-1
+		and Storage policy specified which is tagged to datastore in rack-1 (vSAN DS)
+
+		Steps:
+		1. Create a Storage Class with immediate Binding mode and allowed topology set to region-1 > zone-1 > building-1.
+		2. Set a Storage policy specific to datastore in rack-1 (vSAN tagged Storage Policy) in SC.
+		3. Create a RWX PVC using the Storage Class created in step #1.
+		4. Wait for PVC to reach Bound state.
+		5. Volume provisioning should happen on the datastore of the allowed topology as given in the SC.
+		6. Create deployment Pod with relica count 3 using the PVC created in step #3.
+		7. Set node selector teams so that all Pods should get created on rack-1
+		8. Wait for deployment Pod to reach running ready state.
+		9. Deployment Pods should get created on any worker node of AZ1.
+		10. Verify CNS metadata for PVC and Pod.
+		11. Perform scaleup operation on deployment Pods. Increase the replica count from 3 to 6.
+		12. Verify scaling operation should go fine.
+		13. Perform scale down operation on deployment Pods. Decrease the replica count from 6 to 2.
+		14. Verify scale down operation went smooth.
+		15. Perform cleanup by deleting Pods, PVCs and SC.
+	*/
+
+	ginkgo.It("Deployment Pods attached to single RWX PVC with vSAN storage policy of rack-1 "+
+		"defined in SC along with top level allowed topology "+
+		"specified", ginkgo.Label(p0, file, vanilla, level5, level2, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// deployment pod and pvc count
+		replica = 3
+		createPvcItr = 1
+		createDepItr = 1
+
+		//storage policy read of cluster-1(rack-1)
+		storagePolicyName := GetAndExpectStringEnvVar(envVsanDsStoragePolicyCluster1)
+		scParameters["storagepolicyname"] = storagePolicyName
+
+		ginkgo.By("Set node selector term for deployment pods so that all pods should get created on one single " +
+			"AZ i.e. cluster-1(rack-1)")
+		allowedTopologies := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag0)[4:]
+		nodeSelectorTerms, err := getNodeSelectorMapForDeploymentPods(allowedTopologies)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Get allowed topologies for Storage Class (region1 > zone1 > building1)
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories, 3)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with higher "+
+			"level allowed topology", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap, scParameters,
+			diskSize, allowedTopologyForSC, bindingModeImm, false, accessmode, "", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, storagePolicyName, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// taking pvclaims and pvs 0th index because we are creating only single RWX PVC in this case
+		pvclaim = pvclaims[0]
+		pv = pvs[0]
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume placement, it should get created on the datastore as taken in the SC")
+		datastoreUrlsRack1, _, _, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isCorrectPlacement := e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle, datastoreUrlsRack1)
+		gomega.Expect(isCorrectPlacement).To(gomega.BeTrue(), fmt.Sprintf("Volume provisioning has happened on "+
+			"the wrong datastore. Expected 'true', got '%v'", isCorrectPlacement))
+
+		ginkgo.By("Create Deployments and specify node selector terms")
+		deploymentList, pods, err := createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, false, labelsMap,
+			pvclaim, nodeSelectorTerms, execRWXCommandPod, nginxImage, false, nil, createDepItr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			framework.Logf("Delete deployment set")
+			err := client.AppsV1().Deployments(namespace).Delete(ctx, deploymentList[0].Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify deployment pods are scheduled on a specified node selector terms")
+		err = verifyDeploymentPodNodeAffinity(ctx, client, namespace, allowedTopologies, pods)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scale up deployment to 6 replica")
+		replica = 6
+		deploymentList, pods, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica,
+			true, labelsMap, pvclaim, nodeSelectorTerms, execRWXCommandPod, nginxImage, true, deploymentList[0], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify deployment pods are scheduled on a specified node selector terms")
+		err = verifyDeploymentPodNodeAffinity(ctx, client, namespace, allowedTopologies, pods)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scale down deployment to 1 replica")
+		replica = 1
+		deploymentList, pods, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, true,
+			labelsMap, pvclaim, nodeSelectorTerms, execRWXCommandPod, nginxImage,
+			true, deploymentList[0], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify volume metadata for deployment pod, pvc and pv")
+		err = waitAndVerifyCnsVolumeMetadata(ctx, pv.Spec.CSI.VolumeHandle, pvclaim, pv, &pods.Items[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/*
+		TESTCASE-5
+		Deployment Pods with multiple replicas attached to single RWX PVC
+		SC → Immediate Binding Mode with allowed topology specified  as
+		region-1 > zone-1 > building-1 > levl-1 > rack-2/rack-3
+		and datastore url specified which is shared across rack-2 and rack-3 (Non-vSAN FS datastore)
+
+		Steps:
+		1. Create a Storage Class with binding mode set to Immediate and with allowed topology set to
+		region-1 > zone-1 > building-1 > levl-1 > rack-2/rack-3 for level-5
+		2. Set datastore url shared across rack-2 and rack-3 (take a datastore which is not file Share compatible)
+		3. Create RWX PVC using the SC created above.
+		4. PVC creation will be stuck in a Pending state with an appropriate error due to
+		non-VSAN FS datastore used.
+		5. Perform cleanup by deleting PVC, SC.
+	*/
+
+	ginkgo.It("RWX PVC created with non VSAN FS compatible "+
+		"datastore", ginkgo.Label(p1, file, vanilla, level5, level2, newTest, negative), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// non vSAN FS compatible datastore
+		dsUrl := GetAndExpectStringEnvVar(envNonVsanDsUrl)
+		scParameters["datastoreurl"] = dsUrl
+		expectedErrMsg := "not found in candidate list for volume provisioning"
+
+		/* Get allowed topologies for Storage Class
+		region1 > zone1 > building1 > level1 > rack > (rack2 and rack3)
+		Taking Shared datstore which is not vSAN compatible between Rack2 and Rack3 */
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag1, leafNodeTag2)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with allowed "+
+			"topolgies specified as cluster-2/cluster-3 "+
+			"and non-compatible shared datastore", accessmode, nfs4FSType))
+		storageclass, pvclaim, err := createPVCAndStorageClass(ctx, client, namespace, labelsMap, scParameters,
+			diskSize, allowedTopologyForSC,
+			bindingModeImm, false, accessmode)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Expect claim to fail provisioning volume since no valid VSAN datastore is specified in storage class")
+		err = fpv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute/2)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
+		isFailureFound := checkEventsforError(client, namespace,
+			metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvclaim.Name)}, expectedErrMsg)
+		gomega.Expect(isFailureFound).To(gomega.BeTrue(), "Unable to verify pvc create failure")
+	})
+
+	/*
+		TESTCASE-6
+		Deployment Pod creation
+		SC → Immediate Binding Mode with allowed topology specified as region-1 > zone-1 > building-1 > level-1 > rack-3 and
+		storage policy specified which is tagged to datastore in rack-3 (vSAN DS)
+
+		Steps:
+		1. Create a Storage Class with volumeBindingMode set to Immediate and specify allowed topologies for the SC, such as
+		region-1 > zone-1 > building-1 > level-1 > rack-3 and a storage policy specific to cluster3 (rack-3).
+		2. Create a PVC with accessmode set to "RWX".
+		3. Verify volume provisioning should happen on the SC allowed topology.
+		3. Create a deployment Pod with node selector term set to rack-2 using the PVC created
+		in step 2 with a replica count of 1 and configured with ReadWriteMany (RWX) access mode.
+		4. Deployment Pod should get created on the given AZ as specified in the node selector term of deployment pod.
+		5. Verify CNS metadata for PVC and Pod.
+		7. Scaleup deployment pod replica count to 3.
+		8. Verify deployment pod scaling operation went smooth.
+		9. New deployment Pod should get created on the given AZ as specified in the node selector term of deployment pod.
+		6. Perform cleanup by deleting deployment Pod, PVC and SC.
+	*/
+
+	ginkgo.It("RWX volume creation on one zone and pods scheduled on another zone with "+
+		"immediate mode set in SC", ginkgo.Label(p0, file, vanilla, level5, level2, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// deployment pod and pvc count
+		replica = 1
+		createPvcItr = 1
+		createDepItr = 1
+
+		// storage policy of cluster-3(rack-3)
+		storagePolicyName := GetAndExpectStringEnvVar(envVsanDsStoragePolicyCluster3)
+		scParameters["storagepolicyname"] = storagePolicyName
+
+		// Node selector term for deployment Pod region1 > zone1 > building1 > level1 > rack2
+		ginkgo.By("Set specific allowed topology for node selector terms")
+		allowedTopologies := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag1)
+		nodeSelectorTerms, err := getNodeSelectorMapForDeploymentPods(allowedTopologies)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Get allowed topologies for Storage Class region1 > zone1 > building1 > level1 > rack3
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag2)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with allowed "+
+			"topology specified to cluster3", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace,
+			labelsMap, scParameters, diskSize, allowedTopologyForSC, bindingModeImm, false, accessmode,
+			"", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, storagePolicyName, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		//taking pvclaims and pvs 0th index because we are creating only single RWX PVC in this case
+		pvclaim = pvclaims[0]
+		pv = pvs[0]
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		}()
+
+		ginkgo.By("Verify volume placement")
+		_, _, datastoreUrlsRack3, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isCorrectPlacement := e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle, datastoreUrlsRack3)
+		gomega.Expect(isCorrectPlacement).To(gomega.BeTrue(), fmt.Sprintf("Volume provisioning has "+
+			"happened on the wrong datastore. Expected 'true', got '%v'", isCorrectPlacement))
+
+		ginkgo.By("Create Deployment pod with node selector terms specific to rack-2 but sc allowed topology set to rack-3")
+		deploymentList, pods, err := createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, false,
+			labelsMap, pvclaim, nodeSelectorTerms, execRWXCommandPod, nginxImage, false, nil, createDepItr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			framework.Logf("Delete deployment set")
+			err := client.AppsV1().Deployments(namespace).Delete(ctx, deploymentList[0].Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume metadata for deployment pod, pvc and pv")
+		err = waitAndVerifyCnsVolumeMetadata(ctx, pv.Spec.CSI.VolumeHandle, pvclaim, pv, &pods.Items[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify deployment pods are scheduled on a specified node selector terms")
+		err = verifyDeploymentPodNodeAffinity(ctx, client, namespace, allowedTopologies, pods)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scale up deployment to 3 replica")
+		replica = 3
+		deploymentList, pods, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica,
+			true, labelsMap, pvclaim, nodeSelectorTerms, execRWXCommandPod,
+			nginxImage, true, deploymentList[0], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify deployment pods are scheduled on a specified node selector terms")
+		err = verifyDeploymentPodNodeAffinity(ctx, client, namespace, allowedTopologies, pods)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	})
+
+	/*
+		TESTCASE-7
+		StatefulSet Workload with Parallel Pod Management and Scale-Up/Scale-Down Operations
+		SC → WFC Binding Mode with allowed topology specified as region-1 > zone-1
+
+		Steps:
+		1. Create a Storage Class with volumeBindingMode set to WFFC and specify allowed topology (e.g., region-1 > zone-1).
+		2. Create statefulSet with 3 replicas, each configured with ReadWriteMany (RWX) access mode
+		and with parallel Pod management policy and specify pod affinity
+		3. Ensure that all the PVCs and Pods are successfully created.
+		-  The PVCs should be created in any available Availability Zone (AZ).
+		-  The Pods should be created in any AZ
+		4. Increase the replica count of statefulset to 5.
+		5. Decrease the replica count of statefulset to 1
+		6. Verify that the scaling up and scaling down of the StatefulSet is successful.
+		7. Volume provisioning and Pod placement will occur in the available availability
+		zones (AZs) specified in the SC during the scale-up operation.
+		8. Verify CNS metadata for any one PVC and Pod.
+		9. Perform cleanup by deleting StatefulSet, PVCs, and SC
+	*/
+
+	ginkgo.It("Statefulset creation with RWX PVCs with top level allowed "+
+		"topology specified", ginkgo.Label(p1, file, vanilla, level5, level2, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stsReplicas := 3
+		scaleUpReplicaCount := 5
+		scaleDownReplicaCount := 1
+
+		// Get allowed topologies for Storage Class (region1 > zone1)
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories, 2)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and "+
+			"fstype %q with allowed topology specified at top level "+
+			"and with WFFC binding mode", accessmode, nfs4FSType))
+		scSpec := getVSphereStorageClassSpec(defaultNginxStorageClassName, scParameters,
+			allowedTopologyForSC, "", bindingModeWffc, false)
+		sc, err := client.StorageV1().StorageClasses().Create(ctx, scSpec, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err = client.StorageV1().StorageClasses().Delete(ctx, sc.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Create StatefulSet with replica count 3 with RWX PVC access mode with pod affinity set to true")
+		service, statefulset, err := createStafeulSetAndVerifyPVAndPodNodeAffinty(ctx, client, namespace, true,
+			int32(stsReplicas), false, allowedTopologyForSC, true, false, false, accessmode, sc, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			fss.DeleteAllStatefulSets(ctx, client, namespace)
+			deleteService(namespace, client, service)
+		}()
+
+		ginkgo.By("Verify volume placement, should match with the allowed topology specified")
+		_, _, _, datastoreUrls, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = volumePlacementVerificationForSts(ctx, client, statefulset, namespace, datastoreUrls)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Perform scaleup/scaledown operation on statefulsets")
+		err = performScalingOnStatefulSetAndVerifyPvNodeAffinity(ctx, client, int32(scaleUpReplicaCount),
+			int32(scaleDownReplicaCount),
+			statefulset, false, namespace, nil, true, true, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	/*
+		TESTCASE-8
+		Storage Class Creation with Invalid Label Details in One Level
+		SC → Immediate Binding Mode with invalid allowed topology specified  i.e.
+		region-1 > zone-1 > building-1 > level-1 > rack-15
+
+		Steps:
+		1. Create a Storage Class with invalid label details, specifically using a label path such as
+		"region-1 > zone-1 > building-1 > level-1 > rack-15"
+		2. Create a PVC) using the SC created in step #1 with RWX access mode.
+		3. As the label path is invalid, an appropriate error message should be displayed.
+		4. Perform cleanup by deleting PVC and SC.
+	*/
+
+	ginkgo.It("Storage class created with invalid allowed "+
+		"topology", ginkgo.Label(p2, file, vanilla, level5, level2, stable, negative, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		expectedErrMsg := "failed to fetch vCenter associated with topology segments"
+
+		// Get allowed topologies for Storage Class
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength)
+		allowedTopologyForSC[4].Values = []string{"rack15"}
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with invalid "+
+			"allowed topolgies specified", accessmode, nfs4FSType))
+		storageclass, pvclaim, err := createPVCAndStorageClass(ctx, client, namespace, labelsMap, scParameters, "",
+			allowedTopologyForSC, "", false, accessmode)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Expect claim to fail provisioning volume since invalid allowed topology is specified in the storage class")
+		err = fpv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute/2)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
+		isFailureFound := checkEventsforError(client, namespace,
+			metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvclaim.Name)}, expectedErrMsg)
+		gomega.Expect(isFailureFound).To(gomega.BeTrue(), "Unable to verify pvc create failure")
+	})
+
+	/*
+		TESTCASE-9
+		Create Storage Class with a single label in allowed topology
+		SC → Immediate Binding Mode with specific allowed topology specified  i.e. k8s-rack > rack-1
+
+		Steps:
+		1. Create a Storage Class with only one level of topology details specified i.e. k8s-rack > rack-1.
+		2. Create a PVC using the SC created in step #1, with ReadWriteMany (RWX) access mode.
+		3. Wait for PVC to reach Bound state.
+		4. Create deployment Pod with replica count 1 and specify node selector as same as allowed topology of SC.
+		5. Wait for deployment Pod to be in running state.
+		6. PVC should get created on the AZ as specified in the SC allowed topology and the Pod
+		 placement should happen on the AZ as specified in the node selector terms.
+		7. Increase the replica count to 3.
+		8. Wait for new pods to be in running state.
+		9. New Pods should get created on the same AZ as specified in the node selector term of deployment.
+		7. Perform cleanup by deleting Pods, PVC and SC.
+	*/
+
+	ginkgo.It("Deployment pod creation with RWX pvc having only single level in "+
+		"allowed topology", ginkgo.Label(p1, file, vanilla, level5, level2, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// deployment pod and pvc count
+		replica = 1
+		createPvcItr = 1
+		createDepItr = 1
+
+		// Get allowed topologies for Storage Class (rack > rack1)
+		ginkgo.By("Set node selector term for deployment pods so that all pods should get created " +
+			"on one single AZ i.e. cluster-1(rack-1)")
+		allowedTopologies := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag0)[4:]
+		nodeSelectorTerms, err := getNodeSelectorMapForDeploymentPods(allowedTopologies)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with allowed topology "+
+			"specified to single level cluster-1", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, allowedTopologies, bindingModeImm, false, accessmode, "", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		//taking pvclaims and pvs 0th index because we are creating only single RWX PVC in this case
+		pvclaim = pvclaims[0]
+		pv = pvs[0]
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume placement, should match with the allowed topology specified")
+		datastoreUrlsRack1, _, _, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isCorrectPlacement := e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle, datastoreUrlsRack1)
+		gomega.Expect(isCorrectPlacement).To(gomega.BeTrue(), fmt.Sprintf("Volume provisioning has happened on "+
+			"the wrong datastore. Expected 'true', got '%v'", isCorrectPlacement))
+
+		ginkgo.By("Create Deployment")
+		deploymentList, pods, err := createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, false, labelsMap,
+			pvclaim, nodeSelectorTerms, execRWXCommandPod, nginxImage, false, nil, createDepItr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			framework.Logf("Delete deployment set")
+			err := client.AppsV1().Deployments(namespace).Delete(ctx, deploymentList[0].Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Verify volume metadata for deployment pod, pvc and pv")
+		err = waitAndVerifyCnsVolumeMetadata(ctx, pv.Spec.CSI.VolumeHandle, pvclaim, pv, &pods.Items[0])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify deployment pods are scheduled on a specified node selector terms")
+		err = verifyDeploymentPodNodeAffinity(ctx, client, namespace, allowedTopologies, pods)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scale up deployment to 3 replica")
+		replica = 3
+		deploymentList, pods, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica,
+			true, labelsMap, pvclaim, nodeSelectorTerms, execRWXCommandPod, nginxImage, true, deploymentList[0], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify deployment pods are scheduled on a specified node selector terms")
+		err = verifyDeploymentPodNodeAffinity(ctx, client, namespace, allowedTopologies, pods)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	})
+
+	/*
+		TESTCASE-10
+		Create Storage Class with a single label in allowed topology and with datastore url
+		SC → top level allowed topology specified i.e. k8s-region:region-1 with WFC Binding mode and
+		datastore url passed (vSAN ds of rack-3)
+
+		Steps:
+		1. Create Storage Class with only top level of topology details specified i.e. region-1
+		2. Create PVC using the Storage Class created in step #1, with ReadWriteMany (RWX) access mode.
+		3. Wait for PVC to reach Bound state.
+		4. Create multiple Pods using the PVC created in the step #2 with node selector term specific to rack-3
+		5. Wait for Pod to be in running state.
+		6. PVC should get created on the AZ as specified in the SC allowed topology
+		and the Pod placement should happen on any AZ.
+		7. Perform cleanup by deleting Pods,PVC and SC.
+	*/
+
+	ginkgo.It("RWX Pvc creation with single level allowed topology "+
+		"passed with datastore url", ginkgo.Label(p0, file, vanilla, level5, level2, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// variable declaration
+		var pvs []*v1.PersistentVolume
+		var pvclaim *v1.PersistentVolumeClaim
+		var pv *v1.PersistentVolume
+
+		// pvc and pod count
+		createPvcItr = 1
+		no_pods_to_deploy := 3
+
+		// vSAN datastore url of cluster-3(rack-3)
+		datastoreurl := GetAndExpectStringEnvVar(envVsanDsUrlCluster3)
+		scParameters[scParamDatastoreURL] = datastoreurl
+
+		// Create allowed topologies for Storage Class: k8s-region > region-1
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories, 1)
+
+		ginkgo.By("Set node selector term for standlone pods so that all pods should get " +
+			"created on one single AZ i.e. cluster-3(rack-3)")
+		allowedTopologies := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag2)
+		nodeSelectorTerms, err := getNodeSelectorMapForDeploymentPods(allowedTopologies)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with allowed "+
+			"topology set at the top level", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, nil, scParameters, diskSize,
+			allowedTopologyForSC, bindingModeWffc, false, accessmode, "", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		//taking pvclaims 0th index because we are creating only single RWX PVC in this case
+		pvclaim = pvclaims[0]
+
+		ginkgo.By("Create 3 standalone Pods using the same PVC")
+		podList, err := createStandalonePodsForRWXVolume(client, ctx, namespace, nodeSelectorTerms, pvclaim, false,
+			execRWXCommandPod, no_pods_to_deploy)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			for i := 0; i < len(podList); i++ {
+				ginkgo.By(fmt.Sprintf("Deleting the pod %s in namespace %s", podList[i].Name, namespace))
+				err := fpod.DeletePodWithWait(ctx, client, podList[i])
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", datastoreurl)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		//taking pvs 0th index because we are creating only single RWX PVC in this case
+		pv = pvs[0]
+
+		ginkgo.By("Verify volume placement, should match with the allowed topology specified")
+		_, _, datastoreUrlsRack3, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		isCorrectPlacement := e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle, datastoreUrlsRack3)
+		gomega.Expect(isCorrectPlacement).To(gomega.BeTrue(), fmt.Sprintf("Volume provisioning has happened on the "+
+			"wrong datastore. Expected 'true', got '%v'", isCorrectPlacement))
+
+		ginkgo.By("Verify standalone pods are scheduled on a selected node selector terms")
+		for i := 0; i < len(podList); i++ {
+			err = verifyStandalonePodAffinity(ctx, client, podList[i], allowedTopologies)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+	})
+
+	/*
+		TESTCASE-11
+		Volume expansion on file volumes
+		SC → all levels of topology details with Immediate Binding mode
+
+		Steps:
+		1. Create Storage Class with all levels of topology details specified in the
+		Storage Class and with Immediate Binding mode.
+		2. Create PVC with RWX access mode using SC created above.
+		3. Verify that the PVC transitions to the Bound state and PVC is created in any of the Availability Zone.
+		4. Trigger Offline Volume Expansion on the PVC created in step #2
+		5. Verify that the PVC resize operation fails with an appropriate error message, as
+		volume expansion is not supported for File Volumes.
+		6. Perform Cleanup by deleting PVC and SC.
+	*/
+
+	ginkgo.It("Volume expansion on file "+
+		"volumes", ginkgo.Label(p2, file, vanilla, level5, level2, negative, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		expectedErrMsg := "volume expansion is only supported for block volume type"
+
+		// Get allowed topologies for Storage Class i.e. region1 > zone1 > building1 > level1 > rack > rack1/rack2/rack3
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories, topologyLength)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q and set allowVolumeExpansion "+
+			"to true with all allowed topolgies specified", accessmode, nfs4FSType))
+		storageclass, pvclaim, err := createPVCAndStorageClass(ctx, client, namespace, labelsMap, scParameters,
+			diskSize, allowedTopologyForSC, bindingModeImm, true, accessmode)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Wait for PVC and PV to reach Bound state")
+		_, err = fpv.WaitForPVClaimBoundPhase(ctx, client, []*v1.PersistentVolumeClaim{pvclaim},
+			framework.ClaimProvisionTimeout)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Modify PVC spec to trigger volume expansion, Expect to fail as file volume expansion is not supported")
+		currentPvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
+		newSize := currentPvcSize.DeepCopy()
+		newSize.Add(resource.MustParse("3Gi"))
+		framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
+
+		newPVC, err := expandPVCSize(pvclaim, newSize, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		pvclaim = newPVC
+		gomega.Expect(pvclaim).NotTo(gomega.BeNil())
+
+		pvcSize := pvclaim.Spec.Resources.Requests[v1.ResourceStorage]
+		if pvcSize.Cmp(newSize) != 0 {
+			framework.Failf("error updating pvc size %q", pvclaim.Name)
+		}
+
+		ginkgo.By("Verify if controller resize failed")
+		err = waitForPvResizeForGivenPvc(pvclaim, client, pollTimeoutShort)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+
+		ginkgo.By("Volume expansion should fail for file volume")
+		ginkgo.By(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
+		isFailureFound := checkEventsforError(client, namespace,
+			metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvclaim.Name)}, expectedErrMsg)
+		gomega.Expect(isFailureFound).To(gomega.BeTrue(),
+			fmt.Sprintf("Expected pvc creation failure with error message: %s", expectedErrMsg))
+	})
+
+	/*
+		TESTCASE-12
+		PVC creation using shared datastore lacking capability of vSAN FS
+		SC → default values, shared datastore url passed shared across all AZs
+		lacking vSAN FS capability, Immediate Binding mode
+
+		Steps:
+		1. Create a Storage Class with default values and pass datastore Url shared across all AZs but
+		lacking the vSAN FS capability with Immediate binding mode.
+		2. Create a PVC using the SC created in step #1, with ReadWriteMany (RWX) access mode.
+		3. PVC should get stuck in Pending state with appropriate error message because the datastore
+		url passed in SC is not vSAN FS enabled datastore
+		4. Perform cleanup by deleting PVC and SC
+	*/
+
+	ginkgo.It("RWX Pvc creation using shared datastore lacking "+
+		"capability of vSAN FS", ginkgo.Label(p2, file, vanilla, level5, level2, negative, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		datastoreurl := GetAndExpectStringEnvVar(envNonVsanDsUrl)
+		scParameters[scParamDatastoreURL] = datastoreurl
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with no allowed "+
+			"topolgies specified", accessmode, nfs4FSType))
+		storageclass, pvclaim, err := createPVCAndStorageClass(ctx, client, namespace, labelsMap, scParameters,
+			diskSize, nil, bindingModeImm, false, accessmode)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Expect claim to fail provisioning volume since no valid VSAN datastore is specified in storage class")
+		err = fpv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute/2)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		expectedErrMsg := "failed to provision volume with StorageClass \"" + storageclass.Name + "\""
+		ginkgo.By(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
+		isFailureFound := checkEventsforError(client, namespace,
+			metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvclaim.Name)}, expectedErrMsg)
+		gomega.Expect(isFailureFound).To(gomega.BeTrue(), "Unable to verify pvc create failure")
+	})
+
+	/*
+		TESTCASE-13
+		Allowed topology specifies rack-2, but the storage policy is provided from rack-3
+		SC → specific allowed topology i.e. k8s-rack:rack-2 and storage Policy specified tagged with
+		rack-3 datastore
+
+		Steps:
+		1. Create a Storage Class  with specific allowed topology (rack-2) and storage policy
+		tagged with rack-3 vSAN datastore
+		2. Create a PVC using the SC created in step #1, with ReadWriteMany (RWX) access mode.
+		3. PVC should get stuck in Pending state with an appropriate error message
+		4. Perform cleanup by deleting PVC and SC
+	*/
+
+	ginkgo.It("Allowed topology specific to one zone and storage polocy "+
+		"provided is from another zone", ginkgo.Label(p2, file, vanilla, level5, level2, negative, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		expectedErrMsg := "No compatible datastores found for storage policy"
+
+		// storage policy of rack3
+		storagePolicyName := GetAndExpectStringEnvVar(envVsanDsStoragePolicyCluster3)
+		scParameters["storagepolicyname"] = storagePolicyName
+
+		/* Get allowed topologies for Storage Class
+		(region1 > zone1 > building1 > level1 > rack > rack2) */
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag1)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q with no "+
+			"allowed topolgies specified", accessmode, nfs4FSType))
+		storageclass, pvclaim, err := createPVCAndStorageClass(ctx, client, namespace, labelsMap, scParameters,
+			diskSize, allowedTopologyForSC, bindingModeImm, false, accessmode)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+		defer func() {
+			err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaim.Name, namespace)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		ginkgo.By("Expect claim to fail provisioning volume since no valid datastore is specified in the storage class")
+		err = fpv.WaitForPersistentVolumeClaimPhase(ctx, v1.ClaimBound, client,
+			pvclaim.Namespace, pvclaim.Name, framework.Poll, time.Minute/2)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		ginkgo.By(fmt.Sprintf("Expected failure message: %+q", expectedErrMsg))
+		isFailureFound := checkEventsforError(client, namespace,
+			metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pvclaim.Name)}, expectedErrMsg)
+		gomega.Expect(isFailureFound).To(gomega.BeTrue(), "Unable to verify pvc create failure")
+	})
+
+	/*
+		TESTCASE-15
+		Deployment Pod with Scale-Up/Scale-Down Operations
+		SC → WFC Binding Mode with allowed topology specified i.e.
+		region-1 > zone-1 > building-1 > level-1 > rack-1 and rack-3
+
+		Steps:
+		1. Create Storage Class with WFFC binding mode and allowed topology set to
+		region-1 > zone-1 > building-1 > level-1 > rack-1 and rack-3
+		2. Create 4 PVCs with "RWX" access mode using SC created in step #1.
+		3. Wait for PVCs to reach to Bound state.
+		4. Create deployment Pod for each PVC with replica count 1.
+		5. Verify volume placement. Provisioning should happen as per the allowed topology specified in the SC.
+		6. Pods should get created on any AZ.
+		7. Perform scaling up operation on deployment pod. Increase the replica count to 5
+		8. New Pods should get created on any AZ. Volumes should get placed on the Az as given in the SC.
+		8. Verify scaling up operation went smooth.
+		9. Perform scale operation on deployment pod. Decrease the replica count to 2
+		10. Verify scaling down operation went smooth.
+		11. Perform cleanup by deleting Pods, PVC and SC
+	*/
+
+	ginkgo.It("Multiple deployment pods with scaling operation "+
+		"attached to rwx pvcs", ginkgo.Label(p0, file, vanilla, level5, level2, newTest), func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// variable declaration
+		var depl []*appsv1.Deployment
+
+		// pvc and deployment pod count
+		replica = 3
+		createPvcItr = 4
+		createDepItr = 4
+
+		/* Get allowed topologies for Storage Class
+		(region1 > zone1 > building1 > level1 > rack > rack1/rack3) */
+		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
+			topologyLength, leafNode, leafNodeTag0, leafNodeTag2)
+
+		ginkgo.By(fmt.Sprintf("Creating Storage Class with access mode %q and fstype %q", accessmode, nfs4FSType))
+		storageclass, pvclaims, err := createStorageClassWithMultiplePVCs(client, namespace, labelsMap,
+			scParameters, diskSize, allowedTopologyForSC, bindingModeWffc, false, accessmode,
+			"", nil, createPvcItr, false, false)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name, *metav1.NewDeleteOptions(0))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}()
+
+		defer func() {
+			for i := 0; i < len(pvclaims); i++ {
+				pv = getPvFromClaim(client, pvclaims[i].Namespace, pvclaims[i].Name)
+				err := fpv.DeletePersistentVolumeClaim(ctx, client, pvclaims[i].Name, namespace)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = e2eVSphere.waitForCNSVolumeToBeDeleted(pv.Spec.CSI.VolumeHandle)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Create Deployments")
+		for i := 0; i < len(pvclaims); i++ {
+			deploymentList, _, err := createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica, false, labelsMap,
+				pvclaims[i], nil, execRWXCommandPod, nginxImage, false, nil, createDepItr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			depl = append(depl, deploymentList...)
+		}
+		defer func() {
+			framework.Logf("Delete deployment set")
+			for i := 0; i < len(depl); i++ {
+				err := client.AppsV1().Deployments(namespace).Delete(ctx, depl[i].Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
+		}()
+
+		ginkgo.By("Verify PVC Bound state and CNS side verification")
+		pvs, err = checkVolumeStateAndPerformCnsVerification(ctx, client, pvclaims, "", "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Verify volume placement, should match with the allowed topology specified")
+		datastoreUrlsRack1, _, datastoreUrlsRack3, _, err := fetchDatastoreListMap(ctx, client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var datastoreUrls []string
+		datastoreUrls = append(datastoreUrls, datastoreUrlsRack1...)
+		datastoreUrls = append(datastoreUrls, datastoreUrlsRack3...)
+		for i := 0; i < len(pvs); i++ {
+			isCorrectPlacement := e2eVSphere.verifyPreferredDatastoreMatch(pvs[i].Spec.CSI.VolumeHandle, datastoreUrls)
+			gomega.Expect(isCorrectPlacement).To(gomega.BeTrue(), fmt.Sprintf("Volume provisioning has happened on the "+
+				"wrong datastore. Expected 'true', got '%v'", isCorrectPlacement))
+		}
+
+		ginkgo.By("Scale up deployment1 pods to 5 replicas")
+		replica = 3
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica,
+			true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, depl[0], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("Scale down deployment2 pods to 2 replica")
+		replica = 2
+		_, _, err = createVerifyAndScaleDeploymentPods(ctx, client, namespace, replica,
+			true, labelsMap, pvclaim, nil, execRWXCommandPod, nginxImage, true, depl[1], 0)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})

--- a/tests/e2e/preferential_topology.go
+++ b/tests/e2e/preferential_topology.go
@@ -121,7 +121,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// fetching cluster details
-		clusters, err = getTopologyLevel5ClusterGroupNames(masterIp, sshClientConfig, dataCenters)
+		clusters, err = getTopologyLevel5ClusterGroupNames(masterIp, sshClientConfig, dataCenters, 0)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// creating level-5 allowed topology map
@@ -141,11 +141,11 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// fetching list of datastores available in different racks
-		rack1DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[0])
+		rack1DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[0], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		rack2DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[1])
+		rack2DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[1], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		rack3DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[2])
+		rack3DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[2], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// fetching list of datastores which is specific to each rack
@@ -173,7 +173,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		}
 
 		//set preferred datatsore time interval
-		setPreferredDatastoreTimeInterval(client, ctx, csiNamespace, csiReplicas, false)
+		setPreferredDatastoreTimeInterval(client, ctx, csiNamespace, csiReplicas)
 
 		clientIndex = 0
 
@@ -190,11 +190,11 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		framework.Logf("Perform preferred datastore tags cleanup after test completion")
-		err = deleteTagCreatedForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks, false)
+		err = deleteTagCreatedForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Recreate preferred datastore tags post cleanup")
-		err = createTagForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks, false)
+		err = createTagForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		if isSPSServiceStopped {
@@ -244,13 +244,13 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datastore for volume provisioning in rack-2(cluster-2))")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastoreRack2 := preferredDatastorePaths[0]
 		defer func() {
 			ginkgo.By("Remove preferred datastore tag")
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastoreRack2,
-				allowedTopologyRacks[1], false, clientIndex)
+				allowedTopologyRacks[1], clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -297,24 +297,24 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack2, false, false, false, nil)
+			nonShareddatastoreListMapRack2, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false, false)
+			namespace, allowedTopologyForRack2, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// choose preferred datastore in rack-1
 		ginkgo.By("Tag preferred datatstore for volume provisioning in rack-1(cluster-1))")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			ginkgo.By("Remove preferred datastore tag")
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[0], false, clientIndex)
+				allowedTopologyRacks[0], clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -370,13 +370,13 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
-		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack1, false, nil)
+		verifyVolumeProvisioningForStandalonePods(client, pod, preferredDatastorePaths,
+			nonShareddatastoreListMapRack1, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack1, false)
+			allowedTopologyForRack1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -416,17 +416,17 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datastore for volume provisioning in rack-3(cluster-3))")
 		preferredDatastorePaths, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[2],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastore, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[2],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
 		defer func() {
 			ginkgo.By("Remove preferred datatsore tag")
 			for i := 0; i < len(preferredDatastorePaths); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
-					allowedTopologyRacks[2], false, clientIndex)
+					allowedTopologyRacks[2], clientIndex)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
@@ -474,31 +474,31 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			rack3DatastoreListMap, false, false, false, nil)
+			rack3DatastoreListMap, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack3, false, false)
+			namespace, allowedTopologyForRack3, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// perform statefulset scaleup
 		replicas = 10
 		ginkgo.By("Scale up statefulset replica count from 3 to 10")
-		err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			rack3DatastoreListMap, false, false, false, nil)
+			rack3DatastoreListMap, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack3, false, false)
+			namespace, allowedTopologyForRack3, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -541,18 +541,18 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-2(cluster-2))")
 		preferredDatastorePaths, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastoreChosen = 1
 		preferredDatastore, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
 		defer func() {
 			ginkgo.By("Remove preferred datastore tag")
 			for i := 0; i < len(preferredDatastorePaths); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
-					allowedTopologyRacks[1], false, clientIndex)
+					allowedTopologyRacks[1], clientIndex)
 			}
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
@@ -601,37 +601,37 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			rack2DatastoreListMap, false, false, false, nil)
+			rack2DatastoreListMap, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false, false)
+			namespace, allowedTopologyForRack2, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// perform statefulset scaleup
 		replicas = 10
 		ginkgo.By("Scale up statefulset replica count from 3 to 10")
-		err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			rack2DatastoreListMap, false, false, false, nil)
+			rack2DatastoreListMap, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false, false)
+			namespace, allowedTopologyForRack2, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// perform statefulset scaledown
 		replicas = 5
 		ginkgo.By("Scale down statefulset replica count from 10 to 5")
-		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -664,12 +664,12 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-1(cluster-1))")
 		preferredDatastorePaths, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			ginkgo.By("Remove preferred datatsore tag")
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[0], false, clientIndex)
+				allowedTopologyRacks[0], clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		}()
@@ -717,13 +717,13 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			shareddatastoreListMap, true, false, false, nil)
+			shareddatastoreListMap, true, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -757,7 +757,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-2(cluster-2))")
 		preferredDatastorePaths, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = tagSameDatastoreAsPreferenceToDifferentRacks(masterIp, sshClientConfig, allowedTopologyRacks[1],
 			preferredDatastoreChosen, preferredDatastorePaths)
@@ -766,9 +766,9 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			ginkgo.By("Remove preferred datatsore tag")
 			for j := 0; j < len(allowedTopologyRacks)-1; j++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-					allowedTopologyRacks[j], false, clientIndex)
+					allowedTopologyRacks[j], clientIndex)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
 		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
@@ -814,13 +814,13 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			shareddatastoreListMap, false, false, false, nil)
+			shareddatastoreListMap, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack2, false, false)
+			namespace, allowedTopologyForRack2, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -857,7 +857,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datatsore for volume provisioning")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		for i := 1; i < len(allowedTopologyRacks); i++ {
 			err = tagSameDatastoreAsPreferenceToDifferentRacks(masterIp, sshClientConfig, allowedTopologyRacks[i],
@@ -868,9 +868,10 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 			ginkgo.By("Remove preferred datatsore tag")
 			for j := 0; j < len(allowedTopologyRacks); j++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-					allowedTopologyRacks[j], false, clientIndex)
+					allowedTopologyRacks[j], clientIndex)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		}()
 
 		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
@@ -914,13 +915,13 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			shareddatastoreListMap, true, false, false, nil)
+			shareddatastoreListMap, true, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -953,12 +954,12 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datastore for volume provisioning")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[2],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			ginkgo.By("Remove the preferred datastore tag")
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[2], false, clientIndex)
+				allowedTopologyRacks[2], clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -1003,13 +1004,13 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			shareddatastoreListMap, true, false, false, nil)
+			shareddatastoreListMap, true, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -1050,7 +1051,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datastore for volume provisioning in rack-1(cluster-1))")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
@@ -1095,28 +1096,28 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack1, false, false, false, nil)
+			nonShareddatastoreListMapRack1, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack1, true, false)
+			namespace, allowedTopologyForRack1, true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Remove preferred datatsore tag which is chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-			allowedTopologyRacks[0], false, clientIndex)
+			allowedTopologyRacks[0], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Tag new preferred datastore from rack-1 for volume provisioning")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			ginkgo.By("Remove the datastore preference chosen for volume provisioning")
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[0], false, clientIndex)
+				allowedTopologyRacks[0], clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -1168,13 +1169,13 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
-		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, preferredDatastorePaths,
-			shareddatastoreListMap, false, nil)
+		verifyVolumeProvisioningForStandalonePods(client, pod, preferredDatastorePaths,
+			shareddatastoreListMap, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack1, false)
+			allowedTopologyForRack1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	})
@@ -1222,7 +1223,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datastore for volume provisioning in rack-3(cluster-3))")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[2],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastore := preferredDatastorePaths
 
@@ -1268,29 +1269,29 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack3, false, false, false, nil)
+			nonShareddatastoreListMapRack3, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack3, false, false)
+			namespace, allowedTopologyForRack3, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Remove preferred datatsore tag chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-			allowedTopologyRacks[2], false, clientIndex)
+			allowedTopologyRacks[2], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Tag new preferred datatsore for volume provisioning in rack-3")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[2],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack3, preferredDatastorePaths, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack3, preferredDatastorePaths, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			ginkgo.By("Remove preferred datatsore tag")
 			for i := 0; i < len(preferredDatastorePaths); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
-					allowedTopologyRacks[2], false, clientIndex)
+					allowedTopologyRacks[2], clientIndex)
 			}
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
@@ -1343,32 +1344,32 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
-		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack3, false, nil)
+		verifyVolumeProvisioningForStandalonePods(client, pod, preferredDatastorePaths,
+			nonShareddatastoreListMapRack3, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack3, false)
+			allowedTopologyForRack3)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// perform statefulset scaleup
 		sts1Replicas = 10
 		ginkgo.By("Scale up statefulset replica count from 3 to 10")
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
-		err = scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
+		err = scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		//verifying volume is provisioned on the preferred datastore
 		ginkgo.By("Verify volume is provisioned on the specified datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack3, false, true, false, nil)
+			nonShareddatastoreListMapRack3, false, true, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack3, true, false)
+			namespace, allowedTopologyForRack3, true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -1421,7 +1422,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datastore for volume provisioning in rack-1(cluster-1))")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
@@ -1466,23 +1467,23 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// verify volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
-			shareddatastoreListMap, false, false, false, nil)
+			shareddatastoreListMap, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack1, false, false)
+			namespace, allowedTopologyForRack1, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-			allowedTopologyRacks[0], false, clientIndex)
+			allowedTopologyRacks[0], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Tag new preferred datatsore for volume provisioning in rack-1(cluster-1)")
 		preferredDatastore, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
 
@@ -1493,42 +1494,42 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 13
 		ginkgo.By("Scale up statefulset replica count from 3 to 13")
-		err = scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
+		err = scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the specified datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
-			rack1DatastoreListMap, false, false, false, nil)
+			rack1DatastoreListMap, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack1, false, false)
+			namespace, allowedTopologyForRack1, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// perform statefulset scaledown
 		sts1Replicas = 6
 		ginkgo.By("Scale down statefulset replica count from 13 to 6")
-		err = scaleDownStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
+		err = scaleDownStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[1],
-			allowedTopologyRacks[0], false, clientIndex)
+			allowedTopologyRacks[0], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Tag new datastore chosen for volume provisioning")
 		preferredDatastore, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack1, preferredDatastorePaths, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, preferredDatastorePaths, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
 		defer func() {
 			ginkgo.By("Remove preferred datastore tags chosen for volume provisioning")
 			for i := 0; i < len(preferredDatastorePaths); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
-					allowedTopologyRacks[0], false, clientIndex)
+					allowedTopologyRacks[0], clientIndex)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
@@ -1540,19 +1541,19 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 20
 		ginkgo.By("Scale up statefulset replica count from 6 to 20")
-		err = scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
+		err = scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the specified datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
-			rack1DatastoreListMap, false, false, false, nil)
+			rack1DatastoreListMap, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack1, false, false)
+			namespace, allowedTopologyForRack1, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -1615,7 +1616,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-1(cluster-1)")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
@@ -1659,23 +1660,23 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// verify volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack1, true, false, false, nil)
+			nonShareddatastoreListMapRack1, true, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Remove preferred datatsore tag which was chosen for volume provisioning in rack-1")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-			allowedTopologyRacks[0], false, clientIndex)
+			allowedTopologyRacks[0], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Tag new preferred datatsore for volume provisioning in rack-2(cluster-2)")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
@@ -1685,34 +1686,34 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 7
 		ginkgo.By("Scale up statefulset replica count from 3 to 7")
-		err = scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
+		err = scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		//verify volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack2, true, false, false, nil)
+			nonShareddatastoreListMapRack2, true, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Remove the datastore preference chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-			allowedTopologyRacks[1], false, clientIndex)
+			allowedTopologyRacks[1], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Tag new preferred datatsore for volume provisioning in rack-3(cluster-3)")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[2],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			ginkgo.By("Remove the datastore preference chosen for volume provisioning")
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[2], false, clientIndex)
+				allowedTopologyRacks[2], clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		}()
@@ -1724,19 +1725,19 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// perform statefulset scaleup
 		sts1Replicas = 13
 		ginkgo.By("Scale up statefulset replica count from 7 to 13")
-		err = scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
+		err = scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// verify volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack3, true, false, false, nil)
+			nonShareddatastoreListMapRack3, true, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -1776,18 +1777,18 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-2(cluster-2)")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastoreChosen = 1
 		preferredDatastore, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			ginkgo.By("Remove preferred datastore tag")
 			for i := 0; i < len(preferredDatastorePaths); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
-					allowedTopologyRacks[1], false, clientIndex)
+					allowedTopologyRacks[1], clientIndex)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
@@ -1833,13 +1834,13 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// verify volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
-			rack2DatastoreListMap, false, false, false, nil)
+			rack2DatastoreListMap, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Verify affinity details
 		ginkgo.By("Verify node and pv topology affinity details")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologyForRack2, false, false)
+			namespace, allowedTopologyForRack2, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -1875,17 +1876,17 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-2(cluster-2)")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastore, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
 		defer func() {
 			ginkgo.By("Remove preferred datastore tag")
 			for i := 0; i < len(preferredDatastorePaths); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
-					allowedTopologyRacks[1], false, clientIndex)
+					allowedTopologyRacks[1], clientIndex)
 			}
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
@@ -1957,12 +1958,12 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datatsore for volume provisioning in rack-2(cluster-2)")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			ginkgo.By("Remove preferred datastore tag")
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[1], false, clientIndex)
+				allowedTopologyRacks[1], clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -2017,13 +2018,13 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
-		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, storagePolicyDs,
-			nonShareddatastoreListMapRack2, false, nil)
+		verifyVolumeProvisioningForStandalonePods(client, pod, storagePolicyDs,
+			nonShareddatastoreListMapRack2, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack2, false)
+			allowedTopologyForRack2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -2065,24 +2066,24 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag different preferred datatsores in different racks")
 		preferredDatastore1, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore1...)
 
 		preferredDatastore2, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore2...)
 
 		preferredDatastore3, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[2],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore3...)
 
 		defer func() {
 			for i := 0; i < len(allowedTopologyRacks); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
-					allowedTopologyRacks[i], false, clientIndex)
+					allowedTopologyRacks[i], clientIndex)
 			}
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
@@ -2145,31 +2146,31 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		//verify volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
-			allDatastoresListMap, true, false, false, nil)
+			allDatastoresListMap, true, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Verify affinity details
 		ginkgo.By("Verify node and pv topology affinity details")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// perform statefulset scaleup
 		sts1Replicas = 13
 		ginkgo.By("Scale up statefulset replica count from 7 to 13")
-		err = scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false, false)
+		err = scaleUpStatefulSetPod(ctx, client, sts1, namespace, sts1Replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, sts1, namespace, preferredDatastorePaths,
-			allDatastoresListMap, true, false, false, nil)
+			allDatastoresListMap, true, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Verify affinity details
 		ginkgo.By("Verify node and pv topology affinity details")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, sts1,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -2201,17 +2202,17 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Tag rack-1 to preferred datatsore which is accessible only on rack-2")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastoreChosen = 1
 		preferredDatastore, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastore...)
 		defer func() {
 			for i := 0; i < len(preferredDatastorePaths); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
-					allowedTopologyRacks[0], false, clientIndex)
+					allowedTopologyRacks[0], clientIndex)
 			}
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
@@ -2273,13 +2274,13 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
-		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, preferredDatastorePaths,
-			rack2DatastoreListMap, false, nil)
+		verifyVolumeProvisioningForStandalonePods(client, pod, preferredDatastorePaths,
+			rack2DatastoreListMap, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies, false)
+			allowedTopologies)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -2327,7 +2328,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Assign Tags to preferred datatsore for volume provisioning in rack-2(cluster-2)")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		for i := 1; i < len(allowedTopologyRacks); i++ {
 			err = tagSameDatastoreAsPreferenceToDifferentRacks(masterIp, sshClientConfig, allowedTopologyRacks[i],
@@ -2337,7 +2338,7 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		defer func() {
 			for i := 0; i < len(allowedTopologyRacks); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-					allowedTopologyRacks[i], false, clientIndex)
+					allowedTopologyRacks[i], clientIndex)
 			}
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
@@ -2393,13 +2394,13 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
-		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, storagePolicyDs,
-			nonShareddatastoreListMapRack2, false, nil)
+		verifyVolumeProvisioningForStandalonePods(client, pod, storagePolicyDs,
+			nonShareddatastoreListMapRack2, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack2, false)
+			allowedTopologyForRack2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -2431,11 +2432,11 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Assign Tags to preferred datatsore for volume provisioning")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[0], false, clientIndex)
+				allowedTopologyRacks[0], clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -2499,12 +2500,12 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// choose preferred datastore
 		ginkgo.By("Assign Tag to preferred datatsore for volume provisioning in rack-2(cluster-2)")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			for i := 0; i < len(preferredDatastorePaths); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
-					allowedTopologyRacks[1], false, clientIndex)
+					allowedTopologyRacks[1], clientIndex)
 			}
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
@@ -2631,14 +2632,14 @@ var _ = ginkgo.Describe("[Preferential-Topology] Preferential-Topology-Provision
 		// verifying volume provisioning
 		ginkgo.By("Verify volume provisioning for Pod-1/Pod-2")
 		for i := 0; i < len(podList); i++ {
-			verifyVolumeProvisioningForStandalonePods(ctx, client, podList[i], namespace,
-				preferredDatastorePaths, nonShareddatastoreListMapRack2, false, nil)
+			verifyVolumeProvisioningForStandalonePods(client, podList[i],
+				preferredDatastorePaths, nonShareddatastoreListMapRack2, nil)
 		}
 
 		ginkgo.By("Verify pv and pod node affinity details for pv-1/pod-1 and pv-2/pod-2")
 		for i := 0; i < len(podList); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, podList[i],
-				namespace, allowedTopologyForRack2, false)
+				namespace, allowedTopologyForRack2)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 	})

--- a/tests/e2e/preferential_topology_snapshot.go
+++ b/tests/e2e/preferential_topology_snapshot.go
@@ -138,7 +138,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// fetching cluster details
-		clusters, err = getTopologyLevel5ClusterGroupNames(masterIp, sshClientConfig, dataCenters)
+		clusters, err = getTopologyLevel5ClusterGroupNames(masterIp, sshClientConfig, dataCenters, 0)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		topologyAffinityDetails, topologyCategories = createTopologyMapLevel5(topologyMap,
@@ -150,11 +150,11 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// fetching list of datastores available in different racks
-		rack1DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[0])
+		rack1DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[0], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		rack2DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[1])
+		rack2DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[1], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		rack3DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[2])
+		rack3DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[2], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// fetching list of datastores which is specific to each rack
@@ -188,7 +188,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		csiReplicas = *csiDeployment.Spec.Replicas
 
 		//set preferred datatsore time interval
-		setPreferredDatastoreTimeInterval(client, ctx, csiNamespace, csiReplicas, false)
+		setPreferredDatastoreTimeInterval(client, ctx, csiNamespace, csiReplicas)
 
 		clientIndex = 0
 	})
@@ -204,11 +204,11 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 		framework.Logf("Perform preferred datastore tags cleanup after test completion")
-		err = deleteTagCreatedForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks, false)
+		err = deleteTagCreatedForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Recreate preferred datastore tags post cleanup")
-		err = createTagForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks, false)
+		err = createTagForPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -247,12 +247,12 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datastore for volume provisioning in rack-1(cluster-1))")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack1, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			ginkgo.By("Remove preferred datastore tag")
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[0], false, clientIndex)
+				allowedTopologyRacks[0], clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -292,11 +292,11 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		ginkgo.By("Create volume snapshot class, volume snapshot")
 		volumeSnapshot, volumeSnapshotClass, snapshotId := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
-			pvclaim, volHandle, false, false)
+			pvclaim, volHandle, false)
 		defer func() {
 			ginkgo.By("Perform cleanup of snapshot created")
 			performCleanUpForSnapshotCreated(ctx, snapc, namespace, volHandle, volumeSnapshot, snapshotId,
-				volumeSnapshotClass, pandoraSyncWaitTime, false)
+				volumeSnapshotClass, pandoraSyncWaitTime)
 		}()
 
 		ginkgo.By("Create PVC from snapshot")
@@ -336,13 +336,13 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
-		verifyVolumeProvisioningForStandalonePods(ctx, client, pod, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack1, false, nil)
+		verifyVolumeProvisioningForStandalonePods(client, pod, preferredDatastorePaths,
+			nonShareddatastoreListMapRack1, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologyForRack1, false)
+			allowedTopologyForRack1)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -377,7 +377,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		// choose preferred datastore
 		ginkgo.By("Tag preferred datastore for volume provisioning in rack-2(cluster-2))")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Waiting for %v for preferred datastore to get refreshed in the environment",
@@ -417,26 +417,26 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		ginkgo.By("Create volume snapshot class, volume snapshot")
 		volumeSnapshot, volumeSnapshotClass, snapshotId := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
-			pvclaim, volHandle, false, false)
+			pvclaim, volHandle, false)
 		defer func() {
 			ginkgo.By("Perform cleanup of snapshot created")
 			performCleanUpForSnapshotCreated(ctx, snapc, namespace, volHandle, volumeSnapshot, snapshotId,
-				volumeSnapshotClass, pandoraSyncWaitTime, false)
+				volumeSnapshotClass, pandoraSyncWaitTime)
 		}()
 
 		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
 		err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-			allowedTopologyRacks[1], false, clientIndex)
+			allowedTopologyRacks[1], clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Tag new preferred datatsore for volume provisioning")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[1],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack2, preferredDatastorePaths, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack2, preferredDatastorePaths, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			ginkgo.By("Remove preferred datastore tag")
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[1], false, clientIndex)
+				allowedTopologyRacks[1], clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -538,13 +538,13 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		ginkgo.By("Tag different preferred datastore for volume provisioning in different racks")
 		for i := 0; i < len(allowedTopologyRacks); i++ {
 			preferredDatastorePath, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[i],
-				preferredDatastoreChosen, datastorestMap[i], nil, false, clientIndex)
+				preferredDatastoreChosen, datastorestMap[i], nil, clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			preferredDatastorePaths = append(preferredDatastorePaths, preferredDatastorePath...)
 		}
 
 		sharedPreferredDatastorePaths, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[0],
-			preferredDatastoreChosen, shareddatastoreListMap, nil, false, clientIndex)
+			preferredDatastoreChosen, shareddatastoreListMap, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		preferredDatastorePaths = append(preferredDatastorePaths, sharedPreferredDatastorePaths...)
 		for i := 1; i < len(allowedTopologyRacks); i++ {
@@ -555,10 +555,9 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		defer func() {
 			for i := 0; i < len(allowedTopologyRacks); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, sharedPreferredDatastorePaths[0],
-					allowedTopologyRacks[i], false, clientIndex)
+					allowedTopologyRacks[i], clientIndex)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
-
 		}()
 
 		// fetch datastore map which is tagged as preferred datastore in different racks
@@ -682,25 +681,25 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		for i := 0; i < len(podList); i++ {
-			verifyVolumeProvisioningForStandalonePods(ctx, client, podList[i], namespace,
-				preferredDatastorePaths, allDatastoresListMap, false, nil)
+			verifyVolumeProvisioningForStandalonePods(client, podList[i],
+				preferredDatastorePaths, allDatastoresListMap, nil)
 		}
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		for i := 0; i < len(podList); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, podList[i],
-				namespace, allowedTopologies, false)
+				namespace, allowedTopologies)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
 		ginkgo.By("Create volume snapshot class, volume snapshot")
 		volumeSnapshot1, volumeSnapshotClass1, snapshotId1 := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
-			pvclaim1, volHandle1, false, false)
+			pvclaim1, volHandle1, false)
 		defer func() {
 			ginkgo.By("Perform cleanup of snapshot created")
 			performCleanUpForSnapshotCreated(ctx, snapc, namespace, volHandle1, volumeSnapshot1, snapshotId1,
-				volumeSnapshotClass1, pandoraSyncWaitTime, false)
+				volumeSnapshotClass1, pandoraSyncWaitTime)
 		}()
 
 		ginkgo.By("Create PVC-3 from snapshot")
@@ -721,7 +720,7 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Verify snapshot entry is deleted from CNS")
-			err = verifySnapshotIsDeletedInCNS(volHandle3, snapshotId1, false)
+			err = verifySnapshotIsDeletedInCNS(volHandle3, snapshotId1)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -744,19 +743,19 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
-		verifyVolumeProvisioningForStandalonePods(ctx, client, pod3, namespace, preferredDatastorePaths,
-			allDatastoresListMap, false, nil)
+		verifyVolumeProvisioningForStandalonePods(client, pod3, preferredDatastorePaths,
+			allDatastoresListMap, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod3, namespace,
-			allowedTopologies, false)
+			allowedTopologies)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Remove preferred datastore tag chosen for volume provisioning")
 		for i := 0; i < len(allowedTopologyRacks); i++ {
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[i],
-				allowedTopologyRacks[i], false, clientIndex)
+				allowedTopologyRacks[i], clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -764,14 +763,14 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		ginkgo.By("Assign new preferred datastore tags for volume provisioning in different racks")
 		for i := 0; i < len(allowedTopologyRacks); i++ {
 			preferredDatastorePath, err := tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[i],
-				preferredDatastoreChosen, datastorestMap[i], preferredDatastorePaths, false, clientIndex)
+				preferredDatastoreChosen, datastorestMap[i], preferredDatastorePaths, clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			preferredDatastorePathsNew = append(preferredDatastorePathsNew, preferredDatastorePath...)
 		}
 		defer func() {
 			for i := 0; i < len(allowedTopologyRacks); i++ {
 				err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePathsNew[i],
-					allowedTopologyRacks[i], false, clientIndex)
+					allowedTopologyRacks[i], clientIndex)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		}()
@@ -839,20 +838,20 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
-		verifyVolumeProvisioningForStandalonePods(ctx, client, pod4, namespace, preferredDatastorePathsNew,
-			allDatastoresListMap, false, nil)
+		verifyVolumeProvisioningForStandalonePods(client, pod4, preferredDatastorePathsNew,
+			allDatastoresListMap, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod4, namespace,
-			allowedTopologies, false)
+			allowedTopologies)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		volumeSnapshot2, volumeSnapshotClass2, snapshotId2 := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
-			pvclaim4, volHandle4, false, false)
+			pvclaim4, volHandle4, false)
 		defer func() {
 			performCleanUpForSnapshotCreated(ctx, snapc, namespace, pv4.Spec.CSI.VolumeHandle, volumeSnapshot2,
-				snapshotId2, volumeSnapshotClass2, pandoraSyncWaitTime, false)
+				snapshotId2, volumeSnapshotClass2, pandoraSyncWaitTime)
 		}()
 
 		ginkgo.By("Create PVC-5 from snapshot")
@@ -892,13 +891,13 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		// verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
-		verifyVolumeProvisioningForStandalonePods(ctx, client, pod5, namespace, preferredDatastorePathsNew,
-			allDatastoresListMap, false, nil)
+		verifyVolumeProvisioningForStandalonePods(client, pod5, preferredDatastorePathsNew,
+			allDatastoresListMap, nil)
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod5, namespace,
-			allowedTopologies, false)
+			allowedTopologies)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -937,11 +936,11 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		ginkgo.By("Tag preferred datastore for volume provisioning in rack-3(cluster-3)")
 		preferredDatastorePaths, err = tagPreferredDatastore(masterIp, sshClientConfig, allowedTopologyRacks[2],
-			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil, false, clientIndex)
+			preferredDatastoreChosen, nonShareddatastoreListMapRack3, nil, clientIndex)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			err = detachTagCreatedOnPreferredDatastore(masterIp, sshClientConfig, preferredDatastorePaths[0],
-				allowedTopologyRacks[2], false, clientIndex)
+				allowedTopologyRacks[2], clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 
@@ -986,13 +985,13 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack3, false, false, false, nil)
+			nonShareddatastoreListMapRack3, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack3, false, false)
+			namespace, allowedTopologyForRack3, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Fetching pod 3, pvc3 and pv3 details")
@@ -1013,11 +1012,11 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 
 		ginkgo.By("Create volume snapshot class, volume snapshot")
 		volumeSnapshot, volumeSnapshotClass, snapshotId := createSnapshotClassAndVolSnapshot(ctx, snapc, namespace,
-			pvclaim3, volHandle3, true, false)
+			pvclaim3, volHandle3, true)
 		defer func() {
 			ginkgo.By("Perform cleanup of snapshot created")
 			performCleanUpForSnapshotCreated(ctx, snapc, namespace, volHandle3, volumeSnapshot, snapshotId,
-				volumeSnapshotClass, pandoraSyncWaitTime, false)
+				volumeSnapshotClass, pandoraSyncWaitTime)
 		}()
 
 		ginkgo.By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas-1))
@@ -1061,13 +1060,13 @@ var _ = ginkgo.Describe("[Preferential-Topology-Snapshot] Preferential Topology 
 		//verifying volume provisioning
 		ginkgo.By("Verify volume is provisioned on the preferred datatsore")
 		err = verifyVolumeProvisioningForStatefulSet(ctx, client, statefulset, namespace, preferredDatastorePaths,
-			nonShareddatastoreListMapRack3, false, false, false, nil)
+			nonShareddatastoreListMapRack3, false, false, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologyForRack3, false, false)
+			namespace, allowedTopologyForRack3, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 })

--- a/tests/e2e/prevent_duplicate_cluster_ids.go
+++ b/tests/e2e/prevent_duplicate_cluster_ids.go
@@ -187,7 +187,7 @@ var _ = ginkgo.Describe("Prevent duplicate cluster ID", func() {
 		}
 		ginkgo.By("Creating statefulset with replica 3 and a deployment")
 		statefulset, deployment, _ := createStsDeployment(ctx, client, namespace, sc, true,
-			false, 0, "", accessMode, false)
+			false, 0, "", accessMode)
 		replicas := *(statefulset.Spec.Replicas)
 
 		defer func() {
@@ -345,7 +345,7 @@ var _ = ginkgo.Describe("Prevent duplicate cluster ID", func() {
 		}
 		ginkgo.By("Creating statefulset with replica 3 and a deployment")
 		statefulset, deployment, _ := createStsDeployment(ctx, client, namespace, sc, true,
-			false, 0, "", accessMode, false)
+			false, 0, "", accessMode)
 		replicas := *(statefulset.Spec.Replicas)
 
 		defer func() {
@@ -503,7 +503,7 @@ var _ = ginkgo.Describe("Prevent duplicate cluster ID", func() {
 		}
 		ginkgo.By("Creating statefulset with replica 3 and a deployment")
 		statefulset, deployment, _ := createStsDeployment(ctx, client, namespace, sc, true,
-			false, 0, "", accessMode, false)
+			false, 0, "", accessMode)
 		replicas := *(statefulset.Spec.Replicas)
 
 		defer func() {
@@ -757,7 +757,7 @@ var _ = ginkgo.Describe("Prevent duplicate cluster ID", func() {
 		}
 		ginkgo.By("Creating statefulset with replica 3 and a deployment")
 		statefulset, deployment, _ := createStsDeployment(ctx, client, namespace, sc, true,
-			false, 0, "", accessMode, false)
+			false, 0, "", accessMode)
 		replicas := *(statefulset.Spec.Replicas)
 
 		defer func() {
@@ -864,7 +864,7 @@ var _ = ginkgo.Describe("Prevent duplicate cluster ID", func() {
 		}
 		ginkgo.By("Creating statefulset with replica 3 and a deployment")
 		statefulset, deployment, _ := createStsDeployment(ctx, client, namespace, sc, true,
-			false, 0, "", accessMode, false)
+			false, 0, "", accessMode)
 		replicas := *(statefulset.Spec.Replicas)
 
 		defer func() {

--- a/tests/e2e/raw_block_volume.go
+++ b/tests/e2e/raw_block_volume.go
@@ -1209,7 +1209,7 @@ var _ = ginkgo.Describe("raw block volume support", func() {
 		defer func() {
 			if snapshotContentCreated {
 				framework.Logf("Deleting volume snapshot content")
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 

--- a/tests/e2e/rwx_topology_utils.go
+++ b/tests/e2e/rwx_topology_utils.go
@@ -1,0 +1,621 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/object"
+	"golang.org/x/crypto/ssh"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fdep "k8s.io/kubernetes/test/e2e/framework/deployment"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+	fnodes "k8s.io/kubernetes/test/e2e/framework/node"
+	fpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+	fpv "k8s.io/kubernetes/test/e2e/framework/pv"
+)
+
+/*
+The createStorageClassWithMultiplePVCs utility function facilitates the creation of a storage class
+along with multiple PVCs. The decision to skip or create PVCs or the storage class
+is controlled by the user through a boolean parameter.
+Additionally, the user can specify the scale of PVC creation using an iterator variable.
+This function returns a list containing the PVCs and storage class created,
+along with an error message in case of any failures.
+*/
+func createStorageClassWithMultiplePVCs(client clientset.Interface, namespace string, pvclaimlabels map[string]string,
+	scParameters map[string]string, ds string, allowedTopologies []v1.TopologySelectorLabelRequirement,
+	bindingMode storagev1.VolumeBindingMode, allowVolumeExpansion bool, accessMode v1.PersistentVolumeAccessMode,
+	storageClassName string, storageClass *storagev1.StorageClass, pvcItr int, skipStorageClassCreation bool,
+	skipPvcCreation bool) (*storagev1.StorageClass, []*v1.PersistentVolumeClaim, error) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var sc *storagev1.StorageClass
+	var err error
+	var pvclaims []*v1.PersistentVolumeClaim
+
+	if !skipStorageClassCreation {
+		// creating storage class if skipStorageClassCreation is set to false
+		scName := ""
+		if len(storageClassName) > 0 {
+			scName = storageClassName
+		}
+		sc, err = createStorageClass(client, scParameters,
+			allowedTopologies, "", bindingMode, allowVolumeExpansion, scName)
+		if err != nil {
+			return sc, nil, err
+		}
+	}
+
+	if !skipPvcCreation {
+		// we need storage class name in case we are only creating pvcs and skipping sc creation
+		if skipStorageClassCreation {
+			sc = storageClass
+		}
+		// creating pvc if skipPvcCreation is set to false
+		for i := 0; i < pvcItr; i++ {
+			pvclaim, err := createPVC(ctx, client, namespace, pvclaimlabels, ds, sc, accessMode)
+			pvclaims = append(pvclaims, pvclaim)
+			if err != nil {
+				return sc, pvclaims, err
+			}
+		}
+	}
+	return sc, pvclaims, nil
+}
+
+/*
+The checkVolumeStateAndPerformCnsVerification utility function verifies if the PVCs have reached
+the Bound state and performs in-depth verification on the CNS Cloud Native Storage side.
+It accepts a list of PVCs as input, conducts state and CNS verification for both RWO
+and RWX volumes, and returns a list of PVs created successfully or an error message in case of any failures.
+*/
+func checkVolumeStateAndPerformCnsVerification(ctx context.Context, client clientset.Interface,
+	pvclaims []*v1.PersistentVolumeClaim, storagePolicyName string, datastoreUrl string) ([]*v1.PersistentVolume, error) {
+
+	var queryResult *cnstypes.CnsQueryResult
+	var pvs []*v1.PersistentVolume
+	var storagePolicyID string
+
+	for i := 0; i < len(pvclaims); i++ {
+		pv, err := fpv.WaitForPVClaimBoundPhase(ctx, client, []*v1.PersistentVolumeClaim{pvclaims[i]},
+			framework.ClaimProvisionTimeout)
+		pvs = append(pvs, pv[0])
+		volHandle := pv[0].Spec.CSI.VolumeHandle
+		if err != nil {
+			return pvs, err
+		}
+
+		// cns side verification
+		ginkgo.By(fmt.Sprintf("Invoking QueryCNSVolumeWithResult with VolumeID: %s", volHandle))
+		if multivc {
+			queryResult, err = multiVCe2eVSphere.queryCNSVolumeWithResultInMultiVC(volHandle)
+		} else {
+			queryResult, err = e2eVSphere.queryCNSVolumeWithResult(volHandle)
+		}
+
+		if len(queryResult.Volumes) == 0 || err != nil {
+			return pvs, fmt.Errorf("queryCNSVolumeWithResult returned no volume")
+		}
+
+		// if it is an rwx volume
+		if rwxAccessMode {
+			ginkgo.By(fmt.Sprintf("volume Name:%s, capacity:%d volumeType:%s health:%s accesspoint: %s",
+				queryResult.Volumes[0].Name,
+				queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).CapacityInMb,
+				queryResult.Volumes[0].VolumeType, queryResult.Volumes[0].HealthStatus,
+				queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.CnsVsanFileShareBackingDetails).AccessPoints),
+			)
+
+			framework.Logf("Verifying disk size specified in PVC is honored")
+			if queryResult.Volumes[0].BackingObjectDetails.(*cnstypes.
+				CnsVsanFileShareBackingDetails).CapacityInMb != diskSizeInMb {
+				return pvs, fmt.Errorf("wrong disk size provisioned")
+			}
+
+			framework.Logf("Verify if VolumeID is created on the VSAN datastores")
+			if !strings.HasPrefix(queryResult.Volumes[0].DatastoreUrl, "ds:///vmfs/volumes/vsan:") {
+				return pvs, fmt.Errorf("volume is not provisioned on vSan datastore")
+			}
+		}
+
+		framework.Logf("Verifying volume type specified in PVC is honored")
+		if queryResult.Volumes[0].VolumeType != testVolumeType {
+			return pvs, fmt.Errorf("volume type is not %q", testVolumeType)
+		}
+
+		framework.Logf("Verify the volume is provisioned using specified storage policy")
+		if storagePolicyName != "" {
+			if !multivc {
+				storagePolicyID = e2eVSphere.GetSpbmPolicyID(storagePolicyName)
+				if storagePolicyID != queryResult.Volumes[0].StoragePolicyId {
+					return pvs, fmt.Errorf("storage policy verification failed. Actual storage policy: %q does not match "+
+						"with the Expected storage policy: %q", queryResult.Volumes[0].StoragePolicyId, storagePolicyID)
+				}
+			} else {
+				storagePolicyID = multiVCe2eVSphere.GetSpbmPolicyIDInMultiVc(storagePolicyName)
+				if !strings.Contains(storagePolicyID, queryResult.Volumes[0].StoragePolicyId) {
+					return pvs, fmt.Errorf("storage policy verification failed. Actual storage policy: %q does not match "+
+						"with the Expected storage policy: %q", queryResult.Volumes[0].StoragePolicyId, storagePolicyID)
+				}
+			}
+		}
+
+		framework.Logf("Verify the volume is provisioned on the datastore url specified in the Storage Class")
+		if datastoreUrl != "" {
+			if queryResult.Volumes[0].DatastoreUrl != datastoreUrl {
+				return pvs, fmt.Errorf("volume is not provisioned on wrong datastore")
+			}
+		}
+	}
+	return pvs, nil
+}
+
+/*
+The createStandalonePodsForRWXVolume utility creates standalone pods for a specified volume.
+Users can determine the number of pods to create via a parameter.
+The utility ensures that these pods have different read/write permissions.
+Additionally, it verifies whether pods with varying permissions can read from or write to the same volume.
+Upon completion, the utility returns a list of the created pods or an error message if any failures occur.
+*/
+func createStandalonePodsForRWXVolume(client clientset.Interface, ctx context.Context, namespace string,
+	nodeSelector map[string]string, pvclaim *v1.PersistentVolumeClaim, isPrivileged bool,
+	command string, no_pods_to_deploy int) ([]*v1.Pod, error) {
+	var podList []*v1.Pod
+
+	for i := 0; i <= no_pods_to_deploy; i++ {
+		var pod *v1.Pod
+		var err error
+
+		// here we are making sure that Pod3 should not get created with READ/WRITE permissions
+		if i != 2 {
+			framework.Logf("Creating Pod %d", i)
+			pod, err = createPod(ctx, client, namespace, nodeSelector, []*v1.PersistentVolumeClaim{pvclaim},
+				false, execRWXCommandPod)
+			podList = append(podList, pod)
+			if err != nil {
+				return podList, fmt.Errorf("failed to create pod: %v", err)
+			}
+
+			framework.Logf("Verify the volume is accessible and Read/write is possible")
+			cmd := []string{"exec", pod.Name, "--namespace=" + namespace, "--", "/bin/sh", "-c",
+				"cat /mnt/volume1/Pod.html "}
+			output, err := e2ekubectl.RunKubectl(namespace, cmd...)
+			if err != nil {
+				return podList, fmt.Errorf("error executing command on pod %s: %v", pod.Name, err)
+			}
+			if !strings.Contains(output, "Hello message from Pod") {
+				return podList, fmt.Errorf("expected message not found in pod output")
+			}
+
+			framework.Logf("Veirfy read/write permission for a pod")
+			wrtiecmd := []string{"exec", pod.Name, "--namespace=" + namespace, "--", "/bin/sh", "-c",
+				"echo 'Hello message from test into Pod' > /mnt/volume1/Pod.html"}
+			e2ekubectl.RunKubectlOrDie(namespace, wrtiecmd...)
+		}
+
+		// here we are creating Pod3 with read-only permissions
+		if i == 2 {
+			pod = fpod.MakePod(namespace, nodeSelector, pvclaims, isPrivileged, command)
+			pod.Spec.Containers[0].Image = busyBoxImageOnGcr
+			createdPod, err := client.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+			if err != nil {
+				return podList, fmt.Errorf("error creating pod: %v", err)
+			}
+			pod = createdPod
+
+			writeCmd := []string{"exec", pod.Name, "--namespace=" + namespace, "--", "/bin/sh", "-c",
+				"echo 'Hello message from test into Pod' > /mnt/volume1/Pod.html"}
+			output, err := e2ekubectl.RunKubectl(namespace, writeCmd...)
+			if err != nil {
+				framework.Logf("error executing write command on pod %s due to readonly permissions: %v", pod.Name, err)
+			}
+
+			framework.Logf("Verify that the write operation fails for readOnly Pod")
+			if !strings.Contains(output, "container not found") {
+				framework.Logf("error executing write command on pod %s due to readonly permissions: %v", pod.Name, err)
+			}
+
+		}
+
+		framework.Logf("Now creating and accessing files from different pods having read/write permissions")
+		// i=0 means creating a file for pod0
+		if i == 0 {
+			ginkgo.By("Create file1.txt on Pod1")
+			err := e2eoutput.CreateEmptyFileOnPod(namespace, pod.Name, filePath1)
+			if err != nil {
+				return podList, fmt.Errorf("error creating file1.txt on Pod: %v", err)
+			}
+
+			//Write data on file1.txt on Pod1
+			data := "This file file1 is written by Pod1"
+			ginkgo.By("Write on file1.txt from Pod1")
+			writeDataOnFileFromPod(namespace, pod.Name, filePath1, data)
+		}
+		// i=1 means creating a file for pod1
+		if i == 1 {
+			//Read file1.txt created from Pod2
+			ginkgo.By("Read file1.txt from Pod2 created by Pod1")
+			output := readFileFromPod(namespace, pod.Name, filePath1)
+			ginkgo.By(fmt.Sprintf("File contents from file1.txt are: %s", output))
+			data := "This file file1 is written by Pod1"
+			data = data + " \n Hello from pod2"
+			ginkgo.By(fmt.Sprintf("File contents from file1.txt are: %s", data))
+
+			//Create a file file2.txt from Pod2
+			err := e2eoutput.CreateEmptyFileOnPod(namespace, pod.Name, filePath2)
+			if err != nil {
+				return podList, fmt.Errorf("error creating file2.txt on Pod: %v", err)
+			}
+
+			//Write to the file
+			ginkgo.By("Write on file2.txt from Pod2")
+			data = "This file file2 is written by Pod2"
+			writeDataOnFileFromPod(namespace, pod.Name, filePath2, data)
+		}
+	}
+	return podList, nil
+}
+
+/*
+The getNodeSelectorMapForDeploymentPods utility is designed for scenarios where users want to deploy pods
+and their replicas in specific availability zones (AZ) of their choice. This utility generates
+node selector terms based on the allowed topology specified by the user. It returns a node selector terms
+configuration that can be utilized when creating deployment pods.
+It returns an error if the provided list of allowed topologies is empty
+*/
+func getNodeSelectorMapForDeploymentPods(allowedTopologies []v1.TopologySelectorLabelRequirement) (map[string]string,
+	error) {
+	if len(allowedTopologies) == 0 {
+		return nil, errors.New("allowedTopologies cannot be empty")
+	}
+
+	nodeSelectorMap := make(map[string]string)
+	rackTopology := allowedTopologies[len(allowedTopologies)-1]
+
+	for i := 0; i < len(allowedTopologies)-1; i++ {
+		topologySelector := allowedTopologies[i]
+		nodeSelectorMap[topologySelector.Key] = strings.Join(topologySelector.Values, ",")
+	}
+
+	if len(rackTopology.Values) == 0 {
+		return nil, errors.New("no values specified for rack topology")
+	}
+
+	for i := 0; i < len(rackTopology.Values); i++ {
+		nodeSelectorMap[rackTopology.Key] = rackTopology.Values[i]
+	}
+
+	return nodeSelectorMap, nil
+}
+
+/*
+The verifyDeploymentPodNodeAffinity utility verifies whether pods created during deployment
+adhere to the specified node selector term, ensuring they are deployed on the designated
+availability zone (AZ) or not.
+*/
+func verifyDeploymentPodNodeAffinity(ctx context.Context, client clientset.Interface,
+	namespace string, allowedTopologies []v1.TopologySelectorLabelRequirement,
+	pods *v1.PodList) error {
+	allowedTopologiesMap := createAllowedTopologiesMap(allowedTopologies)
+	for _, pod := range pods.Items {
+		_, err := client.CoreV1().Pods(namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		for _, volumespec := range pod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+
+				// fetch node details
+				nodeList, err := fnodes.GetReadySchedulableNodes(ctx, client)
+				if err != nil {
+					return err
+				}
+				if len(nodeList.Items) <= 0 {
+					return fmt.Errorf("unable to find ready and schedulable Node")
+				}
+
+				// verify pod is running on appropriate nodes
+				ginkgo.By("Verifying If Pods are running on appropriate nodes as mentioned in SC")
+				res, err := verifyPodLocationLevel5(&pod, nodeList, allowedTopologiesMap)
+				if res {
+					framework.Logf("Pod %v is running on an appropriate node as specified in the "+
+						"allowed topologies of Storage Class", pod.Name)
+				}
+				if !res {
+					return fmt.Errorf("pod %v is not running on an appropriate node as specified "+
+						"in the allowed topologies of Storage Class", pod.Name)
+				}
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+/*
+The createVerifyAndScaleDeploymentPods utility manages deployment creation, scaling, and verification.
+Users control creation and scaling via boolean parameters, specifying replica counts and the number of deployments.
+It returns deployment lists and handles scaling operations, providing scaled deployments and pod lists.
+*/
+
+func createVerifyAndScaleDeploymentPods(ctx context.Context, client clientset.Interface,
+	namespace string, replica int32, scaleDeploymentPod bool, labelsMap map[string]string,
+	pvclaim *v1.PersistentVolumeClaim, nodeSelectorTerms map[string]string, podCmd string,
+	podImage string, skipDeploymentCreation bool,
+	deploymentToScale *appsv1.Deployment, createDepItr int) ([]*appsv1.Deployment, *v1.PodList, error) {
+
+	var deploymentList []*appsv1.Deployment
+	var pods *v1.PodList
+	var err error
+
+	// creating deployment when skipDeploymentCreation is set to false
+	if !skipDeploymentCreation {
+		for i := 0; i < createDepItr; i++ {
+			deployment, err := createDeployment(ctx, client, int32(replica), labelsMap, nodeSelectorTerms, namespace,
+				[]*v1.PersistentVolumeClaim{pvclaim}, podCmd, false, podImage)
+			if err != nil {
+				return deploymentList, pods, fmt.Errorf("failed to get pods for deployment: %w", err)
+			}
+
+			// checking replica pod running status
+			framework.Logf("Wait for deployment pods to be up and running")
+			pods, err = fdep.GetPodsForDeployment(ctx, client, deployment)
+			if err != nil {
+				return deploymentList, pods, fmt.Errorf("failed to get pods for deployment: %w", err)
+			}
+			pod := pods.Items[0]
+			err = fpod.WaitForPodNameRunningInNamespace(ctx, client, pod.Name, namespace)
+			if err != nil {
+				return deploymentList, pods, fmt.Errorf("failed to wait for pod running: %w", err)
+			}
+			deploymentList = append(deploymentList, deployment)
+		}
+	}
+
+	// get deployment pod replicas
+	if scaleDeploymentPod {
+		deploymentToScale, err = client.AppsV1().Deployments(namespace).Get(ctx, deploymentToScale.Name, metav1.GetOptions{})
+		if err != nil {
+			return deploymentList, nil, fmt.Errorf("failed to get pods for deployment: %w", err)
+		}
+		pods, err = fdep.GetPodsForDeployment(ctx, client, deploymentToScale)
+		if err != nil {
+			return deploymentList, pods, fmt.Errorf("failed to get pods for deployment: %w", err)
+		}
+		pod := pods.Items[0]
+		rep := deploymentToScale.Spec.Replicas
+		*rep = replica
+		deploymentToScale.Spec.Replicas = rep
+		_, err = client.AppsV1().Deployments(namespace).Update(ctx, deploymentToScale, metav1.UpdateOptions{})
+		if err != nil {
+			return deploymentList, pods, fmt.Errorf("failed to update deployment: %w", err)
+		}
+
+		pods, err = fdep.GetPodsForDeployment(ctx, client, deploymentToScale)
+		if err != nil {
+			return deploymentList, pods, fmt.Errorf("failed to get pods for deployment: %w", err)
+		}
+		pod = pods.Items[0]
+		rep = deploymentToScale.Spec.Replicas
+		if *rep < replica {
+			// this check is when we scale down deployment pods
+			err = fpod.WaitForPodNotFoundInNamespace(ctx, client, pod.Name, namespace, pollTimeout)
+			if err != nil {
+				return deploymentList, pods, fmt.Errorf("failed to wait for pod not found: %w", err)
+			}
+		} else {
+			// this check is when we scale up deployment pods, all new replica pod should come to running states
+			ginkgo.By("Wait for deployment pods to be up and running")
+			err = fpod.WaitForPodRunningInNamespaceSlow(ctx, client, pod.Name, namespace)
+			if err != nil {
+				return deploymentList, pods, fmt.Errorf("failed to wait for pod running: %w", err)
+			}
+		}
+		deploymentList = append(deploymentList, deploymentToScale)
+	}
+	return deploymentList, pods, nil
+}
+
+/*
+The fetchDatastoreListMap utility returns the individual datastore URLs for each VC cluster and
+also retruns a combined list of all datastore URLs across all VCs. If any errors occur during this process,
+it returns an error appropriately.
+*/
+func fetchDatastoreListMap(ctx context.Context,
+	client clientset.Interface) ([]string, []string, []string, []string, error) {
+
+	var datastoreUrlsRack1, datastoreUrlsRack2, datastoreUrlsRack3, datastoreUrls []string
+	nimbusGeneratedK8sVmPwd := GetAndExpectStringEnvVar(nimbusK8sVmPwd)
+	var dataCenters []*object.Datacenter
+	var err error
+	var rack2DatastoreListMap, rack3DatastoreListMap map[string]string
+
+	sshClientConfig := &ssh.ClientConfig{
+		User: "root",
+		Auth: []ssh.AuthMethod{
+			ssh.Password(nimbusGeneratedK8sVmPwd),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	allMasterIps := getK8sMasterIPs(ctx, client)
+	masterIp := allMasterIps[0]
+
+	// fetching datacenter details
+	if !multivc {
+		dataCenters, err = e2eVSphere.getAllDatacenters(ctx)
+	} else {
+		dataCenters, err = multiVCe2eVSphere.getAllDatacentersForMultiVC(ctx)
+	}
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	// fetching cluster details
+	// // here clientIndex=1 means VC-1 list of datastores we are fetching
+	clientIndex := 0
+	clusters, err := getTopologyLevel5ClusterGroupNames(masterIp, sshClientConfig, dataCenters, clientIndex)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	// fetching list of datastores available in different racks
+	rack1DatastoreListMap, err := getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[0], clientIndex)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	if !multivc {
+		rack2DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[1], clientIndex)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+	} else {
+		// here clientIndex=1 means VC-2 list of datastores we are fetching
+		clientIndex := 1
+		rack2DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[0], clientIndex)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+	}
+
+	if !multivc {
+		rack3DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[2], clientIndex)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+	} else {
+		// here clientIndex=1 means VC-3 list of datastores we are fetching
+		clientIndex := 2
+		rack3DatastoreListMap, err = getListOfDatastoresByClusterName(masterIp, sshClientConfig, clusters[0], clientIndex)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+	}
+
+	// create datastore map for each cluster
+	for _, value := range rack1DatastoreListMap {
+		datastoreUrlsRack1 = append(datastoreUrlsRack1, value)
+	}
+
+	for _, value := range rack2DatastoreListMap {
+		datastoreUrlsRack2 = append(datastoreUrlsRack2, value)
+	}
+
+	for _, value := range rack3DatastoreListMap {
+		datastoreUrlsRack3 = append(datastoreUrlsRack3, value)
+	}
+
+	datastoreUrls = append(datastoreUrls, datastoreUrlsRack1...)
+	datastoreUrls = append(datastoreUrls, datastoreUrlsRack2...)
+	datastoreUrls = append(datastoreUrls, datastoreUrlsRack3...)
+
+	return datastoreUrlsRack1, datastoreUrlsRack2, datastoreUrlsRack3, datastoreUrls, nil
+}
+
+/*
+The verifyStandalonePodAffinity utility checks whether standalone pods have been scheduled on the
+appropriate Availability Zone (AZ) nodes as specified in the Storage Class.
+If the pods are not scheduled on the correct AZ nodes, the utility returns an error.
+*/
+func verifyStandalonePodAffinity(ctx context.Context, client clientset.Interface, pod *v1.Pod,
+	allowedTopologies []v1.TopologySelectorLabelRequirement) error {
+	allowedTopologiesMap := createAllowedTopologiesMap(allowedTopologies)
+	for _, volumespec := range pod.Spec.Volumes {
+		if volumespec.PersistentVolumeClaim != nil {
+			// get pv details
+			pv := getPvFromClaim(client, pod.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+			if pv == nil {
+				return fmt.Errorf("failed to get PV for claim: %s", volumespec.PersistentVolumeClaim.ClaimName)
+			}
+
+			// fetch node details
+			nodeList, err := fnodes.GetReadySchedulableNodes(ctx, client)
+			if err != nil {
+				return fmt.Errorf("error getting ready and schedulable nodes: %v", err)
+			}
+			if !(len(nodeList.Items) > 0) {
+				return errors.New("no ready and schedulable nodes found")
+			}
+
+			// verify pod is running on appropriate nodes
+			ginkgo.By("Verifying If Pods are running on appropriate nodes as mentioned in SC")
+			res, err := verifyPodLocationLevel5(pod, nodeList, allowedTopologiesMap)
+			if err != nil {
+				return fmt.Errorf("error verifying pod location: %v", err)
+			}
+			if !res {
+				return fmt.Errorf("pod %v is not running on appropriate node as specified in allowed "+
+					"topologies of Storage Class", pod.Name)
+			}
+		}
+	}
+	return nil
+}
+
+/*
+volumePlacementVerificationForSts utility ensures that volumes are created on the datastore
+corresponding to the specified Availability Zone (AZ) as defined in the allowed topology of the Storage Class.
+If the volume placement is incorrect, the utility returns an appropriate error message.
+*/
+
+func volumePlacementVerificationForSts(ctx context.Context, client clientset.Interface, statefulset *appsv1.StatefulSet,
+	namespace string, datastoreUrls []string) error {
+	var isCorrectPlacement bool
+	ssPods := GetListOfPodsInSts(client, statefulset)
+	for _, sspod := range ssPods.Items {
+		_, err := client.CoreV1().Pods(namespace).Get(ctx, sspod.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get pod %s: %v", sspod.Name, err)
+		}
+
+		for _, volumespec := range sspod.Spec.Volumes {
+			if volumespec.PersistentVolumeClaim != nil {
+				pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+				if !multivc {
+					isCorrectPlacement = e2eVSphere.verifyPreferredDatastoreMatch(pv.Spec.CSI.VolumeHandle,
+						datastoreUrls)
+				} else {
+					isCorrectPlacement = multiVCe2eVSphere.verifyPreferredDatastoreMatchInMultiVC(pv.Spec.CSI.VolumeHandle,
+						datastoreUrls)
+				}
+				if !isCorrectPlacement {
+					return fmt.Errorf("volume provisioning has happened on the "+
+						"wrong datastore for pvc %s", volumespec.PersistentVolumeClaim.ClaimName)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/tests/e2e/statefulsets.go
+++ b/tests/e2e/statefulsets.go
@@ -902,7 +902,7 @@ var _ = ginkgo.Describe("statefulset", func() {
 
 		ginkgo.By("Creating statfulset and deployment from storageclass")
 		statefulset, _, _ := createStsDeployment(ctx, client, namespace, sc, true,
-			false, 0, "", "", false)
+			false, 0, "", "")
 		replicas := *(statefulset.Spec.Replicas)
 		csiNs := GetAndExpectStringEnvVar(envCSINamespace)
 		csipods, err := client.CoreV1().Pods(csiNs).List(ctx, metav1.ListOptions{})

--- a/tests/e2e/svmotion_volumes.go
+++ b/tests/e2e/svmotion_volumes.go
@@ -1365,7 +1365,7 @@ var _ = ginkgo.Describe("[csi-block-vanilla] [csi-block-vanilla-parallelized] Re
 		}()
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volumeID, snapshotId, false)
+		err = verifySnapshotIsCreatedInCNS(volumeID, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Verify the data on the PVCs match what was written in step 7")

--- a/tests/e2e/tkgs_ha.go
+++ b/tests/e2e/tkgs_ha.go
@@ -261,7 +261,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -870,7 +870,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -1038,7 +1038,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer func() {
 			if snapshotContentCreated {
-				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+				err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -1055,7 +1055,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 
 		framework.Logf("Get volume snapshot handle from Supervisor Cluster")
 		snapshotId, _, svcVolumeSnapshotName, err := getSnapshotHandleFromSupervisorCluster(ctx,
-			volumeSnapshotClass, *snapshotContent.Status.SnapshotHandle)
+			*snapshotContent.Status.SnapshotHandle)
 
 		ginkgo.By("Create pre-provisioned snapshot")
 		_, staticSnapshot, staticSnapshotContentCreated,
@@ -1345,7 +1345,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer func() {
 				if snapshotContentCreated {
-					err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, namespace, pandoraSyncWaitTime)
+					err = deleteVolumeSnapshotContent(ctx, snapshotContent, snapc, pandoraSyncWaitTime)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
 
@@ -1362,7 +1362,7 @@ var _ = ginkgo.Describe("[csi-tkgs-ha] Tkgs-HA-SanityTests", func() {
 
 			framework.Logf("Get volume snapshot handle from Supervisor Cluster")
 			snapshotId, _, svcVolumeSnapshotName, err := getSnapshotHandleFromSupervisorCluster(ctx,
-				volumeSnapshotClass, *snapshotContent.Status.SnapshotHandle)
+				*snapshotContent.Status.SnapshotHandle)
 
 			ginkgo.By("Create pre-provisioned snapshot")
 			_, staticSnapshot, staticSnapshotContentCreated,

--- a/tests/e2e/topology_multi_replica.go
+++ b/tests/e2e/topology_multi_replica.go
@@ -313,7 +313,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(statefulSets); i++ {
 				err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-					statefulSets[i], namespace, allowedTopologies, true, false)
+					statefulSets[i], namespace, allowedTopologies, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -334,7 +334,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 2
 			ginkgo.By("Scale down statefulset replica and verify the replica count")
 			for i := 0; i < len(statefulSets); i++ {
-				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 				gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -364,7 +364,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 0
 			ginkgo.By("Scale down statefulset replica count to 0")
 			for i := 0; i < len(statefulSets); i++ {
-				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 				gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -516,7 +516,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(statefulSets); i++ {
 				err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-					statefulSets[i], namespace, allowedTopologies, true, false)
+					statefulSets[i], namespace, allowedTopologies, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -524,7 +524,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 2
 			ginkgo.By("Scale down statefulset replica count")
 			for i := 0; i < len(statefulSets); i++ {
-				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 				gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -551,7 +551,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 0
 			ginkgo.By("Scale down statefulset replica count to 0")
 			for i := 0; i < len(statefulSets); i++ {
-				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 				gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -699,7 +699,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(statefulSets); i++ {
 				err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-					statefulSets[i], namespace, allowedTopologies, true, false)
+					statefulSets[i], namespace, allowedTopologies, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -728,7 +728,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Scale up StaefulSets replicas in parallel")
 			statefulSetReplicaCount = 5
 			for i := 0; i < len(statefulSets); i++ {
-				err = scaleUpStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+				err = scaleUpStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -737,7 +737,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(statefulSets); i++ {
 				err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-					statefulSets[i], namespace, allowedTopologies, true, false)
+					statefulSets[i], namespace, allowedTopologies, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -745,7 +745,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 0
 			ginkgo.By("Scale down statefulset replica count to 0")
 			for i := 0; i < len(statefulSets); i++ {
-				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		})
@@ -956,7 +956,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(podList); i++ {
 				err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, podList[i],
-					namespace, allowedTopologies, false)
+					namespace, allowedTopologies)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		})
@@ -1164,7 +1164,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(podList); i++ {
 				err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, podList[i],
-					namespace, allowedTopologies, false)
+					namespace, allowedTopologies)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		})
@@ -1251,7 +1251,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 				/* Verify PV nde affinity and that the pods are running on appropriate nodes
 				for each StatefulSet pod */
 				err = verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5(ctx, client, deployment,
-					namespace, allowedTopologies, true, false)
+					namespace, allowedTopologies, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				deploymentList = append(deploymentList, deployment)
 				// Delete elected leader Csi-Controller-Pod where CSi-Attacher is running
@@ -1444,7 +1444,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(statefulSets); i++ {
 				err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-					statefulSets[i], namespace, allowedTopologies, true, false)
+					statefulSets[i], namespace, allowedTopologies, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -1463,7 +1463,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 2
 			ginkgo.By("Scale down statefulset replica count")
 			for i := 0; i < len(statefulSets); i++ {
-				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				if i == 1 {
 					/* Delete newly elected leader CSi-Controller-Pod where CSI-Attacher is running */
@@ -1487,7 +1487,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			statefulSetReplicaCount = 0
 			ginkgo.By("Scale down statefulset replica count to 0")
 			for i := 0; i < len(statefulSets); i++ {
-				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+				err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 
@@ -1673,7 +1673,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(podList); i++ {
 				err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, podList[i],
-					namespace, allowedTopologies, false)
+					namespace, allowedTopologies)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		})
@@ -1757,7 +1757,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			username := vsphereCfg.Global.User
 			newPassword := e2eTestPassword
 			err = invokeVCenterChangePassword(ctx, username, nimbusGeneratedVcPwd, newPassword, vcAddress,
-				false, clientIndex)
+				clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Modifying the password in the secret")
@@ -1798,7 +1798,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Reverting the password change")
-			err = invokeVCenterChangePassword(ctx, username, newPassword, nimbusGeneratedVcPwd, vcAddress, false,
+			err = invokeVCenterChangePassword(ctx, username, newPassword, nimbusGeneratedVcPwd, vcAddress,
 				clientIndex)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1915,7 +1915,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 			ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 			for i := 0; i < len(podList); i++ {
 				err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, podList[i],
-					namespace, allowedTopologies, false)
+					namespace, allowedTopologies)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		})
@@ -2084,7 +2084,7 @@ var _ = ginkgo.Describe("[csi-topology-multireplica-level5] Topology-Aware-Provi
 				"appropriate node as specified in the allowed topologies of SC")
 			for i := 0; i < len(podList); i++ {
 				err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, podList[i], namespace,
-					allowedTopologies, false)
+					allowedTopologies)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 

--- a/tests/e2e/topology_operation_strom_cases.go
+++ b/tests/e2e/topology_operation_strom_cases.go
@@ -207,7 +207,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -240,7 +240,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		ginkgo.By("Scale up statefulset replica and verify the replica count")
 		statefulSetReplicaCount = 35
 		err = scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount,
-			true, false)
+			true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -249,7 +249,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		// Scale down statefulSets replica count
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		err = scaleDownStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount, true, false)
+		err = scaleDownStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount, true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulSets[1])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -295,7 +295,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		// Scale down statefulSets replicas count
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		err = scaleDownStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
+		err = scaleDownStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -305,7 +305,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		statefulSetReplicaCount = 35
 		ginkgo.By("Scale up statefulset replica and verify the replica count")
 		err = scaleUpStatefulSetPod(ctx, client, statefulSets[1], namespace, statefulSetReplicaCount,
-			true, false)
+			true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ssPodsAfterScaleDown = GetListOfPodsInSts(client, statefulSets[1])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -316,7 +316,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -360,7 +360,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -584,7 +584,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -613,7 +613,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -641,7 +641,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 			statefulSetReplicaCount = 20
 			ginkgo.By("Scale up statefulset replica and verify the replica count")
 			err = scaleUpStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount,
-				true, false)
+				true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -653,7 +653,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -661,7 +661,7 @@ var _ = ginkgo.Describe("[csi-topology-operation-strom-level5] "+
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),

--- a/tests/e2e/topology_site_down_cases.go
+++ b/tests/e2e/topology_site_down_cases.go
@@ -191,7 +191,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -233,7 +233,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -242,7 +242,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
 		err = scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount,
-			true, false)
+			true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -252,7 +252,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -283,7 +283,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -308,7 +308,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -401,7 +401,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -442,7 +442,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -451,7 +451,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
 		err = scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount,
-			true, false)
+			true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -461,7 +461,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -484,7 +484,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -509,7 +509,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -602,7 +602,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -639,7 +639,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -660,7 +660,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
 		err = scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount,
-			true, false)
+			true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -670,7 +670,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -682,7 +682,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -707,7 +707,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -803,7 +803,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -835,7 +835,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		}
@@ -845,7 +845,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
 		err = scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount,
-			true, false)
+			true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -855,7 +855,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -878,7 +878,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		}
@@ -904,7 +904,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -1000,7 +1000,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -1036,7 +1036,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -1044,7 +1044,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Scaleup any one StatefulSets replica")
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica and verify the replica count")
-		err = scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true, false)
+		err = scaleUpStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount, true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -1054,7 +1054,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 10
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -1077,7 +1077,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -1102,7 +1102,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -1196,7 +1196,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -1293,7 +1293,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 5
 		ginkgo.By("Scale down statefulset replica count")
 		err = scaleDownStatefulSetPod(ctx, client, statefulSets[0], namespace, statefulSetReplicaCount,
-			true, false)
+			true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[0])
 		gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),
@@ -1312,7 +1312,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		for i := 0; i < len(statefulSets); i++ {
 			err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-				statefulSets[i], namespace, allowedTopologies, true, false)
+				statefulSets[i], namespace, allowedTopologies, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}
 
@@ -1337,7 +1337,7 @@ var _ = ginkgo.Describe("[csi-topology-sitedown-level5] Topology-Aware-Provision
 		statefulSetReplicaCount = 0
 		ginkgo.By("Scale down statefulset replica count")
 		for i := 0; i < len(statefulSets); i++ {
-			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true, false)
+			err = scaleDownStatefulSetPod(ctx, client, statefulSets[i], namespace, statefulSetReplicaCount, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ssPodsAfterScaleDown := GetListOfPodsInSts(client, statefulSets[i])
 			gomega.Expect(len(ssPodsAfterScaleDown.Items) == int(statefulSetReplicaCount)).To(gomega.BeTrue(),

--- a/tests/e2e/topology_snapshot.go
+++ b/tests/e2e/topology_snapshot.go
@@ -236,7 +236,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		snapshotId := strings.Split(snapshothandle, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		_, err = snapc.SnapshotV1().VolumeSnapshotContents().Get(ctx,
@@ -274,7 +274,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies, false)
+			allowedTopologies)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		defer func() {
@@ -301,7 +301,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		snapshotContentCreated = false
 
 		ginkgo.By("Verify snapshot entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId, false)
+		err = verifySnapshotIsDeletedInCNS(volHandle, snapshotId)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Deleting volume snapshot Again to check Not found error")
@@ -373,7 +373,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		// Verify PV node affinity and that the PODS are running on appropriate nodes
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		framework.Logf("Fetching pod 3, pvc3 and pv3 details")
@@ -448,7 +448,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		snapshotId2 := strings.Split(snapshothandle3, "+")[1]
 
 		ginkgo.By("Query CNS and check the volume snapshot entry")
-		err = verifySnapshotIsCreatedInCNS(volHandle3, snapshotId2, false)
+		err = verifySnapshotIsCreatedInCNS(volHandle3, snapshotId2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		pvcSpec := getPersistentVolumeClaimSpecWithDatasource(namespace, "1Gi", storageclass, nil,
@@ -478,7 +478,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		ginkgo.By("Verify newly created PV node affinity and that the new PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Delete volume snapshot and verify the snapshot content is deleted")
@@ -492,7 +492,7 @@ var _ = ginkgo.Describe("[topology-snapshot] Topology Volume Snapshot tests", fu
 		snapshotContentCreated = false
 
 		ginkgo.By("Verify snapshot  entry is deleted from CNS")
-		err = verifySnapshotIsDeletedInCNS(volHandle3, snapshotId2, false)
+		err = verifySnapshotIsDeletedInCNS(volHandle3, snapshotId2)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 

--- a/tests/e2e/volume_provisioning_with_level5_topology.go
+++ b/tests/e2e/volume_provisioning_with_level5_topology.go
@@ -194,13 +194,13 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Verify PV node affinity and that the PODS are running on appropriate nodes
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate node")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale down statefulset to 0 replicas
 		replicas -= 3
 		ginkgo.By("Scale down statefulset replica count to 0")
-		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -274,31 +274,31 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		// Verify PV node affinity and that the PODS are running on appropriate node
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate nodes")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client,
-			statefulset, namespace, allowedTopologies, false, false)
+			statefulset, namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale up statefulset replica count to 5
 		replicas += 5
 		ginkgo.By("Scale up statefulset replica count to 5")
-		err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale down statefulset replica count to 1
 		replicas -= 1
 		ginkgo.By("Scale down statefulset replica count to 1")
-		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Verify newly created PV node affinity details  and that the new PODS are running on appropriate nodes
 		ginkgo.By("Verify newly created PV node affinity details  and that the new PODS are running on appropriate nodes")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale down statefulset replicas to 0
 		replicas = 0
 		ginkgo.By("Scale down statefulset replica count to 0")
-		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -373,13 +373,13 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale up statefulset replicas to 5
 		replicas += 5
 		ginkgo.By("Scale up statefulset replica count to 5")
-		err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		/* Verify newly created PV node affinity and that the news PODS are running
@@ -387,13 +387,13 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify newly created PV node affinity and that the news PODS " +
 			"are running on appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale down statefulset replicas to 0
 		replicas = 0
 		ginkgo.By("Scale down statefulset replica count to 0")
-		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -468,19 +468,19 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale up statefulset replicas to 5
 		replicas += 5
 		ginkgo.By("Scale up statefulset replica count to 5")
-		err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale down statefulset replicas to 1
 		replicas -= 1
 		ginkgo.By("Scale down statefulset replica count to 1")
-		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		/* "Verify newly created PV node affinity and that the new PODS are
@@ -488,13 +488,13 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify newly created PV node affinity and that the new PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale down statefulset replicas to 0
 		replicas = 0
 		ginkgo.By("Scale down statefulset replica count to 0")
-		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -577,19 +577,19 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale up statefulset replicas to 5
 		replicas += 5
 		ginkgo.By("Scale up statefulset replica count to 5")
-		err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleUpStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale down statefulset replicas to 1
 		replicas -= 1
 		ginkgo.By("Scale down statefulset replica count to 1")
-		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		/* Verify newly created PV node affinity and that the new PODS are running on
@@ -597,13 +597,13 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify newly created PV node affinity and that the new PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale down statefulset replicas to 0
 		replicas = 0
 		ginkgo.By("Scale down statefulset replica count to 0")
-		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -684,7 +684,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running " +
 			"on appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForDeploymentSetsLevel5(ctx, client, deployment,
-			namespace, allowedTopologyForSC, false, false)
+			namespace, allowedTopologyForSC, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -754,13 +754,13 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStatefulsetsLevel5(ctx, client, statefulset,
-			namespace, allowedTopologies, false, false)
+			namespace, allowedTopologies, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Scale down statefulset to 0 replicas
 		replicas -= 3
 		ginkgo.By("Scale down statefulset replica count to 0")
-		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false, false)
+		err = scaleDownStatefulSetPod(ctx, client, statefulset, namespace, replicas, false)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -815,56 +815,6 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		gomega.Expect(err).To(gomega.HaveOccurred())
 		framework.Logf("Volume Provisioning Failed for PVC %s due to invalid topology "+
 			"label given in Storage Class", pvc.Name)
-	})
-
-	/*
-		TESTCASE-16
-		Verify that Topology is not supported on file volumes
-		Steps:
-		1. Create SC with Immediate BindingMode with allowed topologies.
-		(here in this case - region1 > zone1 > building1 > level1 > rack > (rack1,rack2,rack3))
-		2. Create PVC using above SC with access mode "accessModes" ReadWriteMany.
-		3. Verify PVC creation is stuck in pending state forever.
-		4. Delete PVC and SC.
-	*/
-
-	ginkgo.It("Verify volume provisioning when storage class specified with Immediate "+
-		"BindingMode and pvc specified with "+
-		"ReadWriteMany access mode", ginkgo.Label(p2, block, vanilla, level5, stable, negative), func() {
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		// Get allowed topologies for Storage Class for all 5 levels
-		allowedTopologyForSC := getTopologySelector(topologyAffinityDetails, topologyCategories,
-			topologyLength)
-
-		// Create SC with Immediate BindingMode and allowed topology set to 5 levels
-		storageclass, err := createStorageClass(client, nil, allowedTopologyForSC, "", "", false, "")
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		defer func() {
-			err := client.StorageV1().StorageClasses().Delete(ctx, storageclass.Name,
-				*metav1.NewDeleteOptions(0))
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		}()
-
-		// Create PVC with accessMode as "ReadWriteMany" using above SC
-		pvc, err := createPVC(ctx, client, namespace, nil, "", storageclass, v1.ReadWriteMany)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		defer func() {
-			if pvc != nil {
-				ginkgo.By("Delete the PVC")
-				err = fpv.DeletePersistentVolumeClaim(ctx, client, pvc.Name, namespace)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			}
-		}()
-
-		// Expect PVC claim to fail as volume topology feature for file volumes is not supported
-		ginkgo.By("Expect PVC claim to fail as volume topology feature for file " +
-			"volumes is not supported")
-		expectedErrMsg := "volume topology feature for file volumes is not supported."
-		framework.Logf("Expected failure message: %+q", expectedErrMsg)
-		err = waitForEvent(ctx, client, namespace, expectedErrMsg, pvc.Name)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Expected error : %q", expectedErrMsg))
 	})
 
 	/*
@@ -958,7 +908,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on appropriate " +
 			"node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies, false)
+			allowedTopologies)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -1047,7 +997,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies, false)
+			allowedTopologies)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -1178,7 +1128,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies, false)
+			allowedTopologies)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	})
@@ -1324,7 +1274,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies, false)
+			allowedTopologies)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Deleting Pod
@@ -1391,7 +1341,7 @@ var _ = ginkgo.Describe("[csi-topology-for-level5] Topology-Provisioning-For-Sta
 		ginkgo.By("Verify PV node affinity and that the PODS are running on " +
 			"appropriate node as specified in the allowed topologies of SC")
 		err = verifyPVnodeAffinityAndPODnodedetailsForStandalonePodLevel5(ctx, client, pod, namespace,
-			allowedTopologies, false)
+			allowedTopologies)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Verify volume metadata for POD, PVC and PV

--- a/tests/e2e/volume_provisioning_with_topology.go
+++ b/tests/e2e/volume_provisioning_with_topology.go
@@ -271,7 +271,7 @@ var _ = ginkgo.Describe("[csi-topology-vanilla] Basic-Topology-Aware-Provisionin
 		storagePolicyNameFromOtherZone := GetAndExpectStringEnvVar(envStoragePolicyNameFromInaccessibleZone)
 		scParameters := make(map[string]string)
 		scParameters[scParamStoragePolicyName] = storagePolicyNameFromOtherZone
-		errStringToVerify := "No compatible datastore found for storagePolicy"
+		errStringToVerify := "No compatible datastores found for accessibility requirements"
 		invokeTopologyBasedVolumeProvisioningWithInaccessibleParameters(f, client,
 			namespace, scParameters, allowedTopologies, errStringToVerify)
 	})

--- a/tests/e2e/vsan_stretched_cluster.go
+++ b/tests/e2e/vsan_stretched_cluster.go
@@ -249,14 +249,9 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		defer func() {
 			deleteService(namespace, client, service)
 		}()
-
+		ginkgo.By("Creating statefulset and deployment with volumes from the stretched datastore")
 		statefulset, _, _ = createStsDeployment(ctx, client, namespace, sc, true,
-			false, 0, "", accessMode, false)
-		replicas = *(statefulset.Spec.Replicas)
-		fss.WaitForStatusReadyReplicas(ctx, client, statefulset, replicas)
-		gomega.Expect(fss.CheckMount(ctx, client, statefulset, mountPath)).NotTo(gomega.HaveOccurred())
-
-		ginkgo.By("Read statefull pod's before scale down")
+			false, 0, "", "")
 		ssPodsBeforeScaleDown := fss.GetPodList(ctx, client, statefulset)
 
 		csipods, err := client.CoreV1().Pods(csiNs).List(ctx, metav1.ListOptions{})
@@ -459,13 +454,13 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 
 		ginkgo.By("Creating statefulset and deployment with volumes from the stretched datastore")
 		statefulset, _, _ := createStsDeployment(ctx, client, namespace, sc, true,
-			false, 0, "", accessMode, false)
+			false, 0, "", accessMode)
 		replicas := *(statefulset.Spec.Replicas)
 		ginkgo.By("Creating statefulsets sts1 with replica count 1 and sts2 with 5 and wait for all" +
 			"the replicas to be running")
-		statefulset1, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 1, "web", accessMode, false)
+		statefulset1, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 1, "web", "")
 		replicas1 := *(statefulset1.Spec.Replicas)
-		statefulset2, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 5, "web-nginx", accessMode, false)
+		statefulset2, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 5, "web-nginx", "")
 		ss2PodsBeforeScaleDown := fss.GetPodList(ctx, client, statefulset2)
 		replicas2 := *(statefulset2.Spec.Replicas)
 		fss.WaitForStatusReadyReplicas(ctx, client, statefulset, replicas)
@@ -888,7 +883,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		}()
 		ginkgo.By("Creating statefulset and deployment with volumes from the stretched datastore")
 		statefulset, deployment, _ := createStsDeployment(ctx, client, namespace, sc, true,
-			false, 0, "", accessMode, false)
+			false, 0, "", "")
 		ssPodsBeforeScaleDown := fss.GetPodList(ctx, client, statefulset)
 		replicas := *(statefulset.Spec.Replicas)
 
@@ -1911,7 +1906,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 
 		ginkgo.By("Creating statefulset and deployment with volumes from the stretched datastore")
 		statefulset, _, _ := createStsDeployment(ctx, client, namespace, sc, true,
-			false, 0, "", accessMode, false)
+			false, 0, "", "")
 		replicas := *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
 		fss.WaitForStatusReadyReplicas(ctx, client, statefulset, replicas)
@@ -2026,10 +2021,10 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 
 		ginkgo.By("Creating statefulsets sts1 with replica count 1 and sts2 with 5 and wait for all" +
 			"the replicas to be running")
-		statefulset1, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 1, "web", accessMode, false)
+		statefulset1, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 1, "web", accessMode)
 		replicas1 := *(statefulset1.Spec.Replicas)
 		statefulset2, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 5, "web-nginx",
-			accessMode, false)
+			accessMode)
 		ss2PodsBeforeScaleDown := fss.GetPodList(ctx, client, statefulset2)
 		replicas2 := *(statefulset2.Spec.Replicas)
 
@@ -2160,7 +2155,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		}()
 
 		statefulset, _, _ := createStsDeployment(ctx, client, namespace, sc, true, false, 0, "",
-			accessMode, false)
+			"")
 		replicas := *(statefulset.Spec.Replicas)
 		ssPodsBeforeScaleDown := fss.GetPodList(ctx, client, statefulset)
 		// Scale down replicas of statefulset and verify CNS entries for volumes
@@ -2256,10 +2251,10 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		ginkgo.By("Creating statefulsets sts1 with replica count 1 and sts2 with 5 and wait for all" +
 			"the replicas to be running")
 		statefulset1, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 1, "web",
-			accessMode, false)
+			accessMode)
 		replicas1 := *(statefulset1.Spec.Replicas)
 		statefulset2, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 5, "web-nginx",
-			accessMode, false)
+			accessMode)
 		ss2PodsBeforeScaleDown := fss.GetPodList(ctx, client, statefulset2)
 		replicas2 := *(statefulset2.Spec.Replicas)
 
@@ -2611,10 +2606,10 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		ginkgo.By("Creating statefulsets sts1 with replica count 1 and sts2 with 5 and wait for all" +
 			"the replicas to be running")
 		statefulset1, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 1, "web",
-			accessMode, false)
+			accessMode)
 		replicas1 := *(statefulset1.Spec.Replicas)
 		statefulset2, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 5, "web-nginx",
-			accessMode, false)
+			accessMode)
 		ss2PodsBeforeScaleDown := fss.GetPodList(ctx, client, statefulset2)
 		replicas2 := *(statefulset2.Spec.Replicas)
 
@@ -2773,10 +2768,10 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 		ginkgo.By("Creating statefulsets sts1 with replica count 1 and sts2 with 5 and wait for all" +
 			"the replicas to be running")
 		statefulset1, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 1, "web",
-			accessMode, false)
+			accessMode)
 		replicas1 := *(statefulset1.Spec.Replicas)
 		statefulset2, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 5, "web-nginx",
-			accessMode, false)
+			accessMode)
 		ss2PodsBeforeScaleDown := fss.GetPodList(ctx, client, statefulset2)
 		replicas2 := *(statefulset2.Spec.Replicas)
 
@@ -2937,7 +2932,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 			statefulsetName := prefix1 + strconv.Itoa(i)
 			framework.Logf("Creating statefulset: %s", statefulsetName)
 			statefulset, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 1, statefulsetName,
-				accessMode, false)
+				accessMode)
 			replicas1 = *(statefulset.Spec.Replicas)
 			stsList = append(stsList, statefulset)
 		}
@@ -2947,7 +2942,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 			statefulsetName := prefix2 + strconv.Itoa(i)
 			framework.Logf("Creating statefulset: %s", statefulsetName)
 			statefulset, _, _ := createStsDeployment(ctx, client, namespace, sc, false, true, 2, statefulsetName,
-				accessMode, false)
+				accessMode)
 			replicas2 = *(statefulset.Spec.Replicas)
 			stsList = append(stsList, statefulset)
 		}
@@ -3157,7 +3152,7 @@ var _ = ginkgo.Describe("[vsan-stretch-vanilla] vsan stretched cluster tests", f
 
 		ginkgo.By("Creating statefulset and deployment with volumes from the stretched datastore")
 		statefulset, _, _ = createStsDeployment(ctx, client, namespace, sc, true,
-			false, 0, "", accessMode, false)
+			false, 0, "", accessMode)
 		replicas = *(statefulset.Spec.Replicas)
 		// Waiting for pods status to be Ready
 		fss.WaitForStatusReadyReplicas(ctx, client, statefulset, replicas)

--- a/tests/e2e/vsan_stretched_cluster_utils.go
+++ b/tests/e2e/vsan_stretched_cluster_utils.go
@@ -641,7 +641,7 @@ func checkVmStorageCompliance(client clientset.Interface, storagePolicy string) 
 func createStsDeployment(ctx context.Context, client clientset.Interface, namespace string,
 	sc *storagev1.StorageClass, isDeploymentRequired bool, modifyStsSpec bool,
 	replicaCount int32, stsName string,
-	accessMode v1.PersistentVolumeAccessMode, isMultiVcSetup bool) (*appsv1.StatefulSet, *appsv1.Deployment, []string) {
+	accessMode v1.PersistentVolumeAccessMode) (*appsv1.StatefulSet, *appsv1.Deployment, []string) {
 	var pvclaims []*v1.PersistentVolumeClaim
 	if accessMode == "" {
 		// If accessMode is not specified, set the default accessMode.
@@ -681,7 +681,7 @@ func createStsDeployment(ctx context.Context, client clientset.Interface, namesp
 				pv := getPvFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
 				volumesBeforeScaleDown = append(volumesBeforeScaleDown, pv.Spec.CSI.VolumeHandle)
 				// Verify the attached volume match the one in CNS cache
-				if !isMultiVcSetup {
+				if !multivc {
 					err := verifyVolumeMetadataInCNS(&e2eVSphere, pv.Spec.CSI.VolumeHandle,
 						volumespec.PersistentVolumeClaim.ClaimName, pv.ObjectMeta.Name, sspod.Name)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/vsphere.go
+++ b/tests/e2e/vsphere.go
@@ -142,12 +142,12 @@ func (vs *vSphere) queryCNSVolumeSnapshotWithResult(fcdID string,
 }
 
 // verifySnapshotIsDeletedInCNS verifies the snapshotId's presence on CNS
-func verifySnapshotIsDeletedInCNS(volumeId string, snapshotId string, isMultiVcSetup bool) error {
+func verifySnapshotIsDeletedInCNS(volumeId string, snapshotId string) error {
 	ginkgo.By(fmt.Sprintf("Invoking queryCNSVolumeSnapshotWithResult with VolumeID: %s and SnapshotID: %s",
 		volumeId, snapshotId))
 	var querySnapshotResult *cnstypes.CnsSnapshotQueryResult
 	var err error
-	if !isMultiVcSetup {
+	if !multivc {
 		querySnapshotResult, err = e2eVSphere.queryCNSVolumeSnapshotWithResult(volumeId, snapshotId)
 	} else {
 		querySnapshotResult, err = multiVCe2eVSphere.queryCNSVolumeSnapshotWithResultInMultiVC(volumeId, snapshotId)
@@ -163,12 +163,12 @@ func verifySnapshotIsDeletedInCNS(volumeId string, snapshotId string, isMultiVcS
 }
 
 // verifySnapshotIsCreatedInCNS verifies the snapshotId's presence on CNS
-func verifySnapshotIsCreatedInCNS(volumeId string, snapshotId string, isMultiVC bool) error {
+func verifySnapshotIsCreatedInCNS(volumeId string, snapshotId string) error {
 	ginkgo.By(fmt.Sprintf("Invoking queryCNSVolumeSnapshotWithResult with VolumeID: %s and SnapshotID: %s",
 		volumeId, snapshotId))
 	var querySnapshotResult *cnstypes.CnsSnapshotQueryResult
 	var err error
-	if !isMultiVC {
+	if !multivc {
 		querySnapshotResult, err = e2eVSphere.queryCNSVolumeSnapshotWithResult(volumeId, snapshotId)
 	} else {
 		querySnapshotResult, err = multiVCe2eVSphere.queryCNSVolumeSnapshotWithResultInMultiVC(volumeId, snapshotId)
@@ -1179,6 +1179,11 @@ func (vs *vSphere) verifyPreferredDatastoreMatch(volumeID string, dsUrls []strin
 	for _, dsUrl := range dsUrls {
 		if actualDatastoreUrl == dsUrl {
 			flag = true
+			if rwxAccessMode {
+				if !strings.HasPrefix(dsUrl, "ds:///vmfs/volumes/vsan:") {
+					return false
+				}
+			}
 			return flag
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
RWX topology HCI and No-HCI Mesh testcases automation. 

Below are the changes going on in this PR - 
* Covered all Positive test scenarios for singlevc, multivc and hci mesh single vc
* Removed one multivc bool parameter from all functions and replaced it with cont multivc parameter
* Removed the unwanted function parameter which has not been used in the function logic

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Yes

BlockConfigSecret results:
[BlockConfigSecret.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/14986983/BlockConfigSecret.txt)

MultiVC results:
[MultiVC.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/14986986/MultiVC.txt)

Preferential results:
[Preferential-logs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/15026844/Preferential-logs.txt)

Topology results:
[Topology.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/14986990/Topology.txt)

RWX Topology results:
[rwxtopology-logs.txt](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/15026880/rwxtopology-logs.txt)


sipriya@C02CR8ENMD6M vsphere-csi-driver % golangci-lint run --enable=lll --timeout=5m
sipriya@C02CR8ENMD6M vsphere-csi-driver % 
