### PR TITLE
WorkloadDomainIsolation: Static volume support on supervisor

### DIFF
--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -1690,8 +1690,12 @@ func (volTopology *wcpControllerVolumeTopology) GetTopologyInfoFromNodes(ctx con
 	// In VC 9.0, if StorageTopologyType is not set, all the zones the selected datastore
 	// is accessible from will be added as node affinity terms on the PV even if the zones
 	// are not associated with the namespace of the PVC.
+	// This code block runs for static as well as dynamic volume provisioning case.
 	case "":
-		// This code block runs for static as well as dynamic volume provisioning case.
+		// TopoSegToDatastoresMap will be nil in case of static volume provisioning.
+		if params.TopoSegToDatastoresMap == nil {
+			params.TopoSegToDatastoresMap = make(map[string][]*cnsvsphere.DatastoreInfo)
+		}
 		var selectedSegments []map[string]string
 		for zone, clusters := range azClustersMap {
 			if _, exists := params.TopoSegToDatastoresMap[zone]; !exists {

--- a/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
+++ b/pkg/syncer/cnsoperator/controller/cnsregistervolume/cnsregistervolume_controller.go
@@ -74,6 +74,9 @@ var (
 
 	topologyMgr                 commoncotypes.ControllerTopologyService
 	clusterComputeResourceMoIds []string
+	// workloadDomainIsolationEnabled determines if the workload domain
+	// isolation feature is available on a supervisor cluster.
+	workloadDomainIsolationEnabled bool
 )
 
 // Add creates a new CnsRegisterVolume Controller and adds it to the Manager,
@@ -86,6 +89,9 @@ func Add(mgr manager.Manager, clusterFlavor cnstypes.CnsClusterFlavor,
 		log.Debug("Not initializing the CnsRegisterVolume Controller as its a non-WCP CSI deployment")
 		return nil
 	}
+	workloadDomainIsolationEnabled = commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx,
+		common.WorkloadDomainIsolation)
+
 	var volumeInfoService cnsvolumeinfo.VolumeInfoService
 	if clusterFlavor == cnstypes.CnsClusterFlavorWorkload {
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.TKGsHA) {
@@ -216,7 +222,7 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 	timeout = backOffDuration[instance.Name]
 	backOffDurationMapMutex.Unlock()
 
-	// If the CnsRegistereVolume instance is already registered, remove the
+	// If the CnsRegisterVolume instance is already registered, remove the
 	// instance from the queue.
 	if instance.Status.Registered {
 		backOffDurationMapMutex.Lock()
@@ -298,18 +304,20 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
 
-	if syncer.IsPodVMOnStretchSupervisorFSSEnabled && len(clusterComputeResourceMoIds) > 1 {
-		azClustersMap := topologyMgr.GetAZClustersMap(ctx)
-		isAccessible := isDatastoreAccessibleToAZClusters(ctx, vc, azClustersMap, volume.DatastoreUrl)
-		if !isAccessible {
-			log.Errorf("Volume: %s present on datastore: %s is not accessible to any of the AZ clusters: %v",
-				volumeID, volume.DatastoreUrl, azClustersMap)
-			setInstanceError(ctx, r, instance, "Volume in the spec is not accessible to any of the AZ clusters")
-			_, err = common.DeleteVolumeUtil(ctx, r.volumeManager, volumeID, false)
-			if err != nil {
-				log.Errorf("Failed to untag CNS volume: %s with error: %+v", volumeID, err)
+	if syncer.IsPodVMOnStretchSupervisorFSSEnabled {
+		if workloadDomainIsolationEnabled || len(clusterComputeResourceMoIds) > 1 {
+			azClustersMap := topologyMgr.GetAZClustersMap(ctx)
+			isAccessible := isDatastoreAccessibleToAZClusters(ctx, vc, azClustersMap, volume.DatastoreUrl)
+			if !isAccessible {
+				log.Errorf("Volume: %s present on datastore: %s is not accessible to any of the AZ clusters: %v",
+					volumeID, volume.DatastoreUrl, azClustersMap)
+				setInstanceError(ctx, r, instance, "Volume in the spec is not accessible to any of the AZ clusters")
+				_, err = common.DeleteVolumeUtil(ctx, r.volumeManager, volumeID, false)
+				if err != nil {
+					log.Errorf("Failed to untag CNS volume: %s with error: %+v", volumeID, err)
+				}
+				return reconcile.Result{RequeueAfter: timeout}, nil
 			}
-			return reconcile.Result{RequeueAfter: timeout}, nil
 		}
 	} else {
 		// Verify if the volume is accessible to Supervisor cluster.
@@ -338,39 +346,6 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
 
-	if syncer.IsPodVMOnStretchSupervisorFSSEnabled && len(clusterComputeResourceMoIds) > 1 {
-		// Calculate accessible topology for the provisioned volume.
-		datastoreAccessibleTopology, err := topologyMgr.GetTopologyInfoFromNodes(ctx,
-			commoncotypes.WCPRetrieveTopologyInfoParams{
-				DatastoreURL:        volume.DatastoreUrl,
-				StorageTopologyType: "zonal",
-				TopologyRequirement: nil,
-				Vc:                  vc})
-		if err != nil {
-			msg := fmt.Sprintf("failed to find volume topology. Error: %v", err)
-			log.Error(msg)
-			setInstanceError(ctx, r, instance, msg)
-			return reconcile.Result{RequeueAfter: timeout}, nil
-		}
-		matchExpressions := make([]v1.NodeSelectorRequirement, 0)
-		for key, value := range datastoreAccessibleTopology[0] {
-			matchExpressions = append(matchExpressions, v1.NodeSelectorRequirement{
-				Key:      key,
-				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{value},
-			})
-		}
-		pvNodeAffinity = &v1.VolumeNodeAffinity{
-			Required: &v1.NodeSelector{
-				NodeSelectorTerms: []v1.NodeSelectorTerm{
-					{
-						MatchExpressions: matchExpressions,
-					},
-				},
-			},
-		}
-	}
-
 	k8sclient, err := k8s.NewClient(ctx)
 	if err != nil {
 		log.Errorf("Failed to initialize K8S client when registering the CnsRegisterVolume "+
@@ -391,6 +366,77 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 	}
 	log.Infof("Volume with storagepolicyId: %s is mapping to K8S storage class: %s and assigned to namespace: %s",
 		volume.StoragePolicyId, storageClassName, request.Namespace)
+
+	sc, err := k8sclient.StorageV1().StorageClasses().Get(ctx, storageClassName, metav1.GetOptions{})
+	if err != nil {
+		msg := fmt.Sprintf("Failed to fetch StorageClass: %q with error: %+v", storageClassName, err)
+		log.Error(msg)
+		setInstanceError(ctx, r, instance, msg)
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
+
+	// Calculate accessible topology for the provisioned volume.
+	var datastoreAccessibleTopology []map[string]string
+	if syncer.IsPodVMOnStretchSupervisorFSSEnabled {
+		if workloadDomainIsolationEnabled {
+			datastoreAccessibleTopology, err = topologyMgr.GetTopologyInfoFromNodes(ctx,
+				commoncotypes.WCPRetrieveTopologyInfoParams{
+					DatastoreURL:        volume.DatastoreUrl,
+					StorageTopologyType: sc.Parameters["StorageTopologyType"],
+					TopologyRequirement: nil,
+					Vc:                  vc})
+		} else if len(clusterComputeResourceMoIds) > 1 {
+			datastoreAccessibleTopology, err = topologyMgr.GetTopologyInfoFromNodes(ctx,
+				commoncotypes.WCPRetrieveTopologyInfoParams{
+					DatastoreURL:        volume.DatastoreUrl,
+					StorageTopologyType: "zonal",
+					TopologyRequirement: nil,
+					Vc:                  vc})
+		}
+		if err != nil {
+			msg := fmt.Sprintf("failed to find volume topology. Error: %v", err)
+			log.Error(msg)
+			setInstanceError(ctx, r, instance, msg)
+			return reconcile.Result{RequeueAfter: timeout}, nil
+		}
+
+		// Create node affinity terms from datastoreAccessibleTopology.
+		var terms []v1.NodeSelectorTerm
+		if workloadDomainIsolationEnabled {
+			for _, topologyTerms := range datastoreAccessibleTopology {
+
+				var expressions []v1.NodeSelectorRequirement
+				for key, value := range topologyTerms {
+					expressions = append(expressions, v1.NodeSelectorRequirement{
+						Key:      key,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{value},
+					})
+				}
+				terms = append(terms, v1.NodeSelectorTerm{
+					MatchExpressions: expressions,
+				})
+			}
+		} else {
+			matchExpressions := make([]v1.NodeSelectorRequirement, 0)
+			for key, value := range datastoreAccessibleTopology[0] {
+				matchExpressions = append(matchExpressions, v1.NodeSelectorRequirement{
+					Key:      key,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{value},
+				})
+			}
+			terms = append(terms, v1.NodeSelectorTerm{
+				MatchExpressions: matchExpressions,
+			})
+		}
+
+		pvNodeAffinity = &v1.VolumeNodeAffinity{
+			Required: &v1.NodeSelector{
+				NodeSelectorTerms: terms,
+			},
+		}
+	}
 
 	capacityInMb := volume.BackingObjectDetails.GetCnsBackingObjectDetails().CapacityInMb
 	accessMode := instance.Spec.AccessMode
@@ -436,9 +482,15 @@ func (r *ReconcileCnsRegisterVolume) Reconcile(ctx context.Context,
 		return reconcile.Result{RequeueAfter: timeout}, nil
 	}
 	// Create PVC mapping to above created PV.
-	log.Infof("Now creating pvc: %s", instance.Spec.PvcName)
-	pvcSpec := getPersistentVolumeClaimSpec(instance.Spec.PvcName, instance.Namespace, capacityInMb,
-		storageClassName, accessMode, pvName)
+	log.Infof("Creating PVC: %s", instance.Spec.PvcName)
+	pvcSpec, err := getPersistentVolumeClaimSpec(ctx, instance.Spec.PvcName, instance.Namespace, capacityInMb,
+		storageClassName, accessMode, pvName, datastoreAccessibleTopology)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to create spec for PVC: %q. Error: %v", instance.Spec.PvcName, err)
+		log.Errorf(msg)
+		setInstanceError(ctx, r, instance, msg)
+		return reconcile.Result{RequeueAfter: timeout}, nil
+	}
 	log.Debugf("PVC spec is: %+v", pvcSpec)
 	pvc, err := k8sclient.CoreV1().PersistentVolumeClaims(instance.Namespace).Create(ctx,
 		pvcSpec, metav1.CreateOptions{})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:  This PR introduces static volume provisioning support by taking into consideration the StorageTopologyType parameter in the SC.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
Verified Creating Static volume on shared datastore.

```
# cat register-volume.yaml
apiVersion: cns.vmware.com/v1alpha1
kind: CnsRegisterVolume
metadata:
  name: static-pv-test
  namespace: svc-tkg-domain-c52
spec:
  volumeID: ddd12989-909e-44bf-8e57-4b84b9f9293b
  accessMode: ReadWriteOnce
  pvcName: static-pvc-test
```

```
# kubectl create -f register-volume.yaml
cnsregistervolume.cns.vmware.com/static-pv-test created
```


```
# kubectl describe cnsregistervolume static-pv-test  -n svc-tkg-domain-c52
Name:         static-pv-test
Namespace:    svc-tkg-domain-c52
Labels:       <none>
Annotations:  <none>
API Version:  cns.vmware.com/v1alpha1
Kind:         CnsRegisterVolume
Metadata:
  Creation Timestamp:  2024-09-04T21:46:00Z
  Generation:          1
  Resource Version:    8352632
  UID:                 3ecedace-9b67-4460-99a2-37929d9baf9b
Spec:
  Access Mode:  ReadWriteOnce
  Pvc Name:     static-pvc-test
  Volume ID:    ddd12989-909e-44bf-8e57-4b84b9f9293b
Events:         <none>
```


```
# kubectl get pvc static-pvc-test -n svc-tkg-domain-c52
NAME              STATUS   VOLUME                                           CAPACITY   ACCESS MODES   STORAGECLASS               VOLUMEATTRIBUTESCLASS   AGE
static-pvc-test   Bound    static-pv-ddd12989-909e-44bf-8e57-4b84b9f9293b   1Gi        RWO            wcplocal-storage-profile   <unset>                 13s
```

```
# kubectl describe pvc static-pvc-test -n svc-tkg-domain-c52
Name:          static-pvc-test
Namespace:     svc-tkg-domain-c52
StorageClass:  wcplocal-storage-profile
Status:        Bound
Volume:        static-pv-ddd12989-909e-44bf-8e57-4b84b9f9293b
Labels:        <none>
Annotations:   csi.vsphere.volume-accessible-topology: [{"topology.kubernetes.io/zone":"zone-1"},{"topology.kubernetes.io/zone":"zone-3"}]
               pv.kubernetes.io/bind-completed: yes
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:        <none>
```


```
# kubectl describe pv static-pv-ddd12989-909e-44bf-8e57-4b84b9f9293b
Name:              static-pv-ddd12989-909e-44bf-8e57-4b84b9f9293b
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      wcplocal-storage-profile
Status:            Bound
Claim:             svc-tkg-domain-c52/static-pvc-test
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:
  Required Terms:
    Term 0:        topology.kubernetes.io/zone in [zone-1]
    Term 1:        topology.kubernetes.io/zone in [zone-3]
Message:
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      ddd12989-909e-44bf-8e57-4b84b9f9293b
    ReadOnly:          false
    VolumeAttributes:  <none>
Events:                <none>
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
WorkloadDomainIsolation: Static volume support on supervisor
```
