### PR TITLE
Fix aggregated snapshot size formatting and other fixes

### DIFF
--- a/pkg/common/cns-lib/volume/manager.go
+++ b/pkg/common/cns-lib/volume/manager.go
@@ -2473,7 +2473,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 					log.Infof("Fetched aggregated Snapshot Capacity is %d for volume with volumeID %q",
 						aggregatedSnapshotCapacityInMb, volumeID)
 					cnsSnapshotInfo.AggregatedSnapshotCapacityInMb = aggregatedSnapshotCapacityInMb
-					aggregatedSnapshotCapacity := resource.NewQuantity(aggregatedSnapshotCapacityInMb, resource.BinarySI)
+					aggregatedSnapshotCapacity := resource.NewQuantity(aggregatedSnapshotCapacityInMb*MbInBytes, resource.BinarySI)
 					quotaInfo.AggregatedSnapshotSize = aggregatedSnapshotCapacity
 					quotaInfo.SnapshotLatestOperationCompleteTime.Time = queriedCnsSnapshot.CreateTime
 					log.Infof("Snapshot %q for volume %q confirmed to be created, update quotainfo: %+v",
@@ -2566,7 +2566,7 @@ func (m *defaultManager) createSnapshotWithImprovedIdempotencyCheck(ctx context.
 		log.Infof("For volumeID %q new AggregatedSnapshotSize is %d and SnapshotLatestOperationCompleteTime is %q",
 			volumeID, snapshotCreateResult.AggregatedSnapshotCapacityInMb, *createSnapshotsTaskInfo.CompleteTime)
 		cnsSnapshotInfo.AggregatedSnapshotCapacityInMb = snapshotCreateResult.AggregatedSnapshotCapacityInMb
-		aggregatedSnapshotCapacity := resource.NewQuantity(snapshotCreateResult.AggregatedSnapshotCapacityInMb,
+		aggregatedSnapshotCapacity := resource.NewQuantity(snapshotCreateResult.AggregatedSnapshotCapacityInMb*MbInBytes,
 			resource.BinarySI)
 		quotaInfo.AggregatedSnapshotSize = aggregatedSnapshotCapacity
 		quotaInfo.SnapshotLatestOperationCompleteTime.Time = *createSnapshotsTaskInfo.CompleteTime
@@ -2748,7 +2748,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 						AggregatedSnapshotCapacityInMb:      aggregatedSnapshotCapacityInMb,
 						SnapshotLatestOperationCompleteTime: currentTime,
 					}
-					aggregatedSnapshotCapacity := resource.NewQuantity(aggregatedSnapshotCapacityInMb, resource.BinarySI)
+					aggregatedSnapshotCapacity := resource.NewQuantity(aggregatedSnapshotCapacityInMb*MbInBytes, resource.BinarySI)
 					quotaInfo.AggregatedSnapshotSize = aggregatedSnapshotCapacity
 					quotaInfo.SnapshotLatestOperationCompleteTime.Time = currentTime
 				}
@@ -2807,7 +2807,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 					}
 					log.Infof("Fetched aggregated Snapshot Capacity is %d for volume with volumeID %q",
 						aggregatedSnapshotCapacityInMb, volumeID)
-					aggregatedSnapshotCapacity := resource.NewQuantity(aggregatedSnapshotCapacityInMb, resource.BinarySI)
+					aggregatedSnapshotCapacity := resource.NewQuantity(aggregatedSnapshotCapacityInMb*MbInBytes, resource.BinarySI)
 					quotaInfo.AggregatedSnapshotSize = aggregatedSnapshotCapacity
 					quotaInfo.SnapshotLatestOperationCompleteTime.Time = currentTime
 					log.Infof("Snapshot %q for volume %q confirmed to be deleted, update quotainfo: %+v",
@@ -2890,7 +2890,7 @@ func (m *defaultManager) deleteSnapshotWithImprovedIdempotencyCheck(
 			SnapshotLatestOperationCompleteTime: *deleteSnapshotsTaskInfo.CompleteTime,
 			AggregatedSnapshotCapacityInMb:      snapshotDeleteResult.AggregatedSnapshotCapacityInMb,
 		}
-		aggregatedSnapshotCapacity := resource.NewQuantity(snapshotDeleteResult.AggregatedSnapshotCapacityInMb,
+		aggregatedSnapshotCapacity := resource.NewQuantity(snapshotDeleteResult.AggregatedSnapshotCapacityInMb*MbInBytes,
 			resource.BinarySI)
 		quotaInfo.AggregatedSnapshotSize = aggregatedSnapshotCapacity
 		quotaInfo.SnapshotLatestOperationCompleteTime.Time = *deleteSnapshotsTaskInfo.CompleteTime

--- a/pkg/csi/service/common/util.go
+++ b/pkg/csi/service/common/util.go
@@ -455,13 +455,14 @@ func GetValidatedCNSVolumeInfoPatch(ctx context.Context,
 			},
 		}
 	} else {
+		aggregatedSnapshotSizeBytes := cnsSnapshotInfo.AggregatedSnapshotCapacityInMb * MbInBytes
 		log.Infof("retrieved aggregated snapshot capacity %d for volume %q",
 			cnsSnapshotInfo.AggregatedSnapshotCapacityInMb, cnsSnapshotInfo.SourceVolumeID)
 		patch = map[string]interface{}{
 			"spec": map[string]interface{}{
 				"validaggregatedsnapshotsize": true,
 				"aggregatedsnapshotsize": resource.NewQuantity(
-					cnsSnapshotInfo.AggregatedSnapshotCapacityInMb, resource.BinarySI),
+					aggregatedSnapshotSizeBytes, resource.BinarySI),
 				"snapshotlatestoperationcompletetime": &metav1.Time{
 					Time: cnsSnapshotInfo.SnapshotLatestOperationCompleteTime},
 			},


### PR DESCRIPTION
Fixing aggregated snapshot size formatting, so that quantity will be in MB throughout CR's 
Allow storage quota updates on operation request CR events for PVC if CR event is not for snapshot

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing Performed
```
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# k get storagepolicyusage -n storage-policy-test wcp-profile-8qnt9qivb1-snapshot-usage -o yaml
apiVersion: cns.vmware.com/v1alpha2
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-08-06T04:29:48Z"
  generation: 15
  name: wcp-profile-8qnt9qivb1-snapshot-usage
  namespace: storage-policy-test
  resourceVersion: "459350"
  uid: 7e1efb2b-086f-4812-8af9-286990ca6569
spec:
  resourceApiGroup: snapshot.storage.k8s.io
  resourceExtensionName: snapshot.cns.vsphere.vmware.com
  resourceKind: VolumeSnapshot
  storageClassName: wcp-profile-8qnt9qivb1
  storagePolicyId: 446f8d3f-b569-4a23-b704-ed3389ff2836
status:
  quotaUsage:
    reserved: "0"
    used: "0"
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# kubectl get cnsvolumeinfo -n vmware-system-csi -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CNSVolumeInfo
  metadata:
    creationTimestamp: "2024-08-06T10:32:40Z"
    generation: 16
    name: cbe5488d-ca1b-420e-a887-460c87368e90
    namespace: vmware-system-csi
    resourceVersion: "459348"
    uid: b7f0f1ff-8d82-4d8b-aedf-d389cfdab1b9
  spec:
    aggregatedsnapshotsize: "0"
    capacity: 5Gi
    namespace: storage-policy-test
    snapshotlatestoperationcompletetime: "2024-08-06T14:44:50Z"
    storageClassName: wcp-profile-8qnt9qivb1
    storagePolicyID: 446f8d3f-b569-4a23-b704-ed3389ff2836
    vCenterServer: sc2-10-186-79-65.eng.vmware.com
    validaggregatedsnapshotsize: true
    volumeID: cbe5488d-ca1b-420e-a887-460c87368e90
kind: List
metadata:
  resourceVersion: ""
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# kubectl get pvc -A
NAMESPACE             NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             VOLUMEATTRIBUTESCLASS   AGE
storage-policy-test   example-vanilla-rwo-pvc   Bound    pvc-75b84776-81db-4898-9085-15c95da3979d   5Gi        RWO            wcp-profile-8qnt9qivb1   <unset>                 4h13m
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# k apply -f snap.yaml -n storage-policy-test
volumesnapshot.snapshot.storage.k8s.io/example-vanilla-rwo-filesystem-snapshot created
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# kubectl get vs -A
NAMESPACE             NAME                                      READYTOUSE   SOURCEPVC                 SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
storage-policy-test   example-vanilla-rwo-filesystem-snapshot   true         example-vanilla-rwo-pvc                           5Gi           volumesnapshotclass-delete   snapcontent-d2928be4-d56b-4bf1-a195-1d3a33b67bb2   3s             4s
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# kubectl get cnsvolumeinfo -n vmware-system-csi -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha1
  kind: CNSVolumeInfo
  metadata:
    creationTimestamp: "2024-08-06T10:32:40Z"
    generation: 17
    name: cbe5488d-ca1b-420e-a887-460c87368e90
    namespace: vmware-system-csi
    resourceVersion: "461094"
    uid: b7f0f1ff-8d82-4d8b-aedf-d389cfdab1b9
  spec:
    aggregatedsnapshotsize: 209Mi
    capacity: 5Gi
    namespace: storage-policy-test
    snapshotlatestoperationcompletetime: "2024-08-06T14:47:16Z"
    storageClassName: wcp-profile-8qnt9qivb1
    storagePolicyID: 446f8d3f-b569-4a23-b704-ed3389ff2836
    vCenterServer: sc2-10-186-79-65.eng.vmware.com
    validaggregatedsnapshotsize: true
    volumeID: cbe5488d-ca1b-420e-a887-460c87368e90
kind: List
metadata:
  resourceVersion: ""
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# kubectl get cnsvolumeoperationrequest -n vmware-system-csi  
NAME                                                                                 AGE
pvc-75b84776-81db-4898-9085-15c95da3979d                                             4h15m
snapshot-d2928be4-d56b-4bf1-a195-1d3a33b67bb2-cbe5488d-ca1b-420e-a887-460c87368e90   22s
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# kubectl get cnsvolumeoperationrequest -n vmware-system-csi  snapshot-d2928be4-d56b-4bf1-a195-1d3a33b67bb2-cbe5488d-ca1b-420e-a887-460c87368e90 -o yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsVolumeOperationRequest
metadata:
  creationTimestamp: "2024-08-06T14:47:16Z"
  generation: 2
  name: snapshot-d2928be4-d56b-4bf1-a195-1d3a33b67bb2-cbe5488d-ca1b-420e-a887-460c87368e90
  namespace: vmware-system-csi
  resourceVersion: "461093"
  uid: 772abeb1-bc0c-43dc-af15-699fc8bfdce4
spec:
  name: snapshot-d2928be4-d56b-4bf1-a195-1d3a33b67bb2-cbe5488d-ca1b-420e-a887-460c87368e90
status:
  firstOperationDetails:
    opId: 60884aaf
    taskId: task-920
    taskInvocationTimestamp: "2024-08-06T14:47:16Z"
    taskStatus: Success
  latestOperationDetails:
  - opId: 60884aaf
    taskId: task-920
    taskInvocationTimestamp: "2024-08-06T14:47:16Z"
    taskStatus: Success
  quotaDetails:
    aggregatedsnapshotsize: 209Mi
    namespace: storage-policy-test
    reserved: "0"
    snapshotlatestoperationcompletetime: "2024-08-06T14:47:16Z"
    storageClassName: wcp-profile-8qnt9qivb1
    storagePolicyId: 446f8d3f-b569-4a23-b704-ed3389ff2836
  snapshotID: 64792375-1ae5-4018-b1a4-3932d66cd40e
  volumeID: cbe5488d-ca1b-420e-a887-460c87368e90
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# k get storagepolicyusage -n storage-policy-test wcp-profile-8qnt9qivb1-snapshot-usage -o yaml
apiVersion: cns.vmware.com/v1alpha2
kind: StoragePolicyUsage
metadata:
  creationTimestamp: "2024-08-06T04:29:48Z"
  generation: 18
  name: wcp-profile-8qnt9qivb1-snapshot-usage
  namespace: storage-policy-test
  resourceVersion: "461096"
  uid: 7e1efb2b-086f-4812-8af9-286990ca6569
spec:
  resourceApiGroup: snapshot.storage.k8s.io
  resourceExtensionName: snapshot.cns.vsphere.vmware.com
  resourceKind: VolumeSnapshot
  storageClassName: wcp-profile-8qnt9qivb1
  storagePolicyId: 446f8d3f-b569-4a23-b704-ed3389ff2836
status:
  quotaUsage:
    reserved: "0"
    used: 209Mi
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# k get storagepolicyquota -n storage-policy-test wcp-profile-8qnt9qivb1-snapshot-usage -o yaml
Error from server (NotFound): storagepolicyquotas.cns.vmware.com "wcp-profile-8qnt9qivb1-snapshot-usage" not found
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# k get storagepolicyquota -n storage-policy-test wcp-pro^Cle-8qnt9qivb1-snapshot-usage -o yaml
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# k get storagepolicyquota wcp-profile-8qnt9qivb1-storagepolicyquota -n storage-policy-test -o yaml
apiVersion: cns.vmware.com/v1alpha2
kind: StoragePolicyQuota
metadata:
  creationTimestamp: "2024-08-06T04:29:48Z"
  generation: 1
  name: wcp-profile-8qnt9qivb1-storagepolicyquota
  namespace: storage-policy-test
  resourceVersion: "461105"
  uid: 042f8657-eccb-4552-a581-e8ae8f4a534c
spec:
  limit: "9223372036854775807"
  storagePolicyId: 446f8d3f-b569-4a23-b704-ed3389ff2836
status:
  extensions:
  - extensionName: vmservice.cns.vsphere.vmware.com
    extensionQuotaUsage:
    - scQuotaUsage:
        reserved: "0"
        used: "0"
      storageClassName: wcp-profile-8qnt9qivb1-storagepolicyquota
  - extensionName: volume.cns.vsphere.vmware.com
    extensionQuotaUsage:
    - scQuotaUsage:
        reserved: "0"
        used: 5Gi
      storageClassName: wcp-profile-8qnt9qivb1
  - extensionName: snapshot.cns.vsphere.vmware.com
    extensionQuotaUsage:
    - scQuotaUsage:
        reserved: "0"
        used: 209Mi
      storageClassName: wcp-profile-8qnt9qivb1
  total:
  - scQuotaUsage:
      reserved: "0"
      used: "0"
    storageClassName: wcp-profile-8qnt9qivb1-storagepolicyquota
  - scQuotaUsage:
      reserved: "0"
      used: "5587861504"
    storageClassName: wcp-profile-8qnt9qivb1
root@423ae6e95ca2ae6e32d92a7a0649bc32 [ ~ ]# 

```
vsphere csi  controller log
[vsphere-csi-controller_qty_format.log](https://github.com/user-attachments/files/16512124/vsphere-csi-controller_qty_format.log)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixing aggregated snapshot size formatting, so that quantity will be in MB throughout CR's 
Allow storage quota updates on operation request CR events for PVC if CR event is not for snapshot
```
