### PR TITLE
disable netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,8 @@
 # Netlify build
 [build]
-    command = "./hack/build-gitbooks.sh"
-    publish = "docs/book/_book"
+    ignore = "exit 0"
+#   command = "./hack/build-gitbooks.sh"
+#   publish = "docs/book/_book" 
 
 # Netlify redirects
 [[redirects]]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
disable netlify build.
automatic PR merge is disabled to netlify build failure.
temporarily disabling netlify build.




**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
disable netlify build
```
