### PR TITLE
Volume Provisioning for vDPp workloads on Stretched Supervisor cluster

### DIFF
--- a/pkg/csi/service/common/types.go
+++ b/pkg/csi/service/common/types.go
@@ -85,7 +85,7 @@ type CreateVolumeSpec struct {
 	// TODO: Move this StorageClassParams
 	AffineToHost            string
 	VolumeType              string
-	VsanDirectDatastoreURL  string // Datastore URL from vSan direct storage pool
+	VsanDatastoreURL        string // Datastore URL used by host local volumes (vSAN Direct/vSAN SNA)
 	ContentSourceSnapshotID string // SnapshotID from VolumeContentSource in CreateVolumeRequest
 }
 

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -780,7 +780,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		}
 
 		volumeInfo, faultType, err = common.CreateBlockVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
-			c.manager, &createVolumeSpec, sharedDatastores, filterSuspendedDatastores, false, nil)
+			c.manager, &createVolumeSpec, sharedDatastores, filterSuspendedDatastores, false, false, nil)
 		if err != nil {
 			return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 				"failed to create volume. Error: %+v", err)

--- a/pkg/syncer/k8scloudoperator/k8scloudoperator.go
+++ b/pkg/syncer/k8scloudoperator/k8scloudoperator.go
@@ -349,7 +349,7 @@ func (k8sCloudOperator *k8sCloudOperator) PlacePersistenceVolumeClaim(ctx contex
 
 	scName, err := GetSCNameFromPVC(pvc)
 	if err != nil {
-		log.Errorf("Fail to get Storage class name from PVC with +v", err)
+		log.Errorf("Fail to get Storage class name from PVC with %+v", err)
 		return out, err
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:
This PR enhances the WCP Block Volume provisioning workflow to enable host-local volume provisioning for vDPp workloads

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

## Testing done:

### vSAN Direct volume provisioning
 Created a vSAN Direct storage policy `vsan direct policy` and assigned it to a namespace in supervisor `vdpp-on-svc`. 
  
<details><summary>storage class spec</summary>
<p>

```
➜  1663 kubectl get sc -o yaml vsan-direct-policy
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  annotations:
    cns.vmware.com/StoragePoolTypeHint: cns.vmware.com/vsanD
  creationTimestamp: "2024-07-22T05:46:00Z"
  name: vsan-direct-policy
  resourceVersion: "3623881"
  uid: a63fa5ed-4e66-4488-80d7-2711245618fa
parameters:
  StorageTopologyType: Zonal
  storagePolicyID: 8e24d3f6-c1e0-4194-9b0c-af711df91fbd
provisioner: csi.vsphere.vmware.com
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
```

</p>
</details> 
 


#### With no topology specified
<details><summary>Statefulset spec</summary>
<p>

```
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: direct-no-topology
  namespace: vdpp-on-ssvc
spec:
  serviceName: "direct-no-topology"
  replicas: 3
  selector:
    matchLabels:
      app: direct-no-topology
  template:
    metadata:
      labels:
        app: direct-no-topology
    spec:
      containers:
      - name: nginx
        image: sabu-persistence-service-docker-local.artifactory.eng.vmware.com/vsatyanarayana/nginx-unprivileged-amd64:latest
        ports:
        - containerPort: 80
          name: web
        volumeMounts:
        - name: pvc-storage
          mountPath: /usr/share/nginx/html
  volumeClaimTemplates:
  - metadata:
      name: pvc-storage
      labels:
        "appplatform.vmware.com/instance-id": "direct-no-topology"
    spec:
      accessModes: ["ReadWriteOnce"]
      storageClassName: "vsan-direct-policy"
      resources:
        requests:
          storage: 1Gi
 ```
          
</p>
</details> 

##### Observations

<details><summary>PVC info</summary>
<p>

```
➜  1663 kv get pvc
NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         VOLUMEATTRIBUTESCLASS   AGE
pvc-storage-direct-no-topology-0   Bound    pvc-2df01059-97a2-4bc8-aa5c-1f7af143817a   1Gi        RWO            vsan-direct-policy   <unset>                 4h
pvc-storage-direct-no-topology-1   Bound    pvc-15c81610-d4da-486e-9ee7-a4bda14af7b2   1Gi        RWO            vsan-direct-policy   <unset>                 3h58m
pvc-storage-direct-no-topology-2   Bound    pvc-1dd90a2c-b908-46df-a95d-b8671d09e2ae   1Gi        RWO            vsan-direct-policy   <unset>                 3h58m
---

➜  1663 kv get pvc -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"sc1-10-182-164-78.nimbus.eng.vmware.com","topology.kubernetes.io/zone":"zone-1"}]'
      failure-domain.beta.vmware.com/storagepool: storagepool-vsand-10.182.164.78-mpx.vmhba0-c0-t3-l0
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/selected-node: sc1-10-182-164-78.nimbus.eng.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Wed Jul 24 10:26:45 UTC
        2024
    creationTimestamp: "2024-07-24T10:23:02Z"
    finalizers:
    - kubernetes.io/pvc-protection
    labels:
      app: direct-no-topology
      appplatform.vmware.com/instance-id: direct-no-topology
    name: pvc-storage-direct-no-topology-0
    namespace: vdpp-on-ssvc
    resourceVersion: "5738471"
    uid: 2df01059-97a2-4bc8-aa5c-1f7af143817a
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: vsan-direct-policy
    volumeMode: Filesystem
    volumeName: pvc-2df01059-97a2-4bc8-aa5c-1f7af143817a
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"sc1-10-182-169-160.nimbus.eng.vmware.com","topology.kubernetes.io/zone":"zone-2"}]'
      failure-domain.beta.vmware.com/storagepool: storagepool-vsand-10.182.169.160-mpx.vmhba0-c0-t3-l0
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/selected-node: sc1-10-182-169-160.nimbus.eng.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Wed Jul 24 10:26:45 UTC
        2024
    creationTimestamp: "2024-07-24T10:24:40Z"
    finalizers:
    - kubernetes.io/pvc-protection
    labels:
      app: direct-no-topology
      appplatform.vmware.com/instance-id: direct-no-topology
    name: pvc-storage-direct-no-topology-1
    namespace: vdpp-on-ssvc
    resourceVersion: "5738472"
    uid: 15c81610-d4da-486e-9ee7-a4bda14af7b2
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: vsan-direct-policy
    volumeMode: Filesystem
    volumeName: pvc-15c81610-d4da-486e-9ee7-a4bda14af7b2
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"sc1-10-182-162-103.nimbus.eng.vmware.com","topology.kubernetes.io/zone":"zone-3"}]'
      failure-domain.beta.vmware.com/storagepool: storagepool-vsand-10.182.162.103-mpx.vmhba0-c0-t3-l0
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/selected-node: sc1-10-182-162-103.nimbus.eng.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Wed Jul 24 10:26:45 UTC
        2024
    creationTimestamp: "2024-07-24T10:24:52Z"
    finalizers:
    - kubernetes.io/pvc-protection
    labels:
      app: direct-no-topology
      appplatform.vmware.com/instance-id: direct-no-topology
    name: pvc-storage-direct-no-topology-2
    namespace: vdpp-on-ssvc
    resourceVersion: "5738474"
    uid: 1dd90a2c-b908-46df-a95d-b8671d09e2ae
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: vsan-direct-policy
    volumeMode: Filesystem
    volumeName: pvc-1dd90a2c-b908-46df-a95d-b8671d09e2ae
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
kind: List
metadata:
  resourceVersion: ""
```

</p>
</details>

<details><summary>PV Info</summary>
<p>

```
➜  1663 kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                           STORAGECLASS         VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-15c81610-d4da-486e-9ee7-a4bda14af7b2   1Gi        RWO            Delete           Bound    vdpp-on-ssvc/pvc-storage-direct-no-topology-1   vsan-direct-policy   <unset>                          4h7m
pvc-1dd90a2c-b908-46df-a95d-b8671d09e2ae   1Gi        RWO            Delete           Bound    vdpp-on-ssvc/pvc-storage-direct-no-topology-2   vsan-direct-policy   <unset>                          4h7m
pvc-2df01059-97a2-4bc8-aa5c-1f7af143817a   1Gi        RWO            Delete           Bound    vdpp-on-ssvc/pvc-storage-direct-no-topology-0   vsan-direct-policy   <unset>                          4h7m
---

apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolume
  metadata:
    annotations:
      pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
      volume.kubernetes.io/provisioner-deletion-secret-name: ""
      volume.kubernetes.io/provisioner-deletion-secret-namespace: ""
    creationTimestamp: "2024-07-24T10:24:41Z"
    finalizers:
    - kubernetes.io/pv-protection
    - external-attacher/csi-vsphere-vmware-com
    name: pvc-15c81610-d4da-486e-9ee7-a4bda14af7b2
    resourceVersion: "5736791"
    uid: 853f307c-395c-45b6-867f-1e4bbacabf84
  spec:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    claimRef:
      apiVersion: v1
      kind: PersistentVolumeClaim
      name: pvc-storage-direct-no-topology-1
      namespace: vdpp-on-ssvc
      resourceVersion: "5736744"
      uid: 15c81610-d4da-486e-9ee7-a4bda14af7b2
    csi:
      driver: csi.vsphere.vmware.com
      fsType: ext4
      volumeAttributes:
        storage.kubernetes.io/csiProvisionerIdentity: 1721816499195-389-csi.vsphere.vmware.com
        type: vSphere CNS Block Volume
      volumeHandle: 391f5bcb-25d2-448d-84ff-84dbbb111c3f
    nodeAffinity:
      required:
        nodeSelectorTerms:
        - matchExpressions:
          - key: topology.kubernetes.io/zone
            operator: In
            values:
            - zone-2
          - key: kubernetes.io/hostname
            operator: In
            values:
            - sc1-10-182-169-160.nimbus.eng.vmware.com
    persistentVolumeReclaimPolicy: Delete
    storageClassName: vsan-direct-policy
    volumeMode: Filesystem
  status:
    lastPhaseTransitionTime: "2024-07-24T10:24:41Z"
    phase: Bound
- apiVersion: v1
  kind: PersistentVolume
  metadata:
    annotations:
      pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
      volume.kubernetes.io/provisioner-deletion-secret-name: ""
      volume.kubernetes.io/provisioner-deletion-secret-namespace: ""
    creationTimestamp: "2024-07-24T10:24:53Z"
    finalizers:
    - kubernetes.io/pv-protection
    - external-attacher/csi-vsphere-vmware-com
    name: pvc-1dd90a2c-b908-46df-a95d-b8671d09e2ae
    resourceVersion: "5737000"
    uid: 475362fe-fe2f-4ebd-97c4-7a7de11e9588
  spec:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    claimRef:
      apiVersion: v1
      kind: PersistentVolumeClaim
      name: pvc-storage-direct-no-topology-2
      namespace: vdpp-on-ssvc
      resourceVersion: "5736958"
      uid: 1dd90a2c-b908-46df-a95d-b8671d09e2ae
    csi:
      driver: csi.vsphere.vmware.com
      fsType: ext4
      volumeAttributes:
        storage.kubernetes.io/csiProvisionerIdentity: 1721816499195-389-csi.vsphere.vmware.com
        type: vSphere CNS Block Volume
      volumeHandle: 1e974c3a-8d84-4203-a36a-3cd63de21b4e
    nodeAffinity:
      required:
        nodeSelectorTerms:
        - matchExpressions:
          - key: topology.kubernetes.io/zone
            operator: In
            values:
            - zone-3
          - key: kubernetes.io/hostname
            operator: In
            values:
            - sc1-10-182-162-103.nimbus.eng.vmware.com
    persistentVolumeReclaimPolicy: Delete
    storageClassName: vsan-direct-policy
    volumeMode: Filesystem
  status:
    lastPhaseTransitionTime: "2024-07-24T10:24:53Z"
    phase: Bound
- apiVersion: v1
  kind: PersistentVolume
  metadata:
    annotations:
      pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
      volume.kubernetes.io/provisioner-deletion-secret-name: ""
      volume.kubernetes.io/provisioner-deletion-secret-namespace: ""
    creationTimestamp: "2024-07-24T10:24:25Z"
    finalizers:
    - kubernetes.io/pv-protection
    - external-attacher/csi-vsphere-vmware-com
    name: pvc-2df01059-97a2-4bc8-aa5c-1f7af143817a
    resourceVersion: "5736548"
    uid: a9e29827-c3d3-4f6e-8320-4eb4363f446a
  spec:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    claimRef:
      apiVersion: v1
      kind: PersistentVolumeClaim
      name: pvc-storage-direct-no-topology-0
      namespace: vdpp-on-ssvc
      resourceVersion: "5736500"
      uid: 2df01059-97a2-4bc8-aa5c-1f7af143817a
    csi:
      driver: csi.vsphere.vmware.com
      fsType: ext4
      volumeAttributes:
        storage.kubernetes.io/csiProvisionerIdentity: 1721816499195-389-csi.vsphere.vmware.com
        type: vSphere CNS Block Volume
      volumeHandle: b261bd22-bc5e-4a30-a13b-30b837a948b7
    nodeAffinity:
      required:
        nodeSelectorTerms:
        - matchExpressions:
          - key: topology.kubernetes.io/zone
            operator: In
            values:
            - zone-1
          - key: kubernetes.io/hostname
            operator: In
            values:
            - sc1-10-182-164-78.nimbus.eng.vmware.com
    persistentVolumeReclaimPolicy: Delete
    storageClassName: vsan-direct-policy
    volumeMode: Filesystem
  status:
    lastPhaseTransitionTime: "2024-07-24T10:24:25Z"
    phase: Bound
kind: List
metadata:
  resourceVersion: ""
```

</p>
</details> 


#### With topology spread constraints
<details><summary>Statefulset spec</summary>
<p>

```
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: direct-only-zones
  namespace: vdpp-on-ssvc
spec:
  serviceName: "direct-only-zones"
  replicas: 3
  selector:
    matchLabels:
      app: direct-only-zones
  template:
    metadata:
      labels:
        app: direct-only-zones
    spec:
      topologySpreadConstraints:
        - maxSkew: 1
          topologyKey: topology.kubernetes.io/zone
          whenUnsatisfiable: DoNotSchedule
          labelSelector:
            matchLabels:
              app: direct-only-zones
      containers:
        - name: nginx
          image: sabu-persistence-service-docker-local.artifactory.eng.vmware.com/vsatyanarayana/nginx-unprivileged-amd64:latest
          ports:
            - containerPort: 80
              name: web
          volumeMounts:
            - name: pvc-storage
              mountPath: /usr/share/nginx/html
  volumeClaimTemplates:
    - metadata:
        name: pvc-storage
        labels:
          "appplatform.vmware.com/instance-id": "direct-only-zones"
      spec:
        accessModes: ["ReadWriteOnce"]
        storageClassName: "vsan-direct-policy"
        resources:
          requests:
            storage: 1Gi
```

</p>
</details> 

##### Observations

<details><summary>PVC Info</summary>
<p>

```
NAME                              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         VOLUMEATTRIBUTESCLASS   AGE
pvc-storage-direct-only-zones-0   Bound    pvc-fd255fa1-18e7-4d6e-8e0c-16d36fddabc9   1Gi        RWO            vsan-direct-policy   <unset>                 8m6s
pvc-storage-direct-only-zones-1   Bound    pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47   1Gi        RWO            vsan-direct-policy   <unset>                 6m28s
pvc-storage-direct-only-zones-2   Bound    pvc-b6b23e1e-e8f4-4adf-b5db-7fe671299257   1Gi        RWO            vsan-direct-policy   <unset>                 6m15s
---

apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"sc1-10-182-164-78.nimbus.eng.vmware.com","topology.kubernetes.io/zone":"zone-1"}]'
      failure-domain.beta.vmware.com/storagepool: storagepool-vsand-10.182.164.78-mpx.vmhba0-c0-t3-l0
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/selected-node: sc1-10-182-164-78.nimbus.eng.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Thu Jul 25 09:08:34 UTC
        2024
    creationTimestamp: "2024-07-25T09:04:28Z"
    finalizers:
    - kubernetes.io/pvc-protection
    labels:
      app: direct-only-zones
      appplatform.vmware.com/instance-id: direct-only-zones
    name: pvc-storage-direct-only-zones-0
    namespace: vdpp-on-ssvc
    resourceVersion: "6650710"
    uid: fd255fa1-18e7-4d6e-8e0c-16d36fddabc9
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: vsan-direct-policy
    volumeMode: Filesystem
    volumeName: pvc-fd255fa1-18e7-4d6e-8e0c-16d36fddabc9
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"sc1-10-182-169-160.nimbus.eng.vmware.com","topology.kubernetes.io/zone":"zone-2"}]'
      failure-domain.beta.vmware.com/storagepool: storagepool-vsand-10.182.169.160-mpx.vmhba0-c0-t3-l0
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/selected-node: sc1-10-182-169-160.nimbus.eng.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Thu Jul 25 09:08:34 UTC
        2024
    creationTimestamp: "2024-07-25T09:06:06Z"
    finalizers:
    - kubernetes.io/pvc-protection
    labels:
      app: direct-only-zones
      appplatform.vmware.com/instance-id: direct-only-zones
    name: pvc-storage-direct-only-zones-1
    namespace: vdpp-on-ssvc
    resourceVersion: "6650704"
    uid: 42cd49bf-c26b-4834-9269-cb182c9d1b47
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: vsan-direct-policy
    volumeMode: Filesystem
    volumeName: pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      csi.vsphere.volume-accessible-topology: '[{"kubernetes.io/hostname":"sc1-10-182-162-103.nimbus.eng.vmware.com","topology.kubernetes.io/zone":"zone-3"}]'
      failure-domain.beta.vmware.com/storagepool: storagepool-vsand-10.182.162.103-mpx.vmhba0-c0-t3-l0
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volume.kubernetes.io/selected-node: sc1-10-182-162-103.nimbus.eng.vmware.com
      volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
      volumehealth.storage.kubernetes.io/health: accessible
      volumehealth.storage.kubernetes.io/health-timestamp: Thu Jul 25 09:08:34 UTC
        2024
    creationTimestamp: "2024-07-25T09:06:19Z"
    finalizers:
    - kubernetes.io/pvc-protection
    labels:
      app: direct-only-zones
      appplatform.vmware.com/instance-id: direct-only-zones
    name: pvc-storage-direct-only-zones-2
    namespace: vdpp-on-ssvc
    resourceVersion: "6650706"
    uid: b6b23e1e-e8f4-4adf-b5db-7fe671299257
  spec:
    accessModes:
    - ReadWriteOnce
    resources:
      requests:
        storage: 1Gi
    storageClassName: vsan-direct-policy
    volumeMode: Filesystem
    volumeName: pvc-b6b23e1e-e8f4-4adf-b5db-7fe671299257
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
kind: List
metadata:
  resourceVersion: ""


```

</p>
</details> 

<details><summary>PV Info</summary>
<p>

```
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                          STORAGECLASS         VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47   1Gi        RWO            Delete           Bound    vdpp-on-ssvc/pvc-storage-direct-only-zones-1   vsan-direct-policy   <unset>                          5m43s
pvc-b6b23e1e-e8f4-4adf-b5db-7fe671299257   1Gi        RWO            Delete           Bound    vdpp-on-ssvc/pvc-storage-direct-only-zones-2   vsan-direct-policy   <unset>                          5m30s
pvc-fd255fa1-18e7-4d6e-8e0c-16d36fddabc9   1Gi        RWO            Delete           Bound    vdpp-on-ssvc/pvc-storage-direct-only-zones-0   vsan-direct-policy   <unset>                          5m54s
---

apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolume
  metadata:
    annotations:
      pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
      volume.kubernetes.io/provisioner-deletion-secret-name: ""
      volume.kubernetes.io/provisioner-deletion-secret-namespace: ""
    creationTimestamp: "2024-07-25T09:06:07Z"
    finalizers:
    - kubernetes.io/pv-protection
    - external-attacher/csi-vsphere-vmware-com
    name: pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47
    resourceVersion: "6648878"
    uid: 16ead47b-9cd9-4f30-8581-2a4885d05600
  spec:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    claimRef:
      apiVersion: v1
      kind: PersistentVolumeClaim
      name: pvc-storage-direct-only-zones-1
      namespace: vdpp-on-ssvc
      resourceVersion: "6648829"
      uid: 42cd49bf-c26b-4834-9269-cb182c9d1b47
    csi:
      driver: csi.vsphere.vmware.com
      fsType: ext4
      volumeAttributes:
        storage.kubernetes.io/csiProvisionerIdentity: 1721898219032-2170-csi.vsphere.vmware.com
        type: vSphere CNS Block Volume
      volumeHandle: 6a3c39d0-c574-4de9-b4c3-b8f15b6af42a
    nodeAffinity:
      required:
        nodeSelectorTerms:
        - matchExpressions:
          - key: topology.kubernetes.io/zone
            operator: In
            values:
            - zone-2
          - key: kubernetes.io/hostname
            operator: In
            values:
            - sc1-10-182-169-160.nimbus.eng.vmware.com
    persistentVolumeReclaimPolicy: Delete
    storageClassName: vsan-direct-policy
    volumeMode: Filesystem
  status:
    lastPhaseTransitionTime: "2024-07-25T09:06:07Z"
    phase: Bound
- apiVersion: v1
  kind: PersistentVolume
  metadata:
    annotations:
      pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
      volume.kubernetes.io/provisioner-deletion-secret-name: ""
      volume.kubernetes.io/provisioner-deletion-secret-namespace: ""
    creationTimestamp: "2024-07-25T09:06:20Z"
    finalizers:
    - kubernetes.io/pv-protection
    - external-attacher/csi-vsphere-vmware-com
    name: pvc-b6b23e1e-e8f4-4adf-b5db-7fe671299257
    resourceVersion: "6649091"
    uid: 89c8e0ba-46f0-4efe-9339-b783b87e93a9
  spec:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    claimRef:
      apiVersion: v1
      kind: PersistentVolumeClaim
      name: pvc-storage-direct-only-zones-2
      namespace: vdpp-on-ssvc
      resourceVersion: "6649034"
      uid: b6b23e1e-e8f4-4adf-b5db-7fe671299257
    csi:
      driver: csi.vsphere.vmware.com
      fsType: ext4
      volumeAttributes:
        storage.kubernetes.io/csiProvisionerIdentity: 1721898219032-2170-csi.vsphere.vmware.com
        type: vSphere CNS Block Volume
      volumeHandle: eea28a02-c243-45b3-95bf-d572eb14777a
    nodeAffinity:
      required:
        nodeSelectorTerms:
        - matchExpressions:
          - key: topology.kubernetes.io/zone
            operator: In
            values:
            - zone-3
          - key: kubernetes.io/hostname
            operator: In
            values:
            - sc1-10-182-162-103.nimbus.eng.vmware.com
    persistentVolumeReclaimPolicy: Delete
    storageClassName: vsan-direct-policy
    volumeMode: Filesystem
  status:
    lastPhaseTransitionTime: "2024-07-25T09:06:20Z"
    phase: Bound
- apiVersion: v1
  kind: PersistentVolume
  metadata:
    annotations:
      pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
      volume.kubernetes.io/provisioner-deletion-secret-name: ""
      volume.kubernetes.io/provisioner-deletion-secret-namespace: ""
    creationTimestamp: "2024-07-25T09:05:56Z"
    finalizers:
    - kubernetes.io/pv-protection
    - external-attacher/csi-vsphere-vmware-com
    name: pvc-fd255fa1-18e7-4d6e-8e0c-16d36fddabc9
    resourceVersion: "6648668"
    uid: 177852aa-1242-431f-8d96-35f725defd1f
  spec:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    claimRef:
      apiVersion: v1
      kind: PersistentVolumeClaim
      name: pvc-storage-direct-only-zones-0
      namespace: vdpp-on-ssvc
      resourceVersion: "6647687"
      uid: fd255fa1-18e7-4d6e-8e0c-16d36fddabc9
    csi:
      driver: csi.vsphere.vmware.com
      fsType: ext4
      volumeAttributes:
        storage.kubernetes.io/csiProvisionerIdentity: 1721898219032-2170-csi.vsphere.vmware.com
        type: vSphere CNS Block Volume
      volumeHandle: f99b1eb4-619c-4560-b837-621c49a77ce6
    nodeAffinity:
      required:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/hostname
            operator: In
            values:
            - sc1-10-182-164-78.nimbus.eng.vmware.com
          - key: topology.kubernetes.io/zone
            operator: In
            values:
            - zone-1
    persistentVolumeReclaimPolicy: Delete
    storageClassName: vsan-direct-policy
    volumeMode: Filesystem
  status:
    lastPhaseTransitionTime: "2024-07-25T09:05:56Z"
    phase: Bound
kind: List
metadata:
  resourceVersion: ""

```

</p>
</details> 

<details><summary>CreateVolume logs for pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47</summary>
<p>

```
2024-07-25T09:06:06.607Z	INFO	wcp/controller.go:931	CreateVolume: called with args {Name:pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[StorageTopologyType:Zonal csi.storage.k8s.io/pv/name:pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47 csi.storage.k8s.io/pvc/name:pvc-storage-direct-only-zones-1 csi.storage.k8s.io/pvc/namespace:vdpp-on-ssvc csi.storage.k8s.io/sc/name:vsan-direct-policy storagePolicyID:8e24d3f6-c1e0-4194-9b0c-af711df91fbd storagePool:storagepool-vsand-10.182.169.160-mpx.vmhba0-c0-t3-l0] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:"kubernetes.io/hostname" value:"sc1-10-182-169-160.nimbus.eng.vmware.com" > segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"sc1-10-182-169-160.nimbus.eng.vmware.com" > segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.608Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/vmware/wcp/vsphere-cloud-provider.conf	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.609Z	DEBUG	config/config.go:372	Initializing vc server sc1-10-182-166-3.eng.vmware.com	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.610Z	DEBUG	config/config.go:417	vc server sc1-10-182-166-3.eng.vmware.com config: &{User:wcp-storage-user-984c9b97-4598-47ef-bcc6-4e0d2135f6b4-ff6393aa-efc0-4d93-9335-d4e91c53f5a8@vsphere.local Password:pmq[KcxR[:}$q.9TGR!" VCenterPort:443 InsecureFlag:false CAFile: Thumbprint: Datacenters:datacenter-44 TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.610Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.610Z	DEBUG	config/config.go:496	Setting default queryLimit to 10000	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.610Z	DEBUG	config/config.go:501	Setting default list volume threshold to 50	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.615Z	INFO	wcp/controller.go:474	Host Local volume provisioning with requirement: requisite:<segments:<key:"kubernetes.io/hostname" value:"sc1-10-182-169-160.nimbus.eng.vmware.com" > segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > preferred:<segments:<key:"kubernetes.io/hostname" value:"sc1-10-182-169-160.nimbus.eng.vmware.com" > segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > > 	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.623Z	INFO	wcp/controller.go:540	Storage pool Accessible nodes for volume topology: [sc1-10-182-169-160.nimbus.eng.vmware.com]	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.631Z	INFO	wcp/controller.go:548	Will select datastore ds:///vmfs/volumes/6698ecc4-d0e79a40-c5e3-0200a620c229/ as per the provided storage pool storagepool-vsand-10.182.169.160-mpx.vmhba0-c0-t3-l0	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.631Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/vmware/wcp/vsphere-cloud-provider.conf	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.632Z	DEBUG	config/config.go:372	Initializing vc server sc1-10-182-166-3.eng.vmware.com	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.632Z	DEBUG	config/config.go:417	vc server sc1-10-182-166-3.eng.vmware.com config: &{User:wcp-storage-user-984c9b97-4598-47ef-bcc6-4e0d2135f6b4-ff6393aa-efc0-4d93-9335-d4e91c53f5a8@vsphere.local Password:pmq[KcxR[:}$q.9TGR!" VCenterPort:443 InsecureFlag:false CAFile: Thumbprint: Datacenters:datacenter-44 TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.632Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.632Z	DEBUG	config/config.go:496	Setting default queryLimit to 10000	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.632Z	DEBUG	config/config.go:501	Setting default list volume threshold to 50	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.655Z	DEBUG	vsphere/utils.go:482	datastore corresponding to URL ds:///vmfs/volumes/6698ecc4-d0e79a40-c5e3-0200a620c229/ not found in cluster domain-c59	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.655Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/vmware/wcp/vsphere-cloud-provider.conf	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.656Z	DEBUG	config/config.go:372	Initializing vc server sc1-10-182-166-3.eng.vmware.com	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.656Z	DEBUG	config/config.go:417	vc server sc1-10-182-166-3.eng.vmware.com config: &{User:wcp-storage-user-984c9b97-4598-47ef-bcc6-4e0d2135f6b4-ff6393aa-efc0-4d93-9335-d4e91c53f5a8@vsphere.local Password:pmq[KcxR[:}$q.9TGR!" VCenterPort:443 InsecureFlag:false CAFile: Thumbprint: Datacenters:datacenter-44 TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.656Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.656Z	DEBUG	config/config.go:496	Setting default queryLimit to 10000	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.656Z	DEBUG	config/config.go:501	Setting default list volume threshold to 50	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.677Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/vmware/wcp/vsphere-cloud-provider.conf	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.678Z	DEBUG	config/config.go:372	Initializing vc server sc1-10-182-166-3.eng.vmware.com	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.678Z	DEBUG	config/config.go:417	vc server sc1-10-182-166-3.eng.vmware.com config: &{User:wcp-storage-user-984c9b97-4598-47ef-bcc6-4e0d2135f6b4-ff6393aa-efc0-4d93-9335-d4e91c53f5a8@vsphere.local Password:pmq[KcxR[:}$q.9TGR!" VCenterPort:443 InsecureFlag:false CAFile: Thumbprint: Datacenters:datacenter-44 TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.679Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.679Z	DEBUG	config/config.go:496	Setting default queryLimit to 10000	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.680Z	DEBUG	config/config.go:501	Setting default list volume threshold to 50	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.690Z	INFO	vsphere/utils.go:574	Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-65, datastore URL: ds:///vmfs/volumes/6698ecc4-d0e79a40-c5e3-0200a620c229/]	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.726Z	DEBUG	vsphere/datacenter.go:75	Found datastore MoRef Datastore:datastore-65 for datastoreURL: "ds:///vmfs/volumes/6698ecc4-d0e79a40-c5e3-0200a620c229/" in datacenter: "" on vCenter: "sc1-10-182-166-3.eng.vmware.com"	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.726Z	DEBUG	common/vsphereutil.go:116	Successfully fetched the datastore Datastore:datastore-65 from the URL: ds:///vmfs/volumes/6698ecc4-d0e79a40-c5e3-0200a620c229/	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.727Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/vmware/wcp/vsphere-cloud-provider.conf	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.727Z	DEBUG	config/config.go:372	Initializing vc server sc1-10-182-166-3.eng.vmware.com	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.727Z	DEBUG	config/config.go:417	vc server sc1-10-182-166-3.eng.vmware.com config: &{User:wcp-storage-user-984c9b97-4598-47ef-bcc6-4e0d2135f6b4-ff6393aa-efc0-4d93-9335-d4e91c53f5a8@vsphere.local Password:pmq[KcxR[:}$q.9TGR!" VCenterPort:443 InsecureFlag:false CAFile: Thumbprint: Datacenters:datacenter-44 TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.727Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.727Z	DEBUG	config/config.go:496	Setting default queryLimit to 10000	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.727Z	DEBUG	config/config.go:501	Setting default list volume threshold to 50	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.734Z	DEBUG	volume/util.go:204	Update VSphereUser from wcp-storage-user-984c9b97-4598-47ef-bcc6-4e0d2135f6b4-ff6393aa-efc0-4d93-9335-d4e91c53f5a8@vsphere.local to VSPHERE.LOCAL\wcp-storage-user-984c9b97-4598-47ef-bcc6-4e0d2135f6b4-ff6393aa-efc0-4d93-9335-d4e91c53f5a8	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.735Z	DEBUG	volume/manager.go:512	Received CreateVolume extraParams: {VolSizeBytes:1073741824 StorageClassName:vsan-direct-policy Namespace:vdpp-on-ssvc IsPodVMOnStretchSupervisorFSSEnabled:true}	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.735Z	INFO	volume/manager.go:527	QuotaInfo during CreateVolume call: {Reserved:1Gi StoragePolicyId:8e24d3f6-c1e0-4194-9b0c-af711df91fbd StorageClassName:vsan-direct-policy Namespace:vdpp-on-ssvc AggregatedSnapshotSize:<nil> SnapshotLatestOperationCompleteTime:0001-01-01 00:00:00 +0000 UTC}	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.735Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:151	Getting CnsVolumeOperationRequest instance with name vmware-system-csi/pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.763Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:245	Created CnsVolumeOperationRequest instance vmware-system-csi/pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47 with latest information for task with ID: 	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.811Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:323	Updated CnsVolumeOperationRequest instance vmware-system-csi/pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47 with latest information for task with ID: task-3002	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.811Z	INFO	volume/listview.go:141	AddTask called for Task:task-3002	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.811Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/vmware/wcp/vsphere-cloud-provider.conf	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.812Z	DEBUG	config/config.go:372	Initializing vc server sc1-10-182-166-3.eng.vmware.com	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.812Z	DEBUG	config/config.go:417	vc server sc1-10-182-166-3.eng.vmware.com config: &{User:wcp-storage-user-984c9b97-4598-47ef-bcc6-4e0d2135f6b4-ff6393aa-efc0-4d93-9335-d4e91c53f5a8@vsphere.local Password:pmq[KcxR[:}$q.9TGR!" VCenterPort:443 InsecureFlag:false CAFile: Thumbprint: Datacenters:datacenter-44 TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.812Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.812Z	DEBUG	config/config.go:496	Setting default queryLimit to 10000	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.812Z	DEBUG	config/config.go:501	Setting default list volume threshold to 50	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.818Z	DEBUG	volume/listview.go:146	connection to vc successful	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.818Z	DEBUG	volume/listview.go:154	task Task:task-3002 added to map	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.818Z	INFO	volume/listview.go:155	client is valid. trying to add task to listview object	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:06.823Z	INFO	volume/listview.go:177	task Task:task-3002 added to listView	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.481Z	DEBUG	config/config.go:528	GetCnsconfig called with cfgPath: /etc/vmware/wcp/vsphere-cloud-provider.conf	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.483Z	DEBUG	config/config.go:372	Initializing vc server sc1-10-182-166-3.eng.vmware.com	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.483Z	DEBUG	config/config.go:417	vc server sc1-10-182-166-3.eng.vmware.com config: &{User:wcp-storage-user-984c9b97-4598-47ef-bcc6-4e0d2135f6b4-ff6393aa-efc0-4d93-9335-d4e91c53f5a8@vsphere.local Password:pmq[KcxR[:}$q.9TGR!" VCenterPort:443 InsecureFlag:false CAFile: Thumbprint: Datacenters:datacenter-44 TargetvSANFileShareClusters: MigrationDataStoreURL:}	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.483Z	DEBUG	config/config.go:426	No Net Permissions given in Config. Using default permissions.	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.483Z	DEBUG	config/config.go:496	Setting default queryLimit to 10000	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.483Z	DEBUG	config/config.go:501	Setting default list volume threshold to 50	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.489Z	DEBUG	volume/listview.go:190	connection to vc successful	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.489Z	INFO	volume/listview.go:192	client is valid. trying to remove task from listview object	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.495Z	INFO	volume/listview.go:197	task Task:task-3002 removed from listView	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.496Z	DEBUG	volume/listview.go:199	task Task:task-3002 removed from map	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.496Z	INFO	volume/manager.go:438	CreateVolume: VolumeName: "pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47", opId: "04412912"	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.496Z	DEBUG	volume/util.go:308	volumeCreateResult.PlacementResults :[{Datastore:datastore-65 []}]	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.500Z	INFO	volume/util.go:329	Volume created successfully. VolumeName: "pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47", volumeID: "6a3c39d0-c574-4de9-b4c3-b8f15b6af42a"	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.500Z	DEBUG	volume/util.go:331	CreateVolume volumeId {{} "6a3c39d0-c574-4de9-b4c3-b8f15b6af42a"} is placed on datastore "ds:///vmfs/volumes/6698ecc4-d0e79a40-c5e3-0200a620c229/"	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.500Z	INFO	volume/manager.go:588	Setting the reserved field for VolumeOperationDetails instance pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47 to 0	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.527Z	DEBUG	cnsvolumeoperationrequest/cnsvolumeoperationrequest.go:323	Updated CnsVolumeOperationRequest instance vmware-system-csi/pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47 with latest information for task with ID: task-3002	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.527Z	DEBUG	volume/manager.go:846	internalCreateVolume: returns fault ""	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.528Z	DEBUG	wcp/controller.go:785	Volume Accessible Topology: [segments:<key:"kubernetes.io/hostname" value:"sc1-10-182-169-160.nimbus.eng.vmware.com" > segments:<key:"topology.kubernetes.io/zone" value:"zone-2" > ]	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.528Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:205	creating cnsvolumeinfo for volumeID: "6a3c39d0-c574-4de9-b4c3-b8f15b6af42a", StoragePolicyID: "8e24d3f6-c1e0-4194-9b0c-af711df91fbd", StorageClassName: "vsan-direct-policy", vCenter: "sc1-10-182-166-3.eng.vmware.com", Capacity: {i:{value:1073741824 scale:0} d:{Dec:<nil>} s: Format:BinarySI} in the namespace: "vmware-system-csi"	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.538Z	INFO	cnsvolumeinfo/cnsvolumeinfoservice.go:234	Successfully created CNSVolumeInfo CR for volumeID: "6a3c39d0-c574-4de9-b4c3-b8f15b6af42a", StoragePolicyID: "8e24d3f6-c1e0-4194-9b0c-af711df91fbd", StorageClassName: "vsan-direct-policy", vCenter: "sc1-10-182-166-3.eng.vmware.com", Capacity: {i:{value:1073741824 scale:0} d:{Dec:<nil>} s: Format:BinarySI} mapping in the namespace: "vmware-system-csi"	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.539Z	DEBUG	wcp/controller.go:970	createVolumeInternal: returns fault ""	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}
2024-07-25T09:06:07.539Z	INFO	wcp/controller.go:982	Volume created successfully. Volume Handle: "6a3c39d0-c574-4de9-b4c3-b8f15b6af42a", PV Name: "pvc-42cd49bf-c26b-4834-9269-cb182c9d1b47"	{"TraceId": "e760f0a9-f20a-4f08-854d-a73a5bde8ed7"}

```

</p>
</details> 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
