### PR TITLE
Sync snapshot details and update csnvolumeinfo

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -442,22 +442,20 @@ func GetValidatedCNSVolumeInfoPatch(ctx context.Context,
 	cnsSnapshotInfo *cnsvolume.CnsSnapshotInfo) (map[string]interface{}, error) {
 	log := logger.GetLogger(ctx)
 	var patch map[string]interface{}
-	if cnsSnapshotInfo == nil || cnsSnapshotInfo.SnapshotID == "" || cnsSnapshotInfo.SourceVolumeID == "" {
-		log.Errorf("SnapshotID %q or VolumeID %q values cannot be empty",
-			cnsSnapshotInfo.SnapshotID, cnsSnapshotInfo.SourceVolumeID)
-		return nil, logger.LogNewErrorf(log, "SnapshotID and VolumeID values cannot be empty")
+	if cnsSnapshotInfo == nil || cnsSnapshotInfo.SourceVolumeID == "" {
+		log.Errorf("VolumeID %q values cannot be empty", cnsSnapshotInfo.SourceVolumeID)
+		return nil, logger.LogNewErrorf(log, "VolumeID values cannot be empty")
 	}
 	if cnsSnapshotInfo.AggregatedSnapshotCapacityInMb == -1 {
-		log.Infof("Couldn't retrieve aggregated snapshot capacity for volume %q and snapshot %q",
-			cnsSnapshotInfo.SourceVolumeID, cnsSnapshotInfo.SnapshotID)
+		log.Infof("Couldn't retrieve aggregated snapshot capacity for volume %q", cnsSnapshotInfo.SourceVolumeID)
 		patch = map[string]interface{}{
 			"spec": map[string]interface{}{
 				"validaggregatedsnapshotsize": false,
 			},
 		}
 	} else {
-		log.Infof("retrieved aggregated snapshot capacity %d for volume %q and snapshot %q",
-			cnsSnapshotInfo.AggregatedSnapshotCapacityInMb, cnsSnapshotInfo.SourceVolumeID, cnsSnapshotInfo.SnapshotID)
+		log.Infof("retrieved aggregated snapshot capacity %d for volume %q",
+			cnsSnapshotInfo.AggregatedSnapshotCapacityInMb, cnsSnapshotInfo.SourceVolumeID)
 		patch = map[string]interface{}{
 			"spec": map[string]interface{}{
 				"validaggregatedsnapshotsize":         true,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
With this PR csi fullsync will ensure CNSVolumeInfo holds correct snapshot details of the volume.
in cases where mismatch found for AggregatedSnapshotSize, it will patch cnsvolumeinfo with correct values fetched from CNS.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing Performed
```
root@420e33d19796412054b9c95a707aef4f [ ~ ]# k get cnsvolumeinfo -A 
NAMESPACE           NAME                                   AGE
vmware-system-csi   14d1a3c4-339c-4c00-8c2f-28bd7ff4f015   14d
vmware-system-csi   15bddb90-744b-49f4-be45-ae893fc9004d   14d
vmware-system-csi   626443ec-791f-4c9e-a8fd-d0539539dcf9   3m28s
vmware-system-csi   668bc299-a6e4-48c5-bc38-ad3ccfbbeb27   14d
vmware-system-csi   871896ca-3f33-4d39-8909-1b34a9075fbb   14d
root@420e33d19796412054b9c95a707aef4f [ ~ ]# kubectl describe cnsvolumeinfo 668bc299-a6e4-48c5-bc38-ad3ccfbbeb27 -n vmware-system-csi
Name:         668bc299-a6e4-48c5-bc38-ad3ccfbbeb27
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CNSVolumeInfo
Metadata:
  Creation Timestamp:  2024-07-10T11:26:17Z
  Generation:          3
  Resource Version:    14120191
  UID:                 7342d225-9983-42f2-9022-d6fc2c7c4aef
Spec:
  Aggregatedsnapshotsize:               0
  Capacity:                             1Gi
  Namespace:                            storage-policy-test
  Snapshotlatestoperationcompletetime:  2024-07-24T17:14:52Z
  Storage Class Name:                   wcp-profile-c6rt9t0cli
  Storage Policy ID:                    43333687-ec93-4e67-a5bc-5fa84c4f3f9b
  V Center Server:                      sc1-10-78-163-98.eng.vmware.com
  Validaggregatedsnapshotsize:          false
  Volume ID:                            668bc299-a6e4-48c5-bc38-ad3ccfbbeb27
Events:                                 <none>
root@420e33d19796412054b9c95a707aef4f [ ~ ]# kubectl describe cnsvolumeinfo 626443ec-791f-4c9e-a8fd-d0539539dcf9 -n vmware-system-csi
Name:         626443ec-791f-4c9e-a8fd-d0539539dcf9
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CNSVolumeInfo
Metadata:
  Creation Timestamp:  2024-07-24T22:09:51Z
  Generation:          2
  Resource Version:    14182838
  UID:                 57ec4bf9-318c-45d9-b7bd-09b9d13f4486
Spec:
  Aggregatedsnapshotsize:               103
  Capacity:                             1Gi
  Namespace:                            storage-policy-test
  Snapshotlatestoperationcompletetime:  2024-07-24T22:09:52Z
  Storage Class Name:                   wcp-profile-c6rt9t0cli
  Storage Policy ID:                    43333687-ec93-4e67-a5bc-5fa84c4f3f9b
  V Center Server:                      sc1-10-78-163-98.eng.vmware.com
  Validaggregatedsnapshotsize:          true
  Volume ID:                            626443ec-791f-4c9e-a8fd-d0539539dcf9
Events:                                 <none>
root@420e33d19796412054b9c95a707aef4f [ ~ ]# kubectl apply -f pvc2.yaml -n storage-policy-test
persistentvolumeclaim/example-vanilla-rwo-pvc2 created
root@420e33d19796412054b9c95a707aef4f [ ~ ]# 
root@420e33d19796412054b9c95a707aef4f [ ~ ]# k get pvc -A
NAMESPACE              NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                       VOLUMEATTRIBUTESCLASS   AGE
storage-class-test-2   wcp-profile                Bound    pvc-e848fed4-7809-4623-a354-3bdbda9c2040   1Gi        RWO            test-storage-class-update-policy   <unset>                 14d
storage-policy-test    example-vanilla-rwo-pvc    Bound    pvc-6596fdf9-5d5f-4631-a93b-b8610d831726   1Gi        RWO            wcp-profile-c6rt9t0cli             <unset>                 13d
storage-policy-test    example-vanilla-rwo-pvc2   Bound    pvc-46f9324e-9bda-4474-8ed9-f9625f473c6b   1Gi        RWO            wcp-profile-c6rt9t0cli             <unset>                 6s
storage-policy-test    wcp-profile                Bound    pvc-e52e70c8-7b65-4eb6-ac72-a9bfb684f132   1Gi        RWO            wcp-profile-c6rt9t0cli             <unset>                 14d
storage-policy-test    wcp-profile-second         Bound    pvc-97dee485-3176-41a7-b692-d9c81af776ad   1Gi        RWO            wcp-profile-c6rt9t0cli             <unset>                 14d
root@420e33d19796412054b9c95a707aef4f [ ~ ]# k get cnsvolumeinfo -A 
NAMESPACE           NAME                                   AGE
vmware-system-csi   14d1a3c4-339c-4c00-8c2f-28bd7ff4f015   14d
vmware-system-csi   15bddb90-744b-49f4-be45-ae893fc9004d   14d
vmware-system-csi   626443ec-791f-4c9e-a8fd-d0539539dcf9   4m39s
vmware-system-csi   6584f98e-d3ed-44e2-bf69-697096dc6ccd   8s
vmware-system-csi   668bc299-a6e4-48c5-bc38-ad3ccfbbeb27   14d
vmware-system-csi   871896ca-3f33-4d39-8909-1b34a9075fbb   14d
root@420e33d19796412054b9c95a707aef4f [ ~ ]# kubectl delete cnsvolumeinfo 626443ec-791f-4c9e-a8fd-d0539539dcf9 -n vmware-system-csi
cnsvolumeinfo.cns.vmware.com "626443ec-791f-4c9e-a8fd-d0539539dcf9" deleted
root@420e33d19796412054b9c95a707aef4f [ ~ ]# kubectl -n vmware-system-csi scale deploy/vsphere-csi-controller --replicas=0
deployment.apps/vsphere-csi-controller scaled
root@420e33d19796412054b9c95a707aef4f [ ~ ]# k get cnsvolumeinfo -A 
NAMESPACE           NAME                                   AGE
vmware-system-csi   14d1a3c4-339c-4c00-8c2f-28bd7ff4f015   14d
vmware-system-csi   15bddb90-744b-49f4-be45-ae893fc9004d   14d
vmware-system-csi   6584f98e-d3ed-44e2-bf69-697096dc6ccd   26s
vmware-system-csi   668bc299-a6e4-48c5-bc38-ad3ccfbbeb27   14d
vmware-system-csi   871896ca-3f33-4d39-8909-1b34a9075fbb   14d
root@420e33d19796412054b9c95a707aef4f [ ~ ]# kubectl describe cnsvolumeinfo 6584f98e-d3ed-44e2-bf69-697096dc6ccd -n vmware-system-csi
Name:         6584f98e-d3ed-44e2-bf69-697096dc6ccd
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CNSVolumeInfo
Metadata:
  Creation Timestamp:  2024-07-24T22:14:22Z
  Generation:          1
  Resource Version:    14186109
  UID:                 5dddc087-dd82-48a2-aed2-3625b803e73a
Spec:
  Capacity:                     1Gi
  Namespace:                    storage-policy-test
  Storage Class Name:           wcp-profile-c6rt9t0cli
  Storage Policy ID:            43333687-ec93-4e67-a5bc-5fa84c4f3f9b
  V Center Server:              sc1-10-78-163-98.eng.vmware.com
  Validaggregatedsnapshotsize:  false
  Volume ID:                    6584f98e-d3ed-44e2-bf69-697096dc6ccd
Events:                         <none>
root@420e33d19796412054b9c95a707aef4f [ ~ ]# kubectl get pods -n vmware-system-csi  
NAME                                   READY   STATUS    RESTARTS   AGE
vsphere-csi-webhook-57fd454d7c-dp6bk   1/1     Running   0          13d
vsphere-csi-webhook-57fd454d7c-s9tsv   1/1     Running   0          13d
root@420e33d19796412054b9c95a707aef4f [ ~ ]# kubectl -n vmware-system-csi scale deploy/vsphere-csi-controller --replicas=2
deployment.apps/vsphere-csi-controller scaled
root@420e33d19796412054b9c95a707aef4f [ ~ ]# kubectl get pods -n vmware-system-csi  
NAME                                      READY   STATUS    RESTARTS   AGE
vsphere-csi-controller-5cb7674594-dnk6p   7/7     Running   0          5s
vsphere-csi-controller-5cb7674594-fgt4q   7/7     Running   0          5s
vsphere-csi-webhook-57fd454d7c-dp6bk      1/1     Running   0          13d
vsphere-csi-webhook-57fd454d7c-s9tsv      1/1     Running   0          13d
root@420e33d19796412054b9c95a707aef4f [ ~ ]# k get cnsvolumeinfo -A  -w
NAMESPACE           NAME                                   AGE
vmware-system-csi   14d1a3c4-339c-4c00-8c2f-28bd7ff4f015   14d
vmware-system-csi   15bddb90-744b-49f4-be45-ae893fc9004d   14d
vmware-system-csi   626443ec-791f-4c9e-a8fd-d0539539dcf9   115s
vmware-system-csi   6584f98e-d3ed-44e2-bf69-697096dc6ccd   5m44s
vmware-system-csi   668bc299-a6e4-48c5-bc38-ad3ccfbbeb27   14d
vmware-system-csi   871896ca-3f33-4d39-8909-1b34a9075fbb   14d
root@420e33d19796412054b9c95a707aef4f [ ~ ]# kubectl describe cnsvolumeinfo 626443ec-791f-4c9e-a8fd-d0539539dcf9  -n vmware-system-csi
Name:         626443ec-791f-4c9e-a8fd-d0539539dcf9
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CNSVolumeInfo
Metadata:
  Creation Timestamp:  2024-07-24T22:18:11Z
  Generation:          2
  Resource Version:    14188685
  UID:                 e8e1b5ac-cd4a-4953-a819-d08f8529d8e1
Spec:
  Aggregatedsnapshotsize:               103
  Capacity:                             1Gi
  Namespace:                            storage-policy-test
  Snapshotlatestoperationcompletetime:  2024-07-24T22:18:12Z
  Storage Class Name:                   wcp-profile-c6rt9t0cli
  Storage Policy ID:                    43333687-ec93-4e67-a5bc-5fa84c4f3f9b
  V Center Server:                      sc1-10-78-163-98.eng.vmware.com
  Validaggregatedsnapshotsize:          true
  Volume ID:                            626443ec-791f-4c9e-a8fd-d0539539dcf9
Events:                                 <none>
root@420e33d19796412054b9c95a707aef4f [ ~ ]# kubectl describe cnsvolumeinfo 6584f98e-d3ed-44e2-bf69-697096dc6ccd  -n vmware-system-csi
Name:         6584f98e-d3ed-44e2-bf69-697096dc6ccd
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CNSVolumeInfo
Metadata:
  Creation Timestamp:  2024-07-24T22:14:22Z
  Generation:          2
  Resource Version:    14188684
  UID:                 5dddc087-dd82-48a2-aed2-3625b803e73a
Spec:
  Aggregatedsnapshotsize:               0
  Capacity:                             1Gi
  Namespace:                            storage-policy-test
  Snapshotlatestoperationcompletetime:  2024-07-24T22:18:12Z
  Storage Class Name:                   wcp-profile-c6rt9t0cli
  Storage Policy ID:                    43333687-ec93-4e67-a5bc-5fa84c4f3f9b
  V Center Server:                      sc1-10-78-163-98.eng.vmware.com
  Validaggregatedsnapshotsize:          true
  Volume ID:                            6584f98e-d3ed-44e2-bf69-697096dc6ccd
Events:                                 <none>
root@420e33d19796412054b9c95a707aef4f [ ~ ]# kubectl describe cnsvolumeinfo 668bc299-a6e4-48c5-bc38-ad3ccfbbeb27  -n vmware-system-csi
Name:         668bc299-a6e4-48c5-bc38-ad3ccfbbeb27
Namespace:    vmware-system-csi
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CNSVolumeInfo
Metadata:
  Creation Timestamp:  2024-07-10T11:26:17Z
  Generation:          3
  Resource Version:    14120191
  UID:                 7342d225-9983-42f2-9022-d6fc2c7c4aef
Spec:
  Aggregatedsnapshotsize:               0
  Capacity:                             1Gi
  Namespace:                            storage-policy-test
  Snapshotlatestoperationcompletetime:  2024-07-24T17:14:52Z
  Storage Class Name:                   wcp-profile-c6rt9t0cli
  Storage Policy ID:                    43333687-ec93-4e67-a5bc-5fa84c4f3f9b
  V Center Server:                      sc1-10-78-163-98.eng.vmware.com
  Validaggregatedsnapshotsize:          false
  Volume ID:                            668bc299-a6e4-48c5-bc38-ad3ccfbbeb27
Events:                                 <none>
```
full sync for CNSVolumeInfo log:
[full_sync_for_cnsvolumeinfo.log](https://github.com/user-attachments/files/16368029/full_sync_for_cnsvolumeinfo.log)

regression testing 
Running e2e tests

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Ensure CNSVolumeInfo holds correct snapshot details of the volume
```
