### PR TITLE
Cherry-pick #2920 Set metadatasyncer to wait initial period before making call to VC

### DIFF
--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -149,7 +149,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.3.0-rc.3
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.3.0-rc.4
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -277,7 +277,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.3.0-rc.3
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.3.0-rc.4
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -337,7 +337,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.3.0-rc.3
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.3.0-rc.4
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=30s"
@@ -470,7 +470,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.3.0-rc.3
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.3.0-rc.4
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -615,7 +615,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.3.0-rc.3
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.3.0-rc.4
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -2004,7 +2004,7 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 		// pvcUpdated and pvUpdated. This helps avoid race condition between
 		// pvUpdated and pvcUpdated handlers when static PV and PVC is created
 		// almost at the same time using single YAML file.
-		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true,
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, false,
 			func(ctx context.Context) (bool, error) {
 				queryFilter := cnstypes.CnsQueryFilter{
 					VolumeIds: []cnstypes.CnsVolumeId{{Id: volumeHandle}},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Cherry-pick #2920

**Testing done**:
Added in #2920

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cherry-pick #2920 Set metadatasyncer to wait initial period before making call to VC
```
