### PR TITLE
CSI unit tests framework improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,6 +279,8 @@ TEST_FLAGS ?= -v -count=1
 .PHONY: unit build-unit-tests
 unit unit-test:
 	env -u VSPHERE_SERVER -u VSPHERE_DATACENTER -u VSPHERE_PASSWORD -u VSPHERE_USER -u VSPHERE_STORAGE_POLICY_NAME -u KUBECONFIG -u WCP_ENDPOINT -u WCP_PORT -u WCP_NAMESPACE -u TOKEN -u CERTIFICATE go test $(TEST_FLAGS) $(PKGS_WITH_TESTS)
+unit-cover:
+	env -u VSPHERE_SERVER -u VSPHERE_DATACENTER -u VSPHERE_PASSWORD -u VSPHERE_USER -u VSPHERE_STORAGE_POLICY_NAME -u KUBECONFIG -u WCP_ENDPOINT -u WCP_PORT -u WCP_NAMESPACE -u TOKEN -u CERTIFICATE go test $(TEST_FLAGS) $(PKGS_WITH_TESTS) && go tool cover -html=cover.out
 build-unit-tests:
 	$(foreach pkg,$(PKGS_WITH_TESTS),go test $(TEST_FLAGS) -c $(pkg); )
 
@@ -342,22 +344,18 @@ endif
 	go test $(TEST_FLAGS) -tags=integration-unit $(INTEGRATION_TEST_PKGS)
 
 # The default test target.
-.PHONY: test build-tests
+.PHONY: test test-cover build-tests
 test: unit
+test-cover: unit-cover
 build-tests: build-unit-tests
 
 .PHONY: cover
 cover: TEST_FLAGS += -cover
 cover: test
 
-# The default test target.
-.PHONY: test build-tests
-test: unit
-build-tests: build-unit-tests
-
-.PHONY: cover
-cover: TEST_FLAGS += -cover
-cover: test
+.PHONY: coverprofile
+coverprofile: TEST_FLAGS += -coverprofile cover.out
+coverprofile: test-cover
 
 .PHONY: test-e2e
 test-e2e:

--- a/pkg/common/cns-lib/vsphere/cns_test.go
+++ b/pkg/common/cns-lib/vsphere/cns_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	cnssim "github.com/vmware/govmomi/cns/simulator"
+	pbmsim "github.com/vmware/govmomi/pbm/simulator"
+	"github.com/vmware/govmomi/simulator"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+)
+
+// We should get expected failure when username is not a fully qualified domain name
+func TestConnectCnsWithInvalidUser(t *testing.T) {
+	// Create context.
+	ctx := context.Background()
+
+	cfg := &config.Config{}
+	model := simulator.VPX()
+	defer model.Remove()
+
+	err := model.Create()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	model.Service.TLS = new(tls.Config)
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	// CNS Service simulator.
+	model.Service.RegisterSDK(cnssim.New())
+
+	// PBM Service simulator.
+	model.Service.RegisterSDK(pbmsim.New())
+	cfg.Global.InsecureFlag = true
+
+	cfg.Global.VCenterIP = s.URL.Hostname()
+	cfg.Global.VCenterPort = s.URL.Port()
+	// Username doesn't have fully qualified domain name
+	cfg.Global.User = "username-without-fqdn"
+	cfg.Global.Password, _ = s.URL.User.Password()
+	cfg.Global.Datacenters = "DC0"
+
+	// Write values to test_vsphere.conf.
+	os.Setenv("VSPHERE_CSI_CONFIG", "test_vsphere.conf")
+	conf := []byte(fmt.Sprintf("[Global]\ninsecure-flag = \"%t\"\n"+
+		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"",
+		cfg.Global.InsecureFlag, cfg.Global.VCenterIP, cfg.Global.User, cfg.Global.Password,
+		cfg.Global.Datacenters, cfg.Global.VCenterPort))
+	err = os.WriteFile("test_vsphere.conf", conf, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		os.Unsetenv("VSPHERE_CSI_CONFIG")
+		os.Remove("test_vsphere.conf")
+	}()
+
+	cfg.VirtualCenter = make(map[string]*config.VirtualCenterConfig)
+	cfg.VirtualCenter[s.URL.Hostname()] = &config.VirtualCenterConfig{
+		User:         cfg.Global.User,
+		Password:     cfg.Global.Password,
+		VCenterPort:  cfg.Global.VCenterPort,
+		InsecureFlag: cfg.Global.InsecureFlag,
+		Datacenters:  cfg.Global.Datacenters,
+	}
+
+	// CNS based CSI requires a valid cluster name.
+	cfg.Global.ClusterID = "test-cluster"
+
+	vcenterconfig, err := GetVirtualCenterConfig(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vcManager := GetVirtualCenterManager(ctx)
+	vcenter, err := vcManager.RegisterVirtualCenter(ctx, vcenterconfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = vcenter.ConnectCns(ctx)
+	if err != nil {
+		t.Logf("Expected error received, as username is not a fully qualified domain name.")
+	} else {
+		t.Fatal("CNS client creation should fail as username is not a fully qualified domain name.")
+	}
+}

--- a/pkg/common/cns-lib/vsphere/tagmanager_test_utils.go
+++ b/pkg/common/cns-lib/vsphere/tagmanager_test_utils.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"fmt"
+
+	_ "github.com/vmware/govmomi/vapi/simulator"
+	"github.com/vmware/govmomi/vapi/tags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	regionCategoryName string = "k8s-region"
+	regionTagName      string = "region-1"
+	zoneCategoryName   string = "k8s-zone"
+	zoneTagName        string = "zone-A"
+)
+
+// CreateNewCategory creates a new category using tag manager
+func CreateNewCategory(ctx context.Context, categoryName string, cardinality string,
+	tagManager *tags.Manager) (string, error) {
+	// Create a new category
+	tagSpec := tags.Category{Name: categoryName, Cardinality: cardinality}
+	categoryID, err := tagManager.CreateCategory(ctx, &tagSpec)
+	if err != nil {
+		return "", fmt.Errorf("error creating a new tag category %s, err: %v",
+			categoryName, err)
+	}
+	fmt.Printf("Successfully created a new category %s with categoryID %v\n",
+		categoryName, categoryID)
+
+	return categoryID, nil
+}
+
+// CreateNewTag creates a new tag within the given category
+func CreateNewTag(ctx context.Context, categoryId string, tagName string,
+	description string, tagManager *tags.Manager) (string, error) {
+	// Create a new tag within the given category
+	tagID, err := tagManager.CreateTag(ctx, &tags.Tag{Name: tagName, CategoryID: categoryId,
+		Description: description})
+	if err != nil {
+		return "", fmt.Errorf("error creating a new tag %s within category %s, err: %v",
+			tagName, categoryId, err)
+	}
+	fmt.Printf("Successfully created a new tag %s with tagID %v within category %s\n",
+		tagName, tagID, categoryId)
+
+	return tagID, nil
+}
+
+// AttachTag attaches a tag to the given managed object
+func AttachTag(ctx context.Context, tagID string, moref types.ManagedObjectReference,
+	tagManager *tags.Manager) error {
+	err := tagManager.AttachTag(ctx, tagID, moref)
+	if err != nil {
+		return fmt.Errorf("error attaching a tag %s to moref %v, err: %v",
+			tagID, moref, err)
+	}
+	fmt.Printf("Successfully attached a tag %s with moref %v\n", tagID, moref)
+
+	return nil
+}

--- a/pkg/common/cns-lib/vsphere/virtualmachine_test.go
+++ b/pkg/common/cns-lib/vsphere/virtualmachine_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/rest"
+	_ "github.com/vmware/govmomi/vapi/simulator"
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+var (
+	onceForVMTest sync.Once
+	ctx           context.Context
+	tagManager    *tags.Manager
+	vm            *VirtualMachine
+)
+
+func getClientFromVCSimAndAttachTags(t *testing.T) {
+	var client *govmomi.Client
+
+	onceForVMTest.Do(func() {
+		ctx = context.Background()
+		tlsConfig := new(tls.Config)
+
+		// Create a new vcsim instance
+		model := simulator.VPX()
+		// Update model values as per requirement
+		model.Datacenter = 1
+		model.Cluster = 1
+		model.Host = 0
+
+		defer model.Remove()
+		err := model.Create()
+		if err != nil {
+			t.Fatalf("Failed to create simulator model, err: %v\n", err)
+		}
+
+		model.Service.TLS = tlsConfig
+		// Requird for tag manager to work
+		model.Service.RegisterEndpoints = true
+
+		// Create a vcsim server
+		s := model.Service.NewServer()
+
+		// Create a new client
+		client, err = govmomi.NewClient(ctx, s.URL, true)
+		if err != nil {
+			t.Fatalf("Failed to create new govmomi client, err: %v\n", err)
+		}
+
+		userinfo := simulator.DefaultLogin
+		// Create a new rest client and a tag manager
+		restClient := rest.NewClient(client.Client)
+		err = restClient.Login(ctx, userinfo)
+		if err != nil {
+			t.Fatalf("failed to login to the rest client, err: %v", err)
+		}
+
+		tagManager = tags.NewManager(restClient)
+		if tagManager == nil {
+			t.Fatalf("failed to create a new tagManager")
+		}
+		fmt.Printf("New tag manager created with useragent %s\n", tagManager.UserAgent)
+
+		// Create a new region category
+		regionCategoryId, err := CreateNewCategory(ctx, regionCategoryName, "SINGLE", tagManager)
+		if err != nil {
+			t.Fatalf("Error creating a new category %s, err: %v\n", regionCategoryName, err)
+		}
+		// Create a new tag within the region category
+		description := "region-tag"
+		regionTagId, err := CreateNewTag(ctx, regionCategoryId, regionTagName, description, tagManager)
+		if err != nil {
+			t.Fatalf("Error creating a new tag %s, err: %v\n", regionTagName, err)
+		}
+
+		// Add region tag to the datacenter
+		dcMoRef := simulator.Map.Any("Datacenter").(*simulator.Datacenter).Reference()
+		err = AttachTag(ctx, regionTagId, dcMoRef, tagManager)
+		if err != nil {
+			t.Fatalf("Error adding region tag to datacenter, err: %v", err)
+		}
+
+		// Create a new zone category
+		zoneCategoryId, err := CreateNewCategory(ctx, zoneCategoryName, "SINGLE", tagManager)
+		if err != nil {
+			t.Fatalf("Error creating a new category %s, err: %v\n", zoneCategoryName, err)
+		}
+		// Create a new tag within the zone category
+		description = "zone-tag"
+		zoneTagId, err := CreateNewTag(ctx, zoneCategoryId, zoneTagName, description, tagManager)
+		if err != nil {
+			t.Fatalf("Error creating a new tag %s, err: %v\n", zoneTagName, err)
+		}
+
+		// Add zone tag to the cluster
+		clusterMoRef := simulator.Map.Any("ClusterComputeResource").(*simulator.ClusterComputeResource).Reference()
+		err = AttachTag(ctx, zoneTagId, clusterMoRef, tagManager)
+		if err != nil {
+			t.Fatalf("Error adding region tag to datacenter, err: %v", err)
+		}
+
+		// Get any nodeVM instance which belongs to above datacenter and cluster and check GetZoneRegion of that VM
+		dcobj := object.NewDatacenter(client.Client, dcMoRef)
+		dc := &Datacenter{
+			Datacenter: dcobj,
+		}
+		obj := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+		vm = &VirtualMachine{
+			Datacenter:     dc,
+			VirtualMachine: object.NewVirtualMachine(client.Client, obj.Reference()),
+		}
+	})
+}
+
+// TestGetZoneRegion creates new category and tag using tag manager for region
+// and zone respectively. It attaches region tag to datacenter and zone tag to cluster moref.
+// After that it calls existing function GetZoneRegion for one of the VMs belonging to this datacenter
+// and cluster and checks if we can successfully fetch tags from the ancestors of this VM that we added
+// using tagManager.
+func TestGetZoneRegion(t *testing.T) {
+	getClientFromVCSimAndAttachTags(t)
+
+	// GetZoneRegion function returns zone and region tag values of the nodeVM for the
+	// given zone and region category names.
+	zone, region, err := vm.GetZoneRegion(ctx, zoneCategoryName, regionCategoryName, tagManager)
+	if err != nil {
+		t.Fatalf("Error occurred while getting zone and region of VM, err: %v\n", err)
+	}
+	if zone == zoneTagName && region == regionTagName {
+		fmt.Printf("Expected zone and region tag values received for the VM, region: %s and zone: %s\n",
+			region, zone)
+	} else {
+		t.Fatalf("Didn't get expected values for zone and region for VM. Got region: %s and zone: %s. "+
+			"Expected values are - region: %s and zone: %s\n",
+			region, zone, regionTagName, zoneTagName)
+	}
+}
+
+// TestIsInZoneRegion creates new category and tag using tag manager for region
+// and zone respectively. It attaches region tag to datacenter and zone tag to cluster moref.
+// After that it calls existing function IsInZoneRegion for one of the VMs belonging to this datacenter
+// and cluster and checks if vm belongs to the specified zone and region.
+func TestIsInZoneRegion(t *testing.T) {
+	getClientFromVCSimAndAttachTags(t)
+
+	// IsInZoneRegion function checks if VM belongs to specified zone and region tag values.
+	// This function returns true if yes, false otherwise.
+	isInZoneRegion, err := vm.IsInZoneRegion(ctx, zoneCategoryName, regionCategoryName, zoneTagName,
+		regionTagName, tagManager)
+	if err != nil {
+		t.Fatalf("Error occurred while checking if VM is in specified zone and region, err: %v\n", err)
+	}
+	if isInZoneRegion == true {
+		fmt.Printf("VM belongs to specified zone and region as expected.\n")
+	} else {
+		t.Fatalf("VM should belong to specified zone and region")
+	}
+}

--- a/pkg/common/unittestcommon/types.go
+++ b/pkg/common/unittestcommon/types.go
@@ -26,6 +26,15 @@ import (
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
 )
 
+const (
+	VCSimDefaultDatacenters     int = 1
+	VCSimDefaultClusters        int = 1
+	VCSimDefaultHostsPerCluster int = 3
+	VCSimDefaultStandalonHosts  int = 1
+	VCSimDefaultDatastores      int = 1
+	VCSimDefaultVMsPerCluster   int = 2
+)
+
 // FakeK8SOrchestrator is used to mock common K8S Orchestrator instance to store FSS values
 type FakeK8SOrchestrator struct {
 	// RWMutex to synchronize access to 'featureStates' field from multiple callers
@@ -69,4 +78,20 @@ type mockControllerVolumeTopology struct {
 
 // mockNodeVolumeTopology is a mock of the k8sorchestrator nodeVolumeTopology type.
 type mockNodeVolumeTopology struct {
+}
+
+type VcsimParams struct {
+	Datacenters     int
+	Clusters        int
+	HostsPerCluster int
+	StandaloneHosts int
+	VMsPerCluster   int
+	// Note that specified number of datastores are created for each datacenter and datastore is accessible from
+	// all hosts belonging to a datacenter. Internally each datastore will have temporary local file storage and
+	// it will be mounted on every HostSystem of the datacenter.
+	Datastores int
+	// Version is the dot-separated VC version like 7.0.3
+	Version string
+	// ApiVersion is the dot-separated API version like 7.0
+	ApiVersion string
 }

--- a/pkg/csi/service/vanilla/controller_topology_test.go
+++ b/pkg/csi/service/vanilla/controller_topology_test.go
@@ -1,0 +1,503 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vanilla
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	cnstypes "github.com/vmware/govmomi/cns/types"
+	"github.com/vmware/govmomi/find"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/vmware/govmomi/simulator"
+	clientset "k8s.io/client-go/kubernetes"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/node"
+	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
+	cnsvsphere "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/vsphere"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/unittestcommon"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco"
+	commoncotypes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common/commonco/types"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/internalapis/cnsvolumeoperationrequest"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+)
+
+var (
+	ctxtopology                    context.Context
+	controllerTestInstanceTopology *controllerTestTopology
+	onceForControllerTestTopology  sync.Once
+)
+
+type controllerTestTopology struct {
+	controller *controller
+	config     *config.Config
+	vcenter    *cnsvsphere.VirtualCenter
+	// Add a VolumeOperationRequest interface to set up certain test scenario
+	operationStore cnsvolumeoperationrequest.VolumeOperationRequest
+}
+
+type FakeTopologyManager struct {
+	nodeLabels map[string]map[string]string
+}
+
+type FakeNodeManagerTopology struct {
+	cnsNodeManager node.Manager
+	k8sClient      clientset.Interface
+}
+
+func (f *FakeNodeManagerTopology) Initialize(ctx context.Context) error {
+	f.cnsNodeManager = node.GetManager(ctx)
+	f.cnsNodeManager.SetKubernetesClient(f.k8sClient)
+	var t *testing.T
+
+	// node.GetManager returns a singleton instance of the Manager interface,
+	// so we may have nodes registered as part of previous test from same folder.
+	// Unregister all nodes which are already registered with nodeManager.
+	err := f.cnsNodeManager.UnregisterAllNodes(ctx)
+	if err != nil {
+		t.Errorf("Error occurred while unregistering all nodes, err: %v", err)
+	}
+
+	objVMs := simulator.Map.All("VirtualMachine")
+	var i int
+	for _, vm := range objVMs {
+		i++
+		obj := vm.(*simulator.VirtualMachine)
+		nodeUUID := obj.Config.Uuid
+		nodeName := "k8s-node-" + strconv.Itoa(i)
+		// Register new node entry in nodeManager
+		err := f.cnsNodeManager.RegisterNode(ctx, nodeUUID, nodeName)
+		if err != nil {
+			t.Errorf("Error occurred while registering a node: %s, nodeUUID: %s, err: %v", nodeName, nodeUUID, err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *FakeNodeManagerTopology) GetSharedDatastoresInK8SCluster(ctx context.Context) ([]*cnsvsphere.DatastoreInfo,
+	error) {
+	// This function is not required for topology
+	return nil, nil
+}
+
+func (f *FakeNodeManagerTopology) GetNodeVMByNameAndUpdateCache(ctx context.Context,
+	nodeName string) (*cnsvsphere.VirtualMachine, error) {
+	return f.cnsNodeManager.GetNodeVMByNameAndUpdateCache(ctx, nodeName)
+}
+
+func (f *FakeNodeManagerTopology) GetNodeVMByNameOrUUID(
+	ctx context.Context, nodeNameOrUUID string) (*cnsvsphere.VirtualMachine, error) {
+	return f.cnsNodeManager.GetNodeVMByNameOrUUID(ctx, nodeNameOrUUID)
+}
+
+func (f *FakeNodeManagerTopology) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error) {
+	return f.cnsNodeManager.GetNodeNameByUUID(ctx, nodeUUID)
+}
+
+func (f *FakeNodeManagerTopology) GetNodeVMByUuid(ctx context.Context, nodeUUID string) (*cnsvsphere.VirtualMachine,
+	error) {
+	return f.cnsNodeManager.GetNodeVMByUuid(ctx, nodeUUID)
+}
+
+func (f *FakeNodeManagerTopology) GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachine, error) {
+	return f.cnsNodeManager.GetAllNodes(ctx)
+}
+
+func (f *FakeNodeManagerTopology) GetAllNodesByVC(ctx context.Context, vcHost string) ([]*cnsvsphere.VirtualMachine,
+	error) {
+	// This function is required only for multi VC env.
+	return nil, nil
+}
+
+// generateNodeLabels adds region and zone specific labels on all nodeVMs generated using vcsim
+func generateNodeLabels(ctx context.Context, vc *cnsvsphere.VirtualCenter) (map[string]map[string]string, error) {
+	nodeLabelsMap := map[string]map[string]string{}
+	var i int
+
+	finder := find.NewFinder(vc.Client.Client, false)
+	objDCs := simulator.Map.All("Datacenter")
+	for _, dc := range objDCs {
+		i++
+		dcref := dc.(*simulator.Datacenter)
+		dcname := dcref.Name
+		fmt.Printf("generateNodeLabels for datacenter=%s\n", dcname)
+		datacenter, err := finder.Datacenter(ctx, dcname)
+		if err != nil {
+			fmt.Printf("Error occurred while getting datacenter using finder\n")
+			return nil, err
+		}
+		finder.SetDatacenter(datacenter)
+
+		vms, err := finder.VirtualMachineList(ctx, "*")
+		if err != nil {
+			fmt.Printf("Error occurred while getting virtual machine list for datacenter\n")
+			return nil, err
+		}
+		for _, vm := range vms {
+			nodeUUID := vm.UUID(ctx)
+			nodeLabelsMap[nodeUUID] = make(map[string]string)
+			region := "region-" + strconv.Itoa(i)
+			zone := "zone-" + strconv.Itoa(i)
+			nodeLabelsMap[nodeUUID]["topology.csi.vmware.com/k8s-region"] = region
+			nodeLabelsMap[nodeUUID]["topology.csi.vmware.com/k8s-zone"] = zone
+
+			fmt.Printf("Nodename = %s, uuid = %s, region = %s, zone = %s\n", vm, nodeUUID, region, zone)
+		}
+	}
+
+	return nodeLabelsMap, nil
+}
+
+func getSharedDatastoresInTopology(ctx context.Context, topoRequirement []*csi.Topology,
+	nodeLabels map[string]map[string]string) ([]*cnsvsphere.DatastoreInfo, error) {
+	var (
+		t                *testing.T
+		err              error
+		sharedDatastores []*cnsvsphere.DatastoreInfo
+		matchingNodeVMs  []*cnsvsphere.VirtualMachine
+	)
+	// A topology requirement is an array of topology segments.
+	for _, topology := range topoRequirement {
+		segments := topology.GetSegments()
+
+		// Get nodes with topology labels matching the topology segments
+		matchingNodeVMs, err = getNodesMatchingTopologySegment(ctx, segments, nodeLabels)
+		if err != nil {
+			t.Errorf("Failed to find nodes in topology segment %+v. Error: %+v", segments, err)
+			return nil, err
+		}
+
+		if len(matchingNodeVMs) == 0 {
+			fmt.Printf("No nodes in the cluster matched the topology requirement provided: %+v\n",
+				segments)
+			continue
+		}
+
+		// Fetch shared datastores for the matching nodeVMs.
+		fmt.Printf("Obtained list of nodeVMs %+v\n", matchingNodeVMs)
+		sharedDatastoresInTopology, err := cnsvsphere.GetSharedDatastoresForVMs(ctx, matchingNodeVMs)
+		if err != nil {
+			t.Errorf("failed to get shared datastores for nodes: %+v in topology segment %+v. Error: %+v",
+				matchingNodeVMs, segments, err)
+			return nil, err
+		}
+
+		// Update sharedDatastores with the list of datastores received for current topology segments.
+		// Duplicates will not be added.
+		for _, ds := range sharedDatastoresInTopology {
+			var found bool
+			for _, sharedDS := range sharedDatastores {
+				if sharedDS.Info.Url == ds.Info.Url {
+					found = true
+					break
+				}
+			}
+			if !found {
+				sharedDatastores = append(sharedDatastores, ds)
+			}
+		}
+	}
+
+	return sharedDatastores, nil
+}
+
+func getNodesMatchingTopologySegment(ctx context.Context, segments map[string]string,
+	nodeLabels map[string]map[string]string) ([]*cnsvsphere.VirtualMachine, error) {
+	var (
+		matchingNodeVMs []*cnsvsphere.VirtualMachine
+		err             error
+		t               *testing.T
+	)
+
+	for nodeUUID, labels := range nodeLabels {
+		isMatch := true
+		for key, value := range segments {
+			if labels[key] != value {
+				fmt.Printf("Node %q with topology labels %+v did not match the topology requirement - %q:%q\n",
+					nodeUUID, labels, key, value)
+				isMatch = false
+				break
+			}
+		}
+		if isMatch {
+			var nodeVM *cnsvsphere.VirtualMachine
+			nodeVM, err = cnsvsphere.GetVirtualMachineByUUID(ctx, nodeUUID, false)
+			if err != nil {
+				t.Errorf("Couldn't find VM instance with nodeUUID %s, err: %v", nodeUUID, err)
+				return nil, err
+			}
+
+			matchingNodeVMs = append(matchingNodeVMs, nodeVM)
+		}
+	}
+
+	return matchingNodeVMs, nil
+}
+
+// TODO: Currently mocking GetSharedDatastoresInTopology function by adding region and zone labels on nodeVMs
+// and returning shared datastores as per topology parameters. We can generate CSI node topology instances in fake
+// kubeclient etc. and check if mocking can be avoided.
+func (f *FakeTopologyManager) GetSharedDatastoresInTopology(ctx context.Context, topologyFetchDSParams interface{}) (
+	[]*cnsvsphere.DatastoreInfo, error) {
+	var (
+		t                *testing.T
+		err              error
+		sharedDatastores []*cnsvsphere.DatastoreInfo
+		topoRequirement  []*csi.Topology
+	)
+
+	params := topologyFetchDSParams.(commoncotypes.VanillaTopologyFetchDSParams)
+	fmt.Printf("topologyRequirement is: %+v\n", params.TopologyRequirement)
+
+	// Fetch shared datastores for the preferred topology requirement.
+	if params.TopologyRequirement.GetPreferred() != nil {
+		fmt.Printf("Using preferred topology to get shared datastores\n")
+		topoRequirement = params.TopologyRequirement.GetPreferred()
+		sharedDatastores, err = getSharedDatastoresInTopology(ctx, topoRequirement, f.nodeLabels)
+		if err != nil {
+			t.Errorf("Error finding shared datastores using preferred topology: %+v",
+				params.TopologyRequirement.GetPreferred())
+			return nil, err
+		}
+	}
+
+	// If there are no shared datastores for the preferred topology requirement, fetch shared
+	// datastores for the requisite topology requirement instead.
+	if len(sharedDatastores) == 0 && params.TopologyRequirement.GetRequisite() != nil {
+		fmt.Printf("Using requisite topology to get shared datastores\n")
+		topoRequirement = params.TopologyRequirement.GetRequisite()
+		sharedDatastores, err = getSharedDatastoresInTopology(ctx, topoRequirement, f.nodeLabels)
+		if err != nil {
+			t.Errorf("Error finding shared datastores using requisite topology: %+v",
+				params.TopologyRequirement.GetRequisite())
+			return nil, err
+		}
+	}
+
+	return sharedDatastores, nil
+}
+
+func (f *FakeTopologyManager) GetTopologyInfoFromNodes(ctx context.Context, retrieveTopologyInfoParams interface{}) (
+	[]map[string]string, error) {
+	// This function is not yet implemented
+	return nil, nil
+}
+
+func (f *FakeTopologyManager) GetAZClustersMap(ctx context.Context) map[string][]string {
+	// This function is not yet implemented
+	return nil
+}
+
+var vcsimParamsTopology = unittestcommon.VcsimParams{
+	Datacenters:     2,
+	Clusters:        1,
+	HostsPerCluster: 1,
+	VMsPerCluster:   2,
+	StandaloneHosts: 0,
+	Datastores:      1,
+	Version:         "7.0.3",
+	ApiVersion:      "7.0",
+}
+
+func getControllerTestWithTopology(t *testing.T) *controllerTestTopology {
+	onceForControllerTestTopology.Do(func() {
+		// Create context.
+		ctxtopology = context.Background()
+		config, _ := unittestcommon.ConfigFromEnvOrVCSim(ctxtopology, vcsimParamsTopology, true)
+
+		// CNS based CSI requires a valid cluster name.
+		config.Global.ClusterID = testClusterName
+
+		vcenterconfig, err := cnsvsphere.GetVirtualCenterConfig(ctxtopology, config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		vcManager := cnsvsphere.GetVirtualCenterManager(ctxtopology)
+		// GetVirtualCenterManager returns a singleton instance of VirtualCenterManager,
+		// so it could have already registered VCs as part of previous unit test run from
+		// same folder.
+		// Unregister old VCs and register new VC.
+		err = vcManager.UnregisterAllVirtualCenters(ctxtopology)
+		if err != nil {
+			t.Fatal(err)
+		}
+		vcenter, err := vcManager.RegisterVirtualCenter(ctxtopology, vcenterconfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = vcenter.ConnectCns(ctxtopology)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fakeOpStore, err := unittestcommon.InitFakeVolumeOperationRequestInterface()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		volumeManager, err := cnsvolume.GetManager(ctxtopology, vcenter, fakeOpStore, true, false, false, false,
+			cnstypes.CnsClusterFlavorVanilla)
+		if err != nil {
+			t.Fatalf("failed to create an instance of volume manager. err=%v", err)
+		}
+		// GetManager returns a singleton instance of VolumeManager. So, it could be pointing
+		// to old VC instance as part of previous unit test run from same folder.
+		// Call ResetManager to get new VolumeManager instance with current VC configuration.
+		err = volumeManager.ResetManager(ctxtopology, vcenter)
+		if err != nil {
+			t.Fatalf("failed to reset volume manager with new vcenter. err=%v", err)
+		}
+
+		manager := &common.Manager{
+			VcenterConfig:  vcenterconfig,
+			CnsConfig:      config,
+			VolumeManager:  volumeManager,
+			VcenterManager: vcManager,
+		}
+
+		var k8sClient clientset.Interface
+		if k8senv := os.Getenv("KUBECONFIG"); k8senv != "" {
+			k8sClient, err = k8s.CreateKubernetesClientFromConfig(k8senv)
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			k8sClient = testclient.NewSimpleClientset()
+		}
+
+		nodeManager := &FakeNodeManagerTopology{
+			k8sClient: k8sClient}
+		err = nodeManager.Initialize(ctxtopology)
+		if err != nil {
+			t.Fatalf("Failed to initialize the node manager, err= =%v", err)
+		}
+
+		mockNodeLabels, err := generateNodeLabels(ctxtopology, vcenter)
+		if err != nil {
+			t.Fatalf("Failed to add mock node labels, err = %v", err)
+		}
+
+		c := &controller{
+			manager: manager,
+			nodeMgr: nodeManager,
+			authMgr: &FakeAuthManager{
+				vcenter: vcenter,
+			},
+			topologyMgr: &FakeTopologyManager{
+				nodeLabels: mockNodeLabels,
+			},
+		}
+		commonco.ContainerOrchestratorUtility, err =
+			unittestcommon.GetFakeContainerOrchestratorInterface(common.Kubernetes)
+		if err != nil {
+			t.Fatalf("Failed to create co agnostic interface. err=%v", err)
+		}
+		controllerTestInstanceTopology = &controllerTestTopology{
+			controller:     c,
+			config:         config,
+			vcenter:        vcenter,
+			operationStore: fakeOpStore,
+		}
+	})
+	return controllerTestInstanceTopology
+}
+
+// Test CreateVolume functionality with specific AccessibilityRequirements
+func TestCreateVolumeWithAccessibilityRequirements(t *testing.T) {
+	// Create context.
+	ct := getControllerTestWithTopology(t)
+
+	// Create volume
+	params := make(map[string]string)
+	capabilities := []*csi.VolumeCapability{
+		{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: testVolumeName + "-" + uuid.New().String(),
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 * common.GbInBytes,
+		},
+		Parameters:         params,
+		VolumeCapabilities: capabilities,
+		AccessibilityRequirements: &csi.TopologyRequirement{
+			Requisite: []*csi.Topology{
+				{
+					Segments: map[string]string{
+						"topology.csi.vmware.com/k8s-zone": "zone-1",
+					},
+				},
+			},
+			Preferred: []*csi.Topology{},
+		},
+	}
+
+	respCreate, err := ct.controller.CreateVolume(ctxtopology, reqCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	volID := respCreate.Volume.VolumeId
+
+	queryFilter := cnstypes.CnsQueryFilter{
+		VolumeIds: []cnstypes.CnsVolumeId{
+			{
+				Id: volID,
+			},
+		},
+	}
+	queryResult, err := ct.vcenter.CnsClient.QueryVolume(ctxtopology, queryFilter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(queryResult.Volumes) != 1 && queryResult.Volumes[0].VolumeId.Id != volID {
+		t.Fatalf("failed to find the newly created volume with ID: %s", volID)
+	}
+
+	// Delete volume
+	reqDelete := &csi.DeleteVolumeRequest{
+		VolumeId: volID,
+	}
+	_, err = ct.controller.DeleteVolume(ctxtopology, reqDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the volume has been deleted.
+	queryResult, err = ct.vcenter.CnsClient.QueryVolume(ctxtopology, queryFilter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(queryResult.Volumes) != 0 {
+		t.Fatalf("Volume should not exist after deletion with ID: %s", volID)
+	}
+}

--- a/pkg/csi/service/wcp/controller_test.go
+++ b/pkg/csi/service/wcp/controller_test.go
@@ -18,9 +18,6 @@ package wcp
 
 import (
 	"context"
-	"crypto/tls"
-	"fmt"
-	"log"
 	"os"
 	"strings"
 	"sync"
@@ -31,16 +28,9 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/google/uuid"
-	cnssim "github.com/vmware/govmomi/cns/simulator"
 	cnstypes "github.com/vmware/govmomi/cns/types"
-	"github.com/vmware/govmomi/find"
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/pbm"
-	pbmsim "github.com/vmware/govmomi/pbm/simulator"
-	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/simulator"
-	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/types"
 	v1 "k8s.io/api/core/v1"
 
 	cnsvolume "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
@@ -73,85 +63,29 @@ type controllerTest struct {
 	vcenter    *cnsvsphere.VirtualCenter
 }
 
-// configFromSim starts a vcsim instance and returns config for use against the
-// vcsim instance. The vcsim instance is configured with an empty tls.Config.
-func configFromSim() (*config.Config, func()) {
-	return configFromSimWithTLS(new(tls.Config), true)
-}
-
-// configFromSimWithTLS starts a vcsim instance and returns config for use
-// against the vcsim instance. The vcsim instance is configured with a
-// tls.Config. The returned client config can be configured to allow/decline
-// insecure connections.
-func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (*config.Config, func()) {
-	cfg := &config.Config{}
-	model := simulator.VPX()
-	defer model.Remove()
-
-	err := model.Create()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	model.Service.TLS = tlsConfig
-	s := model.Service.NewServer()
-
-	// CNS Service simulator.
-	model.Service.RegisterSDK(cnssim.New())
-
-	// PBM Service simulator.
-	model.Service.RegisterSDK(pbmsim.New())
-	cfg.Global.InsecureFlag = insecureAllowed
-
-	cfg.Global.VCenterIP = s.URL.Hostname()
-	cfg.Global.VCenterPort = s.URL.Port()
-	cfg.Global.User = s.URL.User.Username() + "@vsphere.local"
-	cfg.Global.Password, _ = s.URL.User.Password()
-	cfg.Global.Datacenters = "DC0"
-
-	// Write values to test_vsphere.conf.
-	os.Setenv("VSPHERE_CSI_CONFIG", "test_vsphere.conf")
-	conf := []byte(fmt.Sprintf("[Global]\ninsecure-flag = \"%t\"\n"+
-		"[VirtualCenter \"%s\"]\nuser = \"%s\"\npassword = \"%s\"\ndatacenters = \"%s\"\nport = \"%s\"",
-		cfg.Global.InsecureFlag, cfg.Global.VCenterIP, cfg.Global.User, cfg.Global.Password,
-		cfg.Global.Datacenters, cfg.Global.VCenterPort))
-	err = os.WriteFile("test_vsphere.conf", conf, 0644)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	cfg.VirtualCenter = make(map[string]*config.VirtualCenterConfig)
-	cfg.VirtualCenter[s.URL.Hostname()] = &config.VirtualCenterConfig{
-		User:         cfg.Global.User,
-		Password:     cfg.Global.Password,
-		VCenterPort:  cfg.Global.VCenterPort,
-		InsecureFlag: cfg.Global.InsecureFlag,
-		Datacenters:  cfg.Global.Datacenters,
-	}
-
-	return cfg, func() {
-		s.Close()
-		model.Remove()
-	}
-}
-
-func configFromEnvOrSim() (*config.Config, func()) {
-	cfg := &config.Config{}
-	if err := config.FromEnv(ctx, cfg); err != nil {
-		return configFromSim()
-	}
-	return cfg, func() {}
+var vcsimParams = unittestcommon.VcsimParams{
+	Datacenters:     1,
+	Clusters:        1,
+	HostsPerCluster: 2,
+	VMsPerCluster:   2,
+	StandaloneHosts: 0,
+	Datastores:      1,
+	Version:         "7.0.3",
+	ApiVersion:      "7.0",
 }
 
 func getControllerTest(t *testing.T) *controllerTest {
 	onceForControllerTest.Do(func() {
 		// Create context.
 		ctx = context.Background()
-		config, _ := configFromEnvOrSim()
+		config, _ := unittestcommon.ConfigFromEnvOrVCSim(ctx, vcsimParams, false)
 
 		// CNS based CSI requires a valid cluster name.
 		config.Global.ClusterID = testClusterName
-		clusterComputeResourceMoIds = append(clusterComputeResourceMoIds, config.Global.ClusterID)
+
+		clusterMoRef := simulator.Map.Any("ClusterComputeResource").(*simulator.ClusterComputeResource).Reference()
+		clusterComputeResourceMoIds = append(clusterComputeResourceMoIds, clusterMoRef.Value)
+
 		vcenterconfig, err := cnsvsphere.GetVirtualCenterConfig(ctx, config)
 		if err != nil {
 			t.Fatal(err)
@@ -204,85 +138,7 @@ func getControllerTest(t *testing.T) *controllerTest {
 	return controllerTestInstance
 }
 
-func getFakeDatastores(ctx context.Context, vc *cnsvsphere.VirtualCenter,
-	clusterID string, includevSANDirectDatastores bool) ([]*cnsvsphere.DatastoreInfo,
-	[]*cnsvsphere.DatastoreInfo, error) {
-	var sharedDatastoreURL string
-	if v := os.Getenv("VSPHERE_DATASTORE_URL"); v != "" {
-		sharedDatastoreURL = v
-	} else {
-		sharedDatastoreURL = simulator.Map.Any("Datastore").(*simulator.Datastore).Info.GetDatastoreInfo().Url
-	}
-
-	var vsanDirectDatastoreURL string
-	if v := os.Getenv("VSAN_DIRECT_DATASTORE_URL"); v != "" {
-		vsanDirectDatastoreURL = v
-	} else {
-		vsanDirectDatastoreURL = simulator.Map.Any("Datastore").(*simulator.Datastore).Info.GetDatastoreInfo().Url
-	}
-
-	var datacenterName string
-	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
-		datacenterName = v
-	} else {
-		datacenterName = simulator.Map.Any("Datacenter").(*simulator.Datacenter).Name
-	}
-
-	finder := find.NewFinder(vc.Client.Client, false)
-	dc, _ := finder.Datacenter(ctx, datacenterName)
-	finder.SetDatacenter(dc)
-	datastores, err := finder.DatastoreList(ctx, "*")
-	if err != nil {
-		return nil, nil, err
-	}
-	var dsList []types.ManagedObjectReference
-	for _, ds := range datastores {
-		dsList = append(dsList, ds.Reference())
-	}
-	var dsMoList []mo.Datastore
-	pc := property.DefaultCollector(dc.Client())
-	properties := []string{"info"}
-	err = pc.Retrieve(ctx, dsList, properties, &dsMoList)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var sharedDatastoreManagedObject *mo.Datastore
-	var vsanDirectDatastoreManagedObject *mo.Datastore
-	for _, dsMo := range dsMoList {
-		if dsMo.Info.GetDatastoreInfo().Url == sharedDatastoreURL {
-			sharedDatastoreManagedObject = &dsMo
-		}
-		if dsMo.Info.GetDatastoreInfo().Url == vsanDirectDatastoreURL {
-			vsanDirectDatastoreManagedObject = &dsMo
-		}
-	}
-	if sharedDatastoreManagedObject == nil {
-		return nil, nil, fmt.Errorf("Failed to get shared datastores")
-	}
-	if vsanDirectDatastoreManagedObject == nil {
-		return nil, nil, fmt.Errorf("Failed to get shared vsan direct datastores")
-	}
-	return []*cnsvsphere.DatastoreInfo{
-			{
-				Datastore: &cnsvsphere.Datastore{
-					Datastore:  object.NewDatastore(nil, sharedDatastoreManagedObject.Reference()),
-					Datacenter: nil},
-				Info:         sharedDatastoreManagedObject.Info.GetDatastoreInfo(),
-				CustomValues: []types.BaseCustomFieldValue{},
-			},
-		}, []*cnsvsphere.DatastoreInfo{
-			{
-				Datastore: &cnsvsphere.Datastore{
-					Datastore:  object.NewDatastore(nil, vsanDirectDatastoreManagedObject.Reference()),
-					Datacenter: nil},
-				Info:         vsanDirectDatastoreManagedObject.Info.GetDatastoreInfo(),
-				CustomValues: []types.BaseCustomFieldValue{},
-			},
-		}, nil
-}
-
-// TestCreateVolumeWithoutStoragePolicyWcp creates volume with storage policy.
+// TestWCPCreateVolumeWithStoragePolicy creates volume with storage policy.
 func TestWCPCreateVolumeWithStoragePolicy(t *testing.T) {
 	ct := getControllerTest(t)
 
@@ -331,7 +187,6 @@ func TestWCPCreateVolumeWithStoragePolicy(t *testing.T) {
 		},
 	}
 
-	getCandidateDatastores = getFakeDatastores
 	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
 	if err != nil {
 		t.Fatal(err)
@@ -450,7 +305,6 @@ func TestWCPCreateVolumeWithZonalLabelPresentButNoStorageTopoType(t *testing.T) 
 		},
 	}
 
-	getCandidateDatastores = getFakeDatastores
 	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
 	if err != nil && strings.Contains(err.Error(), "InvalidArgument") {
 		t.Logf("expected error is thrown: %v", err)
@@ -541,7 +395,6 @@ func TestWCPCreateDeleteSnapshot(t *testing.T) {
 		},
 	}
 
-	getCandidateDatastores = getFakeDatastores
 	respCreate, err := ct.controller.CreateVolume(ctx, reqCreate)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR has changes to improve CSI unit test framework.
1. Added a common function to get VC instance using vcsim as per requirement like number of datacenters, clusters, hosts, VMs, datastores etc.
2. Updated node manager interface used for testing by registering nodes generated using vcsim
3. Updated GetSharedDatastoresInK8sCluster function in unit test to test actual functions instead of using mock code
4. Updated wcp controller unit test to test actual GetCandidateDatastoresInCluster function instead of using mock code
5. Added a framework for writing unit tests around topology like creating a volume with specified AccessibilityRequirements
6. Added a unit test to create category and tag using tag manager and attach tag to objects like datacenter, cluster etc.
7. Added few negative test scenarios
8. Added new option "make coverprofile", which runs all unit tests and opens coverage report at file level in the default browser.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
All unit tests are passing when run using "make test" command

**Special notes for your reviewer**:

**Release note**:
```release-note
CSI unit tests framework improvement
```
