### PR TITLE
attempt to logout and clear idle sessions before creating new one

### DIFF
--- a/pkg/common/cns-lib/volume/listview.go
+++ b/pkg/common/cns-lib/volume/listview.go
@@ -221,9 +221,16 @@ func (l *ListViewImpl) isClientValid(reconnect bool) error {
 		return ErrSessionNotAuthenticated
 	}
 
+	log.Infof("logging out current session and clearing idle sessions")
+
+	err := l.govmomiClient.Logout(l.ctx)
+	if err != nil {
+		log.Errorf("failed to logout current listview session. still cleared idle sessions. err: %v", err)
+	}
+
 	log.Infof("creating a new session...")
 
-	err := cnsvsphere.ReadVCConfigs(l.ctx, l.virtualCenter)
+	err = cnsvsphere.ReadVCConfigs(l.ctx, l.virtualCenter)
 	if err != nil {
 		return logger.LogNewErrorf(log, "failed to read VC config. err: %v", err)
 	}

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -326,6 +326,14 @@ func (vc *VirtualCenter) connect(ctx context.Context, requestNewSession bool) er
 			return nil
 		}
 	}
+
+	log.Infof("logging out current session and clearing idle sessions")
+
+	err = vc.Client.Logout(ctx)
+	if err != nil {
+		log.Errorf("failed to logout current session. still clearing idle sessions. err: %v", err)
+	}
+
 	// If session has expired, create a new instance.
 	log.Infof("Creating a new client session as the existing one isn't valid or not authenticated")
 	if vc.Config.ReloadVCConfigForNewClient {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

After the current VC session is determined to be invalid, we can attempt to logout of that session and clear any idle sessions associated with that govmomiClient before creating a new client and a new session. 

After testing on DSM clusters, they found idle sessions were not piling up as before. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Block-vanilla

```
Build #2853 (Jun 26, 2024, 9:53:06 PM)
adkulkarni
PR 2930
------------------------------ Ran 1 of 877 Specs in 373.242 seconds SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 876 Skipped PASS Ginkgo ran 1 suite in 7m13.584881461s Test Suite Passed -- ------------------------------ Ran 2 of 877 Specs in 3841.310 seconds SUCCESS! -- 2 Passed | 0 Failed | 1 Flaked | 0 Pending | 875 Skipped PASS Ginkgo ran 1 suite in 1h4m18.245782855s Test Suite Passed -- ------------------------------ Ran 12 of 877 Specs in 1036.846 seconds SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 865 Skipped Ginkgo ran 1 suite in 17m34.240638449s Test Suite Passed

Build #2848 (Jun 26, 2024, 7:35:40 PM)
adkulkarni
PR 2930
------------------------------ Ran 12 of 877 Specs in 1036.231 seconds SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 865 Skipped Ginkgo ran 1 suite in 18m13.516747066s Test Suite Passed 

```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
