### PR TITLE
Reconcile storagepolicyquota in syncer

### DIFF
--- a/pkg/kubernetes/dynamicInformers.go
+++ b/pkg/kubernetes/dynamicInformers.go
@@ -36,9 +36,9 @@ var (
 	supervisorDynamicInformerInitLock   = &sync.Mutex{}
 )
 
-// newDynamicInformerFactory creates a dynamic informer factory for a given
+// NewDynamicInformerFactory creates a dynamic informer factory for a given
 // namespace if it doesn't exist already.
-func newDynamicInformerFactory(ctx context.Context, cfg *restclient.Config, namespace string,
+func NewDynamicInformerFactory(ctx context.Context, cfg *restclient.Config, namespace string,
 	isInCluster bool) (dynamicinformer.DynamicSharedInformerFactory, error) {
 	log := logger.GetLogger(ctx)
 	var (
@@ -92,7 +92,7 @@ func GetDynamicInformer(ctx context.Context, crdGroup, crdVersion, crdName, name
 	log := logger.GetLogger(ctx)
 	var err error
 
-	dynamicInformerFactory, err := newDynamicInformerFactory(ctx, cfg, namespace, isInCluster)
+	dynamicInformerFactory, err := NewDynamicInformerFactory(ctx, cfg, namespace, isInCluster)
 	if err != nil {
 		log.Errorf("could not retrieve dynamic informer factory for %q namespace. Error: %+v", namespace, err)
 		return nil, err

--- a/pkg/syncer/storage_policy_quota_reconciler.go
+++ b/pkg/syncer/storage_policy_quota_reconciler.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	cnsoperatorv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
+	storagepolicyusagev1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/storagepolicy/v1alpha1"
+	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
+	k8s "sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes"
+)
+
+// ObjectToProcess defines object to be processd for addition/deletion event of StoragePolicyQuota
+type ObjectToProcess struct {
+	policyQuota *storagepolicyusagev1alpha1.StoragePolicyQuota
+	isDeleted   bool
+}
+
+// StoragePolicyQuotaReconciler is the interface for StoragePolicyQuota reconciler.
+type StoragePolicyQuotaReconciler interface {
+	// Run starts the reconciler.
+	Run(ctx context.Context, workers int)
+}
+
+type storagePolicyQuotaReconciler struct {
+	// metadataSyncer informer to get FSS information.
+	metadataSyncerInformer *metadataSyncInformer
+	// StoragePolicyQuota queue to add/delete StoragePolicyUsage CRs.
+	svcQuotaOpsQueue workqueue.RateLimitingInterface
+	// StoragePolicyQuota Synced.
+	svcQuotaSynced cache.InformerSynced
+}
+
+// newStoragePolicyQuotaReconciler returns a StoragePolicyQuotaReconciler.
+func newStoragePolicyQuotaReconciler(
+	ctx context.Context,
+	metadataSyncerInformer *metadataSyncInformer,
+	svcStoragePolicyQuotaRateLimiter workqueue.RateLimiter,
+	stopCh <-chan struct{}) (*storagePolicyQuotaReconciler, error) {
+
+	log := logger.GetLogger(ctx)
+	// Create an informer for StoragePolicyQuota instances.
+	k8sConfig, err := k8s.GetKubeConfig(ctx)
+	if err != nil {
+		return nil, logger.LogNewErrorf(log, "newStoragePolicyQuotaReconciler: failed to get kubeconfig with error: %v", err)
+	}
+	dynamicInformerFactory, err := k8s.NewDynamicInformerFactory(ctx, k8sConfig, metav1.NamespaceAll, true)
+	if err != nil {
+		log.Errorf("newStoragePolicyQuotaReconciler: could not retrieve dynamic informer factory. Error: %+v", err)
+		return nil, err
+	}
+	// Return informer from shared dynamic informer factory for input resource.
+	gvr := schema.GroupVersionResource{Group: cnsoperatorv1alpha1.GroupName, Version: cnsoperatorv1alpha1.Version,
+		Resource: cnsoperatorv1alpha1.CnsStoragePolicyQuotaPlural}
+	storagePolicyQuotaInformer := dynamicInformerFactory.ForResource(gvr)
+	svcQuotaOpsQueue := workqueue.NewRateLimitingQueueWithConfig(
+		svcStoragePolicyQuotaRateLimiter, workqueue.RateLimitingQueueConfig{
+			Name: "storage-policy-quota-ops",
+		})
+
+	rc := &storagePolicyQuotaReconciler{
+		metadataSyncerInformer: metadataSyncerInformer,
+		svcQuotaSynced:         storagePolicyQuotaInformer.Informer().HasSynced,
+		svcQuotaOpsQueue:       svcQuotaOpsQueue,
+	}
+
+	_, err = storagePolicyQuotaInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    rc.addStoragePolicyQuota,
+			DeleteFunc: rc.delStoragePolicyQuota,
+		})
+	if err != nil {
+		return nil, logger.LogNewErrorf(log, "newStoragePolicyQuotaReconciler: failed to add event handler on "+
+			"StoragePolicyQuota informer. Error: %v", err)
+	}
+
+	// Start StoragePolicyQuota Informer.
+	dynamicInformerFactory.Start(stopCh)
+	if !cache.WaitForCacheSync(stopCh, rc.svcQuotaSynced) {
+		return nil, fmt.Errorf("newStoragePolicyQuotaReconciler: cannot sync StoragePolicyQuota cache")
+	}
+
+	return rc, nil
+}
+
+func (rc *storagePolicyQuotaReconciler) addStoragePolicyQuota(obj interface{}) {
+	_, log := logger.GetNewContextWithLogger()
+	policyQuotaObj := &storagepolicyusagev1alpha1.StoragePolicyQuota{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object,
+		policyQuotaObj)
+	if err != nil {
+		log.Errorf("addStoragePolicyQuota: failed to cast object %+v to %s. Error: %v", obj,
+			cnsoperatorv1alpha1.CnsStoragePolicyQuotaSingular, err)
+		return
+	}
+	objToProcess := &ObjectToProcess{
+		policyQuota: policyQuotaObj,
+		isDeleted:   false,
+	}
+	rc.svcQuotaOpsQueue.Add(objToProcess)
+}
+
+func (rc *storagePolicyQuotaReconciler) delStoragePolicyQuota(obj interface{}) {
+	_, log := logger.GetNewContextWithLogger()
+	policyQuotaObj := &storagepolicyusagev1alpha1.StoragePolicyQuota{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object,
+		policyQuotaObj)
+	if err != nil {
+		log.Errorf("delStoragePolicyQuota: failed to cast object %+v to %s. Error: %v", obj,
+			cnsoperatorv1alpha1.CnsStoragePolicyQuotaSingular, err)
+		return
+	}
+	objToProcess := &ObjectToProcess{
+		policyQuota: policyQuotaObj,
+		isDeleted:   true,
+	}
+	rc.svcQuotaOpsQueue.Add(objToProcess)
+}
+
+// Run starts the reconciler.
+func (rc *storagePolicyQuotaReconciler) Run(
+	ctx context.Context, workers int) {
+	log := logger.GetLogger(ctx)
+	defer rc.svcQuotaOpsQueue.ShutDown()
+
+	log.Infof("Starting StoragePolicyQuota reconciler")
+	defer log.Infof("Shutting down StoragePolicyQuota reconciler after draining")
+
+	stopCh := ctx.Done()
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(func() { rc.syncStoragePolicyQuotas(ctx) }, 0, stopCh)
+	}
+	<-stopCh
+}
+
+// syncStoragePolicyQuotas is the main worker to add/delete StoragePolicyUsage for given StoragePolicyQuota.
+func (rc *storagePolicyQuotaReconciler) syncStoragePolicyQuotas(ctx context.Context) {
+	obj, quit := rc.svcQuotaOpsQueue.Get()
+	if quit {
+		return
+	}
+	defer rc.svcQuotaOpsQueue.Done(obj)
+	objToProcess := obj.(*ObjectToProcess)
+	policyQuotaObj := objToProcess.policyQuota
+	// If object has been deleted, process deletion of corresponding StoragePolicyUsage(s).
+	// Otherwise process the object for addition of corresponding StoragePolicyUsage(s).
+	if !objToProcess.isDeleted {
+		if err := rc.syncStoragePolicyQuotaAddCase(ctx, policyQuotaObj); err != nil {
+			// Put StoragePolicyQuota back to the queue so that we can retry later.
+			rc.svcQuotaOpsQueue.AddRateLimited(obj)
+		} else {
+			rc.svcQuotaOpsQueue.Forget(obj)
+		}
+	} else {
+		if err := rc.syncStoragePolicyQuotaDelCase(ctx, policyQuotaObj); err != nil {
+			// Put StoragePolicyQuota back to the queue so that we can retry later.
+			rc.svcQuotaOpsQueue.AddRateLimited(obj)
+		} else {
+			rc.svcQuotaOpsQueue.Forget(obj)
+		}
+	}
+}
+
+// syncStoragePolicyQuotaAddCase processes one StoragePolicyQuota CR added to cluster
+// and creates corresponding StoragePolicyUsage CR(s) for associated storage policy
+// and namespace.
+func (rc *storagePolicyQuotaReconciler) syncStoragePolicyQuotaAddCase(ctx context.Context,
+	storagePolicyQuota *storagepolicyusagev1alpha1.StoragePolicyQuota) error {
+	log := logger.GetLogger(ctx)
+	log.Infof("syncStoragePolicyQuotaAddCase: Started StoragePolicyQuota processing %s/%s",
+		storagePolicyQuota.Namespace, storagePolicyQuota.Name)
+
+	_, err := getOrCreateStoragePolicyUsageCR(ctx, storagePolicyQuota.Spec.StoragePolicyId,
+		storagePolicyQuota.Namespace, rc.metadataSyncerInformer)
+	if err != nil {
+		log.Errorf("syncStoragePolicyQuotaAddCase: Could not create StoragePolicyUsage CR for %s/%s err: %v",
+			storagePolicyQuota.Namespace, storagePolicyQuota.Name, err)
+		return err
+	}
+
+	return nil
+}
+
+// syncStoragePolicyQuotaAddCase processes one StoragePolicyQuota CR deleted from cluster
+// and deletes corresponding StoragePolicyUsage CR(s) for associated storage policy
+// and namespace.
+func (rc *storagePolicyQuotaReconciler) syncStoragePolicyQuotaDelCase(ctx context.Context,
+	storagePolicyQuota *storagepolicyusagev1alpha1.StoragePolicyQuota) error {
+	log := logger.GetLogger(ctx)
+	log.Debugf("syncStoragePolicyQuotaDelCase: Started StoragePolicyQuota processing %s/%s",
+		storagePolicyQuota.Namespace, storagePolicyQuota.Name)
+
+	err := deleteStoragePolicyUsageCR(ctx, storagePolicyQuota.Spec.StoragePolicyId,
+		storagePolicyQuota.Namespace, rc.metadataSyncerInformer)
+	if err != nil {
+		log.Errorf("syncStoragePolicyQuotaDelCase: Could not delete StoragePolicyUsage CR for %s/%s err: %v",
+			storagePolicyQuota.Namespace, storagePolicyQuota.Name, err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -141,3 +141,12 @@ const (
 	// resizeWorkers represents the number of running worker threads
 	resizeWorkers = 10
 )
+
+const (
+	// storagePolicyQuotaRetryIntervalStart represents the start retry interval of the storagePolicyQuota reconciler
+	storagePolicyQuotaRetryIntervalStart = time.Second
+	// storagePolicyQuotaRetryIntervalMax represents the max retry interval of the storagePolicyQuota reconciler
+	storagePolicyQuotaRetryIntervalMax = 5 * time.Minute
+	// storagePolicyQuotaWorkers represents the number of running worker threads
+	storagePolicyQuotaWorkers = 10
+)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds reconciler for StoragePolicyQuota objects in syncer, which looks for add/delete events of StoragePolicyQuota CRs and accordingly creates StoragePolicyUsage CRs.
Earlier this processing was managed by simple informer event in syncer (with handlers policyQuotaCRAdded() & policyQuotaCRDeleted()), however if these informer events get missed, the creation of StoragePolicyUsage CR does not happen again (given that full sync creates StoragePolicyUsage CR if the namespace has any bound/pending volumes, but if namespace does not have any PVC, no StoragePolicyUsage CR gets created in full sync today)
Absense of StoragePolicyUsage CR blocks all further PVC/Snapshot creation/update. Hence it is necessary to reconcile/retry these event handling if missed/failed any time before.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Tested basic storagepolicyquota add scenario on WCP setup
1. Success case - Reconciler could create the missing StoragePolicyUsage CR for given StoragePolicyQuota CR
```
root@421ad0245402d86ac44fc4ad5816ff91 [ ~ ]# kubectl get storagepolicyquota -n svc-tkg-domain-c10
NAME                                                          AGE
management-storage-policy-encryption-storagepolicyquota       12d
management-storage-policy-regular-storagepolicyquota          12d
management-storage-policy-single-node-storagepolicyquota      12d
management-storage-policy-stretched-lite-storagepolicyquota   12d
management-storage-policy-thin-storagepolicyquota             12d
vm-encryption-policy-storagepolicyquota                       12d
vsan-default-storage-policy-storagepolicyquota                12d
wcpglobal-storage-profile-storagepolicyquota                  12d
wcplocal-storage-profile-storagepolicyquota                   27h   <<< storagepolicyquota for policy wcplocal-storage-profile
root@421ad0245402d86ac44fc4ad5816ff91 [ ~ ]#

root@421ad0245402d86ac44fc4ad5816ff91 [ ~ ]#
root@421ad0245402d86ac44fc4ad5816ff91 [ ~ ]# kubectl get storagepolicyusage -n svc-tkg-domain-c10
NAME                                                 AGE
management-storage-policy-encryption-pvc-usage       12d
management-storage-policy-regular-pvc-usage          12d
management-storage-policy-single-node-pvc-usage      12d
management-storage-policy-stretched-lite-pvc-usage   12d
management-storage-policy-thin-pvc-usage             12d
vm-encryption-policy-pvc-usage                       12d
vsan-default-storage-policy-pvc-usage                12d
wcpglobal-storage-profile-pvc-usage                  12d             <<< manually deleted storagepolicyusage for policy "wcplocal-storage-profile"
root@421ad0245402d86ac44fc4ad5816ff91 [ ~ ]#

Updated the change in syncer:

root@421ad0245402d86ac44fc4ad5816ff91 [ ~ ]# kubectl edit deploy -n vmware-system-csi vsphere-csi-controller
deployment.apps/vsphere-csi-controller edited

root@421ad0245402d86ac44fc4ad5816ff91 [ ~ ]# kubectl get storagepolicyusage -n svc-tkg-domain-c10
NAME                                                 AGE
management-storage-policy-encryption-pvc-usage       12d
management-storage-policy-regular-pvc-usage          12d
management-storage-policy-single-node-pvc-usage      12d
management-storage-policy-stretched-lite-pvc-usage   12d
management-storage-policy-thin-pvc-usage             12d
vm-encryption-policy-pvc-usage                       12d
vsan-default-storage-policy-pvc-usage                12d
wcpglobal-storage-profile-pvc-usage                  12d
wcplocal-storage-profile-pvc-usage                   11s         <<< storagepolicyusage for policy "wcplocal-storage-profile" created from reconciler


```

2. Error case - Reconciler failed to create StoragePolicyUsage CR  for given StoragePolicyQuota CR but the event was retried by reconciler queueing logic. On other side, existing logic in full sync (added via https://github.com/kubernetes-sigs/vsphere-csi-driver/commit/7067d7545ef92fad908349c20436dfe912e03602) could create the StoragePolicyUsage CR

```
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]# k get storagepolicyquota -n storage-policy-test
NAMESPACE               NAME                                                          AGE
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-storagepolicyquota   3d20h
storage-policy-test     wcp-profile-jy7h3rs0bp-storagepolicyquota                     3d20h
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]# k get storagepolicyusage -n storage-policy-test
NAMESPACE               NAME                                                                  AGE
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-latebinding-pvc-usage        3d20h
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-latebinding-snapshot-usage   3d20h
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-pvc-usage                    3d20h
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-snapshot-usage               109m
storage-policy-test     wcp-profile-jy7h3rs0bp-latebinding-pvc-usage                          3d20h
storage-policy-test     wcp-profile-jy7h3rs0bp-latebinding-snapshot-usage                     3d20h
storage-policy-test     wcp-profile-jy7h3rs0bp-pvc-usage                                      3d20h
storage-policy-test     wcp-profile-jy7h3rs0bp-snapshot-usage                                 3d20h
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]# k delete storagepolicyusage -n storage-policy-test 0-wcp-test-storage-policyname-jy7h3rs0bp-snapshot-usage      <<< deleted one SPU manually to check if it gets recreated by syncer
storagepolicyusage.cns.vmware.com "0-wcp-test-storage-policyname-jy7h3rs0bp-snapshot-usage" deleted
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#

root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]# k edit deploy -n vmware-system-csi    <<< restarted syncer with new changes with manual failure inserted in getOrCreateStoragePolicyUsageCR() to return err always
deployment.apps/vsphere-csi-controller edited
deployment.apps/vsphere-csi-webhook skipped

root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]# k get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-579c89db85-q8hp5   7/7     Running   0          23s
vsphere-csi-controller-579c89db85-qd6w8   7/7     Running   0          17s
vsphere-csi-webhook-69c89f74df-b8mv9      1/1     Running   0          4d
vsphere-csi-webhook-69c89f74df-lkpqs      1/1     Running   0          4d
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]# k get storagepolicyusage -n storage-policy-test
NAMESPACE               NAME                                                                  AGE
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-latebinding-pvc-usage        3d20h
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-latebinding-snapshot-usage   3d20h
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-pvc-usage                    3d20h
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-snapshot-usage               23s   <<< SPU got re-created
storage-policy-test     wcp-profile-jy7h3rs0bp-latebinding-pvc-usage                          3d20h
storage-policy-test     wcp-profile-jy7h3rs0bp-latebinding-snapshot-usage                     3d20h
storage-policy-test     wcp-profile-jy7h3rs0bp-pvc-usage                                      3d20h
storage-policy-test     wcp-profile-jy7h3rs0bp-snapshot-usage                                 3d20h
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#

root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]# k logs -n vmware-system-csi vsphere-csi-controller-579c89db85-q8hp5 -c vsphere-syncer | less

{"level":"info","time":"2024-08-12T09:27:17.731845534Z","caller":"syncer/storage_policy_quota_reconciler.go:146","msg":"Starting StoragePolicyQuota reconciler","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:17.732250028Z","caller":"syncer/storage_policy_quota_reconciler.go:216","msg":"syncStoragePolicyQuotaAddCase: Started StoragePolicyQuota processing storage-class-test-1/test-storage-class-update-policy-storagepolicyquota","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:17.732538231Z","caller":"syncer/storage_policy_quota_reconciler.go:216","msg":"syncStoragePolicyQuotaAddCase: Started StoragePolicyQuota processing storage-policy-test/0-wcp-test-storage-policyname-jy7h3rs0bp-storagepolicyquota","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"error","time":"2024-08-12T09:27:17.732575558Z","caller":"syncer/storage_policy_quota_reconciler.go:222","msg":"syncStoragePolicyQuotaAddCase: Could not create StoragePolicyUsage CR for storage-policy-test/0-wcp-test-storage-policyname-jy7h3rs0bp-storagepolicyquota err: Returning error for testing failure cases","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.(*storagePolicyQuotaReconciler).syncStoragePolicyQuotaAddCase\n\t/build/pkg/syncer/storage_policy_quota_reconciler.go:222\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.(*storagePolicyQuotaReconciler).syncStoragePolicyQuotasForAdd\n\t/build/pkg/syncer/storage_policy_quota_reconciler.go:176\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.(*storagePolicyQuotaReconciler).Run.func1\n\t/build/pkg/syncer/storage_policy_quota_reconciler.go:152\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.10/pkg/util/wait/backoff.go:226\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.10/pkg/util/wait/backoff.go:227\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.10/pkg/util/wait/backoff.go:204\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.10/pkg/util/wait/backoff.go:161"}


existing full sync logic created the required SPU

{"level":"info","time":"2024-08-12T09:27:17.763102031Z","caller":"syncer/metadatasyncer.go:2917","msg":"Successfully created StoragePolicyUsage \"0-wcp-test-storage-policyname-jy7h3rs0bp-snapshot-usage\"/\"storage-policy-test\" for policyID 61ceb403-5777-440e-89b6-6f9848dc3704 storageclass 0-wcp-test-storage-policyname-jy7h3rs0bp resourceKind VolumeSnapshot.","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:17.76314634Z","caller":"syncer/metadatasyncer.go:3184","msg":"createStoragePolicyUsageCRS: Successfully created the storagePolicyUsage CR \"0-wcp-test-storage-policyname-jy7h3rs0bp-snapshot-usage\" in namespace \"storage-policy-test\"","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}

Further retry attempts made by reconciler to create SPU, which failed always due to induced failure

{"level":"info","time":"2024-08-12T09:27:18.246509667Z","caller":"syncer/metadatasyncer.go:3202","msg":"storagePolicyUsageCRSync: Starting storage policy usage CR sync","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:18.324985123Z","caller":"syncer/metadatasyncer.go:3312","msg":"storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: \"0-wcp-test-storage-policyname-jy7h3rs0bp-latebinding-pvc-usage\" in namespace: \"storage-policy-test\" field is matching with the total capacity. Used: 0 Skipping the Patch operation","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:18.325076981Z","caller":"syncer/metadatasyncer.go:3312","msg":"storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: \"0-wcp-test-storage-policyname-jy7h3rs0bp-pvc-usage\" in namespace: \"storage-policy-test\" field is matching with the total capacity. Used: 0 Skipping the Patch operation","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:18.325090994Z","caller":"syncer/metadatasyncer.go:3312","msg":"storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: \"wcp-profile-jy7h3rs0bp-latebinding-pvc-usage\" in namespace: \"storage-policy-test\" field is matching with the total capacity. Used: 0 Skipping the Patch operation","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:18.325145843Z","caller":"syncer/metadatasyncer.go:3312","msg":"storagePolicyUsageCRSync: The used capacity field for StoragepolicyUsage CR: \"wcp-profile-jy7h3rs0bp-pvc-usage\" in namespace: \"storage-policy-test\" field is matching with the total capacity. Used: 10485760 Skipping the Patch operation","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:18.346461824Z","caller":"syncer/fullsync.go:261","msg":"calling validateAndCorrectVolumeInfoSnapshotDetails with 1 volumes","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:18.346654799Z","caller":"syncer/fullsync.go:517","msg":"validate volume info for storage details for volume 006d8851-d5f3-49d1-b534-447211e015f2","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:18.346714335Z","caller":"syncer/fullsync.go:525","msg":"Received aggregatedSnapshotCapacity -1 for volume \"006d8851-d5f3-49d1-b534-447211e015f2\"","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:18.346730324Z","caller":"syncer/fullsync.go:530","msg":"Update aggregatedSnapshotCapacity for volume \"006d8851-d5f3-49d1-b534-447211e015f2\"","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:18.346766591Z","caller":"syncer/fullsync.go:537","msg":"unable to get snapshot operation completion time for volumeID \"006d8851-d5f3-49d1-b534-447211e015f2\" will use current time 2024-08-12 09:27:18.34673626 +0000 UTC m=+1.327697765 instead","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:18.346826028Z","caller":"common/util.go:451","msg":"Couldn't retrieve aggregated snapshot capacity for volume \"006d8851-d5f3-49d1-b534-447211e015f2\"","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:18.359311975Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:304","msg":"attempt: 1, Successfully patched the cnsvolumeinfo \"006d8851-d5f3-49d1-b534-447211e015f2\" namespace \"vmware-system-csi\"","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"info","time":"2024-08-12T09:27:18.359415744Z","caller":"syncer/fullsync.go:558","msg":"Updated CNSvolumeInfo with Snapshot details successfully for volume \"006d8851-d5f3-49d1-b534-447211e015f2\"","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}

{"level":"info","time":"2024-08-12T09:27:20.74180799Z","caller":"syncer/storage_policy_quota_reconciler.go:216","msg":"syncStoragePolicyQuotaAddCase: Started StoragePolicyQuota processing storage-policy-test/0-wcp-test-storage-policyname-jy7h3rs0bp-storagepolicyquota","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"error","time":"2024-08-12T09:27:20.74184094Z","caller":"syncer/storage_policy_quota_reconciler.go:222","msg":"syncStoragePolicyQuotaAddCase: Could not create StoragePolicyUsage CR for storage-policy-test/0-wcp-test-storage-policyname-jy7h3rs0bp-storagepolicyquota err: Returning error for testing failure cases","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.(*storagePolicyQuotaReconciler).syncStoragePolicyQuotaAddCase\n\t/build/pkg/syncer/storage_policy_quota_reconciler.go:222\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.(*storagePolicyQuotaReconciler).syncStoragePolicyQuotasForAdd\n\t/build/pkg/syncer/storage_policy_quota_reconciler.go:176\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.(*storagePolicyQuotaReconciler).Run.func1\n\t/build/pkg/syncer/storage_policy_quota_reconciler.go:152\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.10/pkg/util/wait/backoff.go:226\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.10/pkg/util/wait/backoff.go:227\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.10/pkg/util/wait/backoff.go:204\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.10/pkg/util/wait/backoff.go:161"}


{"level":"info","time":"2024-08-12T09:27:24.742744743Z","caller":"syncer/storage_policy_quota_reconciler.go:216","msg":"syncStoragePolicyQuotaAddCase: Started StoragePolicyQuota processing storage-policy-test/0-wcp-test-storage-policyname-jy7h3rs0bp-storagepolicyquota","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665"}
{"level":"error","time":"2024-08-12T09:27:24.742802618Z","caller":"syncer/storage_policy_quota_reconciler.go:222","msg":"syncStoragePolicyQuotaAddCase: Could not create StoragePolicyUsage CR for storage-policy-test/0-wcp-test-storage-policyname-jy7h3rs0bp-storagepolicyquota err: Returning error for testing failure cases","TraceId":"fc2e40c3-32cd-4110-88d6-cb0041eef665","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.(*storagePolicyQuotaReconciler).syncStoragePolicyQuotaAddCase\n\t/build/pkg/syncer/storage_policy_quota_reconciler.go:222\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.(*storagePolicyQuotaReconciler).syncStoragePolicyQuotasForAdd\n\t/build/pkg/syncer/storage_policy_quota_reconciler.go:176\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer.(*storagePolicyQuotaReconciler).Run.func1\n\t/build/pkg/syncer/storage_policy_quota_reconciler.go:152\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.10/pkg/util/wait/backoff.go:226\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.10/pkg/util/wait/backoff.go:227\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.10/pkg/util/wait/backoff.go:204\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.10/pkg/util/wait/backoff.go:161"}
```
3. Delete case:

```
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]# k get storagepolicyquotas.cns.vmware.com -n storage-policy-test
NAMESPACE               NAME                                                          AGE
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-storagepolicyquota   12s
storage-policy-test     wcp-profile-jy7h3rs0bp-storagepolicyquota                     4d23h
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#

root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]# k get storagepolicyusage -n storage-policy-test
NAMESPACE               NAME                                                                  AGE
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-latebinding-pvc-usage        4d21h
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-latebinding-snapshot-usage   4d21h
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-pvc-usage                    4d21h
storage-policy-test     0-wcp-test-storage-policyname-jy7h3rs0bp-snapshot-usage               165m
storage-policy-test     wcp-profile-jy7h3rs0bp-latebinding-pvc-usage                          4d20h
storage-policy-test     wcp-profile-jy7h3rs0bp-latebinding-snapshot-usage                     4d20h
storage-policy-test     wcp-profile-jy7h3rs0bp-pvc-usage                                      4d20h
storage-policy-test     wcp-profile-jy7h3rs0bp-snapshot-usage                                 4d20h

root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]# k delete -n storage-policy-test storagepolicyquota 0-wcp-test-storage-policyname-jy7h3rs0bp-storagepolicyquota
storagepolicyquota.cns.vmware.com "0-wcp-test-storage-policyname-jy7h3rs0bp-storagepolicyquota" deleted
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#

root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]# k get storagepolicyusage -n storage-policy-test
NAMESPACE               NAME                                                          AGE
storage-policy-test     wcp-profile-jy7h3rs0bp-latebinding-pvc-usage                  4d23h       << SPU for deleted storage policy quota got deleted
storage-policy-test     wcp-profile-jy7h3rs0bp-latebinding-snapshot-usage             4d23h
storage-policy-test     wcp-profile-jy7h3rs0bp-pvc-usage                              4d23h
storage-policy-test     wcp-profile-jy7h3rs0bp-snapshot-usage                         4d23h
root@42273ba9ae49fdcea1c2fb301a4ddadb [ ~ ]#
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add reconciler for storagepolicyquota CRs in syncer
```
