### PR TITLE
Bump up sidecars to k8s 1.30 releases

### DIFF
--- a/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
+++ b/manifests/vanilla/csi-snapshot-validatingwebhook.yaml
@@ -84,7 +84,7 @@ spec:
       serviceAccountName: snapshot-webhook
       containers:
         - name: snapshot-validation
-          image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v7.0.2 # change the image if you wish to use your own custom validation server image
+          image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v8.0.1 # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/run/secrets/tls/tls.crt', '--tls-private-key-file=/run/secrets/tls/tls.key']
           ports:

--- a/manifests/vanilla/deploy-csi-snapshot-components.sh
+++ b/manifests/vanilla/deploy-csi-snapshot-components.sh
@@ -50,7 +50,7 @@ if ! command -v kubectl > /dev/null; then
   exit 1
 fi
 
-qualified_version="v7.0.2"
+qualified_version="v8.0.1"
 volumesnapshotclasses_crd="volumesnapshotclasses.snapshot.storage.k8s.io"
 volumesnapshotcontents_crd="volumesnapshotcontents.snapshot.storage.k8s.io"
 volumesnapshots_crd="volumesnapshots.snapshot.storage.k8s.io"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -240,7 +240,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.5.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.6.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -258,7 +258,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.10.1
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.11.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -374,7 +374,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -386,9 +386,9 @@ spec:
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
             - "--default-fstype=ext4"
-            # needed only for topology aware setup
-            #- "--feature-gates=Topology=true"
-            #- "--strict-topology"
+            # enable the flag only for topology aware setup
+            - "--feature-gates=Topology=false"
+            - "--strict-topology"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -396,7 +396,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.2
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
           args:
             - "--v=4"
             - "--kube-api-qps=100"
@@ -592,7 +592,7 @@ spec:
       serviceAccountName: vsphere-csi-node
       containers:
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Bump up sidecars to latest versions that are recommended for k8s 1.30 release

New versions added by this PR:
```
snapshot-validation-webhook:v8.0.1
csi-attacher:v4.6.1
csi-resizer:v1.11.1
csi-snapshotter:v8.0.1
node-driver-registrar: 2.10.1
csi-provisioner:5.0.1
```

The PR disables the topology feature flag for provisioner, because the feature is now GA'ed and enabled by default in provisioner. However, for non topology deployments the flag has to be set to false to avoid the breaking changes to have any effect on volume provisioning.

Node driver registrar is not upgraded to latest (2.11.0) due to this issue: https://github.com/kubernetes-csi/node-driver-registrar/issues/415

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump up sidecars to latest versions that are recommended for k8s 1.30 release
```
