### PR TITLE
Update Snapshot-specific CnsVolumeOperationDetails in CSI CreateSnapshot

### DIFF
--- a/pkg/csi/service/common/vsphereutil.go
+++ b/pkg/csi/service/common/vsphereutil.go
@@ -1034,11 +1034,11 @@ func isExpansionRequired(ctx context.Context, volumeID string, requestedSize int
 // The returned string is a combination of CNS VolumeID and CNS SnapshotID concatenated by the "+" sign.
 // The returned *time.Time denotes the creation time of snapshot from the storage system, i.e., CNS.
 func CreateSnapshotUtil(ctx context.Context, volumeManager cnsvolume.Manager, volumeID string,
-	snapshotName string) (string, *time.Time, error) {
+	snapshotName string, extraParams interface{}) (string, *time.Time, error) {
 	log := logger.GetLogger(ctx)
 
 	log.Debugf("vSphere CSI driver is creating snapshot with description, %q, on volume: %q", snapshotName, volumeID)
-	cnsSnapshotInfo, err := volumeManager.CreateSnapshot(ctx, volumeID, snapshotName)
+	cnsSnapshotInfo, err := volumeManager.CreateSnapshot(ctx, volumeID, snapshotName, extraParams)
 	if err != nil {
 		log.Errorf("failed to create snapshot on volume %q with description %q with error %+v",
 			volumeID, snapshotName, err)

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -3067,7 +3067,7 @@ func (c *controller) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshot
 		// sign. That is, a string of "<UUID>+<UUID>". Because, all other CNS snapshot APIs still require both
 		// VolumeID and SnapshotID as the input, while corresponding snapshot APIs in upstream CSI require SnapshotID.
 		// So, we need to bridge the gap in vSphere CSI driver and return a combined SnapshotID to CSI Snapshotter.
-		snapshotID, snapshotCreateTimePtr, err := common.CreateSnapshotUtil(ctx, volumeManager, volumeID, req.Name)
+		snapshotID, snapshotCreateTimePtr, err := common.CreateSnapshotUtil(ctx, volumeManager, volumeID, req.Name, nil)
 		if err != nil {
 			return nil, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to create snapshot on volume %q: %v", volumeID, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update Snapshot-specific CnsVolumeOperationDetails in CSI CreateSnapshot, to deliver the extra params to the volmanager that creates the CnsVolumeOperationDetails.

**Testing done**:
Run e2e test 

Performed manual testing :

verified if snapshot created successfully with extra params :
```
{"level":"info","time":"2024-05-03T12:05:44.008990613Z","caller":"wcp/controller.go:1587","msg":"WCP CreateSnapshot: called with args {SourceVolumeId:ccd01548-20df-480e-82e5-3e5af5e307c4 Name:snapshot-ab0c8958-b1ba-4057-aa9b-fef97ba768cf Secrets:map[] Parameters:map[csi.storage.k8s.io/volumesnapshot/name:example-vanilla-rwo-filesystem-snapshot csi.storage.k8s.io/volumesnapshot/namespace:testsnap csi.storage.k8s.io/volumesnapshotcontent/name:snapcontent-ab0c8958-b1ba-4057-aa9b-fef97ba768cf] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"f3240a6d-bbb0-4dff-9820-167fac9a26ea"}
.
.
{"level":"info","time":"2024-05-03T12:05:44.048301347Z","caller":"volume/manager.go:2355","msg":"QuotaInfo during CreateSnapshot call: {Reserved:1Gi StoragePolicyId: StorageClassName:example-vanilla-rwo-filesystem-sc Namespace:testsnap}","TraceId":"f3240a6d-bbb0-4dff-9820-167fac9a26ea"}
{"level":"info","time":"2024-05-03T12:05:44.065082432Z","caller":"volume/util.go:402","msg":"Calling CnsClient.CreateSnapshots: VolumeID [\"ccd01548-20df-480e-82e5-3e5af5e307c4\"] Description [\"snapshot-ab0c8958-b1ba-4057-aa9b-fef97ba768cf-ccd01548-20df-480e-82e5-3e5af5e307c4\"] cnsSnapshotCreateSpecList [[]types.CnsSnapshotCreateSpec{types.CnsSnapshotCreateSpec{DynamicData:types.DynamicData{}, VolumeId:types.CnsVolumeId{DynamicData:types.DynamicData{}, Id:\"ccd01548-20df-480e-82e5-3e5af5e307c4\"}, Description:\"snapshot-ab0c8958-b1ba-4057-aa9b-fef97ba768cf-ccd01548-20df-480e-82e5-3e5af5e307c4\"}}]","TraceId":"f3240a6d-bbb0-4dff-9820-167fac9a26ea"}
.
.
.
{"level":"info","time":"2024-05-03T12:05:47.739970348Z","caller":"wcp/controller.go:1671","msg":"CreateSnapshot succeeded for snapshot ccd01548-20df-480e-82e5-3e5af5e307c4+0647df87-84bb-48cd-ab2a-9476fc6cc347 on volume ccd01548-20df-480e-82e5-3e5af5e307c4 size 1073741824 Time proto seconds:1714737944 nanos:804338000 Timestamp 2024-05-03 12:05:44.804338 +0000 UTC Response: snapshot:<size_bytes:1073741824 snapshot_id:\"ccd01548-20df-480e-82e5-3e5af5e307c4+0647df87-84bb-48cd-ab2a-9476fc6cc347\" source_volume_id:\"ccd01548-20df-480e-82e5-3e5af5e307c4\" creation_time:<seconds:1714737944 nanos:804338000 > ready_to_use:true > ","TraceId":"f3240a6d-bbb0-4dff-9820-167fac9a26ea"}

```
Controller logs -
[vsphere_csi_controller.log](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/15201036/controller_snapshot_test.log)

Snapshot log -
[snapshot_create.log](https://github.com/kubernetes-sigs/vsphere-csi-driver/files/15201034/snapshot_create_test.log)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update Snapshot-specific CnsVolumeOperationDetails in CSI CreateSnapshot
```
