### PR TITLE
Allow provision RWM volume on the requested zone provided by topology requirements in WCP

### DIFF
--- a/pkg/common/unittestcommon/utils.go
+++ b/pkg/common/unittestcommon/utils.go
@@ -72,6 +72,8 @@ func GetFakeContainerOrchestratorInterface(orchestratorType int) (commonco.COCom
 				"multi-vcenter-csi-topology":        "true",
 				"listview-tasks":                    "true",
 				"storage-quota-m2":                  "false",
+				// Adding FSS from `wcp-cluster-capabilities` configmap in supervisor here for simplicity.
+				"Workload_Domain_Isolation_Supported": "true",
 			},
 		}
 		return fakeCO, nil
@@ -420,11 +422,12 @@ func configFromVCSimWithTLS(tlsConfig *tls.Config, vcsimParams VcsimParams, inse
 
 	cfg.VirtualCenter = make(map[string]*config.VirtualCenterConfig)
 	cfg.VirtualCenter[s.URL.Hostname()] = &config.VirtualCenterConfig{
-		User:         cfg.Global.User,
-		Password:     cfg.Global.Password,
-		VCenterPort:  cfg.Global.VCenterPort,
-		InsecureFlag: cfg.Global.InsecureFlag,
-		Datacenters:  cfg.Global.Datacenters,
+		User:                cfg.Global.User,
+		Password:            cfg.Global.Password,
+		VCenterPort:         cfg.Global.VCenterPort,
+		InsecureFlag:        cfg.Global.InsecureFlag,
+		Datacenters:         cfg.Global.Datacenters,
+		FileVolumeActivated: true, // Set FileVolumeActivated to true to test Workload_Domain_Isolation support
 	}
 
 	// set up the default global maximum of number of snapshots if unset

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -1846,7 +1846,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 				}
 				// TODO: Few errors encountered in CreateFileVolumeUtil can be retried instead of
 				// moving unto next VC. Need to throw a custom error for such scenarios.
-				volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
+				volumeInfo, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
 					vcenter, c.managers.VolumeManagers[vcHost], c.managers.CnsConfig, &createVolumeSpec,
 					fsEnabledCandidateDatastores, filterSuspendedDatastores, false, nil)
 				if err != nil {
@@ -1854,6 +1854,7 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 					combinedErrMssgs = append(combinedErrMssgs, err.Error())
 					continue
 				}
+				volumeID = volumeInfo.VolumeID.Id
 				log.Infof("volume %q created in vCenter %q.", volumeID, vcHost)
 
 				// In case task was successful from previous run but the CR was not created.
@@ -1903,26 +1904,28 @@ func (c *controller) createFileVolume(ctx context.Context, req *csi.CreateVolume
 					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 						"failed to get vCenter instance for host %q. Error: %+v", vcHost, err)
 				}
-				volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
+				volumeInfo, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
 					vcenter, c.managers.VolumeManagers[vcHost], c.managers.CnsConfig, &createVolumeSpec,
 					filteredDatastores, filterSuspendedDatastores, false, nil)
 				if err != nil {
 					return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 						"failed to create volume. Error: %+v", err)
 				}
+				volumeID = volumeInfo.VolumeID.Id
 			} else {
 				vcenter, err = c.manager.VcenterManager.GetVirtualCenter(ctx, c.manager.VcenterConfig.Host)
 				if err != nil {
 					return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 						"failed to get vCenter. Error: %+v", err)
 				}
-				volumeID, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
+				volumeInfo, faultType, err = common.CreateFileVolumeUtil(ctx, cnstypes.CnsClusterFlavorVanilla,
 					vcenter, c.manager.VolumeManager, c.manager.CnsConfig, &createVolumeSpec,
 					filteredDatastores, filterSuspendedDatastores, false, nil)
 				if err != nil {
 					return nil, faultType, logger.LogNewErrorCodef(log, codes.Internal,
 						"failed to create volume. Error: %+v", err)
 				}
+				volumeID = volumeInfo.VolumeID.Id
 			}
 		}
 	}

--- a/pkg/csi/service/wcpguest/controller.go
+++ b/pkg/csi/service/wcpguest/controller.go
@@ -302,8 +302,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 			if errors.IsNotFound(err) {
 				diskSize := strconv.FormatInt(volSizeMB, 10) + "Mi"
 				var annotations map[string]string
-				if !isFileVolumeRequest && commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
-					req.AccessibilityRequirements != nil {
+				if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
+					req.AccessibilityRequirements != nil &&
+					(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolation) ||
+						!isFileVolumeRequest) {
 					// Generate volume topology requirement annotation.
 					annotations = make(map[string]string)
 					topologyAnnotation, err := generateGuestClusterRequestedTopologyJSON(req.AccessibilityRequirements.Preferred)
@@ -396,8 +398,10 @@ func (c *controller) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequ
 
 		// Calculate node affinity terms for topology aware provisioning.
 		var accessibleTopologies []map[string]string
-		if !isFileVolumeRequest && commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
-			req.AccessibilityRequirements != nil {
+		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) &&
+			req.AccessibilityRequirements != nil &&
+			(commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolation) ||
+				!isFileVolumeRequest) {
 			// Retrieve the latest version of the PVC
 			pvc, err = c.supervisorClient.CoreV1().PersistentVolumeClaims(c.supervisorNamespace).Get(
 				ctx, supervisorPVCName, metav1.GetOptions{})

--- a/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsfileaccessconfig/cnsfileaccessconfig_controller.go
@@ -86,7 +86,8 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 				log.Errorf("failed to get clusterComputeResourceMoIds. err: %v", err)
 				return err
 			}
-			if len(clusterComputeResourceMoIds) > 1 {
+			if len(clusterComputeResourceMoIds) > 1 &&
+				!commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.WorkloadDomainIsolation) {
 				log.Infof("Not initializing the CnsFileAccessConfig Controller as stretched supervisor is detected.")
 				return nil
 			}

--- a/pkg/syncer/cnsoperator/manager/init.go
+++ b/pkg/syncer/cnsoperator/manager/init.go
@@ -219,7 +219,7 @@ func InitCnsOperator(ctx context.Context, clusterFlavor cnstypes.CnsClusterFlavo
 			}
 		}
 
-		if !stretchedSupervisor {
+		if !stretchedSupervisor || (stretchedSupervisor && syncer.IsWorkloadDomainIsolationSupported) {
 			if cnsOperator.coCommonInterface.IsFSSEnabled(ctx, common.FileVolume) {
 				// Create CnsFileAccessConfig CRD from manifest if file volume feature
 				// is enabled.

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -105,6 +105,9 @@ var (
 
 	// isStorageQuotaM2FSSEnabled is true if the Snapshot Storage Quota feature is enabled, false otherwise.
 	isStorageQuotaM2FSSEnabled bool
+
+	// IsWorkloadDomainIsolationSupported is true when Workload_Domain_Isolation_Supported FSS is enabled.
+	IsWorkloadDomainIsolationSupported bool
 )
 
 const (
@@ -209,6 +212,8 @@ func InitMetadataSyncer(ctx context.Context, clusterFlavor cnstypes.CnsClusterFl
 		IsMigrationEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.CSIMigration)
 	}
 	isStorageQuotaM2FSSEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.StorageQuotaM2)
+	IsWorkloadDomainIsolationSupported = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.WorkloadDomainIsolation)
 	// Create the kubernetes client from config.
 	k8sClient, err := k8s.NewClient(ctx)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR includes changes to allow provision RWM volume on the requested zone provided by topology requirements in WCP, when workload domain isolation FSS is enabled.
There are certain changes needed from https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/2985, which will complete the overall changes needed for RWM support in multi-zone cluster

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Added unittests to verify the changes, that passed successfully

Testcase in GC controller
```
=== RUN   TestGuestClusterControllerFlowForWorkloadDomainIsolation
{"level":"info","time":"2024-08-31T10:03:39.142563984+05:30","caller":"wcpguest/controller.go:249","msg":"CreateVolume: called with args {Name:pvc-12345 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[svstorageclass:test-storageclass] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:requisite:<segments:<key:\"R1\" value:\"Zone1\" > > preferred:<segments:<key:\"R1\" value:\"Zone1\" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"bfa07701-73bf-43e1-8b79-6a967d77473b"}
{"level":"info","time":"2024-08-31T10:03:39.142805301+05:30","caller":"wcpguest/controller_helper.go:309","msg":"Waiting up to 240 seconds for PersistentVolumeClaim -12345 in namespace test-namespace to have phase Bound","TraceId":"bfa07701-73bf-43e1-8b79-6a967d77473b"}
{"level":"info","time":"2024-08-31T10:03:40.14220787+05:30","caller":"wcpguest/controller_helper.go:333","msg":"PersistentVolumeClaim -12345 in namespace test-namespace is in state Bound","TraceId":"bfa07701-73bf-43e1-8b79-6a967d77473b"}
{"level":"info","time":"2024-08-31T10:03:40.142395154+05:30","caller":"wcpguest/controller.go:421","msg":"Volume \"-12345\" created is accessible from zones: [map[R1:Zone1]]","TraceId":"bfa07701-73bf-43e1-8b79-6a967d77473b"}
{"level":"info","time":"2024-08-31T10:03:40.142431515+05:30","caller":"wcpguest/controller.go:446","msg":"Volume created successfully. Volume Handle: \"-12345\", PV Name: \"pvc-12345\"","TraceId":"bfa07701-73bf-43e1-8b79-6a967d77473b"}
    controller_test.go:404: AccessibleTopology was correctly set in create volume response
{"level":"info","time":"2024-08-31T10:03:40.143824679+05:30","caller":"wcpguest/controller.go:465","msg":"DeleteVolume: called with args: {VolumeId:-12345 Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"a5483328-2d6e-425c-908b-939801c9623b"}
{"level":"info","time":"2024-08-31T10:03:40.143947333+05:30","caller":"wcpguest/controller.go:510","msg":"DeleteVolume: Volume deleted successfully. VolumeID: \"-12345\"","TraceId":"a5483328-2d6e-425c-908b-939801c9623b"}
{"level":"info","time":"2024-08-31T10:03:40.143971492+05:30","caller":"wcpguest/controller.go:525","msg":"Volume \"-12345\" deleted successfully.","TraceId":"a5483328-2d6e-425c-908b-939801c9623b"}
--- PASS: TestGuestClusterControllerFlowForWorkloadDomainIsolation (2.00s)
```

Testcase in WCP controller - only negative scenarios as unittesting framework needs to be enhanced for file volume support

```
=== RUN   TestWCPCreateVolumeWithoutZoneLabelPresentForFileVolume
{"level":"info","time":"2024-08-31T16:09:52.521845996+05:30","caller":"wcp/controller.go:1135","msg":"CreateVolume: called with args {Name:test-pvc-1451bd23-8c2c-4e3d-9671-61c8f25c0745 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[storagepolicyid:aa6d5a82-1c88-45da-85d3-3d74b91a5bad] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements: MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"f36c97a4-0e83-4d9f-838c-658b141a8b32"}                                                             {"level":"error","time":"2024-08-31T16:09:52.521877939+05:30","caller":"wcp/controller.go:979","msg":"volume provisioning request received without topologyRequirement.","TraceId":"f36c97a4-0e83-4d9f-838c-658b141a8b32","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).createFileVolume\n\t/home/pansea/csi-src/vsphere-csi-driver/pkg/csi/service/wcp/controller.go:979\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).CreateVolume.func1\n\t/home/pansea/csi-src/vsphere-csi-driver/pkg/csi/service/wcp/controller.go:1179\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).CreateVolume\n\t/home/pansea/csi-src/vsphere-csi-driver/pkg/csi/service/wcp/controller.go:1183\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.TestWCPCreateVolumeWithoutZoneLabelPresentForFileVolume\n\t/home/pansea/csi-src/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:404\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1595"}
{"level":"error","time":"2024-08-31T16:09:52.521899509+05:30","caller":"wcp/controller.go:1190","msg":"Operation failed, reporting failure status to Prometheus. Operation Type: \"create-volume\", Volume Type: \"file\", Fault Type: \"csi.fault.Internal\"","TraceId":"f36c97a4-0e83-4d9f-838c-658b141a8b32","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).CreateVolume\n\t/home/pansea/csi-src/vsphere-csi-driver/pkg/csi/service/wcp/controller.go:1190\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.TestWCPCreateVolumeWithoutZoneLabelPresentForFileVolume\n\t/home/pansea/csi-src/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:404\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1595"}
    controller_test.go:406: expected error is thrown: rpc error: code = FailedPrecondition desc = volume provisioning request received without topologyRequirement.
--- PASS: TestWCPCreateVolumeWithoutZoneLabelPresentForFileVolume (0.00s)

=== RUN   TestWCPCreateVolumeWithHostLabelPresentForFileVolume
{"level":"info","time":"2024-08-31T16:09:52.526621865+05:30","caller":"wcp/controller.go:1135","msg":"CreateVolume: called with args {Name:test-pvc-8327d65b-6d02-453e-a0d5-1946e8bc4ac3 CapacityRange:required_bytes:1073741824  VolumeCapabilities:[access_mode:<mode:MULTI_NODE_MULTI_WRITER > ] Parameters:map[storagepolicyid:aa6d5a82-1c88-45da-85d3-3d74b91a5bad] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:preferred:<segments:<key:\"kubernetes.io/hostname\" value:\"host1\" > >  MutableParameters:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}","TraceId":"9a7a98c8-cdfd-4f00-b18e-52a79c5ecf72"}
{"level":"error","time":"2024-08-31T16:09:52.526706824+05:30","caller":"wcp/controller.go:971","msg":"support for topology requirement with hostname labels is not yet implemented ","TraceId":"9a7a98c8-cdfd-4f00-b18e-52a79c5ecf72","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).createFileVolume\n\t/home/pansea/csi-src/vsphere-csi-driver/pkg/csi/service/wcp/controller.go:971\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).CreateVolume.func1\n\t/home/pansea/csi-src/vsphere-csi-driver/pkg/csi/service/wcp/controller.go:1179\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).CreateVolume\n\t/home/pansea/csi-src/vsphere-csi-driver/pkg/csi/service/wcp/controller.go:1183\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.TestWCPCreateVolumeWithHostLabelPresentForFileVolume\n\t/home/pansea/csi-src/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:501\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1595"}
{"level":"error","time":"2024-08-31T16:09:52.526741577+05:30","caller":"wcp/controller.go:1190","msg":"Operation failed, reporting failure status to Prometheus. Operation Type: \"create-volume\", Volume Type: \"file\", Fault Type: \"csi.fault.Internal\"","TraceId":"9a7a98c8-cdfd-4f00-b18e-52a79c5ecf72","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.(*controller).CreateVolume\n\t/home/pansea/csi-src/vsphere-csi-driver/pkg/csi/service/wcp/controller.go:1190\nsigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/wcp.TestWCPCreateVolumeWithHostLabelPresentForFileVolume\n\t/home/pansea/csi-src/vsphere-csi-driver/pkg/csi/service/wcp/controller_test.go:501\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1595"}
    controller_test.go:503: expected error is thrown: rpc error: code = Unimplemented desc = support for topology requirement with hostname labels is not yet implemented
--- PASS: TestWCPCreateVolumeWithHostLabelPresentForFileVolume (0.00s)
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Allow provision RWM volume on the requested zone provided by topology requirements in WCP when multiple zones are present with workload domain isolation
```
