### PR TITLE
Add informer for CnsVolumeInfo objects

### DIFF
--- a/pkg/internalapis/cnsvolumeinfo/v1alpha1/register.go
+++ b/pkg/internalapis/cnsvolumeinfo/v1alpha1/register.go
@@ -22,6 +22,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// GroupName represents the group for cnsvolumeinfo apis
+const GroupName = "cns.vmware.com"
+
+// Version represents the version for cnsvolumeinfo apis
+const Version = "v1alpha1"
+
+// CnsVolumeInfoPlural is plural of CnsVolumeInfo
+const CnsVolumeInfoPlural = "cnsvolumeinfoes"
+
+// CnsVolumeInfoSingular is Singular of CnsVolumeInfo
+const CnsVolumeInfoSingular = "cnsvolumeinfo"
+
 // SchemeGroupVersion define schema Group and version
 var SchemeGroupVersion = schema.GroupVersion{
 	Group:   "cns.vmware.com",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adds an informer for CnsVolumeInfo objects. The event handler is responsible for updating VolumeSnapshot StoragePolicyUsage "used" capacity.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified that the informer can start.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
