### PR TITLE
Empty FSS flags should not be defaulted on vanilla clusters

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go
@@ -587,6 +587,12 @@ func initFSS(ctx context.Context, k8sClient clientset.Interface,
 			k8sOrchestratorInstance.supervisorFSS.featureStatesLock.Unlock()
 		}
 	}
+
+	// if configMapNamespace is empty, it means the FSS namespace was not set
+	// so we should not care about watching it.
+	if configMapNamespaceToListen == "" {
+		return nil
+	}
 	// Set up kubernetes configmap listener for CSI namespace.
 	err = k8sOrchestratorInstance.informerManager.AddConfigMapListener(
 		ctx,

--- a/pkg/csi/service/common/commonco/utils.go
+++ b/pkg/csi/service/common/commonco/utils.go
@@ -54,13 +54,10 @@ func SetInitParams(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavor,
 			OperationMode: operationMode,
 		}
 	case cnstypes.CnsClusterFlavorVanilla:
-		if strings.TrimSpace(internalFSSName) == "" {
-			log.Infof("Defaulting feature states configmap name to %q", csiconfig.DefaultInternalFSSConfigMapName)
-			internalFSSName = csiconfig.DefaultInternalFSSConfigMapName
-		}
-		if strings.TrimSpace(internalFSSNamespace) == "" {
-			log.Infof("Defaulting feature states configmap namespace to %q", csiconfig.DefaultCSINamespace)
-			internalFSSNamespace = csiconfig.DefaultCSINamespace
+		if strings.TrimSpace(internalFSSName) == "" || strings.TrimSpace(internalFSSNamespace) == "" {
+			log.Infof("Feature state flags are not fully set, disabling any FSS")
+			internalFSSName = ""
+			internalFSSNamespace = ""
 		}
 		*initParams = k8sorchestrator.K8sVanillaInitParams{
 			InternalFeatureStatesConfigInfo: csiconfig.FeatureStatesConfigInfo{


### PR DESCRIPTION
**What this PR does / why we need it**: This PR removes the defaulting of feature flags namespace and configmap flags when they are empty, not enforcing the need of the FSS flags on vanilla clusters

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
TBD on running cluster

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
FSS flags are not defaulted on vanilla clusters
```
