### PR TITLE
set node affinity rules on the TKG PV using volume-accessible-topology annotation on supervisor PVC

### DIFF
--- a/manifests/guestcluster/1.28/pvcsi.yaml
+++ b/manifests/guestcluster/1.28/pvcsi.yaml
@@ -535,6 +535,7 @@ data:
   "block-volume-snapshot": "true"
   "tkgs-ha": "true"
   "cnsmgr-suspend-create-volume": "true"
+  "workload-domain-isolation": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.29/pvcsi.yaml
+++ b/manifests/guestcluster/1.29/pvcsi.yaml
@@ -535,6 +535,7 @@ data:
   "block-volume-snapshot": "true"
   "tkgs-ha": "true"
   "cnsmgr-suspend-create-volume": "true"
+  "workload-domain-isolation": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/guestcluster/1.30/pvcsi.yaml
+++ b/manifests/guestcluster/1.30/pvcsi.yaml
@@ -535,6 +535,7 @@ data:
   "block-volume-snapshot": "true"
   "tkgs-ha": "true"
   "cnsmgr-suspend-create-volume": "true"
+  "workload-domain-isolation": "false"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/manifests/supervisorcluster/1.27/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.27/cns-csi.yaml
@@ -468,6 +468,7 @@ data:
   "storage-quota-m2": "false"
   "vdpp-on-stretched-supervisor": "false"
   "cns-unregister-volume": "false"
+  "workload-domain-isolation": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.28/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.28/cns-csi.yaml
@@ -468,6 +468,7 @@ data:
   "storage-quota-m2": "false"
   "vdpp-on-stretched-supervisor": "false"
   "cns-unregister-volume": "false"
+  "workload-domain-isolation": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/manifests/supervisorcluster/1.29/cns-csi.yaml
+++ b/manifests/supervisorcluster/1.29/cns-csi.yaml
@@ -468,6 +468,7 @@ data:
   "storage-quota-m2": "false"
   "vdpp-on-stretched-supervisor": "false"
   "cns-unregister-volume": "false"
+  "workload-domain-isolation": "false"
 kind: ConfigMap
 metadata:
   name: csi-feature-states

--- a/pkg/csi/service/common/constants.go
+++ b/pkg/csi/service/common/constants.go
@@ -426,6 +426,9 @@ const (
 	// WorkloadDomainIsolation is the name of the WCP capability which determines if
 	// workload domain isolation feature is available on a supervisor cluster.
 	WorkloadDomainIsolation = "Workload_Domain_Isolation_Supported"
+	// WorkloadDomainIsolationFSS is FSS for Workload Domain isolation feature
+	// Used in PVCSI
+	WorkloadDomainIsolationFSS = "workload-domain-isolation"
 )
 
 var WCPFeatureStates = map[string]struct{}{

--- a/pkg/syncer/pvcsi_fullsync_test.go
+++ b/pkg/syncer/pvcsi_fullsync_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestGenerateVolumeNodeAffinity(t *testing.T) {
+	tests := []struct {
+		name               string
+		accessibleTopology []*csi.Topology
+		expected           *v1.VolumeNodeAffinity
+	}{
+		{
+			name: "Basic test with one topology",
+			accessibleTopology: []*csi.Topology{
+				{Segments: map[string]string{"topology.kubernetes.io/zone": "zone-1"}},
+			},
+			expected: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      "topology.kubernetes.io/zone",
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"zone-1"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple topologies with different segments",
+			accessibleTopology: []*csi.Topology{
+				{Segments: map[string]string{"topology.kubernetes.io/zone": "zone-1"}},
+				{Segments: map[string]string{"topology.kubernetes.io/zone": "zone-2"}},
+			},
+			expected: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      "topology.kubernetes.io/zone",
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"zone-1"},
+								},
+							},
+						},
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      "topology.kubernetes.io/zone",
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"zone-2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:               "Empty topology list",
+			accessibleTopology: []*csi.Topology{},
+			expected:           nil,
+		},
+		{
+			name: "Topology with empty segments",
+			accessibleTopology: []*csi.Topology{
+				{Segments: map[string]string{}},
+			},
+			expected: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: nil, // No terms should be added
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GenerateVolumeNodeAffinity(tt.accessibleTopology)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -943,3 +943,22 @@ func hasClusterDistributionSet(ctx context.Context, volume cnstypes.CnsVolume,
 	}
 	return false
 }
+
+// generateVolumeAccessibleTopologyFromPVCAnnotation returns accessible topologies generated using
+// PVC annotation "csi.vsphere.volume-accessible-topology".
+func generateVolumeAccessibleTopologyFromPVCAnnotation(claim *v1.PersistentVolumeClaim) (
+	[]map[string]string, error) {
+	volumeAccessibleTopology := claim.Annotations[common.AnnVolumeAccessibleTopology]
+	if volumeAccessibleTopology == "" {
+		return nil, fmt.Errorf("annotation %q is not set for the claim: %q, namespace: %q",
+			common.AnnVolumeAccessibleTopology, claim.Name, claim.Namespace)
+	}
+	volumeAccessibleTopologyArray := make([]map[string]string, 0)
+	err := json.Unmarshal([]byte(volumeAccessibleTopology), &volumeAccessibleTopologyArray)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse annotation: %q value %v from the claim: %q, namespace: %q. "+
+			"err: %v", common.AnnVolumeAccessibleTopology, volumeAccessibleTopology,
+			claim.Name, claim.Namespace, err)
+	}
+	return volumeAccessibleTopologyArray, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

updated pvCSI full sync to add node affinity terms to all GC PVs by checking the corresponding volume-accessible-topology annotation on supervisor PVC.


**Testing done**:
Verified using statically created PV



Created PV statically without node affinity rules

```
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
  finalizers:
  - kubernetes.io/pv-protection
  name: pvc-300df59f-2f5b-4df4-a11a-cba39bd0fd98
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 1Gi
  csi:
    driver: csi.vsphere.vmware.com
    fsType: ext4
    volumeAttributes:
      type: vSphere CNS Block Volume
    volumeHandle: 37266d54-8fa2-4c2a-8812-ceda298b39cd-300df59f-2f5b-4df4-a11a-cba39bd0fd98
  persistentVolumeReclaimPolicy: Delete
  storageClassName: zonal-policy
  volumeMode: Filesystem
```

Log

> 2024-09-09T23:53:24.653Z	INFO	syncer/pvcsi_fullsync.go:321	patched PV: pvc-300df59f-2f5b-4df4-a11a-cba39bd0fd98 with node affinity &VolumeNodeAffinity{Required:&NodeSelector{NodeSelectorTerms:[]NodeSelectorTerm{NodeSelectorTerm{MatchExpressions:[]NodeSelectorRequirement{NodeSelectorRequirement{Key:topology.kubernetes.io/zone,Operator:In,Values:[zone-3],},},MatchFields:[]NodeSelectorRequirement{},},},},}	{"TraceId": "752ef842-eb8a-4295-a8aa-0cd0da98ef20"}

PV after PVCSI full sync

```
# kubectl describe pv
Name:              pvc-300df59f-2f5b-4df4-a11a-cba39bd0fd98
Labels:            <none>
Annotations:       pv.kubernetes.io/provisioned-by: csi.vsphere.vmware.com
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      zonal-policy
Status:            Available
Claim:
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          1Gi
Node Affinity:
  Required Terms:
    Term 0:        topology.kubernetes.io/zone in [zone-3]
Message:
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            csi.vsphere.vmware.com
    FSType:            ext4
    VolumeHandle:      37266d54-8fa2-4c2a-8812-ceda298b39cd-300df59f-2f5b-4df4-a11a-cba39bd0fd98
    ReadOnly:          false
    VolumeAttributes:      type=vSphere CNS Block Volume
Events:                <none>
```


Unit tests

```
% go test -run TestParseJSONToTopologies
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer    1.469s


% go test -run TestGenerateVolumeNodeAffinity
PASS
ok      sigs.k8s.io/vsphere-csi-driver/v3/pkg/syncer    1.431s
```


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
set node affinity rules on the TKG PV using volume-accessible-topology annotation on supervisor PVC
```
