### PR TITLE
Use optimistic merge for paravirt volumes patch

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -624,7 +624,9 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 		}
 
 		// Create a patch for the VM prior to modifying it with the new volumes.
-		vmPatch := client.MergeFrom(virtualMachine.DeepCopy())
+		vmPatch := client.MergeFromWithOptions(
+			virtualMachine.DeepCopy(),
+			client.MergeFromWithOptimisticLock{})
 
 		// Volume is not present in the virtualMachine.Spec.Volumes, so adding
 		// volume in the spec and patching virtualMachine instance.


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This patch fixes a possible race condition that occurs when using patch to update the volumes list in a VM Op VirtualMachine. It is possible with a vanilla patch that in between calculating and applying the patch the original object changed.

CRDs cannot use the strategic merge strategy, so instead this fix switches to an optimistic merge, which acts like update and refuses to make changes if the object has changed, but unlike update, does not drop fields.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

This fixes an internal bug blocking a vSphere Kubernetes Release. Please find us in Slack.

**Testing done**:

```shell
$ go test ./pkg/csi/service/wcpguest 
ok  	sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcpguest	6.604s
```


**Special notes for your reviewer**:

Ideally we would use [`StrategicMergeFrom`](https://github.com/kubernetes-sigs/controller-runtime/blob/1f5b39fa59d15fae78e521c9c9f2acabbbb3ea17/pkg/client/patch.go#L164-L179), but it does not support CRDs.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use optimistic merge when updating VirtualMachine volumes list to prevent overwriting list with stale data.
```
