### PR TITLE
Update VolumeSnapshot StoragePolicyUsage 'reserved' based on CnsVolumeOperationRequest Status events

### DIFF
--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -28,6 +28,7 @@ import (
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
 	"github.com/vmware/govmomi/vim25/types"
 	apiMeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -458,9 +459,11 @@ func GetValidatedCNSVolumeInfoPatch(ctx context.Context,
 			cnsSnapshotInfo.AggregatedSnapshotCapacityInMb, cnsSnapshotInfo.SourceVolumeID)
 		patch = map[string]interface{}{
 			"spec": map[string]interface{}{
-				"validaggregatedsnapshotsize":         true,
-				"aggregatedsnapshotsize":              cnsSnapshotInfo.AggregatedSnapshotCapacityInMb,
-				"snapshotlatestoperationcompletetime": &metav1.Time{Time: cnsSnapshotInfo.SnapshotLatestOperationCompleteTime},
+				"validaggregatedsnapshotsize": true,
+				"aggregatedsnapshotsize": resource.NewQuantity(
+					cnsSnapshotInfo.AggregatedSnapshotCapacityInMb, resource.BinarySI),
+				"snapshotlatestoperationcompletetime": &metav1.Time{
+					Time: cnsSnapshotInfo.SnapshotLatestOperationCompleteTime},
 			},
 		}
 	}

--- a/pkg/csi/service/wcp/controller.go
+++ b/pkg/csi/service/wcp/controller.go
@@ -1875,7 +1875,7 @@ func (c *controller) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshot
 				&cnsvolume.DeletesnapshotExtraParams{
 					StorageClassName:           cnsVolumeInfo.Spec.StorageClassName,
 					StoragePolicyID:            cnsVolumeInfo.Spec.StoragePolicyID,
-					Capacity:                   cnsVolumeInfo.Spec.Capacity,
+					Capacity:                   resource.NewQuantity(0, resource.BinarySI),
 					Namespace:                  cnsVolumeInfo.Namespace,
 					IsStorageQuotaM2FSSEnabled: isStorageQuotaM2FSSEnabled,
 				})

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -517,16 +517,19 @@ func validateAndCorrectVolumeInfoSnapshotDetails(ctx context.Context,
 				if ok {
 					aggregatedSnapshotCapacity = val.AggregatedSnapshotCapacityInMb
 				}
+				log.Infof("Received aggregatedSnapshotCapacity %d for volume %q",
+					aggregatedSnapshotCapacity, cnsVol.VolumeId.Id)
 				if cnsvolumeinfo.Spec.AggregatedSnapshotSize == nil || aggregatedSnapshotCapacity !=
 					cnsvolumeinfo.Spec.AggregatedSnapshotSize.Value() {
 					// use current time as snapshot completion time is not available in fullsync.
+					log.Infof("Update aggregatedSnapshotCapacity for volume %q", cnsVol.VolumeId.Id)
 					currentTime := time.Now()
 					cnsSnapInfo := &volumes.CnsSnapshotInfo{
 						SourceVolumeID:                      cnsvolumeinfo.Spec.VolumeID,
 						SnapshotLatestOperationCompleteTime: time.Now(),
 						AggregatedSnapshotCapacityInMb:      aggregatedSnapshotCapacity,
 					}
-					log.Infof("unable to get snapshot operation completion time for volumeID %d "+
+					log.Infof("unable to get snapshot operation completion time for volumeID %q "+
 						"will use current time %v instead", cnsvolumeinfo.Spec.VolumeID, currentTime)
 					patch, err := common.GetValidatedCNSVolumeInfoPatch(ctx, cnsSnapInfo)
 					if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update StoragePolicyUsage 'reserved' capacity based on CnsVolumeOperationRequest Status events

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual testing performed:
```

root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# kubectl get cnsvolumeoperationrequest  -n vmware-system-csi  
NAME                                       AGE
pvc-4c00c961-6610-4582-bb6c-1418542db943   21h
pvc-cde41a02-9b7a-4001-8e5e-9a6ad3bc110d   3d20h
root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# kubectl get cnsvolumeinfo -A 
NAMESPACE           NAME                                   AGE
vmware-system-csi   3866854f-a024-4216-bc56-3c3f6e9ce08a   3d20h
vmware-system-csi   9bb9b1ac-e3ec-408d-8259-69ef6fd661e8   21h
root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# kubectl apply -f snap.yaml -n storage-policy-test
volumesnapshot.snapshot.storage.k8s.io/example-vanilla-rwo-filesystem-snapshot created
root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# kubectl get volumesnapshot -A
NAMESPACE             NAME                                      READYTOUSE   SOURCEPVC                 SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
storage-policy-test   example-vanilla-rwo-filesystem-snapshot   false        example-vanilla-rwo-pvc                                         volumesnapshotclass-delete   snapcontent-96deaf99-4fae-4a3c-b822-af65a4679c0d                  4s
root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# kubectl get cnsvolumeinfo 3866854f-a024-4216-bc56-3c3f6e9ce08a -n vmware-system-csi  -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CNSVolumeInfo
metadata:
  creationTimestamp: "2024-07-26T21:06:42Z"
  generation: 54
  name: 3866854f-a024-4216-bc56-3c3f6e9ce08a
  namespace: vmware-system-csi
  resourceVersion: "19915689"
  uid: efda9c88-f046-423e-a275-b6bb2ced9a3b
spec:
  aggregatedsnapshotsize: "219"
  capacity: 1Gi
  namespace: storage-policy-test
  snapshotlatestoperationcompletetime: "2024-07-30T17:55:33Z"
  storageClassName: wcp-profile-c6rt9t0cli
  storagePolicyID: 43333687-ec93-4e67-a5bc-5fa84c4f3f9b
  vCenterServer: sc1-10-78-163-98.eng.vmware.com
  validaggregatedsnapshotsize: true
  volumeID: 3866854f-a024-4216-bc56-3c3f6e9ce08a
root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# kubectl get cnsvolumeoperationrequest  -n vmware-system-csi  
NAME                                                                                 AGE
pvc-4c00c961-6610-4582-bb6c-1418542db943                                             21h
pvc-cde41a02-9b7a-4001-8e5e-9a6ad3bc110d                                             3d20h
snapshot-96deaf99-4fae-4a3c-b822-af65a4679c0d-3866854f-a024-4216-bc56-3c3f6e9ce08a   20s
root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# kubectl get cnsvolumeoperationrequest  -n vmware-system-csi   snapshot-96deaf99-4fae-4a3c-b822-af65a4679c0d-3866854f-a024-4216-bc56-3c3f6e9ce08a -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsVolumeOperationRequest
metadata:
  creationTimestamp: "2024-07-30T17:55:33Z"
  generation: 2
  name: snapshot-96deaf99-4fae-4a3c-b822-af65a4679c0d-3866854f-a024-4216-bc56-3c3f6e9ce08a
  namespace: vmware-system-csi
  resourceVersion: "19915686"
  uid: 70544b9a-a137-47fe-8e1e-ced9c572de11
spec:
  name: snapshot-96deaf99-4fae-4a3c-b822-af65a4679c0d-3866854f-a024-4216-bc56-3c3f6e9ce08a
status:
  firstOperationDetails:
    opId: c3f740fd
    taskId: task-11192
    taskInvocationTimestamp: "2024-07-30T17:55:33Z"
    taskStatus: Success
  latestOperationDetails:
  - opId: c3f740fd
    taskId: task-11192
    taskInvocationTimestamp: "2024-07-30T17:55:33Z"
    taskStatus: Success
  quotaDetails:
    aggregatedsnapshotsize: "219"
    namespace: storage-policy-test
    reserved: "0"
    snapshotlatestoperationcompletetime: "2024-07-30T17:55:33Z"
    storageClassName: wcp-profile-c6rt9t0cli
    storagePolicyId: 43333687-ec93-4e67-a5bc-5fa84c4f3f9b
  snapshotID: 998478f1-ac9c-47a0-8444-1799a4f1c9cc
  volumeID: 3866854f-a024-4216-bc56-3c3f6e9ce08a
root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# kubectl get storagepolicyusage wcp-profile-c6rt9t0cli-snapshot-usage -n storage-policy-test -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-07-10T19:26:31Z"
  generation: 123
  name: wcp-profile-c6rt9t0cli-snapshot-usage
  namespace: storage-policy-test
  resourceVersion: "19915698"
  uid: 955f18d6-bab4-4fd8-ba8a-66c42c1b5843
spec:
  resourceApiGroup: snapshot.storage.k8s.io
  resourceExtensionName: snapshot.cns.vsphere.vmware.com
  resourceKind: VolumeSnapshot
  storageClassName: wcp-profile-c6rt9t0cli
  storagePolicyId: 43333687-ec93-4e67-a5bc-5fa84c4f3f9b
status:
  quotaUsage:
    reserved: "0"
    used: "219"
root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# kubectl delete -f snap.yaml -n storage-policy-test
volumesnapshot.snapshot.storage.k8s.io "example-vanilla-rwo-filesystem-snapshot" deleted
root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# kubectl get cnsvolumeoperationrequest  -n vmware-system-csi  
NAME                                                                                       AGE
deletesnapshot-3866854f-a024-4216-bc56-3c3f6e9ce08a-998478f1-ac9c-47a0-8444-1799a4f1c9cc   17s
pvc-4c00c961-6610-4582-bb6c-1418542db943                                                   21h
pvc-cde41a02-9b7a-4001-8e5e-9a6ad3bc110d                                                   3d20h
snapshot-96deaf99-4fae-4a3c-b822-af65a4679c0d-3866854f-a024-4216-bc56-3c3f6e9ce08a         2m23s
root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# kubectl get cnsvolumeoperationrequest  -n vmware-system-csi   deletesnapshot-3866854f-a024-4216-bc56-3c3f6e9ce08a-998478f1-ac9c-47a0-8444-1799a4f1c9cc -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsVolumeOperationRequest
metadata:
  creationTimestamp: "2024-07-30T17:57:39Z"
  generation: 2
  name: deletesnapshot-3866854f-a024-4216-bc56-3c3f6e9ce08a-998478f1-ac9c-47a0-8444-1799a4f1c9cc
  namespace: vmware-system-csi
  resourceVersion: "19917067"
  uid: 62dc0230-90ed-4c03-9472-7e8b3ed4351a
spec:
  name: deletesnapshot-3866854f-a024-4216-bc56-3c3f6e9ce08a-998478f1-ac9c-47a0-8444-1799a4f1c9cc
status:
  firstOperationDetails:
    opId: c3f7412a
    taskId: task-11196
    taskInvocationTimestamp: "2024-07-30T17:57:39Z"
    taskStatus: Success
  latestOperationDetails:
  - opId: c3f7412a
    taskId: task-11196
    taskInvocationTimestamp: "2024-07-30T17:57:39Z"
    taskStatus: Success
  quotaDetails:
    aggregatedsnapshotsize: "0"
    namespace: vmware-system-csi
    reserved: "0"
    snapshotlatestoperationcompletetime: "2024-07-30T17:57:38Z"
    storageClassName: wcp-profile-c6rt9t0cli
    storagePolicyId: 43333687-ec93-4e67-a5bc-5fa84c4f3f9b
root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# kubectl get storagepolicyusage wcp-profile-c6rt9t0cli-snapshot-usage -n storage-policy-test -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-07-10T19:26:31Z"
  generation: 124
  name: wcp-profile-c6rt9t0cli-snapshot-usage
  namespace: storage-policy-test
  resourceVersion: "19917073"
  uid: 955f18d6-bab4-4fd8-ba8a-66c42c1b5843
spec:
  resourceApiGroup: snapshot.storage.k8s.io
  resourceExtensionName: snapshot.cns.vsphere.vmware.com
  resourceKind: VolumeSnapshot
  storageClassName: wcp-profile-c6rt9t0cli
  storagePolicyId: 43333687-ec93-4e67-a5bc-5fa84c4f3f9b
status:
  quotaUsage:
    reserved: "0"
    used: "0"
root@420e933ee69c758d5e49aaa3cae3d651 [ ~ ]# 
``` 
vsphere csi syncer logs:
[update_reserve_snapshotstoragepolicy.log](https://github.com/user-attachments/files/16431818/update_reserve_snapshotstoragepolicy.log)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update StoragePolicyUsage 'reserved' capacity based on CnsVolumeOperationRequest Status events
```

