### PR TITLE
fix kubeconfig env and flag values for CSI controller and syncer

### DIFF
--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func setupFlags() {
+	flag.String("kubeconfig", "", "Path to the kubeconfig file")
+}
+
+func TestGetKubeConfigPath(t *testing.T) {
+	// Helper function to reset flags after each test
+	resetFlags := func() {
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+		setupFlags()
+	}
+
+	// Test case: Environment variable set, flag not set
+	t.Run("EnvVarSetFlagNotSet", func(t *testing.T) {
+		resetFlags()
+		ctx := context.Background()
+		expectedPath := "/path/from/env"
+		os.Setenv(clientcmd.RecommendedConfigPathEnvVar, expectedPath)
+		defer os.Unsetenv(clientcmd.RecommendedConfigPathEnvVar)
+
+		result := getKubeConfigPath(ctx)
+		assert.Equal(t, expectedPath, result)
+	})
+
+	// Test case: Environment variable not set, flag set
+	t.Run("EnvVarNotSetFlagSet", func(t *testing.T) {
+		resetFlags()
+		ctx := context.Background()
+		expectedPath := "/path/from/flag"
+		err := flag.Set("kubeconfig", expectedPath)
+		assert.Nil(t, err, nil)
+		result := getKubeConfigPath(ctx)
+		assert.Equal(t, expectedPath, result)
+	})
+
+	// Test case: Both environment variable and flag set, flag should take precedence
+	t.Run("EnvVarSetFlagSet", func(t *testing.T) {
+		resetFlags()
+		ctx := context.Background()
+		envPath := "/path/from/env"
+		flagPath := "/path/from/flag"
+		err := os.Setenv(clientcmd.RecommendedConfigPathEnvVar, envPath)
+		assert.Nil(t, err, nil)
+		defer os.Unsetenv(clientcmd.RecommendedConfigPathEnvVar)
+		err = flag.Set("kubeconfig", flagPath)
+		assert.Nil(t, err, nil)
+
+		result := getKubeConfigPath(ctx)
+		assert.Equal(t, flagPath, result)
+	})
+
+	// Test case: Neither environment variable nor flag set
+	t.Run("NeitherEnvVarNorFlagSet", func(t *testing.T) {
+		resetFlags()
+		ctx := context.Background()
+
+		result := getKubeConfigPath(ctx)
+		assert.Equal(t, "", result)
+	})
+
+	// Test case: Environment variable set, flag set but empty
+	t.Run("EnvVarSetFlagEmpty", func(t *testing.T) {
+		resetFlags()
+		ctx := context.Background()
+		expectedPath := "/path/from/env"
+		os.Setenv(clientcmd.RecommendedConfigPathEnvVar, expectedPath)
+		defer os.Unsetenv(clientcmd.RecommendedConfigPathEnvVar)
+		err := flag.Set("kubeconfig", "")
+		assert.Nil(t, err, nil)
+
+		result := getKubeConfigPath(ctx)
+		assert.Equal(t, expectedPath, result)
+	})
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is required to support KUBECONFIG env variable for vSphere CSI controller and syncer pod.
when KUBECONFIG env variable is supplied but kubeconfig flag is not set, current code is setting default flag value.

This value is set by controller-runtime - https://github.com/kubernetes-sigs/controller-runtime/blame/main/pkg/client/config/config.go#L40-L58

```
{"level":"info","time":"2024-06-11T17:42:07.435629424Z","caller":"kubernetes/kubernetes.go:77","msg":"kubecfgFlag: &{Name:kubeconfig Usage:Paths to a kubeconfig. Only required if out-of-cluster. Value: DefValue:}","TraceId":"a4361fad-495c-4333-a49a-6eeda97edb5b","TraceId":"a3f66d1a-b463-4640-9fca-6330a8a49624"}
```

default value set in the kubeconfig flag is over riding env variable supplied in the container. This result into env variable being ignored, and code path is creating kubernetes client using in-cluster config instead of using kubeconfig supplied in environment variable.


**Testing done**:


Unit test

```
divyenp@divyenp0LVDQ kubernetes % go test -v -run TestGetKubeConfigPath
=== RUN   TestGetKubeConfigPath
=== RUN   TestGetKubeConfigPath/EnvVarSetFlagNotSet
{"level":"info","time":"2024-06-11T11:48:25.814524-07:00","caller":"kubernetes/kubernetes.go:100","msg":"Kubeconfig path obtained from environment variable \"KUBECONFIG\": \"/path/from/env\""}
{"level":"info","time":"2024-06-11T11:48:25.815015-07:00","caller":"kubernetes/kubernetes.go:111","msg":"Kubeconfig flag is set but empty, using environment variable value"}
{"level":"info","time":"2024-06-11T11:48:25.815026-07:00","caller":"kubernetes/kubernetes.go:121","msg":"Final Kubeconfig path used: \"/path/from/env\""}
=== RUN   TestGetKubeConfigPath/EnvVarNotSetFlagSet
{"level":"info","time":"2024-06-11T11:48:25.815328-07:00","caller":"kubernetes/kubernetes.go:100","msg":"Kubeconfig path obtained from environment variable \"KUBECONFIG\": \"\""}
{"level":"info","time":"2024-06-11T11:48:25.815337-07:00","caller":"kubernetes/kubernetes.go:109","msg":"Kubeconfig path obtained from kubeconfig flag: \"/path/from/flag\""}
{"level":"info","time":"2024-06-11T11:48:25.815342-07:00","caller":"kubernetes/kubernetes.go:121","msg":"Final Kubeconfig path used: \"/path/from/flag\""}
=== RUN   TestGetKubeConfigPath/EnvVarSetFlagSet
{"level":"info","time":"2024-06-11T11:48:25.815551-07:00","caller":"kubernetes/kubernetes.go:100","msg":"Kubeconfig path obtained from environment variable \"KUBECONFIG\": \"/path/from/env\""}
{"level":"info","time":"2024-06-11T11:48:25.815559-07:00","caller":"kubernetes/kubernetes.go:109","msg":"Kubeconfig path obtained from kubeconfig flag: \"/path/from/flag\""}
{"level":"info","time":"2024-06-11T11:48:25.815564-07:00","caller":"kubernetes/kubernetes.go:121","msg":"Final Kubeconfig path used: \"/path/from/flag\""}
=== RUN   TestGetKubeConfigPath/NeitherEnvVarNorFlagSet
{"level":"info","time":"2024-06-11T11:48:25.815601-07:00","caller":"kubernetes/kubernetes.go:100","msg":"Kubeconfig path obtained from environment variable \"KUBECONFIG\": \"\""}
{"level":"info","time":"2024-06-11T11:48:25.81561-07:00","caller":"kubernetes/kubernetes.go:111","msg":"Kubeconfig flag is set but empty, using environment variable value"}
{"level":"info","time":"2024-06-11T11:48:25.815616-07:00","caller":"kubernetes/kubernetes.go:119","msg":"No Kubeconfig path found, either from environment variable or flag"}
=== RUN   TestGetKubeConfigPath/EnvVarSetFlagEmpty
{"level":"info","time":"2024-06-11T11:48:25.815648-07:00","caller":"kubernetes/kubernetes.go:100","msg":"Kubeconfig path obtained from environment variable \"KUBECONFIG\": \"/path/from/env\""}
{"level":"info","time":"2024-06-11T11:48:25.815657-07:00","caller":"kubernetes/kubernetes.go:111","msg":"Kubeconfig flag is set but empty, using environment variable value"}
{"level":"info","time":"2024-06-11T11:48:25.815662-07:00","caller":"kubernetes/kubernetes.go:121","msg":"Final Kubeconfig path used: \"/path/from/env\""}
--- PASS: TestGetKubeConfigPath (0.00s)
    --- PASS: TestGetKubeConfigPath/EnvVarSetFlagNotSet (0.00s)
    --- PASS: TestGetKubeConfigPath/EnvVarNotSetFlagSet (0.00s)
    --- PASS: TestGetKubeConfigPath/EnvVarSetFlagSet (0.00s)
    --- PASS: TestGetKubeConfigPath/NeitherEnvVarNorFlagSet (0.00s)
    --- PASS: TestGetKubeConfigPath/EnvVarSetFlagEmpty (0.00s)
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/kubernetes        0.857s

```


Verified on the live setup when kubeconfig flag is supplied, below is the log


```
{"level":"info","time":"2024-06-11T18:59:25.54610768Z","caller":"kubernetes/kubernetes.go:100","msg":"Kubeconfig path obtained from environment variable \"KUBECONFIG\": \"\"","TraceId":"6f14886c-e45f-4b3f-b2ac-43ea43fdda44","TraceId":"3c7f6a9b-663d-4799-b576-a99a8ce1147a"}
{"level":"info","time":"2024-06-11T18:59:25.546400074Z","caller":"kubernetes/kubernetes.go:109","msg":"Kubeconfig path obtained from kubeconfig flag: \"/mnt/volume2/kubeconfig\"","TraceId":"6f14886c-e45f-4b3f-b2ac-43ea43fdda44","TraceId":"3c7f6a9b-663d-4799-b576-a99a8ce1147a"}
{"level":"info","time":"2024-06-11T18:59:25.54643341Z","caller":"kubernetes/kubernetes.go:121","msg":"Final Kubeconfig path used: \"/mnt/volume2/kubeconfig\"","TraceId":"6f14886c-e45f-4b3f-b2ac-43ea43fdda44","TraceId":"3c7f6a9b-663d-4799-b576-a99a8ce1147a"}
{"level":"info","time":"2024-06-11T18:59:25.546439746Z","caller":"kubernetes/kubernetes.go:75","msg":"k8s client using kubeconfig from /mnt/volume2/kubeconfig","TraceId":"6f14886c-e45f-4b3f-b2ac-43ea43fdda44","TraceId":"3c7f6a9b-663d-4799-b576-a99a8ce1147a"}
```


Verified on the live setup when kubeconfig env variable but flag is not supplied, below is the log

```
{"level":"info","time":"2024-06-11T19:02:08.163661995Z","caller":"kubernetes/kubernetes.go:100","msg":"Kubeconfig path obtained from environment variable \"KUBECONFIG\": \"/mnt/volume2/kubeconfig\"","TraceId":"1a419fdc-7577-47c3-b71e-459a1198704b","TraceId":"15df45c3-9766-4cb1-96b6-5e89e03aba3b"}
{"level":"info","time":"2024-06-11T19:02:08.163997406Z","caller":"kubernetes/kubernetes.go:111","msg":"Kubeconfig flag is set but empty, using environment variable value","TraceId":"1a419fdc-7577-47c3-b71e-459a1198704b","TraceId":"15df45c3-9766-4cb1-96b6-5e89e03aba3b"}
{"level":"info","time":"2024-06-11T19:02:08.164126487Z","caller":"kubernetes/kubernetes.go:121","msg":"Final Kubeconfig path used: \"/mnt/volume2/kubeconfig\"","TraceId":"1a419fdc-7577-47c3-b71e-459a1198704b","TraceId":"15df45c3-9766-4cb1-96b6-5e89e03aba3b"}
{"level":"info","time":"2024-06-11T19:02:08.164470011Z","caller":"kubernetes/kubernetes.go:75","msg":"k8s client using kubeconfig from /mnt/volume2/kubeconfig","TraceId":"1a419fdc-7577-47c3-b71e-459a1198704b","TraceId":"15df45c3-9766-4cb1-96b6-5e89e03aba3b"}
```



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix kubeconfig env and flag values for CSI controller and syncer
```
