### PR TITLE
Increase csi-attacher worker threads to 100 from 10(default) for vanilla

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -251,6 +251,7 @@ spec:
             - "--leader-election-retry-period=30s"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--worker-threads=100"
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR is increasing CSI attacher worker threads in vanilla manifest to 100.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

CSI provisioner worker threads are set to 100 by default, but CSI attacher worker threads are set to only 10 by default. This results in volume provisioning at a faster rate but they can't be utilized in pods at the same rate. We should have same worker threads for create/delete and attach/detach operations.
A similar change was already done in Supervisor manifests as part of #2890.

**Testing done**:
Basic volume operations are working well after this change.

**Release note**:
```
Increase csi-attacher worker threads to 100 for vanilla
```
