### PR TITLE
WorkloadDomainIsolation: Volume provisioning support for single & multi zone supervisor

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/wcp_node.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/wcp_node.go
@@ -73,12 +73,18 @@ func (c *K8sOrchestrator) createCSINode(obj interface{}) {
 	}
 
 	var topologyKeysList []string
-	if len(clusterComputeResourceMoIds) > 1 {
-		// Publish zone and host standard topology keys for stretch supervisor.
+	if c.IsFSSEnabled(ctx, common.WorkloadDomainIsolation) {
+		// Publish zone and host standard topology keys for all types of supervisor clusters.
 		topologyKeysList = append(topologyKeysList, corev1.LabelTopologyZone, corev1.LabelHostname)
 	} else {
-		topologyKeysList = append(topologyKeysList, corev1.LabelHostname)
+		if len(clusterComputeResourceMoIds) > 1 {
+			// Publish zone and host standard topology keys for stretch supervisor.
+			topologyKeysList = append(topologyKeysList, corev1.LabelTopologyZone, corev1.LabelHostname)
+		} else {
+			topologyKeysList = append(topologyKeysList, corev1.LabelHostname)
+		}
 	}
+
 	// NOTE: As this is a WCP node, we can safely assume that only vSphere CSI driver will be run on it.
 	// If spherelet is not creating the CSINodes, we will create them and ignore the error if it is already present.
 	csiNodeSpec := &storagev1.CSINode{

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -421,11 +421,15 @@ const (
 	VdppOnStretchedSupervisor = "vdpp-on-stretched-supervisor"
 	// CSIDetachOnSupervisor enables CSI to detach the disk from the podvm in a supervisor environment
 	CSIDetachOnSupervisor = "CSI_Detach_Supported"
-	// CnsUnregisterVolume enables the cretion of CRD and controller for CnsUnregisterVolume API.
+	// CnsUnregisterVolume enables the creation of CRD and controller for CnsUnregisterVolume API.
 	CnsUnregisterVolume = "cns-unregister-volume"
+	// WorkloadDomainIsolation is the name of the WCP capability which determines if
+	// workload domain isolation feature is available on a supervisor cluster.
+	WorkloadDomainIsolation = "Workload_Domain_Isolation_Supported"
 )
 
 var WCPFeatureStates = map[string]struct{}{
 	PodVMOnStretchedSupervisor: {},
 	CSIDetachOnSupervisor:      {},
+	WorkloadDomainIsolation:    {},
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: With the WorkloadDomainIsolation feature, we plan to publish both zone & host topology keys in CSINodes and handle the accessibility requirements calculation in CSI provisioner. StorageClasses with StorageTopologyType parameter not set will be allowed for volume provisioning and node affinity terms will be set for all zones the selected datatstore has access to.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
**CSINodes publishing both the topology keys**
```
Name:               sc2-10-186-111-215.eng.vmware.com
Labels:             <none>
Annotations:        <none>
CreationTimestamp:  Fri, 30 Aug 2024 09:47:23 +0000
Spec:
  Drivers:
    csi.vsphere.vmware.com:
      Node ID:        sc2-10-186-111-215.eng.vmware.com
      Topology Keys:  [topology.kubernetes.io/zone kubernetes.io/hostname]
Events:               <none>
```

**Volume provisioning on non-stretched supervisor with zonal policy on namespace test-ns confined to 2 zones**

```
k get zones -n test-ns
NAME     AGE
zone-1   9h
zone-3   46m
```

SC
```
Name:                  zonal-policy
IsDefaultClass:        No
Annotations:           <none>
Provisioner:           csi.vsphere.vmware.com
Parameters:            StorageTopologyType=Zonal,storagePolicyID=a59f887b-0090-4080-a493-7f317d0680ae
AllowVolumeExpansion:  True
MountOptions:          <none>
ReclaimPolicy:         Delete
VolumeBindingMode:     Immediate
Events:                <none>
```

PVC
```
Name:          pvc3
Namespace:     test-ns
StorageClass:  zonal-policy
Status:        Bound
Volume:        pvc-c6084d76-489b-4328-8015-2b8057b3f7d2
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"zone-1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Fri Aug 30 18:24:58 UTC 2024
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age                From                                                                                          Message
  ----    ------                 ----               ----                                                                                          -------
  Normal  Provisioning           37m                csi.vsphere.vmware.com_420a4a5d5650ee55c4dbca2529576e9e_ba88659c-2300-4d72-bbad-61d42d7a6813  External provisioner is provisioning volume for claim "test-ns/pvc3"
  Normal  ExternalProvisioning   37m (x3 over 37m)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  ProvisioningSucceeded  37m                csi.vsphere.vmware.com_420a4a5d5650ee55c4dbca2529576e9e_ba88659c-2300-4d72-bbad-61d42d7a6813  Successfully provisioned volume pvc-c6084d76-489b-4328-8015-2b8057b3f7d2
```

PV
```
Name:              pvc-c6084d76-489b-4328-8015-2b8057b3f7d2
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      zonal-policy
Status:            Bound
Claim:             test-ns/pvc3
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.kubernetes.io/zone in [zone-1]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      0464c69c-b806-4f5e-ace6-d30859e3249c
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1725011073549-3327-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```

CSI logs:
```
{"level":"info","time":"2024-08-30T18:24:52.585209803Z","caller":"wcp/controller.go:959","msg":"CreateVolume: called with args {Name:pvc-c6084d76-489b-4328-8015-2b8057b3f7d2 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[StorageTopologyType:Zonal csi.storage.k8s.io/pv/name:pvc-c6084d76-489b-4328-8015-2b8057b3f7d2 csi.storage.k8s.io/pvc/name:pvc3 csi.storage.k8s.io/pvc/namespace:test-ns csi.storage.k8s.io/sc/name:zonal-policy storagePolicyID:a59f887b-0090-4080-a493-7f317d0680ae] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:52.592524498Z","caller":"wcp/controller.go:511","msg":"Topology aware environment detected with requirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > ","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:52.593689993Z","caller":"k8sorchestrator/topology.go:1603","msg":"Clusters matching topology requirement \"zone-3\" are [domain-c58]","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:52.621863125Z","caller":"vsphere/utils.go:458","msg":"Found shared datastores: [Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-102, datastore URL: ds:///vmfs/volumes/849d576f-5fad88fa/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-50, datastore URL: ds:///vmfs/volumes/66ccd732-b59ff4e2-b345-020a0556f268/] and vSAN Direct datastores: []","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:52.622744005Z","caller":"k8sorchestrator/topology.go:1603","msg":"Clusters matching topology requirement \"zone-1\" are [domain-c52]","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:52.646388825Z","caller":"vsphere/utils.go:458","msg":"Found shared datastores: [Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-103, datastore URL: ds:///vmfs/volumes/81898aed-5dbc1134/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-51, datastore URL: ds:///vmfs/volumes/66ccd735-f4d1c216-6e55-020a0590c1ad/] and vSAN Direct datastores: []","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:52.647555672Z","caller":"k8sorchestrator/topology.go:1577","msg":"Shared datastores [Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-102, datastore URL: ds:///vmfs/volumes/849d576f-5fad88fa/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-50, datastore URL: ds:///vmfs/volumes/66ccd732-b59ff4e2-b345-020a0556f268/ Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-103, datastore URL: ds:///vmfs/volumes/81898aed-5dbc1134/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-51, datastore URL: ds:///vmfs/volumes/66ccd735-f4d1c216-6e55-020a0590c1ad/] for topologyRequirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > ","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:52.655613631Z","caller":"vsphere/utils.go:576","msg":"Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-102, datastore URL: ds:///vmfs/volumes/849d576f-5fad88fa/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-50, datastore URL: ds:///vmfs/volumes/66ccd732-b59ff4e2-b345-020a0556f268/ Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-103, datastore URL: ds:///vmfs/volumes/81898aed-5dbc1134/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-51, datastore URL: ds:///vmfs/volumes/66ccd735-f4d1c216-6e55-020a0590c1ad/]","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:52.884531671Z","caller":"volume/manager.go:574","msg":"QuotaInfo during CreateVolume call: {Reserved:1Gi StoragePolicyId:a59f887b-0090-4080-a493-7f317d0680ae StorageClassName:zonal-policy Namespace:test-ns AggregatedSnapshotSize:<nil> SnapshotLatestOperationCompleteTime:0001-01-01 00:00:00 +0000 UTC}","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:53.010969407Z","caller":"volume/listview.go:163","msg":"AddTask called for Task:task-7492","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:53.015060506Z","caller":"volume/listview.go:182","msg":"client is valid. trying to add task to listview object","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:53.019260884Z","caller":"volume/listview.go:204","msg":"task Task:task-7492 added to listView","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:54.165963766Z","caller":"volume/listview.go:233","msg":"client is valid. trying to remove task from listview object","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:54.173274063Z","caller":"volume/listview.go:238","msg":"task Task:task-7492 removed from listView","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:54.173897319Z","caller":"volume/manager.go:485","msg":"CreateVolume: VolumeName: \"pvc-c6084d76-489b-4328-8015-2b8057b3f7d2\", opId: \"d92d68c6\"","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:54.179724977Z","caller":"volume/util.go:329","msg":"Volume created successfully. VolumeName: \"pvc-c6084d76-489b-4328-8015-2b8057b3f7d2\", volumeID: \"0464c69c-b806-4f5e-ace6-d30859e3249c\"","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:54.181295891Z","caller":"volume/manager.go:635","msg":"Setting the reserved field for VolumeOperationDetails instance pvc-c6084d76-489b-4328-8015-2b8057b3f7d2 to 0","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:54.207064013Z","caller":"k8sorchestrator/topology.go:1724","msg":"Topology of the provisioned volume detected as [map[topology.kubernetes.io/zone:zone-1]]","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:54.214649756Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:205","msg":"creating cnsvolumeinfo for volumeID: \"0464c69c-b806-4f5e-ace6-d30859e3249c\", StoragePolicyID: \"a59f887b-0090-4080-a493-7f317d0680ae\", StorageClassName: \"zonal-policy\", vCenter: \"sc2-10-186-96-115.eng.vmware.com\", Capacity: {i:{value:1073741824 scale:0} d:{Dec:<nil>} s: Format:BinarySI} in the namespace: \"vmware-system-csi\"","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:54.241722251Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:234","msg":"Successfully created CNSVolumeInfo CR for volumeID: \"0464c69c-b806-4f5e-ace6-d30859e3249c\", StoragePolicyID: \"a59f887b-0090-4080-a493-7f317d0680ae\", StorageClassName: \"zonal-policy\", vCenter: \"sc2-10-186-96-115.eng.vmware.com\", Capacity: {i:{value:1073741824 scale:0} d:{Dec:<nil>} s: Format:BinarySI} mapping in the namespace: \"vmware-system-csi\"","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
{"level":"info","time":"2024-08-30T18:24:54.24177893Z","caller":"wcp/controller.go:1010","msg":"Volume created successfully. Volume Handle: \"0464c69c-b806-4f5e-ace6-d30859e3249c\", PV Name: \"pvc-c6084d76-489b-4328-8015-2b8057b3f7d2\"","TraceId":"a668ed5d-3cd5-4162-9e54-ace90d35ead7"}
```

**Volume provisioning on non-stretched supervisor with storage policy without zonal constraint on namespace confined to 1 zone**

PVC
```
Name:          pvc2
Namespace:     svc-tkg-domain-c52
StorageClass:  wcplocal-storage-profile
Status:        Bound
Volume:        pvc-24f7586d-b258-45c6-8a1d-076c16b34384
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"zone-1"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Fri Aug 30 10:02:33 UTC 2024
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:        <none>
```

PV
```
Name:              pvc-24f7586d-b258-45c6-8a1d-076c16b34384
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      wcplocal-storage-profile
Status:            Bound
Claim:             svc-tkg-domain-c52/pvc2
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.kubernetes.io/zone in [zone-1]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      e0e042bd-8e92-4658-b869-841b0b2494a5
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1725011073549-3327-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```


CSI logs
```
{"level":"info","time":"2024-08-30T10:02:29.695813133Z","caller":"wcp/controller.go:959","msg":"CreateVolume: called with args {Name:pvc-24f7586d-b258-45c6-8a1d-076c16b34384 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[csi.storage.k8s.io/pv/name:pvc-24f7586d-b258-45c6-8a1d-076c16b34384 csi.storage.k8s.io/pvc/name:pvc2 csi.storage.k8s.io/pvc/namespace:svc-tkg-domain-c52 csi.storage.k8s.io/sc/name:wcplocal-storage-profile storagePolicyID:ebf9949c-8ead-4d7d-a7d3-316854eea122] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:29.703408551Z","caller":"wcp/controller.go:511","msg":"Topology aware environment detected with requirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > ","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:29.703936102Z","caller":"k8sorchestrator/topology.go:1603","msg":"Clusters matching topology requirement \"zone-1\" are [domain-c52]","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:29.72064922Z","caller":"vsphere/utils.go:458","msg":"Found shared datastores: [Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-103, datastore URL: ds:///vmfs/volumes/81898aed-5dbc1134/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-51, datastore URL: ds:///vmfs/volumes/66ccd735-f4d1c216-6e55-020a0590c1ad/] and vSAN Direct datastores: []","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:29.721411602Z","caller":"k8sorchestrator/topology.go:1577","msg":"Shared datastores [Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-103, datastore URL: ds:///vmfs/volumes/81898aed-5dbc1134/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-51, datastore URL: ds:///vmfs/volumes/66ccd735-f4d1c216-6e55-020a0590c1ad/] for topologyRequirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > ","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:29.726533201Z","caller":"vsphere/utils.go:576","msg":"Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-103, datastore URL: ds:///vmfs/volumes/81898aed-5dbc1134/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-51, datastore URL: ds:///vmfs/volumes/66ccd735-f4d1c216-6e55-020a0590c1ad/]","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:29.79205228Z","caller":"volume/manager.go:574","msg":"QuotaInfo during CreateVolume call: {Reserved:1Gi StoragePolicyId:ebf9949c-8ead-4d7d-a7d3-316854eea122 StorageClassName:wcplocal-storage-profile Namespace:svc-tkg-domain-c52 AggregatedSnapshotSize:<nil> SnapshotLatestOperationCompleteTime:0001-01-01 00:00:00 +0000 UTC}","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:29.873369627Z","caller":"volume/listview.go:163","msg":"AddTask called for Task:task-6811","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:29.876957103Z","caller":"volume/listview.go:182","msg":"client is valid. trying to add task to listview object","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:29.885336846Z","caller":"volume/listview.go:204","msg":"task Task:task-6811 added to listView","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:30.309492666Z","caller":"volume/listview.go:233","msg":"client is valid. trying to remove task from listview object","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:30.313739159Z","caller":"volume/listview.go:238","msg":"task Task:task-6811 removed from listView","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:30.314161758Z","caller":"volume/manager.go:485","msg":"CreateVolume: VolumeName: \"pvc-24f7586d-b258-45c6-8a1d-076c16b34384\", opId: \"d92d3ee8\"","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:30.318741679Z","caller":"volume/util.go:329","msg":"Volume created successfully. VolumeName: \"pvc-24f7586d-b258-45c6-8a1d-076c16b34384\", volumeID: \"e0e042bd-8e92-4658-b869-841b0b2494a5\"","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:30.319417096Z","caller":"volume/manager.go:635","msg":"Setting the reserved field for VolumeOperationDetails instance pvc-24f7586d-b258-45c6-8a1d-076c16b34384 to 0","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:30.367952747Z","caller":"vsphere/utils.go:458","msg":"Found shared datastores: [Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-102, datastore URL: ds:///vmfs/volumes/849d576f-5fad88fa/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-50, datastore URL: ds:///vmfs/volumes/66ccd732-b59ff4e2-b345-020a0556f268/] and vSAN Direct datastores: []","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:30.368756821Z","caller":"k8sorchestrator/topology.go:1724","msg":"Topology of the provisioned volume detected as [map[topology.kubernetes.io/zone:zone-1]]","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:30.369260495Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:205","msg":"creating cnsvolumeinfo for volumeID: \"e0e042bd-8e92-4658-b869-841b0b2494a5\", StoragePolicyID: \"ebf9949c-8ead-4d7d-a7d3-316854eea122\", StorageClassName: \"wcplocal-storage-profile\", vCenter: \"sc2-10-186-96-115.eng.vmware.com\", Capacity: {i:{value:1073741824 scale:0} d:{Dec:<nil>} s: Format:BinarySI} in the namespace: \"vmware-system-csi\"","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:30.39281473Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:234","msg":"Successfully created CNSVolumeInfo CR for volumeID: \"e0e042bd-8e92-4658-b869-841b0b2494a5\", StoragePolicyID: \"ebf9949c-8ead-4d7d-a7d3-316854eea122\", StorageClassName: \"wcplocal-storage-profile\", vCenter: \"sc2-10-186-96-115.eng.vmware.com\", Capacity: {i:{value:1073741824 scale:0} d:{Dec:<nil>} s: Format:BinarySI} mapping in the namespace: \"vmware-system-csi\"","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
{"level":"info","time":"2024-08-30T10:02:30.392954236Z","caller":"wcp/controller.go:1010","msg":"Volume created successfully. Volume Handle: \"e0e042bd-8e92-4658-b869-841b0b2494a5\", PV Name: \"pvc-24f7586d-b258-45c6-8a1d-076c16b34384\"","TraceId":"13a2a81d-e0e3-4d05-ac83-a4a7aef63d22"}
```

**Volume provisioning on non-stretched supervisor with storage policy without zonal constraint compatible with shared datastores on namespace confined to 2 zones**
PVC
```
Name:          pvc4
Namespace:     svc-tkg-domain-c52
StorageClass:  wcplocal-storage-profile
Status:        Bound
Volume:        pvc-bc461dd1-1841-4485-abec-3e5d89f1247f
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"zone-1"},{"topology.kubernetes.io/zone":"zone-3"}]
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
               volumehealth.storage.kubernetes.io/health: accessible
               volumehealth.storage.kubernetes.io/health-timestamp: Fri Aug 30 18:36:08 UTC 2024
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age              From                                                                                          Message
  ----    ------                 ----             ----                                                                                          -------
  Normal  Provisioning           9s               csi.vsphere.vmware.com_420a4a5d5650ee55c4dbca2529576e9e_ba88659c-2300-4d72-bbad-61d42d7a6813  External provisioner is provisioning volume for claim "svc-tkg-domain-c52/pvc4"
  Normal  ExternalProvisioning   7s (x3 over 9s)  persistentvolume-controller                                                                   Waiting for a volume to be created either by the external provisioner 'csi.vsphere.vmware.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  ProvisioningSucceeded  7s               csi.vsphere.vmware.com_420a4a5d5650ee55c4dbca2529576e9e_ba88659c-2300-4d72-bbad-61d42d7a6813  Successfully provisioned volume pvc-bc461dd1-1841-4485-abec-3e5d89f1247f
```

PV:
```
Name:              pvc-bc461dd1-1841-4485-abec-3e5d89f1247f
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      wcplocal-storage-profile
Status:            Bound
Claim:             svc-tkg-domain-c52/pvc4
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.kubernetes.io/zone in [zone-1]
    Term 1:        topology.kubernetes.io/zone in [zone-3]
Message:           
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      ddd12989-909e-44bf-8e57-4b84b9f9293b
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=1725011073549-3327-csi.vsphere.vmware.com
                           type=vSphere CNS Block Volume
Events:                <none>
```

CSI logs
```
{"level":"info","time":"2024-08-30T18:36:04.054432662Z","caller":"wcp/controller.go:959","msg":"CreateVolume: called with args {Name:pvc-bc461dd1-1841-4485-abec-3e5d89f1247f CapacityRange:required_bytes:1073741824  VolumeCapabilities:[mount:<fs_type:\"ext4\" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[csi.storage.k8s.io/pv/name:pvc-bc461dd1-1841-4485-abec-3e5d89f1247f csi.storage.k8s.io/pvc/name:pvc4 csi.storage.k8s.io/pvc/namespace:svc-tkg-domain-c52 csi.storage.k8s.io/sc/name:wcplocal-storage-profile storagePolicyID:ebf9949c-8ead-4d7d-a7d3-316854eea122] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"febf8296-0801-441e-bb74-da23998a999"}
{"level":"info","time":"2024-08-30T18:36:04.061298858Z","caller":"wcp/controller.go:511","msg":"Topology aware environment detected with requirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > ","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:04.061772575Z","caller":"k8sorchestrator/topology.go:1603","msg":"Clusters matching topology requirement \"zone-1\" are [domain-c52]","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:04.076985286Z","caller":"vsphere/utils.go:458","msg":"Found shared datastores: [Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-103, datastore URL: ds:///vmfs/volumes/81898aed-5dbc1134/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-51, datastore URL: ds:///vmfs/volumes/66ccd735-f4d1c216-6e55-020a0590c1ad/] and vSAN Direct datastores: []","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:04.077480113Z","caller":"k8sorchestrator/topology.go:1603","msg":"Clusters matching topology requirement \"zone-3\" are [domain-c58]","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:04.09405772Z","caller":"vsphere/utils.go:458","msg":"Found shared datastores: [Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-102, datastore URL: ds:///vmfs/volumes/849d576f-5fad88fa/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-50, datastore URL: ds:///vmfs/volumes/66ccd732-b59ff4e2-b345-020a0556f268/] and vSAN Direct datastores: []","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:04.094812684Z","caller":"k8sorchestrator/topology.go:1577","msg":"Shared datastores [Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-103, datastore URL: ds:///vmfs/volumes/81898aed-5dbc1134/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-51, datastore URL: ds:///vmfs/volumes/66ccd735-f4d1c216-6e55-020a0590c1ad/ Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-102, datastore URL: ds:///vmfs/volumes/849d576f-5fad88fa/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-50, datastore URL: ds:///vmfs/volumes/66ccd732-b59ff4e2-b345-020a0556f268/] for topologyRequirement: requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > requisite:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-1\" > > preferred:<segments:<key:\"topology.kubernetes.io/zone\" value:\"zone-3\" > > ","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:04.100907952Z","caller":"vsphere/utils.go:576","msg":"Filtered list of datastores after removing suspended ones are: [Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-103, datastore URL: ds:///vmfs/volumes/81898aed-5dbc1134/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-51, datastore URL: ds:///vmfs/volumes/66ccd735-f4d1c216-6e55-020a0590c1ad/ Datastore: Datastore:datastore-101, datastore URL: ds:///vmfs/volumes/98d657cc-a2b77804/ Datastore: Datastore:datastore-102, datastore URL: ds:///vmfs/volumes/849d576f-5fad88fa/ Datastore: Datastore:datastore-48, datastore URL: ds:///vmfs/volumes/66ccd730-d1c0caa6-b945-020a0556f268/ Datastore: Datastore:datastore-50, datastore URL: ds:///vmfs/volumes/66ccd732-b59ff4e2-b345-020a0556f268/]","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:04.160280195Z","caller":"volume/manager.go:574","msg":"QuotaInfo during CreateVolume call: {Reserved:1Gi StoragePolicyId:ebf9949c-8ead-4d7d-a7d3-316854eea122 StorageClassName:wcplocal-storage-profile Namespace:svc-tkg-domain-c52 AggregatedSnapshotSize:<nil> SnapshotLatestOperationCompleteTime:0001-01-01 00:00:00 +0000 UTC}","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:04.277466632Z","caller":"volume/listview.go:163","msg":"AddTask called for Task:task-7513","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:04.282926692Z","caller":"volume/listview.go:182","msg":"client is valid. trying to add task to listview object","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:04.291452227Z","caller":"volume/listview.go:204","msg":"task Task:task-7513 added to listView","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:05.206735881Z","caller":"volume/listview.go:233","msg":"client is valid. trying to remove task from listview object","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:05.211334869Z","caller":"volume/listview.go:238","msg":"task Task:task-7513 removed from listView","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:05.211424333Z","caller":"volume/manager.go:485","msg":"CreateVolume: VolumeName: \"pvc-bc461dd1-1841-4485-abec-3e5d89f1247f\", opId: \"d92d69b6\"","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:05.221200942Z","caller":"volume/util.go:329","msg":"Volume created successfully. VolumeName: \"pvc-bc461dd1-1841-4485-abec-3e5d89f1247f\", volumeID: \"ddd12989-909e-44bf-8e57-4b84b9f9293b\"","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:05.221395933Z","caller":"volume/manager.go:635","msg":"Setting the reserved field for VolumeOperationDetails instance pvc-bc461dd1-1841-4485-abec-3e5d89f1247f to 0","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:05.288610623Z","caller":"k8sorchestrator/topology.go:1724","msg":"Topology of the provisioned volume detected as [map[topology.kubernetes.io/zone:zone-1] map[topology.kubernetes.io/zone:zone-3]]","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:05.28971056Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:205","msg":"creating cnsvolumeinfo for volumeID: \"ddd12989-909e-44bf-8e57-4b84b9f9293b\", StoragePolicyID: \"ebf9949c-8ead-4d7d-a7d3-316854eea122\", StorageClassName: \"wcplocal-storage-profile\", vCenter: \"sc2-10-186-96-115.eng.vmware.com\", Capacity: {i:{value:1073741824 scale:0} d:{Dec:<nil>} s: Format:BinarySI} in the namespace: \"vmware-system-csi\"","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:05.310251986Z","caller":"cnsvolumeinfo/cnsvolumeinfoservice.go:234","msg":"Successfully created CNSVolumeInfo CR for volumeID: \"ddd12989-909e-44bf-8e57-4b84b9f9293b\", StoragePolicyID: \"ebf9949c-8ead-4d7d-a7d3-316854eea122\", StorageClassName: \"wcplocal-storage-profile\", vCenter: \"sc2-10-186-96-115.eng.vmware.com\", Capacity: {i:{value:1073741824 scale:0} d:{Dec:<nil>} s: Format:BinarySI} mapping in the namespace: \"vmware-system-csi\"","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
{"level":"info","time":"2024-08-30T18:36:05.310358712Z","caller":"wcp/controller.go:1010","msg":"Volume created successfully. Volume Handle: \"ddd12989-909e-44bf-8e57-4b84b9f9293b\", PV Name: \"pvc-bc461dd1-1841-4485-abec-3e5d89f1247f\"","TraceId":"febf8296-0801-441e-bb74-da23998a9991"}
```





**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
WorkloadDomainIsolation: Volume provisioning support on single zone non-stretched supervisor
```
