### PR TITLE
Create CnsUnregisterVolume CRD during CNS Operator init in WCP

### DIFF
--- a/pkg/apis/cnsoperator/config/cnsunregistervolume_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsunregistervolume_crd.yaml
@@ -1,0 +1,70 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  creationTimestamp: null
+  name: cnsunregistervolumes.cns.vmware.com
+spec:
+  group: cns.vmware.com
+  names:
+    kind: CnsUnregisterVolume
+    listKind: CnsUnregisterVolumeList
+    plural: cnsunregistervolumes
+    singular: cnsunregistervolume
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CnsUnregisterVolume is the Schema for the cnsunregistervolumes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CnsUnregisterVolumeSpec defines the desired state of CnsUnregisterVolume
+            properties:
+              pvcName:
+                description: Name of the PVC to be unregistered.
+                type: string
+                pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+            required:
+            - pvcName
+            type: object
+          status:
+            description: CnsUnregisterVolumeStatus defines the observed state of CnsUnregisterVolume
+            properties:
+              error:
+                description: The last error encountered during export operation, if
+                  any. This field must only be set by the entity completing the export
+                  operation, i.e. the CNS Operator.
+                type: string
+              unregistered:
+                description: Indicates the volume is successfully unregistered. 
+                  This field must only be set by the entity completing the unregister 
+                  operation, i.e. the CNS Operator.
+                type: boolean
+            required:
+            - unregistered
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/apis/cnsoperator/config/config.go
+++ b/pkg/apis/cnsoperator/config/config.go
@@ -22,6 +22,11 @@ var EmbedCnsRegisterVolumeCRFile embed.FS
 
 const EmbedCnsRegisterVolumeCRFileName = "cnsregistervolume_crd.yaml"
 
+//go:embed cnsunregistervolume_crd.yaml
+var EmbedCnsUnregisterVolumeCRFile embed.FS
+
+const EmbedCnsUnregisterVolumeCRFileName = "cnsunregistervolume_crd.yaml"
+
 //go:embed cns.vmware.com_storagepolicyquotas.yaml
 var EmbedStoragePolicyQuotaCRFile embed.FS
 

--- a/pkg/apis/cnsoperator/register.go
+++ b/pkg/apis/cnsoperator/register.go
@@ -51,6 +51,8 @@ var (
 	CnsVolumeMetadataPlural = "cnsvolumemetadatas"
 	// CnsRegisterVolumePlural is plural of CnsRegisterVolume
 	CnsRegisterVolumePlural = "cnsregistervolumes"
+	// CnsUnregisterVolumePlural is plural of CnsUnregisterVolume
+	CnsUnregisterVolumePlural = "cnsunregistervolumes"
 	// CnsFileAccessConfigPlural is plural of CnsFileAccessConfig
 	CnsFileAccessConfigPlural = "cnsfileaccessconfigs"
 	// CnsStoragePolicyUsageSingular is singular of StoragePolicyUsage

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -164,6 +164,16 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			}
 			log.Infof("%q CRD is created successfully", cnsoperatorv1alpha1.CnsRegisterVolumePlural)
 
+			// Create CnsUnregisterVolume CRD from manifest.
+			log.Infof("Creating %q CRD", cnsoperatorv1alpha1.CnsUnregisterVolumePlural)
+			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, cnsoperatorconfig.EmbedCnsUnregisterVolumeCRFile,
+				cnsoperatorconfig.EmbedCnsUnregisterVolumeCRFileName)
+			if err != nil {
+				log.Errorf("Failed to create %q CRD. Err: %+v", cnsoperatorv1alpha1.CnsUnregisterVolumePlural, err)
+				return err
+			}
+			log.Infof("%q CRD is created successfully", cnsoperatorv1alpha1.CnsUnregisterVolumePlural)
+
 			// Clean up routine to cleanup successful CnsRegisterVolume instances.
 			log.Info("Starting go routine to cleanup successful CnsRegisterVolume instances.")
 			err = watcher(ctx, cnsOperator)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This is a first PR in what will be a series of PRs to add CnsUnregisterVolume API in CSI driver to support export workflow in WCP. It creates `CnsUnregisterVolume` CRD in the cluster during CNS Operator init.  
(Subsequent PRs will add a controller to handle `CnsUnregisterVolume` CRs and required RBAC changes)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Testing done**:
Deployed the changes on a Supervisor cluster and verified that CRD got created during syncer init.
```
root@421bcb93bc658ca6c8f2e696c7e3dd4b [ ~ ]# kubectl get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS      AGE
vsphere-csi-controller-7bcbb97c5b-kqdqc   7/7     Running   0             20s
vsphere-csi-webhook-68c6584d9f-59npw      1/1     Running   0             14d
vsphere-csi-webhook-68c6584d9f-fz5m2      1/1     Running   2 (14d ago)   14d
```


Syncer logs:
```
root@421bcb93bc658ca6c8f2e696c7e3dd4b [ ~ ]# kubectl logs vsphere-csi-controller-7bcbb97c5b-kqdqc -c vsphere-syncer -n vmware-system-csi -f
.
.
{"level":"info","time":"2024-07-17T22:27:39.614294869Z","caller":"manager/init.go:175","msg":"\"cnsunregistervolumes\" CRD is created successfully","TraceId":"3da276ab-172b-404c-ad9f-247244083b53"}
.
.
```


Verify CRD creation on cluster:
```
root@421bcb93bc658ca6c8f2e696c7e3dd4b [ ~ ]# kubectl get crd | grep cnsunregister
cnsunregistervolumes.cns.vmware.com                              2024-07-17T22:27:39Z     <---------

root@421bcb93bc658ca6c8f2e696c7e3dd4b [ ~ ]# kubectl describe crd cnsunregistervolumes.cns.vmware.com
Name:         cnsunregistervolumes.cns.vmware.com
Namespace:
Labels:       <none>
Annotations:  controller-gen.kubebuilder.io/version: v0.13.0
API Version:  apiextensions.k8s.io/v1
Kind:         CustomResourceDefinition
Metadata:
  Creation Timestamp:  2024-07-17T22:27:39Z
  Generation:          1
  Resource Version:    13919805
  UID:                 8a049ed4-a309-4ef4-bb61-acadad047cfd
Spec:
  Conversion:
    Strategy:  None
  Group:       cns.vmware.com
  Names:
    Kind:       CnsUnregisterVolume
    List Kind:  CnsUnregisterVolumeList
    Plural:     cnsunregistervolumes
    Singular:   cnsunregistervolume
  Scope:        Namespaced
  Versions:
    Name:  v1alpha1
    Schema:
      openAPIV3Schema:
        Description:  CnsUnregisterVolume is the Schema for the cnsunregistervolumes API
        Properties:
          API Version:
            Description:  APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
            Type:         string
          Kind:
            Description:  Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
            Type:         string
          Metadata:
            Type:  object
          Spec:
            Description:  CnsUnregisterVolumeSpec defines the desired state of CnsUnregisterVolume
            Properties:
              Pvc Name:
                Description:  Name of the PVC to be unregistered.
                Pattern:      ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                Type:         string
            Required:
              pvcName
            Type:  object
          Status:
            Description:  CnsUnregisterVolumeStatus defines the observed state of CnsUnregisterVolume
            Properties:
              Error:
                Description:  The last error encountered during export operation, if any. This field must only be set by the entity completing the export operation, i.e. the CNS Operator.
                Type:         string
              Unregistered:
                Description:  Indicates the volume is successfully unregistered. This field must only be set by the entity completing the unregister operation, i.e. the CNS Operator.
                Type:         boolean
            Required:
              unregistered
            Type:  object
        Type:      object
    Served:        true
    Storage:       true
Status:
  Accepted Names:
    Kind:       CnsUnregisterVolume
    List Kind:  CnsUnregisterVolumeList
    Plural:     cnsunregistervolumes
    Singular:   cnsunregistervolume
  Conditions:
    Last Transition Time:  2024-07-17T22:27:39Z
    Message:               no conflicts found
    Reason:                NoConflicts
    Status:                True
    Type:                  NamesAccepted
    Last Transition Time:  2024-07-17T22:27:39Z
    Message:               the initial names have been accepted
    Reason:                InitialNamesAccepted
    Status:                True
    Type:                  Established
  Stored Versions:
    v1alpha1
Events:  <none>
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Create CnsUnregisterVolume CRD during CNS Operator init in WCP in syncer
```
