### PR TITLE
Update k8s cluster distribution map to record EKS & AKS clusters

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -294,6 +294,8 @@ func initSyncerComponents(ctx context.Context, clusterFlavor cnstypes.CnsCluster
 					"openshift": "Openshift",
 					"wcp":       "Supervisor",
 					"vmware":    "TanzuKubernetesCluster",
+					"eks":       "EKS",
+					"aks":       "AKS",
 					"nativek8s": "VanillaK8S",
 				}
 				distributionUnknown := true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update k8s cluster distribution map to record EKS & AKS

Example EKS server version:

```
Client Version: v1.24.0
Server Version: v1.24.0-eks-135321
```

Example AKS server version:

```
Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.7"... }
Server Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.7-aks" ... }
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update k8s cluster distribution map to record EKS & AKS clusters
```
