### PR TITLE
Use client-go package for leaderelection to add cleanup logic after leader change

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -23,15 +23,17 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
 
-	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/node"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/config"
@@ -183,19 +185,49 @@ func main() {
 				log.Fatalf("Creating Kubernetes client failed. Err: %v", err)
 			}
 			lockName := "vsphere-syncer"
-			le := leaderelection.NewLeaderElection(k8sClient, lockName, run)
-
-			if *leaderElectionNamespace != "" {
-				le.WithNamespace(*leaderElectionNamespace)
+			id, err := defaultLeaderElectionIdentity()
+			if err != nil {
+				log.Fatalf("error getting the default leader identity. Err: %v", err)
 			}
-
-			le.WithLeaseDuration(*leaderElectionLeaseDuration)
-			le.WithRenewDeadline(*leaderElectionRenewDeadline)
-			le.WithRetryPeriod(*leaderElectionRetryPeriod)
-
-			if err := le.Run(); err != nil {
-				log.Fatalf("Error initializing leader election: %v", err)
+			resourceLockConfig := rl.ResourceLockConfig{
+				Identity: sanitizeName(id),
 			}
+			if *leaderElectionNamespace == "" {
+				*leaderElectionNamespace = inClusterNamespace()
+			}
+			log.Debugf("identity: %v, leaderElectionNamespace: %v",
+				resourceLockConfig.Identity, *leaderElectionNamespace)
+			lock, err := rl.New(rl.LeasesResourceLock, *leaderElectionNamespace, lockName, k8sClient.CoreV1(),
+				k8sClient.CoordinationV1(), resourceLockConfig)
+			if err != nil {
+				log.Fatalf("Creating lock for leader election failed. Err: %v", err)
+			}
+			leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+				Lock:          lock,
+				LeaseDuration: *leaderElectionLeaseDuration,
+				RenewDeadline: *leaderElectionRenewDeadline,
+				RetryPeriod:   *leaderElectionRetryPeriod,
+				Callbacks: leaderelection.LeaderCallbacks{
+					OnStartedLeading: func(_ context.Context) {
+						log.Info("became leader, starting")
+						run(ctx)
+					},
+					OnStoppedLeading: func() {
+						log.Info("stopped leading. disconnecting vc session")
+						utils.LogoutAllvCenterSessions(ctx)
+						os.Exit(0)
+					},
+					OnNewLeader: func(identity string) {
+						if identity == resourceLockConfig.Identity {
+							//  current replica reacquired lease
+							return
+						}
+						log.Infof("new leader detected, current leader: %s", identity)
+					},
+				},
+				ReleaseOnCancel: true,
+				Name:            lockName,
+			})
 		}
 	} else {
 		log.Fatalf("unsupported operation mode: %v", *operationMode)
@@ -338,4 +370,36 @@ func cleanupSessions(ctx context.Context, r interface{}) {
 	log.Info("Recovered from panic. Disconnecting the existing vc sessions.")
 	utils.LogoutAllvCenterSessions(ctx)
 	os.Exit(0)
+}
+
+func defaultLeaderElectionIdentity() (string, error) {
+	return os.Hostname()
+}
+
+// sanitizeName sanitizes the provided string so it can be consumed by leader election library
+func sanitizeName(name string) string {
+	re := regexp.MustCompile("[^a-zA-Z0-9-]")
+	name = re.ReplaceAllString(name, "-")
+	if name[len(name)-1] == '-' {
+		// name must not end with '-'
+		name = name + "X"
+	}
+	return name
+}
+
+// inClusterNamespace returns the namespace in which the pod is running in by checking
+// the env var POD_NAMESPACE, then the file /var/run/secrets/kubernetes.io/serviceaccount/namespace.
+// if neither returns a valid namespace, the "default" namespace is returned
+func inClusterNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
+			return ns
+		}
+	}
+
+	return "default"
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

https://github.com/kubernetes-csi/csi-lib-utils/blob/master/leaderelection/leader_election.go#L187 doesn't allow overriding OnStoppedLeading callback. This means we can't add any code to perform session cleanup which leads to session leak. 

client-go leaderelection package provides similar functionality while allowing us to define logic for OnStoppedLeading and other callbacks. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```

I0709 23:20:59.062686       1 leaderelection.go:245] attempting to acquire leader lease vmware-system-csi/vsphere-syncer...
2024-07-09T23:20:59.109Z	INFO	syncer/main.go:218	new leader detected, current leader: vsphere-csi-controller-845c4d5bf6-smrk9	{"TraceId": "517bb231-f548-4b2a-b675-443bde166d86"}
2024-07-09T23:21:33.693Z	INFO	syncer/main.go:218	new leader detected, current leader: vsphere-csi-controller-845c4d5bf6-2dc9n	{"TraceId": "517bb231-f548-4b2a-b675-443bde166d86"}
I0709 23:21:33.697716       1 leaderelection.go:255] successfully acquired lease vmware-system-csi/vsphere-syncer
2024-07-09T23:21:33.699Z	INFO	syncer/main.go:209	became leader, starting	{"TraceId": "517bb231-f548-4b2a-b675-443bde166d86"}

---

root@k8s-control-574-1720547892:~# k create -f scpodpvc.yaml
storageclass.storage.k8s.io/example-vanilla-rwo-filesystem-sc created
persistentvolumeclaim/example-vanilla-rwo-pvc created
pod/example-vanilla-block-pod created

root@k8s-control-574-1720547892:~# k get pvc
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        VOLUMEATTRIBUTESCLASS   AGE
example-vanilla-rwo-pvc   Bound    pvc-a3665c91-0d6d-419d-89f6-3c394812d6e8   5Gi        RWO            example-vanilla-rwo-filesystem-sc   <unset>                 4m4s
root@k8s-control-574-1720547892:~# k get po
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-block-pod   1/1     Running   0          4m6s
```

```
15:41:55  full-sync-test [csi-block-vanilla-destructive] Scale down driver deployment to zero replica and verify PV metadata is created in CNS [p1, block, vanilla, disruptive, core]
15:41:55  /home/worker/workspace/Block-Vanilla/Results/2632/vsphere-csi-driver/tests/e2e/fullsync_test_for_block_volume.go:696


15:48:25  Ran 1 of 877 Specs in 395.796 seconds
15:48:25  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 876 Skipped
15:48:25  PASS
15:48:25  [38;5;228mYou're using deprecated Ginkgo functionality:[0m
15:48:25  [38;5;228m=============================================[0m
15:48:25    [38;5;11m--always-emit-ginkgo-writer is deprecated  - use -v instead, or one of Ginkgo's machine-readable report formats to get GinkgoWriter output for passing specs.[0m
15:48:25  
15:48:25  [38;5;243mTo silence deprecations that can be silenced set the following environment variable:[0m
15:48:25    [38;5;243mACK_GINKGO_DEPRECATIONS=2.11.0[0m
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use client-go package for syncer leaderelection
```
