### PR TITLE
Fix existing full sync update for StoragePolicyUsage of PVC kind and Create StoragePolicyUsage of VolumeSnapshotKind kind, if not created already, during full sync

### DIFF
--- a/pkg/apis/cnsoperator/storagepolicy/v1alpha1/storagepolicyusage_types.go
+++ b/pkg/apis/cnsoperator/storagepolicy/v1alpha1/storagepolicyusage_types.go
@@ -11,6 +11,8 @@ const (
 	CRDSingular = "storagepolicyusage"
 	// NameSuffixForPVC is the suffix used to name instances of StoragePolicyUsage created for PVCs.
 	NameSuffixForPVC = "pvc-usage"
+	// NameSuffixForSnapshot is the suffix used to name instances of StoragePolicyUsage created for VolumeSnapshots.
+	NameSuffixForSnapshot = "snapshot-usage"
 )
 
 // StoragePolicyUsageSpec defines the desired state of StoragePolicyUsage


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This MR creates StoragePolicyUsage of VolumeSnapshotKind kind during full sync, if not created already during policyQuotaCRAdded() call.
This change also fixes updating of StoragePolicyUsage of snapshot kind incorrectly with used capacity of PVCs due to missing resource kind check during patch in storagePolicyUsageCRSync().

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Before fix: There are 2 PVC of size 1Gi each and no snapshot present

```
root@4233060bcb506d07a44578a2e9cf9a05 [ ~ ]# k get pvc -n storage-policy-test
NAME                 STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             VOLUMEATTRIBUTESCLASS   AGE
wcp-profile          Bound    pvc-e38b5d10-bad3-4c50-bac8-360318c57b89   1Gi        RWO            wcp-profile-p853csuseb   <unset>                 6d22h
wcp-profile-second   Bound    pvc-76de466c-5912-4a42-99d7-c49ce4531c3d   1Gi        RWO            wcp-profile-p853csuseb   <unset>                 6d22h

root@4233060bcb506d07a44578a2e9cf9a05 [ ~ ]# k get vs -n storage-policy-test
No resources found in storage-policy-test namespace.
root@4233060bcb506d07a44578a2e9cf9a05 [ ~ ]#

root@4233060bcb506d07a44578a2e9cf9a05 [ ~ ]# k get storagepolicyusage -n storage-policy-test -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2024-07-09T14:39:59Z"
    generation: 5
    name: wcp-profile-p853csuseb-pvc-usage
    namespace: storage-policy-test
    resourceVersion: "28696"
    uid: 1bcd7cab-19ce-441f-9f1a-dda51c35bdd6
  spec:
    resourceApiGroup: ""
    resourceExtensionName: cns-storage-quota-extension-service-volume
    resourceKind: PersistentVolumeClaim
    storageClassName: wcp-profile-p853csuseb
    storagePolicyId: db3fddc6-506d-4c50-bc69-ffd36c1202a9
  status:
    quotaUsage:
      reserved: "0"
      used: 2Gi
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2024-07-16T13:14:09Z"
    generation: 2
    name: wcp-profile-p853csuseb-snapshot-usage
    namespace: storage-policy-test
    resourceVersion: "6593369"
    uid: 74066929-6509-4faf-aa59-4b656217319c
  spec:
    resourceApiGroup: snapshot.storage.k8s.io
    resourceExtensionName: cns-storage-quota-extension-service-volume
    resourceKind: VolumeSnapshot
    storageClassName: wcp-profile-p853csuseb
    storagePolicyId: db3fddc6-506d-4c50-bc69-ffd36c1202a9
  status:
    quotaUsage:
      used: 2Gi                       <<< Used field updated for snapshot kind StoragePolicyUsage with PVC's used capacity
kind: List
metadata:
  resourceVersion: ""
root@4233060bcb506d07a44578a2e9cf9a05 [ ~ ]#

```
After fix and STORAGE_QUOTA_M2 FSS enabled: 

```
root@4233060bcb506d07a44578a2e9cf9a05 [ ~ ]# k edit cm -n vmware-system-csi csi-feature-states -o yaml
apiVersion: v1
data:
  async-query-volume: "true"
  block-volume-snapshot: "true"
  cnsmgr-suspend-create-volume: "true"
  csi-sv-feature-states-replication: "true"
  fake-attach: "true"
  file-volume: "true"
  improved-csi-idempotency: "true"
  list-volumes: "true"
  listview-tasks: "true"
  online-volume-extend: "true"
  sibling-replica-bound-pvc-check: "true"
  storage-quota-m2: "true"         << FSS  enabled manually
  tkgs-ha: "true"
  trigger-csi-fullsync: "false"
  vdpp-on-stretched-supervisor: "false"
  volume-extend: "true"
  volume-health: "true"
kind: ConfigMap
metadata:
  creationTimestamp: "2024-07-09T14:09:57Z"
  name: csi-feature-states
  namespace: vmware-system-csi
  resourceVersion: "6596030"
  uid: a602068b-6b2f-4943-8739-dfc3c6d03500
root@4233060bcb506d07a44578a2e9cf9a05 [ ~ ]#

root@4233060bcb506d07a44578a2e9cf9a05 [ ~ ]# k get storagepolicyusage -n storage-policy-test -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2024-07-09T14:39:59Z"
    generation: 5
    name: wcp-profile-p853csuseb-pvc-usage
    namespace: storage-policy-test
    resourceVersion: "28696"
    uid: 1bcd7cab-19ce-441f-9f1a-dda51c35bdd6
  spec:
    resourceApiGroup: ""
    resourceExtensionName: cns-storage-quota-extension-service-volume
    resourceKind: PersistentVolumeClaim
    storageClassName: wcp-profile-p853csuseb
    storagePolicyId: db3fddc6-506d-4c50-bc69-ffd36c1202a9
  status:
    quotaUsage:
      reserved: "0"
      used: 2Gi
- apiVersion: cns.vmware.com/v1alpha1
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2024-07-16T13:23:01Z"
    generation: 1
    name: wcp-profile-p853csuseb-snapshot-usage
    namespace: storage-policy-test
    resourceVersion: "6598064"
    uid: c5db4d1f-bef7-40c0-b476-1ececb6104e4
  spec:
    resourceApiGroup: snapshot.storage.k8s.io
    resourceExtensionName: snapshot.cns.vsphere.vmware.com
    resourceKind: VolumeSnapshot
    storageClassName: wcp-profile-p853csuseb
    storagePolicyId: db3fddc6-506d-4c50-bc69-ffd36c1202a9
  status: {}                  <<< no quota update for snapshot kind StoragePolicyUsage as no snapshot present
kind: List
metadata:
  resourceVersion: ""

```
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix existing full sync update for StoragePolicyUsage of PVC kind and Create StoragePolicyUsage of VolumeSnapshotKind kind, if not created already, during full sync
```
