### PR TITLE
Increase probe-timeout to avoid CrashloopBackoff

### DIFF
--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -535,6 +535,7 @@ spec:
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
+            - "--probe-timeout=4s"
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
@@ -677,6 +678,7 @@ spec:
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
+            - "--probe-timeout=4s"
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION
Also ensure probe-timeout of the liveness-probe container is shorter than livenessProbe of the vsphere-csi-node container (5s)

**What this PR does / why we need it**:

Without this, if the socket probe takes too long, another livenessProbe check is started while the previous is not finished. Liveness probe requests pile up until the container liveness-probe failed in CrashLoopBackoff

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:

Yes (deployed since a few months)

**Special notes for your reviewer**:

**Release note**:
```release-note
Increase probe-timeout to avoid CrashloopBackoff
```
