### PR TITLE
Add RBAC for workload domain isolation feature

### DIFF
--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -82,7 +82,7 @@ rules:
     resources: ["statefulsets"]
     verbs: ["list"]
   - apiGroups: ["topology.tanzu.vmware.com"]
-    resources: ["availabilityzones"]
+    resources: ["availabilityzones", "zones"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -82,7 +82,7 @@ rules:
     resources: ["statefulsets"]
     verbs: ["list"]
   - apiGroups: ["topology.tanzu.vmware.com"]
-    resources: ["availabilityzones"]
+    resources: ["availabilityzones", "zones"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -82,7 +82,7 @@ rules:
     resources: ["statefulsets"]
     verbs: ["list"]
   - apiGroups: ["topology.tanzu.vmware.com"]
-    resources: ["availabilityzones"]
+    resources: ["availabilityzones", "zones"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshots" ]

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -439,7 +439,7 @@ func getNodeTopologyInfoForGuest(ctx context.Context, instance *csinodetopologyv
 		topologyLabels = make([]csinodetopologyv1alpha1.TopologyLabel, 0)
 		topologyLabels = append(topologyLabels,
 			csinodetopologyv1alpha1.TopologyLabel{
-				Key:   corev1.LabelZoneFailureDomainStable,
+				Key:   corev1.LabelTopologyZone,
 				Value: virtualMachine.Status.Zone,
 			},
 		)

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller_test.go
@@ -45,7 +45,7 @@ func TestCSINodeTopologyControllerForTKGSHA(t *testing.T) {
 		testUnexpectedVmName    = "test-unexpected-vm-name"
 		testNodeIDInSpec        = "test-node-id"
 		testSupervisorNamespace = "test-supervisor-namespace"
-		expectedZoneKey         = corev1.LabelZoneFailureDomainStable
+		expectedZoneKey         = corev1.LabelTopologyZone
 		expectedZoneValue       = "zone-1"
 		testCSINodeTopology     = &csinodetopologyv1alpha1.CSINodeTopology{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR adds RBAC rules required for workload domain isolation feature to work and replaces the deprecated topology label LabelZoneFailureDomainStable with LabelTopologyZone

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Not required

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add RBAC for workload domain isolation feature and replace deprecated topology label
```
