### PR TITLE
Add new parameter "fileVolumeActivated" in vSphere CSI secret to indicate whether file service is enabled or not

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -197,6 +197,7 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 		QueryLimit:                  cfg.Global.QueryLimit,
 		ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
 		MigrationDataStoreURL:       cfg.VirtualCenter[host].MigrationDataStoreURL,
+		FileVolumeActivated:         cfg.VirtualCenter[host].FileVolumeActivated,
 	}
 
 	log.Debugf("Setting the queryLimit = %v, ListVolumeThreshold = %v", vcConfig.QueryLimit, vcConfig.ListVolumeThreshold)
@@ -242,6 +243,7 @@ func GetVirtualCenterConfigs(ctx context.Context, cfg *config.Config) ([]*Virtua
 			TargetvSANFileShareClusters: targetvSANClustersForFile,
 			QueryLimit:                  cfg.Global.QueryLimit,
 			ListVolumeThreshold:         cfg.Global.ListVolumeThreshold,
+			FileVolumeActivated:         cfg.VirtualCenter[vCenterIP].FileVolumeActivated,
 		}
 		if vcConfig.CAFile == "" {
 			vcConfig.CAFile = cfg.Global.CAFile

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -146,6 +146,8 @@ type VirtualCenterConfig struct {
 	// when ReloadVCConfigForNewClient is set to true it forces re-read config secret when
 	// new vc client needs to be created
 	ReloadVCConfigForNewClient bool
+	// FileVolumeActivated indicates whether file service has been enabled on any vSAN cluster or not
+	FileVolumeActivated bool
 }
 
 // NewClient creates a new govmomi Client instance.

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -155,6 +155,8 @@ type VirtualCenterConfig struct {
 	// MigrationDataStore specifies datastore which is set as default datastore in legacy cloud-config
 	// and hence should be used as default datastore.
 	MigrationDataStoreURL string `gcfg:"migration-datastore-url"`
+	// FileVolumeActivated indicates whether file service has been enabled on any vSAN cluster or not
+	FileVolumeActivated bool
 }
 
 // GCConfig contains information used by guest cluster to access a supervisor

--- a/tests/e2e/config.go
+++ b/tests/e2e/config.go
@@ -71,6 +71,8 @@ type e2eTestConfig struct {
 		SupervisorID string `gcfg:"supervisor-id"`
 		// targetvSANFileShareClusters
 		TargetVsanFileShareClusters string `gcfg:"targetvSANFileShareClusters"`
+		// fileVolumeActivated
+		FileVolumeActivated bool `gcfg:"fileVolumeActivated"`
 	}
 	// Multiple sets of Net Permissions applied to all file shares
 	// The string can uniquely represent each Net Permissions config

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -3176,6 +3176,9 @@ func readConfigFromSecretString(cfg string) (e2eTestConfig, error) {
 			config.Global.SupervisorID = value
 		case "targetvSANFileShareClusters":
 			config.Global.TargetVsanFileShareClusters = value
+		case "fileVolumeActivated":
+			config.Global.FileVolumeActivated, strconvErr = strconv.ParseBool(value)
+			gomega.Expect(strconvErr).NotTo(gomega.HaveOccurred())
 		case "ips":
 			netPerm.Ips = value
 		case "permissions":


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This MR adds new parameter "fileVolumeActivated" per VC in vSphere CSI secret to indicate whether file service is enabled or not within that VC or not.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Tested the change manually as below 

1. CSI secret does not contain new parameter, parameter value read as false by default

```
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]# k get pods -n vmware-system-csi
NAME                                      READY   STATUS    RESTARTS      AGE
vsphere-csi-controller-559b4bbf65-9gkjg   7/7     Running   0             29s
vsphere-csi-controller-559b4bbf65-hs9cj   7/7     Running   0             19s
vsphere-csi-webhook-86bc689bd-b4klt       1/1     Running   1 (14d ago)   21d
vsphere-csi-webhook-86bc689bd-lkdvq       1/1     Running   2 (14d ago)   21d
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]#

root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]# k get secret -n vmware-system-csi vsphere-config-secret -o yaml
apiVersion: v1
data:
  vsphere-cloud-provider.conf: W0dsb2JhbF0KaW5zZWN1cmUtZmxhZyA9ICJmYWxzZSIKY2EtZmlsZSA9ICIvZXRjL3Ztd2FyZS93Y3AvdGxzL3ZtY2EucGVtIgpjbHVzdGVyLWlkID0gImRvbWFpbi1jNTIiCnN1cGVydmlzb3ItaWQgPSAiNTkyZWQ0YzMtNWM4ZS00MzM1LTkyMDctMTYxYWIxODA3ODY5IgpjbnNyZWdpc3RlcnZvbHVtZXMtY2xlYW51cC1pbnRlcnZhbGlubWluID0gNzIwCmNsdXN0ZXItZGlzdHJpYnV0aW9uID0gIlN1cGVydmlzb3JDbHVzdGVyIgpbVmlydHVhbENlbnRlciAic2MyLTEwLTI0My0xNDctMTg2Lm5pbWJ1cy5lbmcudm13YXJlLmNvbSJdCnVzZXIgPSAid2NwLXN0b3JhZ2UtdXNlci01OTJlZDRjMy01YzhlLTQzMzUtOTIwNy0xNjFhYjE4MDc4NjktYTgwOWRlZTktMzg4ZS00YTFmLTk0ZTMtNzkyOTNlOTNiMTIzQHZzcGhlcmUubG9jYWwiCnBhc3N3b3JkID0gIl1kS3MjPzNgRDxwXFxLLUlUajkmZiIKZGF0YWNlbnRlcnMgPSAiZGF0YWNlbnRlci00MCIKcG9ydCA9ICI0NDMiCnRhcmdldHZTQU5GaWxlU2hhcmVDbHVzdGVycyA9ICIiCg==
kind: Secret
metadata:
  creationTimestamp: "2024-07-31T11:01:35Z"
  name: vsphere-config-secret
  namespace: vmware-system-csi
  resourceVersion: "6041522"
  uid: 025ed8fb-5ab4-4301-bc6f-5cbeadb7a268
type: Opaque
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]#
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]#
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]#
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]# echo W0dsb2JhbF0KaW5zZWN1cmUtZmxhZyA9ICJmYWxzZSIKY2EtZmlsZSA9ICIvZXRjL3Ztd2FyZS93Y3AvdGxzL3ZtY2EucGVtIgpjbHVzdGVyLWlkID0gImRvbWFpbi1jNTIiCnN1cGVydmlzb3ItaWQgPSAiNTkyZWQ0YzMtNWM4ZS00MzM1LTkyMDctMTYxYWIxODA3ODY5IgpjbnNyZWdpc3RlcnZvbHVtZXMtY2xlYW51cC1pbnRlcnZhbGlubWluID0gNzIwCmNsdXN0ZXItZGlzdHJpYnV0aW9uID0gIlN1cGVydmlzb3JDbHVzdGVyIgpbVmlydHVhbENlbnRlciAic2MyLTEwLTI0My0xNDctMTg2Lm5pbWJ1cy5lbmcudm13YXJlLmNvbSJdCnVzZXIgPSAid2NwLXN0b3JhZ2UtdXNlci01OTJlZDRjMy01YzhlLTQzMzUtOTIwNy0xNjFhYjE4MDc4NjktYTgwOWRlZTktMzg4ZS00YTFmLTk0ZTMtNzkyOTNlOTNiMTIzQHZzcGhlcmUubG9jYWwiCnBhc3N3b3JkID0gIl1kS3MjPzNgRDxwXFxLLUlUajkmZiIKZGF0YWNlbnRlcnMgPSAiZGF0YWNlbnRlci00MCIKcG9ydCA9ICI0NDMiCnRhcmdldHZTQU5GaWxlU2hhcmVDbHVzdGVycyA9ICIiCg== | base64 -d
[Global]
insecure-flag = "false"
ca-file = "/etc/vmware/wcp/tls/vmca.pem"
cluster-id = "domain-c52"
supervisor-id = "592ed4c3-5c8e-4335-9207-161ab1807869"
cnsregistervolumes-cleanup-intervalinmin = 720
cluster-distribution = "SupervisorCluster"
[VirtualCenter "sc2-10-243-147-186.nimbus.eng.vmware.com"]
user = "wcp-storage-user-592ed4c3-5c8e-4335-9207-161ab1807869-a809dee9-388e-4a1f-94e3-79293e93b123@vsphere.local"
password = "]dKs#?3`D<p\\K-ITj9&f"
datacenters = "datacenter-40"
port = "443"
targetvSANFileShareClusters = ""            <<< secret does not contain new parameter
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]#

root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]# k logs -n vmware-system-csi  vsphere-csi-controller-559b4bbf65-9gkjg -c vsphere-csi-controller | grep File
{"level":"info","time":"2024-08-21T11:31:07.542068014Z","caller":"vsphere/utils.go:203","msg":"Setting the FileVolumeActivated false","TraceId":"786a93e4-9a53-423b-9ae9-a8a62234feb7"}    << temporary logs added show the actual value set
{"level":"info","time":"2024-08-21T11:31:07.59923453Z","caller":"vsphere/utils.go:255","msg":"1 Setting the FileVolumeActivated false","TraceId":"786a93e4-9a53-423b-9ae9-a8a62234feb7"}
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]#

```
2. CSI secret added with new parameter with value "true" and restarted CSI to read new config for now

```
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]# kubectl edit -n vmware-system-csi secret vsphere-config-secret
secret/vsphere-config-secret edited

root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]# k get secret -n vmware-system-csi vsphere-config-secret -o yaml
apiVersion: v1
data:
  vsphere-cloud-provider.conf: W0dsb2JhbF0KaW5zZWN1cmUtZmxhZyA9ICJmYWxzZSIKY2EtZmlsZSA9ICIvZXRjL3Ztd2FyZS93Y3AvdGxzL3ZtY2EucGVtIgpjbHVzdGVyLWlkID0gImRvbWFpbi1jNTIiCnN1cGVydmlzb3ItaWQgPSAiNTkyZWQ0YzMtNWM4ZS00MzM1LTkyMDctMTYxYWIxODA3ODY5IgpjbnNyZWdpc3RlcnZvbHVtZXMtY2xlYW51cC1pbnRlcnZhbGlubWluID0gNzIwCmNsdXN0ZXItZGlzdHJpYnV0aW9uID0gIlN1cGVydmlzb3JDbHVzdGVyIgpbVmlydHVhbENlbnRlciAic2MyLTEwLTI0My0xNDctMTg2Lm5pbWJ1cy5lbmcudm13YXJlLmNvbSJdCnVzZXIgPSAid2NwLXN0b3JhZ2UtdXNlci01OTJlZDRjMy01YzhlLTQzMzUtOTIwNy0xNjFhYjE4MDc4NjktYTgwOWRlZTktMzg4ZS00YTFmLTk0ZTMtNzkyOTNlOTNiMTIzQHZzcGhlcmUubG9jYWwiCnBhc3N3b3JkID0gIl1kS3MjPzNgRDxwXFxLLUlUajkmZiIKZGF0YWNlbnRlcnMgPSAiZGF0YWNlbnRlci00MCIKcG9ydCA9ICI0NDMiCmZpbGVWb2x1bWVBY3RpdmF0ZWQgPSAidHJ1ZSIK
kind: Secret
metadata:
  creationTimestamp: "2024-07-31T11:01:35Z"
  name: vsphere-config-secret
  namespace: vmware-system-csi
  resourceVersion: "19535067"
  uid: 025ed8fb-5ab4-4301-bc6f-5cbeadb7a268
type: Opaque
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]#
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]#
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]# echo W0dsb2JhbF0KaW5zZWN1cmUtZmxhZyA9ICJmYWxzZSIKY2EtZmlsZSA9ICIvZXRjL3Ztd2FyZS93Y3AvdGxzL3ZtY2EucGVtIgpjbHVzdGVyLWlkID0gImRvbWFpbi1jNTIiCnN1cGVydmlzb3ItaWQgPSAiNTkyZWQ0YzMtNWM4ZS00MzM1LTkyMDctMTYxYWIxODA3ODY5IgpjbnNyZWdpc3RlcnZvbHVtZXMtY2xlYW51cC1pbnRlcnZhbGlubWluID0gNzIwCmNsdXN0ZXItZGlzdHJpYnV0aW9uID0gIlN1cGVydmlzb3JDbHVzdGVyIgpbVmlydHVhbENlbnRlciAic2MyLTEwLTI0My0xNDctMTg2Lm5pbWJ1cy5lbmcudm13YXJlLmNvbSJdCnVzZXIgPSAid2NwLXN0b3JhZ2UtdXNlci01OTJlZDRjMy01YzhlLTQzMzUtOTIwNy0xNjFhYjE4MDc4NjktYTgwOWRlZTktMzg4ZS00YTFmLTk0ZTMtNzkyOTNlOTNiMTIzQHZzcGhlcmUubG9jYWwiCnBhc3N3b3JkID0gIl1kS3MjPzNgRDxwXFxLLUlUajkmZiIKZGF0YWNlbnRlcnMgPSAiZGF0YWNlbnRlci00MCIKcG9ydCA9ICI0NDMiCmZpbGVWb2x1bWVBY3RpdmF0ZWQgPSAidHJ1ZSIK | base64 -d
[Global]
insecure-flag = "false"
ca-file = "/etc/vmware/wcp/tls/vmca.pem"
cluster-id = "domain-c52"
supervisor-id = "592ed4c3-5c8e-4335-9207-161ab1807869"
cnsregistervolumes-cleanup-intervalinmin = 720
cluster-distribution = "SupervisorCluster"
[VirtualCenter "sc2-10-243-147-186.nimbus.eng.vmware.com"]
user = "wcp-storage-user-592ed4c3-5c8e-4335-9207-161ab1807869-a809dee9-388e-4a1f-94e3-79293e93b123@vsphere.local"
password = "]dKs#?3`D<p\\K-ITj9&f"
datacenters = "datacenter-40"
port = "443"
fileVolumeActivated = "true"

root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]# k logs -n vmware-system-csi  vsphere-csi-controller-559b4bbf65-9r2rg -c vsphere-csi-controller | grep File
{"level":"info","time":"2024-08-21T11:38:34.828679234Z","caller":"vsphere/utils.go:203","msg":"Setting the FileVolumeActivated true","TraceId":"6bfb9d74-8186-4384-905d-79c8e33cee4a"}
{"level":"info","time":"2024-08-21T11:38:34.883717404Z","caller":"vsphere/utils.go:255","msg":"1 Setting the FileVolumeActivated true","TraceId":"6bfb9d74-8186-4384-905d-79c8e33cee4a"}
root@420ee418f8a14fbab7ec796287d55f8f [ ~ ]#
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add new parameter "fileVolumeActivated" in vSphere CSI secret to indicate whether file service is enabled or not
```
