### PR TITLE
Ensure creation of StoragePolicyUsage CR in fullSync

### DIFF
--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -96,29 +96,6 @@ func getBoundPVs(ctx context.Context, metadataSyncer *metadataSyncInformer) ([]*
 	return boundPVs, nil
 }
 
-// getPVCsInPendingState is a helper function for fetching PVCs not in Bound state.
-func getPVCsInPendingState(ctx context.Context, metadataSyncer *metadataSyncInformer) ([]*v1.PersistentVolumeClaim,
-	error) {
-	log := logger.GetLogger(ctx)
-	var pendingPVCs []*v1.PersistentVolumeClaim
-	// Get all PVCs from kubernetes.
-	allPVCs, err := metadataSyncer.pvcLister.List(labels.Everything())
-	if err != nil {
-		return nil, err
-	}
-	for _, pvc := range allPVCs {
-		if pvc.ObjectMeta.Annotations[common.AnnStorageProvisioner] == csitypes.Name {
-			log.Debugf("getPVCsInPendingState: pvc %s in namespace %s is in state %v",
-				pvc.Name, pvc.Namespace, pvc.Status.Phase)
-			if pvc.Status.Phase == v1.ClaimPending {
-				pendingPVCs = append(pendingPVCs, pvc)
-			}
-		}
-	}
-	log.Infof("getPVCsInPendingState: pendingPVCs %v", pendingPVCs)
-	return pendingPVCs, nil
-}
-
 // fullSyncGetInlineMigratedVolumesInfo is a helper function for retrieving
 // inline PV information from Pods.
 func fullSyncGetInlineMigratedVolumesInfo(ctx context.Context,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: While upgrading to 8.0U3, creation of StoragePolicyUsage CR might get skipped for namespaces with no volumes prior to upgrade if for some reason we loose the StoragePolicyQuota Add event. This PR ensures we create StoragePolicyUsage CR for every SC, existing or new.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested the code in a single supervisor setup.
On syncer init, we see the `policyQuotaCRAdded` handler creating the StoragePolicyUsage for namespaces with no PVCs as well. FullSync tries to create it at the same time but gets an `instance already exists` error.

Tried deleting a StoragePolicyUsage instance on a namespace with no PVCs and confirmed that fullSync will re-create the CR.
Logs:
```
{"level":"info","time":"2024-05-16T00:24:39.983798672Z","caller":"syncer/metadatasyncer.go:3089","msg":"storagePolicyUsageCRSync: Successfully created the storagePolicyUsage CR \"divyen-thindisk-pvc-usage\" in namespace \"test-ns\"","TraceId":"2b0268e2-ce73-4349-9818-4a389223e05e"}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Ensure creation of StoragePolicyUsage CR in fullSync
```
