### PR TITLE
Changing storagequota extension service name to keep it consistent in all StoragePolicyQuota/StoragePolicyUsage CRs (including CRs upgraded from 8.0u3 to 9.0)

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -115,8 +115,8 @@ var (
 const (
 	ResourceKindPVC               = "PersistentVolumeClaim"
 	ResourceKindSnapshot          = "VolumeSnapshot"
-	PVCQuotaExtensionServiceName  = "cns-storage-quota-extension-service-volume"
-	SnapQuotaExtensionServiceName = "cns-storage-quota-extension-service-snapshot"
+	PVCQuotaExtensionServiceName  = "volume.cns.vsphere.vmware.com"
+	SnapQuotaExtensionServiceName = "snapshot.cns.vsphere.vmware.com"
 	scParamStoragePolicyID        = "storagePolicyID"
 )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We already used "volume.cns.vsphere.vmware.com" and "snapshot.cns.vsphere.vmware.com" as extension service name in vSphere 8.0u3 StoragePolicyQuota and StoragePolicyUsage CRs (even though we were not using extension service).
So, to avoid patching older CRs in case of upgrade to vSphere 9.0 version, keeping same extension service name in CR status. Internally storage quota webhook will use appropriate extension service name to send requests for getting resource capacity.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified that PVC creation is successful with these changes:

```
# k get pvc -n quota-ns
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
example-raw-block-pvc   Bound    pvc-a205527a-c03f-4ac6-a00e-9efb10ba84d2   10Mi       RWO            wcpglobal-storage-profile   <unset>                 9m7s
```

storagepolicyquota details:
```
# k describe storagepolicyquota -n quota-ns
Name:         wcpglobal-storage-profile-storagepolicyquota
Namespace:    quota-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         StoragePolicyQuota
Metadata:
  Creation Timestamp:  2024-07-02T11:08:12Z
  Generation:          1
  Resource Version:    38184008
  UID:                 6939d63b-f860-4e34-882f-bd2194122598
Spec:
  Limit:              9223372036854775807
  Storage Policy Id:  d241183b-3e4d-445a-be8a-ca15c753f68c
Status:
  Extensions:
    Extension Name:  volume.cns.vsphere.vmware.com
    Extension Quota Usage:
      Sc Quota Usage:
        Reserved:          0
        Used:              10Mi
      Storage Class Name:  wcpglobal-storage-profile
    Extension Name:        snapshot.cns.vsphere.vmware.com
    Extension Quota Usage:
      Sc Quota Usage:
        Reserved:          0
        Used:              0
      Storage Class Name:  wcpglobal-storage-profile
  Total:
    Sc Quota Usage:
      Reserved:          0
      Used:              10Mi
    Storage Class Name:  wcpglobal-storage-profile
Events:                  <none>
```

storagepolicyusage details:
```
# k describe storagepolicyusage -n quota-ns
Name:         wcpglobal-storage-profile-pvc-usage
Namespace:    quota-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         StoragePolicyUsage
Metadata:
  Creation Timestamp:  2024-07-02T11:08:12Z
  Generation:          3
  Resource Version:    38183998
  UID:                 55ebb079-696e-4345-86af-1df3e867154e
Spec:
  Resource API Group:       
  Resource Extension Name:  volume.cns.vsphere.vmware.com
  Resource Kind:            PersistentVolumeClaim
  Storage Class Name:       wcpglobal-storage-profile
  Storage Policy Id:        d241183b-3e4d-445a-be8a-ca15c753f68c
Status:
  Quota Usage:
    Reserved:  0
    Used:      10Mi
Events:        <none>
```



**Special notes for your reviewer**:

**Release note**:
```release-note
Changing storagequota extension service name to keep it consistent in all StoragePolicyQuota/StoragePolicyUsage CRs (including CRs upgraded from 8.0u3 to 9.0)
```
