### PR TITLE
fix Thumbprint based on login for multi vCenter deployment

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -265,15 +265,11 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 			cfg.Global.VCClientTimeout = defaultVCClientTimeoutInMinutes
 		}
 		vcClientTimeout = cfg.Global.VCClientTimeout
-
-		vcCAFile := cfg.Global.CAFile
-		vcThumbprint := cfg.Global.Thumbprint
-
 		vcConfig := &VirtualCenterConfig{
 			Host:                        vCenterIP,
 			Port:                        port,
-			CAFile:                      vcCAFile,
-			Thumbprint:                  vcThumbprint,
+			CAFile:                      cfg.VirtualCenter[vCenterIP].CAFile,
+			Thumbprint:                  cfg.VirtualCenter[vCenterIP].Thumbprint,
 			Username:                    cfg.VirtualCenter[vCenterIP].User,
 			Password:                    cfg.VirtualCenter[vCenterIP].Password,
 			Insecure:                    cfg.VirtualCenter[vCenterIP].InsecureFlag,
@@ -282,7 +278,12 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 			QueryLimit:                  cfg.Global.QueryLimit,
 			ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
 		}
-
+		if vcConfig.CAFile == "" {
+			vcConfig.CAFile = cfg.Global.CAFile
+		}
+		if vcConfig.Thumbprint == "" {
+			vcConfig.Thumbprint = cfg.Global.Thumbprint
+		}
 		log.Debugf("Setting the queryLimit = %v, ListVolumeThreshold = %v", vcConfig.QueryLimit, vcConfig.ListVolumeThreshold)
 		if strings.TrimSpace(cfg.VirtualCenter[vCenterIP].Datacenters) != "" {
 			vcConfig.DatacenterPaths = strings.Split(cfg.VirtualCenter[vCenterIP].Datacenters, ",")

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -142,6 +142,13 @@ type VirtualCenterConfig struct {
 	VCenterPort string `gcfg:"port"`
 	// True if vCenter uses self-signed cert.
 	InsecureFlag bool `gcfg:"insecure-flag"`
+	// Specifies the path to a CA certificate in PEM format. This has no effect if
+	// InsecureFlag is enabled. Optional; if not configured, the system's CA
+	// certificates will be used.
+	CAFile string `gcfg:"ca-file"`
+	// Thumbprint specifies the certificate thumbprint to use
+	// This has no effect if InsecureFlag is enabled.
+	Thumbprint string `gcfg:"thumbprint"`
 	// Datacenter in which VMs are located.
 	Datacenters string `gcfg:"datacenters"`
 	// TargetvSANFileShareClusters represents file service enabled vSAN clusters on which file volumes can be created.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix Thumbprint based on login for multi vCenter deployment

**Which issue this PR fixes**
fixes #https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/2823

**Testing done**:
Done.

Verified Creating PVC and Pod using following config on multi vCenter deployment

```
[Global]
cluster-distribution = "CSI-Vanilla"
csi-fetch-preferred-datastores-intervalinmin = 1
query-limit = 3
list-volume-threshold = 1

[VirtualCenter "VC-1-IP"]
insecure-flag = "true"
user = "Administrator@vsphere.local"
password = "PSPSh-2lv1Y-beHe"
port = "443"
thumbprint = "7F:81:BC:50:DB:AD:0C:9E:33:4A:75:57:92:5A:5A:FB:28:BD:D6:A5:2E:26:9A:DC:9B:02:8D:5C:A8:B4:D4:BC"
insecure-flag = "false"
datacenters = "VSAN-DC"

[VirtualCenter "VC-2-IP"]
insecure-flag = "true"
user = "Administrator@vsphere.local"
password = "PSPSh-2lv1Y-beHe"
port = "443"
thumbprint = "47:BF:44:18:ED:22:C1:D0:61:59:7C:ED:24:39:C0:71:10:66:BC:66:A1:A8:C6:96:EE:43:21:43:F9:CA:BE:CE"
insecure-flag = "false"
datacenters = "VSAN-DC"

[VirtualCenter "VC-3-IP"]
insecure-flag = "true"
user = "Administrator@vsphere.local"
password = "PSPSh-2lv1Y-beHe"
port = "443"
thumbprint = "98:4B:78:EC:1F:D3:9E:9D:F2:F1:7C:98:C3:0F:77:3F:59:7C:36:C2:E2:1B:14:7A:5B:BF:73:8A:97:84:9C:26"
insecure-flag = "false"
datacenters = "VSAN-DC"

[Snapshot]
global-max-snapshots-per-block-volume = 3

[Labels]
topology-categories="k8s-zone" 
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix Thumbprint based on login for multi vCenter deployment
```
