### PR TITLE
Set CNS dev version for  CNS Client and Vim Client

### DIFF
--- a/pkg/syncer/storagepool/service.go
+++ b/pkg/syncer/storagepool/service.go
@@ -189,6 +189,24 @@ func ResetVC(ctx context.Context, vc *cnsvsphere.VirtualCenter) {
 		log.Errorf("Failed to connect to SPBM service. Err: %+v", err)
 		return
 	}
+	// TODO remove code to add version to CNS API, once CNS releases the next version.
+	if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.StorageQuotaM2) {
+		cnsDevVersion := "dev.version"
+		log.Infof("use version %s for vCenter client", cnsDevVersion)
+		if vc.Client != nil {
+			log.Infof("Setting version %s to vCenter: %q vim25 client",
+				cnsDevVersion, vc.Config.Host)
+			vc.Client.Version = cnsDevVersion
+		}
+		if vc.CnsClient != nil {
+			log.Infof("Setting version %s to vCenter: %q cns client",
+				cnsDevVersion, vc.Config.Host)
+			vc.CnsClient.Version = cnsDevVersion
+			vc.CnsClient.Client.Version = cnsDevVersion
+		}
+		log.Infof("using CNS API version %s for vCenters %q client ",
+			cnsDevVersion, vc.Config.Host)
+	}
 	log.Info("Resetting VC connection in StoragePool service")
 	defaultStoragePoolServiceLock.Lock()
 	defer defaultStoragePoolServiceLock.Unlock()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Set CNS dev version for  CNS Client and Vim Client on reset vc.

Version needs to be added on these client to be able to access CNS API's which are not a part of official release yet.
For Snapshot Storage Quota to get AggregatedSnapshotSize from cns we need to access CNS APIs with version
"dev.version".

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual testing performed

set version to vim and cns client after vc reset:
```
{"level":"info","time":"2024-08-22T02:11:57.646961307Z","caller":"volume/manager.go:398","msg":"Done resetting volume.defaultManager","TraceId":"22382eed-0245-4610-bcc4-771820115c04"}
{"level":"info","time":"2024-08-22T02:11:57.64825273Z","caller":"volume/manager.go:266","msg":"Retrieving existing defaultManager...","TraceId":"22382eed-0245-4610-bcc4-771820115c04"}
{"level":"info","time":"2024-08-22T02:11:57.649621039Z","caller":"volume/manager.go:247","msg":"use version dev.version for vCenter client","TraceId":"22382eed-0245-4610-bcc4-771820115c04"}
{"level":"info","time":"2024-08-22T02:11:57.649635663Z","caller":"volume/manager.go:249","msg":"Setting version dev.version to vCenter: \"sc2-10-43-174-15.nimbus.eng.vmware.com\" vim25 client","TraceId":"22382eed-0245-4610-bcc4-771820115c04"}
{"level":"info","time":"2024-08-22T02:11:57.649644812Z","caller":"volume/manager.go:259","msg":"using CNS API version dev.version for vCenters \"sc2-10-43-174-15.nimbus.eng.vmware.com\" client ","TraceId":"22382eed-0245-4610-bcc4-771820115c04"}
{"level":"info","time":"2024-08-22T02:11:57.653662185Z","caller":"storagepool/listener.go:125","msg":"Got 8 property collector update(s)","TraceId":"dac9ed4b-5839-45c0-8d49-871167c2f037","TraceId":"0566637d-371d-400f-86b2-3a33e39d8640"}
{"level":"info","time":"2024-08-22T02:11:57.653783038Z","caller":"storagepool/listener.go:212","msg":"Scheduled ReconcileAllStoragePools started","TraceId":"dac9ed4b-5839-45c0-8d49-871167c2f037","TraceId":"0566637d-371d-400f-86b2-3a33e39d8640"}
{"level":"info","time":"2024-08-22T02:11:57.684776107Z","caller":"volume/listview.go:101","msg":"created listView object ListView:session[52218d08-eb90-2a64-b258-c5602499e7c7]523b4c96-a35d-e0ce-da34-802fbd68a445 for virtualCenter: sc2-10-43-174-15.nimbus.eng.vmware.com","TraceId":"dac9ed4b-5839-45c0-8d49-871167c2f037"}
{"level":"info","time":"2024-08-22T02:11:57.685490538Z","caller":"volume/listview.go:238","msg":"Starting listening for task updates...","TraceId":"dac9ed4b-5839-45c0-8d49-871167c2f037"}
{"level":"info","time":"2024-08-22T02:11:57.695603895Z","caller":"storagepool/service.go:194","msg":"use version dev.version for vCenter client","TraceId":"22382eed-0245-4610-bcc4-771820115c04"}
{"level":"info","time":"2024-08-22T02:11:57.69581343Z","caller":"storagepool/service.go:196","msg":"Setting version dev.version to vCenter: \"sc2-10-43-174-15.nimbus.eng.vmware.com\" vim25 client","TraceId":"22382eed-0245-4610-bcc4-771820115c04"}
{"level":"info","time":"2024-08-22T02:11:57.696077466Z","caller":"storagepool/service.go:206","msg":"using CNS API version dev.version for vCenters \"sc2-10-43-174-15.nimbus.eng.vmware.com\" client ","TraceId":"22382eed-0245-4610-bcc4-771820115c04"}
{"level":"info","time":"2024-08-22T02:11:57.696291936Z","caller":"storagepool/service.go:210","msg":"Resetting VC connection in StoragePool service","TraceId":"22382eed-0245-4610-bcc4-771820115c04"}
{"level":"info","time":"2024-08-22T02:11:57.696385892Z","caller":"storagepool/service.go:239","msg":"Successfully reset VC connection in StoragePool service","TraceId":"22382eed-0245-4610-bcc4-771820115c04"}
```

after reset vc, creating snapshot CNS returned correct aggregated snapshot size.
```
root@42063a7859a50477ed44c75faeff345c [ ~ ]# k get pvc -A
NAMESPACE   NAME                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                VOLUMEATTRIBUTESCLASS   AGE
test-ns     example-vanilla-rwo-pvc2   Bound    pvc-7e76352d-57ea-4719-a1bc-d1036a1e49c7   5Gi        RWO            wcpglobal-storage-profile   <unset>                 13h
root@42063a7859a50477ed44c75faeff345c [ ~ ]# k apply -f snap2.yaml -n test-ns
volumesnapshot.snapshot.storage.k8s.io/example-vanilla-rwo-filesystem-snapshot2 created
root@42063a7859a50477ed44c75faeff345c [ ~ ]# k get volumesnapshot -A
NAMESPACE   NAME                                       READYTOUSE   SOURCEPVC                  SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS                SNAPSHOTCONTENT                                    CREATIONTIME   AGE
test-ns     example-vanilla-rwo-filesystem-snapshot2   false        example-vanilla-rwo-pvc2                                         volumesnapshotclass-delete   snapcontent-76cb5474-79ed-4014-b4ed-ee0e64313a1d                  16s
root@42063a7859a50477ed44c75faeff345c [ ~ ]# k get storagepolicyusage -n test-ns -o yaml
apiVersion: v1
items:
- apiVersion: cns.vmware.com/v1alpha2
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2024-08-21T15:15:27Z"
    generation: 1
    name: wcpglobal-storage-profile-pvc-usage
    namespace: test-ns
    resourceVersion: "962431"
    uid: 4448d905-03a4-45c6-9ed8-caf4c0377521
  spec:
    resourceApiGroup: ""
    resourceExtensionName: volume.cns.vsphere.vmware.com
    resourceKind: PersistentVolumeClaim
    storageClassName: wcpglobal-storage-profile
    storagePolicyId: 205749e7-1d99-43a7-a77f-aa72cab5bb15
  status:
    quotaUsage:
      reserved: "0"
      used: 5Gi
- apiVersion: cns.vmware.com/v1alpha2
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2024-08-21T19:24:55Z"
    generation: 3
    name: wcpglobal-storage-profile-snapshot-usage
    namespace: test-ns
    resourceVersion: "1443067"
    uid: d31077ec-195b-4c5e-b997-17d733535e57
  spec:
    resourceApiGroup: snapshot.storage.k8s.io
    resourceExtensionName: snapshot.cns.vsphere.vmware.com
    resourceKind: VolumeSnapshot
    storageClassName: wcpglobal-storage-profile
    storagePolicyId: 205749e7-1d99-43a7-a77f-aa72cab5bb15
  status:
    quotaUsage:
      reserved: 5Gi
      used: 274Mi
- apiVersion: cns.vmware.com/v1alpha2
  kind: StoragePolicyUsage
  metadata:
    creationTimestamp: "2024-08-21T15:13:16Z"
    generation: 1
    name: wcpglobal-storage-profile-storagepolicyquota-vm-usage
    namespace: test-ns
    ownerReferences:
    - apiVersion: cns.vmware.com/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: StoragePolicyQuota
      name: wcpglobal-storage-profile-storagepolicyquota
      uid: 1c49056a-d2c6-4445-8b65-a27be97e7a16
    resourceVersion: "939097"
    uid: 70843c10-0f3b-4007-ba5e-01b7048dbcbf
  spec:
    resourceApiGroup: cns.vmware.com
    resourceExtensionName: vmservice.cns.vsphere.vmware.com
    resourceKind: StoragePolicyQuota
    storageClassName: wcpglobal-storage-profile-storagepolicyquota
    storagePolicyId: 205749e7-1d99-43a7-a77f-aa72cab5bb15
  status: {}
kind: List
metadata:
  resourceVersion: ""
```

full syncer logs:
[syncer_logs_vc_reset.log](https://github.com/user-attachments/files/16705676/syncer_logs_vc_reset.log)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

syncer logs:

```release-note
Set CNS dev version for  CNS Client and Vim Client on reset vc
```
