### PR TITLE
Re-create CSINodes for Supervisor worker nodes to publish zone topology label as topology keys.

### DIFF
--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -26,7 +26,7 @@ rules:
     verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
-    verbs: ["get", "list", "watch", "create"]
+    verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -26,7 +26,7 @@ rules:
     verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
-    verbs: ["get", "list", "watch", "create"]
+    verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -26,7 +26,7 @@ rules:
     verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
-    verbs: ["get", "list", "watch", "create"]
+    verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]

--- a/pkg/csi/service/common/commonco/k8sorchestrator/wcp_node.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/wcp_node.go
@@ -19,13 +19,13 @@ package k8sorchestrator
 import (
 	"context"
 	"os"
+	"slices"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/common"
 	"sigs.k8s.io/vsphere-csi-driver/v3/pkg/csi/service/logger"
 )
@@ -73,7 +73,8 @@ func (c *K8sOrchestrator) createCSINode(obj interface{}) {
 	}
 
 	var topologyKeysList []string
-	if c.IsFSSEnabled(ctx, common.WorkloadDomainIsolation) {
+	isWorkloadDomainIsolationEnabled := c.IsFSSEnabled(ctx, common.WorkloadDomainIsolation)
+	if isWorkloadDomainIsolationEnabled {
 		// Publish zone and host standard topology keys for all types of supervisor clusters.
 		topologyKeysList = append(topologyKeysList, corev1.LabelTopologyZone, corev1.LabelHostname)
 	} else {
@@ -109,14 +110,46 @@ func (c *K8sOrchestrator) createCSINode(obj interface{}) {
 			},
 		},
 	}
-	csinode, err := c.k8sClient.StorageV1().CSINodes().Create(ctx, csiNodeSpec, metav1.CreateOptions{})
+	csinode, err := c.k8sClient.StorageV1().CSINodes().Get(ctx, node.Name, metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			log.Warnf("CSINode object for node %q already exists.", node.Name)
-			return
+		if apierrors.IsNotFound(err) {
+			_, err = c.k8sClient.StorageV1().CSINodes().Create(ctx, csiNodeSpec, metav1.CreateOptions{})
+			if err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					log.Warnf("CSINode object for node %q already exists.", node.Name)
+					return
+				}
+				log.Errorf("failed to create CSINode object %+v. Error: %v", csiNodeSpec, err)
+				os.Exit(1)
+			} else {
+				log.Infof("Created CSINode object %+v for node %q", csinode, node.Name)
+				return
+			}
+		} else {
+			log.Errorf("failed to get CSINode object %+v. Error: %v", csiNodeSpec, err)
+			os.Exit(1)
 		}
-		log.Errorf("failed to create CSINode object %+v. Error: %v", csiNodeSpec, err)
-		os.Exit(1)
+	} else {
+		// If CSINode object is present, re-create CSINode object if zone topology key is not present on it
+		if isWorkloadDomainIsolationEnabled {
+			if !slices.Contains(csinode.Spec.Drivers[0].TopologyKeys, corev1.LabelTopologyZone) {
+				log.Infof("topology key: %q not present on CSINodes object for node: %q. Re-creating CSINodes object.",
+					corev1.LabelTopologyZone, node.Name)
+				err = c.k8sClient.StorageV1().CSINodes().Delete(ctx, csiNodeSpec.Name, metav1.DeleteOptions{})
+				if err != nil {
+					log.Errorf("failed to delete CSINode object for node: %q. Error: %v", csiNodeSpec.Name, err)
+					os.Exit(1)
+				}
+				_, err = c.k8sClient.StorageV1().CSINodes().Create(ctx, csiNodeSpec, metav1.CreateOptions{})
+				if err == nil {
+					log.Infof("re-created CSINodes object %+v for the node: %q with zonal topology keys",
+						csinode, csiNodeSpec.Name)
+					return
+				} else {
+					log.Errorf("failed to create CSINode object %+v. Error: %v", csiNodeSpec, err)
+					os.Exit(1)
+				}
+			}
+		}
 	}
-	log.Infof("Created CSINode object %+v for node %q", csinode, node.Name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Re-create CSINodes for Supervisor worker nodes to publish zone topology label as topology keys.


**Testing done**:
Testing done.

CSINodes were present on the system without `topology.kubernetes.io/zone` in topologyKeys

```
# kubectl get csinodes sc2-10-186-99-166.eng.vmware.com -o yaml
apiVersion: storage.k8s.io/v1
kind: CSINode
metadata:
  creationTimestamp: "2024-09-05T20:33:56Z"
  name: sc2-10-186-99-166.eng.vmware.com
  ownerReferences:
  - apiVersion: v1
    kind: Node
    name: sc2-10-186-99-166.eng.vmware.com
    uid: 6a046d96-b23b-4c90-b40b-8b16b95607b9
  resourceVersion: "9218420"
  uid: baa0ae5d-b453-418e-a96f-a20cd0661357
spec:
  drivers:
  - name: csi.vsphere.vmware.com
    nodeID: sc2-10-186-99-166.eng.vmware.com
    topologyKeys:
    - kubernetes.io/hostname
```

Upgraded Syncer container with this change. Syncer has re-created this CSINodes CR with zonal topology key.

Logs

```
{"level":"info","time":"2024-09-05T22:33:56.661970895Z","caller":"k8sorchestrator/wcp_node.go:136","msg":"topology key: \"topology.kubernetes.io/zone\" not present on CSINodes object for node: \"sc2-10-186-99-166.eng.vmware.com\". Re-creating CSINodes object.","TraceId":"82966acf-8cac-4bd6-8147-78a4207794a2"}
{"level":"info","time":"2024-09-05T22:33:56.696896964Z","caller":"k8sorchestrator/wcp_node.go:145","msg":"re-created CSINodes object &CSINode{ObjectMeta:{sc2-10-186-99-166.eng.vmware.com    baa0ae5d-b453-418e-a96f-a20cd0661357 9218420 0 2024-09-05 20:33:56 +0000 UTC <nil> <nil> map[] map[] [{v1 Node sc2-10-186-99-166.eng.vmware.com 6a046d96-b23b-4c90-b40b-8b16b95607b9 <nil> <nil>}] [] [{kubectl-create Update storage.k8s.io/v1 2024-09-05 20:33:56 +0000 UTC FieldsV1 {\"f:metadata\":{\"f:ownerReferences\":{\".\":{},\"k:{\\\"uid\\\":\\\"6a046d96-b23b-4c90-b40b-8b16b95607b9\\\"}\":{}}},\"f:spec\":{\"f:drivers\":{\"k:{\\\"name\\\":\\\"csi.vsphere.vmware.com\\\"}\":{\".\":{},\"f:name\":{},\"f:nodeID\":{},\"f:topologyKeys\":{}}}}} }]},Spec:CSINodeSpec{Drivers:[]CSINodeDriver{CSINodeDriver{Name:csi.vsphere.vmware.com,NodeID:sc2-10-186-99-166.eng.vmware.com,TopologyKeys:[kubernetes.io/hostname],Allocatable:nil,},},},} for the node: \"sc2-10-186-99-166.eng.vmware.com\" with zonal topology keys","TraceId":"82966acf-8cac-4bd6-8147-78a4207794a2"}

```

CSINodes CR after re-create with updated topology keys
```
# kubectl get csinodes sc2-10-186-99-166.eng.vmware.com -o yaml
apiVersion: storage.k8s.io/v1
kind: CSINode
metadata:
  creationTimestamp: "2024-09-05T22:33:56Z"
  name: sc2-10-186-99-166.eng.vmware.com
  ownerReferences:
  - apiVersion: v1
    kind: Node
    name: sc2-10-186-99-166.eng.vmware.com
    uid: 6a046d96-b23b-4c90-b40b-8b16b95607b9
  resourceVersion: "9295591"
  uid: 724b11bb-9748-4b97-9466-6e574b9fa79e
spec:
  drivers:
  - name: csi.vsphere.vmware.com
    nodeID: sc2-10-186-99-166.eng.vmware.com
    topologyKeys:
    - topology.kubernetes.io/zone
    - kubernetes.io/hostname
 ```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Re-create CSINodes for Supervisor worker nodes to publish zone topology label as topology keys.
```
