### PR TITLE
Pinning go version to 1.21

### DIFF
--- a/cmd/vsphere-csi/main.go
+++ b/cmd/vsphere-csi/main.go
@@ -58,7 +58,7 @@ func main() {
 	// Set CO Init params.
 	clusterFlavor, err := csiconfig.GetClusterFlavor(ctx)
 	if err != nil {
-		log.Errorf("failed retrieving cluster flavor. Error: %v", err)
+		log.Errorf("failed retrieving the cluster flavor. Error: %v", err)
 	}
 	serviceMode := os.Getenv(csitypes.EnvVarMode)
 	commonco.SetInitParams(ctx, clusterFlavor, &service.COInitParams, *supervisorFSSName, *supervisorFSSNamespace,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/vsphere-csi-driver/v3
 
-go 1.22.3
+go 1.21
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.3.1

--- a/hack/check-golangci-lint.sh
+++ b/hack/check-golangci-lint.sh
@@ -53,8 +53,8 @@ shift $((OPTIND-1))
 
 export GOOS=linux
 if [ ! "${DO_DOCKER-}" ]; then
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.58.2
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.59.1
   "$(go env GOPATH)"/bin/golangci-lint run -v --timeout=1200s
 else
-  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v1.58.2 golangci-lint run -v --timeout=1200s
+  docker run --rm -v "$(pwd)":/app -w /app golangci/golangci-lint:v1.59.1 golangci-lint run -v --timeout=1200s
 fi

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -57,7 +57,7 @@ BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
 # CUSTOM_REPO_FOR_GOLANG can be used to pass custom repository for golang builder image.
 # Please ensure it ends with a '/'.
 # Example: CUSTOM_REPO_FOR_GOLANG=<docker-registry>/dockerhub-proxy-cache/library/
-GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.22
+GOLANG_IMAGE=${CUSTOM_REPO_FOR_GOLANG:-}golang:1.21
 
 ARCH=amd64
 OSVERSION=1809

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -17,7 +17,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.22
+ARG GOLANG_IMAGE=golang:1.21
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##

--- a/images/driver/Dockerfile
+++ b/images/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.22
+ARG GOLANG_IMAGE=golang:1.21
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest

--- a/images/syncer/Dockerfile
+++ b/images/syncer/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.22
+ARG GOLANG_IMAGE=golang:1.21
 
 # This build arg allows the specification of a custom base image.
 ARG BASE_IMAGE=gcr.io/cloud-provider-vsphere/extra/csi-driver-base:latest

--- a/images/windows/driver/Dockerfile
+++ b/images/windows/driver/Dockerfile
@@ -16,7 +16,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.22
+ARG GOLANG_IMAGE=golang:1.21
 ARG OSVERSION
 ARG ARCH=amd64
 

--- a/tests/e2e/docs/supervisor_cluster_setup.md
+++ b/tests/e2e/docs/supervisor_cluster_setup.md
@@ -140,7 +140,7 @@ datacenters should be comma separated if deployed on multi-datacenters
 
 ## Requirements
 
-Go version: 1.22
+Go version: 1.21
 
 Export the go binary in your PATH to run end-to-end tests
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

With the GoLang upgraded to 1.22, golangci lint checker is failing with the below error and blocks the merge of other PRs.

```
level=error msg="Running error: context loading failed: failed to load packages: failed to load packages: failed to load with go/packages: err: exit status 1: stderr: go: go.mod requires go >= 1.22.4 (running go 1.21.3; GOTOOLCHAIN=local)\n"
```

Hence we are pinning go version to 1.21 in go.mod until the above error is resolved.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Pinning go version to 1.21
```
