### PR TITLE
Bug fix: static volume provision fails with panic while updating storagepolicyusage

### DIFF
--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -537,7 +537,8 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 
 			// Patch an increase of "reserved" in storagePolicyUsageCR.
 			patchedStoragePolicyUsageCR := storagePolicyUsageCR.DeepCopy()
-			if storagePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage != nil {
+			if storagePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage != nil &&
+				storagePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved != nil {
 				patchedStoragePolicyUsageCR.Status.ResourceTypeLevelQuotaUsage.Reserved.Add(*capacity)
 			} else {
 				var (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Static volume provision fails with panic while updating storagepolicyusage, fixing the bug by adding validation to check reserved field in storagepolicyusage status is nil.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Manual Testing Performed

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
bug fix - static volume provision fails with panic while updating storagepolicyusage
```
