### PR TITLE
Add CSI FSS for CnsUnregisterVolume CRD creation

### DIFF
--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -463,6 +463,7 @@ data:
   "cnsmgr-suspend-create-volume": "true"
   "storage-quota-m2": "false"
   "vdpp-on-stretched-supervisor": "false"
+  "cns-unregister-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -463,6 +463,7 @@ data:
   "cnsmgr-suspend-create-volume": "true"
   "storage-quota-m2": "false"
   "vdpp-on-stretched-supervisor": "false"
+  "cns-unregister-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -463,6 +463,7 @@ data:
   "cnsmgr-suspend-create-volume": "true"
   "storage-quota-m2": "false"
   "vdpp-on-stretched-supervisor": "false"
+  "cns-unregister-volume": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -421,6 +421,8 @@ const (
 	VdppOnStretchedSupervisor = "vdpp-on-stretched-supervisor"
 	// CSIDetachOnSupervisor enables CSI to detach the disk from the podvm in a supervisor environment
 	CSIDetachOnSupervisor = "CSI_Detach_Supported"
+	// CnsUnregisterVolume enables the cretion of CRD and controller for CnsUnregisterVolume API.
+	CnsUnregisterVolume = "cns-unregister-volume"
 )
 
 var WCPFeatureStates = map[string]struct{}{

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -164,16 +164,6 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			}
 			log.Infof("%q CRD is created successfully", cnsoperatorv1alpha1.CnsRegisterVolumePlural)
 
-			// Create CnsUnregisterVolume CRD from manifest.
-			log.Infof("Creating %q CRD", cnsoperatorv1alpha1.CnsUnregisterVolumePlural)
-			err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, cnsoperatorconfig.EmbedCnsUnregisterVolumeCRFile,
-				cnsoperatorconfig.EmbedCnsUnregisterVolumeCRFileName)
-			if err != nil {
-				log.Errorf("Failed to create %q CRD. Err: %+v", cnsoperatorv1alpha1.CnsUnregisterVolumePlural, err)
-				return err
-			}
-			log.Infof("%q CRD is created successfully", cnsoperatorv1alpha1.CnsUnregisterVolumePlural)
-
 			// Clean up routine to cleanup successful CnsRegisterVolume instances.
 			log.Info("Starting go routine to cleanup successful CnsRegisterVolume instances.")
 			err = watcher(ctx, cnsOperator)
@@ -194,6 +184,18 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 					}
 				}
 			}()
+
+			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CnsUnregisterVolume) {
+				// Create CnsUnregisterVolume CRD from manifest.
+				log.Infof("Creating %q CRD", cnsoperatorv1alpha1.CnsUnregisterVolumePlural)
+				err = k8s.CreateCustomResourceDefinitionFromManifest(ctx, cnsoperatorconfig.EmbedCnsUnregisterVolumeCRFile,
+					cnsoperatorconfig.EmbedCnsUnregisterVolumeCRFileName)
+				if err != nil {
+					log.Errorf("Failed to create %q CRD. Err: %+v", cnsoperatorv1alpha1.CnsUnregisterVolumePlural, err)
+					return err
+				}
+				log.Infof("%q CRD is created successfully", cnsoperatorv1alpha1.CnsUnregisterVolumePlural)
+			}
 		}
 
 		if !stretchedSupervisor {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR puts the creation of CnsUnregisterVolume CRD behind a CSI-level FSS as discussed in https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2967#issuecomment-2249013170

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
1. Deployed the changes on a Supervisor cluster without `cns-unregister-volume` feature added in the configmap `csi-feature-states`.   
Tried creating a CnsUnregisterVolume CR and it failed expectedly.
```
root@42058b530a050865327221fb99c01531 [ ~/manifests ]# kubectl apply -f cns-unregister-volume.yaml -n playground-ns
Error from server (NotFound): error when creating "cns-unregister-volume.yaml": the server could not find the requested resource (post cnsunregistervolumes.cns.vmware.com)
```

2. Enabled the feature `cns-unregister-volume` in configmap `csi-feature-states`.
```
root@42058b530a050865327221fb99c01531 [ ~ ]# kubectl edit cm csi-feature-states -n vmware-system-csi

apiVersion: v1
data:
  async-query-volume: "true"
  block-volume-snapshot: "true"
  cnsmgr-suspend-create-volume: "true"
  .
  .
  cns-unregister-volume: "true"               <<--------
kind: ConfigMap
metadata:
  creationTimestamp: "2024-07-16T20:08:11Z"
  name: csi-feature-states
  namespace: vmware-system-csi
  .
  . 

```

Checked the syncer logs and verified that the CRD is getting created.
```
.
.
{"level":"info","time":"2024-07-25T18:46:53.209563603Z","caller":"manager/init.go:197","msg":"\"cnsunregistervolumes\" CRD is created successfully","TraceId":"5d30ef3a-7c70-456e-a97b-4553a53df782"}
.
.
```

3. Verified that the CRD is present in the cluster
```
root@42058b530a050865327221fb99c01531 [ ~ ]# kubectl get crd | grep cns
cnscsisvfeaturestates.cns.vmware.com                             2024-07-16T20:15:23Z
cnsfileaccessconfigs.cns.vmware.com                              2024-07-16T20:15:24Z
cnsfilevolumeclients.cns.vmware.com                              2024-07-16T20:15:24Z
cnsnodevmattachments.cns.vmware.com                              2024-07-16T20:15:23Z
cnsregistervolumes.cns.vmware.com                                2024-07-25T18:38:22Z
cnsunregistervolumes.cns.vmware.com                              2024-07-25T18:42:41Z     <<<----------
cnsvolumeinfoes.cns.vmware.com                                   2024-07-16T20:15:20Z
cnsvolumemetadatas.cns.vmware.com                                2024-07-16T20:15:23Z
cnsvolumeoperationrequests.cns.vmware.com                        2024-07-16T20:15:19Z
storagepolicyquotas.cns.vmware.com                               2024-07-16T20:08:08Z
storagepolicyusages.cns.vmware.com                               2024-07-16T20:08:08Z
storagepools.cns.vmware.com                                      2024-07-16T20:15:22Z
storagequotas.cns.vmware.com                                     2024-07-16T20:08:08Z
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add CSI FSS for CnsUnregisterVolume CRD creation
```
