### PR TITLE
Add implementation for CnsUnregisterVolume controller

### DIFF
--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -14,7 +14,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "create", "delete", "patch"]

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -14,7 +14,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "create", "delete", "patch"]

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -14,7 +14,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "create", "delete", "patch"]

--- a/pkg/apis/cnsoperator/cnsunregistervolume/v1alpha1/cnsunregistervolume_types.go
+++ b/pkg/apis/cnsoperator/cnsunregistervolume/v1alpha1/cnsunregistervolume_types.go
@@ -23,8 +23,8 @@ import (
 // CnsUnregisterVolumeSpec defines the desired state of CnsUnregisterVolume
 // +k8s:openapi-gen=true
 type CnsUnregisterVolumeSpec struct {
-	// Name of the PVC to be unregistered
-	PvcName string `json:"pvcName"`
+	// VolumeID indicates the volume handle of CNS volume to be unregistered
+	VolumeID string `json:"volumeID"`
 }
 
 // CnsUnregisterVolumeStatus defines the observed state of CnsUnregisterVolume

--- a/pkg/apis/cnsoperator/config/cnsunregistervolume_crd.yaml
+++ b/pkg/apis/cnsoperator/config/cnsunregistervolume_crd.yaml
@@ -36,12 +36,12 @@ spec:
           spec:
             description: CnsUnregisterVolumeSpec defines the desired state of CnsUnregisterVolume
             properties:
-              pvcName:
-                description: Name of the PVC to be unregistered.
+              volumeID:
+                description: VolumeID indicates the volume handle of CNS volume to be unregistered.
                 type: string
                 pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
             required:
-            - pvcName
+            - volumeID
             type: object
           status:
             description: CnsUnregisterVolumeStatus defines the observed state of CnsUnregisterVolume


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds the core implementation for CnsUnregisterVolume controller. I changed the CR spec to have CNS volumeID instead of PVC name for better error handling if there's a reconciliation from partial failures.

On a high level, this is the logic in controller:  
	1. Fetch the PV corresponding to the PVC and set on it the ReclaimPolicy to Retain.
	2. Delete PVC, wait for it to get deleted.
	3. Delete PV.
	4. Invoke CNS DeleteVolume API with deleteDisk set to false.
	5. Set the `CnsUnregisterVolume.Status.Unregistered` to true.
	
Please note upon PV deletion in step 3, CSI metadata syncer will also try to delete the volume from CNS without deleting the underlying FCD. Since we already deleted volume in step 4, it might fail with volume not being a CNS volume but that should be okay.

The logic for CR cleanup and other validations before unregistering will be added in a follow-up MR.

**Testing done**:
1. Created an FCD and statically provisioned a volume in Supervisor using `CnsRegisterVolume`. Verified that the provisioning was successful and checked the corresponding PV/PVC.
```
root@42058b530a050865327221fb99c01531 [ ~/manifests ]# kubectl get pvc -n playground-ns
NAME              STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
vanilla-rwo-pvc   Bound    static-pv-1f65e479-b2db-40c4-9451-4ff9f92df27d   2Gi        RWO            wcpglobal-storage-profile   <unset>                 11s

root@42058b530a050865327221fb99c01531 [ ~/manifests ]# kubectl describe pv static-pv-1f65e479-b2db-40c4-9451-4ff9f92df27d
Name:            static-pv-1f65e479-b2db-40c4-9451-4ff9f92df27d
Labels:          <none>
Annotations:     pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    wcpglobal-storage-profile
Status:          Bound
Claim:           playground-ns/vanilla-rwo-pvc
Reclaim Policy:  Delete
Access Modes:    RWO
VolumeMode:      Filesystem
Capacity:        2Gi
Node Affinity:   <none>
Message:
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      1f65e479-b2db-40c4-9451-4ff9f92df27d           <<<<------
    ReadOnly:          false
    VolumeAttributes:  <none>
Events:                <none>
```

2. Edited `vsphere-csi-controller-role` ClusterRole to add RBAC for deleting a PVC.
```
root@42058b530a050865327221fb99c01531 [ ~/manifests ]# kubectl edit clusterrole vsphere-csi-controller-role
.
.
- apiGroups:
  - ""
  resources:
  - persistentvolumeclaims
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
  - delete          <<<----------
.
.
```

2. Created a `CnsUnregisterVolume` CR in the same namespace as PVC with below spec:
```
apiVersion: cns.vmware.com/v1alpha1
kind: CnsUnregisterVolume
metadata:
  name: unregister-pvc-1
spec:
    volumeID: 1f65e479-b2db-40c4-9451-4ff9f92df27d
```

```
root@42058b530a050865327221fb99c01531 [ ~/manifests ]# kubectl apply -f cns-unregister-volume.yaml -n playground-ns
cnsunregistervolume.cns.vmware.com/unregister-pvc-1 created
```

3. Checked the syncer logs to verify that the controller is acting as expected by changing the PV `ReclaimPolicy` to `Delete` and then deleting the PV/PVC and the CNS volume.
```
.
.
{"level":"info","time":"2024-07-31T21:54:08.633800799Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:181","msg":"Reconciling CnsUnregisterVolume instance \"unregister-pvc-1\" from namespace \"playground-ns\". timeout \"1s\" seconds"}
.{"level":"info","time":"2024-07-31T21:54:08.754678426Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:262","msg":"Updated ReclaimPolicy on PV \"static-pv-1f65e479-b2db-40c4-9451-4ff9f92df27d\" to \"Retain\""}
{"level":"info","time":"2024-07-31T21:54:08.809520814Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:276","msg":"Deleted PVC \"vanilla-rwo-pvc\" in namespace \"playground-ns\""}
{"level":"info","time":"2024-07-31T21:54:08.821878669Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:291","msg":"Deleted PV \"static-pv-1f65e479-b2db-40c4-9451-4ff9f92df27d\""}
{"level":"info","time":"2024-07-31T21:54:09.33361492Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:300","msg":"Deleted CNS volume \"1f65e479-b2db-40c4-9451-4ff9f92df27d\" with deleteDisk set to false"} 
.
.
{"level":"info","time":"2024-07-31T21:54:10.27463274Z","caller":"cnsunregistervolume/cnsunregistervolume_controller.go:314","msg":"Successfully unregistered the volume on namespace: playground-ns"} 
.
.
```

4. Checked that PV/PVC were deleted from the Supervisor cluster:
```
root@42058b530a050865327221fb99c01531 [ ~/manifests ]# kubectl get pvc -n playground-ns
No resources found in playground-ns namespace.
```

Also checked that the volume is not present in vCenter CNS UI i.e. it has been unregistered in CNS.

5. Invoked the FCD API `RetrieveVStorageObject` from vCenter mob and verified that FCD is not deleted. Also used the same volumeHandle in another static volume provisioning request and verified that it works.

6. Checked the `CnsUnregisterVolume` CR and verified that the `status.Unregistered` field is set to true.
```
root@42058b530a050865327221fb99c01531 [ ~ ]# kubectl describe cnsunregistervolume -A
Name:         unregister-pvc-1
Namespace:    playground-ns
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsUnregisterVolume
Metadata:
  Creation Timestamp:  2024-07-31T20:41:55Z
  Generation:          5
  Resource Version:    14754469
  UID:                 01b8f85b-b2a4-4ee2-89ff-90906b753328
Spec:
  Volume ID:  1f65e479-b2db-40c4-9451-4ff9f92df27d
Status:
  Unregistered:  true
Events:
  Type     Reason                        Age                 From            Message
  ----     ------                        ----                ----            -------
  Normal   CnsUnregisterVolumeSucceeded  12m                 cns.vmware.com  Successfully unregistered the volume on namespace: playground-ns
  ```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add implementation for CnsUnregisterVolume controller
```
