### PR TITLE
Support Storage Pools on Stretched Supervisor cluster

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -755,6 +755,7 @@ func GetConfigPath(ctx context.Context) string {
 			cfgPath = DefaultCloudConfigPath
 		}
 	}
+
 	return cfgPath
 }
 

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package config
 
-import vsanfstypes "github.com/vmware/govmomi/vsan/vsanfs/types"
+import (
+	vsanfstypes "github.com/vmware/govmomi/vsan/vsanfs/types"
+)
 
 // Config is used to read and store information from the cloud configuration file
 type Config struct {

--- a/pkg/syncer/storagepool/listener.go
+++ b/pkg/syncer/storagepool/listener.go
@@ -43,11 +43,9 @@ var (
 )
 
 func startPropertyCollectorListener(ctx context.Context) {
-	scWatchCntlr := defaultStoragePoolService.GetScWatch()
-	SpController := defaultStoragePoolService.GetSPController()
 	exitChannel := make(chan interface{})
 	go managePCListenerInstance(ctx, exitChannel)
-	initListener(ctx, scWatchCntlr, SpController, exitChannel)
+	initListener(ctx, defaultStoragePoolService.GetScWatch(), defaultStoragePoolService.GetSPController(), exitChannel)
 }
 
 // managePCListenerInstance is responsible for making sure that Property
@@ -69,13 +67,7 @@ func initListener(ctx context.Context, scWatchCntlr *StorageClassWatch,
 	spController *SpController, exitChannel chan interface{}) {
 	log := logger.GetLogger(ctx)
 
-	// Initialize a PropertyCollector that watches all objects in the hierarchy
-	// of cluster -> hosts in the cluster -> datastores mounted on hosts. One or
-	// more StoragePool instances would be created for each Datastore.
-	clusterMoref := types.ManagedObjectReference{
-		Type:  "ClusterComputeResource",
-		Value: spController.clusterID,
-	}
+	filter := new(property.WaitFilter)
 	ts := types.TraversalSpec{
 		Type: "ClusterComputeResource",
 		Path: "host",
@@ -88,8 +80,16 @@ func initListener(ctx context.Context, scWatchCntlr *StorageClassWatch,
 			},
 		},
 	}
-	filter := new(property.WaitFilter)
-	filter.Add(clusterMoref, clusterMoref.Type, []string{"host"}, &ts)
+	for _, clusterID := range scWatchCntlr.clusterIDs {
+		// Initialize a PropertyCollector that watches all objects in the hierarchy
+		// of cluster -> hosts in the cluster -> datastores mounted on hosts. One or
+		// more StoragePool instances would be created for each Datastore.
+		clusterMoref := types.ManagedObjectReference{
+			Type:  "ClusterComputeResource",
+			Value: clusterID,
+		}
+		filter.Add(clusterMoref, clusterMoref.Type, []string{"host"}, &ts)
+	}
 	prodHost := types.PropertySpec{
 		Type:    "HostSystem",
 		PathSet: []string{"datastore", "runtime.inMaintenanceMode"},
@@ -230,36 +230,34 @@ func ReconcileAllStoragePools(ctx context.Context, scWatchCntlr *StorageClassWat
 		log.Errorf("failed to connect to vCenter. Err: %+v", err)
 		return err
 	}
+
 	// Get datastores from VC.
-	sharedDatastores, vsanDirectDatastores, err := cnsvsphere.GetCandidateDatastoresInCluster(ctx, &vc,
-		spCtl.clusterID, true)
-	if err != nil {
-		log.Errorf("Failed to find datastores from VC. Err: %+v", err)
-		return err
-	}
-	datastores := append(sharedDatastores, vsanDirectDatastores...)
+	clusterIDToDSs := cnsvsphere.GetCandidateDatastoresInClusters(ctx, &vc,
+		spCtl.clusterIDs, true)
 	validStoragePoolNames := make(map[string]bool)
 	// Create StoragePools that are missing and add them to intendedStateMap.
-	for _, dsInfo := range datastores {
-		spName := makeStoragePoolName(dsInfo.Info.Name)
-		validStoragePoolNames[spName] = true
-		intendedState, err := newIntendedState(ctx, dsInfo, scWatchCntlr)
-		if err != nil {
-			log.Errorf("Error reconciling StoragePool for datastore %s. Err: %v", dsInfo.Reference().Value, err)
-			continue
-		}
-		err = spCtl.applyIntendedState(ctx, intendedState)
-		if err != nil {
-			log.Errorf("Error applying intended state of StoragePool %s. Err: %v", intendedState.spName, err)
-			continue
-		}
-
-		// Create vsan-sna StoragePools for local vsan datastore.
-		if intendedState.dsType == vsanDsType && !intendedState.isRemoteVsan {
-			err := spCtl.updateVsanSnaIntendedState(ctx, intendedState, validStoragePoolNames, scWatchCntlr)
+	for clusterID, DSs := range clusterIDToDSs {
+		for _, dsInfo := range DSs {
+			validStoragePoolNames[makeStoragePoolName(dsInfo.Info.Name)] = true
+			intendedState, err := newIntendedState(ctx, clusterID, dsInfo, scWatchCntlr)
 			if err != nil {
-				log.Errorf("Error updating intended state of vSAN SNA StoragePools. Err: %v", err)
+				log.Errorf("Error reconciling StoragePool for datastore %s. Err: %v", dsInfo.Reference().Value, err)
 				continue
+			}
+
+			err = spCtl.applyIntendedState(ctx, intendedState)
+			if err != nil {
+				log.Errorf("Error applying intended state of StoragePool %s. Err: %v", intendedState.spName, err)
+				continue
+			}
+
+			// Create vsan-sna StoragePools for local vsan datastore.
+			if intendedState.dsType == vsanDsType && !intendedState.isRemoteVsan {
+				err := spCtl.updateVsanSnaIntendedState(ctx, intendedState, validStoragePoolNames, scWatchCntlr)
+				if err != nil {
+					log.Errorf("Error updating intended state of vSAN SNA StoragePools. Err: %v", err)
+					continue
+				}
 			}
 		}
 	}

--- a/pkg/syncer/storagepool/migrationController.go
+++ b/pkg/syncer/storagepool/migrationController.go
@@ -43,16 +43,15 @@ import (
 // migrationController is responsible for processing CNS volume relocation
 // to another StoragePool.
 type migrationController struct {
-	vc        *cnsvsphere.VirtualCenter
-	clusterID string
+	vc         *cnsvsphere.VirtualCenter
+	clusterIDs []string
 }
 
-func initMigrationController(vc *cnsvsphere.VirtualCenter, clusterID string) *migrationController {
-	migrationCntlr := migrationController{
-		vc:        vc,
-		clusterID: clusterID,
+func initMigrationController(vc *cnsvsphere.VirtualCenter, clusterIDs []string) *migrationController {
+	return &migrationController{
+		vc:         vc,
+		clusterIDs: clusterIDs,
 	}
-	return &migrationCntlr
 }
 
 func (m *migrationController) relocateCNSVolume(ctx context.Context, volumeID string, targetSPName string) error {
@@ -70,7 +69,7 @@ func (m *migrationController) relocateCNSVolume(ctx context.Context, volumeID st
 	if !found || err != nil {
 		return fmt.Errorf("failed to find datastoreUrl in StoragePool %s", targetSPName)
 	}
-	dsInfo, err := cnsvsphere.GetDatastoreInfoByURL(ctx, m.vc, m.clusterID, datastoreURL)
+	dsInfo, err := cnsvsphere.GetDatastoreInfoByURL(ctx, m.vc, m.clusterIDs, datastoreURL)
 	if err != nil {
 		return fmt.Errorf("failed to get datastore corresponding to URL %v", datastoreURL)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces the Storage Pool functionality in Stretched Supervisor cluster which is a key prerequisite to support vDPp workloads on Stretched Supervisor. 
This feature is controlled by two FSSs - `PodVM_On_Stretched_Supervisor_Supported` and `vdpp-on-stretched-supervisor`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
On a Stretched Supervisor with vSAN Datastores and vSAN Direct datastores enabled, I've verified the following behaviour - 

> When one of the FSSs is `false` the Storage Pool controller exited by logging the following information -

 ```
{"level":"info","time":"2024-07-10T11:29:09.272501334Z","caller":"storagepool/service.go:70","msg":"`PodVM_On_Stretched_Supervisor_Supported` and `vdpp-on-stretched-supervisor` should be enabled for storage pool service on Stretched Supervisor. Exiting..."}
```

> When both the FSSs are `true`, the Storage Pool controller created the Storage Pools for all the datastores that are accessible from all the hosts in the clusters.
```
➜  2125 kubectl get storagepools         
NAME                                                         AGE
storagepool-local-0                                          65s
storagepool-local-0-2                                        64s
storagepool-local-0-3                                        62s
storagepool-local-1                                          65s
storagepool-local-1-2                                        64s
storagepool-local-1-3                                        62s
storagepool-sharedvmfs-0                                     66s
storagepool-vsand-10.184.64.122-mpx.vmhba0-c0-t3-l0          60s
storagepool-vsand-10.184.64.122-mpx.vmhba0-c0-t4-l0          61s
storagepool-vsand-10.184.74.26-mpx.vmhba0-c0-t3-l0           60s
storagepool-vsand-10.184.74.26-mpx.vmhba0-c0-t4-l0           60s
storagepool-vsand-10.184.76.238-mpx.vmhba0-c0-t3-l0          61s
storagepool-vsand-10.184.76.238-mpx.vmhba0-c0-t4-l0          62s
storagepool-vsandatastore                                    65s
storagepool-vsandatastore-sc2-10-184-76-238.eng.vmware.com   64s
```
> Created a vSAN SNA storage policy called `Test vsan sna policy` and a vSAN Direct storage policy called `Test vsan direct policy` and assigned them to a Namespace. The Storage Classes got created as expected.
```
➜  2125 kubectl get sc | grep test
test-vsan-direct-policy                             csi.vsphere.vmware.com   Delete          WaitForFirstConsumer   true                   9h
test-vsan-direct-policy-latebinding                 csi.vsphere.vmware.com   Delete          WaitForFirstConsumer   true                   9h
test-vsan-sna-policy                                csi.vsphere.vmware.com   Delete          WaitForFirstConsumer   true                   8h
test-vsan-sna-policy-latebinding                    csi.vsphere.vmware.com   Delete          WaitForFirstConsumer   true                   8h
```
> Restarted the Storage Pool controller to verify if the storage pools got updated as expected.
```
➜  2125 sp=storagepool-vsand-10.184.64.122-mpx.vmhba0-c0-t3-l0 
➜  2125 kubectl get storagepools $sp -o yaml                  
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePool
metadata:
  creationTimestamp: "2024-07-10T15:05:53Z"
  generation: 1
  labels:
    cns.vmware.com/StoragePoolType: vsanD
  name: storagepool-vsand-10.184.64.122-mpx.vmhba0-c0-t3-l0
  resourceVersion: "1044272"
  uid: 0f49d887-3cf4-4455-9912-4af4b87e4c90
spec:
  driver: csi.vsphere.vmware.com
  parameters:
    datastoreUrl: ds:///vmfs/volumes/668d2bf3-f955de61-9638-020064fadeb6/
status:
  accessibleNodes:
  - sc2-10-184-64-122.eng.vmware.com
  capacity:
    allocatableSpace: 213227929600
    freeSpace: 213232123904
    total: 214479929344
  compatibleStorageClasses:
  - test-vsan-direct-policy
  - test-vsan-direct-policy-latebinding
  - vm-encryption-policy
  - vm-encryption-policy-latebinding

➜  2125 sp=storagepool-vsandatastore-sc2-10-184-76-238.eng.vmware.com
➜  2125 kubectl get storagepools $sp -o yaml                         
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePool
metadata:
  creationTimestamp: "2024-07-10T15:05:49Z"
  generation: 1
  labels:
    cns.vmware.com/StoragePoolType: vsan-sna
  name: storagepool-vsandatastore-sc2-10-184-76-238.eng.vmware.com
  resourceVersion: "1044220"
  uid: d67b696c-fdd6-4713-93d6-0a5845522ddc
spec:
  driver: csi.vsphere.vmware.com
  parameters:
    datastoreUrl: ds:///vmfs/volumes/vsan:5278209714451b3b-5d7c4e04e0973942/
status:
  accessibleNodes:
  - sc2-10-184-76-238.eng.vmware.com
  capacity:
    allocatableSpace: 405592713306
    freeSpace: 422492409694
    total: 429479952384
  compatibleStorageClasses:
  - test-vsan-sna-policy
  - test-vsan-sna-policy-latebinding
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
