### PR TITLE
remove x509sha1 support and overriding tlsmaxrsasize

### DIFF
--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -343,8 +343,6 @@ spec:
               value: "200"
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
-            - name: GODEBUG
-              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -395,8 +393,6 @@ spec:
               value: "200"
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
-            - name: GODEBUG
-              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2113

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -343,8 +343,6 @@ spec:
               value: "200"
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
-            - name: GODEBUG
-              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -395,8 +393,6 @@ spec:
               value: "200"
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
-            - name: GODEBUG
-              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2113

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -343,8 +343,6 @@ spec:
               value: "200"
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
-            - name: GODEBUG
-              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -395,8 +393,6 @@ spec:
               value: "200"
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
-            - name: GODEBUG
-              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2113

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -343,8 +343,6 @@ spec:
               value: "200"
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
-            - name: GODEBUG
-              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -395,8 +393,6 @@ spec:
               value: "200"
             - name: INCLUSTER_CLIENT_BURST
               value: "200"
-            - name: GODEBUG
-              value: x509sha1=1
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 2113

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -299,8 +299,6 @@ spec:
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
-            - name: GODEBUG
-              value: x509sha1=1,tlsmaxrsasize=16384
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -363,8 +361,6 @@ spec:
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
-            - name: GODEBUG
-              value: x509sha1=1,tlsmaxrsasize=16384
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is removing x509sha1 support and overriding setting tlsmaxrsasize.


**Testing done**:
Verified using sha1 root certificate is not supported

```
"Cannot connect to vCenter with err: Post \"https://sc-rdops-vm11-dhcp-65-241.eng.vmware.com:443/sdk\": tls: failed to verify certificate
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
remove x509sha1 support and overriding tlsmaxrsasize
```
