### PR TITLE
fix fullSyncGetQueryResults function to use batch of volumeIds for query

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -34,6 +34,9 @@ const (
 	// However, using that constant creates an import cycle.
 	// TODO: Refactor to move all the constants into a top level directory.
 	DefaultQuerySnapshotLimit = int64(128)
+	// queryVolumeLimit is the page size, which should be set in the cursor when driver needs to
+	// query many volumes using QueryVolume API
+	queryVolumeLimit = int64(1000)
 )
 
 // QueryVolumeUtil helps to invoke query volume API based on the feature
@@ -256,7 +259,6 @@ func LogoutAllvCenterSessions(ctx context.Context) {
 func QueryAllVolumesForCluster(ctx context.Context, m cnsvolume.Manager, clusterID string,
 	querySelection cnstypes.CnsQuerySelection) (*cnstypes.CnsQueryResult, error) {
 	log := logger.GetLogger(ctx)
-	var queryVolumeLimit = int64(500)
 	queryFilter := cnstypes.CnsQueryFilter{
 		ContainerClusterIds: []string{clusterID},
 		Cursor: &cnstypes.CnsCursor{

--- a/pkg/syncer/types.go
+++ b/pkg/syncer/types.go
@@ -38,10 +38,6 @@ const (
 	// default interval for csi full sync, used unless overridden by user in csi-controller YAML
 	defaultFullSyncIntervalInMin = 30
 
-	// queryVolumeLimit is the page size, which should be set in the cursor when syncer container need to
-	// query many volumes using QueryVolume API
-	queryVolumeLimit = int64(500)
-
 	// key for HealthStatus annotation on PVC
 	annVolumeHealth = "volumehealth.storage.kubernetes.io/health"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix fullSyncGetQueryResults function to use batch of volumeIds for query

API is updated to fail if more than 1000 volumes supplied.
There is a possibility that QueryVolume API can be called with more than 1000 volumeIDs.

For now keeping batch size to 500 to ensure we do not see sql core dump on the server side during query.




**Testing done**:
Verified full sync is happening without any regression on the setup with 50k volumes.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix fullSyncGetQueryResults function to use batch of volumeIds for query
```
