### PR TITLE
[cherrypick - release-3.3] GetDevMounts: eval symlinks found in mount table (#2593)

### DIFF
--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -827,7 +827,14 @@ func (osUtils *OsUtils) GetDevMounts(ctx context.Context,
 		return devMnts, err
 	}
 	for _, m := range mnts {
-		if m.Device == sysDevice.RealDev || (m.Device == "devtmpfs" && m.Source == sysDevice.RealDev) {
+		// the device in the mount table may be a symlink
+		realDev, err := filepath.EvalSymlinks(m.Device)
+		if err != nil {
+			realDev = m.Device
+		}
+
+		if m.Device == sysDevice.RealDev || realDev == sysDevice.RealDev ||
+			(m.Device == "devtmpfs" && m.Source == sysDevice.RealDev) {
 			devMnts = append(devMnts, m)
 		}
 	}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry pick https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2593 to release-3.3 branch

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix FailedPrecondition error in NodePublishVolume when multipathd is enabled
```
