### PR TITLE
Add RWX file volume support for vpc

### DIFF
--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -102,6 +102,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeinfoes"]
     verbs: ["create", "get", "list", "watch", "delete", "patch"]
+  - apiGroups: ["crd.nsx.vmware.com"]
+    resources: ["networkinfos"]
+    verbs: ["get", "watch", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -102,6 +102,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeinfoes"]
     verbs: ["create", "get", "list", "watch", "delete", "patch"]
+  - apiGroups: ["crd.nsx.vmware.com"]
+    resources: ["networkinfos"]
+    verbs: ["get", "watch", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -102,6 +102,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeinfoes"]
     verbs: ["create", "get", "list", "watch", "delete", "patch"]
+  - apiGroups: ["crd.nsx.vmware.com"]
+    resources: ["networkinfos"]
+    verbs: ["get", "watch", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/supervisorcluster/1.30/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.30/cns-csi.yaml
@@ -102,6 +102,9 @@ rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["cnsvolumeinfoes"]
     verbs: ["create", "get", "list", "watch", "delete", "patch"]
+  - apiGroups: ["crd.nsx.vmware.com"]
+    resources: ["networkinfos"]
+    verbs: ["get", "watch", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -100,7 +100,7 @@ const (
 	// NfsV4FsType represents nfs4 mount type.
 	NfsV4FsType = "nfs4"
 
-	//NTFSFsType represents ntfs
+	// NTFSFsType represents ntfs
 	NTFSFsType = "ntfs"
 
 	// NfsFsType represents nfs mount type.
@@ -290,10 +290,10 @@ const (
 	// topology labels applied on the node by vSphere CSI driver.
 	TopologyLabelsDomain = "topology.csi.vmware.com"
 
-	//AnnGuestClusterRequestedTopology is the key for guest cluster requested topology
+	// AnnGuestClusterRequestedTopology is the key for guest cluster requested topology
 	AnnGuestClusterRequestedTopology = "csi.vsphere.volume-requested-topology"
 
-	//AnnVolumeAccessibleTopology is the annotation set by the supervisor cluster on PVC
+	// AnnVolumeAccessibleTopology is the annotation set by the supervisor cluster on PVC
 	AnnVolumeAccessibleTopology = "csi.vsphere.volume-accessible-topology"
 
 	// PVtoBackingDiskObjectIdSupportedVCenterMajor is the minimum major version of vCenter
@@ -429,10 +429,13 @@ const (
 	// WorkloadDomainIsolationFSS is FSS for Workload Domain isolation feature
 	// Used in PVCSI
 	WorkloadDomainIsolationFSS = "workload-domain-isolation"
+	// VPCCapabilitySupervisor is a supervisor capability indicating if VPC FSS is enabled
+	VPCCapabilitySupervisor = "VPC_Supported"
 )
 
 var WCPFeatureStates = map[string]struct{}{
 	PodVMOnStretchedSupervisor: {},
 	CSIDetachOnSupervisor:      {},
 	WorkloadDomainIsolation:    {},
+	VPCCapabilitySupervisor:    {},
 }

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	vsanfstypes "github.com/vmware/govmomi/vsan/vsanfs/types"
+
 	cnsoperatorapis "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator"
 	cnsfileaccessconfigv1alpha1 "sigs.k8s.io/vsphere-csi-driver/v3/pkg/apis/cnsoperator/cnsfileaccessconfig/v1alpha1"
 	volumes "sigs.k8s.io/vsphere-csi-driver/v3/pkg/common/cns-lib/volume"
@@ -506,20 +507,32 @@ func (r *ReconcileCnsFileAccessConfig) getVMExternalIP(ctx context.Context,
 	if err != nil {
 		return "", logger.LogNewErrorf(log, "Failed to identify the network provider. Error: %+v", err)
 	}
-	var nsxConfiguration bool
+
 	if networkProvider == "" {
 		return "", logger.LogNewError(log, "unable to find network provider information")
 	}
-	if networkProvider == cnsoperatorutil.NSXTNetworkProvider {
-		nsxConfiguration = true
-	} else if networkProvider == cnsoperatorutil.VDSNetworkProvider {
-		nsxConfiguration = false
-	} else {
+
+	networkTypes := []string{cnsoperatorutil.NSXTNetworkProvider, cnsoperatorutil.
+		VDSNetworkProvider}
+
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.VPCCapabilitySupervisor) {
+		networkTypes = append(networkTypes, cnsoperatorutil.VPCNetworkProvider)
+	}
+
+	supported_found := false
+	for _, networkType := range networkTypes {
+		if networkType == networkProvider {
+			supported_found = true
+			break
+		}
+	}
+
+	if !supported_found {
 		return "", logger.LogNewErrorf(log, "Unknown network provider. Error: %+v", err)
 	}
 
 	tkgVMIP, err := cnsoperatorutil.GetTKGVMIP(ctx, r.vmOperatorClient,
-		r.dynamicClient, vm.Namespace, vm.Name, nsxConfiguration)
+		r.dynamicClient, vm.Namespace, vm.Name, networkProvider)
 	if err != nil {
 		return "", logger.LogNewErrorf(log, "Failed to get external facing IP address for VM %q/%q. Err: %+v",
 			vm.Namespace, vm.Name, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

RWX file volumes are supported on VDS and NSXT network types. This change extends this support to NSX_VPC network type. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
```
root@4203cd5b838ec14743e125450cb17eab [ ~ ]# k -n kube-system get configmap wcp-cluster-capabilities -o yaml | grep "VPC_Supported: "
  VPC_Supported: "true"

root@4203cd5b838ec14743e125450cb17eab [ ~ ]# k -n kube-system get configmap wcp-network-config -o yaml
apiVersion: v1
data:
  api_server_management_endpoint: 10.182.185.246
  api_servers_management_ips: 10.182.182.26,10.182.183.22,10.182.179.76
  network_provider: NSX_VPC
kind: ConfigMap
metadata:
  creationTimestamp: "2024-08-31T04:59:59Z"
  name: wcp-network-config
  namespace: kube-system
  resourceVersion: "11572420"
  uid: 8cd9b507-0957-4a04-8a12-669bd4ad0578
```

```
root@4203cd5b838ec14743e125450cb17eab [ ~ ]# k --kubeconfig kubeconfig get pvc
NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
example-vanilla-file-pvc   Bound    pvc-fd5943c0-4c6e-4170-9ff9-81f91cf67ba9   5Gi        RWX            wcpglobal-storage-profile   <unset>                 6h19m

root@4203cd5b838ec14743e125450cb17eab [ ~ ]# k --kubeconfig kubeconfig get po
NAME                        READY   STATUS    RESTARTS   AGE
example-vanilla-file-pod1   1/1     Running   0          27s
example-vanilla-file-pod2   1/1     Running   0          26s
example-vanilla-file-pod3   1/1     Running   0          26s

root@4203cd5b838ec14743e125450cb17eab [ ~ ]# k --kubeconfig kubeconfig describe po | grep "ClaimName"
    ClaimName:  example-vanilla-file-pvc
    ClaimName:  example-vanilla-file-pvc
    ClaimName:  example-vanilla-file-pvc
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
