### PR TITLE
Ensure probe-timeout is shorter than livenessProbe

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -676,6 +676,7 @@ spec:
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
+            - "--probe-timeout=4s"
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Ensure probe-timeout of the liveness-probe container is shorter than livenessProbe of the vsphere-csi-node container

Without this, if the socket probe takes too long, another livenessProbe check is started while the previous is not finished. Liveness probe requests pile up until the container liveness-probe failed in CrashLoopBackoff

**Testing done**:
Yes

**Special notes for your reviewer**:

**Release note**:

```release-note
Ensure probe-timeout of the liveness-probe container is shorter than livenessProbe of the vsphere-csi-node container
```
