### PR TITLE
Updated storage quota extension service name

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -103,8 +103,8 @@ var (
 const (
 	ResourceKindPVC               = "PersistentVolumeClaim"
 	ResourceKindSnapshot          = "VolumeSnapshot"
-	PVCQuotaExtensionServiceName  = "volume.cns.vsphere.vmware.com"
-	SnapQuotaExtensionServiceName = "snapshot.cns.vsphere.vmware.com"
+	PVCQuotaExtensionServiceName  = "cns-storage-quota-extension-service-volume"
+	SnapQuotaExtensionServiceName = "cns-storage-quota-extension-service-snapshot"
 	scParamStoragePolicyID        = "storagePolicyID"
 )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Updated storage quota extension service name

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Testing completed with these changes on WCP setup.

Testing logs:

```
# kubectl describe storagepolicyquota -n quota-ns-10
Name:         wcpglobal-storage-profile-storagepolicyquota
Namespace:    quota-ns-10
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         StoragePolicyQuota
Metadata:
  Creation Timestamp:  2024-06-05T10:07:00Z
  Generation:          1
  Resource Version:    13756183
  UID:                 e0a32c81-046e-48fe-8d03-f8d2761d172b
Spec:
  Limit:              9223372036854775807
  Storage Policy Id:  d241183b-3e4d-445a-be8a-ca15c753f68c
Status:
  Extensions:
    Extension Name:  cns-storage-quota-extension-service-volume
    Extension Quota Usage:
      Sc Quota Usage:
        Reserved:          0
        Used:              10Mi
      Storage Class Name:  wcpglobal-storage-profile
  Total:
    Sc Quota Usage:
      Reserved:          0
      Used:              10Mi
    Storage Class Name:  wcpglobal-storage-profile
Events:                  <none>


# kubectl describe storagepolicyusage -n quota-ns-10
Name:         wcpglobal-storage-profile-pvc-usage
Namespace:    quota-ns-10
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         StoragePolicyUsage
Metadata:
  Creation Timestamp:  2024-06-05T10:07:00Z
  Generation:          3
  Resource Version:    13756182
  UID:                 0d596fb2-3345-41d7-8596-8fd5055fa07e
Spec:
  Resource API Group:       
  Resource Extension Name:  cns-storage-quota-extension-service-volume
  Resource Kind:            PersistentVolumeClaim
  Storage Class Name:       wcpglobal-storage-profile
  Storage Policy Id:        d241183b-3e4d-445a-be8a-ca15c753f68c
Status:
  Quota Usage:
    Reserved:  0
    Used:      10Mi
Events:        <none>



# k get pvc -n quota-ns-10
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc   Bound    pvc-00c0b4c1-9dd1-484e-91fa-03f00d107ac5   10Mi       RWO            wcpglobal-storage-profile   <unset>                 10m

```

**Special notes for your reviewer**:

**Release note**:
```release-note
Updated storage quota extension service name
```
