### PR TITLE
Use optimistic merge for paravirt volumes patch

### DIFF
--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -624,7 +624,9 @@ func controllerPublishForBlockVolume(ctx context.Context, req *csi.ControllerPub
 		}
 
 		// Create a patch for the VM prior to modifying it with the new volumes.
-		vmPatch := client.MergeFrom(virtualMachine.DeepCopy())
+		vmPatch := client.MergeFromWithOptions(
+			virtualMachine.DeepCopy(),
+			client.MergeFromWithOptimisticLock{})
 
 		// Volume is not present in the virtualMachine.Spec.Volumes, so adding
 		// volume in the spec and patching virtualMachine instance.


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This is a cross-port of #2925

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

```shell
$ go test ./pkg/csi/service/wcpguest 
ok  	sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcpguest	6.628s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use optimistic merge when updating VirtualMachine volumes list to prevent overwriting list with stale data.
```
