### PR TITLE
Update CSI snapshotter version to latest in supervisor cns-csi.yaml

### DIFF
--- a/manifests/supervisorcluster/1.26/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.26/cns-csi.yaml
@@ -409,7 +409,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: csi-snapshotter
-          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.6
+          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.7
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -413,7 +413,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: csi-snapshotter
-          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.6
+          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.7
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -413,7 +413,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: csi-snapshotter
-          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.6
+          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.7
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -413,7 +413,7 @@ spec:
             - mountPath: /etc/vmware/wcp/tls/
               name: host-vmca
         - name: csi-snapshotter
-          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.6
+          image: localhost:5000/vmware.io/csi-snapshotter:v6.1.0_vmware.7
           args:
             - "--v=4"
             - "--timeout=300s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
With recent changes in external snapshotter build script, its version was incremented to v6.1.0+vmware.7 but cns-csi.yaml installed on WCP setup were using old version v6.1.0+vmware.6 in csi-snapshotter image, that failed to start the sidecars on WCP setup.
Fixing the version in cns-csi.yaml to look for correct image version for csi-snapshotter

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Checked live setup where csi-snapshotter always remained in ImagePullBackOff due to this issue, after updating the yaml locally, sidecar came up successfully

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update CSI snapshotter version to latest in supervisor cns-csi.yaml
```
