### PR TITLE
For windows mount point, check directory mode for symlink check instead of CSI proxy isSymLink() function, to handle corrupted mount point in case node reboot

### DIFF
--- a/pkg/csi/service/osutils/windows_os_utils.go
+++ b/pkg/csi/service/osutils/windows_os_utils.go
@@ -18,9 +18,7 @@ package osutils
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -136,7 +134,7 @@ func (osUtils *OsUtils) haveMountPoint(ctx context.Context, target string) (bool
 	}
 	// check if disk is mounted and formatted correctly, here the path should exist as it is created by CO and already checked
 	notMounted, err := mounter.IsLikelyNotMountPoint(target)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+	if err != nil && !os.IsNotExist(err) {
 		return false, logger.LogNewErrorCodef(log, codes.Internal,
 			"Could not determine if staging path is already mounted, err: %v", err)
 	}


### PR DESCRIPTION
 

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
If windows worker node crashes/reboots abruptly, the mount point directory created by CO for CSI volumes published gets corrupted sometimes and the symlink/dir fails to read after reboot/crash. This causes volume attach to fail after nodes are up back.
This MR allow unmounting and reformating/remounting of the mount point on such windows worker node after node reboot/crash, if the directory exists but cannot be read due to some issue while crashing.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Fix tested on ST setup where the issue was originally seen in which after node reboot, pods running on that windows worker node enter into "Unknown" state and stay in the same state forever until they either get rescheduled to another node or restarted with mount point cleaned up.
After fix, all pods on nodes crashing/rebooting came back to running state in sometime after node is up.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
For windows mount point, check directory mode for symlink check instead of CSI proxy isSymLink() function, to handle corrupted mount point in case node reboot
```
